### PR TITLE
chore: temporarily skip GitGuardian release scan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'
+      skip_jobs: 'secret_scanning'
       require_approval: false
       require_signatures: false
       generate_sbom: true


### PR DESCRIPTION
## Summary

Temporarily adds `skip_jobs: 'secret_scanning'` to the `release` job in `.github/workflows/deploy.yml` so the queued Lisa npm publish can complete despite the exhausted GitGuardian API quota (`no more API calls available`).

The publish triggered by #490 failed at the GitGuardian Secret Detection gate in the release pipeline, so `@codyswann/lisa` was never published past `2.20.0`. This mirrors #487.

**This is a temporary bypass of only the secret-scanning job** — all other release gates still run. A follow-up PR will remove this line to restore the GitGuardian blocker once the publish lands.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to optimize the deployment process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->