### PR TITLE
fix: add .claude/worktrees/** to ESLint ignore patterns

### DIFF
--- a/src/configs/eslint/base.ts
+++ b/src/configs/eslint/base.ts
@@ -44,6 +44,7 @@ export const defaultIgnores = [
   "generated/**",
   "components/ui/**",
   ".lisabak/**",
+  ".claude/worktrees/**",
   ".claude-active-project/**",
   ".claude-active-plan/**",
   "coverage/**",

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -30,6 +30,7 @@
     ".maestro",
 
     ".lisabak/**",
+    ".claude/worktrees/**",
     ".claude-active-project/**",
     ".claude-active-plan/**",
     "coverage/**",


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/**` to ESLint ignore in both `src/configs/eslint/base.ts` and `typescript/copy-overwrite/eslint.ignore.config.json`
- Worktree directories contain isolated repo copies that cause parser errors during slow lint

Discovered during project updates — propswap/infrastructure and propswap/frontend hit this.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to exclude additional development directories from linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->