### PR TITLE
docs: add upstream bug fixing guidance to lisa-update-projects skill

### DIFF
--- a/.claude/skills/lisa-update-projects/SKILL.md
+++ b/.claude/skills/lisa-update-projects/SKILL.md
@@ -41,3 +41,19 @@ Updates local Lisa projects in batches by running the package manager update com
 14. If you hit any pre-push blockers, fix them and upstream anything that needs to. Do not lower any thresholds to get around a pre-push block. Instead, fix the code.
 
 For steps 4-13, use up to 4 parallel subagents to accomplish those steps.
+
+## Fixing Upstream Bugs
+
+If the Lisa postinstall crashes, rolls back changes, or applies incorrect templates during a project update, **do not just work around it in the downstream project**. Instead:
+
+1. Diagnose the root cause in the Lisa source code at the current working directory.
+2. Fix the bug in Lisa (create a branch, commit, push, and open a PR).
+3. Wait for the fix to merge and release before continuing project updates, OR apply the workaround in downstream projects only as a temporary measure while the upstream fix is in flight.
+
+Common symptoms that indicate an upstream Lisa bug:
+- Postinstall crashes with errors (e.g., missing function, module resolution failures)
+- Templates from a parent stack (typescript) overwriting child stack templates (expo, nestjs, cdk) — this means the postinstall crashed after applying parent templates but before child templates could override them, triggering a rollback
+- Rollback messages in the postinstall output (`[WARN] Rolling back changes...`) followed by an error
+- Files that should be stack-specific (eslint.config.ts, tsconfig.json, knip.json) containing generic TypeScript config instead of the expected child stack config
+
+The goal is to fix bugs at the source so they don't recur on every future update across all projects.


### PR DESCRIPTION
## Summary

- Adds a "Fixing Upstream Bugs" section to the `lisa-update-projects` skill
- Instructs agents to diagnose and fix Lisa bugs at the source rather than just working around them in downstream projects
- Lists common symptoms (postinstall crashes, rollbacks, wrong stack configs) so agents can recognize upstream issues

## Context

During the Lisa 1.71.0 project updates, 14 agents independently worked around the `fse.readJson` bug by manually restoring configs — but none fixed the root cause in Lisa. This guidance ensures future runs fix bugs upstream first.

## Test plan

- [x] All pre-push checks pass (293 unit tests, 28 integration tests)

🤖 Generated with Claude Code