### PR TITLE
chore(gitignore): ignore .claude/scheduled_tasks.lock

### DIFF
--- a/all/copy-contents/.gitignore
+++ b/all/copy-contents/.gitignore
@@ -162,6 +162,7 @@ tasks.json
 **/.claude/settings.local.json
 **/.claude/debug/
 **/.claude/worktrees/
+**/.claude/scheduled_tasks.lock
 .roo
 .roo/
 .roomodes


### PR DESCRIPTION
## Summary
- Add `**/.claude/scheduled_tasks.lock` to `all/copy-contents/.gitignore` so Claude Code's scheduled-task lock file is ignored by every project.

Discovered during lisa-update-projects run — qualis/app had this as an untracked file.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude additional temporary files from version control, improving repository maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->