### PR TITLE
revert(marketplace): remove ref:main from git-subdir sources

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa",
-        "ref": "main"
+        "path": "plugins/lisa"
       },
       "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
       "category": "productivity"
@@ -23,8 +22,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-typescript",
-        "ref": "main"
+        "path": "plugins/lisa-typescript"
       },
       "description": "TypeScript hooks — formatting, linting, and ast-grep scanning on edit",
       "category": "productivity"
@@ -34,8 +32,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-expo",
-        "ref": "main"
+        "path": "plugins/lisa-expo"
       },
       "description": "Expo/React Native skills, agents, and rules",
       "category": "productivity"
@@ -45,8 +42,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-nestjs",
-        "ref": "main"
+        "path": "plugins/lisa-nestjs"
       },
       "description": "NestJS skills (GraphQL, TypeORM)",
       "category": "productivity"
@@ -56,8 +52,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-cdk",
-        "ref": "main"
+        "path": "plugins/lisa-cdk"
       },
       "description": "AWS CDK plugin",
       "category": "productivity"
@@ -67,8 +62,7 @@
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-rails",
-        "ref": "main"
+        "path": "plugins/lisa-rails"
       },
       "description": "Ruby on Rails skills, rules, and conventions",
       "category": "productivity"


### PR DESCRIPTION
## Summary
Reverts #451. User reports the marketplace was working before that PR, with `git-subdir` sources declaring only `url` + `path` (no `ref`).

After #451 shipped:
- Claude Code's `git-subdir` extraction succeeded into `temp_subdir_<id>/` but never moved staged content to the final cache.
- `.orphaned_at` marker files appeared inside the temp_subdir, suggesting Claude Code was mutating the staging area mid-flow.
- The most recent error pointed at `rename temp_subdir → cache/<plugin>/` (flat path under cache, no marketplace prefix, no version), which is **not** the structure other working plugins use on disk.

The earlier reasoning (42crunch and Adobe both declare `ref` and work, therefore Lisa needs `ref` too) is being abandoned here based on user's lived experience that things were working before this change.

## Kept
The `pluginRoot` removal from #452 stays — it was a separate cleanup for parity with `claude-plugins-official`'s structure and wasn't implicated in the working state.

## On merge → propagation
- semantic-release cuts 2.8.8.
- Marketplace clones refresh; per-plugin sources lose the `ref` field.
- Behavior should return to the pre-#451 state where lisa skills loaded.

🤖 Generated with Claude Code