### PR TITLE
feat(jira-read-ticket): add download-attachment helper

### DIFF
--- a/plugins/lisa/skills/jira-read-ticket/SKILL.md
+++ b/plugins/lisa/skills/jira-read-ticket/SKILL.md
@@ -34,7 +34,23 @@ Call `mcp__atlassian__getJiraIssue` for the target ticket. Extract and preserve:
 - Full description (preserve formatting)
 - Acceptance criteria section if separately structured
 - **Validation Journey** section if present (pass verbatim to downstream)
-- Attachments list (names + URLs, do not download unless needed)
+- Attachments list — capture `id`, `filename`, `mimeType`, `size`, and `content` URL for each. Do not download unless a downstream task needs the bytes (see "Downloading attachments" below).
+
+#### Downloading attachments (opt-in)
+
+The Atlassian MCP exposes attachment metadata but no binary-fetch tool ([JRACLOUD-97830](https://jira.atlassian.com/browse/JRACLOUD-97830), [ECO-1265](https://jira.atlassian.com/browse/ECO-1265)). Fetch attachment bytes only when a downstream task explicitly needs them — e.g., a design-fidelity check on an image, log-file analysis, PDF text extraction. For everything else, keep the URL reference and move on.
+
+```bash
+bash .claude/skills/jira-read-ticket/scripts/download-attachment.sh <id-or-content-url> <output-path>
+```
+
+Requires `JIRA_SERVER`, `JIRA_LOGIN`, and `JIRA_API_TOKEN` in the environment (same contract as `jira-evidence`). If those are not set the helper exits with code 2 and a clear remediation message — record the URL only and continue.
+
+After download, branch on `mimeType`:
+- `image/*` — pass the local path to image-aware downstream tools
+- `text/*`, `application/json`, `application/xml`, `application/x-yaml` — read inline as text
+- `application/pdf` — extract text via downstream tooling if needed
+- everything else — record path only; do not attempt to inline binary content
 
 ### Comments
 
@@ -121,7 +137,7 @@ Produce a single structured output that the caller can pass verbatim to downstre
 <chronological comments, flagged items called out>
 
 ### Attachments
-<list>
+<list with id, filename, mimeType, size, content URL — note any that were downloaded and their local paths>
 
 ## Remote Links
 ### Pull Requests (<count>)

--- a/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -27,8 +27,12 @@
 
 set -euo pipefail
 
-ID_OR_URL="${1:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
-OUTPUT_PATH="${2:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+if [[ $# -lt 2 ]]; then
+  echo "Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>" >&2
+  exit 3
+fi
+ID_OR_URL="$1"
+OUTPUT_PATH="$2"
 
 # Resolve credentials: prefer env, fall back to jira-cli config for server/login.
 JIRA_CONFIG="${HOME}/.config/.jira/.config.yml"
@@ -60,7 +64,7 @@ else
   ATTACHMENT_URL="${JIRA_SERVER%/}/rest/api/3/attachment/content/$ID_OR_URL"
 fi
 
-JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64)
+JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64 | tr -d '\n')
 
 # Atlassian responds 302 to a signed URL on media.atlassian.com that has its
 # own auth and rejects Basic. Two-step: capture Location, then GET unauthed.

--- a/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -80,18 +80,18 @@ HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
 
 case "$HTTP_CODE" in
   302|303|307)
-    SIGNED_URL=$(awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
+    SIGNED_URL=$(awk '/^[Ll]ocation:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
     if [[ -z "$SIGNED_URL" ]]; then
       echo "ERROR: Got HTTP $HTTP_CODE but no Location header in response." >&2
       exit 1
     fi
-    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL"
+    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL" || { echo "ERROR: Download from signed URL failed." >&2; exit 1; }
     ;;
   200)
     curl -sSf -o "$OUTPUT_PATH" \
       -H "Authorization: Basic $JIRA_AUTH" \
       -H "Accept: */*" \
-      "$ATTACHMENT_URL"
+      "$ATTACHMENT_URL" || { echo "ERROR: Direct download from $ATTACHMENT_URL failed." >&2; exit 1; }
     ;;
   401|403)
     echo "ERROR: Authentication failed (HTTP $HTTP_CODE). Verify JIRA_LOGIN and JIRA_API_TOKEN." >&2

