### PR TITLE
feat(rules): forbid squash-merging promotion PRs

### DIFF
--- a/plugins/lisa/rules/base-rules.md
+++ b/plugins/lisa/rules/base-rules.md
@@ -56,6 +56,7 @@ Git Discipline:
 - When opening a PR, watch the PR. If any status checks fail, fix them. For all bot code reviews, if the feedback is valid, implement it and push the change to the PR. Then resolve the feedback. If the feedback is not valid, reply to the feedback explaining why it's not valid and then resolve the feedback. Do this in a loop until the PR is able to be merged and then merge it.
 - When merging a PR into an environment branch (dev, staging, main), watch the resultant deploy until it fully succeeds. If it fails for any reason, fix the failure and then open a new PR with the fix.
 - When referencing a PR in a response, always include the url
+- **Promotion PRs (environment branch → environment branch — e.g., `dev` → `staging`, `staging` → `main`) MUST be merged with a regular merge commit (`gh pr merge --merge`), NEVER squash-merged.** Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into a single commit titled with the PR title, which (a) strips the `[skip ci]` markers so the release workflow re-runs and double-bumps the version on the destination branch, and (b) breaks the release workflow's promotion-detection regex (which inspects the merge-commit subject for `Merge branch 'X' into Y` or `Merge pull request #N from .../<env-branch>`). The merge commit produced by `--merge` keeps the subject clean and the per-commit `[skip ci]` markers attached where they belong. Feature PRs (anything → `dev`) use `--squash` as usual.
 
 Testing Discipline:
 - Never skip or disable any tests or quality checks.

--- a/plugins/lisa/skills/git-submit-pr/SKILL.md
+++ b/plugins/lisa/skills/git-submit-pr/SKILL.md
@@ -24,7 +24,7 @@ Push current branch and create or update a pull request. Optional hint: $ARGUMEN
    - Check for existing PR on this branch
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
-5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`
+5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`. Always `--merge`, never `--squash`. Squashing a promotion PR (env → env, e.g. `dev` → `staging`) flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
 
 ### PR Description Format
 

--- a/plugins/lisa/skills/git-submit-pr/SKILL.md
+++ b/plugins/lisa/skills/git-submit-pr/SKILL.md
@@ -24,7 +24,9 @@ Push current branch and create or update a pull request. Optional hint: $ARGUMEN
    - Check for existing PR on this branch
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
-5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`. Always `--merge`, never `--squash`. Squashing a promotion PR (env → env, e.g. `dev` → `staging`) flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
+5. **Auto-merge**: Choose merge strategy by PR type:
+   - **Promotion PRs** (env → env, e.g. `dev` → `staging`): use `gh pr merge --auto --merge` (never squash). Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
+   - **Feature PRs** (anything → `dev`): use `gh pr merge --auto --squash`.
 
 ### PR Description Format
 

--- a/plugins/src/base/rules/base-rules.md
+++ b/plugins/src/base/rules/base-rules.md
@@ -56,6 +56,7 @@ Git Discipline:
 - When opening a PR, watch the PR. If any status checks fail, fix them. For all bot code reviews, if the feedback is valid, implement it and push the change to the PR. Then resolve the feedback. If the feedback is not valid, reply to the feedback explaining why it's not valid and then resolve the feedback. Do this in a loop until the PR is able to be merged and then merge it.
 - When merging a PR into an environment branch (dev, staging, main), watch the resultant deploy until it fully succeeds. If it fails for any reason, fix the failure and then open a new PR with the fix.
 - When referencing a PR in a response, always include the url
+- **Promotion PRs (environment branch → environment branch — e.g., `dev` → `staging`, `staging` → `main`) MUST be merged with a regular merge commit (`gh pr merge --merge`), NEVER squash-merged.** Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into a single commit titled with the PR title, which (a) strips the `[skip ci]` markers so the release workflow re-runs and double-bumps the version on the destination branch, and (b) breaks the release workflow's promotion-detection regex (which inspects the merge-commit subject for `Merge branch 'X' into Y` or `Merge pull request #N from .../<env-branch>`). The merge commit produced by `--merge` keeps the subject clean and the per-commit `[skip ci]` markers attached where they belong. Feature PRs (anything → `dev`) use `--squash` as usual.
 
 Testing Discipline:
 - Never skip or disable any tests or quality checks.

--- a/plugins/src/base/skills/git-submit-pr/SKILL.md
+++ b/plugins/src/base/skills/git-submit-pr/SKILL.md
@@ -24,7 +24,7 @@ Push current branch and create or update a pull request. Optional hint: $ARGUMEN
    - Check for existing PR on this branch
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
-5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`
+5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`. Always `--merge`, never `--squash`. Squashing a promotion PR (env → env, e.g. `dev` → `staging`) flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
 
 ### PR Description Format
 

--- a/plugins/src/base/skills/git-submit-pr/SKILL.md
+++ b/plugins/src/base/skills/git-submit-pr/SKILL.md
@@ -24,7 +24,9 @@ Push current branch and create or update a pull request. Optional hint: $ARGUMEN
    - Check for existing PR on this branch
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
-5. **Auto-merge**: Enable auto-merge on the PR using `gh pr merge --auto --merge`. Always `--merge`, never `--squash`. Squashing a promotion PR (env → env, e.g. `dev` → `staging`) flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
+5. **Auto-merge**: Choose merge strategy by PR type:
+   - **Promotion PRs** (env → env, e.g. `dev` → `staging`): use `gh pr merge --auto --merge` (never squash). Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
+   - **Feature PRs** (anything → `dev`): use `gh pr merge --auto --squash`.
 
 ### PR Description Format
 


### PR DESCRIPTION
## Summary
- Add a base-rule (and reinforce in `lisa:git-submit-pr`) that promotion PRs (env → env, e.g. `dev` → `staging`, `staging` → `main`) MUST be merged with `gh pr merge --merge`, never `--squash`.

## Why
Host projects keep squash-merging promotion PRs from the GitHub UI, which collapses the per-release `chore(release): X.Y.Z [skip ci]` commits into a single commit titled with the PR title. That:
1. Strips the `[skip ci]` markers so the release workflow re-runs and double-bumps the version on the destination branch.
2. Breaks the release workflow's promotion-detection regex (`.github/workflows/release.yml#check_promotion`), which inspects the merge-commit subject for `Merge branch 'X' into Y` or `Merge pull request #N from .../<env-branch>`.

`--merge` keeps each `chore(release)` commit (and its `[skip ci]`) intact under a clean merge subject the workflow can recognize. Feature PRs (anything → `dev`) continue to use `--squash`.

## Test plan
- [ ] CI green
- [ ] Next promotion PR opened by Lisa or a host-project session uses `--merge`, not `--squash`
- [ ] On the next dev → staging promotion, the staging release workflow's check_promotion job correctly skips the version bump (no double-bump)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced governance rules requiring promotion PRs between environment branches to use regular merge commits (no squash) to preserve release-detection and version-bump semantics.
  * Expanded git PR submission docs with a PR-type auto-merge strategy: promotion PRs use non-squash merges to retain commits and markers; feature PRs may continue to use squash merges, with guidance on preserving release-related metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->