### PR TITLE
fix(ci): add persist-credentials: false to Claude workflow checkouts

### DIFF
--- a/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Update all open PR branches
         uses: anthropics/claude-code-action@v1
@@ -70,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Update PR branch
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           ref: ${{ inputs.head_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           ref: ${{ inputs.head_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- Adds `persist-credentials: false` to all `actions/checkout@v6` steps in the 8 reusable Claude workflows
- Fixes CI checks not running when Claude pushes to existing PR branches (e.g., ci-auto-fix, code-review-response, @claude mentions)
- Root cause: `actions/checkout@v6` persists `GITHUB_TOKEN` via `includeIf.gitdir` in an external config file that `configureGitAuth()` doesn't clean, causing pushes to authenticate with `GITHUB_TOKEN` instead of the App token, which suppresses `pull_request: synchronize` events
- No new secrets required — the App token from OIDC exchange becomes the sole auth mechanism

## Test plan
- [ ] Trigger a CI auto-fix workflow and verify CI runs on the pushed commit
- [ ] Trigger a code review response workflow and verify CI runs after Claude pushes fixes
- [ ] Verify @claude mention workflows still trigger CI on push
- [ ] Verify nightly/branch_prefix workflows continue working as before

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security across continuous integration and deployment infrastructure by updating credential handling in multiple automated workflows. These changes improve the platform's security posture by preventing unnecessary credential persistence during build and deployment processes. Existing functionality and workflow capabilities remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->