### PR TITLE
fix(templates): bump axios floor to >=1.15.2 and exclude fast-uri advisories

### DIFF
--- a/typescript/copy-overwrite/audit.ignore.config.json
+++ b/typescript/copy-overwrite/audit.ignore.config.json
@@ -137,6 +137,16 @@
       "id": "GHSA-j759-j44w-7fr8",
       "package": "@xmldom/xmldom",
       "reason": "XML node injection via unvalidated comment serialization. Transitive via expo > @expo/config-plugins > @expo/plist; only serializes developer-authored plist files at build/prebuild time, no runtime code path serializes attacker-controlled XML."
+    },
+    {
+      "id": "GHSA-v39h-62p7-jpjc",
+      "package": "fast-uri",
+      "reason": "Host confusion via percent-encoded authority delimiters in fast-uri parser. Transitive devDep via eslint > @eslint/eslintrc > ajv > fast-uri (also via commitlint, lisa); no production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+    },
+    {
+      "id": "GHSA-q3j6-qgpj-74h6",
+      "package": "fast-uri",
+      "reason": "Path traversal via percent-encoded dot segments in fast-uri parser. Transitive devDep via eslint > @eslint/eslintrc > ajv > fast-uri (also via commitlint, lisa); no production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
     }
   ]
 }

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -23,12 +23,12 @@
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "axios": ">=1.15.0",
+      "axios": ">=1.15.2",
       "handlebars": ">=4.7.9"
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "axios": ">=1.15.0",
+      "axios": ">=1.15.2",
       "handlebars": ">=4.7.9"
     }
   },


### PR DESCRIPTION
## Summary
- Bumps axios resolutions/overrides floor in `typescript/package-lisa/package.lisa.json` from `>=1.15.0` to `>=1.15.2` to dodge GHSA-q8qp-cvcw-x6jj (prototype pollution) and GHSA-pmwg-cvhr-8vh7 (SSRF via NO_PROXY bypass)
- Adds `fast-uri` GHSA-v39h-62p7-jpjc and GHSA-q3j6-qgpj-74h6 to `typescript/copy-overwrite/audit.ignore.config.json` — both surface only through dev/build tools (eslint > ajv > fast-uri); already needed downstream in propswap projects

## Test plan
- [ ] CI passes
- [ ] Downstream projects pick up the new floor on next Lisa update and no longer trigger CodeRabbit's axios advisory finding

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency constraint to version 1.15.2
  * Updated security vulnerability audit exclusions for the fast-uri package

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/467)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->