### PR TITLE
feat(all): add .coderabbit.yml as copy-overwrite template

### DIFF
--- a/.claude/rules/lisa.md
+++ b/.claude/rules/lisa.md
@@ -37,7 +37,7 @@ These directories contain files deployed by Lisa **and** files you create. Do no
 - `.claude/rules/coding-philosophy.md`, `.claude/rules/plan.md`, `.claude/rules/verfication.md`
 - `CLAUDE.md`, `HUMAN.md`, `.safety-net.json`
 - `.prettierrc.json`, `.prettierignore`, `.lintstagedrc.json`, `.versionrc`, `.nvmrc`
-- `.yamllint`, `.gitleaksignore`, `commitlint.config.cjs`, `sgconfig.yml`, `knip.json`
+- `.yamllint`, `.gitleaksignore`, `.coderabbit.yml`, `commitlint.config.cjs`, `sgconfig.yml`, `knip.json`
 - `eslint.base.ts`, `eslint.typescript.ts`, `eslint.expo.ts`, `eslint.nestjs.ts`, `eslint.cdk.ts`, `eslint.slow.config.ts`
 - `jest.base.ts`, `jest.typescript.ts`, `jest.expo.ts`, `jest.nestjs.ts`, `jest.cdk.ts`
 - `tsconfig.base.json`, `tsconfig.typescript.json`, `tsconfig.expo.json`, `tsconfig.nestjs.json`, `tsconfig.cdk.json`

--- a/all/copy-overwrite/.claude/rules/lisa.md
+++ b/all/copy-overwrite/.claude/rules/lisa.md
@@ -37,7 +37,7 @@ These directories contain files deployed by Lisa **and** files you create. Do no
 - `.claude/rules/coding-philosophy.md`, `.claude/rules/plan.md`, `.claude/rules/verfication.md`
 - `CLAUDE.md`, `HUMAN.md`, `.safety-net.json`
 - `.prettierrc.json`, `.prettierignore`, `.lintstagedrc.json`, `.versionrc`, `.nvmrc`
-- `.yamllint`, `.gitleaksignore`, `commitlint.config.cjs`, `sgconfig.yml`, `knip.json`
+- `.yamllint`, `.gitleaksignore`, `.coderabbit.yml`, `commitlint.config.cjs`, `sgconfig.yml`, `knip.json`
 - `eslint.base.ts`, `eslint.typescript.ts`, `eslint.expo.ts`, `eslint.nestjs.ts`, `eslint.cdk.ts`, `eslint.slow.config.ts`
 - `jest.base.ts`, `jest.typescript.ts`, `jest.expo.ts`, `jest.nestjs.ts`, `jest.cdk.ts`
 - `tsconfig.base.json`, `tsconfig.typescript.json`, `tsconfig.expo.json`, `tsconfig.nestjs.json`, `tsconfig.cdk.json`

--- a/all/copy-overwrite/.coderabbit.yml
+++ b/all/copy-overwrite/.coderabbit.yml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+early_access: true
+inheritance: true
+reviews:
+  request_changes_workflow: true
+  collapse_walkthrough: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  in_progress_fortune: false
+  poem: false
+  auto_review:
+    drafts: true
+  pre_merge_checks:
+    docstrings:
+      mode: error
+    title:
+      mode: error
+    description:
+      mode: error
+  tools:
+    markdownlint:
+      enabled: false
+    swiftlint:
+      enabled: false
+    phpstan:
+      enabled: false
+    phpmd:
+      enabled: false
+    phpcs:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    detekt:
+      enabled: false
+    fortitudeLint:
+      enabled: false
+    buf:
+      enabled: false
+    regal:
+      enabled: false
+    pmd:
+      enabled: false
+    clang:
+      enabled: false
+    cppcheck:
+      enabled: false
+    circleci:
+      enabled: false
+    checkmake:
+      enabled: false
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - '**/.claude/**/*'
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  labeling:
+    auto_apply_labels: true


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yml` to `all/copy-overwrite/` so it deploys to every downstream project via the copy-overwrite strategy
- Document `.coderabbit.yml` as a managed file (no local override) in both the template and project `lisa.md` rules

## Test plan
- [ ] Verify `all/copy-overwrite/.coderabbit.yml` exists and matches root `.coderabbit.yml`
- [ ] Verify `.claude/rules/lisa.md` lists `.coderabbit.yml` in the no-override section
- [ ] Verify `all/copy-overwrite/.claude/rules/lisa.md` lists `.coderabbit.yml` in the no-override section
- [ ] Run `lisa` on a downstream project and confirm `.coderabbit.yml` is deployed

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration management rules to designate certain configuration files as system-managed and protected from local modifications, ensuring they remain synchronized and consistent across all development environments.
  * Introduced new comprehensive configuration file enabling automated development workflows, integrating multiple external analysis and development tools, incorporating knowledge base functionality, and supporting intelligent issue enrichment and labeling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->