### PR TITLE
fix(nestjs): add sentry deps and dev binaries to knip ignore lists

### DIFF
--- a/nestjs/copy-overwrite/knip.json
+++ b/nestjs/copy-overwrite/knip.json
@@ -37,6 +37,8 @@
     "@nestjs/platform-express",
     "@nestjs/terminus",
     "@nestjs/typeorm",
+    "@sentry/cli",
+    "@sentry/hub",
     "@sentry/profiling-node",
     "@vendia/serverless-express",
     "aws-jwt-verify",
@@ -59,7 +61,23 @@
     "typeorm",
     "typeorm-naming-strategies"
   ],
-  "ignoreBinaries": ["expo", "playwright", "audit", "docker", "eval"],
+  "ignoreBinaries": [
+    "expo",
+    "playwright",
+    "audit",
+    "docker",
+    "eval",
+    "ast-grep",
+    "eslint",
+    "husky",
+    "knip",
+    "prettier",
+    "sentry-cli",
+    "sls",
+    "tsc",
+    "tsx",
+    "vitest"
+  ],
   "ignoreExportsUsedInFile": true,
   "rules": {
     "devDependencies": "off"


### PR DESCRIPTION
## Summary
- Upstreamed from `geminisportsai/backend-v2` Lisa update on 2026-04-14
- Adds `@sentry/cli` and `@sentry/hub` to `ignoreDependencies`
- Adds common dev binaries (ast-grep, eslint, husky, knip, prettier, sentry-cli, sls, tsc, tsx, vitest) to `ignoreBinaries` so NestJS projects using standard tooling don't see false knip warnings

## Test plan
- [ ] `bun update @codyswann/lisa` in a NestJS project does not remove these ignores
- [ ] knip no longer warns about the added dev binaries / sentry deps

🤖 Generated with Claude Code