### PR TITLE
fix: upstream template fixes from api-creator onboarding

### DIFF
--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -5,7 +5,7 @@ name: Claude CI Auto-Fix
 
 on:
   workflow_run:
-    workflows: ['CI Quality Checks']
+    workflows: ['🔍 CI Quality Checks']
     types: [completed]
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,137 @@
-You take orders from dumb humans who don't know anything about software development. Never assume they know what they're talking about and understand that any action you take for them, you have to be able to prove empirically that you did what they asked. So if the request is not clear enough or you don't know how to empirically prove that you did it, get clarification before starting.
+Requirement Verification:
 
-CRITICAL RULES:
+Never assume the person providing instructions has given you complete, correct, or technically precise requirements. Treat every request as potentially underspecified. Before starting any work:
 
-Always output "I'm tired boss" before starting any task, request or anything else.
-Always figure out the Package manager the project uses: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lockb 2>/dev/null | head -1`
-Always invoke /jsdoc-best-practices skill when writing or reviewing JSDoc documentation to ensure "why" over "what" and proper tag usage
-Always read @package.json without limit or offset to understand what scripts and third party packages are used
-Always regenerate the lockfile (by running the project's package manager install command) after adding, removing, or updating dependencies or devDependencies in package.json
-Always read @eslint.config.ts without limit or offset to understand this project's linting standards
-Always read @.prettierrc.json without limit or offset to understand this project's formatting standards
-Always make atomic commits with clear conventional messages
-Always create clear documentation preambles with JSDoc for new code
-Always update preambles when updating or modifying code
-Always add language specifiers to fenced code blocks in Markdown.
-Always use project-relative paths rather than absolute paths in documentation and Markdown.
-Always ignore build folders (dist, build, etc) unless specified otherwise
-Always delete and remove old code completely - no deprecation needed
-Always add `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5" ` when running `git push`
-Always ignore knip configuration hints (warnings) — only fix actual unused exports/dependencies reported as errors
-Always include plan files as part of a PR unless otherwise specified
+1. Verify the request is specific enough to produce a verifiable outcome. If it is not, stop and ask for clarification.
+2. Verify you can empirically prove the work is done when complete (e.g. a passing test, a working API call, observable behavior in a browser, a log entry). If you cannot define how to prove it, stop and ask for clarification.
+3. If a request contradicts existing code, architecture, or conventions, do not silently comply. Raise the contradiction and confirm intent before proceeding.
 
-Never use "pre-existing" as an excuse not to fix something. It doesn't matter if it was pre-existing or not, they must be fixed.
-Never modify this file (CLAUDE.md) directly. To add a memory or learning, add it to .claude/rules/PROJECT_RULES.md or create a skill with /skill-creator.
-Never commit changes to an environment branch (dev, staging, main) directly. This is enforced by the pre-commit hook.
-Never skip or disable any tests or quality checks.
-Never add .skip to a test unless explicitly asked to
-Never directly modify a file in node_modules/
-Never use --no-verify with git commands.
-Never make assumptions about whether something worked. Test it empirically to confirm.
-Never cover up bugs or issues. Always fix them properly.
-Never write functions or methods unless they are needed.
-Never say "not related to our changes" or "not relevant to this task". Always provide a solution.
-Never create functions or variables with versioned names (processV2, handleNew, ClientOld)
-Never write migration code unless explicitly requested
-Never write unhelpful comments like "removed code"
-Never commit changes to an environment branch (dev, staging, main) directly. This is enforced by the pre-commit hook.
-Never skip or disable any tests or quality checks.
-Never use --no-verify or attempt to bypass a git hook
-Never create placeholders
-Never create TODOs
-Never create versions of files (i.e. V2 or Optimized)
-Never assume test expectations before verifying actual implementation behavior (run tests to learn the behavior, then adjust expectations to match)
-Never duplicate test helper functions without using eslint-disable comments for sonarjs/no-identical-functions when duplication is intentional for test isolation (exception to the general eslint-disable rule below)
-Never add eslint-disable for lint warnings (except sonarjs/no-identical-functions in tests as noted above)
-Never delete anything that isn't tracked in git
-Never delete anything outside of this project's directory
-Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change
-Never stash changes you can't commit. Either fix whatever is prevening the commit or fail out and let the human know why.
-Never lower thresholds for tests to pass a pre-push hook. You must increase test coverage to make it pass
-Never handle tasks yourself when working in a team of agents. Always delegate to a specialied agent.
+DO NOT START WORK if any of the above are unclear. Asking a clarifying question is always cheaper than implementing the wrong thing.
 
-ONLY use eslint-disable as a last resort and confirm with human before doing so
-ONLY use eslint-disable for test file max-lines when comprehensive test coverage requires extensive test cases (must include matching eslint-enable)
-ONLY use eslint-disable functional/no-loop-statements in tests when using loops for test consolidation improves readability over dozens of individual tests
-ONLY use ts-ignore as a last resort and confirm with human before doing so
-ONLY use ts-expect-error as a last resort and confirm with human before doing so
-ONLY use ts-nocheck as a last resort and confirm with human before doing so
+Project Discovery:
+- Determine the project's package manager before installing or running anything.
+- Read the project manifest (e.g. package.json, pyproject.toml, Cargo.toml, go.mod) to understand available scripts and dependencies.
+- Read the project's linting and formatting configuration to understand its standards.
+- Regenerate the lockfile after adding, removing, or updating dependencies.
+- Ignore build output directories (dist, build, out, target, etc) unless specified otherwise.
+- Ignore configuration linter hints/warnings — only fix actual unused exports/dependencies reported as errors.
 
-Never update CHANGELOG
+Code Quality:
+- Make atomic commits with clear conventional commit messages.
+- Create clear documentation preambles for new code. Update preambles when modifying existing code.
+- Document the "why", not the "what". Code explains what it does; documentation explains why it exists.
+- Add language specifiers to fenced code blocks in Markdown.
+- Use project-relative paths rather than absolute paths in documentation and Markdown.
+- Delete old code completely when replacing it. No deprecation unless specifically requested.
+- Fix bugs and issues properly. Never cover them up or work around them.
+- Test empirically to confirm something worked. Never assume.
+- Never assume test expectations before verifying actual implementation behavior. Run tests to learn the behavior, then adjust expectations to match.
+- Always provide a solution. Never dismiss something as "not related to our changes" or "not relevant to this task".
 
