### PR TITLE
fix: exclude test files from typescript tsconfig template

### DIFF
--- a/typescript/copy-overwrite/tsconfig.json
+++ b/typescript/copy-overwrite/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": "./"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", ".build", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Add `**/*.test.ts` and `**/*.spec.ts` to `exclude` in the TypeScript template's `tsconfig.json`
- Aligns with the NestJS template which already excludes test files
- Without this, projects switching from NestJS to TypeScript type get typecheck errors in test files that were previously excluded

## Test plan
- [x] All 292 unit tests pass
- [x] All 27 integration tests pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation configuration to refine build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->