### PR TITLE
fix(ci): use shell arithmetic for dynamic max-turns calculation

### DIFF
--- a/.github/workflows/reusable-claude-nightly-jira-triage.yml
+++ b/.github/workflows/reusable-claude-nightly-jira-triage.yml
@@ -39,6 +39,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Calculate max turns
+        id: config
+        run: echo "max_turns=$(( ${{ inputs.ticket_count }} * 20 ))" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code to triage Jira tickets
         uses: anthropics/claude-code-action@v1
         with:
@@ -211,7 +215,7 @@ jobs:
             - For each ticket: key, summary, relevance (relevant/skipped), number of ambiguities found, number of edge cases found, whether verification methodology was added
           claude_args: |
             --allowedTools "Read,Glob,Grep,Bash(*)"
-            --max-turns ${{ inputs.ticket_count * 20 }}
+            --max-turns ${{ steps.config.outputs.max_turns }}
             --system-prompt "You are a precise Jira ticket triage agent. Multiple repositories may triage the same Jira ticket. Read existing comments before posting to avoid duplication. Prefix all comments with [$REPO_NAME]. Only post findings relevant to the code in THIS repository. Focus on being specific and actionable. Every ambiguity must have a concrete clarifying question. Every edge case must reference code. Every verification method must be executable by an automated agent. Use jq for all JSON construction to ensure proper escaping. Do not modify any code in the repository -- you are read-only. Always use the Glob and Grep tools for codebase searching -- do not use find or grep via Bash. Do not load or use tools beyond Read, Glob, Grep, and Bash."
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary
- GitHub Actions expressions don't support `*` operator, causing "Unexpected symbol: '*'" parse errors when dispatching the Jira triage workflow
- Adds a shell step using `$(( ))` arithmetic to compute `ticket_count * 20` and passes the result via `GITHUB_OUTPUT`
- References the computed value in `claude_args` via `steps.config.outputs.max_turns`

## Test plan
- [ ] Trigger the Jira triage workflow via `gh workflow run` on frontend-v2 and verify it queues successfully
- [ ] Verify the workflow completes without `error_max_turns`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD workflow automation for better efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->