### PR TITLE
feat: add configurable coverage_increment input to nightly test coverage workflow

### DIFF
--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'npm'
         type: string
+      coverage_increment:
+        description: 'Percentage points to increase coverage thresholds per run (lower for large gaps)'
+        required: false
+        default: 5
+        type: number
       auto_merge:
         description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
         required: false
@@ -99,7 +104,7 @@ jobs:
             const global = thresholds.global || {};
             const metrics = ['statements', 'branches', 'functions', 'lines'];
             const target = 90;
-            const increment = 5;
+            const increment = ${{ inputs.coverage_increment }};
 
             const current = {};
             const proposed = {};
@@ -147,7 +152,7 @@ jobs:
             Current coverage thresholds in jest.thresholds.json:
             ${{ steps.thresholds.outputs.current }}
 
-            Proposed new thresholds (each metric increased by 5%, capped at 90%):
+            Proposed new thresholds (each metric increased by ${{ inputs.coverage_increment }}%, capped at 90%):
             ${{ steps.thresholds.outputs.proposed }}
 
             Metrics being bumped: ${{ steps.thresholds.outputs.bumps }}

--- a/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
@@ -17,5 +17,7 @@ permissions:
 jobs:
   improve-coverage:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-coverage.yml@main
+    with:
+      # coverage_increment: 5  # Lower this (e.g., 2) for projects with large coverage gaps
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `coverage_increment` input to the reusable nightly test coverage workflow (defaults to 5)
- Downstream projects can override with a lower value (e.g., 2) for large coverage gaps where 5% is too ambitious for a single nightly run
- Updates the create-only template with a commented-out example

## Test plan

- [ ] Verify YAML is valid
- [ ] PropSwap/frontend PR #476 uses `coverage_increment: 2` against this

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable coverage increment parameter to the test coverage workflow, enabling flexible threshold adjustments.

* **Chores**
  * Updated workflow documentation with configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->