### PR TITLE
feat(ci): add multi-repo Jira triage workflow

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -233,6 +233,28 @@ Incrementally lowers ESLint code complexity thresholds toward target minimums:
 
 Does not modify the `maxLines` threshold. Skips if all metrics are at/below targets. Prevents duplicate PRs.
 
+### Claude Nightly Jira Triage (`claude-nightly-jira-triage.yml`)
+
+**Triggers**: Cron at 6 AM UTC weekdays, manual dispatch
+
+**Auto-enables**: When Jira credentials are configured (`JIRA_BASE_URL`, `JIRA_USER_EMAIL`, `JIRA_PROJECT_KEY` repository variables and `JIRA_API_TOKEN` secret). No feature flag needed.
+
+Automatically triages untriaged Jira tickets by examining them and posting actionable comments. Supports multi-repo setups where multiple repositories share a single Jira project:
+
+1. Fetches untriaged tickets via JQL using repo-scoped labels (`claude-triaged-<repo-name>`, e.g., `claude-triaged-frontend-v2`). Each repo filters by its own label so every repo triages independently
+2. **Relevance Gating**: Searches the local codebase for code related to the ticket. If no relevant code is found, adds the repo-scoped label and skips -- no noise posted to the ticket
+3. **Cross-repo Awareness**: Reads existing comments on the ticket before posting. If another repo already posted triage findings, only adds supplementary findings from this repo's perspective. All comments are prefixed with the repo name (e.g., `*[frontend-v2] Ambiguity detected*`)
+4. **Ambiguity Detection**: Flags vague language, untestable criteria, undefined terms, and missing scope. Posts a comment per ambiguity with a suggested clarifying question
+5. **Edge Case Analysis**: Searches the codebase for related files, checks git history, and identifies boundary conditions, error handling gaps, and integration risks. Posts a consolidated comment referencing only files in this repo
+6. **Verification Methodology**: For each acceptance criterion, specifies a concrete verification method scoped to what this repo can test (e.g., frontend suggests Playwright tests, backend suggests API curl commands). Posts a structured table comment
+7. Labels the ticket with the repo-scoped label (`claude-triaged-<repo-name>`) so it is not reprocessed by this repo
+
+**Manual dispatch inputs**:
+- `ticket_key`: Triage a specific ticket by key (e.g., `PROJ-123`)
+- `ticket_count`: Number of tickets to process in batch mode (default: 5)
+
+This workflow is read-only — it does not modify code or create PRs. It only reads the codebase and posts Jira comments.
+
 ### Auto-update PR Branches (`auto-update-pr-branches.yml`)
 
 **Triggers**: Push to `main`, `staging`, or `dev`
@@ -474,6 +496,9 @@ Variables are non-sensitive configuration values. Set them in **Settings** > **S
 |----------|-------------|---------|
 | `ENABLE_CLAUDE_NIGHTLY` | Enable nightly Claude workflows | `true` |
 | `ENABLE_CLAUDE_CODE_REVIEW_RESPONSE` | Enable Claude response to CodeRabbit reviews | `true` |
+| `JIRA_BASE_URL` | Jira instance base URL (enables Jira triage workflow) | `https://company.atlassian.net` |
+| `JIRA_USER_EMAIL` | Email associated with the Jira API token | `user@company.com` |
+| `JIRA_PROJECT_KEY` | Jira project key for ticket queries | `PROJ` |
 | `SENTRY_ORG` | Sentry organization slug | `my-company` |
 | `SENTRY_PROJECT` | Sentry project slug | `frontend-app` |
 
@@ -574,6 +599,7 @@ with:
 │   ├── claude-nightly-test-improvement.yml     # Nightly test quality
 │   ├── claude-nightly-test-coverage.yml        # Nightly test coverage
 │   ├── claude-nightly-code-complexity.yml      # Nightly code complexity
