### PR TITLE
fix: improve nightly complexity workflow reliability

### DIFF
--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -215,8 +215,8 @@ jobs:
                 e. Never use --no-verify to bypass the security audit
           claude_args: |
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
-            --max-turns 40
-            --system-prompt "You are reducing code complexity to meet stricter RuboCop thresholds in a Rails project. Read CLAUDE.md for project rules. Refactor methods to reduce complexity metrics. Use early returns, extract service objects, use polymorphism, and simplify conditionals. Follow Rails conventions: skinny controllers, fat models (but not too fat — use service objects), concerns for shared behavior. You must update rubocop.thresholds.yml with the new values after refactoring passes rubocop. IMPORTANT: Always use bundle exec to run project commands."
+            --max-turns 50
+            --system-prompt "You are reducing code complexity to meet stricter RuboCop thresholds in a Rails project. Read CLAUDE.md for project rules. Refactor methods to reduce complexity metrics. Use early returns, extract service objects, use polymorphism, and simplify conditionals. Follow Rails conventions: skinny controllers, fat models (but not too fat — use service objects), concerns for shared behavior. You must update rubocop.thresholds.yml with the new values after refactoring passes rubocop. IMPORTANT: Always use bundle exec to run project commands. CRITICAL: Always Read a file with the Read tool before attempting to Edit it. Never construct edit strings from memory alone."
 
       - name: Trigger CodeRabbit review
         env:

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -178,8 +178,8 @@ jobs:
             Metrics being reduced: ${{ steps.thresholds.outputs.reductions }}
           claude_args: |
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
-            --max-turns 40
-            --system-prompt "You are reducing code complexity to meet stricter ESLint thresholds. Read CLAUDE.md for project rules. Do NOT modify the maxLines threshold. IMPORTANT: Always use the project's package manager scripts (e.g. bun run lint, bun run test) instead of running binaries from node_modules/.bin/ directly."
+            --max-turns 50
+            --system-prompt "You are reducing code complexity to meet stricter ESLint thresholds. Read CLAUDE.md for project rules. Do NOT modify the maxLines threshold. IMPORTANT: Always use the project's package manager scripts (e.g. bun run lint, bun run test) instead of running binaries from node_modules/.bin/ directly. CRITICAL: Always Read a file with the Read tool before attempting to Edit it. Never construct edit strings from memory alone."
 
       - name: Trigger CodeRabbit review
         env:


### PR DESCRIPTION
## Summary
- Increase `--max-turns` from 40 to 50 to give Claude more recovery headroom when edits fail
- Add "read before edit" instruction to system prompt to prevent Edit tool failures from stale file content in memory
- Applied to both TypeScript and Rails reusable workflows

## Context
The [ask-gemini nightly run](https://github.com/geminisportsai/ask-gemini/actions/runs/23579255224) failed because Claude constructed an `old_string` from memory that didn't match the actual file, then hit max turns (41) trying to recover.

## Test plan
- [ ] Next nightly run completes successfully
- [ ] Verify workflows still trigger correctly via `workflow_dispatch`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code complexity reduction workflow with improved interaction capacity and stricter tool constraints for more reliable file modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->