--- a/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/lisa/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# download-attachment.sh — Download a JIRA attachment to a local file.
+#
+# Usage:
+#   bash download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>
+#
+# Why this helper exists:
+#   The Atlassian MCP server (mcp__atlassian__*) returns attachment metadata
+#   (id, filename, mimeType, size, content URL) on getJiraIssue but provides
+#   no tool to fetch the binary content. This script closes the gap by
+#   hitting the Jira REST API directly with Basic auth, mirroring the
+#   env-var contract already used by jira-evidence/scripts/post-evidence.sh.
+#
+#   See https://jira.atlassian.com/browse/JRACLOUD-97830 for the upstream
+#   gap; remove this helper once Atlassian ships a download tool in the MCP.
+#
+# Required env vars:
+#   JIRA_SERVER     - https://<your-tenant>.atlassian.net
+#   JIRA_LOGIN      - login email
+#   JIRA_API_TOKEN  - API token (https://id.atlassian.com/manage-profile/security/api-tokens)
+#
+# Exit codes:
+#   0  success
+#   1  download failed (HTTP error)
+#   2  missing required env var
+#   3  invalid arguments
+
+set -euo pipefail
+
+ID_OR_URL="${1:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+OUTPUT_PATH="${2:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+
+# Resolve credentials: prefer env, fall back to jira-cli config for server/login.
+JIRA_CONFIG="${HOME}/.config/.jira/.config.yml"
+if [[ -z "${JIRA_SERVER:-}" && -f "$JIRA_CONFIG" ]]; then
+  JIRA_SERVER=$(grep '^server:' "$JIRA_CONFIG" | awk '{print $2}')
+fi
+if [[ -z "${JIRA_LOGIN:-}" && -f "$JIRA_CONFIG" ]]; then
+  JIRA_LOGIN=$(grep '^login:' "$JIRA_CONFIG" | awk '{print $2}')
+fi
+
+for VAR in JIRA_SERVER JIRA_LOGIN JIRA_API_TOKEN; do
+  if [[ -z "${!VAR:-}" ]]; then
+    echo "ERROR: $VAR is not set." >&2
+    echo "Required env vars: JIRA_SERVER, JIRA_LOGIN, JIRA_API_TOKEN." >&2
+    echo "Generate an API token: https://id.atlassian.com/manage-profile/security/api-tokens" >&2
+    exit 2
+  fi
+done
+
+OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+if [[ ! -d "$OUTPUT_DIR" ]]; then
+  echo "ERROR: Output directory does not exist: $OUTPUT_DIR" >&2
+  exit 3
+fi
+
+if [[ "$ID_OR_URL" == http*://* ]]; then
+  ATTACHMENT_URL="$ID_OR_URL"
+else
+  ATTACHMENT_URL="${JIRA_SERVER%/}/rest/api/3/attachment/content/$ID_OR_URL"
+fi
+
+JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64)
+
+# Atlassian responds 302 to a signed URL on media.atlassian.com that has its
+# own auth and rejects Basic. Two-step: capture Location, then GET unauthed.
+HEADERS_FILE=$(mktemp)
+trap 'rm -f "$HEADERS_FILE"' EXIT
+
+HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+  --max-redirs 0 \
+  -D "$HEADERS_FILE" \
+  -H "Authorization: Basic $JIRA_AUTH" \
+  -H "Accept: */*" \
+  "$ATTACHMENT_URL" || true)
+
+case "$HTTP_CODE" in
+  302|303|307)
+    SIGNED_URL=$(awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
+    if [[ -z "$SIGNED_URL" ]]; then
+      echo "ERROR: Got HTTP $HTTP_CODE but no Location header in response." >&2
+      exit 1
+    fi
+    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL"
+    ;;
+  200)
+    curl -sSf -o "$OUTPUT_PATH" \
+      -H "Authorization: Basic $JIRA_AUTH" \
+      -H "Accept: */*" \
+      "$ATTACHMENT_URL"
+    ;;
+  401|403)
+    echo "ERROR: Authentication failed (HTTP $HTTP_CODE). Verify JIRA_LOGIN and JIRA_API_TOKEN." >&2
+    exit 1
+    ;;
+  404)
+    echo "ERROR: Attachment not found at $ATTACHMENT_URL (HTTP 404). Verify the ID and your access." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: Unexpected HTTP $HTTP_CODE from $ATTACHMENT_URL" >&2
+    exit 1
+    ;;
+esac
+
+echo "  ✓ Downloaded -> $OUTPUT_PATH"

