### PR TITLE
feat: add slow lint rules with nightly workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -882,9 +882,10 @@ jobs:
             # npm audit generates its own lockfile and doesn't respect bun's resolutions
             # Risk: None - bun.lock shows tar@7.5.3 is used, not the vulnerable version
 
-            # Step 1: Run npm audit and capture output separately from exit status
+            # Step 1: Run npm audit and capture JSON output only
             # npm audit returns non-zero when vulnerabilities are found, so we capture but don't fail on it
-            AUDIT_OUTPUT=$(npm audit --omit=dev --json 2>&1) || true
+            # Discard stderr to prevent warnings from mixing with JSON and breaking jq parsing
+            AUDIT_OUTPUT=$(npm audit --omit=dev --json 2>/dev/null) || true
 
             # Step 2: Validate we got non-empty output
             if [ -z "$AUDIT_OUTPUT" ]; then

--- a/typescript/copy-overwrite/.github/workflows/quality.yml
+++ b/typescript/copy-overwrite/.github/workflows/quality.yml
@@ -882,9 +882,10 @@ jobs:
             # npm audit generates its own lockfile and doesn't respect bun's resolutions
             # Risk: None - bun.lock shows tar@7.5.3 is used, not the vulnerable version
 
-            # Step 1: Run npm audit and capture output separately from exit status
+            # Step 1: Run npm audit and capture JSON output only
             # npm audit returns non-zero when vulnerabilities are found, so we capture but don't fail on it
-            AUDIT_OUTPUT=$(npm audit --omit=dev --json 2>&1) || true
+            # Discard stderr to prevent warnings from mixing with JSON and breaking jq parsing
+            AUDIT_OUTPUT=$(npm audit --omit=dev --json 2>/dev/null) || true
 
             # Step 2: Validate we got non-empty output
             if [ -z "$AUDIT_OUTPUT" ]; then

--- a/typescript/merge/package.json
+++ b/typescript/merge/package.json
@@ -30,9 +30,9 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.0.0",
-    "eslint-import-resolver-typescript": "^4.0.0",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-code-organization": "file:./eslint-plugin-code-organization",
-    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-functional": "^9.0.0",
     "eslint-plugin-jsdoc": "^61.5.0",
     "eslint-plugin-prettier": "^5.5.0",
@@ -76,45 +76,5 @@
   "resolutions": {},
   "trustedDependencies": [
     "@sentry/cli"
-  ],
-  "name": "@codyswann/lisa",
-  "version": "1.0.2",
-  "description": "Claude Code governance framework that applies guardrails, guidance, and automated enforcement to projects",
-  "main": "dist/index.js",
-  "bin": {
-    "lisa": "dist/index.js"
-  },
-  "keywords": [
-    "claude",
-    "claude-code",
-    "governance",
-    "linting",
-    "configuration"
-  ],
-  "author": "Cody Swann",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/CodySwannGT/lisa.git"
-  },
-  "bugs": {
-    "url": "https://github.com/CodySwannGT/lisa/issues"
-  },
-  "homepage": "https://github.com/CodySwannGT/lisa#readme",
-  "dependencies": {
-    "@inquirer/prompts": "^7.0.0",
-    "commander": "^12.0.0",
-    "fs-extra": "^11.0.0",
-    "lodash.merge": "^4.6.2",
-    "picocolors": "^1.0.0"
-  },
-  "files": [
-    "dist",
-    "all",
-    "typescript",
-    "expo",
-    "nestjs",
-    "cdk",
-    "eslint-plugin-code-organization"
   ]
 }


### PR DESCRIPTION
## Summary
- Add ESLint slow rules configuration (import/namespace, import/no-cycle) that run on a nightly schedule
- Fix max-lines and max-lines-per-function config being swapped
- Fix silent failures in bun security scan
- Fix npm audit stderr mixing with JSON output, breaking jq parsing

## Changes
- New `eslint.slow.config.mjs` for slow rules (import/no-cycle, import/namespace)
- New nightly workflow to run slow lint rules
- Fix threshold config for max-lines rules
- Prevent stderr from contaminating npm audit JSON output in bun fallback

## Test plan
- [x] All 112 tests pass
- [x] Lint passes
- [x] TypeScript compiles
- [x] Pre-push hooks run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm audit output handling in quality workflow to prevent JSON parsing failures from spurious warnings.

* **Chores**
  * Updated dependencies: eslint-import-resolver-typescript (^4.0.0 → ^4.4.4) and eslint-plugin-import (^2.31.0 → ^2.32.0).
  * Restructured package configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->