### PR TITLE
fix: test:integration pattern for nestjs and typescript template defaults

### DIFF
--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -33,7 +33,7 @@
       "security:zap": "bash scripts/zap-baseline.sh",
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
-      "test:integration": "vitest run tests/integration --passWithNoTests",
+      "test:integration": "vitest run '.integration.' --passWithNoTests",
       "test:cov": "vitest run --coverage",
       "test:watch": "vitest"
     },

--- a/plugins/src/base/agents/verification-specialist.md
+++ b/plugins/src/base/agents/verification-specialist.md
@@ -8,7 +8,7 @@ tools: Read, Write, Edit, Bash, Grep, Glob
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verfication.md` at the start of every investigation for the full verification framework, types, and examples.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and examples.
 
 ## Core Philosophy
 

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -6,7 +6,6 @@
       "format": "prettier --check . --write",
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
-      "test:integration": "vitest run tests/integration --passWithNoTests",
       "test:cov": "vitest run --coverage",
       "test:watch": "vitest",
       "lint:fix": "eslint . --fix",
@@ -32,7 +31,8 @@
   "defaults": {
     "scripts": {
       "build": "tsc",
-      "postinstall": "node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true"
+      "postinstall": "node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true",
+      "test:integration": "vitest run tests/integration --passWithNoTests"
     },
     "engines": {
       "npm": "please-use-bun",


### PR DESCRIPTION
## Summary
- **NestJS template**: Changed `test:integration` from `vitest run tests/integration --passWithNoTests` to `vitest run '.integration.' --passWithNoTests` since NestJS projects colocate integration tests as `*.integration.test.ts` under `src/`, not in a separate `tests/integration/` directory
- **TypeScript template**: Moved `test:integration` from `force` to `defaults` so projects with custom scripts (like PropSwap after switching from NestJS) keep their existing `test:integration` script
- **verification-specialist**: Fixed typo (verfication -> verification)

## Test plan
- [x] All 292 unit tests pass
- [x] All 27 integration tests pass
- [x] Lint, typecheck, knip all pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test script patterns and reorganized test configurations across project setups for improved consistency in development workflows.

* **Documentation**
  * Corrected a file path reference in verification framework documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->