### PR TITLE
chore: upstream changes from local main

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -165,7 +165,7 @@ Automatically fixes CI failures by having Claude analyze error logs and push fix
 Automatically triages CodeRabbit review comments and either fixes valid findings or replies to dismiss invalid ones.
 
 - Triggers when CodeRabbit submits a review (not per inline comment — once per review summary)
-- Skips PRs authored by bots to prevent bot-to-bot loops
+- Skips PRs authored by `coderabbitai[bot]` or `dependabot[bot]` to prevent bot-to-bot loops (PRs authored by `claude[bot]` or other bots are allowed)
 - For each review comment, Claude determines if the finding is valid or a misunderstanding
 - Valid findings: fixes the code and commits with conventional messages
 - Invalid findings: replies to the comment explaining why the suggestion does not apply

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -49,7 +49,8 @@ jobs:
     if: |
       vars.ENABLE_CLAUDE_CODE_REVIEW_RESPONSE == 'true' &&
       inputs.review_user_login == 'coderabbitai[bot]' &&
-      !endsWith(inputs.pr_user_login, '[bot]')
+      inputs.pr_user_login != 'coderabbitai[bot]' &&
+      inputs.pr_user_login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "NestJS-specific skills (GraphQL, TypeORM)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "1.85.2",
+  "version": "1.85.8",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
+++ b/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
@@ -165,7 +165,7 @@ Automatically fixes CI failures by having Claude analyze error logs and push fix
 Automatically triages CodeRabbit review comments and either fixes valid findings or replies to dismiss invalid ones.
 
 - Triggers when CodeRabbit submits a review (not per inline comment — once per review summary)
-- Skips PRs authored by bots to prevent bot-to-bot loops
+- Skips PRs authored by `coderabbitai[bot]` or `dependabot[bot]` to prevent bot-to-bot loops (PRs authored by `claude[bot]` or other bots are allowed)
 - For each review comment, Claude determines if the finding is valid or a misunderstanding
 - Valid findings: fixes the code and commits with conventional messages
 - Invalid findings: replies to the comment explaining why the suggestion does not apply


### PR DESCRIPTION
## Summary
Upstream the substantive content from local main that was sitting unpushed (originally committed as `1937427` with `--no-verify`). Cherry-picked onto a fresh branch off `origin/main` to drop 21 noise merge commits that had no content.

Touches:
- \`.github/GITHUB_ACTIONS.md\` and its mirror in \`typescript/copy-overwrite/\`
- \`.github/workflows/reusable-claude-code-review-response.yml\`
- \`plugin.json\` version fields for \`lisa\`, \`lisa-cdk\`, \`lisa-expo\`, \`lisa-nestjs\`, \`lisa-rails\`, \`lisa-typescript\`

Total: 9 files, +10/-9.

## Test plan
- [ ] CI passes (lint, typecheck, tests, security scans).
- [ ] After merge, sync local main with \`git fetch && git reset --hard origin/main\` to drop the 21 leftover merge-noise commits.

🤖 Generated with Claude Code