### PR TITLE
fix(ci): use Claude Code action for auto-update and add missing permissions

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   autoupdate:

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -8,6 +8,13 @@ on:
     workflows: ['CI Quality Checks']
     types: [completed]
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   auto-fix:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-ci-auto-fix.yml@main

--- a/.github/workflows/claude-code-review-response.yml
+++ b/.github/workflows/claude-code-review-response.yml
@@ -7,6 +7,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   respond-to-review:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-code-review-response.yml@main

--- a/.github/workflows/claude-deploy-auto-fix.yml
+++ b/.github/workflows/claude-deploy-auto-fix.yml
@@ -8,6 +8,13 @@ on:
     workflows: ['Release and Deploy', '🚀 Release and Deploy']
     types: [completed]
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   auto-fix:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-deploy-auto-fix.yml@main

--- a/.github/workflows/claude-nightly-code-complexity.yml
+++ b/.github/workflows/claude-nightly-code-complexity.yml
@@ -8,6 +8,12 @@ on:
     - cron: '0 5 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   reduce-complexity:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-code-complexity.yml@main

--- a/.github/workflows/claude-nightly-test-coverage.yml
+++ b/.github/workflows/claude-nightly-test-coverage.yml
@@ -8,6 +8,12 @@ on:
     - cron: '0 4 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   improve-coverage:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-coverage.yml@main

--- a/.github/workflows/claude-nightly-test-improvement.yml
+++ b/.github/workflows/claude-nightly-test-improvement.yml
@@ -17,6 +17,12 @@ on:
           - nightly
           - general
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   improve-tests:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-improvement.yml@main

--- a/.github/workflows/reusable-auto-update-pr-branches.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches.yml
@@ -30,6 +30,9 @@ on:
         required: true
         type: string
     secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Code OAuth token for authenticating pushes that trigger downstream workflows'
+        required: false
       TRIGGER_TOKEN:
         description: 'Optional token to use instead of GITHUB_TOKEN so pushes trigger downstream workflows'
         required: false
@@ -37,6 +40,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   autoupdate-on-push:
@@ -44,24 +48,49 @@ jobs:
     if: inputs.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Update all open PR branches
+        uses: anthropics/claude-code-action@v1
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.TRIGGER_TOKEN || secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          prs=$(gh pr list --repo "${{ inputs.repo_full_name }}" --base "${{ inputs.ref_name }}" --state open --json number --jq '.[].number')
-          for pr in $prs; do
-            echo "Updating PR #$pr..."
-            gh api -X PUT "repos/${{ inputs.repo_full_name }}/pulls/$pr/update-branch" -f update_method=merge || echo "PR #$pr update failed or already up to date"
-          done
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Update all open pull request branches targeting "${{ inputs.ref_name }}" in "${{ inputs.repo_full_name }}".
+
+            Run this command:
+            ```
+            prs=$(gh pr list --repo "${{ inputs.repo_full_name }}" --base "${{ inputs.ref_name }}" --state open --json number --jq '.[].number')
+            for pr in $prs; do
+              echo "Updating PR #$pr..."
+              gh api -X PUT "repos/${{ inputs.repo_full_name }}/pulls/$pr/update-branch" -f update_method=merge || echo "PR #$pr update failed or already up to date"
+            done
+            ```
+          claude_args: |
+            --allowedTools "Bash(*)"
+            --max-turns 3
 
   autoupdate-on-pr:
     name: Update PR branch against ${{ inputs.pr_base_ref }}
     if: inputs.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Update PR branch
+        uses: anthropics/claude-code-action@v1
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.TRIGGER_TOKEN || secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: gh api -X PUT "repos/${{ inputs.repo_full_name }}/pulls/${{ inputs.pr_number }}/update-branch" -f update_method=merge
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Update pull request #${{ inputs.pr_number }} branch in "${{ inputs.repo_full_name }}".
+
+            Run this command:
+            ```
+            gh api -X PUT "repos/${{ inputs.repo_full_name }}/pulls/${{ inputs.pr_number }}/update-branch" -f update_method=merge
+            ```
+          claude_args: |
+            --allowedTools "Bash(*)"
+            --max-turns 3

--- a/typescript/create-only/.github/workflows/auto-update-pr-branches.yml
+++ b/typescript/create-only/.github/workflows/auto-update-pr-branches.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   autoupdate:
@@ -26,4 +27,4 @@ jobs:
       pr_number: ${{ github.event.pull_request.number || 0 }}
       repo_full_name: ${{ github.repository }}
     secrets:
-      TRIGGER_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces `chinthakagodawita/autoupdate` Docker action and raw `gh api` calls with `anthropics/claude-code-action@v1` in the auto-update reusable workflow
- Claude Code action authenticates via the Claude GitHub App, whose pushes trigger downstream CI workflows (unlike `GITHUB_TOKEN`)
- Adds missing `permissions` blocks to all 6 Claude caller workflows in Lisa's own `.github/workflows/`
- Adds `id-token: write` to auto-update caller workflows for Claude Code OIDC auth

## Test plan
- [ ] Merge this PR to main
- [ ] Verify PR #239 gets an auto-update merge that triggers CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)