### PR TITLE
fix(ci): add NODE_OPTIONS heap limit to test workflow steps

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -381,6 +381,8 @@ jobs:
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
             bun run test
           fi
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         working-directory: ${{ inputs.working_directory || '.' }}
 
   test_unit:
@@ -440,6 +442,8 @@ jobs:
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
             bun run test:cov
           fi
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: ⏭️ Skip unit tests (no test:unit script)
@@ -503,6 +507,8 @@ jobs:
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
             bun run test:integration
           fi
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: ⏭️ Skip integration tests (no test:integration script)
@@ -566,6 +572,8 @@ jobs:
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
             bun run test:e2e
           fi
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: ⏭️ Skip E2E tests (no test:e2e script)


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS: --max-old-space-size=6144` env var to test, test_unit, test_integration, and test_e2e workflow steps
- Matches the pattern already used by lint, typecheck, build, and format steps
- Fixes OOM crashes in CI when running Jest on large test suites via `bun run`

## Root cause
Script-level `NODE_OPTIONS=value command` syntax in package.json is not reliably passed through by bun's script runner. The workflow-level `env:` block ensures the env var is set before the process starts, regardless of package manager.

## Test plan
- [ ] CI passes on backend-v2 PR after this is merged and workflow is picked up

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution environment configuration to enhance stability and resource allocation during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->