### PR TITLE
feat(tasks): preserve task history across /clear with session-based storage

### DIFF
--- a/.claude/commands/tasks/load.md
+++ b/.claude/commands/tasks/load.md
@@ -8,17 +8,34 @@ allowed-tools: Read, Bash, TaskCreate, TaskUpdate, TaskList
 
 Load tasks from `projects/$ARGUMENTS/tasks/` into the current Claude Code session.
 
+Tasks are stored in session subdirectories to preserve history across `/clear` commands:
+```
+projects/$ARGUMENTS/tasks/
+├── {session-1-uuid}/
+│   ├── 1.json
+│   └── 2.json
+└── {session-2-uuid}/
+    ├── 1.json
+    └── 2.json
+```
+
 ## Process
 
 ### Step 1: Validate Project
 
-Check if the project exists:
+Check if the project exists and has task files:
 
 ```bash
-ls projects/$ARGUMENTS/tasks/*.json 2>/dev/null
+find projects/$ARGUMENTS/tasks -name "*.json" 2>/dev/null | head -5
 ```
 
 If no task files exist, report: "No tasks found in projects/$ARGUMENTS/tasks/"
+
+List available sessions:
+
+```bash
+ls -dt projects/$ARGUMENTS/tasks/*/ 2>/dev/null | head -10
+```
 
 ### Step 2: Set Active Project
 
@@ -32,7 +49,13 @@ This ensures any new tasks created will sync back to this project.
 
 ### Step 3: Load Tasks
 
-For each JSON file in `projects/$ARGUMENTS/tasks/`:
+Find and load all task JSON files from ALL session directories:
+
+```bash
+find projects/$ARGUMENTS/tasks -name "*.json" -type f
+```
+
+For each JSON file found:
 
 1. Read the task JSON file
 2. Use TaskCreate to recreate the task with:
@@ -48,6 +71,7 @@ After loading all tasks, report:
 
 ```
 Loaded X tasks from projects/$ARGUMENTS/tasks/
+- Sessions found: N
 - Pending: Y
 - Completed: Z
 
@@ -59,5 +83,6 @@ New tasks will automatically sync to this project.
 
 - Tasks are recreated with new IDs in the current session
 - The original task IDs from the project are not preserved
+- Tasks from ALL sessions are loaded (full history)
 - Task dependencies (blocks/blockedBy) are NOT currently preserved across load/sync cycles
 - Use TaskList to see the loaded tasks

--- a/.claude/hooks/sync-tasks.sh
+++ b/.claude/hooks/sync-tasks.sh
@@ -4,7 +4,10 @@
 #
 # This hook is triggered on PostToolUse for TaskCreate and TaskUpdate.
 # It reads the task metadata to determine the project and syncs
-# task JSON files to ./projects/{project}/tasks/
+# task JSON files to ./projects/{project}/tasks/{session-id}/
+#
+# This session-based structure preserves task history across /clear commands,
+# preventing overwrites when new sessions create tasks with the same IDs.
 #
 # Input (via stdin): JSON with tool_name, tool_input, tool_output
 #
@@ -82,8 +85,14 @@ if [[ -z "$TASK_FILE" || ! -f "$TASK_FILE" ]]; then
   exit 0
 fi
 
-# Ensure project tasks directory exists
-PROJECT_TASKS_DIR="./projects/${PROJECT}/tasks"
+# Require session ID for proper history tracking
+if [[ -z "$SESSION_ID" ]]; then
+  echo "Warning: No session_id available, skipping sync" >&2
+  exit 0
+fi
+
+# Ensure project tasks directory exists (includes session ID for history preservation)
+PROJECT_TASKS_DIR="./projects/${PROJECT}/tasks/${SESSION_ID}"
 mkdir -p "$PROJECT_TASKS_DIR"
 
 # Copy task file to project directory

--- a/all/copy-overwrite/.claude/commands/tasks/load.md
+++ b/all/copy-overwrite/.claude/commands/tasks/load.md
@@ -8,17 +8,34 @@ allowed-tools: Read, Bash, TaskCreate, TaskUpdate, TaskList
 
 Load tasks from `projects/$ARGUMENTS/tasks/` into the current Claude Code session.
 
+Tasks are stored in session subdirectories to preserve history across `/clear` commands:
+```
+projects/$ARGUMENTS/tasks/
+├── {session-1-uuid}/
+│   ├── 1.json
+│   └── 2.json
+└── {session-2-uuid}/
+    ├── 1.json
+    └── 2.json
+```
+
 ## Process
 
 ### Step 1: Validate Project
 
-Check if the project exists:
+Check if the project exists and has task files:
 
 ```bash
