### PR TITLE
fix: use correct object format for extraKnownMarketplaces

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,11 @@
   },
   "plansDirectory": "./plans",
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   }
 }

--- a/all/merge/.claude/settings.json
+++ b/all/merge/.claude/settings.json
@@ -14,7 +14,12 @@
     "atlassian@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",

--- a/cdk/merge/.claude/settings.json
+++ b/cdk/merge/.claude/settings.json
@@ -13,7 +13,12 @@
     "cdk@lisa": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",

--- a/expo/merge/.claude/settings.json
+++ b/expo/merge/.claude/settings.json
@@ -15,7 +15,12 @@
     "expo@lisa": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",

--- a/nestjs/merge/.claude/settings.json
+++ b/nestjs/merge/.claude/settings.json
@@ -13,7 +13,12 @@
     "nestjs@lisa": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",

--- a/rails/merge/.claude/settings.json
+++ b/rails/merge/.claude/settings.json
@@ -13,7 +13,12 @@
     "rails@lisa": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",

--- a/typescript/merge/.claude/settings.json
+++ b/typescript/merge/.claude/settings.json
@@ -13,7 +13,12 @@
     "typescript@lisa": true
   },
   "extraKnownMarketplaces": {
-    "CodySwannGT/lisa": true
+    "CodySwannGT/lisa": {
+      "source": {
+        "source": "github",
+        "repo": "CodySwannGT/lisa"
+      }
+    }
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1800000",


### PR DESCRIPTION
## Summary

- Fix `extraKnownMarketplaces` entries in all 7 settings.json files (all, typescript, expo, nestjs, rails, cdk, and Lisa's own)
- Entries were `"CodySwannGT/lisa": true` (boolean) but Claude Code expects `{ "source": "github", "repo": "CodySwannGT/lisa" }` (object)
- The boolean format causes a validation error on startup: `Expected object, but received boolean`

## Test plan

- [ ] CI passes
- [ ] After merging and publishing, run `bun update @codyswann/lisa` in a downstream project and verify no startup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace configuration metadata across multiple environments to use structured format with explicit source and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->