### PR TITLE
chore(expo): add netinfo and aws-exports to knip ignore list

### DIFF
--- a/expo/copy-overwrite/knip.json
+++ b/expo/copy-overwrite/knip.json
@@ -55,6 +55,8 @@
   ],
   "ignoreBinaries": ["audit", "ast-grep", "maestro", "eas", "source-map-explorer"],
   "ignoreDependencies": [
+    "@react-native-community/netinfo",
+    "aws-exports",
     "@babel/core",
     "@babel/plugin-proposal-export-namespace-from",
     "@commitlint/cli",


### PR DESCRIPTION
## Summary

- Add `@react-native-community/netinfo` to Expo knip.json `ignoreDependencies`
- Add `aws-exports` to Expo knip.json `ignoreDependencies`

These dependencies are commonly used in Expo projects but may not be directly imported in ways that knip can detect, causing false positive "unused dependency" warnings.

## Test plan

- [ ] Run `knip` on an Expo project using these dependencies to verify no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration.

---

**Note:** This release contains only internal maintenance updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->