### PR TITLE
chore: restore GitGuardian release blocker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,6 @@ jobs:
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'
-      skip_jobs: 'secret_scanning'
       require_approval: false
       require_signatures: false
       generate_sbom: true


### PR DESCRIPTION
## Summary

Reverts the temporary `skip_jobs: 'secret_scanning'` bypass added in #492. The queued publish has landed — **`@codyswann/lisa@2.21.0` is now live on npm** (includes the Harper/Fabric runtime skills from #490).

This restores GitGuardian secret scanning as a hard release gate for future publishes.

## Follow-up

GitGuardian remains out of API credits. The next release will block on the secret-scan gate again until the quota is restored or upgraded.

🤖 Generated with Claude Code