### PR TITLE
feat(intake): post product-friendly contextual comments on PRDs

### DIFF
--- a/plugins/src/base/skills/jira-validate-ticket/SKILL.md
+++ b/plugins/src/base/skills/jira-validate-ticket/SKILL.md
@@ -66,6 +66,39 @@ If the caller passes only a ticket key, fetch the ticket via `mcp__atlassian__ge
 
 Gates are grouped into **Specification** (spec-only checks, no JIRA lookups) and **Feasibility** (requires JIRA lookups). The dry-run path may opt to run Specification gates only; the write path runs both.
 
+Each gate is tagged with a fixed `category` and a `product_relevant` boolean. Categories drive how downstream callers (notably `lisa:notion-prd-intake`) translate failures into product-facing comments; `product_relevant=false` failures indicate internal data-quality problems (broken parent links, missing core fields) that the agent should fix itself rather than ask product to clarify.
+
+| Gate | Category | Product-relevant |
+|------|----------|------------------|
+| S1 Required core fields | `structural` | false |
+| S2 Summary format | `structural` | false |
+| S3 Description three audiences | `product-clarity` | true |
+| S4 Acceptance criteria in Gherkin | `acceptance-criteria` | true |
+| S5 Bug-specific content | `product-clarity` | true |
+| S6 Spike-specific content | `scope` | true |
+| S7 Epic parent declared | `structural` | false |
+| S8 Target Backend Environment | `technical` | false |
+| S9 Sign-in Required | `technical` | false |
+| S10 Single-repo scope | `scope` | true |
+| S11 Validation Journey | `acceptance-criteria` | true |
+| S12 Source Precedence | `design-ux` | true |
+| S13 Relationship Search | `dependency` | true |
+| F1 Issue type valid in project | `structural` | false |
+| F2 Epic parent exists and is an Epic | `structural` | false |
+| F3 Linked tickets exist | `structural` | false |
+| F4 Required custom fields populated | `structural` | false |
+
+Category values are drawn from this fixed set:
+
+- `product-clarity` — feature behavior or user intent unclear in the PRD
+- `acceptance-criteria` — pass/fail conditions missing or ambiguous
+- `design-ux` — visual or interaction spec missing
+- `scope` — boundary unclear, items overlap, split needed
+- `dependency` — blocked by another team / system / decision
+- `data` — data source / shape / volume unspecified
+- `technical` — engineering decision required (rare from PRD path; mostly internal)
+- `structural` — internal data-quality problem the agent must fix itself, not surface to product
+
 ### Specification Gates
 
 #### S1 — Required core fields
@@ -209,16 +242,32 @@ Output is a single fenced text block. Callers parse it; do not add free-form pro
 
 ### Verdict: PASS | FAIL
 ### Failures: <count>
-### Remediation
-- <gate-id>: <concrete fix the caller can apply or surface to the user>
-- <gate-id>: <concrete fix>
+### Failure details
+- gate: <gate-id>
+  category: <product-clarity|acceptance-criteria|design-ux|scope|dependency|data|technical|structural>
+  product_relevant: <true|false>
+  what: <plain-language description of what is missing or wrong, no gate-IDs, no JIRA terminology — written so a non-engineer product owner understands the issue>
+  recommendation: <1–3 concrete options the caller (or downstream product team) can pick from. Never "clarify this" — always a specific suggested resolution.>
+- gate: <gate-id>
+  category: ...
+  ...
 ```
 
 The verdict is `PASS` if and only if every applicable gate is `PASS`. Any `FAIL` makes the verdict `FAIL`. `N/A` does not affect the verdict.
