### PR TITLE
fix(marketplace): add ref:main to git-subdir plugin sources

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa"
+        "path": "plugins/lisa",
+        "ref": "main"
       },
       "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
       "category": "productivity"
@@ -23,7 +24,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-typescript"
+        "path": "plugins/lisa-typescript",
+        "ref": "main"
       },
       "description": "TypeScript hooks — formatting, linting, and ast-grep scanning on edit",
       "category": "productivity"
@@ -33,7 +35,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-expo"
+        "path": "plugins/lisa-expo",
+        "ref": "main"
       },
       "description": "Expo/React Native skills, agents, and rules",
       "category": "productivity"
@@ -43,7 +46,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-nestjs"
+        "path": "plugins/lisa-nestjs",
+        "ref": "main"
       },
       "description": "NestJS skills (GraphQL, TypeORM)",
       "category": "productivity"
@@ -53,7 +57,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-cdk"
+        "path": "plugins/lisa-cdk",
+        "ref": "main"
       },
       "description": "AWS CDK plugin",
       "category": "productivity"
@@ -63,7 +68,8 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-rails"
+        "path": "plugins/lisa-rails",
+        "ref": "main"
       },
       "description": "Ruby on Rails skills, rules, and conventions",
       "category": "productivity"


### PR DESCRIPTION
## Summary
Lisa's marketplace.json declares each plugin with a `git-subdir` source but no `ref`/`sha`. Every other working `git-subdir` plugin in installed marketplaces (42crunch, Adobe creative-cloud, etc.) declares an explicit `ref`.

## Symptoms observed before this fix
- After 2.8.5 ships and host project's install record is at 2.8.5, `/plugin` Update fails with `ENOENT: no such file or directory, copyfile '~/.claude/plugins/cache/lisa/commands/security/zap-scan.md' → '~/.claude/plugins/cache/lisa/lisa/2.8.0/commands/security/zap-scan.md'`. The file existed at `cache/temp_subdir_<id>/commands/security/zap-scan.md` — Claude Code's copy step is reading from the wrong source path.
- `~/.claude/plugins/cache/lisa/` gets wiped entirely on Claude Code restart, even when manually populated with valid content matching the install records (other marketplaces' caches survive — only lisa's gets GC'd).
- The marketplace clone at `~/.claude/plugins/marketplaces/lisa/` is fine; the issue is purely in the per-session fetch/cache flow Claude Code runs for git-subdir plugins.
- End-user: lisa skills don't appear in `/skills`, and `/plugin` actions all dead-end on the same Remove dialog.

## Fix
Add `"ref": "main"` to each of the 6 plugin sources in `.claude-plugin/marketplace.json`. `main` is the right ref because Lisa releases bump plugin manifests on `main` (see #449/#450), and host projects pick up updates via `/plugin` Update.

## Why this likely matters
Adobe's marketplace declares: `{"source": "git-subdir", "url": "...", "path": "...", "ref": "main"}`. 42crunch declares both `ref` and `sha`. Lisa's was declaring url+path only. Without `ref`, Claude Code's resolver appears to leave the cache in an inconsistent state that GC then cleans up.

## After merge → propagation
- semantic-release will cut **2.8.6**.
- Host projects' marketplace clones refresh against main, picking up the new `ref` field.
- Next `/plugin` action / Claude Code restart in a host project should successfully fetch lisa into `cache/lisa/lisa/2.8.6/` without the partial-extract / GC-on-restart pathology.

## Caveat
This diagnosis is based on the difference between Lisa's marketplace.json and other working git-subdir entries. I have not been able to find Claude Code source/docs that explicitly mandate `ref`. If the symptoms persist after this lands, something else is going on (possibly a Claude Code bug specific to git-subdir extracting from a `path` deeper than one level, or to repos that contain lots of unrelated content).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved plugin source pinning to ensure consistent and stable plugin versions across installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->