### PR TITLE
fix(templates): restore amplify/rubocop-todo ignores and harden sync-down

### DIFF
--- a/.github/workflows/reusable-claude-sync-down-branches.yml
+++ b/.github/workflows/reusable-claude-sync-down-branches.yml
@@ -35,6 +35,8 @@ jobs:
         env:
           CHAIN: ${{ inputs.chain }}
           SOURCE: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           if ! echo "$CHAIN" | jq empty 2>/dev/null; then
             echo "::error::Invalid chain JSON: $CHAIN"
@@ -43,6 +45,15 @@ jobs:
           TARGET=$(echo "$CHAIN" | jq -r --arg src "$SOURCE" '.[$src] // empty')
           if [ -z "$TARGET" ]; then
             echo "No sync target for source branch '$SOURCE' — terminal in chain. Exiting."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Verify the target branch actually exists on the remote. If a project
+          # configures a chain entry whose target was never created (e.g. a
+          # `staging -> dev` chain on a repo that has no `dev`), exit cleanly
+          # instead of failing the workflow.
+          if ! gh api "repos/$REPO/branches/$TARGET" --silent 2>/dev/null; then
+            echo "::warning::Target branch '$TARGET' does not exist on $REPO — skipping back-sync. Update the chain in your sync-down-branches.yml wrapper to remove this mapping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,16 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/**/*.ts","lambdas/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts"],
-  "project": ["src/**/*.ts","lambdas/**/*.ts", "lib/**/*.ts"],
+  "entry": [
+    "src/**/*.ts",
+    "lambdas/**/*.ts",
+    "lib/**/*.ts",
+    "scripts/**/*.ts"
+  ],
+  "project": [
+    "src/**/*.ts",
+    "lambdas/**/*.ts",
+    "lib/**/*.ts"
+  ],
   "ignore": [
     "**/*.test.ts",
     "**/*.spec.ts",
@@ -48,7 +57,15 @@
     "graphql-ws",
     "lodash"
   ],
-  "ignoreBinaries": ["expo", "playwright", "audit", "docker", "eval", "serve"],
+  "ignoreBinaries": [
+    "audit",
+    "docker",
+    "eval",
+    "expo",
+    "gh",
+    "playwright",
+    "serve"
+  ],
   "ignoreExportsUsedInFile": true,
   "rules": {
     "devDependencies": "off"

--- a/rails/copy-overwrite/.rubocop.yml
+++ b/rails/copy-overwrite/.rubocop.yml
@@ -1,6 +1,11 @@
 inherit_from:
+  - .rubocop_todo.yml
   - rubocop.thresholds.yml
   - .rubocop.local.yml
+
+inherit_mode:
+  merge:
+    - Exclude
 
 plugins:
   - rubocop-rails

--- a/rails/create-only/.rubocop_todo.yml
+++ b/rails/create-only/.rubocop_todo.yml
@@ -1,0 +1,8 @@
+# This is the standard RuboCop "fix later" file.
+# Lisa creates it empty so .rubocop.yml's `inherit_from` resolves cleanly
+# in projects that don't yet have legacy violations to track.
+#
+# Generate or update with:
+#   bundle exec rubocop --auto-gen-config
+#
+# This file is create-only — Lisa will not overwrite your TODO list.

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -75,6 +75,8 @@
     "cdk.out/**",
 
     "audit.ignore.config.json",
-    "audit.ignore.local.json"
+    "audit.ignore.local.json",
+
+    "amplify/**"
   ]
 }


### PR DESCRIPTION
## Summary

Three template regressions surfaced during a 2.15.0 rollout across 13 downstream projects. Each blocked at least one PR from going green.

### 1. `typescript/copy-overwrite/eslint.ignore.config.json` — restore `amplify/**`

The sibling `.prettierignore` template still ignores `amplify/`, but eslint dropped it. Result: any TS project using AWS Amplify CLI now lints auto-generated `cdk-stack.ts` / `backend-config.json`-adjacent files. Surfaced on `propswap/infrastructure` and `propswap/backend` (the latter explicitly failed CI on the lisa-update PR until patched project-side).

### 2. `rails/copy-overwrite/.rubocop.yml` — restore `.rubocop_todo.yml` inheritance

The previous template carried:

```yaml
inherit_from:
  - .rubocop_todo.yml
  ...

inherit_mode:
  merge:
    - Exclude
```

Both blocks were dropped. `.rubocop_todo.yml` is the standard "fix later" allowlist auto-generated by `rubocop --auto-gen-config`; without it, every existing TODO violation re-erupts as a hard error. Surfaced on `qualis/app` (100+ pre-existing violations across controllers, services, models). Restoring the inheritance plus shipping an empty `.rubocop_todo.yml` create-only stub so projects without legacy violations still load cleanly.

### 3. `reusable-claude-sync-down-branches.yml` — handle missing target branches

The new back-sync workflow assumed every chain target exists on the remote. When `propswap/backend` (no `dev` branch) merged into staging, the workflow tried to open `staging -> dev` and failed at `actions/checkout` because the ref didn't exist. Now we pre-flight via `gh api repos/.../branches/$TARGET` and exit cleanly with a workflow warning instructing the project to update their wrapper's chain.

## Files

- `typescript/copy-overwrite/eslint.ignore.config.json` — add `amplify/**` (matches `.prettierignore` template's "no-op for non-Amplify projects" semantics)
- `rails/copy-overwrite/.rubocop.yml` — restore inherit_from + inherit_mode
- `rails/create-only/.rubocop_todo.yml` — new empty stub
- `.github/workflows/reusable-claude-sync-down-branches.yml` — gh-api branch existence check
- `knip.json` — add `gh` to ignoreBinaries (used by the workflow check above)

## Test plan
- [ ] Land in 2.15.x patch release; re-run lisa update on `propswap/backend` → CI passes without project-side `eslint.config.local.ts` workaround
- [ ] Re-run on `qualis/app` → rubocop respects existing `.rubocop_todo.yml` without project-side `.rubocop.local.yml` workaround
- [ ] Force a back-sync on a 2-env repo (no `dev`); confirm sync workflow emits the warning and exits 0 instead of failing

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow validation to verify target branches exist before proceeding with sync operations
  * Reorganized and expanded configuration patterns for improved dependency tracking and code analysis coverage
  * Updated code quality tool configurations with enhanced inheritance structure and improved file organization
  * Extended code linting ignore patterns to include additional build directories
  * Added configuration template for systematically tracking code quality improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->