### PR TITLE
fix: remove check-tired-boss hook from settings templates

### DIFF
--- a/all/copy-overwrite/.claude/settings.json
+++ b/all/copy-overwrite/.claude/settings.json
@@ -42,11 +42,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-tired-boss.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-ntfy.sh",
             "timeout": 5
           }

--- a/typescript/copy-overwrite/.claude/settings.json
+++ b/typescript/copy-overwrite/.claude/settings.json
@@ -193,11 +193,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-tired-boss.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-ntfy.sh",
             "timeout": 5
           }


### PR DESCRIPTION
## Summary

- Removes the `check-tired-boss.sh` hook entry from Stop hooks in both `all/copy-overwrite/.claude/settings.json` and `typescript/copy-overwrite/.claude/settings.json`
- Fixes invalid JSON caused by `//` comment syntax that was used to comment out the hook entries

## Test plan

- [ ] Verify both settings.json files are valid JSON (`jq . <file>`)
- [ ] Run `bun run test` — all 184 tests pass
- [ ] Run `bun run dev . -y` and confirm `.claude/settings.json` no longer contains `check-tired-boss.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an automated check from system hooks configuration across multiple settings files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->