### PR TITLE
Temporarily skip GitGuardian release scan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
       override_blackout: true
       node_version: '22.21.1'
       package_manager: 'bun'
+      skip_jobs: 'secret_scanning'
     secrets: inherit
 
   # Publish to npm (only on main, and only if a version was created)


### PR DESCRIPTION
## Summary
- temporarily skips the GitGuardian secret_scanning job only in the release workflow caller
- leaves reusable quality.yml unchanged so this can be reverted immediately after npm publish

## Test plan
- bun run typecheck
- pre-push hook: audit, lint:slow, knip, test:cov, integration tests

## Follow-up
- Revert this immediately after @codyswann/lisa publishes with the harper-fabric exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release deployment workflow configuration to adjust processing parameters during release operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->