### PR TITLE
fix: change reusable workflow package_manager default from bun to npm

### DIFF
--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -38,7 +38,7 @@ on:
       package_manager:
         description: 'Package manager to use (npm, yarn, or bun)'
         required: false
-        default: 'bun'
+        default: 'npm'
         type: string
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -14,7 +14,7 @@ on:
       package_manager:
         description: 'Package manager to use (npm, yarn, or bun)'
         required: false
-        default: 'bun'
+        default: 'npm'
         type: string
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -14,7 +14,7 @@ on:
       package_manager:
         description: 'Package manager to use (npm, yarn, or bun)'
         required: false
-        default: 'bun'
+        default: 'npm'
         type: string
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -19,7 +19,7 @@ on:
       package_manager:
         description: 'Package manager to use (npm, yarn, or bun)'
         required: false
-        default: 'bun'
+        default: 'npm'
         type: string
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:

--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
-      package_manager: 'bun'
+      package_manager: 'npm'
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/cdk/create-only/.github/workflows/deploy.yml
+++ b/cdk/create-only/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       generate_sbom: true
       override_blackout: true
       node_version: '22.21.1'
-      package_manager: 'bun'
+      package_manager: 'npm'
     secrets:
       DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
       RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}


### PR DESCRIPTION
## Summary
- CDK projects use npm (package-lock.json) but 4 reusable workflows defaulted `package_manager` to `bun`
- When downstream calling workflows (e.g., `claude-code-review-response.yml`) don't pass `package_manager`, they inherit the bad `bun` default
- This causes `bun install --frozen-lockfile` to fail because bun tries to migrate `package-lock.json` and the lockfile changes are rejected
- Fixed default from `bun` to `npm` in all affected reusable workflows and CDK create-only templates

**Affected reusable workflows:**
- `reusable-claude-code-review-response.yml`
- `reusable-claude-nightly-code-complexity.yml`
- `reusable-claude-nightly-test-coverage.yml`
- `reusable-claude-nightly-test-improvement.yml`

**Affected CDK templates:**
- `cdk/create-only/.github/workflows/ci.yml`
- `cdk/create-only/.github/workflows/deploy.yml`

**Evidence:** https://github.com/geminisportsai/infrastructure-v2/actions/runs/22728776231/job/65911781432?pr=102

## Test plan
- [x] Verify `bun` default remains only in NestJS/Expo ZAP workflows (which correctly use bun)
- [x] Verify all other reusable workflows that already used `npm` default are unchanged
- [ ] After merge, re-trigger the failing CDK workflow to confirm it passes

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default package manager from Bun to npm across CI/CD workflows. This changes the dependency installation method used during automated builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->