### PR TITLE
feat(hooks): mechanically enforce TeamCreate-first for lifecycle skills

### DIFF
--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -15,6 +15,15 @@
             "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code user-prompt-submit || true"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -35,6 +44,15 @@
             "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-todo || true"
           }
         ]
+      },
+      {
+        "matcher": "TeamCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -53,6 +71,15 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-no-verify.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
           }
         ]
       }
@@ -131,6 +158,15 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-flow-context.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
           }
         ]
       }

--- a/plugins/lisa/hooks/enforce-team-first.sh
+++ b/plugins/lisa/hooks/enforce-team-first.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Enforces team-first orchestration for lifecycle skills.
+#
+# Triggered on four hook events:
+#   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake in the
+#                         raw prompt and arms enforcement for the session
+#   - PreToolUse        : detects the same skills via a `Skill` tool call,
+#                         arms enforcement, and blocks bypass tool calls
+#                         until ToolSearch+TeamCreate have fired
+#   - PostToolUse       : on a successful TeamCreate, marks the session as
+#                         team-created (lifts enforcement)
+#   - SubagentStart     : marks the new subagent session as a teammate so
+#                         it is exempt — teammates inherit the lead's team
+#                         and must never call TeamCreate (double-create
+#                         is rejected by the harness)
+#
+# Per-session state lives under "$STATE_DIR" as flag files keyed by
+# session_id. Stale state (>24h) is cleaned on each invocation.
+#
+# Fail-open: any unexpected jq parse failure or missing field exits 0
+# rather than blocking. A broken hook must never brick a session.
+
+set -uo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+STATE_DIR="${TMPDIR:-/tmp}/lisa-team-enforce"
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+
+SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
+SKILL_FLAG="${STATE_DIR}/${SESSION_ID}.skill"
+TEAM_FLAG="${STATE_DIR}/${SESSION_ID}.team"
+
+# Best-effort cleanup of stale state files. Errors are ignored.
+find "$STATE_DIR" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
+
+is_lifecycle_skill() {
+  case "$1" in
+    lisa:research|lisa:plan|lisa:implement|lisa:intake) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+case "$HOOK_EVENT" in
+  SubagentStart)
+    touch "$SUBAGENT_FLAG" 2>/dev/null || true
+    exit 0
+    ;;
+
+  UserPromptSubmit)
+    PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // empty' 2>/dev/null || true)
+    if [ -n "$PROMPT" ]; then
+      # Match a slash command at the start of the prompt (allow optional whitespace).
+      LEADING=$(printf '%s' "$PROMPT" | sed -n '1p' | sed -E 's/^[[:space:]]*//')
+      case "$LEADING" in
+        /lisa:research*|/lisa:plan*|/lisa:implement*|/lisa:intake*)
+          # Strip leading slash and any args after the first whitespace.
+          SKILL_NAME=$(printf '%s' "$LEADING" | sed -E 's|^/||; s/[[:space:]].*$//')
+          printf '%s\n' "$SKILL_NAME" >"$SKILL_FLAG" 2>/dev/null || true
+          ;;
+      esac
+    fi
+    exit 0
+    ;;
+
+  PostToolUse)
+    TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+      ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
+      IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
+      if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
+        touch "$TEAM_FLAG" 2>/dev/null || true
+      fi
+    fi
+    exit 0
+    ;;
+
+  PreToolUse)
+    : # fall through
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac
+
+# --- PreToolUse enforcement path ---
+
+# Teammates inherit the team; never enforce on subagent sessions.
+if [ -f "$SUBAGENT_FLAG" ]; then
+  exit 0
+fi
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+if [ -z "$TOOL_NAME" ]; then
+  exit 0
+fi
+
+# Detect lifecycle skill invocation via the Skill tool.
+if [ "$TOOL_NAME" = "Skill" ]; then
+  SKILL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null || true)
+  if is_lifecycle_skill "$SKILL_NAME"; then
+    printf '%s\n' "$SKILL_NAME" >"$SKILL_FLAG" 2>/dev/null || true
+    # The skill load itself is allowed; enforcement begins on the next call.
+    exit 0
+  fi
+fi
+
+# No lifecycle skill armed — nothing to enforce.
+if [ ! -f "$SKILL_FLAG" ]; then
+  exit 0
+fi
+
+# Team has been created — enforcement complete.
+if [ -f "$TEAM_FLAG" ]; then
+  exit 0
+fi
+
+# These two are the path forward; never block them.
+case "$TOOL_NAME" in
+  ToolSearch|TeamCreate)
+    exit 0
+    ;;
+esac
+
+# Determine whether this tool is a bypass path. Anything not in this set
+# is allowed (e.g. TodoWrite, AskUserQuestion, ExitPlanMode) so we don't
+# over-block.
+should_block=0
+case "$TOOL_NAME" in
+  Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate)
+    should_block=1 ;;
+  Skill|Read|Write|Edit|MultiEdit|NotebookEdit|Bash|Grep|Glob|WebSearch|WebFetch)
+    should_block=1 ;;
+  mcp__*)
+    should_block=1 ;;
+esac
+
+if [ "$should_block" -eq 0 ]; then
+  exit 0
+fi
+
+ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
+cat >&2 <<EOF
+Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
+Before any other tool call, you must:
+
+  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
+  2. TeamCreate                                   (actually create the team)
+
+The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
+the ticket, exploring the code, fetching context — those are tasks for the
+team you are about to create, not for the lead session before the team
+exists.
+
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
+ToolSearch.
+EOF
+exit 2

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -13,6 +13,12 @@
             "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code user-prompt-submit || true"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
