### PR TITLE
feat: add /project:document command to update docs after implementation

### DIFF
--- a/.claude/commands/project/document.md
+++ b/.claude/commands/project/document.md
@@ -1,0 +1,56 @@
+---
+description: Updates all documentation related to changes implemented in the project
+argument-hint: <project-directory>
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, Skill
+---
+
+The current branch is a feature branch with implementation of the project in $ARGUMENTS.
+
+Changes on this branch need corresponding documentation updates to keep README, API docs, changelogs, and JSDoc current.
+
+**IMPORTANT**: Perform each step and move to the next without stopping.
+
+## Setup
+
+Set active project marker: `echo "$ARGUMENTS" | sed 's|.*/||' > .claude-active-project`
+
+Extract `<project-name>` from the last segment of `$ARGUMENTS`.
+
+## Create and Execute Tasks
+
+Create workflow tracking tasks with `metadata.project` set to the project name:
+
+```
+TaskCreate:
+  subject: "Identify changed files and documentation targets"
+  description: "Use git to identify files changed on this branch (git diff main...HEAD --name-only). For each changed file, identify related documentation: README sections, API docs, inline JSDoc, CHANGELOG entries, architecture docs, configuration docs. Compile a mapping of: changed file → related documentation file(s). Save to $ARGUMENTS/doc-targets.json with structure: { \"file.ts\": [\"README.md#section\", \"docs/api.md\"], ... }"
+  metadata: { project: "<project-name>" }
+
+TaskCreate:
+  subject: "Update README and user-facing docs"
+  description: "For each documentation target in $ARGUMENTS/doc-targets.json that is a README section or user guide: Read the changed implementation file. Read the current documentation section. Update the documentation to accurately reflect the new/changed behavior, examples, or configuration. Preserve existing structure and tone."
+  metadata: { project: "<project-name>" }
+
+TaskCreate:
+  subject: "Update API and technical documentation"
+  description: "For each documentation target that is API docs, architecture docs, or technical guides: Read the changed implementation. Read the current documentation. Update to reflect new endpoints, parameters, type signatures, behavior changes, or architectural decisions. Ensure consistency with code comments."
+  metadata: { project: "<project-name>" }
+
+TaskCreate:
+  subject: "Update CHANGELOG"
+  description: "If CHANGELOG.md or CHANGELOG.{md,txt,rst} exists in project root: Add entry for all user-facing changes. Group by type (Added, Changed, Fixed, Deprecated). Reference relevant files or features. Follow existing CHANGELOG format and conventions."
+  metadata: { project: "<project-name>" }
+
+TaskCreate:
+  subject: "Verify JSDoc on changed files"
+  description: "Read $ARGUMENTS/doc-targets.json. For each changed file (key), verify its JSDoc preamble and function/export documentation are current: Run /jsdoc-best-practices skill. Check that file-level preambles explain the module's purpose and when to use it. Check that exported functions/types have 'why' documentation (not just 'what'). Update any stale or missing documentation."
+  metadata: { project: "<project-name>" }
+```
+
+**Execute each task via a subagent** to preserve main context. Launch up to 5 in parallel where tasks don't have dependencies. Do not stop until all are completed.
+
+---
+
+## Next Step
+
+After completing this phase, tell the user: "To continue, run `/project:verify $ARGUMENTS`"

--- a/.claude/commands/project/execute.md
+++ b/.claude/commands/project/execute.md
@@ -42,6 +42,11 @@ TaskCreate:
   metadata: { project: "<project-name>" }
 
 TaskCreate:
+  subject: "Documentation"
+  description: "Run /project:document $ARGUMENTS to update documentation related to changes."
+  metadata: { project: "<project-name>" }
+
+TaskCreate:
   subject: "Verification"
   description: "Run /project:verify $ARGUMENTS to verify all requirements are met."
   metadata: { project: "<project-name>" }


### PR DESCRIPTION
## Summary

Adds `/project:document` - a new step in the `/project:execute` workflow that runs between review and verify to ensure all documentation stays in sync with code changes.

## What It Does

- Identifies all files changed on the feature branch
- Maps each changed file to related documentation (README sections, API docs, JSDoc, CHANGELOG)
- Updates user-facing documentation with new examples and behavior changes
- Updates technical documentation for API/architecture changes
- Updates CHANGELOG entries following existing conventions
- Verifies and updates JSDoc preambles and function documentation

## Workflow Impact

The execute workflow now follows this order:
1. Plan
2. Implement
3. Review
4. **Document** ← NEW
5. Verify
6. Debrief
7. Archive

This ensures documentation is accurate before verification runs.

## Test Plan

- [x] New command file created with proper structure
- [x] Command integrated into `/project:execute` workflow
- [x] All existing tests pass
- [x] No type errors or linting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated documentation management workflow that processes code changes and maintains project documentation including README, API docs, CHANGELOG, and code documentation verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->