### PR TITLE
fix(ci): replace secrets: inherit with explicit secrets for cross-repo workflows

### DIFF
--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -130,4 +130,9 @@ jobs:
     with:
       node_version: '22.21.1'
       package_manager: 'bun'
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}

--- a/cdk/create-only/.github/workflows/deploy.yml
+++ b/cdk/create-only/.github/workflows/deploy.yml
@@ -55,5 +55,12 @@ jobs:
       override_blackout: true
       node_version: '22.21.1'
       package_manager: 'bun'
-    secrets: inherit
+    secrets:
+      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+      SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 # Trigger staging deployment after CDK trust fix

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
       node_version: '22.21.1'
       package_manager: 'bun'
       skip_jobs: 'test,test:integration,test:e2e'
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
   lighthouse:
     name: 💡 Lighthouse CI
     needs: [quality]

--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -71,7 +71,14 @@ jobs:
       package_manager: 'bun'
       override_blackout: true
       emergency_release: false
-    secrets: inherit
+    secrets:
+      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+      SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
   # Step 2: Deploy to AWS (Custom deployment logic)
   check_eas_setup:

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
       node_version: '22.21.1'
       package_manager: 'bun'
       skip_jobs: 'test,test:integration,test:e2e'
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
 
   zap:
     name: 🕷️ ZAP Baseline Scan

--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -69,7 +69,14 @@ jobs:
       require_signatures: false
       node_version: '22.21.1'
       package_manager: 'bun'
-    secrets: inherit
+    secrets:
+      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+      SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
   verify_aws_credentials:
     name: Verify AWS Credentials
@@ -242,7 +249,9 @@ jobs:
       virtual_users: 50
       fail_on_threshold: false # Don't fail the release if load test fails
       upload_results: true
-    secrets: inherit
+    secrets:
+      K6_CLOUD_TOKEN: ${{ secrets.K6_CLOUD_TOKEN }}
+      CUSTOM_HEADERS: ${{ secrets.CUSTOM_HEADERS }}
 
   # Post-deployment monitoring (optional)
   post_deployment_monitoring:

--- a/typescript/create-only/.github/workflows/auto-update-pr-branches.yml
+++ b/typescript/create-only/.github/workflows/auto-update-pr-branches.yml
@@ -21,4 +21,3 @@ jobs:
       pr_base_ref: ${{ github.event.pull_request.base.ref || '' }}
       pr_number: ${{ github.event.pull_request.number || 0 }}
       repo_full_name: ${{ github.repository }}
-    secrets: inherit

--- a/typescript/create-only/.github/workflows/ci.yml
+++ b/typescript/create-only/.github/workflows/ci.yml
@@ -15,4 +15,9 @@ jobs:
       node_version: '22.21.1'
       package_manager: 'bun'
       skip_jobs: ''
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}

--- a/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
@@ -17,4 +17,5 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-code-review-response.yml
+++ b/typescript/create-only/.github/workflows/claude-code-review-response.yml
@@ -17,4 +17,5 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       repo_owner: ${{ github.repository_owner }}
       repo_name: ${{ github.event.repository.name }}
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
@@ -17,4 +17,5 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
@@ -11,4 +11,5 @@ on:
 jobs:
   reduce-complexity:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-code-complexity.yml@main
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
@@ -11,4 +11,5 @@ on:
 jobs:
   improve-coverage:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-coverage.yml@main
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
@@ -22,4 +22,5 @@ jobs:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-improvement.yml@main
     with:
       mode: ${{ github.event.inputs.mode || 'nightly' }}
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude.yml
+++ b/typescript/create-only/.github/workflows/claude.yml
@@ -22,4 +22,5 @@ jobs:
       review_body: ${{ github.event.review.body || '' }}
       issue_body: ${{ github.event.issue.body || '' }}
       issue_title: ${{ github.event.issue.title || '' }}
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- `secrets: inherit` does not pass secrets to reusable workflows in a different GitHub owner/org
- Since downstream wrapper workflows call reusable workflows in `CodySwannGT/lisa` (different owner than downstream orgs like `geminisportsai`), secrets were silently not passed
- This caused deploy keys, SONAR_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, etc. to not reach the reusable workflows, breaking deploys and other CI features

## Changes
Replaced `secrets: inherit` with explicit secret declarations in all create-only wrapper workflow templates across all stacks (typescript, expo, nestjs, cdk):

| Workflow | Secrets |
|---|---|
| `deploy.yml` | `DEPLOY_KEY`, `RELEASE_SIGNING_KEY`, `SIGNING_KEY_ID`, `SIGNING_KEY_PASSPHRASE`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |
| `ci.yml` | `SONAR_TOKEN`, `SNYK_TOKEN`, `GITGUARDIAN_API_KEY`, `FOSSA_API_KEY`, `MAESTRO_API_KEY` |
| `claude*.yml` (6 workflows) | `CLAUDE_CODE_OAUTH_TOKEN` |
| `auto-update-pr-branches.yml` | Removed (reusable workflow declares no secrets) |
| nestjs `deploy.yml` load_testing | `K6_CLOUD_TOKEN`, `CUSTOM_HEADERS` |

## Test plan
- [x] Verified all cross-repo `secrets: inherit` references replaced with explicit secrets
- [x] Verified local workflow references (e.g., `create-issue-on-failure.yml`) still use `secrets: inherit` (same-repo is fine)
- [x] Companion PR in frontend-v2 applies same fix to existing workflow files
- [ ] Trigger deploy in frontend-v2 to verify deploy key bypass works

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions CI/CD workflow configurations across multiple project templates to use explicit secret definitions instead of implicit inheritance for improved pipeline configuration clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->