### PR TITLE
feat(ci): add auto_merge input to PR-creating Claude workflows

### DIFF
--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: '22.21.1'
         type: string
+      auto_merge:
+        description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
+        required: false
+        default: true
+        type: boolean
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -185,6 +190,19 @@ jobs:
           else
             echo "fixed=false" >> "$GITHUB_OUTPUT"
             echo "Claude did not create a fix PR."
+          fi
+
+      - name: Enable auto-merge
+        if: inputs.auto_merge && steps.loop-guard.outputs.skip != 'true' && steps.check-fix.outputs.fixed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr list --head "claude/deploy-fix-" --state open --json url --jq '.[0].url' 2>/dev/null || echo "")
+          if [ -n "$PR_URL" ]; then
+            gh pr merge "$PR_URL" --auto --squash
+            echo "Auto-merge enabled for $PR_URL"
+          else
+            echo "No PR found to auto-merge."
           fi
 
   create-issue:

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'npm'
         type: string
+      auto_merge:
+        description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
+        required: false
+        default: true
+        type: boolean
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -161,3 +166,16 @@ jobs:
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
             --max-turns 40
             --system-prompt "You are reducing code complexity to meet stricter ESLint thresholds. Read CLAUDE.md for project rules. Refactor functions to reduce cognitive complexity and lines per function. Use early returns, extract helpers, and lookup tables. Do NOT modify the maxLines threshold. You must update eslint.thresholds.json with the new values after refactoring passes lint. IMPORTANT: Always use the project's package manager scripts (e.g. bun run lint, bun run test) instead of running binaries from node_modules/.bin/ directly."
+
+      - name: Enable auto-merge
+        if: inputs.auto_merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr list --head "claude/nightly-code-complexity-" --state open --json url --jq '.[0].url' 2>/dev/null || echo "")
+          if [ -n "$PR_URL" ]; then
+            gh pr merge "$PR_URL" --auto --squash
+            echo "Auto-merge enabled for $PR_URL"
+          else
+            echo "No PR found to auto-merge."
+          fi

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'npm'
         type: string
+      auto_merge:
+        description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
+        required: false
+        default: true
+        type: boolean
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -158,3 +163,16 @@ jobs:
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
             --max-turns 40
             --system-prompt "You are improving test coverage to meet higher thresholds. Read CLAUDE.md for project rules. Follow TDD practices. Write tests that verify behavior, not implementation details. Include edge cases and error paths. You must update jest.thresholds.json with the new values after tests pass."
+
+      - name: Enable auto-merge
+        if: inputs.auto_merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr list --head "claude/nightly-test-coverage-" --state open --json url --jq '.[0].url' 2>/dev/null || echo "")
+          if [ -n "$PR_URL" ]; then
+            gh pr merge "$PR_URL" --auto --squash
+            echo "Auto-merge enabled for $PR_URL"
+          else
+            echo "No PR found to auto-merge."
+          fi

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'npm'
         type: string
+      auto_merge:
+        description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
+        required: false
+        default: true
+        type: boolean
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -156,3 +161,16 @@ jobs:
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
             --max-turns 40
             --system-prompt "You are improving test quality. Read CLAUDE.md for project rules. Follow TDD practices. Focus on making tests more robust, not just adding more tests. Prefer behavior testing over implementation testing."
+
+      - name: Enable auto-merge
+        if: inputs.auto_merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr list --head "claude/nightly-test-improvement-" --state open --json url --jq '.[0].url' 2>/dev/null || echo "")
+          if [ -n "$PR_URL" ]; then
+            gh pr merge "$PR_URL" --auto --squash
+            echo "Auto-merge enabled for $PR_URL"
+          else
+            echo "No PR found to auto-merge."
+          fi

