### PR TITLE
fix: support legacy plugin keys in install script

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -55,7 +55,11 @@ SETTINGS_FILE="$PROJECT_ROOT/.claude/settings.json"
 LISA_PLUGIN=""
 if [ -f "$SETTINGS_FILE" ]; then
   for stack in typescript expo nestjs cdk rails; do
+    # Check new format (lisa-*@lisa) first, fall back to legacy format (*@lisa)
     if grep -q "\"lisa-${stack}@lisa\"" "$SETTINGS_FILE" 2>/dev/null; then
+      LISA_PLUGIN="lisa-${stack}@lisa"
+      break
+    elif grep -q "\"${stack}@lisa\"" "$SETTINGS_FILE" 2>/dev/null; then
       LISA_PLUGIN="lisa-${stack}@lisa"
       break
     fi


### PR DESCRIPTION
## Summary

- Add fallback detection for legacy plugin key format (`expo@lisa`) in `install-claude-plugins.sh` so projects that haven't yet migrated to the new `lisa-expo@lisa` keys still get the correct plugin installed during `bun update @codyswann/lisa`

## Test plan

- [ ] Run `bun update @codyswann/lisa` in a project with old `"expo@lisa"` key in settings.json — plugin should install as `lisa-expo@lisa`
- [ ] Run `bun update @codyswann/lisa` in a project with new `"lisa-expo@lisa"` key — plugin should install normally

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced plugin installation script to support an additional plugin identifier format while maintaining backward compatibility with existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->