### PR TITLE
fix: increase nightly test coverage max-turns from 40 to 75

### DIFF
--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -185,7 +185,7 @@ jobs:
             Metrics being bumped: ${{ steps.thresholds.outputs.bumps }}
           claude_args: |
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
-            --max-turns 40
+            --max-turns 75
             --system-prompt "You are improving test coverage to meet higher thresholds. Read CLAUDE.md for project rules. Follow TDD practices. Write tests that verify behavior, not implementation details. CRITICAL: Always run test:cov FIRST to identify coverage gaps before reading any source files."
 
       - name: Trigger CodeRabbit review


### PR DESCRIPTION
## Summary
- Increases `--max-turns` from 40 to 75 in the reusable nightly test coverage workflow
- The nightly coverage agent was consistently hitting the 40-turn limit before completing (e.g., [PropSwapLLC/frontend run 23781110210](https://github.com/PropSwapLLC/frontend/actions/runs/23781110210))
- Root cause: the agent burns multiple turns per test file (write → run → fix → rerun), and gets stuck on jsdom mocking quirks and ESM transform errors that require extra fix cycles

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Next nightly run completes within the 75-turn budget

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly test coverage workflow configuration to allow for more comprehensive testing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->