### PR TITLE
feat: enforce lockfile regeneration after dependency changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Always output "I'm tired boss" before starting any task, request or anything els
 Always figure out the Package manager the project uses: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lockb 2>/dev/null | head -1`
 Always invoke /jsdoc-best-practices skill when writing or reviewing JSDoc documentation to ensure "why" over "what" and proper tag usage
 Always read @package.json without limit or offset to understand what scripts and third party packages are used
+Always regenerate the lockfile (by running the project's package manager install command) after adding, removing, or updating dependencies or devDependencies in package.json
 Always read @eslint.config.ts without limit or offset to understand this project's linting standards
 Always read @.prettierrc.json without limit or offset to understand this project's formatting standards
 Always make atomic commits with clear conventional messages

--- a/all/copy-overwrite/CLAUDE.md
+++ b/all/copy-overwrite/CLAUDE.md
@@ -6,6 +6,7 @@ Always output "I'm tired boss" before starting any task, request or anything els
 Always figure out the Package manager the project uses: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lockb 2>/dev/null | head -1`
 Always invoke /jsdoc-best-practices skill when writing or reviewing JSDoc documentation to ensure "why" over "what" and proper tag usage
 Always read @package.json without limit or offset to understand what scripts and third party packages are used
+Always regenerate the lockfile (by running the project's package manager install command) after adding, removing, or updating dependencies or devDependencies in package.json
 Always read @eslint.config.ts without limit or offset to understand this project's linting standards
 Always read @.prettierrc.json without limit or offset to understand this project's formatting standards
 Always make atomic commits with clear conventional messages


### PR DESCRIPTION
## Summary

- Adds an "Always" rule to CLAUDE.md enforcing that the lockfile must be regenerated (via the project's package manager install command) whenever `dependencies` or `devDependencies` in `package.json` are modified
- Applied to both the template (`all/copy-overwrite/CLAUDE.md`) and Lisa's own `CLAUDE.md`

## Test plan

- [ ] Verify `all/copy-overwrite/CLAUDE.md` contains the new rule on line 9
- [ ] Verify `CLAUDE.md` (Lisa's own) contains the identical rule
- [ ] Confirm both files are identical with `diff CLAUDE.md all/copy-overwrite/CLAUDE.md`
- [ ] Apply Lisa to a downstream project and verify the rule appears in the generated CLAUDE.md

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to clarify the workflow for managing package dependencies and ensuring the lockfile remains synchronized with package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->