### PR TITLE
fix: resolve CDK vitest coverage paths relative to project root

### DIFF
--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/hooks/install-pkgs.sh
+++ b/plugins/lisa/hooks/install-pkgs.sh
@@ -21,6 +21,11 @@ else
   npm install
 fi
 
+# The tools below use Linux-specific binaries and paths — skip on other platforms.
+if [ "$(uname -s)" != "Linux" ]; then
+  exit 0
+fi
+
 # Install Gitleaks for secret detection (pre-commit hook)
 echo "Installing Gitleaks for secret detection..."
 GITLEAKS_VERSION="8.18.4"

--- a/plugins/lisa/hooks/setup-jira-cli.sh
+++ b/plugins/lisa/hooks/setup-jira-cli.sh
@@ -17,9 +17,8 @@
 set -euo pipefail
 
 # Fix jira-cli installation if install-pkgs.sh failed to extract correctly.
-# The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
-# but install-pkgs.sh expects a top-level "jira" file.
-if ! command -v jira &>/dev/null; then
+# Only attempt on Linux — the binary download is Linux-only.
+if [[ "$(uname -s)" == "Linux" ]] && ! command -v jira &>/dev/null; then
   JIRA_CLI_VERSION="1.7.0"
   TMPDIR=$(mktemp -d)
   curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \

--- a/plugins/lisa/skills/acceptance-criteria/SKILL.md
+++ b/plugins/lisa/skills/acceptance-criteria/SKILL.md
@@ -21,7 +21,7 @@ Evaluate changes from a non-technical user's perspective. Define acceptance crit
 
 Structure findings as:
 
-```markdown
+```
 ## Product Analysis
 
 ### User Goal

--- a/plugins/lisa/skills/performance-review/SKILL.md
+++ b/plugins/lisa/skills/performance-review/SKILL.md
@@ -22,7 +22,7 @@ Identify bottlenecks, inefficiencies, and scalability risks in code changes.
 
 Structure findings as:
 
-```markdown
+```
 ## Performance Analysis
 
 ### Critical Issues

--- a/plugins/lisa/skills/security-review/SKILL.md
+++ b/plugins/lisa/skills/security-review/SKILL.md
@@ -20,7 +20,7 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 
 Structure findings as:
 
-```markdown
+```
 ## Security Analysis
 
 ### Threat Model (STRIDE)

--- a/plugins/lisa/skills/task-decomposition/SKILL.md
+++ b/plugins/lisa/skills/task-decomposition/SKILL.md
@@ -58,7 +58,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 
 ## Output Format
 
-```markdown
+```
 ## Task Breakdown
 
 ### Task 1: [imperative description]

--- a/src/configs/vitest/cdk.ts
+++ b/src/configs/vitest/cdk.ts
@@ -73,7 +73,7 @@ export const getCdkVitestConfig = ({
     testTimeout: 10000,
     coverage: {
       provider: "v8",
-      include: ["lib/**/*.ts", "util/**/*.ts"],
+      include: ["../lib/**/*.ts", "../util/**/*.ts"],
       exclude: [...defaultCoverageExclusions],
       thresholds: mapThresholds(
         thresholds

--- a/tests/unit/config/vitest-cdk.test.ts
+++ b/tests/unit/config/vitest-cdk.test.ts
@@ -9,8 +9,8 @@
  */
 import { getCdkVitestConfig } from "../../../src/configs/vitest/cdk.js";
 
-const LIB_TS_GLOB = "lib/**/*.ts";
-const UTIL_TS_GLOB = "util/**/*.ts";
+const LIB_TS_GLOB = "../lib/**/*.ts";
+const UTIL_TS_GLOB = "../util/**/*.ts";
 
 describe("vitest.cdk", () => {
   describe("getCdkVitestConfig", () => {


### PR DESCRIPTION
## Summary
- CDK vitest coverage `include` paths (`lib/**/*.ts`, `util/**/*.ts`) were resolved relative to `test.root` (`test/`), causing vitest to look for `test/lib/` and `test/util/` — which don't exist
- Result: 0% coverage despite all tests passing (e.g., 260 tests in infrastructure project)
- Fix: prefix paths with `../` so they resolve back to the project root
- This caused the nightly coverage improvement CI job to burn all 40 turns investigating why coverage was 0% instead of writing tests

## Test plan
- [x] Unit test updated to match new paths
- [x] All 293 tests pass locally
- [ ] CI passes
- [ ] After npm publish, verify `vitest run --coverage` in infrastructure project reports non-zero coverage

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.72.0 for all plugins across the platform.

* **Improvements**
  * Platform compatibility: Linux-specific dependencies, tools, and installation steps now only execute on Linux systems. This prevents unnecessary errors and installation failures when running on other operating systems.

* **Documentation**
  * Fixed Markdown code fence formatting in skill modules for improved rendering and content parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->