### PR TITLE
fix(ci): pass package_manager through auto-fix workflows

### DIFF
--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -24,4 +24,5 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
+      package_manager: 'bun'
     secrets: inherit

--- a/.github/workflows/claude-deploy-auto-fix.yml
+++ b/.github/workflows/claude-deploy-auto-fix.yml
@@ -24,4 +24,5 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
+      package_manager: 'bun'
     secrets: inherit

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -26,6 +26,11 @@ on:
         description: 'ID of the workflow run'
         required: true
         type: string
+      package_manager:
+        description: 'Package manager to use (npm, yarn, or bun)'
+        required: false
+        type: string
+        default: 'npm'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -164,4 +169,5 @@ jobs:
     with:
       workflow_name: 'CI Quality Checks'
       failed_job: 'Claude auto-fix failed — manual intervention needed'
+      package_manager: ${{ inputs.package_manager }}
     secrets: inherit

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -26,6 +26,11 @@ on:
         description: 'ID of the workflow run'
         required: true
         type: string
+      package_manager:
+        description: 'Package manager to use (npm, yarn, or bun)'
+        required: false
+        type: string
+        default: 'npm'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -162,4 +167,5 @@ jobs:
     with:
       workflow_name: 'Release and Deploy'
       failed_job: 'Claude deploy auto-fix failed — manual intervention needed'
+      package_manager: ${{ inputs.package_manager }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Add `package_manager` input to `reusable-claude-ci-auto-fix.yml` and `reusable-claude-deploy-auto-fix.yml`, forwarding it to `create-issue-on-failure.yml`
- Lisa's own caller workflows (`claude-ci-auto-fix.yml`, `claude-deploy-auto-fix.yml`) now pass `package_manager: 'bun'`
- Fixes `actions/setup-node` cache error: `Dependencies lock file is not found... Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock` — because Lisa uses bun, not npm

Ref: https://github.com/CodySwannGT/lisa/actions/runs/22621010127/job/65545778156

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Trigger a deploy failure scenario and confirm the create-issue job no longer fails with the npm cache error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated CI/CD workflows with configurable package manager support. The workflows now support 'bun' as a package manager option alongside npm, increasing flexibility for automated fixes and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->