### PR TITLE
chore: minor fixes to Safety Net and deploy workflow

### DIFF
--- a/all/copy-overwrite/.safety-net.json
+++ b/all/copy-overwrite/.safety-net.json
@@ -12,7 +12,7 @@
       "name": "block-git-push-no-verify",
       "command": "git",
       "subcommand": "push",
-      "block_args": ["--no-verify", "-n"],
+      "block_args": ["--no-verify"],
       "reason": "--no-verify is not allowed. Fix the push to pass all checks."
     }
   ]


### PR DESCRIPTION
## Summary

- Fix Safety Net git push rule: remove the short dry-run flag from blocked args (it's not a no-verify alias for push, unlike commit)
- Block git commit short alias for no-verify flag
- Fix guardrails block parsing to find END_MARKER after BEGIN_MARKER
- Add outputs to deploy job for downstream jobs
- Refactor deploy workflow to use determine_environment output
- Various deploy workflow fixes (Bun setup, SSH keepalive)

## Test plan

- [x] All 113 tests pass
- [x] Verify push dry-run flag is not blocked
- [x] Verify commit no-verify short flag is still blocked
- [x] Verify push no-verify long flag is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the "-n" flag was being incorrectly blocked with git push commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->