### PR TITLE
fix: prevent TypeScript vitest migration from deleting Jest configs in CDK/Expo stacks

### DIFF
--- a/cdk/deletions.json
+++ b/cdk/deletions.json
@@ -1,0 +1,7 @@
+{
+  "paths": [
+    "vitest.config.ts",
+    "vitest.config.local.ts",
+    "vitest.thresholds.json"
+  ]
+}

--- a/expo/deletions.json
+++ b/expo/deletions.json
@@ -32,7 +32,10 @@
     ".github/workflows/lighthouse.yml",
     ".github/workflows/zap-baseline.yml",
     "eslint-plugin-component-structure",
-    "eslint-plugin-ui-standards"
+    "eslint-plugin-ui-standards",
+    "vitest.config.ts",
+    "vitest.config.local.ts",
+    "vitest.thresholds.json"
   ],
   "keep": [
     ".github/workflows/build.yml",

--- a/typescript/deletions.json
+++ b/typescript/deletions.json
@@ -32,10 +32,7 @@
     ".github/workflows/reusable-claude-deploy-auto-fix.yml",
     ".github/workflows/reusable-claude-nightly-code-complexity.yml",
     ".github/workflows/reusable-claude-nightly-test-coverage.yml",
-    ".github/workflows/reusable-claude-nightly-test-improvement.yml",
-    "jest.config.ts",
-    "jest.config.local.ts",
-    "jest.thresholds.json"
+    ".github/workflows/reusable-claude-nightly-test-improvement.yml"
   ],
   "keep": [
     "eslint-plugin-code-organization",


### PR DESCRIPTION
## Summary
- Remove jest file deletions (`jest.config.ts`, `jest.config.local.ts`, `jest.thresholds.json`) from `typescript/deletions.json` since child stacks (CDK, Expo) still use Jest. NestJS already handles its own jest cleanup via `nestjs/deletions.json`.
- Create `cdk/deletions.json` to clean up vitest files (`vitest.config.ts`, `vitest.config.local.ts`, `vitest.thresholds.json`) that bleed from the TypeScript stack's `copy-overwrite` directory.
- Add vitest file deletions to `expo/deletions.json` for the same reason.

The root cause: when Lisa runs during `postinstall` in CI, it processes the TypeScript stack first (parent), which deletes jest config files. The CDK/Expo stack then copies `jest.config.ts` back, but `jest.config.local.ts` and `jest.thresholds.json` remain deleted. This causes Jest to fall back to defaults, resulting in "Cannot use import statement outside a module" errors in CDK projects and Playwright tests being picked up in Expo projects.

## Test plan
- [x] All 282 Lisa unit tests pass
- [x] All 27 Lisa integration tests pass
- [ ] After merging and publishing, verify CDK project CIs pass (propswap/infrastructure, geminisportsai/infrastructure-v2, thumbwar/infrastructure, qualis/infrastructure)
- [ ] After merging and publishing, verify Expo project CIs pass (propswap/frontend, geminisportsai/frontend-v2, thumbwar/frontend)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file management configuration across multiple project directories to standardize cleanup operations and improve project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->