### PR TITLE
fix(migrations): apply CI guard to Rails projects with Node package.json

### DIFF
--- a/src/migrations/ensure-lisa-postinstall.ts
+++ b/src/migrations/ensure-lisa-postinstall.ts
@@ -96,18 +96,31 @@ export class EnsureLisaPostinstallMigration implements Migration {
 
   /**
    * Check whether this migration should run on the project
+   *
+   * Primary path: Node project types (typescript, expo, nestjs, cdk, npm-package)
+   * with a package.json whose postinstall lacks the CI-guarded Lisa invocation.
+   *
+   * Fallback path: non-Node projects (e.g. Rails-only) that nevertheless ship a
+   * package.json containing a legacy Lisa postinstall (unguarded). These were
+   * written by an older Lisa version before the CI guard existed and still need
+   * an upgrade. Projects without a package.json are untouched.
    * @param ctx - Migration context
-   * @returns True when a Node project is missing the Lisa invocation in postinstall
+   * @returns True when a Node project is missing the Lisa invocation in postinstall,
+   *   or when a non-Node project has an unguarded legacy Lisa postinstall
    */
   async applies(ctx: MigrationContext): Promise<boolean> {
-    if (!hasNodePostinstallType(ctx.detectedTypes)) {
-      return false;
-    }
     const pkg = await readPackageJson(ctx.projectDir);
     if (!pkg) {
       return false;
     }
     const postinstall = pkg.scripts?.postinstall;
+    if (!hasNodePostinstallType(ctx.detectedTypes)) {
+      return (
+        !!postinstall &&
+        postinstall.includes(LISA_MARKER) &&
+        !postinstall.includes(CI_GUARD_PREFIX)
+      );
+    }
     if (
       postinstall &&
       postinstall.includes(LISA_MARKER) &&

--- a/src/migrations/ensure-lisa-postinstall.ts
+++ b/src/migrations/ensure-lisa-postinstall.ts
@@ -46,6 +46,16 @@ const LEGACY_LISA_INVOCATION_RE =
   /node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
 
 /**
+ * Guarded Lisa invocation pattern (CI guard directly gates the Lisa command).
+ * Used to detect when the migration has already been applied. Avoids false
+ * positives where the CI guard precedes an unrelated command (e.g.
+ * `[ -n "$CI" ] || patch-package && node ...lisa...`), which would leave Lisa
+ * effectively unguarded inside a `&&` chain.
+ */
+const GUARDED_LISA_INVOCATION_RE =
+  /\[ -n "\$CI" \] \|\| node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
+
+/**
  * Compose the new postinstall, prepending the Lisa invocation to any existing command.
  * If the existing script already contains a legacy Lisa invocation (no CI guard),
  * replace it in place with the guarded invocation rather than duplicating it.
@@ -118,14 +128,10 @@ export class EnsureLisaPostinstallMigration implements Migration {
       return (
         !!postinstall &&
         postinstall.includes(LISA_MARKER) &&
-        !postinstall.includes(CI_GUARD_PREFIX)
+        !GUARDED_LISA_INVOCATION_RE.test(postinstall)
       );
     }
-    if (
-      postinstall &&
-      postinstall.includes(LISA_MARKER) &&
-      postinstall.includes(CI_GUARD_PREFIX)
-    ) {
+    if (postinstall && GUARDED_LISA_INVOCATION_RE.test(postinstall)) {
       return false;
     }
     return true;

--- a/tests/unit/migrations/ensure-lisa-postinstall.test.ts
+++ b/tests/unit/migrations/ensure-lisa-postinstall.test.ts
@@ -148,6 +148,38 @@ describe("EnsureLisaPostinstallMigration", () => {
       });
       expect(await migration.applies(createContext())).toBe(true);
     });
+
+    it("returns true for Rails project with package.json containing unguarded Lisa postinstall", async () => {
+      await writePackageJson({
+        scripts: { postinstall: LEGACY_LISA_INVOCATION },
+      });
+      expect(await migration.applies(createContext(["rails"]))).toBe(true);
+    });
+
+    it("returns false for Rails project with package.json whose Lisa postinstall already has CI guard", async () => {
+      await writePackageJson({
+        scripts: { postinstall: LISA_INVOCATION },
+      });
+      expect(await migration.applies(createContext(["rails"]))).toBe(false);
+    });
+
+    it("returns false for Rails project without package.json", async () => {
+      expect(await migration.applies(createContext(["rails"]))).toBe(false);
+    });
+
+    it("returns false for Rails project with package.json but no Lisa postinstall marker", async () => {
+      await writePackageJson({
+        scripts: { postinstall: "bundle exec rails assets:precompile" },
+      });
+      expect(await migration.applies(createContext(["rails"]))).toBe(false);
+    });
+
+    it("returns true for non-Rails Node project with unguarded Lisa postinstall (existing behavior unchanged)", async () => {
+      await writePackageJson({
+        scripts: { postinstall: LEGACY_LISA_INVOCATION },
+      });
+      expect(await migration.applies(createContext(["typescript"]))).toBe(true);
+    });
   });
 
   describe("apply()", () => {
@@ -253,6 +285,21 @@ describe("EnsureLisaPostinstallMigration", () => {
 
       await migration.apply(createContext());
       const shouldRunAgain = await migration.applies(createContext());
+      expect(shouldRunAgain).toBe(false);
+    });
+
+    it("adds CI guard to Rails project with unguarded Lisa postinstall", async () => {
+      await writePackageJson({
+        scripts: { postinstall: LEGACY_LISA_INVOCATION },
+      });
+
+      const result = await migration.apply(createContext(["rails"]));
+
+      expect(result.action).toBe("applied");
+      const pkg = await fs.readJson(path.join(projectDir, PACKAGE_JSON));
+      expect(pkg.scripts.postinstall).toBe(LISA_INVOCATION);
+
+      const shouldRunAgain = await migration.applies(createContext(["rails"]));
       expect(shouldRunAgain).toBe(false);
     });
   });

--- a/tests/unit/migrations/ensure-lisa-postinstall.test.ts
+++ b/tests/unit/migrations/ensure-lisa-postinstall.test.ts
@@ -149,6 +149,24 @@ describe("EnsureLisaPostinstallMigration", () => {
       expect(await migration.applies(createContext())).toBe(true);
     });
 
+    it("returns true when CI guard applies to a different command before unguarded Lisa (Node project)", async () => {
+      await writePackageJson({
+        scripts: {
+          postinstall: `[ -n "$CI" ] || patch-package && ${LEGACY_LISA_INVOCATION}`,
+        },
+      });
+      expect(await migration.applies(createContext())).toBe(true);
+    });
+
+    it("returns true when CI guard applies to a different command before unguarded Lisa (Rails project)", async () => {
+      await writePackageJson({
+        scripts: {
+          postinstall: `[ -n "$CI" ] || patch-package && ${LEGACY_LISA_INVOCATION}`,
+        },
+      });
+      expect(await migration.applies(createContext(["rails"]))).toBe(true);
+    });
+
     it("returns true for Rails project with package.json containing unguarded Lisa postinstall", async () => {
       await writePackageJson({
         scripts: { postinstall: LEGACY_LISA_INVOCATION },


### PR DESCRIPTION
## Summary

- Extend `EnsureLisaPostinstallMigration.applies()` to catch Rails (non-Node) projects that ship a `package.json` whose `scripts.postinstall` contains a legacy (unguarded) Lisa invocation. Previously these projects were skipped because `applies()` short-circuited on Node type detection, leaving them stuck on the pre-CI-guard form.
- Non-Node projects without a `package.json` still skip. Rails projects whose postinstall already has `[ -n "$CI" ] ||` still skip (idempotent).
- Node project behavior is unchanged; the existing gate is preserved for the Node path.

## Test plan

- [x] Rails + package.json + unguarded Lisa postinstall → `applies=true`, `apply()` rewrites to guarded form
- [x] Rails + package.json + already-guarded Lisa postinstall → `applies=false`
- [x] Rails + no package.json → `applies=false`
- [x] Rails + package.json without Lisa marker → `applies=false`
- [x] Non-Rails Node project with unguarded Lisa postinstall → `applies=true` (unchanged)
- [x] Full suite: 407 tests passing (was 401)
- [x] `bun run build`, `bun run typecheck`, `bun run lint`, `bun run test` all green

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI environment guard to postinstall script execution.

* **Tests**
  * Added comprehensive test coverage for postinstall CI guard logic across multiple configuration scenarios.

* **Chores**
  * Updated migration to handle legacy postinstall configurations and prevent duplicated invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->