### PR TITLE
docs: add Claude Code git worktree documentation

### DIFF
--- a/all/copy-contents/.gitignore
+++ b/all/copy-contents/.gitignore
@@ -160,6 +160,7 @@ tasks.json
 # AI Assistant and MCP
 **/.claude/settings.local.json
 **/.claude/debug/
+**/.claude/worktrees/
 .roo
 .roo/
 .roomodes


### PR DESCRIPTION
## Summary
- Add comprehensive Git Worktrees section to `.claude/REFERENCE.0003.md` covering CLI usage (`--worktree`/`-w`), subagent `isolation: worktree`, `EnterWorktree` tool, `WorktreeCreate`/`WorktreeRemove` hook events, known limitations, and version history
- Add `**/.claude/worktrees/` to `all/copy-contents/.gitignore` under the AI Assistant section to prevent worktree contents from appearing as untracked files
- Update hook event count from 15 to 17 and add `isolation` field to subagent frontmatter documentation

## Test plan
- [ ] Verify `.gitignore` entry correctly ignores `.claude/worktrees/` directories at any depth
- [ ] Verify REFERENCE.0003.md renders correctly in GitHub markdown preview
- [ ] Verify no broken links in the new sources section

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git Worktrees support (v2.1.49+) enables temporary isolation for subagents and workflows
  * New EnterWorktree tool for managing worktree contexts
  * WorktreeCreate and WorktreeRemove hook events for lifecycle management
  * Isolation configuration field for agents and subagents

* **Documentation**
  * Expanded documentation covering Git Worktrees usage, configuration, and hook events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->