### PR TITLE
fix(expo): restore useFocusEffect/useIsFocused mocks in jest.setup.ts

### DIFF
--- a/expo/copy-overwrite/jest.setup.ts
+++ b/expo/copy-overwrite/jest.setup.ts
@@ -82,6 +82,12 @@ jest.mock("expo-router", () => ({
       setOptions: jest.fn(),
     })),
   })),
+  // Invoke the callback synchronously so screens that rely on it for
+  // mount-time effects behave like a focused screen under test.
+  useFocusEffect: jest.fn((callback: () => (() => void) | void) => {
+    callback();
+  }),
+  useIsFocused: jest.fn(() => true),
   Link: ({ children }: { children: React.ReactNode }) => children,
   Stack: {
     Screen: () => null,


### PR DESCRIPTION
## Summary
Restore the useFocusEffect and useIsFocused jest mocks inside the expo-router mock in expo/copy-overwrite/jest.setup.ts. These were missing, causing 61 test failures across 4 suites in frontend-v2 after applying Lisa 2.16.0 (any screen that relies on focus-aware mount-time effects breaks under jest).

- useFocusEffect: invoke callback synchronously so mount-time effects behave like a focused screen
- useIsFocused: always true under tests

## Test plan
- [x] frontend-v2 test suite (13064 tests) passes after applying this fix locally
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved navigation hook mocking to ensure focus-dependent mount-time effects execute correctly during testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/468)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->