### PR TITLE
fix(release): stage rebuilt plugin manifests in postbump

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -41,6 +41,6 @@
   ],
   "commit-all": true,
   "scripts": {
-    "postbump": "bash scripts/build-plugins.sh"
+    "postbump": "bash scripts/build-plugins.sh && git add plugins/lisa plugins/lisa-*"
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #449. The `commit-all: true` change alone was not enough — `commit-all` in standard-version 9.5.0 only changes how `git commit` is invoked (no explicit paths, so it commits the **index**). It does **not** auto-stage modified-but-unstaged files.

That's why the just-shipped 2.8.4 release commit only included `package.json` + `CHANGELOG.md` again — the rebuilt plugin manifests in the working tree were never staged, so the index didn't have them.

## Fix
- Restore `git add` in postbump (originally removed in #449 as "redundant" — it wasn't).
- Expand the glob from `plugins/lisa-*` to `plugins/lisa plugins/lisa-*` so the base plugin directory is also staged. The bare `lisa-*` glob never matched `plugins/lisa/`.

## Verification of the diagnosis
From the 2.8.4 release run log:
```
✔ Running lifecycle script "postbump"
ℹ - execute command: "bash scripts/build-plugins.sh"
✔ outputting changes to CHANGELOG.md
✔ committing package.json and CHANGELOG.md and all staged files
```
"and all staged files" confirms `commit-all` was active. But `git show 48883c8 --stat` shows only `CHANGELOG.md` + `package.json`, and `plugins/*/.claude-plugin/plugin.json` are still at 2.8.0 in main. Source confirms standard-version 9.5.0's commit step does not run `git add --all` — it only stages bumpFiles + CHANGELOG and relies on `commit-all` to widen the commit to the rest of the index.

## On merge
- semantic-release bumps to **2.8.5**.
- postbump rebuilds plugin manifests **and stages them**.
- `commit-all` causes the release commit to include them.
- `git show <release-sha> --stat` should list 6 `plugins/*/.claude-plugin/plugin.json` files alongside `package.json` + `CHANGELOG.md`.

🤖 Generated with Claude Code