### PR TITLE
fix(release): include rebuilt plugin manifests in release commit

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -39,7 +39,8 @@
       "type": "json"
     }
   ],
+  "commit-all": true,
   "scripts": {
-    "postbump": "bash scripts/build-plugins.sh && git add plugins/lisa-*"
+    "postbump": "bash scripts/build-plugins.sh"
   }
 }


### PR DESCRIPTION
## Summary
- `standard-version`'s default commit step only commits files listed in `bumpFiles` + the changelog `infile`. The existing postbump's `git add plugins/lisa-*` staged files but they were never included in the `chore(release):` commit.
- Result: every release since the postbump was added (Mar 4) has left `plugins/*/.claude-plugin/plugin.json` at **2.8.0** in git, even as `package.json` moved through 2.8.1 → 2.8.3.
- The marketplace fetches plugins via `git-subdir` from this repo, and Claude Code compares the marketplace's `plugin.json` version against the installed copy. Since both sides see 2.8.0, host projects see *"lisa is already at the latest version (2.8.0)"* in `/plugin` — the "Update now" path is silently broken for every host project.

## Fix
- Set `"commit-all": true` in `.versionrc` so files staged during postbump get included in the release commit.
- Drop the now-redundant `git add plugins/lisa-*` (also fixes a glob bug — that pattern excluded the base `plugins/lisa/` plugin).

## Why this is the backfill too
On merge, semantic-release will bump `package.json` to **2.8.4**, the postbump will rebuild plugin manifests at 2.8.4, and `commit-all` will commit them in the same `chore(release): 2.8.4` commit. Host projects will then see 2.8.4 (newer than their installed 2.8.0) and the update flow will fire — no separate backfill PR needed.

## Test plan
- [ ] Merge and watch the release workflow. The resulting `chore(release): 2.8.4 [skip ci]` commit should include `plugins/*/.claude-plugin/plugin.json` alongside `package.json` and `CHANGELOG.md`.
- [ ] Pull a host project, run `/plugin` → should now show "Update available" / version 2.8.4.

🤖 Generated with Claude Code