### PR TITLE
fix(quality): harden audit-exclusions loader against set -e

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1219,25 +1219,26 @@ jobs:
 
       - name: 📋 Load audit exclusions
         id: audit_exclusions
+        shell: bash
         run: |
+          # Disable -e so jq exiting non-zero (e.g. on an empty/missing
+          # `.exclusions` array under `set -e`) does not abort the step.
+          # An exclusion file that doesn't parse should yield zero
+          # exclusions, not a failed build.
+          set +e
           GHSA_IDS=""
           CVE_IDS=""
           for config_file in audit.ignore.config.json audit.ignore.local.json; do
-            if [ -f "$config_file" ]; then
-              FILE_IDS=$(jq -r '.exclusions[].id' "$config_file" 2>/dev/null)
-              if [ -n "$FILE_IDS" ]; then
-                GHSA_IDS="$GHSA_IDS $FILE_IDS"
-              fi
-              FILE_CVES=$(jq -r '.exclusions[] | select(.cve != null) | .cve' "$config_file" 2>/dev/null)
-              if [ -n "$FILE_CVES" ]; then
-                CVE_IDS="$CVE_IDS $FILE_CVES"
-              fi
-            fi
+            if [ ! -f "$config_file" ]; then continue; fi
+            FILE_IDS=$(jq -r '.exclusions[]?.id // empty' "$config_file" 2>/dev/null)
+            [ -n "$FILE_IDS" ] && GHSA_IDS="$GHSA_IDS $FILE_IDS"
+            FILE_CVES=$(jq -r '.exclusions[]? | select(.cve != null) | .cve' "$config_file" 2>/dev/null)
+            [ -n "$FILE_CVES" ] && CVE_IDS="$CVE_IDS $FILE_CVES"
           done
           GHSA_IDS=$(echo "$GHSA_IDS" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
           CVE_IDS=$(echo "$CVE_IDS" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
-          echo "ghsa_ids=$GHSA_IDS" >> $GITHUB_OUTPUT
-          echo "cve_ids=$CVE_IDS" >> $GITHUB_OUTPUT
+          echo "ghsa_ids=$GHSA_IDS" >> "$GITHUB_OUTPUT"
+          echo "cve_ids=$CVE_IDS" >> "$GITHUB_OUTPUT"
           echo "Loaded GHSA exclusions: $GHSA_IDS"
           echo "Loaded CVE exclusions: $CVE_IDS"
         working-directory: ${{ inputs.working_directory || '.' }}


### PR DESCRIPTION
## Summary
- The `📋 Load audit exclusions` step in `quality.yml` uses bare command substitutions with `jq` under the runner's default `bash -e`. When jq exits non-zero (missing `.exclusions`, malformed JSON, locale issue, etc.), the assignment statement inherits that exit status and `set -e` aborts the step with **no diagnostic output**.
- Reproduced on `propswap/frontend` PR #635: the step exits 5 in under 25 ms with zero stdout, before any echo runs. The local-machine reproduction of the exact same script with the exact same JSON files exits 0 — so the breakage only surfaces under runner-specific conditions (likely a jq version / locale difference on Ubuntu runners that returns non-zero on otherwise valid output).
- An exclusion loader failing should not fail the build — at worst we should fall through with an empty exclusion list and let the audit step decide.

## Fix
- `set +e` at the top of the step so jq's exit status no longer terminates the loader
- `.exclusions[]?` so jq tolerates a missing key
- `// empty` on the id path so malformed entries yield nothing instead of null
- early `continue` for missing files (flatter script)
- quote `"$GITHUB_OUTPUT"`
- pin `shell: bash`

## Test plan
- [x] Local repro of original script: exits 0 with all GHSAs listed
- [x] Local repro of fixed script: same output, exits 0
- [ ] Downstream verification: propswap/frontend `chore/lisa-update-2026-05-12` next CI run consumes `quality.yml@main` and the Load step succeeds

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the reliability of the security scanning process in continuous integration to gracefully handle edge cases with missing, empty, or unparseable configuration files.
  * Improved error handling to suppress non-critical parse errors during security audit operations.
  * Strengthened deduplication and aggregation of security vulnerability identifiers for more comprehensive audit reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->