### PR TITLE
fix(marketplace): switch plugin sources to git-subdir + heal local classification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,37 +10,61 @@
   "plugins": [
     {
       "name": "lisa",
-      "source": "./plugins/lisa",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa"
+      },
       "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
       "category": "productivity"
     },
     {
       "name": "lisa-typescript",
-      "source": "./plugins/lisa-typescript",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa-typescript"
+      },
       "description": "TypeScript hooks — formatting, linting, and ast-grep scanning on edit",
       "category": "productivity"
     },
     {
       "name": "lisa-expo",
-      "source": "./plugins/lisa-expo",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa-expo"
+      },
       "description": "Expo/React Native skills, agents, and rules",
       "category": "productivity"
     },
     {
       "name": "lisa-nestjs",
-      "source": "./plugins/lisa-nestjs",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa-nestjs"
+      },
       "description": "NestJS skills (GraphQL, TypeORM)",
       "category": "productivity"
     },
     {
       "name": "lisa-cdk",
-      "source": "./plugins/lisa-cdk",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa-cdk"
+      },
       "description": "AWS CDK plugin",
       "category": "productivity"
     },
     {
       "name": "lisa-rails",
-      "source": "./plugins/lisa-rails",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/CodySwannGT/lisa.git",
+        "path": "plugins/lisa-rails"
+      },
       "description": "Ruby on Rails skills, rules, and conventions",
       "category": "productivity"
     }

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -124,6 +124,71 @@ if command -v jq >/dev/null 2>&1; then
   fi
 fi
 
