### PR TITLE
fix: remove file:./eslint-plugin-code-organization from downstream template

### DIFF
--- a/package.lisa.json
+++ b/package.lisa.json
@@ -30,7 +30,6 @@
       "@eslint/eslintrc": "^3.2.0",
       "@eslint/js": "^9.39.0",
       "eslint-import-resolver-typescript": "^4.4.4",
-      "eslint-plugin-code-organization": "file:./eslint-plugin-code-organization",
       "eslint-plugin-import": "^2.32.0",
       "eslint-plugin-functional": "^9.0.0",
       "jiti": "^2.4.0",


### PR DESCRIPTION
## Summary

- Removes `eslint-plugin-code-organization: "file:./eslint-plugin-code-organization"` from root `package.lisa.json` `force.devDependencies`
- This entry was causing all downstream projects to receive a `file:` reference pointing to a directory that only exists inside the Lisa repo — `bun install` fails with `FileNotFound` because the directory doesn't exist in downstream projects
- The plugin is now bundled inside `@codyswann/lisa` and loaded via relative path in ESLint configs; downstream projects don't need to reference it directly

## Test plan

- Run `bun install` in a downstream project (e.g. frontend-v2) that has `@codyswann/lisa` in devDependencies
- Verify no `FileNotFound` errors for `eslint-plugin-code-organization`, `eslint-plugin-component-structure`, or `eslint-plugin-ui-standards`
- Verify ESLint still works correctly (plugins are loaded from inside the `@codyswann/lisa` package)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies (removed an unused ESLint plugin).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->