+
+### Failure-detail fields
+
+- **gate**: the gate ID (`S1`–`S13`, `F1`–`F4`).
+- **category**: the gate's fixed category from the table above. Callers use this to label or filter comments — `product-clarity`, `acceptance-criteria`, `design-ux`, `scope`, `dependency`, `data`, `technical`, or `structural`.
+- **product_relevant**: matches the gate's table entry. `false` means the failure is an internal data-quality problem (e.g., the agent built a malformed spec, an issue type is invalid in the project) and the caller should fix it without bothering the product team. `true` means the PRD needs product input to resolve.
+- **what**: plain-language description of the issue. No gate IDs, no JIRA jargon, no engineering shorthand. A product owner reading this on a Notion comment should understand what is unclear and why.
+- **recommendation**: 1–3 concrete options the reader can pick from, not a generic "please clarify." If the answer is genuinely open-ended, list the most plausible candidate resolutions you considered, even if speculative.
 
 ## Rules
 
 - Never write to JIRA. The `allowed-tools` list intentionally excludes `createJiraIssue`, `editJiraIssue`, `createIssueLink`, `addCommentToJiraIssue`.
 - Never auto-fix the spec. This skill reports gaps; callers decide what to do (block, ask the human, regenerate the spec).
 - Never silently skip a gate. If a gate genuinely doesn't apply, return `N/A` with the reason; never omit it.
-- The remediation lines must be concrete and actionable — the dry-run path turns each one into a Notion comment, so vague guidance is useless.
+- The `what` and `recommendation` fields must be concrete and product-readable — the dry-run path turns each failure into a Notion comment, and the audience for those comments is the product team, not engineers. Vague guidance ("clarify this", "decide how to handle X") is useless; always give 1–3 candidate resolutions.
+- Never emit a category outside the fixed set. If a new gate doesn't fit, propose adding the category to the taxonomy in this skill rather than inventing one inline.
+- `product_relevant` is determined by the gate, not by the failure context. Do not flip it per-failure.

--- a/plugins/src/base/skills/notion-prd-intake/SKILL.md
+++ b/plugins/src/base/skills/notion-prd-intake/SKILL.md
@@ -101,7 +101,7 @@ Per-ticket gates prove each ticket is well-formed; they do NOT prove the *set* o
    |---------|--------|
    | `COMPLETE` | Done. Leave `Status = Ticketed`. Move to next PRD. |
    | `COMPLETE_WITH_SCOPE_CREEP` | Post an advisory Notion comment naming the scope-creep tickets (so product can decide whether to close them as out-of-scope). Leave `Status = Ticketed`. |
-   | `GAPS_FOUND` | The created ticket set is incomplete. (a) For each gap, post a Notion comment naming the missing PRD item and where it appears in the PRD, with the suggested fix from the audit report. (b) Post one summary comment listing the tickets that *were* successfully created (so product knows what to keep vs. what to extend). (c) Transition `Status` from `Ticketed` back to `Blocked` via `notion-update-page`. |
+   | `GAPS_FOUND` | The created ticket set is incomplete. (a) For each gap, post a Notion comment using the same product-facing template as Phase 3c.3 — block-anchored via `selection_with_ellipsis` when `prd_anchor` is non-null, page-level otherwise; category badge from the gap's `category` field; `What's unclear` and `Recommendation` from the audit report's `what` and `recommendation` fields. Apply the same forbidden-language rules from Phase 3c.5. (b) Post one summary comment listing the tickets that *were* successfully created (so product knows what to keep vs. what to extend). (c) Transition `Status` from `Ticketed` back to `Blocked` via `notion-update-page`. |
    | `NO_TICKETS_FOUND` | Should not happen if step 2 succeeded. If it does, log it as an Error in the cycle summary and leave `Status = Ticketed` with a comment flagging the audit failure for human review. |
 
 3. The created tickets remain in JIRA regardless of the verdict — they are valid in their own right (they passed `lisa:jira-validate-ticket`). The audit only tells us whether *more* are needed.
@@ -110,24 +110,65 @@ The audit's report should be summarized in the cycle summary alongside the per-P
 
 **If `FAIL`** (one or more planned tickets failed one or more gates):
 
-1. Group the failures by planned ticket.
-2. For each failed ticket, post a Notion comment via `notion-create-comment` with this format:
+The audience for these comments is the **product team**, not engineers. They are not familiar with JIRA gate IDs, validator vocabulary, or skill internals. Follow the rules below strictly — the goal is for a non-engineer product owner to read a comment, understand what is unclear, and know what to do next.
 
-   ```text
-   **Blocker — planned ticket: <ticket-summary>**
+##### 3c.1 Partition failures
 
