### PR TITLE
fix(governance): propagate oxlint deps + restore baseUrl in stack templates

### DIFF
--- a/cdk/copy-overwrite/tsconfig.json
+++ b/cdk/copy-overwrite/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": ["@codyswann/lisa/tsconfig/cdk", "./tsconfig.local.json"]
+  "extends": ["@codyswann/lisa/tsconfig/cdk", "./tsconfig.local.json"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "ignoreDeprecations": "6.0"
+  }
 }

--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -9,7 +9,9 @@
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:integration": "vitest run tests/integration --passWithNoTests",
       "test:cov": "vitest run --coverage",
-      "test:watch": "vitest"
+      "test:watch": "vitest",
+      "lint": "oxlint && eslint . --quiet",
+      "lint:fix": "oxlint --fix && eslint . --fix"
     },
     "dependencies": {
       "@aws-cdk/aws-amplify-alpha": "^2.235.0-alpha.0",
@@ -22,7 +24,10 @@
       "aws-cdk": "^2.1104.0",
       "vite": "^8.0.5",
       "vitest": "^4.1.0",
-      "@vitest/coverage-v8": "^4.1.0"
+      "@vitest/coverage-v8": "^4.1.0",
+      "eslint-plugin-oxlint": "^1.62.0",
+      "oxlint": "^1.62.0",
+      "oxlint-tsgolint": "^0.22.1"
     },
     "bin": {
       "infrastructure": "bin/infrastructure.js"

--- a/expo/copy-overwrite/tsconfig.json
+++ b/expo/copy-overwrite/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": ["@codyswann/lisa/tsconfig/expo", "./tsconfig.local.json"]
+  "extends": ["@codyswann/lisa/tsconfig/expo", "./tsconfig.local.json"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "ignoreDeprecations": "6.0"
+  }
 }

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -48,7 +48,9 @@
       "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:cov": "NODE_ENV=test jest --coverage",
-      "test:watch": "NODE_ENV=test jest --watch"
+      "test:watch": "NODE_ENV=test jest --watch",
+      "lint": "oxlint && eslint . --quiet",
+      "lint:fix": "oxlint --fix && eslint . --fix"
     },
     "dependencies": {
       "@apollo/client": "^3.10.8",
@@ -141,7 +143,10 @@
       "@jest/test-sequencer": "^30.2.0",
       "jest-environment-jsdom": "^30.2.0",
       "jest-expo": "^54.0.12",
-      "serve": "^14.2.0"
+      "serve": "^14.2.0",
+      "eslint-plugin-oxlint": "^1.62.0",
+      "oxlint": "^1.62.0",
+      "oxlint-tsgolint": "^0.22.1"
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",

--- a/nestjs/copy-overwrite/tsconfig.json
+++ b/nestjs/copy-overwrite/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": ["@codyswann/lisa/tsconfig/nestjs", "./tsconfig.local.json"]
+  "extends": ["@codyswann/lisa/tsconfig/nestjs", "./tsconfig.local.json"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "ignoreDeprecations": "6.0"
+  }
 }

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -35,7 +35,9 @@
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:integration": "vitest run '.integration.' --passWithNoTests",
       "test:cov": "vitest run --coverage",
-      "test:watch": "vitest"
+      "test:watch": "vitest",
+      "lint": "oxlint && eslint . --quiet",
+      "lint:fix": "oxlint --fix && eslint . --fix"
     },
     "dependencies": {
       "@apollo/server": "^5.2.0",
@@ -82,7 +84,10 @@
       "serverless-offline": "^14.4.0",
       "vite": "^8.0.5",
       "vitest": "^4.1.0",
-      "@vitest/coverage-v8": "^4.1.0"
+      "@vitest/coverage-v8": "^4.1.0",
+      "eslint-plugin-oxlint": "^1.62.0",
+      "oxlint": "^1.62.0",
+      "oxlint-tsgolint": "^0.22.1"
     }
   }
 }

--- a/typescript/copy-overwrite/tsconfig.json
+++ b/typescript/copy-overwrite/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": ["@codyswann/lisa/tsconfig/typescript", "./tsconfig.local.json"]
+  "extends": ["@codyswann/lisa/tsconfig/typescript", "./tsconfig.local.json"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "ignoreDeprecations": "6.0"
+  }
 }

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -1,20 +1,25 @@
 {
   "force": {
     "scripts": {
-      "lint": "eslint . --quiet",
+      "lint": "oxlint && eslint . --quiet",
       "format:check": "prettier --check .",
       "format": "prettier --check . --write",
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:cov": "vitest run --coverage",
       "test:watch": "vitest",
-      "lint:fix": "eslint . --fix",
+      "lint:fix": "oxlint --fix && eslint . --fix",
       "lint:slow": "eslint . --config eslint.slow.config.ts --quiet",
       "typecheck": "tsc --noEmit",
       "knip": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "prepare": "node -e \"if (process.env.INIT_CWD && process.env.INIT_CWD.includes('.serverless')) { process.exit(0); }\" && husky install || true"
+    },
+    "devDependencies": {
+      "eslint-plugin-oxlint": "^1.62.0",
+      "oxlint": "^1.62.0",
+      "oxlint-tsgolint": "^0.22.1"
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",


### PR DESCRIPTION
## Summary
Two production bugs surfaced when 12 downstream projects ran `lisa update` against v2.6.0. This PR fixes both at the governance source.

## Bug A: oxlint deps not propagated to downstream projects
v2.6.0 added `oxlint`, `eslint-plugin-oxlint`, `oxlint-tsgolint` to the **root** `package.lisa.json` `force.devDependencies` — but Lisa applies the **stack-specific** `<stack>/package-lisa/package.lisa.json` to projects, not the root file. Every project hit `Cannot find module 'eslint-plugin-oxlint'` during pre-push (Lisa's compiled `dist/configs/eslint/<stack>.js` imports the plugin), and `oxlint --fix` in the new lint-staged config errored out with "command not found." Each agent worked around it locally with `bun add -D`.

**Fix:** declare the three oxlint deps + `lint`/`lint:fix` script overrides in all 4 stack `package-lisa/package.lisa.json` files (typescript, expo, nestjs, cdk). Inheritance from typescript→child stacks didn't work in practice; explicit declaration in each is the reliable path.

## Bug B: removing baseUrl broke bare-specifier root imports
v2.6.0 removed `baseUrl: "./"` from `<stack>/copy-overwrite/tsconfig.json` on the rationale that `paths`-based imports work without it under TS 4.1+. True — but does NOT hold for projects with **bare-specifier root imports** like `import x from "tailwind.config"`, `import x from "aws-exports"`, `import x from "e2e/testId"`. Those require baseUrl. Phase 1 had patched per-project, but in `tsconfig.json` itself — which is `copy-overwrite` and gets wiped on every Lisa update.

**Fix:** restore `"baseUrl": "./"` and `"ignoreDeprecations": "6.0"` in all 4 stack copy-overwrite tsconfig.json templates. `ignoreDeprecations` silences the TS5101 deprecation; baseUrl makes resolution work for both styles. Projects that don't need baseUrl pay only the (silenced) deprecation — no behavior change.

## Verification
- Lisa's own `tsc --noEmit` clean.
- Lisa's own `bun run lint` clean (oxlint + eslint).
- All 586 vitest tests pass.

Refs Lisa epic [#345](https://github.com/CodySwannGT/lisa/issues/345). Surfaced by the 12-project `lisa-update` batch run.

🤖 Generated with Claude Code