### PR TITLE
fix: pin graphql to 15.10.1 for AppSync compatibility

### DIFF
--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -50,7 +50,7 @@
       "class-transformer": "^0.5.1",
       "class-validator": "^0.14.3",
       "dataloader": "^2.2.3",
-      "graphql": "^16.12.0",
+      "graphql": "15.10.1",
       "graphql-query-complexity": "^1.1.0",
       "graphql-subscriptions": "^3.0.0",
       "graphql-ws": "^6.0.6",


### PR DESCRIPTION
## Summary
- Pin `graphql` dependency to `15.10.1` in the NestJS stack template
- `graphql ^16.x` is not compatible with AWS AppSync
- The `force` section was overriding project-level pins on every `lisa:update`

## Test plan
- [x] Pre-push hooks pass (lint, knip, tests)
- [ ] Run `lisa:update` on a NestJS project and verify `graphql` stays at `15.10.1`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GraphQL package dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->