### PR TITLE
feat(hooks): add CLAUDE.md compliance hook for 'I'm tired boss' rule

### DIFF
--- a/.claude/hooks/check-tired-boss.sh
+++ b/.claude/hooks/check-tired-boss.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# CLAUDE.md Compliance Hook - "I'm tired boss" Verification
+# =============================================================================
+# Verifies Claude's response starts with "I'm tired boss" as required by
+# CLAUDE.md. This is a Stop hook that blocks if Claude doesn't comply,
+# forcing a retry with an error message.
+#
+# @see CLAUDE.md - "Always output 'I'm tired boss' before starting any task"
+# =============================================================================
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract transcript path
+TRANSCRIPT_PATH=$(echo "$INPUT" | grep -o '"transcript_path"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Exit silently if no transcript available
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+    exit 0
+fi
+
+# Extract the last assistant message from the transcript
+# Use awk for cross-platform compatibility (tac not available on macOS)
+LAST_ASSISTANT=$(awk '/"type"[[:space:]]*:[[:space:]]*"assistant"/{line=$0} END{if(line) print line}' "$TRANSCRIPT_PATH" 2>/dev/null)
+
+if [ -z "$LAST_ASSISTANT" ]; then
+    exit 0
+fi
+
+# Extract the text content from the assistant message
+# Use jq for robust JSON parsing when available, fallback to grep/sed
+RESPONSE_TEXT=""
+if command -v jq >/dev/null 2>&1; then
+    RESPONSE_TEXT=$(echo "$LAST_ASSISTANT" | jq -r '.message.content[] | select(.type == "text") | .text' 2>/dev/null | head -1)
+else
+    # Fallback: simple regex extraction (may fail on escaped quotes)
+    RESPONSE_TEXT=$(echo "$LAST_ASSISTANT" | grep -o '"text"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"//' | sed 's/"$//')
+fi
+
+# Exit if no text content found
+if [ -z "$RESPONSE_TEXT" ]; then
+    exit 0
+fi
+
+# Check if response starts with "I'm tired boss" (case-sensitive)
+REQUIRED_PHRASE="I'm tired boss"
+if echo "$RESPONSE_TEXT" | head -1 | grep -q "^$REQUIRED_PHRASE"; then
+    # Compliance verified
+    exit 0
+fi
+
+# Non-compliant - block and provide feedback
+# Output JSON to block the Stop event
+cat << 'EOF'
+{"decision":"block","reason":"Your response did not start with \"I'm tired boss\". Read @CLAUDE.md and try again. Every response MUST begin with this exact phrase."}
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'REMINDER: Start your response with \"I'\\''m tired boss\" as required by CLAUDE.md.'",
+            "timeout": 1
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",
@@ -55,6 +67,11 @@
       {
         "matcher": "",
         "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-tired-boss.sh",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-ntfy.sh",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+You take orders from dumb humans who don't know anything about software development. Never assume they know what they're talking about and understand that any action you take for them, you have to be able to prove empirically that you did what they asked. So if the request is not clear enough or you don't know how to empirically prove that you did it, get clarification before starting.
+
+CRITICAL RULES:
+
+Always output "I'm tired boss" before starting any task, request or anything else.
 Always figure out the Package manager the project uses: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lockb 2>/dev/null | head -1`
 Always invoke /prompt-complexity-scorer skill first on each user request to evaluate complexity (1-10 scale). For scores 5+, suggest writing to specs/<spec-name>.md before proceeding.
 Always invoke /coding-philosophy skill to enforce immutable coding principles, function structure ordering, and YAGNI+SOLID+DRY+KISS patterns

--- a/all/copy-overwrite/.claude/hooks/check-tired-boss.sh
+++ b/all/copy-overwrite/.claude/hooks/check-tired-boss.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# CLAUDE.md Compliance Hook - "I'm tired boss" Verification
+# =============================================================================
+# Verifies Claude's response starts with "I'm tired boss" as required by
+# CLAUDE.md. This is a Stop hook that blocks if Claude doesn't comply,
+# forcing a retry with an error message.
+#
+# @see CLAUDE.md - "Always output 'I'm tired boss' before starting any task"
+# =============================================================================
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract transcript path
+TRANSCRIPT_PATH=$(echo "$INPUT" | grep -o '"transcript_path"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Exit silently if no transcript available
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+    exit 0
+fi
+
+# Extract the last assistant message from the transcript
+# Use awk for cross-platform compatibility (tac not available on macOS)
+LAST_ASSISTANT=$(awk '/"type"[[:space:]]*:[[:space:]]*"assistant"/{line=$0} END{if(line) print line}' "$TRANSCRIPT_PATH" 2>/dev/null)
+
+if [ -z "$LAST_ASSISTANT" ]; then
+    exit 0
+fi
+
+# Extract the text content from the assistant message
+# Use jq for robust JSON parsing when available, fallback to grep/sed
+RESPONSE_TEXT=""
+if command -v jq >/dev/null 2>&1; then
+    RESPONSE_TEXT=$(echo "$LAST_ASSISTANT" | jq -r '.message.content[] | select(.type == "text") | .text' 2>/dev/null | head -1)
+else
+    # Fallback: simple regex extraction (may fail on escaped quotes)
+    RESPONSE_TEXT=$(echo "$LAST_ASSISTANT" | grep -o '"text"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"//' | sed 's/"$//')
+fi
+
+# Exit if no text content found
+if [ -z "$RESPONSE_TEXT" ]; then
+    exit 0
+fi
+
+# Check if response starts with "I'm tired boss" (case-sensitive)
+REQUIRED_PHRASE="I'm tired boss"
+if echo "$RESPONSE_TEXT" | head -1 | grep -q "^$REQUIRED_PHRASE"; then
+    # Compliance verified
+    exit 0
+fi
+
+# Non-compliant - block and provide feedback
+# Output JSON to block the Stop event
+cat << 'EOF'
+{"decision":"block","reason":"Your response did not start with \"I'm tired boss\". Read @CLAUDE.md and try again. Every response MUST begin with this exact phrase."}
+EOF
+
+exit 0

--- a/all/copy-overwrite/.claude/settings.json
+++ b/all/copy-overwrite/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'REMINDER: Start your response with \"I'\\''m tired boss\" as required by CLAUDE.md.'",
+            "timeout": 1
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "TaskCreate|TaskUpdate",
@@ -28,6 +40,11 @@
       {
         "matcher": "",
         "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-tired-boss.sh",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-ntfy.sh",

--- a/all/copy-overwrite/CLAUDE.md
+++ b/all/copy-overwrite/CLAUDE.md
@@ -1,3 +1,8 @@
+You take orders from dumb humans who don't know anything about software development. Never assume they know what they're talking about and understand that any action you take for them, you have to be able to prove empirically that you did what they asked. So if the request is not clear enough or you don't know how to empirically prove that you did it, get clarification before starting.
+
+CRITICAL RULES:
+
+Always output "I'm tired boss" before starting any task, request or anything else.
 Always figure out the Package manager the project uses: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lockb 2>/dev/null | head -1`
 Always invoke /prompt-complexity-scorer skill first on each user request to evaluate complexity (1-10 scale). For scores 5+, suggest writing to specs/<spec-name>.md before proceeding.
 Always invoke /coding-philosophy skill to enforce immutable coding principles, function structure ordering, and YAGNI+SOLID+DRY+KISS patterns


### PR DESCRIPTION
## Summary
- Add Stop hook (`check-tired-boss.sh`) that verifies Claude's response starts with "I'm tired boss" as required by CLAUDE.md
- Add UserPromptSubmit hook that reminds Claude before each response
- Update template and project files to include the new hooks

## Changes
- **New hook script**: `check-tired-boss.sh` - Parses transcript to check Claude's last response for compliance
- **UserPromptSubmit reminder**: Injects reminder into every user prompt
- **Stop enforcement**: Blocks non-compliant responses with error message to read CLAUDE.md
- **Documentation**: Updated hooks README with full configuration and feature details

## How it works
1. UserPromptSubmit hook reminds Claude before responding
2. Claude responds (hopefully starting with "I'm tired boss")
3. Stop hook checks compliance by reading the transcript
4. If non-compliant, blocks with error message forcing retry
5. If compliant, allows response and triggers notification hook

## Limitations
- User will see non-compliant response before Claude retries (no PreResponse hook exists)
- Works through after-the-fact enforcement rather than prevention

## Test plan
- [x] Hook script created and executable
- [x] Settings.json updated in both template and project
- [x] README documentation added
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation hook that checks response compliance before submission
  * Added UserPromptSubmit hook to insert formatting reminders in user interactions

* **Documentation**
  * Expanded hook documentation and operational guidelines with configuration details

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->