### PR TITLE
feat: auto-read plugins from .claude/settings.json in CI workflows

### DIFF
--- a/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
@@ -44,11 +44,31 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update all open PR branches
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'github-actions'
           prompt: |
@@ -80,6 +100,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'github-actions'
           prompt: |

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -65,6 +65,24 @@ jobs:
           ref: ${{ inputs.head_branch }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -151,6 +169,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           prompt: |

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -65,6 +65,24 @@ jobs:
           ref: ${{ inputs.pr_head_ref }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -96,6 +114,8 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           allowed_bots: 'coderabbitai'

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -67,6 +67,24 @@ jobs:
           ref: ${{ inputs.head_branch }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -153,6 +171,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         continue-on-error: true
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/deploy-fix-

--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -34,6 +34,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -155,6 +173,8 @@ jobs:
           steps.thresholds.outputs.all_at_target != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-code-complexity-

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -39,6 +39,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,6 +159,8 @@ jobs:
           steps.thresholds.outputs.all_at_target != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-code-complexity-

--- a/.github/workflows/reusable-claude-nightly-jira-triage.yml
+++ b/.github/workflows/reusable-claude-nightly-jira-triage.yml
@@ -43,6 +43,24 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Calculate max turns
         id: config
@@ -51,6 +69,8 @@ jobs:
       - name: Run Claude Code to triage Jira tickets
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           prompt: |

--- a/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
@@ -61,6 +61,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -148,6 +166,8 @@ jobs:
           steps.thresholds.outputs.all_at_target != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-coverage-

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -44,6 +44,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -147,6 +165,8 @@ jobs:
           steps.thresholds.outputs.all_at_target != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-coverage-

--- a/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
@@ -40,6 +40,24 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -97,6 +115,8 @@ jobs:
           steps.check-pr.outputs.has_existing_pr != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-improvement-
@@ -132,6 +152,8 @@ jobs:
           steps.check-pr.outputs.has_existing_pr != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-improvement-

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -45,6 +45,24 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -117,6 +135,8 @@ jobs:
           steps.check-pr.outputs.has_existing_pr != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-improvement-
@@ -137,6 +157,8 @@ jobs:
           steps.check-pr.outputs.has_existing_pr != 'true'
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           branch_prefix: claude/nightly-test-improvement-

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -54,11 +54,31 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: Read plugins from project settings
+        id: plugins
+        run: |
+          if [ -f .claude/settings.json ]; then
+            MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+          else
+            MARKETPLACES=""
+            PLUGINS=""
+          fi
+          {
+            echo "marketplaces<<PLUGINS_EOF"
+            echo "$MARKETPLACES"
+            echo "PLUGINS_EOF"
+            echo "plugins<<PLUGINS_EOF"
+            echo "$PLUGINS"
+            echo "PLUGINS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          plugin_marketplaces: ${{ steps.plugins.outputs.marketplaces }}
+          plugins: ${{ steps.plugins.outputs.plugins }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           additional_permissions: |


### PR DESCRIPTION
## Summary
- All 12 reusable workflows that use `claude-code-action` now auto-read `extraKnownMarketplaces` and `enabledPlugins` from `.claude/settings.json`
- Extracted values are passed as `plugin_marketplaces` and `plugins` inputs to the action
- **Root cause**: Nightly CI jobs referenced skills like `/lisa:nightly-lower-code-complexity` but the Lisa plugin wasn't installed — Claude fell back to manual work, burning all turns without finishing
- **Fix**: Projects no longer need to configure plugins separately for CI; `.claude/settings.json` is the single source of truth

## Affected workflows
- `reusable-auto-update-pr-branches-dispatch.yml`
- `reusable-claude-ci-auto-fix.yml`
- `reusable-claude-code-review-response.yml`
- `reusable-claude-deploy-auto-fix.yml`
- `reusable-claude-nightly-code-complexity.yml` (+ rails variant)
- `reusable-claude-nightly-jira-triage.yml`
- `reusable-claude-nightly-test-coverage.yml` (+ rails variant)
- `reusable-claude-nightly-test-improvement.yml` (+ rails variant)
- `reusable-claude.yml`

## Test plan
- [x] All YAML files pass syntax validation
- [x] All 293 Lisa tests pass
- [ ] CI passes
- [ ] Manually verify on next nightly run that plugins are installed and skills are found

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow configurations to automatically read and apply project-level plugin and marketplace settings during code operations. Workflows now extract these configurations from project settings and pass them to the Claude Code action, enabling consistent plugin usage across automation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->