### PR TITLE
feat: require agents to confirm no blockers before starting work

### DIFF
--- a/plugins/lisa/rules/base-rules.md
+++ b/plugins/lisa/rules/base-rules.md
@@ -9,6 +9,8 @@ Never assume the person providing instructions has given you complete, correct, 
 
 DO NOT START WORK if any of the above are unclear. Asking a clarifying question is always cheaper than implementing the wrong thing.
 
+Do not begin a task if there are any blockers, ambiguities, access requirements, unanswered questions, or unknowns that would prevent you from completing it. Identify these before starting — not during implementation. If you cannot confirm that you have everything needed to finish the work end-to-end, stop and surface what is missing.
+
 Project Discovery:
 - Determine the project's package manager before installing or running anything.
 - Read the project manifest (e.g. package.json, pyproject.toml, Cargo.toml, go.mod) to understand available scripts and dependencies.

--- a/plugins/src/base/rules/base-rules.md
+++ b/plugins/src/base/rules/base-rules.md
@@ -9,6 +9,8 @@ Never assume the person providing instructions has given you complete, correct, 
 
 DO NOT START WORK if any of the above are unclear. Asking a clarifying question is always cheaper than implementing the wrong thing.
 
+Do not begin a task if there are any blockers, ambiguities, access requirements, unanswered questions, or unknowns that would prevent you from completing it. Identify these before starting — not during implementation. If you cannot confirm that you have everything needed to finish the work end-to-end, stop and surface what is missing.
+
 Project Discovery:
 - Determine the project's package manager before installing or running anything.
 - Read the project manifest (e.g. package.json, pyproject.toml, Cargo.toml, go.mod) to understand available scripts and dependencies.


### PR DESCRIPTION
## Summary
- Adds rule to `base-rules.md` requiring agents to confirm they have everything needed to complete a task end-to-end before beginning implementation
- Covers blockers, ambiguities, access requirements, unanswered questions, and unknowns
- Forces agents to surface missing prerequisites upfront rather than discovering them mid-implementation

## Test plan
- [ ] Verify rule text is present in `plugins/src/base/rules/base-rules.md` and `plugins/lisa/rules/base-rules.md`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated baseline rules to require identifying potential blockers, ambiguities, access requirements, unanswered questions, or unknowns before task initiation, ensuring issues are surfaced upfront.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->