### PR TITLE
fix: disable import/no-cycle for NestJS module files in slow lint config

### DIFF
--- a/nestjs/copy-overwrite/eslint.slow.config.ts
+++ b/nestjs/copy-overwrite/eslint.slow.config.ts
@@ -9,10 +9,25 @@
  * Thin wrapper around @codyswann/lisa slow eslint config factory.
  * Run periodically via `lint:slow` rather than on every lint pass.
  *
+ * Adds a NestJS-specific override to disable `import/no-cycle` for module
+ * files, since NestJS uses `forwardRef()` to handle circular module
+ * dependencies at runtime.
+ *
  * @see https://github.com/import-js/eslint-plugin-import
  * @module eslint.slow.config
  */
 import { getSlowConfig } from "@codyswann/lisa/eslint/slow";
 import ignoreConfig from "./eslint.ignore.config.json" with { type: "json" };
 
-export default getSlowConfig({ ignorePatterns: ignoreConfig.ignores || [] });
+export default [
+  ...getSlowConfig({ ignorePatterns: ignoreConfig.ignores || [] }),
+
+  // NestJS modules use forwardRef() to resolve circular dependencies at runtime.
+  // ESLint's static import/no-cycle analysis cannot understand this pattern.
+  {
+    files: ["**/*.module.ts"],
+    rules: {
+      "import/no-cycle": "off",
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Adds NestJS-specific override to `eslint.slow.config.ts` template to disable `import/no-cycle` for `*.module.ts` files
- NestJS uses `forwardRef()` to handle circular module dependencies at runtime, which ESLint's static analysis cannot understand
- Discovered during Lisa update rollout to geminisportsai/backend-v2

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 270 tests pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration for NestJS projects to disable cyclic import validation in module files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->