### PR TITLE
feat(plugins): declare plugin dependency graph

### DIFF
--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -5,5 +5,8 @@
   "author": {
     "name": "Cody Swann"
   },
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "hooks": {}
 }

--- a/plugins/lisa-cdk/.codex-plugin/plugin.json
+++ b/plugins/lisa-cdk/.codex-plugin/plugin.json
@@ -10,6 +10,9 @@
     "cdk",
     "infrastructure"
   ],
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "interface": {
     "displayName": "Lisa CDK",
     "shortDescription": "AWS CDK workflows",

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -5,5 +5,8 @@
   "author": {
     "name": "Cody Swann"
   },
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "hooks": {}
 }

--- a/plugins/lisa-expo/.codex-plugin/plugin.json
+++ b/plugins/lisa-expo/.codex-plugin/plugin.json
@@ -11,6 +11,9 @@
     "mobile",
     "mcp"
   ],
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -5,6 +5,9 @@
   "author": {
     "name": "Cody Swann"
   },
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/lisa-nestjs/.codex-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.codex-plugin/plugin.json
@@ -11,6 +11,9 @@
     "typeorm",
     "hooks"
   ],
+  "dependencies": [
+    "lisa-typescript"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json",
   "interface": {

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -5,6 +5,9 @@
   "author": {
     "name": "Cody Swann"
   },
+  "dependencies": [
+    "lisa"
+  ],
   "hooks": {
     "SessionStart": [
       {

--- a/plugins/lisa-rails/.codex-plugin/plugin.json
+++ b/plugins/lisa-rails/.codex-plugin/plugin.json
@@ -11,6 +11,9 @@
     "rubocop",
     "hooks"
   ],
+  "dependencies": [
+    "lisa"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json",
   "interface": {

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -5,6 +5,9 @@
   "author": {
     "name": "Cody Swann"
   },
+  "dependencies": [
+    "lisa"
+  ],
   "hooks": {
     "PostToolUse": [
       {

--- a/plugins/lisa-typescript/.codex-plugin/plugin.json
+++ b/plugins/lisa-typescript/.codex-plugin/plugin.json
@@ -11,6 +11,9 @@
     "formatting",
     "hooks"
   ],
+  "dependencies": [
+    "lisa"
+  ],
   "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "Lisa TypeScript",

--- a/plugins/src/cdk/.claude-plugin/plugin.json
+++ b/plugins/src/cdk/.claude-plugin/plugin.json
@@ -3,5 +3,6 @@
   "version": "1.0.0",
   "description": "AWS CDK-specific plugin",
   "author": { "name": "Cody Swann" },
+  "dependencies": ["lisa-typescript"],
   "hooks": {}
 }

--- a/plugins/src/expo/.claude-plugin/plugin.json
+++ b/plugins/src/expo/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": { "name": "Cody Swann" },
+  "dependencies": ["lisa-typescript"],
   "hooks": {}
 
 }

--- a/plugins/src/nestjs/.claude-plugin/plugin.json
+++ b/plugins/src/nestjs/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": { "name": "Cody Swann" },
+  "dependencies": ["lisa-typescript"],
   "hooks": {
     "PreToolUse": [
       {

--- a/plugins/src/rails/.claude-plugin/plugin.json
+++ b/plugins/src/rails/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": { "name": "Cody Swann" },
+  "dependencies": ["lisa"],
   "hooks": {
     "SessionStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] }

--- a/plugins/src/typescript/.claude-plugin/plugin.json
+++ b/plugins/src/typescript/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
   "author": { "name": "Cody Swann" },
+  "dependencies": ["lisa"],
   "hooks": {
     "PostToolUse": [
       {

--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -47,6 +47,9 @@ function writeCodexManifest(pluginName, version, hooksFile) {
     description: metadata.description ?? claudeManifest.description,
     author: claudeManifest.author ?? { name: "Cody Swann" },
     keywords: metadata.keywords,
+    ...(claudeManifest.dependencies
+      ? { dependencies: claudeManifest.dependencies }
+      : {}),
     ...componentPointers(hooksFile),
     interface: {
       displayName: metadata.displayName,


### PR DESCRIPTION
## Summary

Declare a `dependencies` graph across the stack plugin manifests so Claude Code 2.1.143+ enforces it:

- `lisa-typescript` → `lisa`
- `lisa-expo`, `lisa-nestjs`, `lisa-cdk` → `lisa-typescript`
- `lisa-rails` → `lisa`

`claude plugin enable lisa-expo` will now auto-pull `lisa-typescript` + `lisa`; `claude plugin disable lisa` is refused while a stack plugin still depends on it, with a copy-pasteable disable-chain hint.

Codex artifact generator (`scripts/generate-codex-plugin-artifacts.mjs`) propagates `dependencies` into the `.codex-plugin/plugin.json` manifest so the codex side stays in sync.

## Test plan

- [x] `bun run build:plugins` regenerates all 6 plugins cleanly
- [x] `jq '{name, dependencies}'` confirms each built `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` carries the expected `dependencies` array
- [ ] Confirm on a fresh shell: `claude plugin enable lisa-expo` auto-enables `lisa-typescript` and `lisa`
- [ ] Confirm `claude plugin disable lisa` is refused with a disable-chain hint while `lisa-expo` is enabled

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit dependency declarations to plugin manifests across multiple plugins
  * Updated plugin manifest generation to include dependency information in generated configuration files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->