--- a/plugins/src/base/skills/jira-read-ticket/SKILL.md
+++ b/plugins/src/base/skills/jira-read-ticket/SKILL.md
@@ -34,7 +34,23 @@ Call `mcp__atlassian__getJiraIssue` for the target ticket. Extract and preserve:
 - Full description (preserve formatting)
 - Acceptance criteria section if separately structured
 - **Validation Journey** section if present (pass verbatim to downstream)
-- Attachments list (names + URLs, do not download unless needed)
+- Attachments list — capture `id`, `filename`, `mimeType`, `size`, and `content` URL for each. Do not download unless a downstream task needs the bytes (see "Downloading attachments" below).
+
+#### Downloading attachments (opt-in)
+
+The Atlassian MCP exposes attachment metadata but no binary-fetch tool ([JRACLOUD-97830](https://jira.atlassian.com/browse/JRACLOUD-97830), [ECO-1265](https://jira.atlassian.com/browse/ECO-1265)). Fetch attachment bytes only when a downstream task explicitly needs them — e.g., a design-fidelity check on an image, log-file analysis, PDF text extraction. For everything else, keep the URL reference and move on.
+
+```bash
+bash .claude/skills/jira-read-ticket/scripts/download-attachment.sh <id-or-content-url> <output-path>
+```
+
+Requires `JIRA_SERVER`, `JIRA_LOGIN`, and `JIRA_API_TOKEN` in the environment (same contract as `jira-evidence`). If those are not set the helper exits with code 2 and a clear remediation message — record the URL only and continue.
+
+After download, branch on `mimeType`:
+- `image/*` — pass the local path to image-aware downstream tools
+- `text/*`, `application/json`, `application/xml`, `application/x-yaml` — read inline as text
+- `application/pdf` — extract text via downstream tooling if needed
+- everything else — record path only; do not attempt to inline binary content
 
 ### Comments
 
@@ -121,7 +137,7 @@ Produce a single structured output that the caller can pass verbatim to downstre
 <chronological comments, flagged items called out>
 
 ### Attachments
-<list>
+<list with id, filename, mimeType, size, content URL — note any that were downloaded and their local paths>
 
 ## Remote Links
 ### Pull Requests (<count>)

--- a/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -27,8 +27,12 @@
 
 set -euo pipefail
 
-ID_OR_URL="${1:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
-OUTPUT_PATH="${2:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+if [[ $# -lt 2 ]]; then
+  echo "Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>" >&2
+  exit 3
+fi
+ID_OR_URL="$1"
+OUTPUT_PATH="$2"
 
 # Resolve credentials: prefer env, fall back to jira-cli config for server/login.
 JIRA_CONFIG="${HOME}/.config/.jira/.config.yml"
@@ -60,7 +64,7 @@ else
   ATTACHMENT_URL="${JIRA_SERVER%/}/rest/api/3/attachment/content/$ID_OR_URL"
 fi
 
-JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64)
+JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64 | tr -d '\n')
 
 # Atlassian responds 302 to a signed URL on media.atlassian.com that has its
 # own auth and rejects Basic. Two-step: capture Location, then GET unauthed.

--- a/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -80,18 +80,18 @@ HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
 
 case "$HTTP_CODE" in
   302|303|307)