-   The PRD as written can't produce a valid JIRA ticket for this scope. Specifically:
+1. Drop every failure where `product_relevant = false`. Those are internal data-quality problems — the agent should fix its own spec rather than ask product to clarify a missing core field. Record the dropped failures under `Errors` in the cycle summary so engineers can see them; never surface them on the PRD.
+2. Group the remaining product-relevant failures by `prd_anchor` (the snippet from `notion-to-jira`'s dry-run report). Failures that share an anchor become one comment thread on that block. Failures with `prd_anchor: null` are batched into one page-level summary comment, since they have no source section to attach to.
 
-   - **<gate-id> (<gate-name>)**: <reason>. *Fix:* <concrete remediation>.
-   - **<gate-id> (<gate-name>)**: <reason>. *Fix:* <concrete remediation>.
+##### 3c.2 Render each comment
 
-   Once these are addressed in the PRD, set Status back to `Ready` and Claude will re-run intake.
-   ```
+For each anchored group, post via `mcp__claude_ai_Notion__notion-create-comment` with:
+- `page_id`: the PRD page ID
+- `selection_with_ellipsis`: the `prd_anchor` value (e.g. `"# User taps Fol...esume action"`)
+- `rich_text`: the body, formatted using the template below
 
-3. Set `Status = Blocked` via `notion-update-page`.
-4. Do NOT write any JIRA tickets.
+For the unanchored group, post a single page-level comment (omit `selection_with_ellipsis`) using the same template, prefixed with `Issues without a specific section anchor:` and one block per failure.
 
-Each comment must name the specific planned ticket and the specific gate — vague guidance is useless to product. The remediation field on the validator's report is already concrete; pass it through.
+##### 3c.3 Comment template
+
+Each comment body MUST contain these four parts, in this order, no exceptions:
+
+```text
+[<Category badge>] <prd_section heading text>
+
+**What's unclear:** <validator's `what` field, verbatim — already product-readable>
+
+**Recommendation:** <validator's `recommendation` field, verbatim — must contain 1–3 concrete options, never a generic "please clarify">
+
+**Action:** Update this section in the PRD, then set Status back to `Ready` and Claude will re-run intake.
+```
+
+If multiple failures share an anchor, render each as its own `**What's unclear:** ... **Recommendation:** ...` block within the same comment, separated by horizontal lines (`---`). Keep the single `[Category badge]` heading at the top using the most-severe / most-blocking category from the group.
+
+##### 3c.4 Category badges
+
+Use these exact badge labels — they are the validator's category values translated for product readers:
+
+| Validator category | Badge label |
+|---------------------|-------------|
+| `product-clarity` | `[Product clarity]` |
+| `acceptance-criteria` | `[Acceptance criteria]` |
+| `design-ux` | `[Design / UX]` |
+| `scope` | `[Scope]` |
+| `dependency` | `[Dependency]` |
+| `data` | `[Data]` |
+| `technical` | `[Technical]` |
+
+`structural` failures must never reach this step (filtered in 3c.1). If you see one here, treat it as an Error and surface internally.
+
+##### 3c.5 Forbidden in product comments
+
+- Gate IDs (`S4`, `F2`, etc.). Never appear in a comment body.
+- JIRA terminology that has no product meaning (e.g. "Gherkin", "epic parent", "issue link", "validation journey", "sub-task hierarchy"). If the validator's `what` field uses one of these terms, paraphrase before posting; do not pass through verbatim.
+- Internal skill names (`lisa:jira-validate-ticket`, `notion-to-jira`).
+- Engineering shorthand (`AC`, `OOS`, `repo`, `env var`).
+- "Clarify this" / "Please specify" without candidate resolutions. The validator is required to provide candidates; if `recommendation` is empty or vague, treat the failure as an Error and surface internally rather than posting a useless comment.
+
+##### 3c.6 Status transition
+
+After all comments are posted (anchored groups + the optional page-level summary), set `Status = Blocked` via `notion-update-page`. Do NOT write any JIRA tickets.
 
 #### 3d. Continue
 
@@ -182,5 +223,7 @@ This skill reads project configuration from environment variables (or `$ARGUMENT
 - Never write to JIRA outside of `lisa:notion-to-jira` → `lisa:jira-write-ticket`. The validator's verdict gates progress; bypassing it produces broken tickets.
 - Never set Notion `Status` to a value this skill doesn't own (`In Review`, `Blocked`, `Ticketed`). Product owns `Draft`, `Ready`, `Shipped`.
 - Never edit the PRD's body. Communication with product happens only through Notion comments.
+- Never post a single page-level dump of all gate failures. One comment per `prd_anchor` group (or one page-level summary for unanchored failures only). The audience is product, not engineers — comments must be block-anchored, categorized, plain-language, and contain a concrete recommendation. See Phase 3c.3 for the required template and Phase 3c.5 for forbidden language.
+- Never include a gate ID, internal skill name, or engineering shorthand in a Notion comment body. If the validator's `what` or `recommendation` field uses one, paraphrase before posting.
 - Never run more than one intake cycle concurrently against the same database. This skill assumes serial execution. (Scheduling is a separate concern; the runtime should not start a new cycle if a previous one is still in flight.)
 - If `lisa:notion-to-jira` returns errors (e.g. unreachable artifact, malformed PRD structure), treat them as gate failures: comment + Blocked. Don't silently fail.

--- a/plugins/src/base/skills/notion-to-jira/SKILL.md
+++ b/plugins/src/base/skills/notion-to-jira/SKILL.md
@@ -28,18 +28,35 @@ Dry-run output format:
 
 ### Planned hierarchy
 - Epic: <summary>
+  prd_section: "<heading text from the PRD that produced this epic>"
+  prd_anchor: "<first ~10 chars>...<last ~10 chars>"   # for selection_with_ellipsis; null if no specific section
   - Story 1.1: <summary>
+    prd_section: "<heading or user-story line>"
+    prd_anchor: "<start>...<end>"
     - Sub-task [<repo>]: <summary>
+      prd_section: "<heading or AC bullet>"
+      prd_anchor: "<start>...<end>"
     - ...
   - Story 1.2: ...
 
 ### Per-ticket validation
 - <ticket-id>: PASS | FAIL — <count> failures
-  - <gate-id>: <one-line reason and remediation>
+  prd_section: "<heading text>"
+  prd_anchor: "<start>...<end>"   # mirrored from Planned hierarchy for caller convenience
+  failures:
+    - gate: <gate-id>
+      category: <category from validator>
+      product_relevant: <true|false>
+      what: <plain-language description from validator>
+      recommendation: <1–3 candidate resolutions from validator>
 
 ### Verdict: PASS | FAIL
 ### Total failures: <n>
 ```
+
+`prd_anchor` and `prd_section` exist so downstream callers (notably `lisa:notion-prd-intake`) can post block-anchored Notion comments via `notion-create-comment` with `selection_with_ellipsis`. Build them as you parse the PRD: when you assign a planned ticket to a heading, user-story line, or AC bullet, capture the first ~10 and last ~10 characters of that section's text and emit them in the report. If a planned ticket genuinely doesn't trace to a specific section (cross-cutting infrastructure, derived sub-tasks), set both fields to `null` — the caller will fall back to a page-level comment.
+
+The `failures` array passes the validator's `Failure details` block through verbatim. Do not re-format `what` or `recommendation` here — those fields are already product-readable per the validator's contract, and re-summarizing risks losing concrete recommendations.
 
 The dry-run mode never writes to JIRA and never calls `mcp__atlassian__createJiraIssue`. It also never sets a Notion status — that is the orchestrating skill's responsibility.
 

--- a/plugins/src/base/skills/prd-ticket-coverage/SKILL.md
+++ b/plugins/src/base/skills/prd-ticket-coverage/SKILL.md
@@ -115,9 +115,13 @@ Atomic PRD items extracted: <n>
 | ... | ... |
 
 ### Gaps  (PRD items with zero ticket coverage — blocks Ticketed status)
-- <item-id> (<type>) — <text>
-  - *Source:* <PRD section reference>
-  - *Suggested fix:* <add a ticket scoped to X / extend ticket Y to cover this / clarify whether this is in scope>
+- item: <item-id> (<type>)
+  text: <text>
+  prd_section: "<heading text from the PRD>"
+  prd_anchor: "<first ~10 chars>...<last ~10 chars>"   # for selection_with_ellipsis; null if no specific section
+  category: <product-clarity|acceptance-criteria|design-ux|scope|dependency|data|technical|structural>
+  what: <plain-language description of the gap, no JIRA jargon — written for the product team>
+  recommendation: <1–3 candidate resolutions: add a ticket scoped to X / extend ticket Y to cover this / mark out-of-scope explicitly. Never "clarify this".>
 
 ### Scope creep  (tickets without PRD trace — informational, does not block)
 - <ticket-key> — <summary>
@@ -127,6 +131,10 @@ Atomic PRD items extracted: <n>
 ### Gap count: <n>
 ### Scope-creep count: <n>
 ```
+
+`prd_anchor` and `prd_section` are built the same way as in `lisa:notion-to-jira` — the start/end snippets locate the source heading or bullet for `selection_with_ellipsis`. Set both to `null` only when the gap is not anchored to any specific section (rare).
+
+`category` is drawn from the same fixed taxonomy used by `lisa:jira-validate-ticket` so downstream callers can apply one consistent comment-formatting policy. Most coverage gaps map to `scope` (item not represented in any ticket) or `product-clarity` (item too vague to map). Use `acceptance-criteria` for missing pass/fail conditions and `design-ux` for missing visuals.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

A real-PRD test run surfaced four problems with the comments left on a Notion PRD when intake routes it to **Blocked**:

1. All gate failures dumped into one giant page-level comment instead of contextual, block-anchored comments at the source section.
2. Comments lacked concrete recommendations — just "clarify this" guidance.
3. Comments were written in engineering language (gate IDs, JIRA jargon) despite the audience being a non-engineer product team.
4. Comments did not label the kind of gap (product clarity vs. acceptance criteria vs. design vs. scope, etc.).

This PR fixes all four end-to-end across the four skills involved.

## What changed

### \`lisa:jira-validate-ticket\` (validator contract)

- Every gate now carries a fixed \`category\` and \`product_relevant\` boolean. Categories: \`product-clarity\`, \`acceptance-criteria\`, \`design-ux\`, \`scope\`, \`dependency\`, \`data\`, \`technical\`, \`structural\`.
- Replaces the single-line \`Remediation\` block in the report with a structured \`Failure details\` block carrying \`gate\` / \`category\` / \`product_relevant\` / \`what\` / \`recommendation\` per failure.
- \`what\` and \`recommendation\` are now required to be product-readable with 1–3 concrete candidate resolutions, never vague guidance.

### \`lisa:notion-to-jira\` (dry-run report)

- Each planned ticket now carries \`prd_section\` and \`prd_anchor\`. \`prd_anchor\` is a \`<first ~10 chars>...<last ~10 chars>\` snippet built directly for Notion's \`selection_with_ellipsis\`.
- Failures pass through verbatim from the validator (no re-formatting) so the comment-builder gets structured data.

### \`lisa:prd-ticket-coverage\` (coverage gap output)

- Each gap entry gains \`prd_section\`, \`prd_anchor\`, \`category\`, \`what\`, and \`recommendation\` using the same taxonomy as the validator.

### \`lisa:notion-prd-intake\` (the comment author)

- Rewrites Phase 3c FAIL into a four-step pipeline:
  1. **Partition** — drop \`product_relevant=false\` failures (internal data-quality issues; the agent fixes them itself rather than asking product).
  2. **Render** — group remaining failures by \`prd_anchor\` and post one block-anchored comment per group via \`selection_with_ellipsis\`.
  3. **Template** — strict format: \`[Category badge]\` + section heading, \`What's unclear\`, \`Recommendation\`, \`Action\`.
  4. **Status** — \`Blocked\` after all comments posted.
- Forbids gate IDs, JIRA terminology, internal skill names, and engineering shorthand in comment bodies.
- Phase 3e \`GAPS_FOUND\` reuses the same template for coverage gaps.

## Test plan

- [ ] CI green
- [ ] Re-run \`/lisa:intake\` against the same large PRD that exposed the original problems and confirm:
  - [ ] Comments are block-anchored (not all on the page level)
  - [ ] Each comment has a category badge
  - [ ] Each comment has a \`Recommendation\` block with concrete options
  - [ ] Comment bodies contain no gate IDs, no JIRA jargon, no internal skill names

🤖 Generated with Claude Code