### PR TITLE
fix: remove invalid workflows permission from autoupdate workflow

### DIFF
--- a/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
+++ b/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   autoupdate:


### PR DESCRIPTION
## Summary
- Removes the `workflows: write` permission from the auto-update PR branches workflow
- This permission is not a valid GITHUB_TOKEN scope in workflow permissions blocks (it exists at the GitHub App/PAT level but not for GITHUB_TOKEN)
- GitHub Actions rejects the workflow at the parsing stage, causing it to fail without running any jobs

## Test plan
- [x] Verified that the workflow fails with `workflows: write` (PropSwapLLC/infrastructure run #22449450872)
- [ ] Verify downstream workflows run successfully after this fix propagates

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted GitHub Actions workflow permissions to reduce the workflow's write access (narrower automation scope). This change tightens automation privileges without altering runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->