### PR TITLE
chore: update NestJS defaults with TypeORM migration scripts

### DIFF
--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -1,4 +1,11 @@
 {
+  "defaults": {
+    "scripts": {
+      "migration:generate": "typeorm-ts-node-commonjs migration:generate -d typeorm.config.ts src/database/migrations/$npm_config_name",
+      "migration:run": "typeorm-ts-node-commonjs migration:run -d typeorm.config.ts",
+      "migration:revert": "typeorm-ts-node-commonjs migration:revert -d typeorm.config.ts"
+    }
+  },
   "force": {
     "scripts": {
       "k6": "./scripts/k6-run.sh",


### PR DESCRIPTION
## Summary

- Previously removed TypeORM migration scripts from NestJS template `force` section (commit 98bd05c)
- Re-adds `migration:generate`, `migration:run`, and `migration:revert` scripts as `defaults` so projects get them as starting templates but can override them
- Uses `defaults` semantics instead of `force` to respect project-level customization

## Test plan

- [ ] Verify `nestjs/package-lisa/package.lisa.json` has the migration scripts under `defaults.scripts`
- [ ] Run `bun run test` to confirm all tests pass
- [ ] Run Lisa against a NestJS project to verify migration scripts appear as defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database migration management scripts to support schema generation, execution, and rollback operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->