### PR TITLE
fix(ci): add permissions to caller workflows for reusable workflow compatibility

### DIFF
--- a/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
@@ -8,6 +8,13 @@ on:
     workflows: ['CI Quality Checks']
     types: [completed]
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   auto-fix:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-ci-auto-fix.yml@main

--- a/typescript/create-only/.github/workflows/claude-code-review-response.yml
+++ b/typescript/create-only/.github/workflows/claude-code-review-response.yml
@@ -7,6 +7,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   respond-to-review:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-code-review-response.yml@main

--- a/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
@@ -8,6 +8,13 @@ on:
     workflows: ['Release and Deploy', '🚀 Release and Deploy']
     types: [completed]
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   auto-fix:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-deploy-auto-fix.yml@main

--- a/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
@@ -8,6 +8,12 @@ on:
     - cron: '0 5 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   reduce-complexity:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-code-complexity.yml@main

--- a/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
@@ -8,6 +8,12 @@ on:
     - cron: '0 4 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   improve-coverage:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-coverage.yml@main

--- a/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
@@ -17,6 +17,12 @@ on:
           - nightly
           - general
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   improve-tests:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-improvement.yml@main

--- a/typescript/create-only/.github/workflows/claude.yml
+++ b/typescript/create-only/.github/workflows/claude.yml
@@ -13,6 +13,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   claude:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude.yml@main


### PR DESCRIPTION
## Summary
- Caller workflows that invoke reusable workflows via `uses` were missing `permissions` declarations
- When repos have restricted default token permissions, the reusable workflow jobs get only `contents: read` and `none` for everything else, causing GitHub validation errors like: "The nested job is requesting X but is only allowed Y"
- Added matching `permissions` blocks to all 7 Claude caller workflow templates in `typescript/create-only/`

## Test plan
- [ ] Verify `claude-deploy-auto-fix.yml` no longer shows the validation error on GitHub
- [ ] Verify all other Claude caller workflows pass GitHub's workflow validation
- [ ] Confirm `auto-update-pr-branches.yml` (which already had permissions) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions across multiple automation pipelines to align with operational requirements. Changes applied to auto-fix, code review response, deployment automation, nightly analysis, test coverage, test improvement, and main CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->