+│   ├── claude-nightly-jira-triage.yml         # Nightly Jira ticket triage
 │   ├── auto-update-pr-branches.yml            # Auto-update PRs from base
 │   └── .env.example                            # Secrets template
 ├── k6/

--- a/.github/workflows/claude-nightly-jira-triage.yml
+++ b/.github/workflows/claude-nightly-jira-triage.yml
@@ -1,0 +1,32 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+name: Claude Nightly Jira Triage
+
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      ticket_key:
+        description: 'Specific Jira ticket key to triage (leave empty for batch mode)'
+        required: false
+        type: string
+      ticket_count:
+        description: 'Number of untriaged tickets to process in batch mode'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-jira-triage.yml@main
+    with:
+      ticket_key: ${{ github.event.inputs.ticket_key || '' }}
+      ticket_count: ${{ fromJSON(github.event.inputs.ticket_count || '5') }}
+    secrets: inherit

--- a/.github/workflows/reusable-claude-nightly-jira-triage.yml
+++ b/.github/workflows/reusable-claude-nightly-jira-triage.yml
@@ -1,0 +1,174 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+name: Claude Nightly Jira Triage (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ticket_count:
+        description: 'Number of untriaged tickets to process'
+        required: false
+        default: 5
+        type: number
+      ticket_key:
+        description: 'Specific Jira ticket key to triage (overrides ticket_count)'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: false
+      JIRA_API_TOKEN:
+        required: false
+
+jobs:
+  triage:
+    if: >-
+      vars.JIRA_BASE_URL != '' &&
+      vars.JIRA_USER_EMAIL != '' &&
+      vars.JIRA_PROJECT_KEY != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run Claude Code to triage Jira tickets
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          prompt: |
+            You are a Jira ticket triage agent. Your job is to examine Jira tickets and leave actionable comments covering ambiguity, edge cases, and verification methodology.
+
+            Use the Jira REST API via curl with Basic auth for all Jira interactions:
+              curl -s -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" -H "Content-Type: application/json" "$JIRA_BASE_URL/rest/api/2/..."
+
+            ## Step 0: Determine tickets to triage
+
+            Repository name: "$REPO_NAME" (used for repo-scoped labels and comment headers)
+            Triage label for this repo: "claude-triaged-$REPO_NAME"
+
+            Ticket key input: "${{ inputs.ticket_key }}"
+            Ticket count input: ${{ inputs.ticket_count }}
+
+            If a specific ticket key is provided (non-empty string), use that single ticket.
+            Otherwise, search for untriaged tickets via JQL -- filter by THIS REPO'S label:
+              GET $JIRA_BASE_URL/rest/api/2/search?jql=project="$JIRA_PROJECT_KEY" AND labels NOT IN ("claude-triaged-$REPO_NAME") AND status != Done ORDER BY created DESC&maxResults=${{ inputs.ticket_count }}
+
+            Parse the response with jq to extract ticket keys:
+              echo "$RESPONSE" | jq -r '.issues[].key'
+
+            If no tickets are found, output "No untriaged tickets found." and stop.
+
+            ## Step 1: For each ticket, fetch full details and existing comments
+
+            GET $JIRA_BASE_URL/rest/api/2/issue/{key}
+            GET $JIRA_BASE_URL/rest/api/2/issue/{key}/comment
+
+            Extract: summary, description, acceptance criteria (from description or custom fields), labels, status, linked issues, and all existing comments.
+
+            ## Step 1.5: Relevance check
+
+            Search the LOCAL codebase using Grep and Glob for code related to the ticket's subject matter (keywords from summary, description, component names, API endpoints, etc.).
+
+            If NO relevant code is found in this repo:
+            - Add the repo-scoped label "claude-triaged-$REPO_NAME" (so this ticket is not re-examined by this repo)
+            - Output "Ticket {key} is not relevant to $REPO_NAME -- skipping"
+            - Move to the next ticket
+
+            If relevant code IS found, proceed to the triage phases below.
+
+            ## Step 1.75: Cross-repo awareness
+
+            Parse existing comments for triage headers from OTHER repos (look for patterns like "*[some-repo-name] Ambiguity detected*", "*[some-repo-name] Edge cases*", etc.).
+            Note which phases other repos have already covered and what findings they posted.
+            In subsequent phases:
+            - Do NOT duplicate findings already posted by another repo's triage comments
+            - DO add supplementary findings specific to THIS repo's codebase
+
+            ## Step 2: Phase 1 - Ambiguity Detection
+
+            Examine the ticket summary, description, and acceptance criteria. Look for:
+            - Vague language ("should work properly", "handle edge cases", "improve performance")
+            - Untestable criteria (no measurable outcome defined)
+            - Undefined terms or acronyms not explained in context
+            - Missing scope boundaries (what's included vs excluded)
+            - Implicit assumptions not stated explicitly
+
+            Skip ambiguities already raised by another repo's triage comments.
+
+            For each NEW ambiguity found, POST a comment to the ticket:
+              POST $JIRA_BASE_URL/rest/api/2/issue/{key}/comment
+              Body: {"body": "*[$REPO_NAME] Ambiguity detected (automated triage):* [description of the ambiguity]\n\n*Suggested clarification:* [specific question to resolve it]"}
+
+            Be specific -- every ambiguity must have a concrete clarifying question.
+
+            ## Step 3: Phase 2 - Edge Case Analysis
+
+            Search the codebase using Grep and Glob for files related to the ticket's subject matter.
+            Check git log for recent changes in those areas:
+              git log --oneline -20 -- <relevant-paths>
+
+            Identify:
+            - Boundary conditions (empty inputs, max values, concurrent access)
+            - Error handling gaps in related code
+            - Integration risks with other components
+            - Data migration or backward compatibility concerns
+
+            Reference only files in THIS repo. Acknowledge edge cases from other repos if relevant, but do not duplicate them.
+
+            POST a single consolidated comment listing all NEW edge cases:
+              POST $JIRA_BASE_URL/rest/api/2/issue/{key}/comment
+              Body: {"body": "*[$REPO_NAME] Edge cases identified (automated triage):*\n\n# Edge Case 1: [title]\n[description with code reference]\n\n# Edge Case 2: [title]\n..."}
+
+            Every edge case must reference specific code files or patterns found in the codebase. If no relevant code is found, note that this appears to be a new feature with no existing code to analyze.
+
+            ## Step 4: Phase 3 - Verification Methodology
+
+            For each acceptance criterion, specify a concrete verification method scoped to what THIS repo can test:
+            - UI behavior: Playwright test description with specific assertions
+            - API behavior: curl command with expected response status and body
+            - Data changes: Database query or service call to verify state
+            - Performance: Benchmark description with target metrics
+
+            Verification methods should reflect what THIS repo can test (e.g., frontend repo suggests Playwright tests, backend repo suggests API curl commands). Do not duplicate verification methods already posted by other repos.
+
+            POST a single comment with a structured verification plan:
+              POST $JIRA_BASE_URL/rest/api/2/issue/{key}/comment
+              Body: {"body": "*[$REPO_NAME] Verification methodology (automated triage):*\n\n||Acceptance Criterion||Verification Method||Type||\n|[criterion]|[method]|[UI/API/Data/Performance]|\n..."}
+
+            Every verification method must be specific enough that an automated agent could execute it.
+
+            ## Step 5: Label the ticket
+
+            After all comments are posted, add the repo-scoped label "claude-triaged-$REPO_NAME":
+
+            First GET current labels:
+              GET $JIRA_BASE_URL/rest/api/2/issue/{key}?fields=labels
+
+            Then PUT updated labels (append "claude-triaged-$REPO_NAME" to existing labels):
+              PUT $JIRA_BASE_URL/rest/api/2/issue/{key}
+              Body: {"fields": {"labels": [... existing labels ..., "claude-triaged-$REPO_NAME"]}}
+
+            ## Step 6: Output summary
+
+            After processing all tickets, output a summary:
+            - Total tickets processed
+            - For each ticket: key, summary, relevance (relevant/skipped), number of ambiguities found, number of edge cases found, whether verification methodology was added
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(*)"
+            --max-turns 40
+            --system-prompt "You are a precise Jira ticket triage agent. Multiple repositories may triage the same Jira ticket. Read existing comments before posting to avoid duplication. Prefix all comments with [$REPO_NAME]. Only post findings relevant to the code in THIS repository. Focus on being specific and actionable. Every ambiguity must have a concrete clarifying question. Every edge case must reference code. Every verification method must be executable by an automated agent. Use jq for all JSON construction to ensure proper escaping. Do not modify any code in the repository -- you are read-only."
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ vars.JIRA_USER_EMAIL }}
+          JIRA_PROJECT_KEY: ${{ vars.JIRA_PROJECT_KEY }}
+          REPO_NAME: ${{ github.event.repository.name }}

