### PR TITLE
feat: include Lisa version in generated manifest

### DIFF
--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -50,6 +50,21 @@ export class ManifestService implements IManifestService {
     this.lisaDir = lisaDir;
   }
 
+  /**
+   * Get the version of Lisa from package.json
+   * @returns The version string from package.json, or "unknown" if it cannot be read
+   */
+  private async getVersion(): Promise<string> {
+    try {
+      const packageJsonPath = path.join(this.lisaDir, "package.json");
+      const content = await readFile(packageJsonPath, "utf-8");
+      const packageJson = JSON.parse(content);
+      return packageJson.version || "unknown";
+    } catch {
+      return "unknown";
+    }
+  }
+
   record(relativePath: string, strategy: CopyStrategy): void {
     this.entries.push({ strategy, relativePath });
   }
@@ -59,9 +74,11 @@ export class ManifestService implements IManifestService {
       throw new Error("Manifest not initialized");
     }
 
+    const version = await this.getVersion();
     const lines = [
       "# Lisa manifest - DO NOT EDIT",
       `# Generated: ${new Date().toISOString()}`,
+      `# Lisa version: ${version}`,
       `# Lisa directory: ${this.lisaDir}`,
       "",
       ...this.entries.map(entry => `${entry.strategy}:${entry.relativePath}`),


### PR DESCRIPTION
## Summary
When Lisa generates the `.lisa-manifest` file, it now records the Lisa version used to generate it. This enables users and tooling to understand which version of Lisa was applied to their project, which is useful for compatibility checks and debugging.

The version is included as a comment in the manifest header:
```
# Lisa version: 1.3.0
```

If the version cannot be determined, it defaults to "unknown".

## Test plan
- All 129 existing tests pass
- Added 2 new tests to verify version is included in manifest header
- Tested with `npm run build` - TypeScript compilation successful
- Tested on a real project using the compiled CLI - version appears in manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manifest output now includes Lisa version information in the header for better traceability and identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->