### PR TITLE
fix(eslint): improve no-return-in-view error message clarity

### DIFF
--- a/expo/copy-overwrite/eslint-plugin-component-structure/rules/no-return-in-view.js
+++ b/expo/copy-overwrite/eslint-plugin-component-structure/rules/no-return-in-view.js
@@ -16,7 +16,7 @@ module.exports = {
     schema: [],
     messages: {
       noReturnInView:
-        "View components should use arrow function shorthand: () => (...) instead of () => { return (...) }. Move any definitions or logic to the corresponding Container file.",
+        "View components should use arrow function shorthand: () => (...) instead of () => { return (...) }. Hoist any definitions outside of the arrow function body or into the corresponding Container.",
     },
   },
 


### PR DESCRIPTION
## Summary

- Clarify the `no-return-in-view` ESLint rule error message to better guide developers
- Previous message suggested moving logic to Container file, which isn't always necessary
- New message suggests hoisting definitions outside the arrow function body as a primary option

## Test plan

- [ ] Apply Lisa to an Expo project and trigger the `no-return-in-view` rule
- [ ] Verify the error message now reads: "View components should use arrow function shorthand: () => (...) instead of () => { return (...) }. Hoist any definitions outside of the arrow function body or into the corresponding Container."

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESLint plugin error message to provide more precise guidance on hoisting definitions and maintaining proper component structure conventions in arrow functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->