### PR TITLE
fix: register Lisa marketplace at project scope

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -47,7 +47,7 @@ fi
 if ! command -v claude &>/dev/null; then exit 0; fi
 
 # Register the Lisa marketplace pointing to this npm package
-claude marketplace add "$LISA_DIR" </dev/null 2>&1 || true
+claude marketplace add "$LISA_DIR" --scope project </dev/null 2>&1 || true
 
 # Detect which stack plugin to install from .claude/settings.json
 SETTINGS_FILE="$PROJECT_ROOT/.claude/settings.json"


### PR DESCRIPTION
## Summary
- Adds `--scope project` to `claude marketplace add` in `install-claude-plugins.sh`
- Without this, the marketplace registered at user scope, and the GitHub-source registration from `extraKnownMarketplaces` in settings.json took precedence
- The GitHub clone doesn't have the built `plugins/lisa-*` directories (they're gitignored), causing Lisa plugins (`typescript@lisa`, `expo@lisa`, etc.) to fail to load with "Plugin directory not found"

## Test plan
- [ ] Run `bun update @codyswann/lisa` in a downstream project
- [ ] Verify `claude plugin list` shows Lisa plugins as loaded (not "failed to load")
- [ ] Verify Lisa skills/hooks/rules are available in Claude Code session

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin installation workflow to apply proper scope configuration for Claude marketplace integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->