### PR TITLE
chore: remove TypeORM migration scripts from NestJS template

### DIFF
--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -19,10 +19,7 @@
       "fetch:graphql:schema:production": "./scripts/fetch-graphql-schema.sh production",
       "deploy:dev": "sls deploy --stage dev",
       "deploy:staging": "sls deploy --stage staging",
-      "deploy:production": "sls deploy --stage production",
-      "migration:generate": "typeorm-ts-node-commonjs migration:generate -d typeorm.config.ts src/database/migrations/$npm_config_name",
-      "migration:run": "typeorm-ts-node-commonjs migration:run -d typeorm.config.ts",
-      "migration:revert": "typeorm-ts-node-commonjs migration:revert -d typeorm.config.ts"
+      "deploy:production": "sls deploy --stage production"
     },
     "dependencies": {
       "@apollo/server": "^5.2.0",


### PR DESCRIPTION
## Summary
- Remove TypeORM migration scripts (`migration:generate`, `migration:run`, `migration:revert`) from the NestJS `package.lisa.json` template
- Migration scripts are project-specific and should not be enforced by the Lisa governance template

## Test plan
- [ ] Verify `nestjs/package-lisa/package.lisa.json` no longer contains TypeORM migration scripts
- [ ] Run `bun run lisa:update` on a NestJS project and confirm migration scripts are not forcefully added
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed migration-related scripts from build configuration to streamline the deployment workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->