### PR TITLE
docs(agents): require ingestion PR auto-merge

### DIFF
--- a/.agents/skills/lisa-wiki-ingest/SKILL.md
+++ b/.agents/skills/lisa-wiki-ingest/SKILL.md
@@ -19,7 +19,7 @@ For every ingestion:
 4. Append `wiki/log.md`.
 5. Advance `wiki/state/<source>/` only after source notes, synthesis, index, and log are complete.
 6. Run verification checks.
-7. Commit and push automatically.
+7. Commit only the ingestion changes, push, open a PR targeting `main`, and enable auto-merge. If ingestion started on `main`, create a dedicated ingestion branch before committing.
 
 ## Initial Repository Ingestion
 

--- a/.claude/skills/lisa-wiki-ingest/SKILL.md
+++ b/.claude/skills/lisa-wiki-ingest/SKILL.md
@@ -14,7 +14,7 @@ For every ingestion:
 4. Append `wiki/log.md`.
 5. Advance `wiki/state/<source>/` only after source notes, synthesis, index, and log are complete.
 6. Run verification checks.
-7. Commit and push automatically.
+7. Commit only the ingestion changes, push, open a PR targeting `main`, and enable auto-merge. If ingestion started on `main`, create a dedicated ingestion branch before committing.
 
 ## Initial Repository Ingestion
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Codex skills for Lisa wiki work live under `.agents/skills/`.
 - Update `wiki/index.md` whenever creating or materially changing wiki pages.
 - Preserve unrelated working tree changes. In particular, do not stage or modify `.lisa.workspaces.json` unless explicitly requested.
 - Do not commit local secrets, MCP OAuth artifacts, tokens, private keys, dependency directories, build outputs, coverage output, or generated distribution files unless the user explicitly requests release artifacts.
-- After every successful ingestion, verify, commit, and push automatically.
+- After every successful ingestion, verify, commit only the ingestion changes, push, open a PR targeting `main`, and enable auto-merge. If ingestion started on `main`, create a dedicated ingestion branch before committing.
 
 ## Lisa-Specific Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,4 +19,4 @@ Core rules:
 - Update `wiki/index.md` when creating or materially changing wiki pages.
 - Preserve unrelated working tree changes.
 - Do not stage local secrets, dependency directories, build output, coverage output, or generated distribution files unless explicitly requested.
-- Commit and push after each successful ingestion.
+- After each successful ingestion, verify, commit only the ingestion changes, push, open a PR targeting `main`, and enable auto-merge. If ingestion started on `main`, create a dedicated ingestion branch before committing.

--- a/wiki/schema/llm-wiki-contract.md
+++ b/wiki/schema/llm-wiki-contract.md
@@ -69,6 +69,8 @@ Before committing:
 - No secrets, tokens, private keys, MCP OAuth artifacts, dependency directories, build outputs, coverage output, or generated distribution files may be staged.
 - Existing unrelated working tree changes must remain unstaged unless the user explicitly requests otherwise.
 
-## Commit And Push
+## Commit And Pull Request
 
-After every successful ingestion, commit and push automatically to the current branch of the existing Lisa repository.
+After every successful ingestion, verify, commit only the ingestion changes, push, open a pull request targeting `main`, and enable auto-merge.
+
+If ingestion starts on `main`, create a dedicated ingestion branch before committing so the PR flow is preserved.


### PR DESCRIPTION
## Summary
- require successful wiki ingestions to commit only ingestion changes, push, open a PR to main, and enable auto-merge
- apply the rule across AGENTS.md, CLAUDE.md, the shared wiki contract, and both Lisa wiki-ingest skill copies

## Verification
- git diff --check
- commit hook: typecheck, gitleaks, lint-staged
- pre-push hook: bun audit, slow lint, knip, coverage tests, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wiki ingestion workflow to require committing ingestion changes, pushing via pull request targeting the main branch, and enabling auto-merge.
  * Added conditional branch management: when ingestion starts on the main branch, a dedicated ingestion branch is created before committing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/475)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->