### PR TITLE
fix(hooks,ci): resolve local bins in TS hooks; gate Playwright aggregator on has_config

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -840,19 +840,33 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
+      - name: 🔍 Check for Playwright config
+        id: check_playwright
+        run: |
+          if [ -f "playwright.config.ts" ] || [ -f "playwright.config.js" ]; then
+            echo "has_config=true" >> $GITHUB_OUTPUT
+            echo "✅ Playwright config found"
+          else
+            echo "has_config=false" >> $GITHUB_OUTPUT
+            echo "⚠️ No Playwright config found — aggregator will skip merge"
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: 🔧 Setup Node.js
+        if: steps.check_playwright.outputs.has_config == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
-        if: inputs.package_manager == 'bun'
+        if: steps.check_playwright.outputs.has_config == 'true' && inputs.package_manager == 'bun'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.8'
 
       - name: 📦 Install dependencies
+        if: steps.check_playwright.outputs.has_config == 'true'
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then
             npm ci
@@ -864,6 +878,7 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 📥 Download all shard blob reports
+        if: steps.check_playwright.outputs.has_config == 'true'
         uses: actions/download-artifact@v4
         with:
           path: ${{ inputs.working_directory || '.' }}/all-blob-reports
@@ -871,6 +886,7 @@ jobs:
           merge-multiple: true
 
       - name: 🎭 Merge blob reports into HTML
+        if: steps.check_playwright.outputs.has_config == 'true'
         run: npx playwright merge-reports --reporter=html ./all-blob-reports
         working-directory: ${{ inputs.working_directory || '.' }}
 
@@ -878,11 +894,17 @@ jobs:
       # consumers (GitHub Actions artifact downloads, Playwright report
       # viewers) don't need to change when a repo opts into sharding.
       - name: 📤 Upload merged Playwright report
+        if: steps.check_playwright.outputs.has_config == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ github.run_id }}
           path: ${{ inputs.working_directory || '.' }}/playwright-report
           retention-days: 14
+
+      - name: 🎭 Playwright aggregator skipped (no config)
+        if: steps.check_playwright.outputs.has_config != 'true'
+        run: |
+          echo "::notice::Playwright aggregator skipped — no playwright.config.ts or playwright.config.js found"
 
   format:
     name: 📐 Check Formatting

--- a/plugins/lisa-typescript/hooks/format-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/format-on-edit.sh
@@ -43,26 +43,27 @@ esac
 # Change to the project directory to ensure package manager commands work
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Detect package manager based on lock file presence
-detect_package_manager() {
-    if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-        echo "bun"
-    elif [ -f "pnpm-lock.yaml" ]; then
-        echo "pnpm"
-    elif [ -f "yarn.lock" ]; then
-        echo "yarn"
-    elif [ -f "package-lock.json" ]; then
-        echo "npm"
-    else
-        echo "npm"  # Default fallback
-    fi
-}
-
-PKG_MANAGER=$(detect_package_manager)
+# Resolve Prettier binary — prefer local node_modules/.bin, then package-manager exec
+if [ -x "./node_modules/.bin/prettier" ]; then
+    PRETTIER_CMD="./node_modules/.bin/prettier"
+    PKG_MANAGER="npm"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    PRETTIER_CMD="bunx prettier"
+    PKG_MANAGER="bun"
+elif [ -f "pnpm-lock.yaml" ]; then
+    PRETTIER_CMD="pnpm exec prettier"
+    PKG_MANAGER="pnpm"
+elif [ -f "yarn.lock" ]; then
+    PRETTIER_CMD="yarn exec prettier"
+    PKG_MANAGER="yarn"
+else
+    PRETTIER_CMD="npx prettier"
+    PKG_MANAGER="npm"
+fi
 
 # Run Prettier on the specific file
 echo "🎨 Running Prettier on: $FILE_PATH"
-$PKG_MANAGER prettier --write "$FILE_PATH" 2>&1 | grep -v "run v" | grep -v "Done in"
+$PRETTIER_CMD --write "$FILE_PATH" 2>&1 | grep -v "run v" | grep -v "Done in"
 
 # Check the exit status
 if [ ${PIPESTATUS[0]} -eq 0 ]; then

