### PR TITLE
chore: restore GitGuardian release blocker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,6 @@ jobs:
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'
-      skip_jobs: 'secret_scanning'
       require_approval: false
       require_signatures: false
       generate_sbom: true


### PR DESCRIPTION
Re-enables GitGuardian secret scanning in the release pipeline (`deploy.yml`) now that the API quota has reset. Reverts the temporary `skip_jobs: 'secret_scanning'` introduced in #505 so the publish could land during the quota outage.

🤖 Generated with Claude Code