### PR TITLE
chore(eslint): add markdown files to ignore list

### DIFF
--- a/eslint.ignore.config.json
+++ b/eslint.ignore.config.json
@@ -44,6 +44,8 @@
 
     "**/lighthouserc.js",
 
+    "**/*.md",
+
     "**/*.config.js",
     "**/*.config.mjs",
     "babel.config.js",

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -44,6 +44,8 @@
 
     "**/lighthouserc.js",
 
+    "**/*.md",
+
     "**/*.config.js",
     "**/*.config.mjs",
     "babel.config.js",


### PR DESCRIPTION
## Summary
- Add `**/*.md` pattern to ESLint ignore configuration
- Updated both root `eslint.ignore.config.json` and `typescript/copy-overwrite/eslint.ignore.config.json`

## Test plan
- Run `bun run lint` to verify markdown files are ignored
- ESLint should not attempt to parse `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to exclude Markdown files from linting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->