### PR TITLE
fix(marketplace): register lisa-harper-fabric and guard marketplace coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,12 @@
       "category": "productivity"
     },
     {
+      "name": "lisa-harper-fabric",
+      "source": "./plugins/lisa-harper-fabric",
+      "description": "Harper/Fabric-specific rules for TypeScript component apps (Claude + Codex)",
+      "category": "productivity"
+    },
+    {
       "name": "lisa-rails",
       "source": "./plugins/lisa-rails",
       "description": "Ruby on Rails skills, rules, and conventions",

--- a/.github/workflows/plugins-sync.yml
+++ b/.github/workflows/plugins-sync.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     paths:
       - 'plugins/**'
+      - '.claude-plugin/marketplace.json'
       - 'scripts/build-plugins.sh'
       - 'scripts/generate-codex-plugin-artifacts.mjs'
       - 'scripts/check-plugins-sync.sh'

--- a/scripts/check-plugins-sync.sh
+++ b/scripts/check-plugins-sync.sh
@@ -43,3 +43,40 @@ if ! git diff --quiet -- plugins/; then
 fi
 
 echo "✓ Plugin artifacts are in sync with plugins/src."
+
+# Marketplace coverage: every built plugin directory (plugins/lisa, plugins/lisa-*)
+# must be registered in .claude-plugin/marketplace.json, and every marketplace
+# entry must point at a directory that exists. The reproducibility check above
+# only proves artifacts match plugins/src — it does NOT prove a built plugin is
+# actually published. lisa-harper-fabric shipped built-but-unpublished for
+# exactly this reason: install-claude-plugins.sh tried "lisa-harper-fabric@lisa"
+# but the marketplace never advertised it, so resolution failed at install time.
+MARKETPLACE="$ROOT_DIR/.claude-plugin/marketplace.json"
+marketplace_fail=0
+
+# Every built plugin dir needs a marketplace entry whose source points to it.
+while IFS= read -r dir; do
+  name="$(basename "$dir")"
+  if ! jq -e --arg src "./plugins/$name" '.plugins[] | select(.source == $src)' "$MARKETPLACE" >/dev/null; then
+    echo "✗ Built plugin plugins/$name is not registered in .claude-plugin/marketplace.json (expected source \"./plugins/$name\")." >&2
+    marketplace_fail=1
+  fi
+done < <(find "$ROOT_DIR/plugins" -maxdepth 1 -mindepth 1 -type d ! -name src | sort)
+
+# Every marketplace entry must point at a directory that exists.
+while IFS= read -r src; do
+  if [ ! -d "$ROOT_DIR/$src" ]; then
+    echo "✗ marketplace.json entry source \"$src\" does not exist as a built plugin directory." >&2
+    marketplace_fail=1
+  fi
+done < <(jq -r '.plugins[].source' "$MARKETPLACE")
+
+if [ "$marketplace_fail" -ne 0 ]; then
+  echo "" >&2
+  echo "  Every plugins/lisa* directory must be registered in .claude-plugin/marketplace.json" >&2
+  echo "  and every marketplace source must point to a real built directory. Edit the manifest" >&2
+  echo "  at .claude-plugin/marketplace.json, then re-run: bun run check:plugins" >&2
+  exit 1
+fi
+
+echo "✓ Marketplace registers every built plugin."


### PR DESCRIPTION
## What

`lisa-harper-fabric` ships as both a Claude plugin and a Codex plugin — but it was wired into **every** distribution point *except* the marketplace manifest, so it failed to install with:

> `lisa-harper-fabric@lisa could not be registered`

| Registration point | Before |
|---|---|
| `plugins/src/harper-fabric/` (source) | ✅ |
| `build-plugins.sh` STACKS → `plugins/lisa-harper-fabric/` | ✅ |
| `generate-codex-plugin-artifacts.mjs` (`.codex-plugin/plugin.json`) | ✅ |
| `install-claude-plugins.sh` (installs `lisa-harper-fabric@lisa`) | ✅ |
| `.claude-plugin/marketplace.json` | ❌ **missing** |

The installer asked Claude Code to install `lisa-harper-fabric@lisa`, but the marketplace never advertised it → resolution failure. The Codex side was already complete; both runtimes were blocked on the same unpublished manifest entry.

## Why it slipped through CI

`check:plugins` only verified `plugins/` ↔ `plugins/src/` reproducibility. It never asserted that a built plugin is actually *published* in the marketplace, so a built-but-unregistered plugin was invisible to CI.

## Changes

1. **`.claude-plugin/marketplace.json`** — add the `lisa-harper-fabric` entry (between `lisa-cdk` and `lisa-rails`, matching build/codex ordering). Fixes both Claude and Codex distribution, since Codex artifacts are already built into the plugin dir.
2. **`scripts/check-plugins-sync.sh`** — new marketplace-coverage assertion: every built `plugins/lisa*` dir must be registered, and every marketplace `source` must point at a real directory. Verified it catches the exact regression (removing the entry fails the check).
3. **`.github/workflows/plugins-sync.yml`** — trigger the Plugins Sync check on `.claude-plugin/marketplace.json` edits too.

## Verification

```
✓ Plugin artifacts are in sync with plugins/src.
✓ Marketplace registers every built plugin.
```

Confirmed the new guard fails when the `lisa-harper-fabric` entry is removed.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lisa-harper-fabric plugin providing Harper/Fabric-specific rules for TypeScript component applications

* **Chores**
  * Updated plugin synchronization workflow to validate marketplace configuration changes in pull requests
  * Implemented marketplace coverage validation to ensure consistency between plugin registry and built plugins

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->