### PR TITLE
fix(commands): reference intent-routing rule by name, not deleted file path

### DIFF
--- a/plugins/lisa/agents/jira-agent.md
+++ b/plugins/lisa/agents/jira-agent.md
@@ -76,7 +76,7 @@ If the ticket type is ambiguous, read the description to classify. A "Task" that
 
 ### 5. Delegate to Flow
 
-Hand off to the appropriate flow as defined in `.claude/rules/intent-routing.md`. Pass the full ticket context (description, acceptance criteria, credentials, reproduction steps) to the first agent in the flow.
+Hand off to the appropriate flow as defined in the `intent-routing` rule (loaded via the lisa plugin). Pass the full ticket context (description, acceptance criteria, credentials, reproduction steps) to the first agent in the flow.
 
 ### 6. Sync Progress at Milestones
 

--- a/plugins/lisa/commands/build.md
+++ b/plugins/lisa/commands/build.md
@@ -3,7 +3,7 @@ description: "Build a feature. Defines acceptance criteria, researches codebase,
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Build** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Build** work type.
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket, extract context, and delegate back to the Implement flow.
 

--- a/plugins/lisa/commands/fix.md
+++ b/plugins/lisa/commands/fix.md
@@ -3,7 +3,7 @@ description: "Fix a bug. Reproduces, analyzes git history, finds root cause, imp
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Fix** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Fix** work type.
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket, extract context, and delegate back to the Implement flow.
 

--- a/plugins/lisa/commands/improve.md
+++ b/plugins/lisa/commands/improve.md
@@ -3,7 +3,7 @@ description: "Improve existing code. Measures baseline, implements improvements 
 argument-hint: "<target-description>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Improve** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Improve** work type.
 
 For specific improvement types, you can also use:
 - `/lisa:plan:add-test-coverage` -- increase test coverage

--- a/plugins/lisa/commands/investigate.md
+++ b/plugins/lisa/commands/investigate.md
@@ -3,7 +3,7 @@ description: "Investigate an issue. Analyzes git history, reproduces, traces exe
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Investigate Only** work type (spike).
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Investigate Only** work type (spike).
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket and extract context.
 

--- a/plugins/lisa/commands/monitor.md
+++ b/plugins/lisa/commands/monitor.md
@@ -3,7 +3,7 @@ description: "Monitor application health. Checks health endpoints, logs, errors,
 argument-hint: "[environment]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Monitor** sub-flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Monitor** sub-flow.
 
 This sub-flow is also invoked as part of the Verify flow's remote verification step. Delegates to `ops-specialist` for health checks, log inspection, error monitoring, and performance analysis.
 

--- a/plugins/lisa/commands/plan.md
+++ b/plugins/lisa/commands/plan.md
@@ -3,7 +3,7 @@ description: "Plan work. Defines acceptance criteria, researches codebase, maps 
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Plan** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Plan** flow.
 
 If no PRD or specification exists, suggest running the **Research** flow first to produce one.
 

--- a/plugins/lisa/commands/plan/create.md
+++ b/plugins/lisa/commands/plan/create.md
@@ -3,6 +3,6 @@ description: "Creates an implementation plan from a ticket URL, file path, or te
 argument-hint: "<ticket-url | @file-path | description>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Plan** flow on $ARGUMENTS.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Plan** flow on $ARGUMENTS.
 
 If requirements are ambiguous or no specification exists, suggest running the **Research** flow first.

--- a/plugins/lisa/commands/plan/execute.md
+++ b/plugins/lisa/commands/plan/execute.md
@@ -3,4 +3,4 @@ description: "Deploys an agent team to research, implement, review and deploy a 
 argument-hint: "<ticket-url | @file-path | description>"
 ---
 
-Pass through to `/build` with $ARGUMENTS. The Build command reads `.claude/rules/intent-routing.md` and runs the full Implement → Review → Verify chain, which is what this command historically did.
+Pass through to `/build` with $ARGUMENTS. The Build command applies the `intent-routing` rule (loaded via the lisa plugin) and runs the full Implement → Review → Verify chain, which is what this command historically did.

--- a/plugins/lisa/commands/research.md
+++ b/plugins/lisa/commands/research.md
@@ -3,6 +3,6 @@ description: "Research a problem space and produce a PRD. Investigates codebase,
 argument-hint: "<problem-statement-or-feature-idea>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Research** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Research** flow.
 
 $ARGUMENTS

--- a/plugins/lisa/commands/review.md
+++ b/plugins/lisa/commands/review.md
@@ -3,7 +3,7 @@ description: "Review code changes. Runs quality, security, performance, product,
 argument-hint: "[pr-link-or-branch]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Review** sub-flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Review** sub-flow.
 
 This sub-flow is also invoked automatically by the Implement flow. It runs `quality-specialist`, `security-specialist`, and `performance-specialist` in parallel, followed by `product-specialist` and `test-specialist`. Consolidates all findings ranked by severity.
 

