### PR TITLE
chore(security): ignore @xmldom/xmldom advisories unreachable via expo plist tooling

### DIFF
--- a/typescript/copy-overwrite/audit.ignore.config.json
+++ b/typescript/copy-overwrite/audit.ignore.config.json
@@ -117,6 +117,26 @@
       "id": "GHSA-fvcv-3m26-pcqx",
       "package": "axios",
       "reason": "Cloud metadata exfiltration requires attacker-controlled outbound request header values. Keep this exclusion only if axios request headers are never sourced from untrusted input."
+    },
+    {
+      "id": "GHSA-2v35-w6hq-6mfw",
+      "package": "@xmldom/xmldom",
+      "reason": "Uncontrolled recursion in XML serialization leading to DoS. Transitive via expo > @expo/config-plugins > @expo/plist; only serializes developer-authored plist files at build/prebuild time, no runtime code path parses or serializes attacker-controlled XML."
+    },
+    {
+      "id": "GHSA-f6ww-3ggp-fr8h",
+      "package": "@xmldom/xmldom",
+      "reason": "XML injection via unvalidated DocumentType serialization. Transitive via expo > @expo/config-plugins > @expo/plist; only serializes developer-authored plist files at build/prebuild time, no runtime code path serializes attacker-controlled XML."
+    },
+    {
+      "id": "GHSA-x6wf-f3px-wcqx",
+      "package": "@xmldom/xmldom",
+      "reason": "XML node injection via unvalidated processing instruction serialization. Transitive via expo > @expo/config-plugins > @expo/plist; only serializes developer-authored plist files at build/prebuild time, no runtime code path serializes attacker-controlled XML."
+    },
+    {
+      "id": "GHSA-j759-j44w-7fr8",
+      "package": "@xmldom/xmldom",
+      "reason": "XML node injection via unvalidated comment serialization. Transitive via expo > @expo/config-plugins > @expo/plist; only serializes developer-authored plist files at build/prebuild time, no runtime code path serializes attacker-controlled XML."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds four `@xmldom/xmldom` advisories (GHSA-2v35-w6hq-6mfw, GHSA-f6ww-3ggp-fr8h, GHSA-x6wf-f3px-wcqx, GHSA-j759-j44w-7fr8) to the TypeScript `audit.ignore.config.json` template
- All four are reachable only via `expo > @expo/config-plugins > @expo/plist`, which serializes developer-authored plist files at build/prebuild time — no runtime code path feeds attacker-controlled XML into the library

## Why
Downstream Expo projects (PropSwapLLC/frontend#583) are blocked by `bun audit --audit-level=high` on these transitive advisories whenever `@expo/plist` hasn't cut a release pinning `@xmldom/xmldom >= 0.8.13`. Since this template is `copy-overwrite`, we need the exclusions upstream so they survive the next Lisa sync.

## Test plan
- [x] `jq empty` validates the updated JSON
- [x] Existing migration tests (`ensure-audit-ignore-local-exclusions`) use fixtures, not hardcoded GHSA ids, so no test update needed

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration with four new vulnerability exclusions for package dependencies, scoped to development build processes with appropriate risk documentation for each exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->