### PR TITLE
fix: add coderabbitai to allowed_bots in code review response workflow

### DIFF
--- a/.github/workflows/claude-code-review-response.yml
+++ b/.github/workflows/claude-code-review-response.yml
@@ -31,6 +31,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'coderabbitai'
           prompt: |
             CodeRabbit just submitted a review on PR #${{ github.event.pull_request.number }}.
 

--- a/typescript/copy-overwrite/.github/workflows/claude-code-review-response.yml
+++ b/typescript/copy-overwrite/.github/workflows/claude-code-review-response.yml
@@ -31,6 +31,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'coderabbitai'
           prompt: |
             CodeRabbit just submitted a review on PR #${{ github.event.pull_request.number }}.
 


### PR DESCRIPTION
## Summary

- The `claude-code-action` rejects workflows initiated by bot actors by default
- Since this workflow triggers on CodeRabbit reviews, CodeRabbit is the actor — causing the action to fail with: `Workflow initiated by non-human actor: coderabbitai (type: Bot)`
- Adds `allowed_bots: 'coderabbitai'` to explicitly permit CodeRabbit-triggered runs

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger CodeRabbit review on PR #201 to verify the workflow runs successfully

🤖 Generated with Claude Code