### PR TITLE
feat(typescript): add jira-cli to remote environment install hook

### DIFF
--- a/.claude/hooks/install_pkgs.sh
+++ b/.claude/hooks/install_pkgs.sh
@@ -27,6 +27,12 @@ GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
 echo "Gitleaks installed: $(gitleaks version)"
 
+# Install jira-cli for JIRA integration
+echo "Installing jira-cli for JIRA integration..."
+JIRA_CLI_VERSION="1.7.0"
+curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin jira
+echo "jira-cli installed: $(jira version)"
+
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
 echo "Installing Chromium for Lighthouse CI..."

--- a/typescript/copy-overwrite/.claude/hooks/install_pkgs.sh
+++ b/typescript/copy-overwrite/.claude/hooks/install_pkgs.sh
@@ -27,6 +27,12 @@ GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
 echo "Gitleaks installed: $(gitleaks version)"
 
+# Install jira-cli for JIRA integration
+echo "Installing jira-cli for JIRA integration..."
+JIRA_CLI_VERSION="1.7.0"
+curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin jira
+echo "jira-cli installed: $(jira version)"
+
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
 echo "Installing Chromium for Lighthouse CI..."


### PR DESCRIPTION
## Summary
- Adds jira-cli v1.7.0 binary installation to the `install_pkgs.sh` hook for Claude Code web remote environments
- Uses the same direct binary download pattern as the existing Gitleaks install
- Updates both the template source (`typescript/copy-overwrite/`) and the deployed copy

## Test plan
- [ ] Verify the download URL resolves: `curl -sSfI "https://github.com/ankitpokhrel/jira-cli/releases/download/v1.7.0/jira_1.7.0_linux_x86_64.tar.gz"`
- [ ] Verify `jira` binary is available after running `install_pkgs.sh` in a remote environment
- [ ] Verify template and deployed copy are identical: `diff typescript/copy-overwrite/.claude/hooks/install_pkgs.sh .claude/hooks/install_pkgs.sh`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Jira CLI (v1.7.0) into development environment setup, enabling enhanced project management and issue tracking capabilities within the development workflow for improved team collaboration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->