### PR TITLE
fix(scripts): use contains() for slow lint rules filter

### DIFF
--- a/scripts/github-status-check.sh
+++ b/scripts/github-status-check.sh
@@ -201,7 +201,7 @@ for REPO in "${REPOS[@]}"; do
     .workflow_runs
     | map(select(.status == "completed"))
     | map(select(.head_branch | startswith("dependabot/") | not))
-    | map(select(.name != "Slow Lint Rules"))
+    | map(select(.name | contains("Slow Lint Rules") | not))
     | group_by(.name + "|" + .head_branch)
     | map(sort_by(.created_at) | reverse | .[0])
     | map(select(.conclusion == "failure"))


### PR DESCRIPTION
## Summary
- Fixed the "Slow Lint Rules" filter in `github-status-check.sh` that wasn't working due to emoji prefix in workflow name
- Changed from exact match (`!= "Slow Lint Rules"`) to contains check (`contains("Slow Lint Rules") | not`)
- Workflow names like "🐢 Slow Lint Rules" are now properly filtered out

## Test plan
- [x] Ran `./scripts/github-status-check.sh` before fix - "Slow Lint Rules" failures appeared (10 total failed actions)
- [x] Ran `./scripts/github-status-check.sh` after fix - "Slow Lint Rules" failures filtered out (6 total failed actions)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub status check filtering to use substring matching for workflow exclusions, allowing broader pattern coverage for status checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->