### PR TITLE
feat(rails): add reek, flog, flay to pre-push hooks

### DIFF
--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -18,3 +18,9 @@ pre-push:
       run: bundle exec rspec
     brakeman:
       run: bundle exec brakeman --no-pager --quiet
+    reek:
+      run: bundle exec reek app/ lib/
+    flog:
+      run: bundle exec flog --all --group app/ lib/
+    flay:
+      run: bundle exec flay app/ lib/


### PR DESCRIPTION
## Summary

- Adds `reek`, `flog`, and `flay` to the managed `lefthook.yml` pre-push hooks for Rails projects
- Matches the exact commands CI already runs in `quality.yml`, closing the gap where developers could push code that passes local hooks but fails CI's quality gate

## Context

This was discovered when PR #36 on qualis-app had 662 reek warnings that were caught by CI but not by local pre-push hooks. The reek/flog/flay checks existed in CI (`quality.yml`) but were missing from the managed `lefthook.yml`.

## Test plan

- [ ] Run `lisa` on a Rails project and verify `lefthook.yml` includes reek, flog, flay commands
- [ ] Run `bundle exec lefthook run pre-push --dry-run` and verify new commands appear
- [ ] Push a branch with reek warnings and verify pre-push hook catches them

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new pre-push validation commands to the development workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->