### PR TITLE
fix(trampoline): use DI seam for spawn instead of vi.doMock (real fix this time)

### DIFF
--- a/src/utils/postinstall-trampoline.ts
+++ b/src/utils/postinstall-trampoline.ts
@@ -256,12 +256,19 @@ export function hashFile(filePath: string): string | null {
  * @param projectDir - Absolute path to the project directory Lisa will reconcile
  * @param lisaDistDir - Absolute path to Lisa's dist directory (where index.js lives)
  * @param parentPid - PID of the package-manager process to wait on (usually process.ppid)
+ * @param spawnFn - Optional spawn implementation; defaults to node:child_process spawn. Tests pass a vi.fn() spy here as a dependency-injection seam, avoiding the unreliable vi.doMock-on-builtins pattern that breaks under v8 coverage in CI runners.
  * @returns Promise that resolves immediately after spawning the detached child
  */
 export async function scheduleReconciliationChild(
   projectDir: string,
   lisaDistDir: string,
-  parentPid: number
+  parentPid: number,
+  // Dependency-injection seam: callers can override the spawn function for
+  // testing. Default is the real node:child_process spawn. Production callers
+  // pass nothing; tests pass a vi.fn() spy and assert on it directly without
+  // relying on vi.doMock for node builtins (which is flaky in CI under v8
+  // coverage). The seam is invisible to production callers.
+  spawnFn: typeof spawn = spawn
 ): Promise<void> {
   const nodeBin = process.execPath;
   const lisaEntry = path.join(lisaDistDir, "index.js");
@@ -278,7 +285,7 @@ export async function scheduleReconciliationChild(
     lockfileRegenPlans: LOCKFILE_REGEN_PLANS,
   });
 
-  const child = spawn(nodeBin, ["-e", trampolineSource], {
+  const child = spawnFn(nodeBin, ["-e", trampolineSource], {
     cwd: projectDir,
     detached: true,
     stdio: "ignore",

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -26,6 +26,7 @@ import {
   isRunningAsLifecycleScript,
   isRunningAsTrampoline,
   isRunningInCI,
+  scheduleReconciliationChild,
   shouldSchedulePostinstallReconciliation,
 } from "../../../src/utils/postinstall-trampoline.js";
 
@@ -45,8 +46,6 @@ const YARN_LOCK = "yarn.lock";
 const IGNORE_SCRIPTS = "--ignore-scripts";
 const INSTALL_CMD = "install";
 const PACKAGE_JSON = "package.json";
-const CHILD_PROCESS_MODULE = "node:child_process";
-const TRAMPOLINE_MODULE = "../../../src/utils/postinstall-trampoline.js";
 
 describe("postinstall-trampoline", () => {
   const originalEnv = { ...process.env };
@@ -401,15 +400,17 @@ describe("postinstall-trampoline", () => {
       delete process.env.CONTINUOUS_INTEGRATION;
 
       const child = makeFakeChild();
+      // Use the dependency-injection seam (4th arg) instead of vi.doMock for
+      // node:child_process. Mocking node builtins via doMock + dynamic import
+      // is unreliable in CI under v8 coverage — the real spawn fires anyway,
+      // causing ENOENT and a missed-spy assertion. Direct DI is bulletproof.
       const spawnSpy = vi.fn().mockReturnValue(child);
-      vi.doMock(CHILD_PROCESS_MODULE, () => ({ spawn: spawnSpy }));
-      vi.resetModules();
-      const fresh = await import(TRAMPOLINE_MODULE);
 
-      await fresh.scheduleReconciliationChild(
+      await scheduleReconciliationChild(
         FAKE_PROJECT_DIR,
         FAKE_LISA_DIST,
-        4242
+        4242,
+        spawnSpy as unknown as typeof import("node:child_process").spawn
       );
 
       expect(spawnSpy).toHaveBeenCalledTimes(1);
@@ -444,9 +445,6 @@ describe("postinstall-trampoline", () => {
       // Detached mode must not wait on the child process — never registers an
       // exit listener because the parent package manager needs to return.
       expect(child.on).not.toHaveBeenCalled();
-
-      vi.doUnmock(CHILD_PROCESS_MODULE);
-      vi.resetModules();
     });
 
     it("spawns a detached process with unref in CI (avoids deadlock with package manager)", async () => {
@@ -458,33 +456,21 @@ describe("postinstall-trampoline", () => {
       //
       // Fix: CI mode behaves the same as interactive mode (detached + unref'd)
       // so the PM can exit, the trampoline detects the exit, and reconciliation
-      // actually runs.
+      // actually runs. This test is a regression guard — scheduleReconciliationChild
+      // has no CI branch in source, so the assertion holds regardless of env.
       //
-      // NOTE: We deliberately do NOT mutate process.env.CI / GITHUB_ACTIONS /
-      // CONTINUOUS_INTEGRATION here. scheduleReconciliationChild does not read
-      // those env vars (no CI branch in the source — both modes do the same
-      // thing), so the assertion below holds regardless. Mutating them
-      // interferes with vitest's own CI detection, which on real CI runners
-      // (where GITHUB_ACTIONS=true at process start) breaks vi.doMock for
-      // builtin modules like node:child_process under v8 coverage. This test
-      // is a regression guard against future CI-specific blocking behavior;
-      // it does not need to actually be running under CI env vars to do that.
-
-      // Defensive: clear any stale module cache from prior tests before
-      // installing the mock, so the dynamic import below picks up the spy.
-      vi.resetModules();
-      vi.doUnmock(CHILD_PROCESS_MODULE);
+      // We use the dependency-injection seam (4th arg) instead of vi.doMock
+      // for node:child_process — the latter is unreliable under v8 coverage
+      // in CI release-workflow runners.
 
       const child = makeFakeChild();
       const spawnSpy = vi.fn().mockReturnValue(child);
-      vi.doMock(CHILD_PROCESS_MODULE, () => ({ spawn: spawnSpy }));
-      vi.resetModules();
-      const fresh = await import(TRAMPOLINE_MODULE);
 
-      await fresh.scheduleReconciliationChild(
+      await scheduleReconciliationChild(
         FAKE_PROJECT_DIR,
         FAKE_LISA_DIST,
-        4242
+        4242,
+        spawnSpy as unknown as typeof import("node:child_process").spawn
       );
 
       expect(spawnSpy).toHaveBeenCalledTimes(1);
@@ -500,8 +486,6 @@ describe("postinstall-trampoline", () => {
       // Must NOT register a blocking exit listener — that would re-introduce
       // the circular wait.
       expect(child.on).not.toHaveBeenCalled();
-
-      vi.doUnmock(CHILD_PROCESS_MODULE);
       vi.resetModules();
     });
   });


### PR DESCRIPTION
## Summary

The earlier fix (#425, removing CI env mutation from the test) didn't actually fix the deterministic test failure — same test failed again on the next release-workflow run after the `lisa-update-projects` skill fix merged.

**Real root cause**: `vi.doMock` for node:builtin modules (`node:child_process`) is unreliable under v8 coverage in CI runners. The mock isn't applied → real spawn fires with `process.execPath` → the runner's hoisted-toolcache node binary path resolves incorrectly inside the vitest worker → ENOENT + missed-spy assertion.

**Real fix**: dependency-injection seam. Add an optional `spawnFn` parameter to `scheduleReconciliationChild`. Production callers pass nothing (default binds to real `spawn`). Tests pass a `vi.fn()` spy directly and assert on it without touching node:builtin module mocking.

Bulletproof — no module-cache state, no doMock timing issues, no v8 coverage interactions, no CI/local divergence.

Backward compatible (param is optional with sensible default).

## Verification

```
CI=true GITHUB_ACTIONS=true CONTINUOUS_INTEGRATION=true \\
  npx vitest run --coverage tests/unit/utils/postinstall-trampoline.test.ts
→ 35/35 passed

CI=true GITHUB_ACTIONS=true npx vitest run --exclude='**/integration/**'
→ 546/546 passed
```

## Test plan

- [ ] CI green (this is what's blocking 2.1.1 / 2.2.0)
- [ ] Release workflow on main publishes the next version to npm

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal modularity of the reconciliation scheduling mechanism for better maintainability.

* **Tests**
  * Updated tests to better validate the reconciliation process behavior without relying on module mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->