### PR TITLE
refactor(eslint): remove no-inline-styles references from configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,6 @@ Lisa includes custom ESLint plugins that enforce code structure:
 **eslint-plugin-component-structure** (Expo)
 - `single-component-per-file` - One component per file
 - `require-memo-in-view` - Memoization in view components
-- `no-inline-styles` - Extract styles to StyleSheet
 
 ### Thresholds
 

--- a/expo/copy-overwrite/.claude/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/expo/copy-overwrite/.claude/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -86,17 +86,6 @@ VALID_SPACING_VALUES = {
     "36", "40", "44", "48", "52", "56", "60", "64", "72", "80", "96"
 }
 
-# Inline style patterns that could be className
-INLINE_STYLE_PATTERNS = [
-    r'style=\{\{[^}]*backgroundColor\s*:',
-    r'style=\{\{[^}]*color\s*:',
-    r'style=\{\{[^}]*padding\s*:',
-    r'style=\{\{[^}]*margin\s*:',
-    r'style=\{\{[^}]*borderRadius\s*:',
-    r'style=\{\{[^}]*borderColor\s*:',
-    r'style=\{\{[^}]*borderWidth\s*:',
-]
-
 # Exceptions - files/patterns to skip
 SKIP_PATTERNS = [
     r'node_modules',
@@ -197,35 +186,6 @@ def check_arbitrary_values(content: str, file_path: str) -> list[Violation]:
     return violations
 
 
-def check_inline_styles(content: str, file_path: str) -> list[Violation]:
-    """Check for inline styles that could be className."""
-    violations = []
-    lines = content.split('\n')
-
-    for i, line in enumerate(lines, 1):
-        # Skip comments
-        if line.strip().startswith('//') or line.strip().startswith('*'):
-            continue
-
-        for pattern in INLINE_STYLE_PATTERNS:
-            if re.search(pattern, line):
-                # Check for exceptions (dynamic values, animations)
-                if 'bottomInset' in line or 'Animated' in line or 'animatedValue' in line:
-                    continue
-                if 'Platform.select' in line or 'Platform.OS' in line:
-                    continue
-
-                violations.append(Violation(
-                    file=file_path,
-                    line=i,
-                    rule="no-inline-styles",
-                    message="Prefer className over inline style for static styling",
-                    severity="warning",
-                ))
-
-    return violations
-
-
 def check_non_scale_spacing(content: str, file_path: str) -> list[Violation]:
     """Check for spacing values not in the standard scale."""
     violations = []
@@ -272,7 +232,6 @@ def validate_file(file_path: str) -> list[Violation]:
     violations.extend(check_rn_imports(content, file_path))
     violations.extend(check_raw_colors(content, file_path))
     violations.extend(check_arbitrary_values(content, file_path))
-    violations.extend(check_inline_styles(content, file_path))
     violations.extend(check_non_scale_spacing(content, file_path))
 
     return violations

--- a/expo/copy-overwrite/eslint-plugin-ui-standards/README.md
+++ b/expo/copy-overwrite/eslint-plugin-ui-standards/README.md
@@ -146,73 +146,6 @@ const MyComponent = () => (
 
 ---
 
-### no-inline-styles
-
-Prevents inline style objects in favor of className-based styling.
-
-#### Rule Details
-
-This rule prohibits inline `style` props with object literals. All styling should use className with Tailwind/NativeWind classes.
-
-**Why this rule exists:**
-- Inline styles bypass the design system
-- Harder to maintain consistency
-- NativeWind provides better performance
-- Enables theme support
-
-#### Examples
-
-**Incorrect:**
-
-```tsx
-const MyView = () => (
-  <View style={{ padding: 16, backgroundColor: 'white' }}>
-    <Text style={{ fontSize: 18, fontWeight: 'bold' }}>Title</Text>
-  </View>
-);
-```
-
-**Incorrect** (StyleSheet is also discouraged):
-
-```tsx
-const styles = StyleSheet.create({
-  container: { padding: 16 }
-});
-
-const MyView = () => (
-  <View style={styles.container}>
-    <Text>Content</Text>
-  </View>
-);
-```
-
-**Correct:**
-
-```tsx
-const MyView = () => (
-  <View className="p-4 bg-white">
-    <Text className="text-lg font-bold">Title</Text>
-  </View>
-);
-```
-
-#### Configuration
-
-```javascript
-// eslint.config.mjs
-{
-  rules: {
-    'ui-standards/no-inline-styles': 'error'
-  }
-}
-```
-
-**Allowed exceptions:**
-- Dynamic styles computed at runtime (with eslint-disable comment)
-- Animation styles (Reanimated)
-
----
-
 ## Installation
 
 This plugin is installed locally as a file dependency:
@@ -239,7 +172,6 @@ export default [
     rules: {
       'ui-standards/no-classname-outside-ui': 'error',
       'ui-standards/no-direct-rn-imports': 'error',
-      'ui-standards/no-inline-styles': 'error',
     },
   },
 ];

--- a/expo/copy-overwrite/eslint.expo.ts
+++ b/expo/copy-overwrite/eslint.expo.ts
@@ -123,7 +123,6 @@ export function getExpoConfig({
         // UI standards (all off by default)
         "ui-standards/no-classname-outside-ui": "off",
         "ui-standards/no-direct-rn-imports": "off",
-        "ui-standards/no-inline-styles": "off",
 
         // Tailwind
         "tailwindcss/classnames-order": [
@@ -218,7 +217,6 @@ export function getExpoConfig({
       ],
       rules: {
         "ui-standards/no-classname-outside-ui": "off",
-        "ui-standards/no-inline-styles": "off",
       },
     },
 


### PR DESCRIPTION
Remove all references to the deleted no-inline-styles rule:
- README.md: Remove from plugin rules list
- eslint.expo.ts: Remove rule configuration
- eslint-plugin-ui-standards/README.md: Remove documentation section
- validate_styling.py: Remove check function and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed inline-styles ESLint rule documentation and configuration examples from README files.

* **Chores**
  * Removed inline-styles validation checks and rule disablement from ESLint configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->