### PR TITLE
feat: add --skip-git-check flag to bypass dirty git check during postinstall

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -3,8 +3,6 @@
 # Runs as Lisa's postinstall lifecycle script.
 set -euo pipefail
 
-if ! command -v claude &>/dev/null; then exit 0; fi
-
 PROJECT_ROOT="${npm_config_local_prefix:-${INIT_CWD:-}}"
 if [ -z "$PROJECT_ROOT" ]; then exit 0; fi
 
@@ -13,8 +11,10 @@ if [ ! -d "$LISA_DIR" ]; then exit 0; fi
 
 cd "$PROJECT_ROOT"
 
-# Apply Lisa templates non-interactively
-if ! node "$LISA_DIR/dist/index.js" --yes "$PROJECT_ROOT"; then
+# Apply Lisa templates non-interactively.
+# --skip-git-check bypasses the dirty working directory check since
+# package.json and the lockfile are always uncommitted during postinstall.
+if ! node "$LISA_DIR/dist/index.js" --yes --skip-git-check "$PROJECT_ROOT"; then
   echo "⚠️  Warning: Lisa template application failed. Migration may be incomplete." >&2
 fi
 
@@ -37,6 +37,9 @@ if "hooks" in d:
 PYEOF
   fi
 fi
+
+# Register the Lisa marketplace and install plugins only when claude CLI is available
+if ! command -v claude &>/dev/null; then exit 0; fi
 
 # Register the Lisa marketplace pointing to this npm package
 claude marketplace add "$LISA_DIR" </dev/null 2>&1 || true

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,10 @@ export function createProgram(): Command {
       "Validate project compatibility without applying changes"
     )
     .option("-u, --uninstall", "Remove Lisa-managed files from the project")
+    .option(
+      "--skip-git-check",
+      "Skip dirty git working directory check (for postinstall use)"
+    )
     .action(async (destination: string | undefined, options: CLIOptions) => {
       await runLisa(destination, options);
     });
@@ -62,6 +66,7 @@ interface CLIOptions {
   yes?: boolean;
   validate?: boolean;
   uninstall?: boolean;
+  skipGitCheck?: boolean;
 }
 
 /**
@@ -83,6 +88,9 @@ function printUsageAndExit(): never {
     "  -v, --validate    Validate project compatibility without applying changes"
   );
   console.log("  -u, --uninstall   Remove Lisa-managed files from the project");
+  console.log(
+    "  --skip-git-check  Skip dirty git working directory check (for postinstall use)"
+  );
   console.log("  -h, --help        Show this help message");
   console.log("");
   console.log("Examples:");
@@ -143,6 +151,7 @@ async function runLisa(
     dryRun,
     yesMode,
     validateOnly: options.validate ?? false,
+    skipGitCheck: options.skipGitCheck ?? false,
   };
 
   const logger = new ConsoleLogger();

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -76,6 +76,9 @@ export interface LisaConfig {
 
   /** If true, only validate compatibility without applying */
   readonly validateOnly: boolean;
+
+  /** If true, skip the dirty git working directory check (for postinstall use) */
+  readonly skipGitCheck: boolean;
 }
 
 /**

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -736,6 +736,11 @@ export class Lisa {
       return;
     }
 
+    // Skip git check when requested (e.g. during postinstall where lockfile is always dirty)
+    if (this.config.skipGitCheck) {
+      return;
+    }
+
     // Check for uncommitted changes
     if (!(await gitService.isDirty(destDir))) {
       return;


### PR DESCRIPTION
## Summary

- Adds `--skip-git-check` CLI flag and `skipGitCheck` field to `LisaConfig` so postinstall can bypass the dirty git working directory check
- Moves the `if ! command -v claude` guard in `install-claude-plugins.sh` to only cover the marketplace/plugin-install section — the `lisa --yes .` template application now runs regardless of whether the `claude` CLI is installed
- `validateGitState()` returns early when `skipGitCheck` is true (before checking if the repo is dirty)

## Test plan

- Run `bun install` in a project that has `@codyswann/lisa` in `devDependencies` and `trustedDependencies`
- Verify postinstall runs `lisa --yes --skip-git-check .` and applies Lisa templates without aborting due to dirty git state
- Verify `lisa --help` shows the new `--skip-git-check` option

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--skip-git-check` command-line flag to bypass Git repository validation checks during setup and plugin installation.

* **Improvements**
  * Enhanced plugin installation workflow for better handling of dependency availability and execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->