### PR TITLE
chore: lisa self-upgrade to 2.19.0 + bundler-audit worktree fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
         "vitest": "^4.1.0",
       },
       "devDependencies": {
-        "@codyswann/lisa": "^1.81.3",
+        "@codyswann/lisa": "^2.19.0",
         "@types/js-yaml": "^4.0.9",
         "eslint-plugin-oxlint": "^1.62.0",
         "js-yaml": "^4.1.1",
@@ -232,7 +232,7 @@
 
     "@codyswann/eslint-plugin-ui-standards": ["@codyswann/eslint-plugin-ui-standards@workspace:eslint-plugin-ui-standards"],
 
-    "@codyswann/lisa": ["@codyswann/lisa@1.81.3", "", { "dependencies": { "@ast-grep/cli": "^0.40.4", "@commitlint/cli": "^20.5.0", "@commitlint/config-conventional": "^20.5.0", "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0", "@eslint/eslintrc": "^3.2.0", "@eslint/js": "^9.39.0", "@inquirer/prompts": "^7.0.0", "@jest/globals": "^30.0.0", "@jest/test-sequencer": "^30.2.0", "@types/fs-extra": "^11.0.0", "@types/jest": "^30.0.0", "@types/lodash.merge": "^4.6.0", "@types/node": "^22.0.0", "@vitest/coverage-v8": "^4.1.0", "commander": "^12.0.0", "esbuild-register": "^3.6.0", "eslint": "^9.39.0", "eslint-config-expo": "^10.0.0", "eslint-config-prettier": "^10.0.0", "eslint-import-resolver-typescript": "^4.4.4", "eslint-plugin-functional": "^9.0.0", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsdoc": "^61.5.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-prettier": "^5.5.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-compiler": "^19.1.0-rc.2", "eslint-plugin-react-hooks": "^7.0.0", "eslint-plugin-react-perf": "^3.3.0", "eslint-plugin-sonarjs": "^3.0.0", "eslint-plugin-tailwindcss": "^3.18.0", "fs-extra": "^11.0.0", "globals": "^16.0.0", "husky": "^8.0.0", "jest": "^30.0.0", "jiti": "^2.4.0", "jscodeshift": "0.15.2", "knip": "^5.0.0", "lint-staged": "^16.2.7", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "picocolors": "^1.0.0", "prettier": "^3.3.3", "standard-version": "^9.5.0", "ts-jest": "^29.4.9", "ts-morph": "^27.0.2", "tsx": "^4.0.0", "typescript": "~5.7.0", "typescript-eslint": "^8.0.0", "vitest": "^4.1.0" }, "bin": { "lisa": "dist/index.js", "setup-deploy-key": "scripts/setup-deploy-key.sh" } }, "sha512-hqBxlVL/1u9OVdFZaqKHAm/URap5z/VEfHlQzuQOBIx477rkOqNHi31ddh12j9l9oBLIAbL8CKQpqkBbWD4WPA=="],
+    "@codyswann/lisa": ["@codyswann/lisa@2.19.0", "", { "dependencies": { "@ast-grep/cli": "^0.40.4", "@commitlint/cli": "^20.5.0", "@commitlint/config-conventional": "^20.5.0", "@decimalturn/toml-patch": "^1.1.1", "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0", "@eslint/eslintrc": "^3.2.0", "@eslint/js": "^9.39.0", "@inquirer/prompts": "^7.0.0", "@jest/globals": "^30.0.0", "@jest/test-sequencer": "^30.2.0", "@types/fs-extra": "^11.0.0", "@types/jest": "^30.0.0", "@types/lodash.merge": "^4.6.0", "@types/node": "^22.0.0", "@vitest/coverage-v8": "^4.1.0", "commander": "^12.0.0", "esbuild-register": "^3.6.0", "eslint": "^9.39.0", "eslint-config-expo": "^10.0.0", "eslint-config-prettier": "^10.0.0", "eslint-import-resolver-typescript": "^4.4.4", "eslint-plugin-functional": "^9.0.0", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsdoc": "^61.5.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-prettier": "^5.5.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-compiler": "^19.1.0-rc.2", "eslint-plugin-react-hooks": "^7.0.0", "eslint-plugin-react-perf": "^3.3.0", "eslint-plugin-sonarjs": "^4.0.3", "eslint-plugin-tailwindcss": "^3.18.0", "fs-extra": "^11.0.0", "globals": "^16.0.0", "husky": "^8.0.0", "jest": "^30.0.0", "jiti": "^2.4.0", "jscodeshift": "0.15.2", "knip": "^5.0.0", "lint-staged": "^16.2.7", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "picocolors": "^1.0.0", "prettier": "^3.3.3", "smol-toml": "^1.6.1", "standard-version": "^9.5.0", "ts-jest": "^29.4.9", "ts-morph": "^27.0.2", "tsx": "^4.0.0", "typescript": "^6.0.3", "typescript-eslint": "^8.0.0", "vitest": "^4.1.0" }, "bin": { "lisa": "dist/index.js", "setup-deploy-key": "scripts/setup-deploy-key.sh" } }, "sha512-0CPu+mlCiED2GEnZfkNtFG+1fSwQwriQsDjpnzwzmCD5jOtQdmtqkon3pvGqRgmDH7CugfJVrcrhKjCq28UoEg=="],
 
     "@commitlint/cli": ["@commitlint/cli@20.5.0", "", { "dependencies": { "@commitlint/format": "^20.5.0", "@commitlint/lint": "^20.5.0", "@commitlint/load": "^20.5.0", "@commitlint/read": "^20.5.0", "@commitlint/types": "^20.5.0", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ=="],
 
@@ -2052,10 +2052,6 @@
 
     "@babel/traverse/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
-    "@codyswann/lisa/eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@3.0.5", "", { "dependencies": { "@eslint-community/regexpp": "4.12.1", "builtin-modules": "3.3.0", "bytes": "3.1.2", "functional-red-black-tree": "1.0.1", "jsx-ast-utils-x": "0.1.0", "lodash.merge": "4.6.2", "minimatch": "9.0.5", "scslre": "0.3.0", "semver": "7.7.2", "typescript": ">=5" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0" } }, "sha512-dI62Ff3zMezUToi161hs2i1HX1ie8Ia2hO0jtNBfdgRBicAG4ydy2WPt0rMTrAe3ZrlqhpAO3w1jcQEdneYoFA=="],
-
-    "@codyswann/lisa/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
-
     "@commitlint/config-validator/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@commitlint/is-ignored/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -2332,12 +2328,6 @@
 
     "@babel/register/make-dir/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
-    "@codyswann/lisa/eslint-plugin-sonarjs/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
-
-    "@codyswann/lisa/eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@codyswann/lisa/eslint-plugin-sonarjs/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -2413,8 +2403,6 @@
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@codyswann/lisa/eslint-plugin-sonarjs/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "vitest": "^4.1.0"
   },
   "devDependencies": {
-    "@codyswann/lisa": "^1.81.3",
+    "@codyswann/lisa": "^2.19.0",
     "@types/js-yaml": "^4.0.9",
     "eslint-plugin-oxlint": "^1.62.0",
     "js-yaml": "^4.1.1",

--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -5,7 +5,11 @@ pre-commit:
       glob: '*.rb'
       run: bundle exec rubocop --force-exclusion {staged_files}
     bundler-audit:
-      run: bundle exec bundler-audit check --update
+      # Unset GIT_DIR/GIT_WORK_TREE so `--update`'s internal git pull of the
+      # ruby-advisory-db (~/.local/share/ruby-advisory-db) does not inherit the
+      # repo's git context. Without this, the command fails when the hook runs
+      # inside a git worktree (the inherited GIT_DIR points at the wrong repo).
+      run: env -u GIT_DIR -u GIT_WORK_TREE bundle exec bundler-audit check --update
 
 commit-msg:
   commands:


### PR DESCRIPTION
## Summary

Final step of the batch `lisa-update-projects` run (2026-05-21): Lisa upgrades itself, plus an upstream template fix surfaced during the downstream updates.

### Changes
- **`chore(deps)`**: bump Lisa's own `@codyswann/lisa` devDependency `1.81.3 → 2.19.0` (dogfooding). Postinstall re-applied templates with **no drift** — only transitive resolutions changed (eslint-plugin-sonarjs 3→4, typescript 5.7→6, +smol-toml/@decimalturn/toml-patch).
- **`fix(rails)`**: unset `GIT_DIR`/`GIT_WORK_TREE` for the `bundler-audit` command in `rails/copy-overwrite/lefthook.yml`. Its `--update` flag does an internal git pull of `~/.local/share/ruby-advisory-db`; inside a git worktree the inherited git context broke every commit. qualis/app had this exact workaround applied manually and `copy-overwrite` was clobbering it each update — upstreaming so it stops regressing.

### Verification
- `bun run typecheck` ✅
- `bun run lint` (oxlint + eslint) ✅ 0 warnings / 0 errors
- pre-push integration tests ✅ 41 passed

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to align with package version
  * Modified pre-commit hook configuration for improved execution reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->