+Git Discipline:
+- Prefix git push with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.
+- Never commit directly to an environment branch (dev, staging, main).
+- Never use --no-verify or attempt to bypass a git hook.
+- Never stash changes you cannot commit. Either fix whatever is preventing the commit or fail out and let the human know why.
+- Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change.
+- When opening a PR, watch the PR. If any status checks fail, fix them. For all bot code reviews, if the feedback is valid, implement it and push the change to the PR. Then resolve the feedback. If the feedback is not valid, reply to the feedback explaining why it's not valid and then resolve the feedback. Do this in a loop until the PR is able to be merged and then merge it.
+- When merging a PR into an environment branch (dev, staging, main), watch the resultant deploy until it fully succeeds. If it fails for any reason, fix the failure and then open a new PR with the fix.
+- When referencing a PR in a response, always include the url
+
+Testing Discipline:
+- Never skip or disable any tests or quality checks.
+- Never add skip directives to a test unless explicitly asked to.
+- Never lower thresholds to pass a pre-push hook. Increase test coverage to make it pass.
+- Never duplicate test helper functions without appropriate lint suppression when duplication is intentional for test isolation.
+
+JIRA Discipline:
+- If working on a JIRA issue, make sure the branch you're working on references and is added to the JIRA issue.
+- If working on a JIRA issue, update the issue as you work through it. For example, if working on a Bug Triage, update the issue with your questions/feedback/suggestions.
+
+Agent Behavior:
+- Never handle tasks yourself when working in a team of agents. Always delegate to a specialized agent.
+
+NEVER:
+- Modify this file directly. To add a memory or learning, use the project's rules file or create a skill.
+- Directly modify files inside dependency directories (e.g. node_modules, .venv, vendor, target).
+- Delete anything that is not tracked in git.
+- Delete anything outside of this project's directory.
+- Create placeholder implementations.
+- Create TODOs.
+- Create versioned copies of files or functions (e.g. V2, Optimized, processNew, handleOld).
+- Write migration code unless explicitly requested.
+- Write functions or methods unless they are needed.
+- Write unhelpful comments like "removed code" or "old implementation".
+- Update CHANGELOG.
+
+ASK FIRST:
+- Before adding a lint suppression comment (e.g. eslint-disable, noqa, #[allow(...)], @SuppressWarnings). These should be a last resort.
+- Before adding a type-checking suppression comment (e.g. ts-ignore, ts-expect-error, ts-nocheck, type: ignore).
+- Lint suppression in test files is acceptable without asking only when comprehensive test coverage requires it (e.g. file length limits) or when intentional duplication improves test isolation. Include matching re-enable comments where applicable.
+
+Bug Triage:
+
+1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc). Do not make assumptions. If anything is missing, stop and ask before proceeding.
+2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
+3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
+5. Define the tests you will write to confirm the fix and prevent a regression.
+6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.
+7. If you can verify your fix before deploying to the target environment (e.g. start the app, invoke the API, open a browser, run the process, check logs), do so before deploying.
+8. Define how you will verify the fix beyond a shadow of a doubt (e.g. deploy to the target environment, invoke the API, open a browser, run the process, check logs).
+
+Bug Implementation:
+
+1. Use the output of Bug Triage as your guide. Do not skip triage.
+
+Task Triage:
+
+1. Verify you have all information needed to implement this task (acceptance criteria, design specs, environment information, dependencies, etc). Do not make assumptions. If anything is missing, stop and ask before proceeding.
+2. Verify you have a clear understanding of the expected behavior or outcome when the task is complete. If not, stop and clarify before starting.
+3. Identify all dependencies (other tasks, services, APIs, data) that must be in place before you can complete this task. If any are unresolved, stop and raise them before starting implementation.
+4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this task (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
+5. Define the tests you will write to confirm the task is implemented correctly and prevent regressions.
+6. Define the documentation you will create or update to explain the "how" and "what" behind this task so another developer understands it.
+7. If you can verify your implementation before deploying to the target environment (e.g. start the app, invoke the API, open a browser, run the process, check logs), do so before deploying.
+8. Define how you will verify the task is complete beyond a shadow of a doubt (e.g. deploy to the target environment, invoke the API, open a browser, run the process, check logs).
+
+Task Implementation:
+
+1. Use the output of Task Triage as your guide. Do not skip triage.
+
+Epic Triage:
+
+1. Verify you have all information needed to understand the full scope of this epic (goals, acceptance criteria, impacted systems, design specs, dependencies, etc). Do not make assumptions. If anything is missing, stop and ask before proceeding.
+2. Verify the epic is broken down into concrete, well-scoped bugs, tasks, and/or stories that are each fully triaged. If ambiguities exist, stop and resolve them before breaking it down.
+3. Identify all cross-cutting concerns (auth, performance, security, data migrations, third-party integrations) that need to be addressed across the epic.
+4. Identify all dependencies between tasks within the epic, or on external epics, teams, or services. Determine the correct order of execution.
+5. Verify you have access to the tools, environments, and permissions needed to deploy and verify all tasks within this epic (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before proceeding.
+6. Define the overall test strategy for the epic (unit, integration, end-to-end, load testing).
+7. Define the documentation that will need to be created or updated to cover the full scope of the epic so another developer understands the architecture, design decisions, and implementation.
+8. Define measurable acceptance criteria that confirm the epic is fully complete.
+9. Define how you will verify the epic is fully delivered beyond a shadow of a doubt (e.g. deploy to the target environment, walk through all acceptance criteria end-to-end, confirm all child tasks/stories are closed, confirm no regressions).
+
+Epic Implementation:
+
+1. Use the output of Epic Triage as your guide. Do not skip triage.
+2. Work through each task and/or story in the order defined during triage, respecting dependencies.
+3. Apply the Bug Implementation and Task Implementation processes to each child bug or task, respectively, as you work through them.
+4. Continuously update the epic and its child issues in JIRA as progress is made.
+5. Do not consider the epic complete until all acceptance criteria are verified in the target environment and all child issues are resolved.
+
+Multi-Repository Awareness:
+
+When working in a microservices architecture, the code you need may span multiple repositories. Watch for these signals that you're missing context:
+
+1. Import paths or package references that don't resolve in the current repository
+2. API calls to internal services where you can't find the contract, schema, or handler
+3. Shared libraries, SDKs, or proto/OpenAPI definitions referenced but not present
+4. Environment variables or config referencing service names you don't have code for
+5. Error messages or stack traces pointing to code outside the current repo
+6. JIRA issues or documentation referencing components in other repositories
+
+When you detect any of the above:
+1. Do NOT guess or make assumptions about what the external code does
+2. Identify which repository contains the missing code
+3. Add that repository to your current session before proceeding
+4. If you cannot determine which repository contains the code, ask — do not proceed without it

--- a/expo-upgrade.md
+++ b/expo-upgrade.md
@@ -1,0 +1,205 @@
+# Lisa Changes Required for Expo SDK 55 Upgrade
+
+This document outlines all changes needed in Lisa to support Expo SDK 55 across managed projects.
+
+## Context
+
+Expo SDK 55 upgrades to React Native 0.83 and React 19.2, removes legacy architecture config flags, changes EAS CLI requirements, and introduces a new `/src` directory convention. Lisa must be updated **before** downstream projects can upgrade.
+
+Changelog: <https://expo.dev/changelog/sdk-55>
+
+---
+
+## 1. Update Package Versions (`expo/package-lisa/package.lisa.json`)
+
+### Dependencies (force section)
+
+| Package | Current | SDK 55 Target |
+|---|---|---|
+| `expo` | `~54.0.31` | `~55.0.0` |
+| `expo-application` | `~7.0.8` | `~55.0.0` |
+| `expo-battery` | `~10.0.8` | `~55.0.0` |
+| `expo-build-properties` | `~1.0.10` | `~55.0.0` |
+| `expo-clipboard` | `~8.0.8` | `~55.0.0` |
+| `expo-constants` | `~18.0.13` | `~55.0.0` |
+| `expo-crypto` | `^15.0.8` | `~55.0.0` |
+| `expo-dev-client` | `~6.0.20` | `~55.0.0` |
+| `expo-device` | `~8.0.10` | `~55.0.0` |
+| `expo-font` | `~14.0.10` | `~55.0.0` |
+| `expo-linear-gradient` | `~15.0.8` | `~55.0.0` |
+| `expo-linking` | `~8.0.11` | `~55.0.0` |
+| `expo-localization` | `^17.0.8` | `~55.0.0` |
+| `expo-network` | `~8.0.8` | `~55.0.0` |
+| `expo-notifications` | `~0.32.16` | `~55.0.0` |
+| `expo-router` | `~6.0.21` | `~55.0.0` |
+| `expo-secure-store` | `~15.0.8` | `~55.0.0` |
+| `expo-splash-screen` | `~31.0.13` | `~55.0.0` |
+| `expo-status-bar` | `~3.0.9` | `~55.0.0` |
+| `expo-system-ui` | `~6.0.9` | `~55.0.0` |
+| `expo-updates` | `~29.0.16` | `~55.0.0` |
+| `@expo/metro-runtime` | `~6.1.2` | Check SDK 55 compatible version |
+| `@expo/html-elements` | `^0.12.5` | Check SDK 55 compatible version |
+| `react` | `19.1.0` | `19.2.0` |
+| `react-dom` | `19.1.0` | `19.2.0` |
+| `react-native` | `0.81.4` | `0.83.x` |
+| `react-native-gesture-handler` | `~2.30.0` | Check SDK 55 compatible version |
+| `react-native-reanimated` | `~4.2.1` | Check SDK 55 compatible version |
+| `react-native-screens` | `~4.19.0` | Check SDK 55 compatible version |
+| `react-native-safe-area-context` | `^5.6.2` | Check SDK 55 compatible version |
+| `react-native-keyboard-controller` | `1.20.4` | Check SDK 55 compatible version |
+| `react-native-web` | `^0.21.2` | Check SDK 55 compatible version |
+| `react-native-svg` | `^15.15.1` | Check SDK 55 compatible version |
+| `@react-native-async-storage/async-storage` | `2.2.0` | Check SDK 55 compatible version |
+| `@sentry/react-native` | `7.2.0` | Check RN 0.83 compatible version |
+| `@shopify/flash-list` | `2.0.2` | Check SDK 55 compatible version |
+| `@shopify/react-native-skia` | `2.2.12` | Check SDK 55 compatible version |
+| `nativewind` | `^4.2.1` | Check SDK 55 compatible version |
+| `tailwindcss` | `^3.4.7` | Check SDK 55 compatible version |
+
+### DevDependencies (force section)
+
+| Package | Current | SDK 55 Target |
+|---|---|---|
+| `jest-expo` | `^54.0.12` | `^55.0.0` |
+| `@react-native-community/cli` | `^20.0.2` | Check SDK 55 compatible version |
+| `@react-native-community/cli-platform-android` | `^20.0.2` | Check SDK 55 compatible version |
+| `@react-native-community/cli-platform-ios` | `^20.0.2` | Check SDK 55 compatible version |
+| `@testing-library/react-native` | `^13.0.0` | Check SDK 55 compatible version |
+| `@types/react` | `~19.1.10` | Match React 19.2 types |
+| `@types/react-dom` | `^19.1.7` | Match React 19.2 types |
+
+> **Action**: Run `npx expo install expo@^55.0.0 --fix` in a test project to get the exact compatible versions for all packages, then update the manifest.
+
+---
+
+## 2. Update EAS Publish Scripts
+
+The `eas update` command now **requires** the `--environment` flag. Update all `eas:publish` scripts in the force section:
+
+```json
+{
+  "eas:publish:dev": "eas update --environment dev --non-interactive",
+  "eas:publish:staging": "eas update --environment staging --non-interactive",
+  "eas:publish:production": "eas update --environment production --non-interactive"
+}
+```
+
+The `--channel` flag may be deprecated or may need to be used alongside `--environment`. Verify with `eas update --help` after upgrading EAS CLI.
+
+---
+
+## 3. Support `/src` Directory Convention
+
+SDK 55's default template puts all application source code in `/src/`. Downstream projects (e.g., frontend-v2) will adopt this convention by moving **all** source directories into `src/`:
+
+```
+src/app/          (Expo Router routes)
+src/components/   (shared UI components)
+src/config/       (app configuration)
+src/constants/    (constant values)
+src/features/     (feature modules)
+src/generated/    (GraphQL codegen output)
+src/hooks/        (custom hooks)
+src/lib/          (utility libraries)
+src/providers/    (context providers)
+src/stores/       (state stores)
+src/types/        (TypeScript type definitions)
+src/utils/        (helper functions)
+```
+
+Directories that stay at root: `assets/`, `__mocks__/`, `tests/`, `e2e/`, `scripts/`, `patches/`, `public/`
+
+### Jest Config (`src/configs/jest/expo.ts`) — MUST UPDATE
+
+`collectCoverageFrom` currently references root-level directories:
+
+```typescript
+// Current
+"components/**/*.{ts,tsx}",
+"features/**/*.{ts,tsx}",
+"hooks/**/*.{ts,tsx}",
+// etc.
+
+// After migration
+"src/components/**/*.{ts,tsx}",
+"src/features/**/*.{ts,tsx}",
+"src/hooks/**/*.{ts,tsx}",
+// etc.
+```
+
+**Option A**: Prefix all patterns with `src/` (breaking for projects that haven't migrated).
+
+**Option B**: Use a configurable `sourceRoot` parameter in `getExpoConfig()` that defaults to `""` but can be set to `"src/"`. Projects pass their source root and Lisa generates the right patterns.
+
+**Recommendation**: Option B — backwards-compatible, lets projects migrate on their own schedule.
+
+### ESLint Config (`src/configs/eslint/expo.ts`) — MUST UPDATE
+
+File patterns reference `features/**/components/**`, `components/**`, etc. These need the same `src/` prefix or configurable source root.
+
+### TypeScript Config (`tsconfig/expo.json`)
+
+No changes needed to the base config. Projects update their `tsconfig.local.json` to point `@/*` to `"./src/*"`.
+
+### Babel Config (`expo/create-only/babel.config.js`)
+
+This is a create-only file — Lisa won't overwrite it. But the **template** for new projects should default to `src/`-prefixed aliases. Existing projects update their own `babel.config.js` manually.
+
+### Tailwind Content Paths
+
+Not managed by Lisa (project-level `tailwind.config.js`), but downstream projects will need to update content arrays to scan `src/` directories.
+
+---
+
+## 4. Review Jest Setup (`expo/copy-overwrite/jest.setup.ts`)
+
+Current setup has workarounds for:
+
+- React 19 null-throw during cleanup (GitHub: expo/expo#38046)
+- Jest 30 compatibility with expo-router (GitHub: expo/expo#40184)
+
+**Action**: Check if these issues are resolved in SDK 55 / jest-expo 55. If so, remove the workarounds. If not, verify they still work with the new versions.
+
+---
+
+## 5. Review Metro Workarounds
+
+The frontend-v2 project has a workaround in `metro.config.js` for Symbol serialization when `EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH` is enabled (expo/expo#39431).
+
+**Action**: Check if this is fixed in SDK 55's Metro bundler. If so, the workaround can be removed from downstream projects.
+
+---
+
+## 6. Node.js Version
+
+SDK 55 supports: `^20.19.4`, `^22.13.0`, `^24.3.0`, `^25.0.0`
+
+Current EAS build node version: `22.21.1` (compatible).
+Current `.nvmrc`: managed by Lisa.
+
+**Action**: Verify the `.nvmrc` version Lisa manages is within SDK 55's supported range. Update if needed.
+
+---
+
+## 7. Xcode Version
+
+SDK 55 requires Xcode 26 minimum. EAS Build defaults to Xcode 26.2.
+
+**Action**: Check if `eas.json` templates or build profiles reference a specific Xcode/image version. If so, ensure they target Xcode 26+.
+
+---
+
+## 8. Checklist
+
+- [ ] Update all package versions in `expo/package-lisa/package.lisa.json`
+- [ ] Update `eas:publish` scripts with `--environment` flag
+- [ ] Add configurable `sourceRoot` to Jest config (`src/configs/jest/expo.ts`) for `/src` convention
+- [ ] Add configurable `sourceRoot` to ESLint config (`src/configs/eslint/expo.ts`) for `/src` convention
+- [ ] Update create-only babel template for new projects to default to `src/` aliases
+- [ ] Verify Jest setup workarounds still needed or can be removed
+- [ ] Verify Metro workarounds still needed or can be removed
+- [ ] Verify Node.js version in `.nvmrc` is compatible
+- [ ] Verify Xcode version in EAS build profiles
+- [ ] Run `lisa .` on a test project (both with and without `/src` convention) and verify all managed files are correct
+- [ ] Run full test suite on updated test project
+- [ ] Publish new Lisa version with SDK 55 support

--- a/npm-package/create-only/.github/workflows/publish-to-npm.yml
+++ b/npm-package/create-only/.github/workflows/publish-to-npm.yml
@@ -102,20 +102,6 @@ jobs:
       - name: Update npm for OIDC support
         run: npm install -g npm@latest
 
-      - name: Get OIDC Token for npm
-        id: npm-oidc
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const token = await core.getIDToken('https://registry.npmjs.org');
-            core.setOutput('npm-token', token);
-            core.setSecret(token);
-
-      - name: Configure npm with OIDC Token
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ steps.npm-oidc.outputs.npm-token }}" >> ~/.npmrc
-          npm config set registry https://registry.npmjs.org
-
       - name: Install dependencies
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then

--- a/plans/inherited-singing-cocke.md
+++ b/plans/inherited-singing-cocke.md
@@ -1,0 +1,153 @@
+# Plan: Publish api-creator to npm
+
+## Context
+
+api-creator is a standalone TypeScript CLI tool that reverse-engineers web APIs into typed CLIs. It needs to be published to npm as an open-source package, modeled after Lisa's publishing pipeline (OIDC trusted publishing, standard-version, conventional commits). It is NOT a Lisa-managed project — we're just replicating the publishing pattern.
+
+The unscoped name `api-creator` is already taken on npm. We'll use `@codyswann/api-creator` (same org as `@codyswann/lisa`).
+
+## Files to Modify
+
+- `/Users/cody/workspace/api-creator/package.json` — rename, add metadata, scripts, devDependencies
+- `/Users/cody/workspace/api-creator/src/cli.ts` — dynamic version from package.json
+- `/Users/cody/workspace/api-creator/README.md` — update install command + npm badge
+
+## Files to Create
+
+- `/Users/cody/workspace/api-creator/.versionrc` — standard-version config
+- `/Users/cody/workspace/api-creator/commitlint.config.cjs` — conventional commits
+- `/Users/cody/workspace/api-creator/.husky/commit-msg` — commitlint hook
+- `/Users/cody/workspace/api-creator/.github/workflows/ci.yml` — PR quality checks
+- `/Users/cody/workspace/api-creator/.github/workflows/release.yml` — release + publish pipeline
+
+## Steps
+
+### 1. Update package.json
+
+```json
+{
+  "name": "@codyswann/api-creator",
+  "version": "0.1.0",
+  "description": "Reverse-engineer any web API into a typed CLI by recording real browser traffic",
+  "type": "module",
+  "main": "./dist/cli.js",
+  "bin": {
+    "api-creator": "./bin/api-creator.js"
+  },
+  "files": ["dist", "bin"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CodySwannGT/api-creator.git"
+  },
+  "homepage": "https://github.com/CodySwannGT/api-creator#readme",
+  "bugs": { "url": "https://github.com/CodySwannGT/api-creator/issues" },
+  "author": "Cody Swann",
+  "license": "MIT",
+  "keywords": ["api", "cli", "har", "typescript", "code-generator", "reverse-engineering", "playwright"],
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build",
+    "prepare": "husky install || true"
+  }
+}
+```
+
+Add devDependencies: `standard-version`, `@commitlint/cli`, `@commitlint/config-conventional`, `husky`.
+
+### 2. Fix version sync in src/cli.ts
+
+Replace hardcoded `.version('0.1.0')` with dynamic version read from package.json:
+
+```typescript
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json') as { version: string };
+
+program.version(version);
+```
+
+### 3. Create .versionrc
+
+Same as Lisa's but without the `postbump` script (no plugins to rebuild):
+
+```json
+{
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "hidden": true },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "test", "hidden": true }
+  ],
+  "bumpFiles": [
+    { "filename": "package.json", "type": "json" }
+  ]
+}
+```
+
+### 4. Create commitlint.config.cjs
+
+```javascript
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+};
+```
+
+### 5. Set up husky + commit-msg hook
+
+- Run `npx husky install`
+- Create `.husky/commit-msg` with `npx commitlint --edit $1`
+
+### 6. Create .github/workflows/ci.yml
+
+PR quality checks: build, typecheck, test. Runs on `pull_request`. Uses Node 22 + npm.
+
+### 7. Create .github/workflows/release.yml
+
+Combined release + publish workflow (simpler than Lisa's 3-file approach since this is a small project):
+
+1. **Release job** (on push to main, skip `[skip ci]`):
+   - npm ci, build, test
+   - standard-version to bump, changelog, tag
+   - git push --follow-tags
+2. **Publish job** (needs release, OIDC trusted publishing):
+   - Wait for tag propagation
+   - OIDC token via `actions/github-script@v7`
+   - `npm publish --access public --provenance`
+
+Pattern copied directly from Lisa's `publish-to-npm.yml`.
+
+### 8. Update README.md
+
+- Install command: `npm install -g @codyswann/api-creator`
+- Add npm version badge
+
+## Bootstrap: First Publish
+
+OIDC trusted publishing requires the package to exist on npm first. For the initial publish:
+
+1. Build locally: `npm run build`
+2. Publish manually: `npm publish --access public`
+3. Configure OIDC trusted publishing on npmjs.com:
+   - Package: `@codyswann/api-creator`
+   - Repository: `CodySwannGT/api-creator`
+   - Workflow: `release.yml`
+
+After this one-time setup, all subsequent releases are fully automated via GitHub Actions.
+
+## Verification
+
+1. `npm run build` succeeds
+2. `npm run test` passes (66 tests)
+3. `npm run typecheck` passes
+4. `npm pack --dry-run` shows only dist/, bin/, LICENSE, README.md, package.json
+5. `npx commitlint --from HEAD~1` validates commit messages
+6. Manual `npm publish --access public` succeeds for initial publish
+7. After OIDC setup: push to main triggers automated release + publish

--- a/plans/toasty-singing-donut.md
+++ b/plans/toasty-singing-donut.md
@@ -1,0 +1,234 @@
+# Plan: Fix api-creator Lisa Onboarding (Conform to Standards)
+
+## Context
+
+The initial onboarding (PR #4) took shortcuts: relaxed ESLint rules in `eslint.config.local.ts`, raised thresholds, lowered coverage requirements, modified Lisa-managed files, and skipped conforming the codebase to Lisa standards. This plan corrects all 8 issues the user raised — the project must fully conform to Lisa defaults with zero local overrides.
+
+## Sessions
+
+| Session | Date | Branch |
+|---------|------|--------|
+| Initial onboarding | 2026-03-19 | `chore/lisa-onboarding` |
+| Corrections (this plan) | 2026-03-19 | `chore/lisa-onboarding` (continue) |
+
+---
+
+## Issue 1: Remove `globals: true` from vitest.config.local.ts
+
+All 9 test files already import `describe`, `it`, `expect` from `"vitest"` explicitly. The `globals: true` override is unnecessary.
+
+**File**: `vitest.config.local.ts`
+**Action**: Remove `globals: true`. Keep only `test.include` for the `test/` directory path.
+
+```ts
+const config: ViteUserConfig = {
+  test: {
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+  },
+};
+```
+
+---
+
+## Issue 2: Reset eslint.thresholds.json to Lisa defaults & fix code
+
+**File**: `eslint.thresholds.json`
+**Action**: Reset to `{ "cognitiveComplexity": 10, "maxLines": 300, "maxLinesPerFunction": 75 }`
+
+### Files exceeding maxLines (300)
+
+| File | Current Lines | Action |
+|------|--------------|--------|
+| `src/generator/cli-project-emitter.ts` | 842 | Split into 3 files |
+| `src/generator/client-emitter.ts` | 466 | Split into 2 files |
+| `src/parser/type-inferrer.ts` | 461 | Split into 2 files |
+| `src/runtime/project-runner.ts` | 379 | Split into 2 files |
+| `src/commands/test.ts` | 373 | Split into 2 files |
+
+### Refactoring strategy for cli-project-emitter.ts (842 → 3 files)
+
+- `src/generator/cli-project-emitter.ts` — Keep `emitProjectPackageJson`, `emitProjectTsconfig`, `emitProjectGitignore`, `emitProjectBinEntry`, `emitProjectReadme` + helpers (`singularize`, `camelToKebab`, `kebabToCamel`)
+- `src/generator/auth-emitter.ts` — Extract `emitAuthModule`
+- `src/generator/commands-emitter.ts` — Extract `emitCommandsModule` (split GraphQL vs REST into separate helper functions to reduce cognitive complexity)
+- `src/generator/cli-entrypoint-emitter.ts` — Extract `emitCli` (split auth command generation into helpers)
+
+### Refactoring strategy for client-emitter.ts (466 → 2 files)
+
+- `src/generator/client-emitter.ts` — Keep core client class emission
+- `src/generator/client-method-emitter.ts` — Extract per-method emission logic (GraphQL vs REST)
+
+### Refactoring strategy for type-inferrer.ts (461 → 2 files)
+
+- `src/parser/type-inferrer.ts` — Keep public API (`inferTypes`, `inferRequestTypes`) and top-level `inferTypeFromBodies`
+- `src/parser/property-inferrer.ts` — Extract `inferPropertyDefinition`, `inferArrayProperty`, `mergeObjectShapes`, `mergeScalarTypes` and helpers
+
+### Refactoring strategy for project-runner.ts (379 → 2 files)
+
+- `src/runtime/project-runner.ts` — Keep `registerProjectRunCommands` orchestration
+- `src/runtime/endpoint-command-builder.ts` — Extract `registerEndpointCommand` logic, split GraphQL vs REST handlers
+
+### Refactoring strategy for commands/test.ts (373 → 2 files)
+
+- `src/commands/test.ts` — Keep command registration and high-level flow
+- `src/commands/test-parsers.ts` — Extract `parseEndpoints`, `parseMethods`, `buildTestSource` helpers
+
+### Functions exceeding maxLinesPerFunction (75) and cognitive complexity (10)
+
+After file splits, further decompose large functions:
+- `emitCommandsModule` (343 lines, complexity 94) → extract `emitGraphQLEndpoint()`, `emitRestEndpoint()`, `buildActionHandler()`
+- `emitCli` (208 lines) → extract `emitAuthSetupCommand()`, `emitAuthStatusCommand()`, `emitParseAuthFromInput()`
+- `registerEndpointCommand` (181 lines, complexity 40) → extract `buildGraphQLAction()`, `buildRestAction()`
+- `inferPropertyDefinition` (91 lines, complexity 27) → extract `inferScalarProperty()`, `inferNestedObjectProperty()`, `inferMixedProperty()`
+- `inferArrayProperty` (84 lines) → extract `inferObjectArrayElements()`, `inferPrimitiveArrayElements()`
+
+---
+
+## Issue 3: Use Lisa's .gitignore
+
+**File**: `api-creator/.gitignore`
+**Action**: Replace with Lisa's `all/copy-contents/.gitignore` template (204 lines) + append api-creator-specific entries at the end:
+
+```
+# api-creator specific
+recordings
+generated
+*.har
+airbnb/
+*.auth
+```
+
+Remove the `.claude/memory/` entry (Issue 5). Remove `.lisabak/`, `coverage/`, `.eslintcache` entries (already in Lisa template).
+
+---
+
+## Issue 4: Upstream `coverage` to Lisa's .prettierignore
+
+**File**: `lisa/typescript/copy-overwrite/.prettierignore`
+**Action**: Add `coverage` line to the template so all TypeScript projects benefit.
+
+Do NOT modify api-creator's `.prettierignore` directly (Lisa-managed, copy-overwrite).
+
+---
+
+## Issue 5: Don't gitignore .claude/memory/
+
+Handled in Issue 3 — the line is removed when replacing .gitignore with Lisa template.
+
+---
+
+## Issue 6: Reset vitest.thresholds.json to 70% & add test coverage
+
+**File**: `vitest.thresholds.json`
+**Action**: Reset to `{ "global": { "statements": 70, "branches": 70, "functions": 70, "lines": 70 } }`
+
+Current coverage: 28.66% statements, 24.71% branches, 32.48% functions, 29.31% lines.
+
+### Files needing tests (sorted by impact)
+
+| Directory | Current Coverage | Priority | Strategy |
+|-----------|-----------------|----------|----------|
+| `src/commands/` (6 files) | 0% | High | Mock fs/readline, test command logic |
+| `src/runtime/` (4 files) | 0% | High | Mock fs/child_process, test curl-parser and project-manager |
+| `src/recorder/` (3 files) | 0% | Medium | Mock Playwright, test capture logic |
+| `src/generator/codegen.ts` | 0% | High | Pure function, easy to test |
+| `src/generator/diff-merger.ts` | 0% | High | Mostly pure logic, easy to test |
+| `src/generator/cli-project-emitter.ts` | 0% | High | String generators, easy to snapshot test |
+| `src/parser/har-reader.ts` | 0% | Medium | Mock fs, test parsing logic |
+
+### Test writing approach
+
+1. Start with pure functions that need no mocking (codegen, emitters, diff-merger)
+2. Add tests for parsers with mock data (curl-parser, har-reader)
+3. Add command tests with mocked I/O (commands/*)
+4. Add runtime tests with mocked fs/child_process
+5. Skip recorder tests if possible (Playwright mocking is complex) — coverage may still reach 70% without them if other areas are well-covered
+
+---
+
+## Issue 7: Don't modify knip.json
+
+**File**: `knip.json`
+**Action**: Revert to Lisa default (no `"eslint", "prettier", "knip", "ast-grep"` in `ignoreBinaries`). These binaries are already declared as direct devDependencies in package.json, so knip can resolve them without ignore entries.
+
+Verify that the Lisa postinstall has already reset knip.json to the default. If it has stale edits, let Lisa overwrite it by re-running: `node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check .`
+
+---
+
+## Issue 8: Empty eslint.config.local.ts & fix all errors
+
+**File**: `eslint.config.local.ts`
+**Action**: Reset to empty default:
+
+```ts
+export default [];
+```
+
+Then fix ALL ESLint violations in the codebase. Categories of fixes:
+
+| Rule | Count | Fix Strategy |
+|------|-------|-------------|
+| `functional/no-let` | ~83 | Replace with `const` + ternary, reduce, or restructure |
+| `functional/immutable-data` | ~100+ | Replace `push` with spread, mutation with new objects |
+| `no-param-reassign` | ~10 | Use new const variables instead of reassigning params |
+| `jsdoc/require-jsdoc` | many | Add JSDoc to all exported functions/interfaces |
+| `jsdoc/require-returns` | many | Add `@returns` to JSDoc blocks |
+| `jsdoc/require-description` | many | Add descriptions to JSDoc blocks |
+| `jsdoc/require-param-description` | many | Add descriptions to `@param` tags |
+| `code-organization/enforce-statement-order` | ~31 | Reorder: definitions → side effects → return |
+| `sonarjs/cognitive-complexity` | 6 | Decompose functions (addressed in Issue 2 refactoring) |
+| `sonarjs/prefer-regexp-exec` | ~10 | Replace `.match()` with `RegExp.exec()` |
+| `sonarjs/no-alphabetical-sort` | ~5 | Add `localeCompare` compare function |
+| `sonarjs/slow-regex` | ~5 | Optimize or flag as acceptable (code-gen string literals) |
+| `sonarjs/no-duplicate-string` | ~5 | Extract to named constants |
+| `sonarjs/no-duplicated-branches` | ~2 | Merge identical branches |
+| `sonarjs/reduce-initial-value` | ~1 | Add initial value to reduce calls |
+| `sonarjs/no-nested-template-literals` | ~2 | Extract inner templates to variables |
+
+---
+
+## Execution Order
+
+1. **Upstream .prettierignore** (Issue 4) — Lisa repo change, quick
+2. **Reset eslint.config.local.ts** to empty (Issue 8)
+3. **Reset eslint.thresholds.json** to defaults (Issue 2)
+4. **Reset vitest.config.local.ts** — remove globals (Issue 1)
+5. **Replace .gitignore** with Lisa template + project entries (Issues 3, 5)
+6. **Revert knip.json** to Lisa default (Issue 7)
+7. **Refactor large files** — split files exceeding 300 lines (Issue 2)
+8. **Decompose large functions** — reduce to <75 lines and complexity <10 (Issue 2)
+9. **Fix all ESLint violations** — functional, jsdoc, sonarjs, code-organization (Issue 8)
+10. **Run `bun run format`** to fix any Prettier issues from refactoring
+11. **Add test coverage** to reach 70% (Issue 6)
+12. **Reset vitest.thresholds.json** to 70/70/70/70 (Issue 6)
+13. **Verify all checks pass**: build, typecheck, lint, test, format:check, knip
+14. **Commit, push, watch CI**
+
+## Critical Files
+
+| File | Action |
+|------|--------|
+| `lisa/typescript/copy-overwrite/.prettierignore` | Add `coverage` |
+| `api-creator/eslint.config.local.ts` | Reset to `export default []` |
+| `api-creator/eslint.thresholds.json` | Reset to `{10, 300, 75}` |
+| `api-creator/vitest.config.local.ts` | Remove `globals: true` |
+| `api-creator/vitest.thresholds.json` | Reset to `{70, 70, 70, 70}` |
+| `api-creator/.gitignore` | Replace with Lisa template + project entries |
+| `api-creator/knip.json` | Revert to Lisa default |
+| `api-creator/src/generator/cli-project-emitter.ts` | Split into 4 files |
+| `api-creator/src/generator/client-emitter.ts` | Split into 2 files |
+| `api-creator/src/parser/type-inferrer.ts` | Split into 2 files |
+| `api-creator/src/runtime/project-runner.ts` | Split into 2 files |
+| `api-creator/src/commands/test.ts` | Split into 2 files |
+| `api-creator/test/**` | Add extensive new test files |
+
+## Verification
+
+1. `bun run build` exits 0
+2. `bun run typecheck` exits 0
+3. `bun run lint` exits 0 (no relaxed rules, default thresholds)
+4. `bun run test` exits 0 (all tests pass)
+5. `bun run test:cov` — all coverage ≥70%
+6. `bun run format:check` exits 0
+7. `bun run knip` exits 0
+8. Pre-commit and pre-push hooks pass
+9. CI passes on GitHub Actions

--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "NestJS-specific skills (GraphQL, TypeORM)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/agents/ops-specialist.md
+++ b/plugins/lisa-rails/agents/ops-specialist.md
@@ -1,0 +1,226 @@
+---
+name: ops-specialist
+description: Operations specialist agent for Rails applications deployed with Kamal on ECS Fargate. Manages local Docker Compose, deploys via Kamal, checks CloudWatch logs, monitors Solid Queue jobs, verifies OpenTelemetry traces, manages database operations, and handles secrets/config via AWS SSM and Secrets Manager.
+tools: Read, Grep, Glob, Bash
+skills:
+  - ops-run-local
+  - ops-deploy
+  - ops-check-logs
+  - ops-verify-jobs
+  - ops-verify-telemetry
+---
+
+# Ops Specialist Agent
+
+You are an operations specialist for a Ruby on Rails application deployed with Kamal on AWS ECS Fargate. Your mission is to **run, monitor, deploy, debug, and maintain the application** across local and remote environments. You operate with full operational knowledge embedded in this prompt — you do not need to search for setup instructions.
+
+## Architecture Summary
+
+| Layer | Stack | Key Tech |
+|-------|-------|----------|
+| Application | Ruby on Rails 8 | Propshaft, Importmap, Solid Queue, Solid Cache, Solid Cable |
+| Database | PostgreSQL (multi-database) | Primary, Queue, Cache, Cable databases |
+| Background Jobs | Solid Queue | Database-backed, no Redis dependency |
+| Deployment | Kamal v2 | Docker multi-stage builds, ECS Fargate |
+| Monitoring | OpenTelemetry | CloudWatch Metrics/Logs, AWS X-Ray |
+| Secrets | AWS Secrets Manager + SSM Parameter Store | Per-environment secrets and config |
+| CI/CD | GitHub Actions | Quality checks, auto-deploy on branch push |
+| Security | Brakeman, Bundler Audit, Rack::Attack | Static analysis, dependency audit, rate limiting |
+
+## Project Discovery
+
+On first invocation, discover project-specific values by reading these files:
+
+| Value | Source File | How to Extract |
+|-------|------------|----------------|
+| App name | `config/deploy.yml` | `service:` key |
+| Docker registry | `config/deploy.yml` | `registry:` and `image:` keys |
+| Deploy servers | `config/deploy.yml` | `servers:` section, per-role hosts |
+| Environment URLs | `config/deploy.staging.yml`, `config/deploy.production.yml` | `proxy.host:` or `env.clear.APPLICATION_HOST` |
+| Database config | `config/database.yml` | Multi-database setup (primary, queue, cache, cable) |
+| Solid Queue config | `config/solid_queue.yml` or `config/queue.yml` | Workers, dispatchers, recurring jobs |
+| Background jobs | `app/jobs/` directory | All `ApplicationJob` subclasses |
+| AWS region | `config/deploy.yml` or `.env` files | `AWS_REGION` or inferred from ECS cluster |
+| SSM prefix | `config/deploy.yml` | `env.secret:` entries referencing SSM paths |
+| Health check path | `config/routes.rb` | `get "up" => "rails/health#show"` or custom health route |
+| Docker Compose | `docker-compose.yml` or `compose.yaml` | Local development service definitions |
+| Kamal accessories | `config/deploy.yml` | `accessories:` section (databases, Redis, etc.) |
+| Ruby version | `.ruby-version` | Ruby version string |
+| Bundler scripts | `Gemfile` | Key gems and their versions |
+| Rake tasks | `lib/tasks/` | Custom rake tasks for ops |
+
+## Skills Reference
+
+| Skill | Purpose |
+|-------|---------|
+| `ops-run-local` | Start, stop, restart, or check status of local Docker Compose development environment |
+| `ops-deploy` | Deploy via Kamal or CI/CD branch push to staging or production |
+| `ops-check-logs` | View local Docker Compose logs or remote CloudWatch logs |
+| `ops-verify-jobs` | Verify Solid Queue background jobs are running and healthy |
+| `ops-verify-telemetry` | Verify OpenTelemetry traces are being collected and exported to X-Ray |
+
+## Database Operations
+
+Database operations are handled inline by this agent (no separate skill needed for Rails — the CLI is simpler than TypeORM).
+
+### Migration Status
+
+```bash
+bin/rails db:migrate:status
+```
+
+### Run Pending Migrations
+
+```bash
+bin/rails db:migrate
+```
+
+**For remote environments** (via Kamal):
+
+```bash
+kamal app exec --roles=web "bin/rails db:migrate" -d staging
+```
+
+### Strong Migrations Compliance
+
+```bash
+bin/rails db:migrate 2>&1 | grep -i "strong_migrations"
+```
+
+Check for unsafe migrations before deploying:
+
+```bash
+bundle exec rubocop --only Rails/StrongMigrations db/migrate/
+```
+
+### Multi-Database Health
+
+```bash
+bin/rails runner "
+  ActiveRecord::Base.connected_to(role: :writing) do
+    puts 'Primary: ' + ActiveRecord::Base.connection.execute('SELECT 1').first.values.join
+  end
+  ActiveRecord::Base.connected_to(database: :queue) do
+    puts 'Queue: ' + ActiveRecord::Base.connection.execute('SELECT 1').first.values.join
+  end rescue puts 'Queue: NOT CONFIGURED'
+  ActiveRecord::Base.connected_to(database: :cache) do
+    puts 'Cache: ' + ActiveRecord::Base.connection.execute('SELECT 1').first.values.join
+  end rescue puts 'Cache: NOT CONFIGURED'
+  ActiveRecord::Base.connected_to(database: :cable) do
+    puts 'Cable: ' + ActiveRecord::Base.connection.execute('SELECT 1').first.values.join
+  end rescue puts 'Cable: NOT CONFIGURED'
+"
+```
+
+## Secrets and Config Management
+
+### SSM Parameter Store Lookups
+
+Discover the SSM prefix from `config/deploy.yml` `env.secret:` entries.
+
+```bash
+aws ssm get-parameters-by-path \
+  --path "/{app_name}/{environment}" \
+  --with-decryption \
+  --region {aws-region} \
+  --query 'Parameters[].{Name:Name,Type:Type,LastModified:LastModifiedDate}' \
+  --output table
+```
+
+### Secrets Manager Status
+
+```bash
+aws secretsmanager list-secrets \
+  --region {aws-region} \
+  --filters Key=name,Values="{app_name}" \
+  --query 'SecretList[].{Name:Name,LastChanged:LastChangedDate}' \
+  --output table
+```
+
+### Environment Comparison
+
+Compare secrets between staging and production:
+
+```bash
+diff <(aws ssm get-parameters-by-path --path "/{app_name}/staging" --region {aws-region} --query 'Parameters[].Name' --output text | tr '\t' '\n' | sed "s|/{app_name}/staging/||" | sort) \
+     <(aws ssm get-parameters-by-path --path "/{app_name}/production" --region {aws-region} --query 'Parameters[].Name' --output text | tr '\t' '\n' | sed "s|/{app_name}/production/||" | sort)
+```
+
+## Health Checks
+
+### Local Health Check
+
+```bash
+curl -sf -o /dev/null -w "HTTP %{http_code} in %{time_total}s" http://localhost:3000/up
+```
+
+### Remote Health Check
+
+Discover the application URL from `config/deploy.{environment}.yml` or environment variables:
+
+```bash
+curl -sf -o /dev/null -w "HTTP %{http_code} in %{time_total}s" https://{app_host}/up
+```
+
+### ECS Service Stability
+
+```bash
+aws ecs describe-services \
+  --cluster {cluster-name} \
+  --services {service-name} \
+  --region {aws-region} \
+  --query 'services[0].{Status:status,Running:runningCount,Desired:desiredCount,Deployments:deployments[].{Status:status,Running:runningCount,Desired:desiredCount,Rollout:rolloutState}}' \
+  --output json
+```
+
+### Full Health Check Script
+
+```bash
+check_env() {
+  local ENV=$1
+  local URL=$2
+
+  echo "=== $ENV ==="
+
+  # Rails /up endpoint
+  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$URL/up" 2>/dev/null || echo "000")
+  TIME=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 "$URL/up" 2>/dev/null || echo "timeout")
+  echo "Health: HTTP $STATUS ($TIME s)"
+
+  # Database connectivity (via /up — Rails health check verifies DB by default)
+  BODY=$(curl -sf --max-time 10 "$URL/up" 2>/dev/null || echo "UNREACHABLE")
+  echo "Body:   $BODY"
+  echo ""
+}
+```
+
+## Troubleshooting Quick Reference
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| `port 3000 already in use` | Previous Rails server running | `lsof -ti :3000 \| xargs kill -9` |
+| `docker compose up` fails | Docker Desktop not running | Start Docker Desktop, then retry |
+| `PG::ConnectionBad` | PostgreSQL not running or wrong credentials | Check `docker compose ps` for postgres container; verify `DATABASE_URL` |
+| Kamal deploy hangs | SSH key not added or wrong host | Verify `ssh {host}` works; check `config/deploy.yml` servers |
+| `kamal lock release` needed | Previous deploy interrupted | Run `kamal lock release -d {env}` then retry |
+| Solid Queue jobs stuck | Worker process crashed | Check `docker compose logs worker`; restart worker container |
+| Migrations fail on deploy | Unsafe migration detected by Strong Migrations | Fix the migration per Strong Migrations guidance, then redeploy |
+| `ActiveRecord::NoDatabaseError` | Database not created | `bin/rails db:create` (local) or check ECS task definition env vars |
+| AWS credentials expired | SSO session timed out | `aws sso login --profile {profile}` |
+| ECS tasks keep restarting | Health check failing or OOM | Check CloudWatch logs for the task; verify `/up` returns 200; check memory limits |
+| OpenTelemetry traces missing | Collector not configured or endpoint wrong | Verify `OTEL_EXPORTER_OTLP_ENDPOINT` in environment; check collector sidecar logs |
+| `Bundler::GemNotFound` | Missing `bundle install` after Gemfile change | `bundle install` locally; for deploy, rebuild Docker image |
+
+## Rules
+
+- Always verify empirically — never assume something works because the code looks correct
+- Always discover project-specific values from source files before operations
+- Always check prerequisites (Docker, ports, AWS credentials) before operations
+- Always read `config/deploy.yml` to discover Kamal configuration before deploy operations
+- Never deploy to production without explicit human confirmation
+- Never run destructive database operations (drop, reset, rollback) without explicit human confirmation
+- Always use the correct AWS profile and region for CLI commands (discover from deploy config)
+- Always start Docker Compose services before running Rails commands locally
+- Always check ECS service stability after deployments (running count matches desired count)
+- Always report results in structured tables
+- Always check Strong Migrations compliance before running migrations on remote databases

--- a/plugins/lisa-rails/skills/ops-check-logs/SKILL.md
+++ b/plugins/lisa-rails/skills/ops-check-logs/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: ops-check-logs
+description: Check application logs from local Docker Compose or remote AWS CloudWatch for Rails applications. Supports log tailing, filtering, and error searching.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Ops: Check Logs
+
+View and search logs across local and remote environments.
+
+**Argument**: `$ARGUMENTS` — target and optional filter (e.g., `local`, `local worker`, `staging errors`, `production 500`, `staging slow-queries`)
+
+## Discovery
+
+1. Read `config/deploy.yml` to discover the service name (used in CloudWatch log group naming)
+2. Read `docker-compose.yml` to identify local service names for targeted log viewing
+3. Discover the AWS region from deploy config or environment variables
+
+## Local Logs (Docker Compose)
+
+### All Services
+
+```bash
+docker compose logs --tail=100
+```
+
+### Follow Mode (tail)
+
+```bash
+docker compose logs -f --tail=50
+```
+
+### Specific Service
+
+```bash
+# Rails web server
+docker compose logs --tail=100 web
+
+# Solid Queue worker
+docker compose logs --tail=100 worker
+
+# PostgreSQL
+docker compose logs --tail=100 postgres
+```
+
+### Filter for Errors
+
+```bash
+docker compose logs --tail=500 web 2>&1 | grep -iE "(error|exception|fatal|500)"
+```
+
+### Rails Development Log (if running outside Docker)
+
+```bash
+tail -n 100 log/development.log
+```
+
+### Filter Rails Log for Slow Queries
+
+```bash
+grep -E "SLOW|ms\)" log/development.log | tail -20
+```
+
+## Remote Logs (Kamal)
+
+### Tail Application Logs
+
+```bash
+kamal app logs -d {environment}
+```
+
+### Follow Mode
+
+```bash
+kamal app logs -d {environment} -f
+```
+
+### Specific Role
+
+```bash
+# Web role
+kamal app logs --roles=web -d {environment}
+
+# Worker role (Solid Queue)
+kamal app logs --roles=worker -d {environment}
+```
+
+## Remote Logs (CloudWatch via AWS CLI)
+
+For advanced filtering and historical log access, use the AWS CLI directly.
+
+### Discover Log Groups
+
+```bash
+aws logs describe-log-groups \
+  --region {aws-region} \
+  --query 'logGroups[].logGroupName' \
+  --output text | tr '\t' '\n' | grep -i "{app_name}"
+```
+
+### Filter for Errors (last 30 minutes)
+
+```bash
+aws logs filter-log-events \
+  --region {aws-region} \
+  --log-group-name "{log-group}" \
+  --start-time $(( ($(date +%s) - 1800) * 1000 )) \
+  --filter-pattern "ERROR" \
+  --query 'events[].message' \
+  --output text
+```
+
+### Filter for 500 Errors
+
+```bash
+aws logs filter-log-events \
+  --region {aws-region} \
+  --log-group-name "{log-group}" \
+  --start-time $(( ($(date +%s) - 1800) * 1000 )) \
+  --filter-pattern '"status=500"' \
+  --query 'events[].message' \
+  --output text
+```
+
+### Filter for Slow Requests (> 1 second)
+
+```bash
+aws logs filter-log-events \
+  --region {aws-region} \
+  --log-group-name "{log-group}" \
+  --start-time $(( ($(date +%s) - 3600) * 1000 )) \
+  --filter-pattern '"duration" "1000"' \
+  --query 'events[].message' \
+  --output text
+```
+
+### Tail Live Logs
+
+```bash
+aws logs tail "{log-group}" \
+  --region {aws-region} \
+  --follow \
+  --since 10m
+```
+
+### Specific Time Range
+
+```bash
+aws logs filter-log-events \
+  --region {aws-region} \
+  --log-group-name "{log-group}" \
+  --start-time $(date -d "{start-time}" +%s000) \
+  --end-time $(date -d "{end-time}" +%s000) \
+  --query 'events[].message' \
+  --output text
+```
+
+## ECS Task Logs
+
+For container-level logs (useful when the application fails to start):
+
+```bash
+# List recent tasks
+aws ecs list-tasks \
+  --cluster {cluster-name} \
+  --service-name {service-name} \
+  --region {aws-region} \
+  --query 'taskArns[]' --output text
+
+# Describe a task to find the log stream
+aws ecs describe-tasks \
+  --cluster {cluster-name} \
+  --tasks {task-arn} \
+  --region {aws-region} \
+  --query 'tasks[0].containers[].{Name:name,Status:lastStatus,ExitCode:exitCode}' \
+  --output table
+```
+
+## Output Format
+
+Report log findings as:
+
+| Source | Timestamp | Level | Context | Message |
+|--------|-----------|-------|---------|---------|
+| CloudWatch | 2026-03-18T10:30:00Z | ERROR | web | ActiveRecord::ConnectionTimeoutError |
+| Docker | — | ERROR | worker | SolidQueue::ProcessMissingError |
+| Rails log | — | WARN | N/A | DEPRECATION WARNING: ... |
+
+Include a summary of findings: total errors, warnings, and any patterns observed.

--- a/plugins/lisa-rails/skills/ops-deploy/SKILL.md
+++ b/plugins/lisa-rails/skills/ops-deploy/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ops-deploy
+description: Deploy Rails applications via Kamal or CI/CD branch push to staging or production environments.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Ops: Deploy
+
+Deploy the Rails application to remote environments.
+
+**Argument**: `$ARGUMENTS` — environment (`staging`, `production`) and optional method (`kamal`, `ci`; default: `kamal`)
+
+## Safety
+
+**CRITICAL**: Production deployments require explicit human confirmation before proceeding. Always ask for confirmation when `$ARGUMENTS` contains `production`.
+
+## Discovery
+
+1. Read `config/deploy.yml` to discover the Kamal configuration: service name, registry, image, servers, accessories
+2. Read `config/deploy.staging.yml` and `config/deploy.production.yml` for environment-specific overrides
+3. Verify the specific environment-variable keys needed for the deploy are present in `.env.staging` / `.env.production` (or in SSM) without printing secret values
+4. Read `Dockerfile` to understand the Docker build stages
+
+## CI/CD Path (Preferred)
+
+The standard deployment path is via CI/CD — pushing to environment branches triggers auto-deploy.
+
+```bash
+# Deploy to staging via CI/CD
+git push origin HEAD:staging
+
+# Deploy to production via CI/CD (requires human confirmation first)
+git push origin HEAD:production
+```
+
+Monitor the deployment via GitHub Actions:
+
+```bash
+gh run list --branch {environment} --limit 3
+gh run watch {run-id}
+```
+
+## Kamal Deployment (Manual)
+
+### Pre-Deploy Checks
+
+1. **Verify Kamal is installed**:
+   ```bash
+   kamal version
+   ```
+
+2. **Verify Docker builds locally**:
+   ```bash
+   docker build -t {app_name}:test .
+   ```
+
+3. **Check current deployment state**:
+   ```bash
+   kamal details -d {environment}
+   ```
+
+4. **Check for deploy lock**:
+   ```bash
+   kamal lock status -d {environment}
+   ```
+   If locked from a previous interrupted deploy: `kamal lock release -d {environment}`
+
+### Deploy to Staging
+
+```bash
+kamal deploy -d staging
+```
+
+### Deploy to Production
+
+**Requires explicit human confirmation.**
+
+```bash
+kamal deploy -d production
+```
+
+### Deploy with Specific Git Ref
+
+```bash
+kamal deploy -d {environment} --version {git-sha-or-tag}
+```
+
+### Rollback
+
+If a deploy causes issues, roll back to the previous version:
+
+```bash
+# List available versions
+kamal app containers -d {environment}
+
+# Rollback to previous version
+kamal rollback {previous-version} -d {environment}
+```
+
+## Post-Deploy Verification
+
+After any deployment:
+
+1. **Health check** the deployed environment:
+   ```bash
+   curl -sf -o /dev/null -w "HTTP %{http_code} in %{time_total}s" https://{app_host}/up
+   ```
+
+2. **Verify ECS service stability** (running count matches desired count):
+   ```bash
+   aws ecs describe-services \
+     --cluster {cluster-name} \
+     --services {service-name} \
+     --region {aws-region} \
+     --query 'services[0].{Running:runningCount,Desired:desiredCount,Status:status}' \
+     --output table
+   ```
+
+3. **Check for migration status** (if migrations were included):
+   ```bash
+   kamal app exec --roles=web "bin/rails db:migrate:status" -d {environment}
+   ```
+
+4. **Check logs** for errors in the first 5 minutes (use `ops-check-logs` skill)
+
+5. **Verify Solid Queue workers** are running (use `ops-verify-jobs` skill)
+
+6. **Verify OpenTelemetry traces** are being exported (use `ops-verify-telemetry` skill)
+
+## Kamal Utility Commands
+
+| Command | Purpose |
+|---------|---------|
+| `kamal details -d {env}` | Show current deployment details |
+| `kamal app logs -d {env}` | Tail application logs |
+| `kamal app exec --roles=web "bin/rails console" -d {env}` | Open Rails console on remote |
+| `kamal audit -d {env}` | Show deploy audit log |
+| `kamal env push -d {env}` | Push updated environment variables |
+| `kamal lock status -d {env}` | Check deploy lock status |
+| `kamal lock release -d {env}` | Release a stale deploy lock |
+| `kamal traefik reboot -d {env}` | Restart the Traefik proxy |
+
+## Output Format
+
+Report deployment result as a table:
+
+| Target | Environment | Method | Status | Verification |
+|--------|-------------|--------|--------|-------------|
+| Rails app | staging | Kamal | SUCCESS/FAIL | /up returns 200 |
+| ECS tasks | staging | N/A | STABLE/UNSTABLE | running == desired |
+| Solid Queue | staging | N/A | RUNNING/DOWN | workers have heartbeat |

--- a/plugins/lisa-rails/skills/ops-run-local/SKILL.md
+++ b/plugins/lisa-rails/skills/ops-run-local/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: ops-run-local
+description: Manage the local Docker Compose development environment for Rails applications. Supports start, stop, restart, and status for the full stack or individual services.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Ops: Run Local
+
+Manage the local Docker Compose development environment.
+
+**Argument**: `$ARGUMENTS` — `start`, `stop`, `restart`, `status`, `start-app`, `start-services` (default: `start`)
+
+## Prerequisites (run before any operation)
+
+1. Verify Docker is running:
+   ```bash
+   docker info > /dev/null 2>&1 && echo "Docker OK" || echo "ERROR: Docker is not running — start Docker Desktop"
+   ```
+
+2. Check port availability:
+   ```bash
+   lsof -i :3000 2>/dev/null | grep LISTEN
+   lsof -i :5432 2>/dev/null | grep LISTEN
+   ```
+
+3. Verify Ruby and Bundler are available:
+   ```bash
+   ruby --version && bundle --version
+   ```
+
+## Discovery
+
+Read the project's `docker-compose.yml` (or `compose.yaml`) to identify available services. Common services include:
+
+- `web` or `app` — the Rails application
+- `postgres` or `db` — PostgreSQL database
+- `worker` — Solid Queue background worker
+- `css` — Tailwind CSS watch process
+
+Read `Procfile.dev` if it exists — it defines the local development process manager configuration (typically run via `bin/dev`).
+
+Read `config/database.yml` to understand which databases need to exist locally.
+
+## Operations
+
+### start (full stack)
+
+Start all Docker Compose services and the Rails application.
+
+1. **Start infrastructure services** (PostgreSQL, etc.):
+   ```bash
+   docker compose up -d postgres
+   ```
+
+2. **Wait for PostgreSQL** (up to 30 seconds):
+   ```bash
+   for i in $(seq 1 30); do
+     docker compose exec -T postgres pg_isready -U postgres > /dev/null 2>&1 && echo "PostgreSQL ready" && break
+     sleep 1
+   done
+   ```
+
+3. **Create and migrate databases** (if needed):
+   ```bash
+   bin/rails db:prepare
+   ```
+
+4. **Start the full stack** via `bin/dev` (Procfile.dev) or Docker Compose:
+   ```bash
+   # Option A: Procfile.dev (preferred — starts web, worker, CSS watcher)
+   bin/dev
+   ```
+   Run this in the background using the Bash tool with `run_in_background: true`.
+
+   ```bash
+   # Option B: Docker Compose (if all services are containerized)
+   docker compose up -d
+   ```
+
+5. **Wait for Rails** (up to 60 seconds):
+   ```bash
+   for i in $(seq 1 60); do
+     curl -sf http://localhost:3000/up > /dev/null 2>&1 && echo "Rails ready" && break
+     sleep 1
+   done
+   ```
+
+6. Report status table.
+
+### start-services (infrastructure only)
+
+Start only infrastructure services (database, cache) without the Rails app.
+
+```bash
+docker compose up -d postgres
+```
+
+Wait for readiness:
+```bash
+for i in $(seq 1 30); do
+  docker compose exec -T postgres pg_isready -U postgres > /dev/null 2>&1 && echo "PostgreSQL ready" && break
+  sleep 1
+done
+```
+
+### start-app (Rails app only, assumes services are running)
+
+```bash
+bin/dev
+```
+
+Run in background. Verify:
+```bash
+for i in $(seq 1 60); do
+  curl -sf http://localhost:3000/up > /dev/null 2>&1 && echo "Rails ready" && break
+  sleep 1
+done
+```
+
+### stop
+
+Stop all local services.
+
+```bash
+# Stop Rails processes (bin/dev uses foreman which spawns child processes)
+lsof -ti :3000 | xargs kill -9 2>/dev/null || echo "No Rails process on :3000"
+
+# Stop Docker Compose services
+docker compose down
+```
+
+### restart
+
+1. Run **stop** (above).
+2. Wait 2 seconds: `sleep 2`
+3. Run **start** (above).
+4. Verify all services respond.
+
+### status
+
+Check what is currently running and responsive.
+
+```bash
+echo "=== Port Check ==="
+echo -n "Rails    :3000 — "; lsof -i :3000 2>/dev/null | grep LISTEN > /dev/null && echo "LISTENING" || echo "NOT LISTENING"
+echo -n "Postgres :5432 — "; lsof -i :5432 2>/dev/null | grep LISTEN > /dev/null && echo "LISTENING" || echo "NOT LISTENING"
+
+echo ""
+echo "=== Health Check ==="
+echo -n "Rails /up — "; curl -sf -o /dev/null -w "HTTP %{http_code} in %{time_total}s" http://localhost:3000/up 2>/dev/null || echo "UNREACHABLE"
+
+echo ""
+echo "=== Docker Compose ==="
+docker compose ps 2>/dev/null || echo "No Docker Compose services running"
+
+echo ""
+echo "=== Solid Queue Worker ==="
+bin/rails runner "puts SolidQueue::Process.where('last_heartbeat_at > ?', 5.minutes.ago).count.to_s + ' active workers'" 2>/dev/null || echo "Cannot query Solid Queue (app may not be running)"
+```
+
+Report results as a table:
+
+| Service | Port | Listening | Responsive |
+|---------|------|-----------|------------|
+| Rails (web) | 3000 | YES/NO | YES/NO |
+| PostgreSQL | 5432 | YES/NO | N/A |
+| Solid Queue worker | N/A | N/A | YES/NO (heartbeat) |

--- a/plugins/lisa-rails/skills/ops-verify-jobs/SKILL.md
+++ b/plugins/lisa-rails/skills/ops-verify-jobs/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: ops-verify-jobs
+description: Verify Solid Queue background jobs are running in Rails applications. Check worker health, queue depth, failed jobs, recurring job execution, and retry stuck jobs.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Ops: Verify Jobs
+
+Verify Solid Queue background jobs are running and healthy.
+
+**Argument**: `$ARGUMENTS` — operation (`status`, `failed`, `retry`, `recurring`, `depth`; default: `status`)
+
+## Discovery
+
+1. Read `config/solid_queue.yml` (or `config/queue.yml`) to understand the worker and dispatcher configuration
+2. Read `app/jobs/` directory to discover all job classes
+3. Read `config/recurring.yml` (if it exists) to discover scheduled/recurring jobs
+
+## Prerequisites
+
+The Rails application must be running (locally or remotely) for database-backed queries to work.
+
+## Operations
+
+### status (overall health)
+
+Check Solid Queue process health via database heartbeats:
+
+```bash
+bin/rails runner "
+  processes = SolidQueue::Process.all
+  puts '=== Solid Queue Processes ==='
+  processes.each do |p|
+    stale = p.last_heartbeat_at < 5.minutes.ago ? 'STALE' : 'OK'
+    puts \"#{p.kind} | PID #{p.pid} | #{p.hostname} | Last heartbeat: #{p.last_heartbeat_at} | #{stale}\"
+  end
+  puts ''
+  puts \"Total: #{processes.count} processes\"
+  puts \"Healthy: #{processes.select { |p| p.last_heartbeat_at > 5.minutes.ago }.count}\"
+  puts \"Stale: #{processes.select { |p| p.last_heartbeat_at <= 5.minutes.ago }.count}\"
+"
+```
+
+### depth (queue depth by queue name)
+
+```bash
+bin/rails runner "
+  puts '=== Queue Depth ==='
+  SolidQueue::Job.where(finished_at: nil).group(:queue_name).count.each do |queue, count|
+    puts \"#{queue}: #{count} pending\"
+  end
+  puts ''
+  total = SolidQueue::Job.where(finished_at: nil).count
+  puts \"Total pending: #{total}\"
+"
+```
+
+### failed (list failed jobs)
+
+```bash
+bin/rails runner "
+  failed = SolidQueue::FailedExecution.includes(:job).order(created_at: :desc).limit(20)
+  puts '=== Failed Jobs ==='
+  failed.each do |f|
+    puts \"#{f.job.class_name} | Queue: #{f.job.queue_name} | Failed at: #{f.created_at} | Error: #{f.error.to_s.truncate(120)}\"
+  end
+  puts ''
+  puts \"Total failed: #{SolidQueue::FailedExecution.count}\"
+"
+```
+
+### retry (retry failed jobs)
+
+Retry all failed jobs:
+
+```bash
+bin/rails runner "
+  count = SolidQueue::FailedExecution.count
+  SolidQueue::FailedExecution.find_each do |fe|
+    fe.retry
+  end
+  puts \"Retried #{count} failed jobs\"
+"
+```
+
+Retry a specific job class:
+
+```bash
+bin/rails runner "
+  failed = SolidQueue::FailedExecution.includes(:job).where(solid_queue_jobs: { class_name: '{JobClassName}' })
+  count = failed.count
+  failed.find_each { |fe| fe.retry }
+  puts \"Retried #{count} #{'{JobClassName}'} jobs\"
+"
+```
+
+### recurring (check recurring job schedule)
+
+```bash
+bin/rails runner "
+  puts '=== Recurring Tasks ==='
+  SolidQueue::RecurringTask.all.each do |task|
+    last_run = SolidQueue::Job.where(class_name: task.class_name).order(created_at: :desc).first
+    last_run_at = last_run&.created_at || 'NEVER'
+    puts \"#{task.key} | #{task.class_name} | Schedule: #{task.schedule} | Last run: #{last_run_at}\"
+  end
+" 2>/dev/null || echo "RecurringTask not available — check config/recurring.yml"
+```
+
+## Remote Verification (via Kamal)
+
+For checking jobs in staging/production environments:
+
+```bash
+kamal app exec --roles=web "bin/rails runner \"
+  processes = SolidQueue::Process.all
+  healthy = processes.select { |p| p.last_heartbeat_at > 5.minutes.ago }.count
+  stale = processes.select { |p| p.last_heartbeat_at <= 5.minutes.ago }.count
+  failed = SolidQueue::FailedExecution.count
+  pending = SolidQueue::Job.where(finished_at: nil).count
+  puts \\\"Processes: #{processes.count} (#{healthy} healthy, #{stale} stale)\\\"
+  puts \\\"Pending jobs: #{pending}\\\"
+  puts \\\"Failed jobs: #{failed}\\\"
+\"" -d {environment}
+```
+
+## Output Format
+
+### Process Status
+
+| Kind | PID | Hostname | Last Heartbeat | Status |
+|------|-----|----------|---------------|--------|
+| Worker | 12345 | web-1 | 30s ago | OK |
+| Dispatcher | 12346 | web-1 | 15s ago | OK |
+
+### Queue Depth
+
+| Queue | Pending | Status |
+|-------|---------|--------|
+| default | 3 | OK |
+| mailers | 0 | OK |
+| low_priority | 150 | WARN (> 100) |
+
+### Failed Jobs
+
+| Job Class | Queue | Failed At | Error (truncated) |
+|-----------|-------|-----------|-------------------|
+| SendEmailJob | mailers | 5m ago | Net::SMTPAuthenticationError |
+| ProcessPaymentJob | default | 1h ago | Stripe::CardError |
+
+Flag concerns:
+- Any stale process (heartbeat > 5 minutes ago)
+- Queue depth > 100 pending jobs
+- Any failed jobs in the last hour
+- Recurring jobs that missed their schedule

--- a/plugins/lisa-rails/skills/ops-verify-telemetry/SKILL.md
+++ b/plugins/lisa-rails/skills/ops-verify-telemetry/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: ops-verify-telemetry
+description: Verify OpenTelemetry traces are being collected and exported to AWS X-Ray for Rails applications. Check collector health, trace export, and CloudWatch metrics.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Ops: Verify Telemetry
+
+Verify OpenTelemetry traces are being collected and exported to X-Ray.
+
+**Argument**: `$ARGUMENTS` — check type (`traces`, `metrics`, `all`; default: `all`)
+
+## Discovery
+
+1. Read `Gemfile` for OpenTelemetry gem configuration:
+   - `opentelemetry-sdk`
+   - `opentelemetry-exporter-otlp`
+   - `opentelemetry-instrumentation-all` (or individual instrumentation gems)
+2. Read `config/initializers/opentelemetry.rb` (or similar) for SDK configuration
+3. Read `config/deploy.yml` or environment files for `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME`
+4. Read `docker-compose.yml` for OpenTelemetry Collector sidecar configuration (if present)
+
+## Local Verification
+
+### Check OpenTelemetry Gems
+
+```bash
+bundle list | grep -i opentelemetry
+```
+
+### Check OpenTelemetry Configuration
+
+```bash
+grep -r "OpenTelemetry" config/initializers/ app/
+```
+
+### Verify OTLP Endpoint is Set
+
+```bash
+echo "OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-not set}"
+echo "OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-not set}"
+```
+
+### Generate a Test Trace (local)
+
+Make a request to the local app and check that traces are produced:
+
+```bash
+# Make a request that should generate a trace
+curl -sf http://localhost:3000/up -w "\nHTTP %{http_code}\n"
+
+# Check Rails logs for OpenTelemetry output (if configured to log)
+grep -i "otel\|opentelemetry\|trace_id" log/development.log | tail -10
+```
+
+### Check Collector Sidecar (if using Docker Compose)
+
+```bash
+docker compose logs otel-collector 2>/dev/null | tail -20 || echo "No otel-collector service in Docker Compose"
+```
+
+## Remote Verification (AWS X-Ray)
+
+### Check Recent Traces
+
+```bash
+aws xray get-trace-summaries \
+  --region {aws-region} \
+  --start-time $(ruby -r time -e 'puts (Time.now.utc - 30 * 60).iso8601') \
+  --end-time $(ruby -r time -e 'puts Time.now.utc.iso8601') \
+  --query 'TraceSummaries | length(@)' \
+  --output text
+```
+
+### Check Traces for the Application Service
+
+```bash
+aws xray get-trace-summaries \
+  --region {aws-region} \
+  --start-time $(ruby -r time -e 'puts (Time.now.utc - 30 * 60).iso8601') \
+  --end-time $(ruby -r time -e 'puts Time.now.utc.iso8601') \
+  --filter-expression "service(\"{service-name}\")" \
+  --query 'TraceSummaries[:10].{TraceId:Id,Duration:Duration,StatusCode:Http.HttpStatus,URL:Http.HttpURL,ResponseTime:ResponseTime}' \
+  --output table
+```
+
+### Check for Error Traces
+
+```bash
+aws xray get-trace-summaries \
+  --region {aws-region} \
+  --start-time $(ruby -r time -e 'puts (Time.now.utc - 3600).iso8601') \
+  --end-time $(ruby -r time -e 'puts Time.now.utc.iso8601') \
+  --filter-expression "service(\"{service-name}\") AND fault = true" \
+  --query 'TraceSummaries[:10].{TraceId:Id,Duration:Duration,StatusCode:Http.HttpStatus,URL:Http.HttpURL}' \
+  --output table
+```
+
+### Get Detailed Trace
+
+```bash
+aws xray batch-get-traces \
+  --region {aws-region} \
+  --trace-ids "{trace-id}" \
+  --query 'Traces[0].Segments[].Document' \
+  --output text | jq '.'
+```
+
+### Check X-Ray Service Map
+
+```bash
+aws xray get-service-graph \
+  --region {aws-region} \
+  --start-time $(ruby -r time -e 'puts (Time.now.utc - 3600).iso8601') \
+  --end-time $(ruby -r time -e 'puts Time.now.utc.iso8601') \
+  --query 'Services[].{Name:Name,Type:Type,Edges:Edges[].{Ref:ReferenceId,Latency:ResponseTimeHistogram[0].Average}}' \
+  --output table
+```
+
+## CloudWatch Metrics Verification
+
+### Check Custom Metrics Published by the Application
+
+```bash
+aws cloudwatch list-metrics \
+  --region {aws-region} \
+  --namespace "{app_name}" \
+  --query 'Metrics[].{MetricName:MetricName,Dimensions:Dimensions[].{Name:Name,Value:Value}}' \
+  --output table
+```
+
+### Check Recent Metric Data Points
+
+```bash
+aws cloudwatch get-metric-statistics \
+  --region {aws-region} \
+  --namespace "{app_name}" \
+  --metric-name "{metric-name}" \
+  --start-time $(ruby -r time -e 'puts (Time.now.utc - 3600).iso8601') \
+  --end-time $(ruby -r time -e 'puts Time.now.utc.iso8601') \
+  --period 300 \
+  --statistics Average Sum \
+  --output table
+```
+
+### Check CloudWatch Alarms
+
+```bash
+aws cloudwatch describe-alarms \
+  --region {aws-region} \
+  --alarm-name-prefix "{app_name}" \
+  --query 'MetricAlarms[].{Name:AlarmName,State:StateValue,Metric:MetricName,Threshold:Threshold}' \
+  --output table
+```
+
+## Remote Verification (via Kamal)
+
+For checking telemetry configuration in deployed environments:
+
+```bash
+kamal app exec --roles=web "bin/rails runner \"
+  puts 'OTEL_EXPORTER_OTLP_ENDPOINT: ' + ENV.fetch('OTEL_EXPORTER_OTLP_ENDPOINT', 'NOT SET')
+  puts 'OTEL_SERVICE_NAME: ' + ENV.fetch('OTEL_SERVICE_NAME', 'NOT SET')
+  puts 'OTEL_TRACES_EXPORTER: ' + ENV.fetch('OTEL_TRACES_EXPORTER', 'NOT SET')
+\"" -d {environment}
+```
+
+## Output Format
+
+### Trace Summary
+
+| Check | Status | Details |
+|-------|--------|---------|
+| OTel gems installed | OK/FAIL | opentelemetry-sdk v1.x.x |
+| OTel initializer present | OK/FAIL | config/initializers/opentelemetry.rb |
+| OTLP endpoint configured | OK/FAIL | https://otel-collector:4318 |
+| Traces in X-Ray (last 30m) | OK/FAIL | 245 traces found |
+| Error traces (last 1h) | OK/WARN | 3 fault traces |
+| CloudWatch metrics | OK/FAIL | 12 custom metrics published |
+| CloudWatch alarms | OK/WARN | 1 alarm in ALARM state |
+
+### Recent Traces
+
+| Trace ID | Duration | Status | URL |
+|----------|----------|--------|-----|
+| 1-abc123 | 45ms | 200 | GET /up |
+| 1-def456 | 120ms | 200 | GET /api/v1/users |
+| 1-ghi789 | 2300ms | 500 | POST /api/v1/orders |
+
+Flag concerns:
+- No traces found in the last 30 minutes
+- Error rate above 5% of total traces
+- Average trace duration above 1 second
+- OTLP endpoint not configured
+- CloudWatch alarms in ALARM state

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "1.64.0",
+  "version": "1.65.3",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/typescript/copy-overwrite/.prettierignore
+++ b/typescript/copy-overwrite/.prettierignore
@@ -22,3 +22,4 @@ src/graphql-generated
 *.mdx
 *.sh
 *.json
+coverage

--- a/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
@@ -5,7 +5,7 @@ name: Claude CI Auto-Fix
 
 on:
   workflow_run:
-    workflows: ['CI Quality Checks']
+    workflows: ['🔍 CI Quality Checks']
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary

- Add `coverage` to `typescript/copy-overwrite/.prettierignore` so all TypeScript projects ignore coverage dirs in Prettier
- Fix `claude-ci-auto-fix.yml` workflow trigger to match renamed `'🔍 CI Quality Checks'` workflow name (Lisa's own + typescript create-only template)
- Remove broken manual OIDC token wiring from `npm-package/create-only/publish-to-npm.yml` — npm CLI v11.5.1+ handles the exchange automatically via `npm publish --provenance`
- Includes previously uncommitted work: CLAUDE.md updates, plugin.json versions, rails ops skills/agents, expo-upgrade notes, plans

## Test plan

- [ ] Verify `coverage` is in `.prettierignore` after running Lisa on a TypeScript project
- [ ] Verify `claude-ci-auto-fix.yml` triggers correctly when CI runs complete
- [ ] Verify npm publish still works with OIDC (no manual token wiring)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operational tooling for Rails applications including deployment, log checking, job verification, and telemetry monitoring capabilities.

* **Documentation**
  * Added Expo SDK 55 upgrade guide with migration steps.
  * Added npm package publishing plan with CI/CD automation.
  * Added Rails operations agent specification and related skill guides.
  * Reorganized and expanded agent guidelines documentation.

* **Chores**
  * Updated plugin versions to 1.65.3.
  * Updated workflow trigger references.
  * Simplified npm publishing workflow by removing manual token configuration.
  * Added coverage directory to ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->