### PR TITLE
fix(oxlint): drop expo categories override that re-escalated correctness to error

### DIFF
--- a/oxlint/expo.json
+++ b/oxlint/expo.json
@@ -12,9 +12,6 @@
     "react-perf",
     "jsx-a11y"
   ],
-  "categories": {
-    "correctness": "error"
-  },
   "ignorePatterns": [
     "build/**",
     "dist/**",


### PR DESCRIPTION
## Summary
v2.6.3 demoted `categories.correctness` from `error` to `warn` in `oxlint/base.json`, but `oxlint/expo.json` still hardcoded the same key to `error`. The expo override took precedence on the inheritance chain, so Expo projects still saw correctness rules as errors — defeating 2.6.3's purpose for the projects that surfaced the bug.

**Confirmed downstream:**
- propswap/frontend: 98 lint errors after 2.6.3 bump
- geminisportsai/frontend-v2: 245 lint errors after 2.6.3 bump

Removing the `categories` block from expo.json lets it inherit `warn` from `base.json` like the other stack configs (typescript, nestjs, cdk — none of which had the override).

## Verification
Lisa's own lint clean: 0 errors / 0 warnings.

Refs Lisa epic [#345](https://github.com/CodySwannGT/lisa/issues/345). Surfaced by Phase 2 frontend-stack rollouts.

🤖 Generated with Claude Code