### PR TITLE
chore(expo): bump tar from 7.5.6 to 7.5.7

### DIFF
--- a/expo/tagged-merge/package.lisa.json
+++ b/expo/tagged-merge/package.lisa.json
@@ -79,7 +79,7 @@
       "react-native-svg": "^15.15.1",
       "react-native-web": "^0.21.2",
       "tailwindcss": "^3.4.7",
-      "tar": "^7.5.6",
+      "tar": "^7.5.7",
       "text-encoding-polyfill": "^0.6.7",
       "usehooks-ts": "^3.1.1",
       "zod": "^4.3.5"
@@ -120,12 +120,12 @@
     },
     "resolutions": {
       "eslint-plugin-react-hooks": "^7.0.0",
-      "tar": "^7.5.6"
+      "tar": "^7.5.7"
     },
     "overrides": {
       "eslint-plugin-react-hooks": "^7.0.0",
       "zod-validation-error": "^4.0.0",
-      "tar": "^7.5.6"
+      "tar": "^7.5.7"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Update tar package version from ^7.5.6 to ^7.5.7 in expo template
- Updates dependencies, resolutions, and overrides sections

## Test plan

- Verify package.lisa.json is valid JSON
- Run `npm run knip` to verify no issues with the configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tar dependency to version ^7.5.7 across package configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->