### PR TITLE
fix: use glob pattern for coverage directory in eslint ignore

### DIFF
--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -33,6 +33,7 @@
     ".claude-active-project/**",
     ".claude-active-plan/**",
     "coverage/**",
+    "**/coverage/**",
     "**/*spec.ts",
     "resolver-test.setup.ts",
     "**/*.factory.ts",


### PR DESCRIPTION
## Summary
- Add `**/coverage/**` to eslint ignore config to catch coverage directories at any depth (e.g., `src/coverage/` from vitest coverage output)

## Test plan
- [x] All tests pass

🤖 Generated with Claude Code