### PR TITLE
fix: remove repo-specific values from github ruleset template

### DIFF
--- a/typescript/github-rulesets/base.json
+++ b/typescript/github-rulesets/base.json
@@ -1,9 +1,6 @@
 {
-  "id": 11725285,
   "name": "base",
   "target": "branch",
-  "source_type": "Repository",
-  "source": "gunnertech/thumbwar-backend",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -11,7 +8,6 @@
       "include": [
         "~DEFAULT_BRANCH",
         "refs/heads/dev",
-        "refs/heads/main",
         "refs/heads/staging"
       ]
     }
@@ -24,83 +20,14 @@
       "type": "non_fast_forward"
     },
     {
-      "type": "code_quality",
-      "parameters": {
-        "severity": "warnings"
-      }
-    },
-    {
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
-        "required_reviewers": [],
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true,
-        "allowed_merge_methods": [
-          "merge",
-          "squash",
-          "rebase"
-        ]
+        "required_review_thread_resolution": true
       }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "do_not_enforce_on_create": true,
-        "required_status_checks": [
-          {
-            "context": "GitGuardian Security Checks",
-            "integration_id": 46505
-          },
-          {
-            "context": "CodeRabbit",
-            "integration_id": 347564
-          },
-          {
-            "context": "🔍 Quality Checks / 🧪 Run Unit Tests",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 🧪 Run Integration Tests",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 🔍 Type Check",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 🏗️ Build",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 📐 Check Formatting",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 🧹 Lint",
-            "integration_id": 15368
-          },
-          {
-            "context": "🔍 Quality Checks / 🔒 Security Scan",
-            "integration_id": 15368
-          }
-        ]
-      }
-    }
-  ],
-  "bypass_actors": [
-    {
-      "actor_id": null,
-      "actor_type": "DeployKey",
-      "bypass_mode": "always"
-    },
-    {
-      "actor_id": null,
-      "actor_type": "OrganizationAdmin",
-      "bypass_mode": "always"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Remove hardcoded integration IDs for required_status_checks that were specific to another repository
- Remove `code_quality` rule type (not available on all GitHub plans)
- Remove `bypass_actors` with null actor_id values
- Keep only portable rules: deletion protection, non_fast_forward, and pull_request requirements

## Test plan

- [x] Run `lisa-github-rulesets.sh --yes .` and verify it succeeds
- [ ] Apply to a new repository and verify ruleset is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)