### PR TITLE
fix(scripts): add production branches to protected list

### DIFF
--- a/scripts/cleanup-amplify-branches.sh
+++ b/scripts/cleanup-amplify-branches.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 # Protected branches that should never be deleted
-PROTECTED_BRANCHES=("main" "dev" "staging")
+PROTECTED_BRANCHES=("main" "dev" "staging" "production" "prod")
 
 # Colors for output
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary

- Add 'production' and 'prod' to the protected branches array in `cleanup-amplify-branches.sh`
- Prevents accidental deletion of production environment branches during cleanup

## Test plan

- [ ] Review the change in `scripts/cleanup-amplify-branches.sh`
- [ ] Verify the PROTECTED_BRANCHES array now includes: main, dev, staging, production, prod
- [ ] Optionally run `./scripts/cleanup-amplify-branches.sh --dry-run` to confirm production branches are protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded branch protection to include production and staging environments, preventing accidental deletion during automated cleanup operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->