### PR TITLE
fix: add knip hints CLAUDE.md rule and CI audit ignore for fast-xml-parser

### DIFF
--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -82,6 +82,7 @@ elif [ "$PACKAGE_MANAGER" = "bun" ]; then
 
   # Excluding GHSA-37qj-frw5-hhjh: fast-xml-parser RangeError DoS with numeric entities
   # Transitive dependency via @react-native-community/cli (Android/iOS build tooling)
+  # Parent packages pin ^4.4.1; fix requires major version 5.x (incompatible)
   # Risk: None - CLI build tool, not a production runtime dependency
   if ! bun audit --audit-level=high --ignore GHSA-5j98-mcp5-4vw2 --ignore GHSA-8qq5-rm4j-mr97 --ignore GHSA-37qj-frw5-hhjh; then
     echo "⚠️ Security audit failed. Please fix high/critical vulnerabilities before pushing."

--- a/typescript/copy-overwrite/.github/workflows/quality.yml
+++ b/typescript/copy-overwrite/.github/workflows/quality.yml
@@ -1012,6 +1012,7 @@ jobs:
 
             # Excluding GHSA-37qj-frw5-hhjh: fast-xml-parser RangeError DoS with numeric entities
             # Transitive dependency via @react-native-community/cli (Android/iOS build tooling)
+            # Parent packages pin ^4.4.1; fix requires major version 5.x (incompatible)
             # Risk: None - CLI build tool, not a production runtime dependency
             if ! bun audit --audit-level=high --ignore GHSA-5j98-mcp5-4vw2 --ignore GHSA-8qq5-rm4j-mr97 --ignore GHSA-37qj-frw5-hhjh; then
               echo "::warning::Found high or critical vulnerabilities"


### PR DESCRIPTION
## Summary

- Add CLAUDE.md rule to ignore knip configuration hints (warnings) — only fix actual unused exports/dependencies reported as errors
- Add GHSA-37qj-frw5-hhjh (fast-xml-parser) to CI quality.yml audit ignore list, matching the pre-push hook configuration

## Test plan

- [x] Lisa tests pass locally
- [x] ThumbWar CI should now pass with these changes applied downstream

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the quality assurance workflow to exclude an additional known security vulnerability from dependency audits; the audit still fails if any unexcluded high/critical issues are found.
  * Added an internal note explaining that the upstream fix requires a major-version update and cannot be applied without a breaking change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->