### PR TITLE
fix: filter CI plugins to only those from extraKnownMarketplaces

### DIFF
--- a/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
@@ -49,7 +49,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -70,7 +70,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -70,7 +70,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -72,7 +72,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -39,7 +39,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -44,7 +44,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-jira-triage.yml
+++ b/.github/workflows/reusable-claude-nightly-jira-triage.yml
@@ -48,7 +48,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
@@ -66,7 +66,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -49,7 +49,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
@@ -45,7 +45,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -50,7 +50,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -59,7 +59,13 @@ jobs:
         run: |
           if [ -f .claude/settings.json ]; then
             MARKETPLACES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source | if .source == "github" then "https://github.com/\(.repo).git" else empty end' .claude/settings.json 2>/dev/null || echo "")
-            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null || echo "")
+            MARKETPLACE_NAMES=$(jq -r '(.extraKnownMarketplaces // {}) | to_entries[] | .value.source.repo // .key | split("/") | last' .claude/settings.json 2>/dev/null || echo "")
+            PLUGINS=$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' .claude/settings.json 2>/dev/null | while IFS= read -r plugin; do
+              mk="${plugin##*@}"
+              if echo "$MARKETPLACE_NAMES" | grep -qx "$mk"; then
+                echo "$plugin"
+              fi
+            done)
           else
             MARKETPLACES=""
             PLUGINS=""


### PR DESCRIPTION
## Summary
Follows up on #324. The first test run on ask-gemini failed because `typescript-lsp@claude-plugins-official` isn't installable via `claude plugin install` — built-in plugins load automatically and don't need explicit installation.

Now only plugins whose `@marketplace` suffix matches a key in `extraKnownMarketplaces` are passed to the action. For example, with ask-gemini's settings:
- `lisa@lisa` → **included** (lisa is in extraKnownMarketplaces)
- `safety-net@cc-marketplace` → **included** (cc-marketplace is in extraKnownMarketplaces)
- `typescript-lsp@claude-plugins-official` → **excluded** (claude-plugins-official is built-in, loads automatically)

## Test plan
- [x] YAML validation passes on all 12 files
- [x] Filtering logic tested with real settings — correctly includes only non-built-in plugins
- [ ] CI passes
- [ ] Re-trigger ask-gemini nightly to verify plugins install and skills are found

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve plugin filtering logic across multiple pipeline configurations. Plugin validation now consistently applies marketplace-based checks to ensure proper marketplace association before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->