### PR TITLE
docs: add workflow configuration inputs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ npx @codyswann/lisa /path/to/project
 
 ### Requirements
 
-- **Node.js 18+**
+- **Node.js 18+** (workflows default to 22.x)
 - **npm**, **bun**, or **pnpm**
 
 ### Optional Tools
@@ -521,6 +521,28 @@ Once configured, all future releases are automatic:
 
 - npm CLI 11.5+ (workflow automatically installs latest)
 - Cannot use self-hosted GitHub runners (not yet supported by npm)
+
+**Workflow Configuration:**
+
+The `publish-to-npm.yml` workflow accepts configurable inputs:
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `node_version` | `20.x` | Node.js version to use |
+| `package_manager` | `npm` | Package manager (`npm`, `yarn`, or `bun`) |
+
+Example with custom configuration:
+
+```yaml
+publish:
+  uses: ./.github/workflows/publish-to-npm.yml
+  needs: [release]
+  with:
+    tag: ${{ needs.release.outputs.tag }}
+    version: ${{ needs.release.outputs.version }}
+    node_version: '22.x'
+    package_manager: 'bun'
+```
 
 ### Extending Lisa for Other Stacks
 


### PR DESCRIPTION
## Summary

- Document `node_version` and `package_manager` configurable inputs for the `publish-to-npm.yml` workflow
- Clarify that workflows default to Node 22.x while minimum requirement remains 18+
- Add example YAML snippet showing custom workflow configuration

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the workflow configuration table displays properly
- [ ] Check that the YAML example has correct syntax highlighting

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced Workflow Configuration section with input parameters and YAML usage examples.
  * Updated Node.js version details for workflows.
  * Expanded stack extension guidance with example prompts for various technologies.
  * Added contributor-focused instructions for adding new stacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->