### PR TITLE
fix: move graphql to defaults so projects can override version

### DIFF
--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -4,6 +4,9 @@
       "migration:generate": "tsx ./node_modules/typeorm/cli.js migration:generate -d typeorm.config.ts src/database/migrations/$npm_config_name",
       "migration:run": "tsx ./node_modules/typeorm/cli.js migration:run -d typeorm.config.ts",
       "migration:revert": "tsx ./node_modules/typeorm/cli.js migration:revert -d typeorm.config.ts"
+    },
+    "dependencies": {
+      "graphql": "15.10.1"
     }
   },
   "force": {
@@ -50,7 +53,6 @@
       "class-transformer": "^0.5.1",
       "class-validator": "^0.14.3",
       "dataloader": "^2.2.3",
-      "graphql": "15.10.1",
       "graphql-query-complexity": "^1.1.0",
       "graphql-subscriptions": "^3.0.0",
       "graphql-ws": "^6.0.6",


### PR DESCRIPTION
## Summary
- Moved `graphql: "15.10.1"` from `force.dependencies` to `defaults.dependencies` in `nestjs/package-lisa/package.lisa.json`
- Projects using graphql 16+ (e.g., geminisportsai) were having their version forcibly overwritten to 15.10.1
- With this change, projects keep their own graphql version while new projects still default to 15.10.1

## Test plan
- [ ] Verify `graphql` is no longer in `force.dependencies`
- [ ] Verify `graphql: "15.10.1"` is in `defaults.dependencies`
- [ ] Run Lisa on geminisportsai/backend-v2 and confirm graphql stays at `^16.12.0`
- [ ] Run Lisa on propswap/backend and confirm graphql stays at `15.10.1`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration in package management settings. Reorganized GraphQL dependency placement to align with default dependency structure. No changes to functionality or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->