+        ]
       }
     ],
     "PostToolUse": [
@@ -26,6 +32,12 @@
         "matcher": "TodoWrite",
         "hooks": [
           { "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-todo || true" }
+        ]
+      },
+      {
+        "matcher": "TeamCreate",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
         ]
       }
     ],
@@ -41,6 +53,12 @@
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-no-verify.sh" }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
+        ]
       }
     ],
     "Stop": [
@@ -55,7 +73,8 @@
     ],
     "SubagentStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-flow-context.sh" }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-flow-context.sh" }] },
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }] }
     ],
     "SessionEnd": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-end || true" }] }

--- a/plugins/src/base/hooks/enforce-team-first.sh
+++ b/plugins/src/base/hooks/enforce-team-first.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Enforces team-first orchestration for lifecycle skills.
+#
+# Triggered on four hook events:
+#   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake in the
+#                         raw prompt and arms enforcement for the session
+#   - PreToolUse        : detects the same skills via a `Skill` tool call,
+#                         arms enforcement, and blocks bypass tool calls
+#                         until ToolSearch+TeamCreate have fired
+#   - PostToolUse       : on a successful TeamCreate, marks the session as
+#                         team-created (lifts enforcement)
+#   - SubagentStart     : marks the new subagent session as a teammate so
+#                         it is exempt — teammates inherit the lead's team
+#                         and must never call TeamCreate (double-create
+#                         is rejected by the harness)
+#
+# Per-session state lives under "$STATE_DIR" as flag files keyed by
+# session_id. Stale state (>24h) is cleaned on each invocation.
+#
+# Fail-open: any unexpected jq parse failure or missing field exits 0
+# rather than blocking. A broken hook must never brick a session.
+
+set -uo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+STATE_DIR="${TMPDIR:-/tmp}/lisa-team-enforce"
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+
+SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
+SKILL_FLAG="${STATE_DIR}/${SESSION_ID}.skill"
+TEAM_FLAG="${STATE_DIR}/${SESSION_ID}.team"
+
+# Best-effort cleanup of stale state files. Errors are ignored.
+find "$STATE_DIR" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
+
+is_lifecycle_skill() {
+  case "$1" in
+    lisa:research|lisa:plan|lisa:implement|lisa:intake) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+case "$HOOK_EVENT" in
+  SubagentStart)
+    touch "$SUBAGENT_FLAG" 2>/dev/null || true
+    exit 0
+    ;;
+
+  UserPromptSubmit)
+    PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // empty' 2>/dev/null || true)
+    if [ -n "$PROMPT" ]; then
+      # Match a slash command at the start of the prompt (allow optional whitespace).
+      LEADING=$(printf '%s' "$PROMPT" | sed -n '1p' | sed -E 's/^[[:space:]]*//')
+      case "$LEADING" in
+        /lisa:research*|/lisa:plan*|/lisa:implement*|/lisa:intake*)
+          # Strip leading slash and any args after the first whitespace.
+          SKILL_NAME=$(printf '%s' "$LEADING" | sed -E 's|^/||; s/[[:space:]].*$//')
+          printf '%s\n' "$SKILL_NAME" >"$SKILL_FLAG" 2>/dev/null || true
+          ;;
+      esac
+    fi
+    exit 0
+    ;;
+
+  PostToolUse)
+    TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+      ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
+      IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
+      if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
+        touch "$TEAM_FLAG" 2>/dev/null || true
+      fi
+    fi
+    exit 0
+    ;;
+
+  PreToolUse)
+    : # fall through
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac
+
+# --- PreToolUse enforcement path ---
+
+# Teammates inherit the team; never enforce on subagent sessions.
+if [ -f "$SUBAGENT_FLAG" ]; then
+  exit 0
+fi
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+if [ -z "$TOOL_NAME" ]; then
+  exit 0
+fi
+
+# Detect lifecycle skill invocation via the Skill tool.
+if [ "$TOOL_NAME" = "Skill" ]; then
+  SKILL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null || true)
+  if is_lifecycle_skill "$SKILL_NAME"; then
+    printf '%s\n' "$SKILL_NAME" >"$SKILL_FLAG" 2>/dev/null || true
+    # The skill load itself is allowed; enforcement begins on the next call.
+    exit 0
+  fi
+fi
+
+# No lifecycle skill armed — nothing to enforce.
+if [ ! -f "$SKILL_FLAG" ]; then
+  exit 0
+fi
+
+# Team has been created — enforcement complete.
+if [ -f "$TEAM_FLAG" ]; then
+  exit 0
+fi
+
+# These two are the path forward; never block them.
+case "$TOOL_NAME" in
+  ToolSearch|TeamCreate)
+    exit 0
+    ;;
+esac
+
+# Determine whether this tool is a bypass path. Anything not in this set
+# is allowed (e.g. TodoWrite, AskUserQuestion, ExitPlanMode) so we don't
+# over-block.
+should_block=0
+case "$TOOL_NAME" in
+  Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate)
+    should_block=1 ;;
+  Skill|Read|Write|Edit|MultiEdit|NotebookEdit|Bash|Grep|Glob|WebSearch|WebFetch)
+    should_block=1 ;;
+  mcp__*)
+    should_block=1 ;;
+esac
+
+if [ "$should_block" -eq 0 ]; then
+  exit 0
+fi
+
+ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
+cat >&2 <<EOF
+Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
+Before any other tool call, you must:
+
+  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
+  2. TeamCreate                                   (actually create the team)
+
+The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
+the ticket, exploring the code, fetching context — those are tasks for the
+team you are about to create, not for the lead session before the team
+exists.
+
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
+ToolSearch.
+EOF
+exit 2

