### PR TITLE
revert(marketplace): restore bare-string sources and pluginRoot

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,66 +4,43 @@
     "name": "Cody Swann"
   },
   "metadata": {
-    "description": "Claude Code governance plugins for TypeScript, Expo, NestJS, CDK, and Rails projects"
+    "description": "Claude Code governance plugins for TypeScript, Expo, NestJS, CDK, and Rails projects",
+    "pluginRoot": "./plugins"
   },
   "plugins": [
     {
       "name": "lisa",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa"
-      },
+      "source": "./plugins/lisa",
       "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
       "category": "productivity"
     },
     {
       "name": "lisa-typescript",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-typescript"
-      },
+      "source": "./plugins/lisa-typescript",
       "description": "TypeScript hooks — formatting, linting, and ast-grep scanning on edit",
       "category": "productivity"
     },
     {
       "name": "lisa-expo",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-expo"
-      },
+      "source": "./plugins/lisa-expo",
       "description": "Expo/React Native skills, agents, and rules",
       "category": "productivity"
     },
     {
       "name": "lisa-nestjs",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-nestjs"
-      },
+      "source": "./plugins/lisa-nestjs",
       "description": "NestJS skills (GraphQL, TypeORM)",
       "category": "productivity"
     },
     {
       "name": "lisa-cdk",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-cdk"
-      },
+      "source": "./plugins/lisa-cdk",
       "description": "AWS CDK plugin",
       "category": "productivity"
     },
     {
       "name": "lisa-rails",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/CodySwannGT/lisa.git",
-        "path": "plugins/lisa-rails"
-      },
+      "source": "./plugins/lisa-rails",
       "description": "Ruby on Rails skills, rules, and conventions",
       "category": "productivity"
     }


### PR DESCRIPTION
## Summary
Reverts #447 and #452 — restores marketplace.json to the **pre-#447 state** that was working yesterday: bare-string `source: "./plugins/lisa"` entries and `metadata.pluginRoot: ./plugins`.

## What we know
- **Pre-#447 (yesterday):** bare-string sources, plugins loaded, skills worked. /plugin "Update now" was disabled because Claude Code classified the plugins as local.
- **Post-#447:** object-form git-subdir sources enabled "Update now" but broke skill loading. Symptoms across host projects: empty `cache/lisa/`, partial extractions in `temp_subdir_<id>/`, Claude Code-written `.orphaned_at` markers, rename targets pointing at `cache/<plugin>/` flat (no marketplace prefix, no version) failing ENOTEMPTY.
- #451 (add ref:main), #452 (remove pluginRoot), #453 (revert ref) all probed without resolving it.

## Why it likely fails post-#447
Every working `git-subdir` plugin in installed marketplaces has its source repo in a *different* git repo than the marketplace.json. Lisa's `marketplace.json` lives in the same repo as its plugins — Claude Code's resolver does not appear to handle that case. The bare-string ("local plugin") path is the one that does work for a same-repo layout: Claude Code reads files directly from the marketplace clone at `~/.claude/plugins/marketplaces/lisa/plugins/<name>/`, with no separate fetch/cache pipeline.

## Trade-off
Loses the `/plugin` "Update now" button (was the original motivation for #447). Updates still propagate via marketplace clone refresh — and since plugins live in the marketplace repo, marketplace refresh *is* the plugin update.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration to load plugins from local sources instead of remote repositories, establishing a local plugin root directory for improved plugin management and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->