### PR TITLE
fix: strip workspaces field from published npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # BEGIN: AI GUARDRAILS
 
+# Publishing artifacts
+package.json.bak
+
 # Dependencies
 node_modules/
 node_modules

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "setup:deploy-key": "bash scripts/setup-deploy-key.sh",
     "lisa:update:local": "bash scripts/lisa-update-local.sh",
     "lisa:commit-and-pr:local": "bash scripts/lisa-commit-and-pr-local.sh",
+    "prepack": "bash scripts/strip-workspaces-for-pack.sh",
+    "postpack": "[ -f package.json.bak ] && mv package.json.bak package.json || true",
     "prepublishOnly": "$npm_execpath run build",
     "postinstall": "bash ./scripts/install-claude-plugins.sh || true; [ -d dist/configs ] || tsc || true"
   },

--- a/scripts/strip-workspaces-for-pack.sh
+++ b/scripts/strip-workspaces-for-pack.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Strips the `workspaces` field from package.json before npm creates a tarball.
+#
+# The workspaces field is only meaningful for Lisa's local monorepo development.
+# When published to npm, it causes bun to erroneously try resolving workspace
+# directory names (e.g. "eslint-plugin-component-structure") as npm packages,
+# producing FileNotFound errors in downstream projects during `bun update`.
+#
+# Called via the `prepack` lifecycle hook; the `postpack` hook restores the
+# original package.json from the backup created here.
+set -euo pipefail
+
+cp package.json package.json.bak
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  delete pkg.workspaces;
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+echo "prepack: stripped workspaces from package.json"


### PR DESCRIPTION
## Summary
- The `workspaces` field in `package.json` was being published to npm, causing bun to try resolving workspace directory names (`eslint-plugin-component-structure`, `eslint-plugin-ui-standards`) as npm packages during `bun update @codyswann/lisa` in downstream projects
- Added `prepack`/`postpack` lifecycle hooks that strip the `workspaces` field before the tarball is created and restore it afterward

## Test plan
- [x] Verified `npm pack` produces a tarball without the `workspaces` field
- [x] Verified `package.json` is restored with `workspaces` after packing
- [x] All 268 unit tests pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package publishing process to properly handle workspace configurations during distribution, with automated backup and restoration mechanisms.
* Added ignore rules for temporary packaging artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->