--- a/plans/sparkling-stirring-waffle.md
+++ b/plans/sparkling-stirring-waffle.md
@@ -1,0 +1,97 @@
+# Plan: Add `auto_merge` input to PR-creating Claude workflows
+
+## Context
+
+Nightly Claude workflows (test-coverage, code-complexity, test-improvement) and the deploy-auto-fix workflow all create PRs via `gh pr create` in Claude's prompt. Currently these PRs sit open until manually merged. Adding an `auto_merge` input (defaulting to `true`) lets Claude's PRs auto-merge once required status checks pass, reducing manual toil.
+
+## Scope
+
+**4 reusable workflows that create PRs:**
+1. `.github/workflows/reusable-claude-nightly-test-coverage.yml`
+2. `.github/workflows/reusable-claude-nightly-code-complexity.yml`
+3. `.github/workflows/reusable-claude-nightly-test-improvement.yml`
+4. `.github/workflows/reusable-claude-deploy-auto-fix.yml`
+
+**4 downstream caller templates (create-only):**
+1. `typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml`
+2. `typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml`
+3. `typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml`
+4. `typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml`
+
+**Not in scope** (don't create PRs):
+- `reusable-claude-ci-auto-fix.yml` (pushes directly to failing branch)
+- `reusable-claude-code-review-response.yml` (pushes to existing PR branch)
+
+## Approach
+
+### 1. Add `auto_merge` input to each reusable workflow
+
+Add to the `workflow_call.inputs` section of all 4 reusable workflows:
+
+```yaml
+auto_merge:
+  description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
+  required: false
+  default: true
+  type: boolean
+```
+
+### 2. Add auto-merge step after each Claude action step
+
+Add a new step after the Claude Code action in each workflow that finds the PR by branch prefix and enables auto-merge:
+
+```yaml
+- name: Enable auto-merge
+  if: inputs.auto_merge
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    PR_URL=$(gh pr list --head "claude/<branch-prefix>" --state open --json url --jq '.[0].url' 2>/dev/null || echo "")
+    if [ -n "$PR_URL" ]; then
+      gh pr merge "$PR_URL" --auto --squash
+      echo "Auto-merge enabled for $PR_URL"
+    else
+      echo "No PR found to auto-merge."
+    fi
+```
+
+This is better than adding it to Claude's prompt because:
+- It doesn't consume Claude turns
+- It's deterministic (not dependent on Claude following instructions)
+- It's visible in the workflow step logs
+- It fails gracefully if the repo doesn't have auto-merge enabled
+
+### 3. Workflow-specific details
+
+Each workflow uses a different `branch_prefix` for `gh pr list --head`:
+
+| Workflow | Branch prefix |
+|---|---|
+| test-coverage | `claude/nightly-test-coverage-` |
+| code-complexity | `claude/nightly-code-complexity-` |
+| test-improvement | `claude/nightly-test-improvement-` |
+| deploy-auto-fix | `claude/deploy-fix-` |
+
+**Special case: `test-improvement`** has two Claude action steps (nightly mode and general mode). The auto-merge step goes after both, with the same branch prefix since both use `claude/nightly-test-improvement-`.
+
+**Special case: `deploy-auto-fix`** already has a post-step `check-fix` that finds the PR. The auto-merge step should go after that step and can reuse the same `gh pr list` pattern. The `if` condition also needs to include `steps.loop-guard.outputs.skip != 'true'` to match the existing guard.
+
+### 4. Update downstream caller templates
+
+The `auto_merge` input defaults to `true`, so no changes to caller templates are strictly required. However, for visibility, update each caller template to show the input is available (commented out or with an explicit `# auto_merge: true` comment). Since these are create-only files, this only affects newly scaffolded projects.
+
+Actually — since `auto_merge` defaults to `true`, callers don't need to pass it. Leave caller templates unchanged. Projects that want to disable it can add `auto_merge: false` to their `with:` block.
+
+## Files to modify
+
+1. `.github/workflows/reusable-claude-nightly-test-coverage.yml` — add input + auto-merge step
+2. `.github/workflows/reusable-claude-nightly-code-complexity.yml` — add input + auto-merge step
+3. `.github/workflows/reusable-claude-nightly-test-improvement.yml` — add input + auto-merge step
+4. `.github/workflows/reusable-claude-deploy-auto-fix.yml` — add input + auto-merge step
+
+## Verification
+
+1. YAML syntax: validate with `yamllint` or `prettier --check` on changed files
+2. Review the `gh pr list --head` pattern matches the `branch_prefix` in each workflow
+3. Verify the `if` conditions on auto-merge steps correctly gate on `inputs.auto_merge` and any prior step guards
+4. Dry-run: trigger a nightly workflow via `workflow_dispatch` on a test repo to confirm auto-merge is enabled on the created PR


### PR DESCRIPTION
## Summary

- Adds `auto_merge` boolean input (default: `true`) to all 4 reusable workflows that create PRs
- Adds an "Enable auto-merge" step after the Claude action that runs `gh pr merge --auto --squash` on the created PR
- Deploy-auto-fix step additionally gates on `loop-guard` and `check-fix` to avoid running when no PR was created

## Affected workflows

| Workflow | Branch prefix |
|---|---|
| `reusable-claude-nightly-test-coverage` | `claude/nightly-test-coverage-` |
| `reusable-claude-nightly-code-complexity` | `claude/nightly-code-complexity-` |
| `reusable-claude-nightly-test-improvement` | `claude/nightly-test-improvement-` |
| `reusable-claude-deploy-auto-fix` | `claude/deploy-fix-` |

## Design decisions

- Auto-merge is a **deterministic workflow step** rather than a Claude prompt instruction — it doesn't consume Claude turns, is visible in step logs, and fails gracefully if the repo doesn't have auto-merge enabled
- Downstream caller templates are **unchanged** since the input defaults to `true`; projects that want to disable it can add `auto_merge: false` to their `with:` block

## Test plan

- [ ] Verify YAML syntax passes prettier (`prettier --check` on all 4 files — confirmed locally)
- [ ] Verify `gh pr list --head` branch prefixes match the `branch_prefix` in each workflow
- [ ] Trigger a nightly workflow via `workflow_dispatch` on a test repo to confirm auto-merge is enabled on the created PR

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added optional auto-merge capability to automated pull request workflows. Pull requests created by these workflows now automatically merge by default when enabled. Users can disable auto-merge if needed.

## Chores
- Enhanced workflow automation infrastructure across multiple templates to support configurable automatic pull request merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->