### PR TITLE
fix(marketplace): remove pluginRoot from metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,7 @@
     "name": "Cody Swann"
   },
   "metadata": {
-    "description": "Claude Code governance plugins for TypeScript, Expo, NestJS, CDK, and Rails projects",
-    "pluginRoot": "./plugins"
+    "description": "Claude Code governance plugins for TypeScript, Expo, NestJS, CDK, and Rails projects"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary
After #451 added `ref: main`, the git-subdir extraction step started succeeding (temp_subdir is populated with the complete plugin tree, 143 files including all skill subdirs), but Claude Code still fails to move staged content into `cache/<marketplace>/<plugin>/<version>/`. Symptoms reported by user: `/skills` shows no lisa skills; `cache/lisa/` is wiped on every Claude Code restart while other marketplace caches survive.

## What's different about Lisa's marketplace.json
The only structural difference between Lisa's marketplace.json and `claude-plugins-official` (a working multi-plugin git-subdir marketplace) is the presence of `metadata.pluginRoot: ./plugins`. claude-plugins-official has no `pluginRoot` field at all.

Each Lisa plugin's source already specifies a full path from the repo root (e.g., `"path": "plugins/lisa"`), so `pluginRoot` is redundant — and is the most likely culprit for the broken move step.

## Fix
Remove `pluginRoot` from `metadata`. Lisa's marketplace.json will now match the structure of working examples.

## Caveat
Same as #451: this is reasoning by analogy to working marketplaces. I have not been able to confirm Claude Code's exact resolver behavior. If `/skills` still shows no lisa skills after this lands and a 2.8.7 release ships, the bug is somewhere I haven't found and we'll need to file a Claude Code issue with the full reproduction steps documented here and in #449/#450/#451.

🤖 Generated with Claude Code