### PR TITLE
fix: add @codyswann/lisa to trustedDependencies template

### DIFF
--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -43,6 +43,7 @@
   "merge": {
     "trustedDependencies": [
       "@ast-grep/cli",
+      "@codyswann/lisa",
       "@sentry/cli"
     ]
   }


### PR DESCRIPTION
## Summary
- Adds `@codyswann/lisa` to the `trustedDependencies` merge array in `typescript/package-lisa/package.lisa.json`
- Bun only runs postinstall scripts for packages listed in `trustedDependencies` — without this entry, Lisa's postinstall (template application and file deletions) was silently skipped in downstream projects
- This caused stale skill files (moved to plugins) to persist in `.claude/skills/` across all downstream projects

## Test plan
- [x] Verified root cause: only 1 of 8 downstream projects had `@codyswann/lisa` in `trustedDependencies`
- [x] Confirmed dry-run shows 50 skill deletions would fire correctly
- [x] Confirmed manual run successfully deletes 96 stale files
- [x] Existing `package-lisa.test.ts` tests pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trusted dependency configurations to enhance build security and merge processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->