### PR TITLE
feat(migrations): relocate project-specific audit exclusions to local file

### DIFF
--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/src/migrations/ensure-audit-ignore-local-exclusions.ts
+++ b/src/migrations/ensure-audit-ignore-local-exclusions.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import * as fse from "fs-extra";
 import type { ProjectType } from "../core/config.js";
-import { readJsonOrNull, writeJson } from "../utils/json-utils.js";
+import { readJson, readJsonOrNull, writeJson } from "../utils/json-utils.js";
 import type {
   Migration,
   MigrationContext,
@@ -42,20 +42,25 @@ const TEMPLATE_PRIORITY: readonly ProjectType[] = [
 /**
  * Find the Lisa template audit.ignore.config.json path for the detected project.
  * The Lisa-owned audit config lives under `<type>/copy-overwrite/audit.ignore.config.json`.
+ * Only returns a path when the file actually exists on disk; continues to the
+ * next priority type otherwise to avoid treating a missing template as an empty
+ * baseline.
  * @param lisaDir - Lisa installation directory
  * @param detectedTypes - Project types detected for the destination project
  * @returns Template path, or null when no matching type ships one
  */
-function findTemplateConfigPath(
+async function findTemplateConfigPath(
   lisaDir: string,
   detectedTypes: readonly ProjectType[]
-): string | null {
+): Promise<string | null> {
   for (const type of TEMPLATE_PRIORITY) {
     if (!detectedTypes.includes(type)) {
       continue;
     }
     const candidate = path.join(lisaDir, type, "copy-overwrite", AUDIT_CONFIG);
-    return candidate;
+    if (await fse.pathExists(candidate)) {
+      return candidate;
+    }
   }
   return null;
 }
@@ -74,6 +79,20 @@ function collectIds(file: AuditIgnoreLike | null): ReadonlySet<string> {
     .map(entry => entry.id)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
   return new Set(ids);
+}
+
+/**
+ * Read a project-owned local JSON file, distinguishing between a missing file
+ * (returns null) and a malformed file (throws). This prevents silent data loss
+ * when a file exists but contains invalid JSON.
+ * @param filePath - Path to the JSON file
+ * @returns Parsed content, or null when the file does not exist
+ */
+async function readLocalJson<T>(filePath: string): Promise<T | null> {
+  if (!(await fse.pathExists(filePath))) {
+    return null;
+  }
+  return readJson<T>(filePath);
 }
 
 /**
@@ -103,6 +122,12 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
    * the copy-overwrite strategy. An exclusion is "project-specific" when its
    * `id` is present in the project's audit.ignore.config.json but absent from
    * the Lisa template for the same project type.
+   *
+   * When no valid Lisa template can be found for the detected project type the
+   * method returns without snapshotting anything. This is intentionally
+   * conservative: without a template we cannot distinguish Lisa-owned from
+   * project-specific exclusions, so migrating could copy Lisa-owned entries
+   * into audit.ignore.local.json.
    * @param ctx - Migration context
    */
   async beforeStrategies(ctx: MigrationContext): Promise<void> {
@@ -115,10 +140,18 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
       return;
     }
 
-    const templatePath = findTemplateConfigPath(ctx.lisaDir, ctx.detectedTypes);
+    const templatePath = await findTemplateConfigPath(
+      ctx.lisaDir,
+      ctx.detectedTypes
+    );
     const template = templatePath
       ? await readJsonOrNull<AuditIgnoreLike>(templatePath)
       : null;
+
+    if (!template) {
+      return;
+    }
+
     const templateIds = collectIds(template);
 
     const projectSpecific = projectConfig.exclusions.filter(entry => {
@@ -142,7 +175,7 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
       return false;
     }
     const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
-    const local = await readJsonOrNull<AuditIgnoreLike>(localPath);
+    const local = await readLocalJson<AuditIgnoreLike>(localPath);
     const localIds = collectIds(local);
     return this.snapshot.some(entry => {
       const id = entry.id;
@@ -152,19 +185,25 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
 
   /**
    * Merge snapshotted project-specific exclusions into audit.ignore.local.json,
-   * skipping any whose id is already present.
+   * skipping any whose id is already present. Deduplicates within the snapshot
+   * itself so that duplicate source entries are only written once.
    * @param ctx - Migration context
    * @returns Result describing the action taken
    */
   async apply(ctx: MigrationContext): Promise<MigrationResult> {
     const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
-    const local = await readJsonOrNull<AuditIgnoreLike>(localPath);
+    const local = await readLocalJson<AuditIgnoreLike>(localPath);
     const existing = Array.isArray(local?.exclusions) ? local.exclusions : [];
     const localIds = collectIds(local);
 
+    const seenIds = new Set(localIds);
     const additions = this.snapshot.filter(entry => {
       const id = entry.id;
-      return typeof id === "string" && !localIds.has(id);
+      if (typeof id !== "string" || seenIds.has(id)) {
+        return false;
+      }
+      seenIds.add(id);
+      return true;
     });
 
     if (additions.length === 0) {

--- a/src/migrations/ensure-audit-ignore-local-exclusions.ts
+++ b/src/migrations/ensure-audit-ignore-local-exclusions.ts
@@ -1,0 +1,204 @@
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import type { ProjectType } from "../core/config.js";
+import { readJsonOrNull, writeJson } from "../utils/json-utils.js";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const AUDIT_CONFIG = "audit.ignore.config.json";
+const AUDIT_LOCAL = "audit.ignore.local.json";
+
+/**
+ * One exclusion entry (partial — we only read `id` to detect duplicates)
+ */
+interface Exclusion {
+  readonly id?: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Minimal shape of an audit ignore file
+ */
+interface AuditIgnoreLike {
+  readonly exclusions?: readonly Exclusion[];
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Preferred order of project types for sourcing the Lisa audit template.
+ * First matching type wins.
+ */
+const TEMPLATE_PRIORITY: readonly ProjectType[] = [
+  "typescript",
+  "expo",
+  "cdk",
+  "nestjs",
+  "npm-package",
+];
+
+/**
+ * Find the Lisa template audit.ignore.config.json path for the detected project.
+ * The Lisa-owned audit config lives under `<type>/copy-overwrite/audit.ignore.config.json`.
+ * @param lisaDir - Lisa installation directory
+ * @param detectedTypes - Project types detected for the destination project
+ * @returns Template path, or null when no matching type ships one
+ */
+function findTemplateConfigPath(
+  lisaDir: string,
+  detectedTypes: readonly ProjectType[]
+): string | null {
+  for (const type of TEMPLATE_PRIORITY) {
+    if (!detectedTypes.includes(type)) {
+      continue;
+    }
+    const candidate = path.join(lisaDir, type, "copy-overwrite", AUDIT_CONFIG);
+    return candidate;
+  }
+  return null;
+}
+
+/**
+ * Extract the set of exclusion ids from a parsed audit ignore file.
+ * Entries missing an `id` are ignored (they cannot be de-duplicated safely).
+ * @param file - Parsed audit ignore file
+ * @returns Set of exclusion ids found in the file
+ */
+function collectIds(file: AuditIgnoreLike | null): ReadonlySet<string> {
+  if (!file || !Array.isArray(file.exclusions)) {
+    return new Set();
+  }
+  const ids = file.exclusions
+    .map(entry => entry.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  return new Set(ids);
+}
+
+/**
+ * Migration: relocate project-specific exclusions from `audit.ignore.config.json`
+ * (Lisa-owned, copy-overwrite) into `audit.ignore.local.json` (project-owned,
+ * create-only) so they survive future Lisa postinstall runs.
+ *
+ * Without this migration, projects that add transient-dependency exclusions to
+ * the Lisa-owned config see them silently stripped every install, producing
+ * noisy diffs and tempting users to commit the regression.
+ *
+ * Mirrors the shape of `EnsureTsconfigLocalIncludesMigration`:
+ *   - `beforeStrategies` snapshots the project's pre-strategy exclusions that
+ *     are not in the Lisa template (i.e., project-specific additions).
+ *   - `apply` (post-strategy) writes any snapshotted exclusions missing from
+ *     `audit.ignore.local.json` into that file.
+ */
+export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
+  readonly name = "ensure-audit-ignore-local-exclusions";
+  readonly description =
+    "Relocate project-specific audit exclusions from audit.ignore.config.json into audit.ignore.local.json";
+
+  private snapshot: readonly Exclusion[] = [];
+
+  /**
+   * Snapshot project-specific exclusions that would otherwise be stripped by
+   * the copy-overwrite strategy. An exclusion is "project-specific" when its
+   * `id` is present in the project's audit.ignore.config.json but absent from
+   * the Lisa template for the same project type.
+   * @param ctx - Migration context
+   */
+  async beforeStrategies(ctx: MigrationContext): Promise<void> {
+    this.snapshot = [];
+
+    const projectConfigPath = path.join(ctx.projectDir, AUDIT_CONFIG);
+    const projectConfig =
+      await readJsonOrNull<AuditIgnoreLike>(projectConfigPath);
+    if (!projectConfig || !Array.isArray(projectConfig.exclusions)) {
+      return;
+    }
+
+    const templatePath = findTemplateConfigPath(ctx.lisaDir, ctx.detectedTypes);
+    const template = templatePath
+      ? await readJsonOrNull<AuditIgnoreLike>(templatePath)
+      : null;
+    const templateIds = collectIds(template);
+
+    const projectSpecific = projectConfig.exclusions.filter(entry => {
+      if (typeof entry.id !== "string" || entry.id.length === 0) {
+        return false;
+      }
+      return !templateIds.has(entry.id);
+    });
+
+    this.snapshot = projectSpecific;
+  }
+
+  /**
+   * The migration applies when at least one snapshotted project-specific
+   * exclusion is missing from `audit.ignore.local.json`.
+   * @param ctx - Migration context
+   * @returns True when there is work to do
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    if (this.snapshot.length === 0) {
+      return false;
+    }
+    const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
+    const local = await readJsonOrNull<AuditIgnoreLike>(localPath);
+    const localIds = collectIds(local);
+    return this.snapshot.some(entry => {
+      const id = entry.id;
+      return typeof id === "string" && !localIds.has(id);
+    });
+  }
+
+  /**
+   * Merge snapshotted project-specific exclusions into audit.ignore.local.json,
+   * skipping any whose id is already present.
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
+    const local = await readJsonOrNull<AuditIgnoreLike>(localPath);
+    const existing = Array.isArray(local?.exclusions) ? local.exclusions : [];
+    const localIds = collectIds(local);
+
+    const additions = this.snapshot.filter(entry => {
+      const id = entry.id;
+      return typeof id === "string" && !localIds.has(id);
+    });
+
+    if (additions.length === 0) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const merged: AuditIgnoreLike = {
+      ...(local ?? {}),
+      exclusions: [...existing, ...additions],
+    };
+
+    const addedIds = additions
+      .map(entry => entry.id)
+      .filter((id): id is string => typeof id === "string");
+    const message = `Relocated ${additions.length} exclusion(s) into audit.ignore.local.json (${addedIds.join(", ")})`;
+
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would relocate exclusions: ${addedIds.join(", ")}`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [AUDIT_LOCAL],
+        message,
+      };
+    }
+
+    await fse.ensureDir(path.dirname(localPath));
+    await writeJson(localPath, merged);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [AUDIT_LOCAL],
+      message,
+    };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,3 +1,4 @@
+import { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 import type {
@@ -12,6 +13,7 @@ export type {
   MigrationContext,
   MigrationResult,
 } from "./migration.interface.js";
+export { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 
@@ -28,6 +30,7 @@ export class MigrationRegistry {
   constructor(migrations?: readonly Migration[]) {
     this.migrations = migrations ?? [
       new EnsureTsconfigLocalIncludesMigration(),
+      new EnsureAuditIgnoreLocalExclusionsMigration(),
       new EnsureLisaPostinstallMigration(),
     ];
   }

--- a/tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts
+++ b/tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts
@@ -291,5 +291,50 @@ describe("EnsureAuditIgnoreLocalExclusionsMigration", () => {
       const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
       expect(patched.exclusions).toEqual([projectSpecific]);
     });
+
+    it("does not migrate when template file is missing for the detected project type", async () => {
+      // Template directory exists for typescript but the file itself does not
+      const dir = path.join(lisaDir, "typescript", "copy-overwrite");
+      await fs.ensureDir(dir);
+      // No audit.ignore.config.json written at that path
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [{ id: PROJECT_ID_A, package: "pkg-a", reason: "r" }],
+      });
+
+      await migration.beforeStrategies(createContext());
+
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+
+    it("throws when audit.ignore.local.json exists but is malformed JSON", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [{ id: PROJECT_ID_A, package: "pkg-a", reason: "r" }],
+      });
+      await fs.writeFile(
+        path.join(projectDir, AUDIT_LOCAL),
+        "{ invalid json }",
+        "utf-8"
+      );
+
+      await migration.beforeStrategies(createContext());
+      await expect(migration.apply(createContext())).rejects.toThrow();
+    });
+
+    it("deduplicates additions when snapshot contains duplicate ids", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      const duplicate = { id: PROJECT_ID_A, package: "pkg-a", reason: "dup" };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [duplicate, duplicate],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toHaveLength(1);
+      expect(patched.exclusions[0].id).toBe(PROJECT_ID_A);
+    });
   });
 });

--- a/tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts
+++ b/tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts
@@ -1,0 +1,295 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureAuditIgnoreLocalExclusionsMigration } from "../../../src/migrations/ensure-audit-ignore-local-exclusions.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const AUDIT_CONFIG = "audit.ignore.config.json";
+const AUDIT_LOCAL = "audit.ignore.local.json";
+
+const TEMPLATE_IDS = ["TEMPLATE-1", "TEMPLATE-2"];
+const PROJECT_ID_A = "PROJECT-A";
+const PROJECT_ID_B = "PROJECT-B";
+
+describe("EnsureAuditIgnoreLocalExclusionsMigration", () => {
+  let migration: EnsureAuditIgnoreLocalExclusionsMigration;
+  let tempDir: string;
+  let lisaDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    migration = new EnsureAuditIgnoreLocalExclusionsMigration();
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Build a migration context for testing.
+   * @param detectedTypes - Detected project types
+   * @param dryRun - Whether to run in dry-run mode
+   * @returns A migration context suitable for tests
+   */
+  function createContext(
+    detectedTypes: readonly ProjectType[] = ["typescript"],
+    dryRun = false
+  ): MigrationContext {
+    return {
+      projectDir,
+      lisaDir,
+      detectedTypes,
+      dryRun,
+      logger: new SilentLogger(),
+    };
+  }
+
+  /**
+   * Seed the Lisa template audit.ignore.config.json for a given project type.
+   * @param type - Project type
+   * @param ids - Exclusion ids shipped by the template
+   */
+  async function seedTemplate(
+    type: ProjectType,
+    ids: readonly string[]
+  ): Promise<void> {
+    const dir = path.join(lisaDir, type, "copy-overwrite");
+    await fs.ensureDir(dir);
+    await fs.writeJson(path.join(dir, AUDIT_CONFIG), {
+      exclusions: ids.map(id => ({ id, package: "pkg", reason: "r" })),
+    });
+  }
+
+  describe("basic properties", () => {
+    it("has correct name and description", () => {
+      expect(migration.name).toBe("ensure-audit-ignore-local-exclusions");
+      expect(migration.description).toContain(AUDIT_LOCAL);
+    });
+  });
+
+  describe("beforeStrategies + applies()", () => {
+    it("returns false when project has no audit.ignore.config.json", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+
+      await migration.beforeStrategies(createContext());
+
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+
+    it("returns false when project file has no project-specific ids (all match template)", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: TEMPLATE_IDS.map(id => ({
+          id,
+          package: "pkg",
+          reason: "r",
+        })),
+      });
+
+      await migration.beforeStrategies(createContext());
+
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+
+    it("returns true when project file has an id missing from template and missing from local", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          ...TEMPLATE_IDS.map(id => ({ id, package: "pkg", reason: "r" })),
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "project-specific" },
+        ],
+      });
+
+      await migration.beforeStrategies(createContext());
+
+      expect(await migration.applies(createContext())).toBe(true);
+    });
+
+    it("returns false when project-specific id is already present in audit.ignore.local.json", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "r-from-config" },
+        ],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "r-from-local" },
+        ],
+      });
+
+      await migration.beforeStrategies(createContext());
+
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+  });
+
+  describe("apply()", () => {
+    it("relocates a single project-specific exclusion into audit.ignore.local.json", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      const projectSpecific = {
+        id: PROJECT_ID_A,
+        package: "pkg-a",
+        reason: "project-specific",
+      };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          ...TEMPLATE_IDS.map(id => ({ id, package: "pkg", reason: "r" })),
+          projectSpecific,
+        ],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      expect(result.changedFiles).toEqual([AUDIT_LOCAL]);
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([projectSpecific]);
+    });
+
+    it("preserves existing entries in audit.ignore.local.json", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      const existingLocal = {
+        id: "EXISTING-LOCAL",
+        package: "existing",
+        reason: "preserved",
+      };
+      const projectSpecific = {
+        id: PROJECT_ID_A,
+        package: "pkg-a",
+        reason: "new-from-config",
+      };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [projectSpecific],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [existingLocal],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([existingLocal, projectSpecific]);
+    });
+
+    it("does not duplicate an id that already exists in audit.ignore.local.json", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      const duplicated = {
+        id: PROJECT_ID_A,
+        package: "pkg-a",
+        reason: "local-wins",
+      };
+      const newProjectSpecific = {
+        id: PROJECT_ID_B,
+        package: "pkg-b",
+        reason: "brand-new",
+      };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "stale-from-config" },
+          newProjectSpecific,
+        ],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [duplicated],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([duplicated, newProjectSpecific]);
+    });
+
+    it("returns noop when every project-specific id is already in local", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "already-local" },
+        ],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [
+          { id: PROJECT_ID_A, package: "pkg-a", reason: "already-local" },
+        ],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("noop");
+    });
+
+    it("dryRun logs and reports applied without writing the file", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [{ id: PROJECT_ID_A, package: "pkg-a", reason: "r" }],
+      });
+      await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+        exclusions: [],
+      });
+
+      await migration.beforeStrategies(createContext(["typescript"], true));
+      const result = await migration.apply(createContext(["typescript"], true));
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([]);
+    });
+
+    it("creates audit.ignore.local.json when missing", async () => {
+      await seedTemplate("typescript", TEMPLATE_IDS);
+      const projectSpecific = {
+        id: PROJECT_ID_A,
+        package: "pkg-a",
+        reason: "r",
+      };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [projectSpecific],
+      });
+
+      await migration.beforeStrategies(createContext());
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([projectSpecific]);
+    });
+
+    it("falls back to expo template when typescript is absent from detectedTypes", async () => {
+      await seedTemplate("expo", ["EXPO-ONLY"]);
+      const projectSpecific = {
+        id: PROJECT_ID_A,
+        package: "pkg-a",
+        reason: "r",
+      };
+      await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+        exclusions: [
+          { id: "EXPO-ONLY", package: "pkg", reason: "shipped" },
+          projectSpecific,
+        ],
+      });
+
+      await migration.beforeStrategies(createContext(["expo"]));
+      const result = await migration.apply(createContext(["expo"]));
+
+      expect(result.action).toBe("applied");
+      const patched = await fs.readJson(path.join(projectDir, AUDIT_LOCAL));
+      expect(patched.exclusions).toEqual([projectSpecific]);
+    });
+  });
+});

