### PR TITLE
fix(rails): use compact jq output in nightly complexity workflow

### DIFF
--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -141,8 +141,8 @@ jobs:
           add_metric() {
             local key="$1" current="$2" proposed="$3" target="$4"
             if [ -n "$current" ]; then
-              CURRENT=$(echo "$CURRENT" | jq --arg k "$key" --argjson v "$current" '. + {($k): $v}')
-              PROPOSED=$(echo "$PROPOSED" | jq --arg k "$key" --argjson v "$proposed" '. + {($k): $v}')
+              CURRENT=$(echo "$CURRENT" | jq -c --arg k "$key" --argjson v "$current" '. + {($k): $v}')
+              PROPOSED=$(echo "$PROPOSED" | jq -c --arg k "$key" --argjson v "$proposed" '. + {($k): $v}')
               if [ "$current" -ne "$proposed" ]; then
                 ALL_AT_TARGET="false"
                 if [ -n "$REDUCTIONS" ]; then


### PR DESCRIPTION
## Summary
- Add `-c` flag to `jq` calls in `add_metric` function of the nightly code complexity Rails workflow
- Without `-c`, `jq` pretty-prints JSON across multiple lines, which breaks `$GITHUB_OUTPUT` (requires single-line `key=value` entries)
- This caused the "Read complexity thresholds" step to fail with `Invalid format '  "MethodLength": 20,'`

## Test plan
- [ ] Re-run the nightly complexity workflow on qualis-app and confirm the "Read complexity thresholds" step passes

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal workflow output formatting for build and testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->