### PR TITLE
fix: add continue-on-error to autoupdate workflow step

### DIFF
--- a/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
+++ b/typescript/copy-overwrite/.github/workflows/auto-update-pr-branches.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Auto-update pull request branches
         uses: chinthakagodawita/autoupdate@v1.7.0
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_FILTER: 'all'


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the autoupdate step in the auto-update PR branches workflow
- Prevents false failure notifications when the action encounters dependabot PRs that modify workflow files (GITHUB_TOKEN can't write to `.github/workflows/`)
- The action already handles these errors gracefully by skipping affected PRs and continuing

## Test plan
- [ ] Verify downstream workflows report green even when dependabot workflow PRs exist

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resilience of automated pull request branch updates by allowing the workflow to continue in case of step failures, reducing disruptions to the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->