### PR TITLE
fix: reduce nightly coverage increment to 2% and increase max-turns to 50

### DIFF
--- a/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
@@ -14,7 +14,7 @@ on:
       coverage_increment:
         description: 'Percentage points to increase coverage thresholds per run (lower for large gaps)'
         required: false
-        default: 5
+        default: 2
         type: number
       auto_merge:
         description: 'Enable auto-merge on created PRs (requires repo auto-merge setting enabled)'
@@ -213,7 +213,7 @@ jobs:
                 e. Never use --no-verify to bypass the security audit
           claude_args: |
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
-            --max-turns 40
+            --max-turns 50
             --system-prompt "You are improving test coverage to meet higher thresholds in a Rails project. Read CLAUDE.md for project rules. Follow RSpec best practices: use describe/context/it blocks, let/before for setup, FactoryBot for test data, shared examples for common behavior. Write tests that verify behavior, not implementation details. Include edge cases and error paths. You must update simplecov.thresholds.json with the new values after tests pass. CRITICAL: Always run bundle exec rspec FIRST to identify coverage gaps before reading any source files. Use the coverage report to target exactly which files and lines need tests. Never explore the codebase broadly — only read the specific uncovered code identified by the coverage report."
 
       - name: Trigger CodeRabbit review
@@ -434,7 +434,7 @@ jobs:
                 e. Never use --no-verify to bypass the security audit
           claude_args: |
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(*),Skill(*)"
-            --max-turns 40
+            --max-turns 50
             --system-prompt "You are improving test coverage to meet higher thresholds in a Rails project. Read CLAUDE.md for project rules. Follow RSpec best practices: use describe/context/it blocks, let/before for setup, FactoryBot for test data, shared examples for common behavior. Write tests that verify behavior, not implementation details. Include edge cases and error paths. You must update simplecov.thresholds.json with the new values after tests pass. CRITICAL: Always run bundle exec rspec FIRST to identify coverage gaps before reading any source files. Use the coverage report to target exactly which files and lines need tests. Never explore the codebase broadly — only read the specific uncovered code identified by the coverage report."
 
       - name: Trigger CodeRabbit review


### PR DESCRIPTION
## Summary
- Reduce `coverage_increment` default from 5 to 2 percentage points per nightly run
- Increase `--max-turns` from 40 to 50 for both postgres and mysql jobs

The 5% increment required writing tests for 12+ files, which exhausted the 40-turn limit before the agent could commit and push (observed in gunnertech/qualis-app#23934244205).

## Test plan
- [ ] Next nightly run completes within 50 turns
- [ ] Coverage thresholds increase by 2% instead of 5%

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage workflow configuration with adjusted threshold increment calculation (5 → 2).
  * Increased maximum interaction capacity for coverage improvement analysis in PostgreSQL and MySQL job execution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->