--- a/tests/unit/migrations/migration-registry.test.ts
+++ b/tests/unit/migrations/migration-registry.test.ts
@@ -63,6 +63,7 @@ describe("MigrationRegistry", () => {
     const names = registry.getAll().map(m => m.name);
 
     expect(names).toContain("ensure-tsconfig-local-includes");
+    expect(names).toContain("ensure-audit-ignore-local-exclusions");
     expect(names).toContain("ensure-lisa-postinstall");
   });
 


### PR DESCRIPTION
## Summary

Adds `EnsureAuditIgnoreLocalExclusionsMigration` that snapshots project-specific exclusions from `audit.ignore.config.json` before the copy-overwrite strategy strips them, then re-adds them to `audit.ignore.local.json` after strategies run. Mirrors `EnsureTsconfigLocalIncludesMigration` (PR #373) for the audit file pair.

## Problem

`audit.ignore.config.json` is Lisa-owned (`<type>/copy-overwrite/`) and gets fully overwritten from the template every postinstall. Projects that add transient-dependency exclusions (e.g., transitive CVEs that the Lisa template doesn't ship) to this file see them silently stripped on every install, producing noisy diffs and tempting users to commit the regression.

Observed in `geminisportsai/frontend-v2`: `GHSA-xq3m-2v4x-88gg` (protobufjs) and `GHSA-rp42-5vxx-qpwr` (basic-ftp) had to be migrated manually in [frontend-v2 PR #1960](https://github.com/geminisportsai/frontend-v2/pull/1960).

## Solution

- `beforeStrategies`: read the project's `audit.ignore.config.json`, read the Lisa template for the detected type, snapshot the exclusions whose `id` is present in the project file but absent from the template — those are project-specific additions.
- `applies`: returns true when at least one snapshotted id is missing from `audit.ignore.local.json`.
- `apply`: append missing exclusions to `audit.ignore.local.json`, keeping any existing local entry as the source of truth for duplicate ids.

Idempotent: re-running the migration on a project where the exclusions already live in the local file is a no-op.

## Test plan

- [x] `bun run test:unit` — 397 pass (27 files)
- [x] New test file: `tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts` — 12 cases covering: beforeStrategies + applies in 4 states, relocation into existing/new/empty local file, duplicate handling, dryRun, and typescript-absent fallback to expo template
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds (tsc + plugin builds)
- [x] Updated `migration-registry.test.ts` to assert the new migration is registered by default

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin manifests to v1.90.0 across CDK, Expo, NestJS, Rails, TypeScript, and core.

* **New Features**
  * Added an automatic migration that detects project-specific audit-ignore entries, snapshots and moves missing exclusions into local audit-ignore configuration, deduplicates entries, supports dry-run, and creates the local file when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->