### PR TITLE
fix(postinstall): heal stale local lisa marketplace registrations

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -103,6 +103,27 @@ if ! command -v claude &>/dev/null; then exit 0; fi
 # pointing to the GitHub repo (CodySwannGT/lisa). Built plugins are committed to the repo
 # so relative paths in marketplace.json resolve correctly.
 
+# Heal stale local registrations of the "lisa" marketplace.
+# Earlier Lisa versions (pre-2.0) registered node_modules/@codyswann/lisa as a
+# *local* marketplace named "lisa" via `claude marketplace add "$LISA_DIR"`.
+# That registration persists in the host project's claude state across upgrades
+# and shadows the github source declared in extraKnownMarketplaces, which makes
+# Claude Code's plugin UI mark the lisa plugin as a local plugin and refuse the
+# "Update now" action with: "Local plugins cannot be updated remotely."
+# If we detect a non-github marketplace named "lisa", uninstall the plugins
+# sourced from it and remove the registration so the github source can take over.
+if command -v jq >/dev/null 2>&1; then
+  STALE_LISA_SOURCE=$(claude plugin marketplace list --json 2>/dev/null \
+    | jq -r '.[] | select(.name == "lisa" and .source != "github") | .source' 2>/dev/null \
+    | head -n 1)
+  if [ -n "${STALE_LISA_SOURCE:-}" ]; then
+    for stale_plugin in "lisa@lisa" "lisa-typescript@lisa" "lisa-expo@lisa" "lisa-nestjs@lisa" "lisa-cdk@lisa" "lisa-rails@lisa"; do
+      claude plugin uninstall "$stale_plugin" --scope project </dev/null >/dev/null 2>&1 || true
+    done
+    claude plugin marketplace remove lisa </dev/null >/dev/null 2>&1 || true
+  fi
+fi
+
 # Always install the base plugin (universal governance for all projects)
 claude plugin install "lisa@lisa" --scope project </dev/null 2>&1 || true
 


### PR DESCRIPTION
## Summary

- Detect host projects where the `lisa` marketplace is registered with a non-github source (a stale local registration from earlier Lisa versions) and self-heal during postinstall.
- Uninstall any plugins sourced from that stale local marketplace and remove the registration so the github source declared in `.claude/settings.json` (`extraKnownMarketplaces.CodySwannGT/lisa`) takes over.

## Why

Earlier Lisa versions registered `node_modules/@codyswann/lisa` as a *local* marketplace named `lisa` via `claude marketplace add "$LISA_DIR"`. That registration persists in the host project's claude state across upgrades and shadows the github source — so Claude Code's plugin UI marks the lisa plugin as local and refuses "Update now" with:

> Local plugins cannot be updated remotely. To update, modify the source at: ./plugins/lisa

The current install script no longer creates that registration, but it never cleans up the stale one. This change makes the postinstall idempotent for already-affected projects.

## Test plan

- [ ] On an affected host project (lisa shows as local in `/plugin` UI), bump `@codyswann/lisa` to a build containing this change and confirm postinstall:
  - removes the stale local `lisa` marketplace entry
  - reinstalls the plugin against the github-source marketplace
  - "Update now" is enabled in the `/plugin` UI on the next session
- [ ] On a clean host project (no stale registration), confirm the new block is a no-op and the existing install path is unchanged.
- [ ] Run with `jq` unavailable — the heal block must be skipped without erroring.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installation process to automatically detect and remove outdated plugin registrations, ensuring a cleaner setup and preventing conflicts from previous installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->