### PR TITLE
fix(deps): upgrade tar and fast-xml-parser in Expo template

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -105,7 +105,7 @@
       "react-native-svg": "^15.15.1",
       "react-native-web": "^0.21.2",
       "tailwindcss": "^3.4.7",
-      "tar": "^7.5.7",
+      "tar": "^7.5.8",
       "text-encoding-polyfill": "^0.6.7",
       "usehooks-ts": "^3.1.1",
       "zod": "^4.3.5"
@@ -148,13 +148,15 @@
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
       "eslint-plugin-react-hooks": "^7.0.0",
-      "tar": "^7.5.7"
+      "fast-xml-parser": "^5.3.6",
+      "tar": "^7.5.8"
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
       "eslint-plugin-react-hooks": "^7.0.0",
+      "fast-xml-parser": "^5.3.6",
       "zod-validation-error": "^4.0.0",
-      "tar": "^7.5.7"
+      "tar": "^7.5.8"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Upgrades `tar` from `^7.5.7` to `^7.5.8` in Expo template (GHSA-83g3-92jg-28cx: arbitrary file read/write via hardlink escape)
- Adds `fast-xml-parser` `^5.3.6` override/resolution to Expo template (GHSA-jmr7-xgp7-cmfj: DoS through entity expansion in DOCTYPE)
- Both are transitive dependencies in Expo projects via `@expo/cli` and `@react-native-community/cli`

## Test plan
- [x] All Lisa tests pass
- [x] Security audit passes with no high/critical vulnerabilities
- [x] Already applied and verified in PropSwapLLC/frontend#431

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to latest compatible versions for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->