--- a/plans/compiled-riding-whisper.md
+++ b/plans/compiled-riding-whisper.md
@@ -1,0 +1,122 @@
+# Plan: Multi-Repo Jira Triage Workflow Updates
+
+## Context
+
+The initial implementation of the Claude Nightly Jira Triage workflow used a single `claude-triaged` label. This breaks in multi-repo setups where multiple repositories (e.g., frontend, backend, infrastructure) share a single Jira project -- the first repo to triage would mark the ticket, causing other repos to skip it. Each repo has a unique codebase perspective, and tickets may be relevant to one repo, multiple repos, or none.
+
+This plan updates the already-implemented workflow files to support multi-repo Jira triage.
+
+## Design Decisions
+
+- **Repo-scoped labels**: `claude-triaged-<repo-name>` (e.g., `claude-triaged-frontend-v2`) instead of a single `claude-triaged`. Each repo only filters by its own label via JQL. Repo name comes from `github.event.repository.name` (already available, no new config needed).
+- **Relevance-first gating**: Before any triage work, Claude searches the local codebase for code related to the ticket. If nothing relevant is found, it adds the label and skips -- no noise posted to the ticket.
+- **Cross-repo awareness**: Before posting comments, Claude reads existing comments on the ticket. If another repo already posted triage findings, Claude reads them and posts only additive findings from its own codebase perspective.
+- **Scoped comment headers**: Every comment is prefixed with the repo name so humans can distinguish which repo's analysis produced each finding. E.g., `*[frontend-v2] Ambiguity detected (automated triage):*`
+- **No feature flag** -- auto-enables when Jira auth vars/secrets are configured (`JIRA_BASE_URL`, `JIRA_USER_EMAIL`, `JIRA_PROJECT_KEY`, `JIRA_API_TOKEN`)
+- **Jira REST API via curl** in the Claude prompt (not MCP plugin) -- more portable and avoids MCP auth complexity in CI
+- **Caller templates** in `typescript` and `rails` create-only directories
+- **Jira comments only** for verification methodology (no repo scripts committed)
+- **Cron at 6 AM UTC weekdays** -- continues the staggering pattern (3AM test improvement, 4AM coverage, 5AM complexity)
+
+## Files to Modify
+
+All 4 workflow files and the documentation file already exist from the initial implementation. This plan only modifies them.
+
+### 1. `.github/workflows/reusable-claude-nightly-jira-triage.yml` (MODIFY)
+
+Changes to the reusable workflow:
+
+**New env var**: Add `REPO_NAME: ${{ github.event.repository.name }}` to the Claude Code Action step's `env:` block. This is automatically available from GitHub context -- no new input or config needed.
+
+**Claude prompt changes** (update the prompt passed to the Claude Code Action):
+
+```
+Step 0: Determine tickets to triage
+  - Repository name: "$REPO_NAME" (used for repo-scoped labels and comment headers)
+  - Triage label for this repo: "claude-triaged-$REPO_NAME"
+  - If ticket_key is provided, use it directly
+  - Otherwise, search via JQL -- filter by THIS REPO'S label:
+    project="KEY" AND labels NOT IN ("claude-triaged-$REPO_NAME") AND status != Done ORDER BY created DESC
+
+Step 1: For each ticket, fetch full details + existing comments
+  - GET /rest/api/2/issue/{key}
+  - GET /rest/api/2/issue/{key}/comment  (to read existing triage comments from other repos)
+  - Extract: summary, description, acceptance criteria, labels, existing comments
+
+Step 1.5 (NEW): Relevance check
+  - Search the LOCAL codebase (Grep/Glob) for code related to the ticket's subject
+  - If NO relevant code is found in this repo:
+    - Add the repo-scoped label (so this ticket is not re-examined by this repo)
+    - Output "Ticket {key} is not relevant to {REPO_NAME} -- skipping"
+    - Move to the next ticket
+  - If relevant code IS found, proceed to triage phases
+
+Step 1.75 (NEW): Cross-repo awareness
+  - Parse existing comments for triage headers from OTHER repos (e.g., "[backend-v2]")
+  - Note which phases other repos have already covered
+  - In subsequent phases, do NOT duplicate findings already posted by other repos
+  - DO add supplementary findings specific to THIS repo's codebase
+
+Step 2: Phase 1 - Ambiguity Detection (scoped)
+  - Same analysis as before, but:
+  - Comment header: "*[$REPO_NAME] Ambiguity detected (automated triage):*"
+  - Skip ambiguities already raised by another repo's triage comments
+
+Step 3: Phase 2 - Edge Case Analysis (scoped)
+  - Same analysis, but scoped to THIS repo's codebase
+  - Comment header: "*[$REPO_NAME] Edge cases identified (automated triage):*"
+  - Reference only files in THIS repo
+  - Acknowledge edge cases from other repos if relevant, but don't duplicate
+
+Step 4: Phase 3 - Verification Methodology (scoped)
+  - Same analysis, but scoped to THIS repo's capabilities
+  - Comment header: "*[$REPO_NAME] Verification methodology (automated triage):*"
+  - Verification methods should reflect what THIS repo can test
+    (e.g., frontend repo suggests Playwright tests, backend repo suggests API curl commands)
+
+Step 5: Label ticket with REPO-SCOPED label
+  - Append "claude-triaged-$REPO_NAME" (NOT generic "claude-triaged")
+
+Step 6: Output summary (unchanged)
+```
+
+**System prompt update**: Add instruction about multi-repo awareness: "Multiple repositories may triage the same Jira ticket. Read existing comments before posting to avoid duplication. Prefix all comments with [$REPO_NAME]. Only post findings relevant to the code in THIS repository."
+
+### 2. `.github/workflows/claude-nightly-jira-triage.yml` (NO CHANGES)
+
+Lisa's own caller workflow -- no changes needed. The repo name is derived automatically from `github.event.repository.name`.
+
+### 3. `typescript/create-only/.github/workflows/claude-nightly-jira-triage.yml` (NO CHANGES)
+
+Downstream caller template -- no changes needed.
+
+### 4. `rails/create-only/.github/workflows/claude-nightly-jira-triage.yml` (NO CHANGES)
+
+Same -- no changes needed.
+
+### 5. `.github/GITHUB_ACTIONS.md` (MODIFY)
+
+Update the workflow description section (already added) to mention:
+- Multi-repo support: each repo triages independently using repo-scoped labels
+- Cross-repo awareness: reads existing triage comments to avoid duplicates
+- Relevance gating: skips tickets that don't relate to the repo's codebase
+
+## Reference Files
+
+- `.github/workflows/reusable-claude-nightly-jira-triage.yml` -- the file we're modifying (current implementation)
+- `.github/workflows/create-jira-issue-on-failure.yml` -- Jira REST API auth pattern (curl with Basic auth, `github.event.repository.name` usage at line 128)
+- `.github/workflows/reusable-claude-code-review-response.yml` -- pattern for passing `repo_name` via `github.event.repository.name`
+
+## Verification
+
+1. **Syntax check**: `actionlint` on the modified reusable workflow
+2. **Single-repo test**: Manual dispatch with a known `ticket_key` -- verify:
+   - Relevance check runs (searches codebase)
+   - If relevant: comments are posted with `[lisa]` prefix (since the repo is `lisa`)
+   - Label added is `claude-triaged-lisa` (not generic `claude-triaged`)
+3. **Multi-repo test**: Run from two different repos pointing at the same Jira project:
+   - First repo triages and posts comments with `[repo-1]` prefix
+   - Second repo triages the SAME ticket: reads repo-1's comments, posts only additive `[repo-2]` findings
+   - Both repos add their own repo-scoped labels
+4. **Irrelevant ticket test**: Run against a ticket that has no related code in the repo -- verify it adds the label and skips without posting comments
+5. **Format check**: `prettier --check` on modified files

