### PR TITLE
fix(lisa-update-projects): use bun add -D <pkg>@latest, not bun update

### DIFF
--- a/.claude/skills/lisa-update-projects/SKILL.md
+++ b/.claude/skills/lisa-update-projects/SKILL.md
@@ -19,7 +19,7 @@ Updates local Lisa projects in batches by running the package manager update com
    - If `engines.bun === "please-use-npm"` (or `engines.yarn` / `engines.pnpm` use the same sentinel), that package manager is **forbidden**. Use `npm`.
    - If a forbidden lockfile exists anyway (e.g., `bun.lock` in a project where `engines.bun === "please-use-npm"`), it is rogue — bun ignores the engines string and writes the lockfile if invoked. Delete it (`git rm bun.lock`) and include the deletion in the commit.
    - Pick the update command from the surviving package manager:
-     - `bun.lock` exists and bun is allowed → `bun update @codyswann/lisa`
+     - `bun.lock` exists and bun is allowed → `bun add -D @codyswann/lisa@latest` (use `bun add -D <pkg>@latest`, **not** `bun update <pkg>`. `bun update` only walks within the existing semver range, so an exact-pinned `1.95.0` or a caret-pinned `^1.95.0` against a new major like `2.x` is a no-op. `bun add -D <pkg>@latest` always resolves to the latest published version and rewrites the manifest.)
      - otherwise → `npm install -D @codyswann/lisa@latest` (use `install -D` not `update`; `npm update` only bumps within the existing semver range and won't move pinned versions or update the manifest)
    - Bun's postinstall runs templates automatically; npm's does not. After `npm install -D`, manually run `node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check .` to apply templates.
    - **Never run both `bun add` and `npm install` against the same project.** That perpetuates the dual-lockfile bug. Pick one based on the engines field and stick to it.


### PR DESCRIPTION
## Summary

`bun update <pkg>` only walks within the existing semver range — so an exact-pinned `1.95.0` or caret-pinned `^1.95.0` against a new major like `2.x` is a no-op. The skill needs to use `bun add -D <pkg>@latest`, which always resolves to the latest published version and rewrites the manifest, mirroring the `npm install -D` behavior the skill already uses for the npm path.

## Why

Came up in **every batch** of the 2.1.0 rollout: subagents had to follow up `bun update` with `bun add -D` after seeing it was a no-op against caret-pinned majors. Documenting it here so future runs of the skill don't repeat that.

## Changes

- `.claude/skills/lisa-update-projects/SKILL.md` step 6 — bun command updated to `bun add -D @codyswann/lisa@latest` with an inline note explaining why `bun update` doesn't work.

## Test plan

- [ ] CI green
- [ ] Next time the skill runs, bun-managed projects bump cleanly without manual follow-up