### PR TITLE
fix: update Claude Code install command to native installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Templates follow governance rules: some files are overwritten on every update (e
 ## Quick Start
 
 ```bash
-brew install claude-code
+curl -fsSL https://claude.ai/install.sh | bash
 ```
 
 > Ask Claude: "I just cloned this repo. Walk me through setup."


### PR DESCRIPTION
## Summary

- Replace incorrect `brew install claude-code` with the recommended native installer (`curl -fsSL https://claude.ai/install.sh | bash`)
- The old brew command doesn't work; Homebrew requires `--cask` flag, and native install is now the recommended method per [Anthropic docs](https://code.claude.com/docs/en/setup)

## Test plan

- [x] Verified against official Claude Code setup docs

🤖 Generated with Claude Code