--- a/rails/create-only/.github/workflows/claude-nightly-jira-triage.yml
+++ b/rails/create-only/.github/workflows/claude-nightly-jira-triage.yml
@@ -1,0 +1,34 @@
+# This file was created by Lisa on first setup.
+# You can customize this file — Lisa will not overwrite it.
+
+name: Claude Nightly Jira Triage
+
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      ticket_key:
+        description: 'Specific Jira ticket key to triage (leave empty for batch mode)'
+        required: false
+        type: string
+      ticket_count:
+        description: 'Number of untriaged tickets to process in batch mode'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-jira-triage.yml@main
+    with:
+      ticket_key: ${{ github.event.inputs.ticket_key || '' }}
+      ticket_count: ${{ fromJSON(github.event.inputs.ticket_count || '5') }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-jira-triage.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-jira-triage.yml
@@ -1,0 +1,34 @@
+# This file was created by Lisa on first setup.
+# You can customize this file — Lisa will not overwrite it.
+
+name: Claude Nightly Jira Triage
+
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      ticket_key:
+        description: 'Specific Jira ticket key to triage (leave empty for batch mode)'
+        required: false
+        type: string
+      ticket_count:
+        description: 'Number of untriaged tickets to process in batch mode'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-jira-triage.yml@main
+    with:
+      ticket_key: ${{ github.event.inputs.ticket_key || '' }}
+      ticket_count: ${{ fromJSON(github.event.inputs.ticket_count || '5') }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds Claude Nightly Jira Triage workflow with multi-repo support using repo-scoped labels (`claude-triaged-<repo-name>`)
- Includes relevance gating (skips tickets with no related code in the repo), cross-repo awareness (reads existing triage comments to avoid duplication), and scoped comment headers (`*[repo-name] ...*`)
- Adds caller workflows for Lisa, TypeScript, and Rails stacks, plus updated GITHUB_ACTIONS.md documentation

## Test plan

- [ ] Validate YAML syntax with `actionlint`
- [ ] Manual dispatch on Lisa repo with a known `SE-` ticket key — verify `[lisa]` prefixed comments and `claude-triaged-lisa` label
- [ ] Manual dispatch on frontend-v2 and backend-v2 against the same ticket — verify cross-repo deduplication
- [ ] Test with an irrelevant ticket — verify it adds label and skips without posting comments

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Jira ticket triage capability powered by Claude AI with both scheduled and manual trigger options
  * Implemented multi-repository support enabling coordinated triage across different projects with automatic relevance detection
  * Added cross-repository awareness to prevent duplicate findings and ensure each repository receives only relevant triage insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->