-    SIGNED_URL=$(awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
+    SIGNED_URL=$(awk '/^[Ll]ocation:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
     if [[ -z "$SIGNED_URL" ]]; then
       echo "ERROR: Got HTTP $HTTP_CODE but no Location header in response." >&2
       exit 1
     fi
-    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL"
+    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL" || { echo "ERROR: Download from signed URL failed." >&2; exit 1; }
     ;;
   200)
     curl -sSf -o "$OUTPUT_PATH" \
       -H "Authorization: Basic $JIRA_AUTH" \
       -H "Accept: */*" \
-      "$ATTACHMENT_URL"
+      "$ATTACHMENT_URL" || { echo "ERROR: Direct download from $ATTACHMENT_URL failed." >&2; exit 1; }
     ;;
   401|403)
     echo "ERROR: Authentication failed (HTTP $HTTP_CODE). Verify JIRA_LOGIN and JIRA_API_TOKEN." >&2

--- a/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
+++ b/plugins/src/base/skills/jira-read-ticket/scripts/download-attachment.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# download-attachment.sh — Download a JIRA attachment to a local file.
+#
+# Usage:
+#   bash download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>
+#
+# Why this helper exists:
+#   The Atlassian MCP server (mcp__atlassian__*) returns attachment metadata
+#   (id, filename, mimeType, size, content URL) on getJiraIssue but provides
+#   no tool to fetch the binary content. This script closes the gap by
+#   hitting the Jira REST API directly with Basic auth, mirroring the
+#   env-var contract already used by jira-evidence/scripts/post-evidence.sh.
+#
+#   See https://jira.atlassian.com/browse/JRACLOUD-97830 for the upstream
+#   gap; remove this helper once Atlassian ships a download tool in the MCP.
+#
+# Required env vars:
+#   JIRA_SERVER     - https://<your-tenant>.atlassian.net
+#   JIRA_LOGIN      - login email
+#   JIRA_API_TOKEN  - API token (https://id.atlassian.com/manage-profile/security/api-tokens)
+#
+# Exit codes:
+#   0  success
+#   1  download failed (HTTP error)
+#   2  missing required env var
+#   3  invalid arguments
+
+set -euo pipefail
+
+ID_OR_URL="${1:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+OUTPUT_PATH="${2:?Usage: download-attachment.sh <ATTACHMENT_ID_OR_URL> <OUTPUT_PATH>}"
+
+# Resolve credentials: prefer env, fall back to jira-cli config for server/login.
+JIRA_CONFIG="${HOME}/.config/.jira/.config.yml"
+if [[ -z "${JIRA_SERVER:-}" && -f "$JIRA_CONFIG" ]]; then
+  JIRA_SERVER=$(grep '^server:' "$JIRA_CONFIG" | awk '{print $2}')
+fi
+if [[ -z "${JIRA_LOGIN:-}" && -f "$JIRA_CONFIG" ]]; then
+  JIRA_LOGIN=$(grep '^login:' "$JIRA_CONFIG" | awk '{print $2}')
+fi
+
+for VAR in JIRA_SERVER JIRA_LOGIN JIRA_API_TOKEN; do
+  if [[ -z "${!VAR:-}" ]]; then
+    echo "ERROR: $VAR is not set." >&2
+    echo "Required env vars: JIRA_SERVER, JIRA_LOGIN, JIRA_API_TOKEN." >&2
+    echo "Generate an API token: https://id.atlassian.com/manage-profile/security/api-tokens" >&2
+    exit 2
+  fi
+done
+
+OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+if [[ ! -d "$OUTPUT_DIR" ]]; then
+  echo "ERROR: Output directory does not exist: $OUTPUT_DIR" >&2
+  exit 3
+fi
+
+if [[ "$ID_OR_URL" == http*://* ]]; then
+  ATTACHMENT_URL="$ID_OR_URL"
+else
+  ATTACHMENT_URL="${JIRA_SERVER%/}/rest/api/3/attachment/content/$ID_OR_URL"
+fi
+
+JIRA_AUTH=$(printf '%s' "$JIRA_LOGIN:$JIRA_API_TOKEN" | base64)
+
+# Atlassian responds 302 to a signed URL on media.atlassian.com that has its
+# own auth and rejects Basic. Two-step: capture Location, then GET unauthed.
+HEADERS_FILE=$(mktemp)
+trap 'rm -f "$HEADERS_FILE"' EXIT
+
+HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+  --max-redirs 0 \
+  -D "$HEADERS_FILE" \
+  -H "Authorization: Basic $JIRA_AUTH" \
+  -H "Accept: */*" \
+  "$ATTACHMENT_URL" || true)
+
+case "$HTTP_CODE" in
+  302|303|307)
+    SIGNED_URL=$(awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/^[Ll]ocation:[ \t]*/,""); sub(/\r$/,""); print; exit}' "$HEADERS_FILE")
+    if [[ -z "$SIGNED_URL" ]]; then
+      echo "ERROR: Got HTTP $HTTP_CODE but no Location header in response." >&2
+      exit 1
+    fi
+    curl -sSf -o "$OUTPUT_PATH" "$SIGNED_URL"
+    ;;
+  200)
+    curl -sSf -o "$OUTPUT_PATH" \
+      -H "Authorization: Basic $JIRA_AUTH" \
+      -H "Accept: */*" \
+      "$ATTACHMENT_URL"
+    ;;
+  401|403)
+    echo "ERROR: Authentication failed (HTTP $HTTP_CODE). Verify JIRA_LOGIN and JIRA_API_TOKEN." >&2
+    exit 1
+    ;;
+  404)
+    echo "ERROR: Attachment not found at $ATTACHMENT_URL (HTTP 404). Verify the ID and your access." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: Unexpected HTTP $HTTP_CODE from $ATTACHMENT_URL" >&2
+    exit 1
+    ;;
+esac
+
+echo "  ✓ Downloaded -> $OUTPUT_PATH"


