### PR TITLE
fix(oxlint): loosen default rules to let ESLint own threshold-based limits

### DIFF
--- a/oxlint/base.json
+++ b/oxlint/base.json
@@ -12,12 +12,14 @@
     "correctness": "error"
   },
   "rules": {
-    "max-lines": ["error", { "max": 300, "skipBlankLines": true, "skipComments": true }],
-    "max-lines-per-function": ["error", { "max": 75, "skipBlankLines": true, "skipComments": true }],
-    "no-console": "warn",
     "no-debugger": "error",
     "prefer-const": "error",
-    "no-var": "error"
+    "no-var": "error",
+    "no-console": "off",
+    "no-unused-vars": "off",
+    "max-lines": "off",
+    "max-lines-per-function": "off",
+    "jsdoc/check-tag-names": "off"
   },
   "ignorePatterns": [
     "build/**",

--- a/oxlint/expo.json
+++ b/oxlint/expo.json
@@ -15,14 +15,6 @@
   "categories": {
     "correctness": "error"
   },
-  "overrides": [
-    {
-      "files": ["**/*.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 400, "skipBlankLines": true, "skipComments": true }]
-      }
-    }
-  ],
   "ignorePatterns": [
     "build/**",
     "dist/**",


### PR DESCRIPTION
## Summary
The published v2.6.x oxlint base hard-coded `max-lines: 300` and `max-lines-per-function: 75` as errors. Real downstream projects have **project-specific** thresholds in `eslint.thresholds.json` (e.g. 600 / 716) that ESLint already enforces dynamically. The hard-coded oxlint defaults flagged ~350 errors per legacy frontend project on the first `lisa update`, blocking every Phase 2 rollout PR.

## Fix
Let ESLint stay the gatekeeper for threshold-driven rules; oxlint owns correctness + a small set of opinionated rules projects shouldn't touch.

**Disabled in oxlint base:**
- `max-lines`, `max-lines-per-function` — owned by ESLint via `eslint.thresholds.json`
- `no-console` — projects ship CLI/dev-tools that legitimately log
- `no-unused-vars` — oxlint lacks ESLint's `caughtErrorsIgnorePattern`; ESLint keeps that enforcement
- `jsdoc/check-tag-names` — projects define custom tags

**Still enforced by oxlint:** `correctness` category (real bugs), `no-debugger`, `prefer-const`, `no-var`.

Also drops the unused `*.tsx max-lines: 400` override in expo.json.

## Verification
- Lisa's own `bun run lint` still clean: 0 errors / 0 warnings, 107 rules, 142 files, 136ms.
- All 586 vitest tests pass.

Refs Lisa epic [#345](https://github.com/CodySwannGT/lisa/issues/345). Surfaced by Phase 2 rollout PRs against propswap/frontend, frontend-v2, thumbwar/frontend (each hit 350+ false-positive lint errors).

🤖 Generated with Claude Code