### PR TITLE
fix(ci): trigger CodeRabbit review on bot-created PRs

### DIFF
--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -203,6 +203,18 @@ jobs:
             echo "Claude did not create a fix PR."
           fi
 
+      - name: Trigger CodeRabbit review
+        if: steps.loop-guard.outputs.skip != 'true' && steps.check-fix.outputs.fixed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.check-fix.outputs.branch }}"
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "@coderabbitai review"
+            echo "Triggered CodeRabbit review on PR #$PR_NUMBER"
+          fi
+
       - name: Enable auto-merge
         if: inputs.auto_merge && steps.loop-guard.outputs.skip != 'true' && steps.check-fix.outputs.fixed == 'true'
         env:

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -170,6 +170,20 @@ jobs:
             --max-turns 40
             --system-prompt "You are reducing code complexity to meet stricter ESLint thresholds. Read CLAUDE.md for project rules. Refactor functions to reduce cognitive complexity and lines per function. Use early returns, extract helpers, and lookup tables. Do NOT modify the maxLines threshold. You must update eslint.thresholds.json with the new values after refactoring passes lint. IMPORTANT: Always use the project's package manager scripts (e.g. bun run lint, bun run test) instead of running binaries from node_modules/.bin/ directly."
 
+      - name: Trigger CodeRabbit review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.claude.outputs.branch_name }}"
+          if [ -z "$BRANCH" ]; then
+            exit 0
+          fi
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "@coderabbitai review"
+            echo "Triggered CodeRabbit review on PR #$PR_NUMBER"
+          fi
+
       - name: Enable auto-merge
         if: inputs.auto_merge
         env:

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -167,6 +167,20 @@ jobs:
             --max-turns 40
             --system-prompt "You are improving test coverage to meet higher thresholds. Read CLAUDE.md for project rules. Follow TDD practices. Write tests that verify behavior, not implementation details. Include edge cases and error paths. You must update jest.thresholds.json with the new values after tests pass."
 
+      - name: Trigger CodeRabbit review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.claude.outputs.branch_name }}"
+          if [ -z "$BRANCH" ]; then
+            exit 0
+          fi
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "@coderabbitai review"
+            echo "Triggered CodeRabbit review on PR #$PR_NUMBER"
+          fi
+
       - name: Enable auto-merge
         if: inputs.auto_merge
         env:

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -165,6 +165,20 @@ jobs:
             --max-turns 40
             --system-prompt "You are improving test quality. Read CLAUDE.md for project rules. Follow TDD practices. Focus on making tests more robust, not just adding more tests. Prefer behavior testing over implementation testing."
 
+      - name: Trigger CodeRabbit review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.claude-nightly.outputs.branch_name || steps.claude-general.outputs.branch_name }}"
+          if [ -z "$BRANCH" ]; then
+            exit 0
+          fi
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "@coderabbitai review"
+            echo "Triggered CodeRabbit review on PR #$PR_NUMBER"
+          fi
+
       - name: Enable auto-merge
         if: inputs.auto_merge
         env:

--- a/plans/dreamy-swinging-squirrel.md
+++ b/plans/dreamy-swinging-squirrel.md
@@ -1,0 +1,33 @@
+# Plan: Create `/jira:triage` skill from CI workflow
+
+## Files to create
+
+- **`plugins/lisa/skills/jira-triage/SKILL.md`** — Skill implementation
+  - Accept `$ARGUMENTS` as ticket URL (`https://...atlassian.net/browse/SE-3979`) or key (`SE-3979`)
+  - Parse ticket key from URL if full URL provided
+  - Fetch ticket details via Atlassian MCP (`mcp__atlassian__getJiraIssue`) or curl fallback
+  - Run same 6-phase triage logic from the workflow (relevance check → ambiguity → edge cases → verification → label → summary)
+  - Use Grep/Glob for local codebase search (not bash grep/find)
+  - Post comments via MCP (`mcp__atlassian__createJiraIssueComment`) or curl with ADF format
+  - Add `claude-triaged-$REPO_NAME` label via MCP or curl
+  - Reference `allowed-tools: ["mcp__atlassian__*", "Bash", "Read", "Glob", "Grep"]`
+  - Reuse cross-repo awareness logic (parse existing triage comments, skip duplicates)
+
+- **`plugins/lisa/commands/jira/triage.md`** — Command pass-through
+  - `argument-hint: "<TICKET-ID-OR-URL>"`
+  - Delegates to `/lisa:jira-triage` skill with `$ARGUMENTS`
+
+## Key differences from CI workflow
+
+- Uses Atlassian MCP tools instead of curl+Basic auth (MCP available locally, not in CI)
+- Operates on a single ticket (no batch search/count mode)
+- `REPO_NAME` derived from current directory's git remote or folder name
+- No `JIRA_BASE_URL`/`JIRA_USER_EMAIL`/`JIRA_API_TOKEN` env vars needed when MCP is configured
+
+## Verification
+
+```bash
+# Confirm files exist and skill is loadable
+cat plugins/lisa/skills/jira-triage/SKILL.md
+cat plugins/lisa/commands/jira/triage.md
+```


### PR DESCRIPTION
## Summary
- CodeRabbit skips reviews on PRs authored by bots (`claude[bot]`), showing "Review skipped - Bot user detected"
- Added a "Trigger CodeRabbit review" step that comments `@coderabbitai review` on the PR after creation, overriding the bot detection
- Applied to all 4 reusable workflows that create PRs: deploy-auto-fix, nightly-code-complexity, nightly-test-coverage, nightly-test-improvement

## Test plan
- [ ] Verify CodeRabbit reviews are triggered on the next bot-created PR from any nightly workflow
- [ ] Confirm no infinite loop with code-review-response (excluded by design — only fires on human-authored PRs)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Jira triage skill for automated ticket analysis and workflow management, enabling efficient ticket processing with MCP integration.

* **Chores**
  * Enhanced CI/CD workflows to automatically trigger code reviews upon successful fix deployments and test improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->