--- a/plugins/lisa/commands/ship.md
+++ b/plugins/lisa/commands/ship.md
@@ -3,6 +3,6 @@ description: "Ship current changes. Alias for /verify."
 argument-hint: "[commit-message-hint]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Verify** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Verify** flow.
 
 $ARGUMENTS

--- a/plugins/lisa/commands/verify.md
+++ b/plugins/lisa/commands/verify.md
@@ -3,7 +3,7 @@ description: "Ship and verify code. Commits, opens PR, handles review loop, merg
 argument-hint: "[commit-message-hint]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Verify** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Verify** flow.
 
 This includes: atomic commits, PR creation, CI/review-fix loop, merge, deploy monitoring, and remote verification.
 

--- a/plugins/lisa/skills/plan-execute/SKILL.md
+++ b/plugins/lisa/skills/plan-execute/SKILL.md
@@ -47,7 +47,7 @@ If Implement, determine the work type:
 3. Improve (refactoring, optimization, coverage improvement)
 4. Investigate Only (spike -- no code changes, just findings)
 
-Run the readiness gate check for the selected flow as defined in `.claude/rules/intent-routing.md`. If the gate fails, stop and report what is missing.
+Run the readiness gate check for the selected flow as defined in the `intent-routing` rule (loaded via the lisa plugin). If the gate fails, stop and report what is missing.
 
 IF it is a Fix (bug), execute the Reproduce sub-flow FIRST:
 1. Write a failing test that demonstrates the bug (preferred)

--- a/plugins/src/base/agents/jira-agent.md
+++ b/plugins/src/base/agents/jira-agent.md
@@ -76,7 +76,7 @@ If the ticket type is ambiguous, read the description to classify. A "Task" that
 
 ### 5. Delegate to Flow
 
-Hand off to the appropriate flow as defined in `.claude/rules/intent-routing.md`. Pass the full ticket context (description, acceptance criteria, credentials, reproduction steps) to the first agent in the flow.
+Hand off to the appropriate flow as defined in the `intent-routing` rule (loaded via the lisa plugin). Pass the full ticket context (description, acceptance criteria, credentials, reproduction steps) to the first agent in the flow.
 
 ### 6. Sync Progress at Milestones
 

--- a/plugins/src/base/commands/build.md
+++ b/plugins/src/base/commands/build.md
@@ -3,7 +3,7 @@ description: "Build a feature. Defines acceptance criteria, researches codebase,
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Build** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Build** work type.
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket, extract context, and delegate back to the Implement flow.
 

--- a/plugins/src/base/commands/fix.md
+++ b/plugins/src/base/commands/fix.md
@@ -3,7 +3,7 @@ description: "Fix a bug. Reproduces, analyzes git history, finds root cause, imp
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Fix** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Fix** work type.
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket, extract context, and delegate back to the Implement flow.
 

--- a/plugins/src/base/commands/improve.md
+++ b/plugins/src/base/commands/improve.md
@@ -3,7 +3,7 @@ description: "Improve existing code. Measures baseline, implements improvements 
 argument-hint: "<target-description>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Improve** work type.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Improve** work type.
 
 For specific improvement types, you can also use:
 - `/lisa:plan:add-test-coverage` -- increase test coverage

--- a/plugins/src/base/commands/investigate.md
+++ b/plugins/src/base/commands/investigate.md
@@ -3,7 +3,7 @@ description: "Investigate an issue. Analyzes git history, reproduces, traces exe
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Implement** flow with the **Investigate Only** work type (spike).
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Implement** flow with the **Investigate Only** work type (spike).
 
 If the argument is a JIRA ticket ID or URL, hand off to the `jira-agent` which will read the ticket and extract context.
 

--- a/plugins/src/base/commands/monitor.md
+++ b/plugins/src/base/commands/monitor.md
@@ -3,7 +3,7 @@ description: "Monitor application health. Checks health endpoints, logs, errors,
 argument-hint: "[environment]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Monitor** sub-flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Monitor** sub-flow.
 
 This sub-flow is also invoked as part of the Verify flow's remote verification step. Delegates to `ops-specialist` for health checks, log inspection, error monitoring, and performance analysis.
 

--- a/plugins/src/base/commands/plan.md
+++ b/plugins/src/base/commands/plan.md
@@ -3,7 +3,7 @@ description: "Plan work. Defines acceptance criteria, researches codebase, maps 
 argument-hint: "<description-or-ticket-id-or-url>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Plan** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Plan** flow.
 
 If no PRD or specification exists, suggest running the **Research** flow first to produce one.
 

