### PR TITLE
fix: enable functional/immutable-data rule for TypeScript files

### DIFF
--- a/eslint.base.mjs
+++ b/eslint.base.mjs
@@ -351,7 +351,7 @@ export const getTsFilesOverride = (filePatterns = ["**/*.ts"]) => ({
   rules: {
     // Enable immutable-data rule now that type-checking is available
     "functional/immutable-data": [
-      "off",
+      "error",
       {
         ignoreClasses: true,
         ignoreImmediateMutation: true,
@@ -384,10 +384,8 @@ export const getTsTestFilesOverride = (
 export {
   eslintComments,
   functional,
-  globals,
-  jsdoc,
-  js,
-  prettier,
+  globals, js, jsdoc, prettier,
   sonarjs,
-  tseslint,
+  tseslint
 };
+

--- a/typescript/copy-overwrite/eslint.base.mjs
+++ b/typescript/copy-overwrite/eslint.base.mjs
@@ -351,7 +351,7 @@ export const getTsFilesOverride = (filePatterns = ["**/*.ts"]) => ({
   rules: {
     // Enable immutable-data rule now that type-checking is available
     "functional/immutable-data": [
-      "off",
+      "error",
       {
         ignoreClasses: true,
         ignoreImmediateMutation: true,
@@ -384,10 +384,8 @@ export const getTsTestFilesOverride = (
 export {
   eslintComments,
   functional,
-  globals,
-  jsdoc,
-  js,
-  prettier,
+  globals, js, jsdoc, prettier,
   sonarjs,
-  tseslint,
+  tseslint
 };
+


### PR DESCRIPTION
## Summary
- Enable `functional/immutable-data` ESLint rule for TypeScript files
- The rule was incorrectly set to "off" despite the comment stating it should be enabled

## Changes
- **eslint.base.mjs**: Change `functional/immutable-data` from "off" to "error"
- **typescript/copy-overwrite/eslint.base.mjs**: Same change for the distributed template

## Test plan
- [ ] Run `bun lint` to verify no existing code violations
- [ ] Verify TypeScript files are checked for immutability patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code immutability enforcement through stricter linting rules for TypeScript files
  * Improved linting configuration organization and formatting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->