### PR TITLE
Restore GitGuardian release blocker [skip ci]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,6 @@ jobs:
       override_blackout: true
       node_version: '22.21.1'
       package_manager: 'bun'
-      skip_jobs: 'secret_scanning'
     secrets: inherit
 
   # Publish to npm (only on main, and only if a version was created)


### PR DESCRIPTION
## Summary
- removes the temporary release-only GitGuardian skip now that @codyswann/lisa@2.20.0 is published
- restores secret_scanning as a hard blocker in the release workflow

## Test plan
- bun run typecheck
- git push pre-push hook: bun audit, slow lint, knip, unit coverage, integration tests
