### PR TITLE
fix: add npm audit exception handling for minimatch and ajv false positives

### DIFF
--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -63,13 +63,24 @@ if [ "$PACKAGE_MANAGER" = "yarn" ]; then
   fi
 
 elif [ "$PACKAGE_MANAGER" = "npm" ]; then
-  # Run npm audit and only fail on high or critical vulnerabilities
-  npm audit --production --audit-level=high
-  if [ $? -ne 0 ]; then
+  # Run npm audit in JSON mode and filter out known false positives before failing.
+  # npm audit lacks a native --ignore flag, so we parse JSON and exclude by GHSA ID.
+
+  # Excluding GHSA-3ppc-4f35-3m26: minimatch ReDoS via repeated wildcards
+  # Nested dep in aws-cdk-lib; fix requires minimatch v10 (incompatible with ^3.1.2)
+  # Risk: None - dev-time CDK tooling, no production runtime exposure
+
+  # Excluding GHSA-2g4f-4pwh-qvx6: ajv ReDoS with $data option
+  # Nested dep in aws-cdk-lib and eslint; no fix available via npm
+  # Risk: Low - $data option not used in this application
+
+  AUDIT_JSON=$(npm audit --production --json 2>/dev/null || true)
+  UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq '[.vulnerabilities | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | .value.via[] | select(type == "object") | .url | ltrimstr("https://github.com/advisories/")] | unique | map(select(. == "GHSA-3ppc-4f35-3m26" or . == "GHSA-2g4f-4pwh-qvx6" | not)) | length')
+  if [ "$UNFIXED_HIGH" -gt 0 ]; then
     echo "⚠️ Security audit failed. Please fix high/critical vulnerabilities before pushing."
     exit 1
   fi
-  echo "✅ No high or critical vulnerabilities found in production dependencies"
+  echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
 
 elif [ "$PACKAGE_MANAGER" = "bun" ]; then
   # Excluding GHSA-5j98-mcp5-4vw2 (CVE-2025-64756): glob CLI command injection

--- a/typescript/copy-overwrite/.github/workflows/quality.yml
+++ b/typescript/copy-overwrite/.github/workflows/quality.yml
@@ -967,12 +967,25 @@ jobs:
       - name: 🔒 Run security audit
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then
-            # Run audit and only fail on high or critical vulnerabilities
-            npm audit --production --audit-level=high || exit_code=$?
-            if [ "${exit_code:-0}" -ne 0 ]; then
-              echo "::warning::Found high or critical vulnerabilities"
-              exit $exit_code
+            # Run npm audit in JSON mode and filter out known false positives before failing.
+            # npm audit lacks a native --ignore flag, so we parse JSON and exclude by GHSA ID.
+
+            # Excluding GHSA-3ppc-4f35-3m26: minimatch ReDoS via repeated wildcards
+            # Nested dep in aws-cdk-lib; fix requires minimatch v10 (incompatible with ^3.1.2)
+            # Risk: None - dev-time CDK tooling, no production runtime exposure
+
+            # Excluding GHSA-2g4f-4pwh-qvx6: ajv ReDoS with $data option
+            # Nested dep in aws-cdk-lib and eslint; no fix available via npm
+            # Risk: Low - $data option not used in this application
+
+            AUDIT_JSON=$(npm audit --production --json 2>/dev/null || true)
+            UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq '[.vulnerabilities | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | .value.via[] | select(type == "object") | .url | ltrimstr("https://github.com/advisories/")] | unique | map(select(. == "GHSA-3ppc-4f35-3m26" or . == "GHSA-2g4f-4pwh-qvx6" | not)) | length')
+            if [ "$UNFIXED_HIGH" -gt 0 ]; then
+              echo "::warning::Found high or critical vulnerabilities (after excluding known false positives)"
+              npm audit --production --audit-level=high || true
+              exit 1
             fi
+            echo "::notice::No high or critical vulnerabilities found (excluding known false positives)"
           elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
             # Yarn audit outputs newline-delimited JSON, so we need to parse each line
 


### PR DESCRIPTION
## Summary

- Adds JSON-based exception handling to the `npm` path of the `🔒 Security Scan` CI step (and matching pre-push hook)
- Excludes **GHSA-3ppc-4f35-3m26** (minimatch ReDoS): nested in `aws-cdk-lib` which requires `minimatch ^3.1.2` — incompatible with the v10 fix; no safe npm override exists
- Excludes **GHSA-2g4f-4pwh-qvx6** (ajv `$data` ReDoS): nested in `aws-cdk-lib` and `eslint`; npm reports "no fix available" and a blanket `>=8.18.0` override would break eslint's ajv 6.x usage
- The bun/yarn paths already had equivalent exception handling; this brings the npm path into parity

## Test plan

- [x] Confirmed `jq` filter returns `0` unfixed high/critical vulns against an actual `npm audit --production --json` output from a CDK project that triggers both GHSAs
- [ ] CI `🔒 Security Scan` passes on a downstream project using `npm` as package manager

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security audit workflows with refined vulnerability detection. Filtering now excludes documented false positives while continuing to catch genuine high and critical security issues. Updated audit reporting to reflect excluded known false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->