### PR TITLE
fix: add workflows permission to autoupdate PR branches action

### DIFF
--- a/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
+++ b/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   autoupdate:


### PR DESCRIPTION
## Summary
- Adds `workflows: write` permission to the auto-update PR branches workflow
- Fixes failures when the autoupdate action tries to merge base branches into PR branches that contain workflow file changes (e.g., dependabot PRs updating GitHub Actions)
- The `GITHUB_TOKEN` needs the `workflows` scope to write to `.github/workflows/` files

## Test plan
- [x] Verify the permission is added correctly
- [ ] Verify downstream projects can auto-update PRs with workflow file changes after this propagates

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal infrastructure updates were made to optimize the continuous integration and delivery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->