### PR TITLE
fix(ci): fail playwright aggregator when any shard fails

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -906,6 +906,27 @@ jobs:
         run: |
           echo "::notice::Playwright aggregator skipped — no playwright.config.ts or playwright.config.js found"
 
+      # The aggregator uses `always()` so the merged HTML report is produced
+      # even when shards fail (report is useful for triage). BUT
+      # `playwright merge-reports` succeeds as long as the blobs themselves
+      # merge, regardless of whether the underlying tests passed — so without
+      # this guard the aggregator's conclusion can mask failing shards and
+      # satisfy required-status-check rulesets on a red PR.
+      #
+      # `needs.playwright_e2e.result` aggregates the matrix shards:
+      #   success  → every shard passed
+      #   skipped  → playwright_e2e was skipped (no config / skip_jobs)
+      #   failure  → at least one shard failed
+      #   cancelled → at least one shard was cancelled
+      #
+      # Fail the aggregator on anything other than success/skipped so the
+      # `🎭 Playwright E2E Tests` check accurately reflects shard health.
+      - name: 🚨 Fail if any Playwright shard failed
+        if: ${{ always() && needs.playwright_e2e.result != 'success' && needs.playwright_e2e.result != 'skipped' }}
+        run: |
+          echo "::error::Playwright shard matrix result is '${{ needs.playwright_e2e.result }}' — at least one shard did not pass"
+          exit 1
+
   format:
     name: 📐 Check Formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `playwright_e2e_aggregate` job in `quality.yml` uses `if: always()` so the merged HTML report is produced even when shards fail (useful for triage). But `playwright merge-reports` succeeds as long as the blob files themselves merge — it does **not** propagate test failures. Without a guard, the aggregator's conclusion masks failing shards and satisfies required-status-check rulesets on red PRs.

## Observed bug

[geminisportsai/frontend-v2 PR #1964](https://github.com/geminisportsai/frontend-v2/pull/1964) merged with shards (2) and (4) red because the unsuffixed `🎭 Playwright E2E Tests` aggregator check reported success (it's the only check referenced in the required-status-check ruleset; the shard-level `(N)` contexts aren't gating).

## Fix

Add a final step in the aggregator that inspects `needs.playwright_e2e.result` and exits 1 when the matrix outcome is anything other than `success` or `skipped`. Matrix job result aggregates shards:
- `success` → every shard passed
- `skipped` → job did not run (no config / `skip_jobs`)
- `failure` → at least one shard failed
- `cancelled` → at least one shard was cancelled

The guard uses `if: always()` so it still runs when shards fail. The rest of the aggregator's steps (merge + HTML report upload) remain unchanged — triage workflow preserved.

## Test plan

- [x] Local YAML read — confirms new step is attached to `playwright_e2e_aggregate`, not a new job (so it inherits the aggregator's `name: 🎭 Playwright E2E Tests` and drives the existing check context).
- [ ] On merge: next consumer run with a failing shard should show the aggregator turning red (previously green).

🤖 Generated with Claude Code