--- a/plugins/src/base/commands/plan/create.md
+++ b/plugins/src/base/commands/plan/create.md
@@ -3,6 +3,6 @@ description: "Creates an implementation plan from a ticket URL, file path, or te
 argument-hint: "<ticket-url | @file-path | description>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Plan** flow on $ARGUMENTS.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Plan** flow on $ARGUMENTS.
 
 If requirements are ambiguous or no specification exists, suggest running the **Research** flow first.

--- a/plugins/src/base/commands/plan/execute.md
+++ b/plugins/src/base/commands/plan/execute.md
@@ -3,4 +3,4 @@ description: "Deploys an agent team to research, implement, review and deploy a 
 argument-hint: "<ticket-url | @file-path | description>"
 ---
 
-Pass through to `/build` with $ARGUMENTS. The Build command reads `.claude/rules/intent-routing.md` and runs the full Implement → Review → Verify chain, which is what this command historically did.
+Pass through to `/build` with $ARGUMENTS. The Build command applies the `intent-routing` rule (loaded via the lisa plugin) and runs the full Implement → Review → Verify chain, which is what this command historically did.

--- a/plugins/src/base/commands/research.md
+++ b/plugins/src/base/commands/research.md
@@ -3,6 +3,6 @@ description: "Research a problem space and produce a PRD. Investigates codebase,
 argument-hint: "<problem-statement-or-feature-idea>"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Research** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Research** flow.
 
 $ARGUMENTS

--- a/plugins/src/base/commands/review.md
+++ b/plugins/src/base/commands/review.md
@@ -3,7 +3,7 @@ description: "Review code changes. Runs quality, security, performance, product,
 argument-hint: "[pr-link-or-branch]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Review** sub-flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Review** sub-flow.
 
 This sub-flow is also invoked automatically by the Implement flow. It runs `quality-specialist`, `security-specialist`, and `performance-specialist` in parallel, followed by `product-specialist` and `test-specialist`. Consolidates all findings ranked by severity.
 

--- a/plugins/src/base/commands/ship.md
+++ b/plugins/src/base/commands/ship.md
@@ -3,6 +3,6 @@ description: "Ship current changes. Alias for /verify."
 argument-hint: "[commit-message-hint]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Verify** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Verify** flow.
 
 $ARGUMENTS

--- a/plugins/src/base/commands/verify.md
+++ b/plugins/src/base/commands/verify.md
@@ -3,7 +3,7 @@ description: "Ship and verify code. Commits, opens PR, handles review loop, merg
 argument-hint: "[commit-message-hint]"
 ---
 
-Read `.claude/rules/intent-routing.md` and execute the **Verify** flow.
+Apply the `intent-routing` rule (loaded via the lisa plugin) and execute the **Verify** flow.
 
 This includes: atomic commits, PR creation, CI/review-fix loop, merge, deploy monitoring, and remote verification.
 

--- a/plugins/src/base/skills/plan-execute/SKILL.md
+++ b/plugins/src/base/skills/plan-execute/SKILL.md
@@ -47,7 +47,7 @@ If Implement, determine the work type:
 3. Improve (refactoring, optimization, coverage improvement)
 4. Investigate Only (spike -- no code changes, just findings)
 
-Run the readiness gate check for the selected flow as defined in `.claude/rules/intent-routing.md`. If the gate fails, stop and report what is missing.
+Run the readiness gate check for the selected flow as defined in the `intent-routing` rule (loaded via the lisa plugin). If the gate fails, stop and report what is missing.
 
 IF it is a Fix (bug), execute the Reproduce sub-flow FIRST:
 1. Write a failing test that demonstrates the bug (preferred)


### PR DESCRIPTION
## Summary

24 command/skill/agent files in both \`plugins/lisa/\` and \`plugins/src/base/\` instructed agents to \`Read \\\`.claude/rules/intent-routing.md\\\`\` — but Lisa deletes that file from every project on install (via \`all/deletions.json:135\`) since PR #341 switched rule distribution from copy-overwrite to plugin hooks.

Result: \`/lisa:build\`, \`/lisa:plan\`, \`/lisa:fix\`, etc. fail with a missing-file error in any post-#341 project before doing any work.

This PR replaces every literal-path reference with "Apply the \`intent-routing\` rule (loaded via the lisa plugin)". The rule is loaded automatically by the plugin system from \`plugins/lisa/rules/intent-routing.md\`, so no project-level file read is needed.

## Files changed

- 12 commands × 2 (lisa + src/base): build, fix, improve, investigate, plan, plan/create, plan/execute, monitor, research, review, ship, verify
- 1 skill × 2: plan-execute/SKILL.md
- 1 agent × 2: jira-agent.md

## Repro

Discovered when running \`/lisa:build <jira-url>\` in geminisportsai/frontend-v2.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated references to the intent-routing rule across all command and agent documentation to use the lisa plugin system for loading and applying routing rules instead of direct file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->