### PR TITLE
fix: replace fse.readJson with readFile+JSON.parse in registerPlugins

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -233,9 +233,9 @@ export class Lisa {
       return;
     }
 
-    const settings = (await fse
-      .readJson(settingsPath)
-      .catch(() => null)) as Record<string, unknown> | null;
+    const settings = await readFile(settingsPath, "utf-8")
+      .then(content => JSON.parse(content) as Record<string, unknown>)
+      .catch(() => null);
 
     if (!settings?.enabledPlugins) {
       return;


### PR DESCRIPTION
## Summary

- Fixes `fse.readJson is not a function` error that causes Lisa postinstall to crash and rollback ALL template changes in downstream projects
- `fs-extra` (CJS) exports `pathExists` and `remove` as named ESM exports but NOT `readJson` — so `import * as fse from "fs-extra"` gives `fse.readJson === undefined`
- Replaces with `readFile` + `JSON.parse` which are already imported from `node:fs/promises`

## Root cause

When Lisa runs as ESM (`"type": "module"`) in downstream projects via `node node_modules/@codyswann/lisa/dist/index.js`, the `import * as fse from "fs-extra"` pattern only exposes a subset of fs-extra's API as named exports. `readJson` is not among them. This caused `registerPlugins()` to throw, which triggered `handleApplyError()` → full rollback of all correctly-applied template changes.

## Impact

This bug affected **all 14 downstream projects** during the Lisa 1.71.0 update. The templates were applied correctly (typescript first, then child stacks like expo/nestjs/cdk override), but the crash in `registerPlugins` rolled everything back. Agents had to manually restore files from the Lisa templates in `node_modules`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] 293 unit tests pass
- [x] 28 integration tests pass
- [x] Pre-push hooks (security audit, slow lint, knip, tests) all pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of settings file parsing to enhance maintainability and consistency with the application's core processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->