-ls projects/$ARGUMENTS/tasks/*.json 2>/dev/null
+find projects/$ARGUMENTS/tasks -name "*.json" 2>/dev/null | head -5
 ```
 
 If no task files exist, report: "No tasks found in projects/$ARGUMENTS/tasks/"
+
+List available sessions:
+
+```bash
+ls -dt projects/$ARGUMENTS/tasks/*/ 2>/dev/null | head -10
+```
 
 ### Step 2: Set Active Project
 
@@ -32,7 +49,13 @@ This ensures any new tasks created will sync back to this project.
 
 ### Step 3: Load Tasks
 
-For each JSON file in `projects/$ARGUMENTS/tasks/`:
+Find and load all task JSON files from ALL session directories:
+
+```bash
+find projects/$ARGUMENTS/tasks -name "*.json" -type f
+```
+
+For each JSON file found:
 
 1. Read the task JSON file
 2. Use TaskCreate to recreate the task with:
@@ -48,6 +71,7 @@ After loading all tasks, report:
 
 ```
 Loaded X tasks from projects/$ARGUMENTS/tasks/
+- Sessions found: N
 - Pending: Y
 - Completed: Z
 
@@ -59,5 +83,6 @@ New tasks will automatically sync to this project.
 
 - Tasks are recreated with new IDs in the current session
 - The original task IDs from the project are not preserved
+- Tasks from ALL sessions are loaded (full history)
 - Task dependencies (blocks/blockedBy) are NOT currently preserved across load/sync cycles
 - Use TaskList to see the loaded tasks

--- a/all/copy-overwrite/.claude/hooks/sync-tasks.sh
+++ b/all/copy-overwrite/.claude/hooks/sync-tasks.sh
@@ -4,7 +4,10 @@
 #
 # This hook is triggered on PostToolUse for TaskCreate and TaskUpdate.
 # It reads the task metadata to determine the project and syncs
-# task JSON files to ./projects/{project}/tasks/
+# task JSON files to ./projects/{project}/tasks/{session-id}/
+#
+# This session-based structure preserves task history across /clear commands,
+# preventing overwrites when new sessions create tasks with the same IDs.
 #
 # Input (via stdin): JSON with tool_name, tool_input, tool_output
 #
@@ -82,8 +85,14 @@ if [[ -z "$TASK_FILE" || ! -f "$TASK_FILE" ]]; then
   exit 0
 fi
 
-# Ensure project tasks directory exists
-PROJECT_TASKS_DIR="./projects/${PROJECT}/tasks"
+# Require session ID for proper history tracking
+if [[ -z "$SESSION_ID" ]]; then
+  echo "Warning: No session_id available, skipping sync" >&2
+  exit 0
+fi
+
+# Ensure project tasks directory exists (includes session ID for history preservation)
+PROJECT_TASKS_DIR="./projects/${PROJECT}/tasks/${SESSION_ID}"
 mkdir -p "$PROJECT_TASKS_DIR"
 
 # Copy task file to project directory


### PR DESCRIPTION
## Summary
- Tasks are now stored with session ID: `projects/{project}/tasks/{session-id}/{id}.json`
- Previously, running `/clear` and starting a new session would overwrite previous tasks with the same IDs
- This change preserves full task history across sessions

## Test plan
- [ ] Run `/tasks:sync test-project` and verify tasks are stored under a session subdirectory
- [ ] Run `/clear`, create new tasks, and verify they go to a new session subdirectory
- [ ] Run `/tasks:load test-project` and verify tasks from all sessions are loaded
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session-based task organization to preserve task history across multiple sessions.
  * Tasks are now automatically loaded from all historical sessions, enabling full history visibility.
  * Implemented session identification to prevent task data overwrites during syncing operations.

* **Improvements**
  * Enhanced task persistence to maintain data integrity when clearing or starting new sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->