### PR TITLE
feat: add impeccable design plugin to expo and rails templates

### DIFF
--- a/expo/merge/.claude/settings.json
+++ b/expo/merge/.claude/settings.json
@@ -12,13 +12,20 @@
     "coderabbit@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
     "posthog@claude-plugins-official": true,
-    "lisa-expo@lisa": true
+    "lisa-expo@lisa": true,
+    "impeccable@impeccable": true
   },
   "extraKnownMarketplaces": {
     "CodySwannGT/lisa": {
       "source": {
         "source": "github",
         "repo": "CodySwannGT/lisa"
+      }
+    },
+    "pbakaus/impeccable": {
+      "source": {
+        "source": "github",
+        "repo": "pbakaus/impeccable"
       }
     }
   },

--- a/rails/merge/.claude/settings.json
+++ b/rails/merge/.claude/settings.json
@@ -10,13 +10,20 @@
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
-    "lisa-rails@lisa": true
+    "lisa-rails@lisa": true,
+    "impeccable@impeccable": true
   },
   "extraKnownMarketplaces": {
     "CodySwannGT/lisa": {
       "source": {
         "source": "github",
         "repo": "CodySwannGT/lisa"
+      }
+    },
+    "pbakaus/impeccable": {
+      "source": {
+        "source": "github",
+        "repo": "pbakaus/impeccable"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds the `pbakaus/impeccable` plugin to Expo and Rails stack templates
- Enables `impeccable@impeccable` in `enabledPlugins` and registers `pbakaus/impeccable` in `extraKnownMarketplaces`
- Provides design skills and 20+ steering commands (`/audit`, `/polish`, `/critique`, etc.) for frontend UI development

## Test plan

- [ ] Run `lisa` on a downstream Expo project and verify `impeccable@impeccable` appears in merged `.claude/settings.json`
- [ ] Open Claude Code in the project and verify `/audit`, `/polish`, etc. are available

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the Impeccable plugin and marketplace integration across development environments to expand available extensions and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->