### PR TITLE
fix: add basic-ftp GHSA exception to typescript audit.ignore template

### DIFF
--- a/typescript/copy-overwrite/audit.ignore.config.json
+++ b/typescript/copy-overwrite/audit.ignore.config.json
@@ -87,6 +87,11 @@
       "id": "GHSA-36jr-mh4h-2g58",
       "package": "d3-color",
       "reason": "ReDoS — transitive via react-native-svg-charts, color parsing not user-controlled"
+    },
+    {
+      "id": "GHSA-chqc-8p9q-pq6q",
+      "package": "basic-ftp",
+      "reason": "FTP command injection via CRLF — devDep only via @lhci/cli > proxy-agent > pac-proxy-agent > get-uri, no FTP usage in production code"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add GHSA-chqc-8p9q-pq6q (basic-ftp FTP command injection via CRLF) to the typescript audit.ignore.config.json template. This vulnerability comes from the @lhci/cli > proxy-agent > pac-proxy-agent > get-uri transitive chain, where @lhci/cli is a Lisa-provided devDep in the Expo stack. Without this exception, lisa template overwrites break pre-push audit hooks in downstream Expo projects.

Follow-up to #367.

## Test plan

- [x] Verified downstream propswap/frontend project pushes successfully after adding this exception locally
- [x] basic-ftp has no production code path — only affects FTP proxy support in @lhci/cli, which we don't use

🤖 Generated with Claude Code