### PR DESCRIPTION
## Summary

- Adds `download-attachment.sh` to the `jira-read-ticket` skill, closing the gap left by the Atlassian MCP — which exposes attachment metadata (id, filename, mimeType, size, content URL) but no binary-fetch tool ([JRACLOUD-97830](https://jira.atlassian.com/browse/JRACLOUD-97830), [ECO-1265](https://jira.atlassian.com/browse/ECO-1265)).
- Reuses the existing `JIRA_SERVER` / `JIRA_LOGIN` / `JIRA_API_TOKEN` env-var contract from `jira-evidence/scripts/post-evidence.sh`. No new credentials, no new dependencies.
- Two-step download (capture `Location`, then GET unauthed) so Basic auth never reaches the signed `media.atlassian.com` URL Atlassian redirects to.
- SKILL.md updated in lockstep at `plugins/lisa/...` and `plugins/src/base/...` with an opt-in "Downloading attachments" subsection that documents when to download, how to handle missing creds, and per-`mimeType` post-download guidance.

## Why not switch MCP servers?

Considered switching to `sooperset/mcp-atlassian` (which has a `get_attachment` tool). Rejected because:
- Tool-name churn across ~10+ skills (`mcp__atlassian__*` → `jira_*`)
- Recent critical CVE in that very feature ([CVE-2026-27825](https://arcticwolf.com/resources/blog-uk/cve-2026-27825-critical-unauthenticated-rce-and-ssrf-in-mcp-atlassian/), patched 0.17.0)
- Adds `uvx`/Docker install burden for every downstream Lisa consumer
- Loses the official MCP's zero-config OAuth path
- Atlassian has the issue tracked upstream; switch-and-switch-back is double churn

## Test plan

- [x] `bash -n` syntax check passes on the script
- [x] Missing-env-var path produces clear remediation message and exits with code 2
- [ ] End-to-end download against a real Jira attachment (requires `JIRA_API_TOKEN` set)
- [ ] Verify `-L`-style cross-host auth stripping works against an actual `media.atlassian.com` redirect
- [x] Pre-commit hooks pass (gitleaks, type check, lint-staged, prettier, commitlint)
- [x] Unit + integration tests pass (645 + 41)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional attachment download for Jira tickets (opt-in workflow)
  * Richer attachment metadata captured: id, filename, MIME type, size, content URL
  * Type-aware handling: images saved as local paths, text/JSON/XML/YAML inlined, PDFs noted for downstream processing; other binaries recorded by path

* **Documentation**
  * Updated Jira skill spec and output template to require enriched attachments list and note any downloaded local paths and behaviors on missing credentials
<!-- end of auto-generated comment: release notes by coderabbit.ai -->