--- a/plugins/lisa-typescript/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/lint-on-edit.sh
@@ -41,15 +41,17 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Detect package manager
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    PKG_MANAGER="bun"
+# Resolve ESLint binary — prefer local node_modules/.bin, then package-manager exec
+if [ -x "./node_modules/.bin/eslint" ]; then
+    ESLINT_CMD="./node_modules/.bin/eslint"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    ESLINT_CMD="bunx eslint"
 elif [ -f "pnpm-lock.yaml" ]; then
-    PKG_MANAGER="pnpm"
+    ESLINT_CMD="pnpm exec eslint"
 elif [ -f "yarn.lock" ]; then
-    PKG_MANAGER="yarn"
+    ESLINT_CMD="yarn exec eslint"
 else
-    PKG_MANAGER="npm"
+    ESLINT_CMD="npx eslint"
 fi
 
 # Run ESLint with --fix --quiet --cache on the specific file
@@ -60,7 +62,7 @@ fi
 echo "Running ESLint --fix on: $FILE_PATH"
 
 # First pass: attempt auto-fix
-OUTPUT=$($PKG_MANAGER eslint --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
+OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
 FIX_EXIT=$?
 
 if [ $FIX_EXIT -eq 0 ]; then
@@ -69,7 +71,7 @@ if [ $FIX_EXIT -eq 0 ]; then
 fi
 
 # Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($PKG_MANAGER eslint --quiet --cache "$FILE_PATH" 2>&1)
+OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
 LINT_EXIT=$?
 
 if [ $LINT_EXIT -eq 0 ]; then

--- a/plugins/src/typescript/hooks/format-on-edit.sh
+++ b/plugins/src/typescript/hooks/format-on-edit.sh
@@ -43,26 +43,27 @@ esac
 # Change to the project directory to ensure package manager commands work
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Detect package manager based on lock file presence
-detect_package_manager() {
-    if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-        echo "bun"
-    elif [ -f "pnpm-lock.yaml" ]; then
-        echo "pnpm"
-    elif [ -f "yarn.lock" ]; then
-        echo "yarn"
-    elif [ -f "package-lock.json" ]; then
-        echo "npm"
-    else
-        echo "npm"  # Default fallback
-    fi
-}
-
-PKG_MANAGER=$(detect_package_manager)
+# Resolve Prettier binary — prefer local node_modules/.bin, then package-manager exec
+if [ -x "./node_modules/.bin/prettier" ]; then
+    PRETTIER_CMD="./node_modules/.bin/prettier"
+    PKG_MANAGER="npm"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    PRETTIER_CMD="bunx prettier"
+    PKG_MANAGER="bun"
+elif [ -f "pnpm-lock.yaml" ]; then
+    PRETTIER_CMD="pnpm exec prettier"
+    PKG_MANAGER="pnpm"
+elif [ -f "yarn.lock" ]; then
+    PRETTIER_CMD="yarn exec prettier"
+    PKG_MANAGER="yarn"
+else
+    PRETTIER_CMD="npx prettier"
+    PKG_MANAGER="npm"
+fi
 
 # Run Prettier on the specific file
 echo "🎨 Running Prettier on: $FILE_PATH"
-$PKG_MANAGER prettier --write "$FILE_PATH" 2>&1 | grep -v "run v" | grep -v "Done in"
+$PRETTIER_CMD --write "$FILE_PATH" 2>&1 | grep -v "run v" | grep -v "Done in"
 
 # Check the exit status
 if [ ${PIPESTATUS[0]} -eq 0 ]; then

--- a/plugins/src/typescript/hooks/lint-on-edit.sh
+++ b/plugins/src/typescript/hooks/lint-on-edit.sh
@@ -41,15 +41,17 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Detect package manager
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    PKG_MANAGER="bun"
+# Resolve ESLint binary — prefer local node_modules/.bin, then package-manager exec
+if [ -x "./node_modules/.bin/eslint" ]; then
+    ESLINT_CMD="./node_modules/.bin/eslint"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    ESLINT_CMD="bunx eslint"
 elif [ -f "pnpm-lock.yaml" ]; then
-    PKG_MANAGER="pnpm"
+    ESLINT_CMD="pnpm exec eslint"
 elif [ -f "yarn.lock" ]; then
-    PKG_MANAGER="yarn"
+    ESLINT_CMD="yarn exec eslint"
 else
-    PKG_MANAGER="npm"
+    ESLINT_CMD="npx eslint"
 fi
 
 # Run ESLint with --fix --quiet --cache on the specific file
@@ -60,7 +62,7 @@ fi
 echo "Running ESLint --fix on: $FILE_PATH"
 
 # First pass: attempt auto-fix
-OUTPUT=$($PKG_MANAGER eslint --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
+OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
 FIX_EXIT=$?
 
 if [ $FIX_EXIT -eq 0 ]; then
@@ -69,7 +71,7 @@ if [ $FIX_EXIT -eq 0 ]; then
 fi
 
 # Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($PKG_MANAGER eslint --quiet --cache "$FILE_PATH" 2>&1)
+OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
 LINT_EXIT=$?
 
 if [ $LINT_EXIT -eq 0 ]; then

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -19,6 +19,7 @@ interface WorkflowInput {
 
 /** Shape of a single step inside a workflow job's `steps:` list. */
 interface WorkflowStep {
+  id?: string;
   name?: string;
   run?: string;
   uses?: string;
@@ -139,6 +140,23 @@ describe("quality.yml reusable workflow", () => {
       // Preserve the original unsharded artifact name so consumers who
       // download `playwright-report-<run-id>` keep working after opt-in.
       expect(upload?.with?.name).toBe("playwright-report-${{ github.run_id }}");
+    });
+
+    it("gates merge-reports on has_config so repos without playwright skip cleanly", () => {
+      // Repos with no playwright.config.* produce no blob artifacts from the
+      // shard matrix (check_playwright.has_config=false in each shard). The
+      // aggregator must apply the same has_config gate to its download/merge
+      // steps — otherwise `npx playwright merge-reports` runs against an
+      // empty directory and fails, breaking the required-status-check.
+      const steps = workflow.jobs.playwright_e2e_aggregate.steps ?? [];
+      const check = steps.find(s => s.id === "check_playwright");
+      expect(check).toBeDefined();
+      const merge = steps.find(
+        s => s.name === "🎭 Merge blob reports into HTML"
+      );
+      expect(merge?.if).toContain(
+        "steps.check_playwright.outputs.has_config == 'true'"
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Two independent bugs surfacing on downstream projects, fixed together.

### 1. TypeScript lint/format hooks broken on npm and bun

`plugins/src/typescript/hooks/lint-on-edit.sh` and `format-on-edit.sh` invoked `\$PKG_MANAGER eslint` / `\$PKG_MANAGER prettier` directly. That only works on pnpm and yarn-classic (which auto-resolve `node_modules/.bin`). On **npm** and **bun** it fails with:

```
Unknown command: "eslint"
```

…which blocks Claude's edits with a confusing error. Reported on `qualis/infrastructure` (a CDK/npm project).

**Fix:** prefer `./node_modules/.bin/<bin>` when present (universal), falling back to the correct exec command per lockfile:
- bun → `bunx`
- pnpm → `pnpm exec`
- yarn → `yarn exec`
- npm → `npx`

Both the source in `plugins/src/typescript/hooks/` and the built copy in `plugins/lisa-typescript/hooks/` are updated together.

### 2. `playwright_e2e_aggregate` fails on repos without Playwright config

Added in #401 to emit the unsuffixed `🎭 Playwright E2E Tests` check context for required-status rulesets. It runs \`if: always()\` so the check is produced regardless of \`playwright_shards\`.

Problem: repos with no \`playwright.config.*\` (e.g. Lisa itself) produce zero blob artifacts from the shard matrix because shards correctly skip their playwright steps. The aggregator then runs \`npx playwright merge-reports ./all-blob-reports\` against an empty directory, which fails and turns the required check red — seen on [run 24470335958](https://github.com/CodySwannGT/lisa/actions/runs/24470335958).

**Fix:** mirror the shard job's \`check_playwright\` step in the aggregator and gate download / merge / upload on \`has_config == 'true'\`. When no config is present the aggregator emits a GitHub \`::notice::\` and exits green, preserving the unsuffixed check context without attempting a merge.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test:integration\` — 40/40 pass (1 new assertion covering the has_config gate on merge-reports)
- [x] YAML validates (\`python3 -c "yaml.safe_load"\`)
- [ ] CI green on this PR — in particular, \`🎭 Playwright E2E Tests\` should now pass on Lisa itself

## Backwards compatibility

- Shards, matrix, artifact names, and aggregator \`name\` unchanged — ruleset contexts identical
- When a repo **has** \`playwright.config.*\`, aggregator behavior is byte-identical to before
- When a repo **has no** \`playwright.config.*\`, the aggregator short-circuits with a notice instead of attempting an empty merge

🤖 Generated with Claude Code