### PR TITLE
feat(eslint): add precondition, entity, and security JSDoc tags

### DIFF
--- a/eslint.base.mjs
+++ b/eslint.base.mjs
@@ -255,7 +255,10 @@ export const getSharedRules = thresholds => ({
   "jsdoc/require-param-description": "error",
   "jsdoc/require-returns-description": "error",
   "jsdoc/require-property-description": "error",
-  "jsdoc/check-tag-names": ["error", { definedTags: ["remarks"] }],
+  "jsdoc/check-tag-names": [
+    "error",
+    { definedTags: ["remarks", "precondition", "entity", "security"] },
+  ],
   "jsdoc/no-types": "off",
   "jsdoc/require-param-type": "off",
   "jsdoc/require-returns-type": "off",

--- a/typescript/copy-overwrite/eslint.base.mjs
+++ b/typescript/copy-overwrite/eslint.base.mjs
@@ -255,7 +255,10 @@ export const getSharedRules = thresholds => ({
   "jsdoc/require-param-description": "error",
   "jsdoc/require-returns-description": "error",
   "jsdoc/require-property-description": "error",
-  "jsdoc/check-tag-names": ["error", { definedTags: ["remarks"] }],
+  "jsdoc/check-tag-names": [
+    "error",
+    { definedTags: ["remarks", "precondition", "entity", "security"] },
+  ],
   "jsdoc/no-types": "off",
   "jsdoc/require-param-type": "off",
   "jsdoc/require-returns-type": "off",


### PR DESCRIPTION
## Summary
- Add `@precondition`, `@entity`, and `@security` to the list of allowed custom JSDoc tags
- Updated both root `eslint.base.mjs` and `typescript/copy-overwrite/eslint.base.mjs`

## Test plan
- Run `bun run lint` on a project using these custom tags to verify no lint errors occur
- The tags should now be recognized without triggering `jsdoc/check-tag-names` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint JSDoc tag validation configuration to support additional tag names: `precondition`, `entity`, and `security`, alongside the existing `remarks` tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->