+# Heal stale "local plugin" classification (heal-v2).
+#
+# Lisa marketplace v2.9+ switched plugin source declarations from bare
+# relative-path strings (e.g. "source": "./plugins/lisa-expo") to object-form
+# `git-subdir` sources. The relative-path form caused Claude Code's /plugin UI
+# to classify each plugin as local — the UI showed "Local plugins cannot be
+# updated remotely. To update, modify the source at: ./plugins/lisa-expo" and
+# disabled the "Update now" action even though the marketplace itself was
+# github-sourced.
+#
+# Plugins installed against the old marketplace.json schema retain that local
+# classification until they're reinstalled. This block refreshes the cached
+# marketplace.json, detects the new schema, and force-reinstalls already-
+# installed lisa-* plugins so they get re-resolved as remote. Worktrees under
+# .claude/worktrees/ have their own per-cwd plugin install state and are
+# healed in the same pass. A marker file gates one-time execution per cwd.
+LISA_PLUGINS=("lisa@lisa" "lisa-typescript@lisa" "lisa-expo@lisa" "lisa-nestjs@lisa" "lisa-cdk@lisa" "lisa-rails@lisa")
+HEAL_V2_MARKER_NAME=".lisa-marketplace-heal-v2"
+
+heal_local_classification() {
+  local cwd="$1"
+  local installed_for_cwd="$2"
+  local marker="$cwd/.claude/$HEAL_V2_MARKER_NAME"
+  [ -f "$marker" ] && return 0
+
+  (
+    cd "$cwd" || exit 0
+    for plugin in "${LISA_PLUGINS[@]}"; do
+      if printf '%s\n' "$installed_for_cwd" | grep -qx "$plugin"; then
+        claude plugin uninstall "$plugin" --scope project </dev/null >/dev/null 2>&1 || true
+        claude plugin install "$plugin" --scope project </dev/null >/dev/null 2>&1 || true
+      fi
+    done
+  )
+  mkdir -p "$cwd/.claude"
+  touch "$marker"
+}
+
+if command -v jq >/dev/null 2>&1; then
+  # Refresh the cached marketplace.json so we're reading the latest schema.
+  claude plugin marketplace update lisa </dev/null >/dev/null 2>&1 || true
+
+  MARKETPLACE_JSON_PATH="$HOME/.claude/plugins/marketplaces/lisa/.claude-plugin/marketplace.json"
+  NEW_SCHEMA="false"
+  if [ -f "$MARKETPLACE_JSON_PATH" ]; then
+    NEW_SCHEMA=$(jq -r '[.plugins[]? | select((.source | type) == "object")] | length > 0' "$MARKETPLACE_JSON_PATH" 2>/dev/null || echo "false")
+  fi
+
+  if [ "$NEW_SCHEMA" = "true" ]; then
+    PLUGIN_LIST_JSON=$(claude plugin list --json 2>/dev/null || echo "[]")
+
+    INSTALLED_FOR_PROJECT=$(printf '%s' "$PLUGIN_LIST_JSON" | jq -r --arg cwd "$PROJECT_ROOT" '.[] | select(.projectPath == $cwd) | .id' 2>/dev/null || true)
+    heal_local_classification "$PROJECT_ROOT" "$INSTALLED_FOR_PROJECT"
+
+    if [ -d "$PROJECT_ROOT/.claude/worktrees" ]; then
+      for worktree_dir in "$PROJECT_ROOT/.claude/worktrees"/*/; do
+        worktree_dir="${worktree_dir%/}"
+        [ -d "$worktree_dir" ] || continue
+        INSTALLED_FOR_WORKTREE=$(printf '%s' "$PLUGIN_LIST_JSON" | jq -r --arg cwd "$worktree_dir" '.[] | select(.projectPath == $cwd) | .id' 2>/dev/null || true)
+        heal_local_classification "$worktree_dir" "$INSTALLED_FOR_WORKTREE"
+      done
+    fi
+  fi
+fi
+
 # Always install the base plugin (universal governance for all projects)
 claude plugin install "lisa@lisa" --scope project </dev/null 2>&1 || true
 

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -194,9 +194,9 @@ claude plugin install "lisa@lisa" --scope project </dev/null 2>&1 || true
 
 # Detect which stack plugin to install from .claude/settings.json
 LISA_STACK=""
-if [ -f "$SETTINGS_FILE" ]; then
+if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
   for stack in expo nestjs cdk rails; do
-    if grep -q "\"lisa-${stack}@lisa\"" "$SETTINGS_FILE" 2>/dev/null; then
+    if jq -e "(.enabledPlugins // {}) | has(\"lisa-${stack}@lisa\")" "$SETTINGS_FILE" >/dev/null 2>&1; then
       LISA_STACK="$stack"
       break
     fi

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -149,15 +149,30 @@ heal_local_classification() {
   local marker="$cwd/.claude/$HEAL_V2_MARKER_NAME"
   [ -f "$marker" ] && return 0
 
-  (
-    cd "$cwd" || exit 0
-    for plugin in "${LISA_PLUGINS[@]}"; do
-      if printf '%s\n' "$installed_for_cwd" | grep -qx "$plugin"; then
+  # Important: do ALL uninstalls before ANY reinstall.
+  # Interleaved uninstall/install across sibling lisa-* plugins wipes other
+  # plugins' cache directories under ~/.claude/plugins/cache/lisa/, leaving
+  # later reinstalls with phantom installPaths and the /plugin UI hiding the
+  # base lisa plugin entirely. Batched ordering keeps all caches intact.
+  local to_heal=()
+  local plugin
+  for plugin in "${LISA_PLUGINS[@]}"; do
+    if printf '%s\n' "$installed_for_cwd" | grep -qx "$plugin"; then
+      to_heal+=("$plugin")
+    fi
+  done
+
+  if [ "${#to_heal[@]}" -gt 0 ]; then
+    (
+      cd "$cwd" || exit 0
+      for plugin in "${to_heal[@]}"; do
         claude plugin uninstall "$plugin" --scope project </dev/null >/dev/null 2>&1 || true
+      done
+      for plugin in "${to_heal[@]}"; do
         claude plugin install "$plugin" --scope project </dev/null >/dev/null 2>&1 || true
-      fi
-    done
-  )
+      done
+    )
+  fi
   mkdir -p "$cwd/.claude"
   touch "$marker"
 }


### PR DESCRIPTION
## Summary

- Switch every plugin in `.claude-plugin/marketplace.json` from bare relative-path string sources (`"source": "./plugins/lisa-expo"`) to object-form `git-subdir` sources pointing back at `CodySwannGT/lisa`. Bare relative paths cause Claude Code's `/plugin` UI to classify each plugin as **local**, disabling the "Update now" action with: *"Local plugins cannot be updated remotely. To update, modify the source at: ./plugins/lisa-expo"* — even though the marketplace itself is github-sourced.
- Add a heal-v2 block to `scripts/install-claude-plugins.sh` so already-installed host projects auto-fix on the next postinstall: refresh the cached `marketplace.json`, detect the new object-form schema, and force uninstall + reinstall of any `lisa-*` plugins installed for `PROJECT_ROOT` *and* for each `.claude/worktrees/*/` cwd. A marker file (`.claude/.lisa-marketplace-heal-v2`) gates one-time execution per cwd.

## Why

PR #446 healed stale *marketplace* registrations (when the lisa marketplace itself was added as `local` instead of `github`). That fixed one symptom but not the underlying one: the plugins inside the marketplace still had relative-path sources, which Claude Code interprets as local. The "Update now" disabled state continued to reproduce in worktrees of `frontend-v2` even after #446 landed.

## How it works after merge

1. Lisa publishes a new version with the updated `marketplace.json`.
2. Host project does `bun install @codyswann/lisa@latest` (or equivalent).
3. Postinstall fires `install-claude-plugins.sh`, which:
   - runs `claude plugin marketplace update lisa` to pick up the new `marketplace.json`
   - detects that `.plugins[].source` is now object-typed → triggers heal
   - uninstalls every `lisa-*` plugin currently installed for the main project, then the existing install loop reinstalls them against the new (remote) source
   - walks `.claude/worktrees/*/` and does the same uninstall + reinstall in each
   - drops a `.lisa-marketplace-heal-v2` marker so subsequent runs no-op

After heal, `claude plugin list --json` entries for the lisa plugins resolve via the new git-subdir source, and the `/plugin` UI shows "Update now" enabled.

## Test plan

- [ ] On the existing affected worktree (`frontend-v2/.claude/worktrees/SE-4698`) bump `@codyswann/lisa` to a build containing this change. Confirm postinstall:
  - refreshes the lisa marketplace cache
  - uninstalls + reinstalls `lisa@lisa`, `lisa-typescript@lisa`, `lisa-expo@lisa` for both the main project and the worktree
  - writes `.claude/.lisa-marketplace-heal-v2` in both
- [ ] Open `/plugin` in the worktree → `lisa-expo @ lisa` is no longer marked Local; "Update now" is enabled.
- [ ] Re-run `bun install` → heal block no-ops on subsequent runs (marker present).
- [ ] On a clean host project with no prior lisa install, the heal block is a harmless no-op (no plugins installed → `INSTALLED_FOR_PROJECT` empty → loop skips uninstall/reinstall, marker still touched).
- [ ] Run with `jq` unavailable → heal block skipped without erroring.
- [ ] `claude plugin validate /path/to/lisa` passes against the new marketplace.json (verified locally).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin sources now reference a centralized Git repository instead of local paths.
  * Automatic migration refreshes installed plugins to adopt the new source format.

* **Chores**
  * Installer logic improved: stack detection uses JSON querying when available and limits migration runs per workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->