--- a/tests/unit/hooks/enforce-team-first.test.ts
+++ b/tests/unit/hooks/enforce-team-first.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for the enforce-team-first.sh hook.
+ *
+ * The hook arms enforcement when /lisa:research|plan|implement|intake is
+ * invoked, blocks bypass tool calls until ToolSearch+TeamCreate fire,
+ * and exempts subagent (teammate) sessions because they inherit the
+ * lead's team.
+ * @module tests/unit/hooks/enforce-team-first
+ */
+import { spawnSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/enforce-team-first.sh");
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const IMPLEMENT_PROMPT = "/lisa:implement SE-1";
+
+let stateRoot: string;
+
+beforeEach(() => {
+  stateRoot = mkdtempSync(path.join(tmpdir(), "lisa-hook-test-"));
+});
+
+afterEach(() => {
+  rmSync(stateRoot, { recursive: true, force: true });
+});
+
+const runHook = (
+  payload: Record<string, unknown>
+): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    input: JSON.stringify(payload),
+    encoding: "utf-8",
+    env: { ...process.env, TMPDIR: stateRoot },
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+const flagPath = (sessionId: string, suffix: string): string =>
+  path.join(stateRoot, "lisa-team-enforce", `${sessionId}.${suffix}`);
+
+const armSession = (sessionId: string, prompt = IMPLEMENT_PROMPT): void => {
+  runHook({
+    hook_event_name: "UserPromptSubmit",
+    session_id: sessionId,
+    prompt,
+  });
+};
+
+const preToolUse = (
+  sessionId: string,
+  toolName: string,
+  toolInput: Record<string, unknown> = {}
+): { status: number | null; stderr: string } =>
+  runHook({
+    hook_event_name: "PreToolUse",
+    session_id: sessionId,
+    tool_name: toolName,
+    tool_input: toolInput,
+  });
+
+describe("enforce-team-first.sh", () => {
+  describe("arming", () => {
+    it("does nothing when no lifecycle skill has been invoked", () => {
+      const { status } = preToolUse("idle", "Bash", { command: "ls" });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it.each([
+      ["/lisa:research onboarding", "research"],
+      ["/lisa:plan https://example.com/prd", "plan"],
+      ["/lisa:implement SE-1", "implement"],
+      ["/lisa:intake SE", "intake"],
+    ])("arms via UserPromptSubmit on %s", (prompt, label) => {
+      const sid = `arm-${label}`;
+      armSession(sid, prompt);
+      expect(existsSync(flagPath(sid, "skill"))).toBe(true);
+    });
+
+    it("does not arm for non-lifecycle slash commands", () => {
+      armSession("not-lifecycle", "/help");
+      expect(existsSync(flagPath("not-lifecycle", "skill"))).toBe(false);
+    });
+
+    it("arms via Skill tool with skill=lisa:implement", () => {
+      const { status } = preToolUse("skill-arm", "Skill", {
+        skill: "lisa:implement",
+      });
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(existsSync(flagPath("skill-arm", "skill"))).toBe(true);
+    });
+
+    it("does not arm for non-lifecycle Skill calls", () => {
+      preToolUse("git-commit", "Skill", { skill: "lisa:git-commit" });
+      expect(existsSync(flagPath("git-commit", "skill"))).toBe(false);
+    });
+  });
+
+  describe("blocks bypass tools when armed and team not yet created", () => {
+    it.each([
+      ["Task", { subagent_type: "Explore" }],
+      ["Read", { file_path: "/foo" }],
+      ["Bash", { command: "ls" }],
+      ["Edit", {}],
+      ["Write", {}],
+      ["MultiEdit", {}],
+      ["Grep", {}],
+      ["Glob", {}],
+      ["WebFetch", {}],
+      ["WebSearch", {}],
+      ["TaskCreate", {}],
+      ["mcp__plugin_atlassian_atlassian__getJiraIssue", {}],
+      ["Skill", { skill: "lisa:tracker-read" }],
+    ])("blocks %s", (tool, input) => {
+      const sid = `block-${tool}`;
+      armSession(sid);
+      const { status } = preToolUse(sid, tool, input);
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("explains the path forward in the block message", () => {
+      armSession("msg");
+      const { stderr } = preToolUse("msg", "Task", {});
+      expect(stderr).toContain("ToolSearch");
+      expect(stderr).toContain("TeamCreate");
+      expect(stderr).toContain("/lisa:implement");
+    });
+  });
+
+  describe("allows the path forward and benign tools", () => {
+    it.each([
+      ["ToolSearch", { query: "select:TeamCreate" }],
+      ["TeamCreate", {}],
+      ["TodoWrite", { todos: [] }],
+      ["AskUserQuestion", {}],
+    ])("allows %s while armed", (tool, input) => {
+      const sid = `allow-${tool}`;
+      armSession(sid);
+      const { status } = preToolUse(sid, tool, input);
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("PostToolUse on TeamCreate", () => {
+    it("lifts enforcement when TeamCreate succeeds", () => {
+      const sid = "post-ok";
+      armSession(sid);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_BLOCKED
+      );
+
+      runHook({
+        hook_event_name: "PostToolUse",
+        session_id: sid,
+        tool_name: "TeamCreate",
+        tool_input: {},
+        tool_response: { team_id: "team-xyz" },
+      });
+      expect(existsSync(flagPath(sid, "team"))).toBe(true);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+
+    it("keeps enforcement when TeamCreate failed (is_error=true)", () => {
+      const sid = "post-fail";
+      armSession(sid);
+      runHook({
+        hook_event_name: "PostToolUse",
+        session_id: sid,
+        tool_name: "TeamCreate",
+        tool_input: {},
+        tool_response: { is_error: true, error: "double-create" },
+      });
+      expect(existsSync(flagPath(sid, "team"))).toBe(false);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+  });
+
+  describe("subagent exemption", () => {
+    it("never blocks once SubagentStart has marked the session", () => {
+      const sid = "sub-1";
+      runHook({ hook_event_name: "SubagentStart", session_id: sid });
+      expect(existsSync(flagPath(sid, "subagent"))).toBe(true);
+
+      armSession(sid, "/lisa:implement SE-2");
+      const { status } = preToolUse(sid, "Bash", { command: "ls" });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("cross-session isolation", () => {
+    it("does not leak flags between session ids", () => {
+      armSession("iso-a");
+      const { status } = preToolUse("iso-b", "Bash", { command: "ls" });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("fail-open behavior", () => {
+    it.each([
+      ["missing session_id", JSON.stringify({ hook_event_name: "PreToolUse" })],
+      ["empty input", ""],
+      ["malformed JSON", "{not json"],
+    ])("exits 0 on %s", (_label, input) => {
+      const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+        input,
+        encoding: "utf-8",
+        env: { ...process.env, TMPDIR: stateRoot },
+      });
+      expect(result.status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("stale state cleanup", () => {
+    it("removes flag files older than 24h", () => {
+      const dir = path.join(stateRoot, "lisa-team-enforce");
+      mkdirSync(dir, { recursive: true });
+      const oldFlag = path.join(dir, "stale-session.skill");
+      writeFileSync(oldFlag, "lisa:implement\n");
+      const past = (Date.now() - 25 * 60 * 60 * 1000) / 1000;
+      utimesSync(oldFlag, past, past);
+      expect(existsSync(oldFlag)).toBe(true);
+
+      preToolUse("fresh", "Read", {});
+      expect(existsSync(oldFlag)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The follow-up to #455. That PR tightened the orchestration preamble for `/lisa:research`, `/lisa:plan`, `/lisa:implement`, and `/lisa:intake` — but everything in there is advisory markdown. A model can still rationalize its way into calling MCP tools or `Agent` directly before `TeamCreate` (which is exactly what happened, producing single-agent ad-hoc fixes instead of real team flows).

This adds mechanical enforcement.

**New hook**: `plugins/src/base/hooks/enforce-team-first.sh`. Wired into `plugin.json` for four events:

- `UserPromptSubmit` — detects `/lisa:research|plan|implement|intake` in the raw prompt and arms enforcement for the session
- `PreToolUse` (matcher: all) — also detects arming via the `Skill` tool, then blocks bypass tool calls until the team exists
- `PostToolUse` (matcher: `TeamCreate`) — on a successful `TeamCreate`, lifts enforcement
- `SubagentStart` — marks the new subagent session as a teammate so it's exempt (teammates inherit the team and must never call `TeamCreate` — the harness rejects double-creates)

**Block list** (when armed and team not yet created): `Task`, `TaskCreate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate`, `Skill`, `Read`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `Bash`, `Grep`, `Glob`, `WebSearch`, `WebFetch`, `mcp__*`.

**Allow list** (always allowed once armed): `ToolSearch`, `TeamCreate`, `TodoWrite`, `AskUserQuestion`. Anything not explicitly named is allowed by default — this hook errs toward under-blocking, not over-blocking.

**Fail-open**: malformed JSON, missing `session_id`, jq errors all `exit 0`. A broken hook must never brick a session.

## Test plan

- [x] 34 unit tests (`tests/unit/hooks/enforce-team-first.test.ts`) covering: arming via prompt, arming via Skill, all 13 bypass tools blocked, all 4 path-forward tools allowed, post-TeamCreate enforcement lift, subagent exemption, cross-session isolation, fail-open on bad input, stale-state cleanup
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] Full test suite: 644 tests passing
- [ ] Smoke check: invoke `/lisa:implement <jira-url>` in a downstream project after merge and confirm an attempt to call MCP tools or `Read` directly returns the block message with `ToolSearch` + `TeamCreate` instructions

🤖 Generated with Claude Code