### PR TITLE
docs: add CodeRabbit to optional tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,21 @@ npx @codyswann/lisa /path/to/project
 
 These tools enhance Lisa's capabilities but are not required:
 
-- **[CodeRabbit](https://coderabbit.ai/)** - AI-powered code review tool used by `/project:review`
+- **[CodeRabbit CLI](https://coderabbit.ai/)** - AI-powered code review tool used by `/project:review`
+
+  **Installation (choose one):**
   ```bash
-  npm install -g coderabbit
+  # Recommended
+  curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+  coderabbit --version  # Verify installation
+
+  # Homebrew (macOS/Linux)
+  brew install coderabbit
+
+  # NPX (no install needed)
+  npx coderabbitai-mcp@latest
   ```
+
   If not installed, the CodeRabbit review step in `/project:review` will be skipped silently.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Add CodeRabbit to the "Optional Tools" section in the README
- Include installation instructions (`npm install -g coderabbit`)
- Note that the CodeRabbit review step is skipped silently if not installed

## Context
The `/project:review` command uses CodeRabbit but it wasn't documented anywhere in the project. This helps users understand what CodeRabbit is and how to install it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Optional Tools" section to Installation describing the CodeRabbit CLI as an optional AI-powered code review helper.
  * Provided installation methods (curl script, Homebrew, npx) and clarified that the CodeRabbit review step is skipped silently if the tool isn't installed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->