### PR TITLE
docs(readme): add reduce-max-lines commands to slash commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Pre-built workflows for common tasks:
 | `/project:implement` | Execute all planned tasks |
 | `/project:review` | Run code review |
 | `/project:verify` | Run all quality checks |
+| `/project:reduce-max-lines` | Reduce max file lines threshold and fix violations |
+| `/project:reduce-max-lines-per-function` | Reduce max lines per function threshold and fix violations |
 | `/git:commit` | Create conventional commit |
 | `/git:submit-pr` | Create pull request |
 | `/lisa:review-implementation` | Compare project files against Lisa templates, upstream changes |


### PR DESCRIPTION
## Summary
- Add `/project:reduce-max-lines` and `/project:reduce-max-lines-per-function` to the slash commands table in README.md
- These commands were added in PR #78 but were not documented in the main README

## Test plan
- [x] Verify the table formatting is correct in the README
- [x] Confirm command names match the actual command files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new slash commands to pre-built workflows: `/project:reduce-max-lines` and `/project:reduce-max-lines-per-function`

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->