### PR TITLE
chore(cdk): add globals to knip ignored dependencies

### DIFF
--- a/cdk/copy-overwrite/knip.json
+++ b/cdk/copy-overwrite/knip.json
@@ -46,7 +46,8 @@
     "aws-cdk-lib",
     "@aws-cdk/*",
     "constructs",
-    "esbuild"
+    "esbuild",
+    "globals"
   ],
   "ignoreExportsUsedInFile": true
 }


### PR DESCRIPTION
## Summary
- Add 'globals' package to the ignored dependencies list in the CDK knip configuration
- Prevents false positives when checking for unused exports in the CDK module

## Test plan
- Verify that the CDK module passes the `knip` dead code detection without false positives
- Run `npm run knip` to confirm configuration is valid and no additional warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to refine dependency analysis settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->