### PR TITLE
fix: remove root: "test" from CDK vitest config to fix 0% coverage

### DIFF
--- a/src/configs/vitest/cdk.ts
+++ b/src/configs/vitest/cdk.ts
@@ -63,17 +63,16 @@ export const getCdkVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
-    root: "test",
     include: [
-      "**/*.test.ts",
-      "**/*.spec.ts",
-      "**/*.integration-test.ts",
-      "**/*.integration-spec.ts",
+      "test/**/*.test.ts",
+      "test/**/*.spec.ts",
+      "test/**/*.integration-test.ts",
+      "test/**/*.integration-spec.ts",
     ],
     testTimeout: 10000,
     coverage: {
       provider: "v8",
-      include: ["../lib/**/*.ts", "../util/**/*.ts"],
+      include: ["lib/**/*.ts", "util/**/*.ts"],
       exclude: [...defaultCoverageExclusions],
       thresholds: mapThresholds(
         thresholds

--- a/tests/unit/config/vitest-cdk.test.ts
+++ b/tests/unit/config/vitest-cdk.test.ts
@@ -2,15 +2,15 @@
  * Unit tests for the CDK Vitest configuration factory.
  *
  * Validates that getCdkVitestConfig produces the correct environment,
- * globals, root, include patterns, timeout, coverage settings, and
+ * globals, include patterns, timeout, coverage settings, and
  * threshold merging behavior.
  *
  * @see src/configs/vitest/cdk.ts
  */
 import { getCdkVitestConfig } from "../../../src/configs/vitest/cdk.js";
 
-const LIB_TS_GLOB = "../lib/**/*.ts";
-const UTIL_TS_GLOB = "../util/**/*.ts";
+const LIB_TS_GLOB = "lib/**/*.ts";
+const UTIL_TS_GLOB = "util/**/*.ts";
 
 describe("vitest.cdk", () => {
   describe("getCdkVitestConfig", () => {
@@ -26,20 +26,20 @@ describe("vitest.cdk", () => {
       expect(config.test?.globals).toBe(true);
     });
 
-    it("sets root to test directory", () => {
+    it("does not set root (defaults to project root for coverage)", () => {
       const config = getCdkVitestConfig();
 
-      expect(config.test?.root).toBe("test");
+      expect(config.test?.root).toBeUndefined();
     });
 
-    it("includes test, spec, and integration patterns", () => {
+    it("includes test patterns prefixed with test/ directory", () => {
       const config = getCdkVitestConfig();
       const include = config.test?.include as string[];
 
-      expect(include).toContain("**/*.test.ts");
-      expect(include).toContain("**/*.spec.ts");
-      expect(include).toContain("**/*.integration-test.ts");
-      expect(include).toContain("**/*.integration-spec.ts");
+      expect(include).toContain("test/**/*.test.ts");
+      expect(include).toContain("test/**/*.spec.ts");
+      expect(include).toContain("test/**/*.integration-test.ts");
+      expect(include).toContain("test/**/*.integration-spec.ts");
     });
 
     it("sets 10 second timeout", () => {


### PR DESCRIPTION
## Summary
- Follows up on #322 which tried `../` prefixed coverage paths — that didn't work because vitest's v8 coverage provider cannot resolve `include` patterns outside of `root`
- The correct fix is to remove `root: "test"` entirely and prefix test include patterns with `test/` instead
- This way both test discovery and coverage collection resolve from the project root
- Verified locally on infrastructure: coverage goes from 0% to **99.1%**

## Test plan
- [x] Unit tests updated (root assertion, include pattern assertions)
- [x] All 293 Lisa tests pass
- [ ] CI passes
- [ ] After npm publish, run `vitest run --coverage` in infrastructure to confirm non-zero coverage

🤖 Generated with Claude Code