### PR TITLE
chore: add @aws-sdk/credential-provider-sso to NestJS knip ignored deps

### DIFF
--- a/nestjs/copy-overwrite/knip.json
+++ b/nestjs/copy-overwrite/knip.json
@@ -24,6 +24,7 @@
     "@aws-sdk/client-cloudwatch",
     "@aws-sdk/client-dynamodb",
     "@aws-sdk/client-lambda",
+    "@aws-sdk/credential-provider-sso",
     "@aws-sdk/lib-dynamodb",
     "@aws-sdk/rds-signer",
     "@graphql-tools/utils",


### PR DESCRIPTION
## Summary
- Add `@aws-sdk/credential-provider-sso` to the NestJS knip.json `ignoredDependencies` list
- This prevents false-positive unused dependency warnings for projects using AWS SSO credential provider

## Test plan
- [ ] Verify `bun run knip` passes without reporting `@aws-sdk/credential-provider-sso` as unused in downstream NestJS projects

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency analysis configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->