### PR TITLE
fix(oxlint): warn-by-default + inline ignorePatterns in copy-overwrite

### DIFF
--- a/cdk/copy-overwrite/.oxlintrc.json
+++ b/cdk/copy-overwrite/.oxlintrc.json
@@ -1,4 +1,15 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/cdk.json"]
+  "extends": ["./node_modules/@codyswann/lisa/oxlint/cdk.json"],
+  "ignorePatterns": [
+    "build/**",
+    "dist/**",
+    ".build/**",
+    "coverage/**",
+    "node_modules/**",
+    "*.generated.*",
+    "**/__generated__/**",
+    "**/generated/**",
+    "cdk.out/**"
+  ]
 }

--- a/expo/copy-overwrite/.oxlintrc.json
+++ b/expo/copy-overwrite/.oxlintrc.json
@@ -1,4 +1,19 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/expo.json"]
+  "extends": ["./node_modules/@codyswann/lisa/oxlint/expo.json"],
+  "ignorePatterns": [
+    "build/**",
+    "dist/**",
+    ".build/**",
+    "coverage/**",
+    "node_modules/**",
+    "*.generated.*",
+    "**/__generated__/**",
+    "**/generated/**",
+    ".expo/**",
+    "ios/**",
+    "android/**",
+    "web-build/**",
+    "components/ui/**"
+  ]
 }

--- a/nestjs/copy-overwrite/.oxlintrc.json
+++ b/nestjs/copy-overwrite/.oxlintrc.json
@@ -1,4 +1,14 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/nestjs.json"]
+  "extends": ["./node_modules/@codyswann/lisa/oxlint/nestjs.json"],
+  "ignorePatterns": [
+    "build/**",
+    "dist/**",
+    ".build/**",
+    "coverage/**",
+    "node_modules/**",
+    "*.generated.*",
+    "**/__generated__/**",
+    "**/generated/**"
+  ]
 }

--- a/oxlint/base.json
+++ b/oxlint/base.json
@@ -9,7 +9,7 @@
     "promise"
   ],
   "categories": {
-    "correctness": "error"
+    "correctness": "warn"
   },
   "rules": {
     "no-debugger": "error",

--- a/typescript/copy-overwrite/.oxlintrc.json
+++ b/typescript/copy-overwrite/.oxlintrc.json
@@ -1,4 +1,14 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/typescript.json"]
+  "extends": ["./node_modules/@codyswann/lisa/oxlint/typescript.json"],
+  "ignorePatterns": [
+    "build/**",
+    "dist/**",
+    ".build/**",
+    "coverage/**",
+    "node_modules/**",
+    "*.generated.*",
+    "**/__generated__/**",
+    "**/generated/**"
+  ]
 }


### PR DESCRIPTION
## Summary
Two issues surfaced when bumping 3 frontend projects to 2.6.2.

### 1. oxlint `extends` doesn't inherit `ignorePatterns`
Verified empirically: a project's `.oxlintrc.json` that extends a Lisa stack config gets the rules and overrides, but NOT the `ignorePatterns`. Lisa's `oxlint/expo.json` listed `components/ui/**` in `ignorePatterns` — that was effectively dead. thumbwar/frontend hit 7 `jsx-a11y` errors from files that should have been ignored.

**Fix:** move `ignorePatterns` into each stack's `<stack>/copy-overwrite/.oxlintrc.json` template so they live at the project's root config — where oxlint reads them directly without relying on inheritance.

### 2. `categories.correctness: error` blocks legacy projects
propswap/frontend and frontend-v2 each had 100–250 real-but-pre-existing rule violations (e.g. `no-unsafe-optional-chaining`, `jsdoc/require-property-type`, `unicorn/no-empty-file`) that ESLint never enforced. Forcing them as errors blocks every Phase 2 rollout PR until the legacy code is cleaned up — defeats the "introduce oxlint without breaking projects" goal.

**Fix:** change `categories.correctness` from `error` to `warn` in `oxlint/base.json`. Rules still surface and are visible in CI output but don't fail `bun run lint`. Truly critical rules (`no-debugger`, `prefer-const`, `no-var`) stay as explicit `error` overrides. Projects can ratchet up per-project after they clean up existing issues — same pattern Lisa uses for ESLint thresholds.

## Verification
Lisa's own `bun run lint` still clean: 0 errors / 0 warnings, 107 rules, 142 files, 116ms.

Refs Lisa epic [#345](https://github.com/CodySwannGT/lisa/issues/345). Surfaced by Phase 2 rollout to propswap/frontend, frontend-v2, thumbwar/frontend.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated linter configuration across projects to exclude common build artifacts, dependency directories, and auto-generated code from linting checks, reducing noise in linting reports.
* Adjusted severity level for code quality checks to treat certain issues as warnings rather than blocking errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->