### PR TITLE
fix(templates): clarify fast-uri reachability via aws-cdk-lib

### DIFF
--- a/typescript/copy-overwrite/audit.ignore.config.json
+++ b/typescript/copy-overwrite/audit.ignore.config.json
@@ -141,12 +141,12 @@
     {
       "id": "GHSA-v39h-62p7-jpjc",
       "package": "fast-uri",
-      "reason": "Host confusion via percent-encoded authority delimiters in fast-uri parser. Transitive devDep via eslint > @eslint/eslintrc > ajv > fast-uri (also via commitlint, lisa); no production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+      "reason": "Host confusion via percent-encoded authority delimiters in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time — its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
     },
     {
       "id": "GHSA-q3j6-qgpj-74h6",
       "package": "fast-uri",
-      "reason": "Path traversal via percent-encoded dot segments in fast-uri parser. Transitive devDep via eslint > @eslint/eslintrc > ajv > fast-uri (also via commitlint, lisa); no production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+      "reason": "Path traversal via percent-encoded dot segments in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time — its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- CodeRabbit flagged the prior `devDeps only` wording on the two fast-uri exclusions as inaccurate since `fast-uri` is reachable transitively through `aws-cdk-lib` (a production dependency in CDK projects).
- Practical exposure is unchanged: `aws-cdk-lib`'s bundled ajv is invoked only at synth/deploy time against developer-authored schemas, not runtime.
- Updated reason text to describe both reachability paths (eslint > ajv > fast-uri, and aws-cdk-lib > fast-uri) and explicitly note that aws-cdk-lib is build-time only.

## Test plan
- [x] Justification text is accurate per `package-lock.json` inspection in downstream CDK projects (thumbwar/infrastructure, propswap/infrastructure)
- [x] No structural change — only the \`reason\` field text was updated

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability audit configurations to clarify how vulnerabilities in transitive dependencies are reachable through build and deployment tooling. Confirmed that affected dependencies are exclusively utilized during build, synthesis, and deployment phases, with no presence or impact in production runtime code paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/469)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->