### PR TITLE
feat: add playwright_setup_command input to quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -119,6 +119,11 @@ on:
         required: false
         default: ''
         type: string
+      playwright_setup_command:
+        description: 'Command to run before Playwright build (e.g., environment setup like copying .env files)'
+        required: false
+        default: ''
+        type: string
     secrets:
       SONAR_TOKEN:
         description: 'SonarCloud token for SAST analysis'
@@ -703,6 +708,11 @@ jobs:
             echo "has_config=false" >> $GITHUB_OUTPUT
             echo "⚠️ No Playwright config found"
           fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🔧 Playwright setup
+        if: steps.check_playwright.outputs.has_config == 'true' && inputs.playwright_setup_command != ''
+        run: ${{ inputs.playwright_setup_command }}
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 🌐 Build web export


### PR DESCRIPTION
## Summary
- Adds `playwright_setup_command` input to the `playwright_e2e` job in `quality.yml`
- The command runs before `expo export --platform web`, allowing projects to set up their environment (e.g., copy `.env.development` to `.env.local`)
- No breaking changes — the input is optional with an empty default

## Motivation
Projects using Expo with environment-specific `.env` files need to copy the correct env file before building for Playwright tests. Without this, `EXPO_PUBLIC_*` variables are undefined in CI builds.

## Example usage
```yaml
quality:
  uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
  with:
    playwright_setup_command: 'cp .env.development .env.local'
```

## Test plan
- [x] Verified the input is properly threaded to the job step
- [x] Verified the step only runs when the input is non-empty
- [x] Verified the step runs before the web export build
- [x] All existing Lisa tests pass (293 unit + 28 integration)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional custom setup command support in CI workflows that executes before end-to-end tests when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->