### PR TITLE
fix: prevent vitest devDependencies and test:watch from bleeding into CDK/Expo

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -8,7 +8,8 @@
       "test": "NODE_ENV=test jest --passWithNoTests",
       "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
-      "test:cov": "NODE_ENV=test jest --coverage"
+      "test:cov": "NODE_ENV=test jest --coverage",
+      "test:watch": "NODE_ENV=test jest --watch"
     },
     "dependencies": {
       "@aws-cdk/aws-amplify-alpha": "^2.235.0-alpha.0",

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -47,7 +47,8 @@
       "test": "NODE_ENV=test jest --passWithNoTests",
       "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
-      "test:cov": "NODE_ENV=test jest --coverage"
+      "test:cov": "NODE_ENV=test jest --coverage",
+      "test:watch": "NODE_ENV=test jest --watch"
     },
     "dependencies": {
       "@apollo/client": "^3.10.8",

--- a/npm-package/package-lisa/package.lisa.json
+++ b/npm-package/package-lisa/package.lisa.json
@@ -3,6 +3,10 @@
     "scripts": {
       "prepublishOnly": "$npm_execpath run build",
       "prepare": "$npm_execpath run build || husky install || true"
+    },
+    "devDependencies": {
+      "vitest": "^4.1.0",
+      "@vitest/coverage-v8": "^4.1.0"
     }
   },
   "defaults": {

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -18,9 +18,7 @@
       "prepare": "node -e \"if (process.env.INIT_CWD && process.env.INIT_CWD.includes('.serverless')) { process.exit(0); }\" && husky install || true"
     },
     "devDependencies": {
-      "@codyswann/lisa": "^1.54.6",
-      "vitest": "^4.1.0",
-      "@vitest/coverage-v8": "^4.1.0"
+      "@codyswann/lisa": "^1.54.6"
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",


### PR DESCRIPTION
## Summary
- Move `vitest` and `@vitest/coverage-v8` devDependencies from `typescript/package.lisa.json` to `npm-package/package.lisa.json` (NestJS already has its own copy)
- Add `test:watch` override to `cdk/package.lisa.json` and `expo/package.lisa.json` to use `jest --watch` instead of the TypeScript base `vitest`

Follow-up to #299. While the first fix prevented jest config deletion, the TypeScript base stack was still adding vitest devDependencies and its vitest-based `test:watch` script to CDK/Expo projects.

## Test plan
- [x] All 282 Lisa unit tests pass
- [x] Build succeeds
- [ ] After merge + publish, verify CDK projects don't get vitest in devDependencies
- [ ] After merge + publish, verify Expo projects don't get vitest in devDependencies

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added watch mode for running tests in CDK and Expo packages.

* **Chores**
  * Updated development dependencies across packages; reorganized testing framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->