### PR TITLE
ci(actions): bump GitHub Actions to Node-24 majors across repo + templates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,10 @@ jobs:
     name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: '22.21.1'
       - name: '🍞 Setup Bun'
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/create-github-issue-on-failure.yml
+++ b/.github/workflows/create-github-issue-on-failure.yml
@@ -64,16 +64,17 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🔖 Create Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT || github.token }}
           script: |

--- a/.github/workflows/create-jira-issue-on-failure.yml
+++ b/.github/workflows/create-jira-issue-on-failure.yml
@@ -84,11 +84,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 

--- a/.github/workflows/create-sentry-issue-on-failure.yml
+++ b/.github/workflows/create-sentry-issue-on-failure.yml
@@ -84,11 +84,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -30,11 +30,12 @@ jobs:
 
     steps:
       - name: '📥 Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: '🔧 Setup Node.js'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -80,7 +81,7 @@ jobs:
         run: ${{ inputs.package_manager }} run lighthouse:check
 
       - name: '📊 Upload Lighthouse reports'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: lighthouse-reports

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up k6
         run: |
@@ -258,7 +258,7 @@ jobs:
       - name: Upload test results
         id: upload_results
         if: always() && inputs.upload_results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: k6-results-${{ inputs.environment }}-${{ inputs.test_scenario }}-${{ github.run_id }}
           path: k6-results/
@@ -266,7 +266,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `${{ steps.generate_summary.outputs.summary }}`;

--- a/.github/workflows/plugins-sync.yml
+++ b/.github/workflows/plugins-sync.yml
@@ -25,7 +25,7 @@ jobs:
     name: 🧩 Plugin artifacts match source
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: '🍞 Setup Bun'
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -62,7 +62,7 @@ jobs:
           echo "✅ Inputs validated: tag=${{ inputs.tag }}, version=${{ inputs.version }}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -93,8 +93,9 @@ jobs:
           bun-version: '1.3.8'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
@@ -104,7 +105,7 @@ jobs:
 
       - name: Get OIDC Token for npm
         id: npm-oidc
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const token = await core.getIDToken('https://registry.npmjs.org');

--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -75,7 +75,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'lint') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -91,7 +91,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'security') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -127,7 +127,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/${{ inputs.database_name }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -166,7 +166,7 @@ jobs:
       DATABASE_PORT: 3306
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -185,7 +185,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'code_quality') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 💎 Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -208,7 +208,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'secret_scanning') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -246,7 +246,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'sg_scan') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Install ast-grep
         run: npm install -g @ast-grep/cli@0.40.4
@@ -300,7 +300,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'license_compliance') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for FOSSA API key
         id: check_fossa
@@ -334,7 +334,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'zap_baseline') && inputs.zap_target_url != '' }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for ZAP rules file
         id: check_rules
@@ -356,7 +356,7 @@ jobs:
 
       - name: 📤 Upload ZAP report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap-baseline-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -164,11 +164,12 @@ jobs:
       cache-hit: ${{ steps.cache.outputs.cache-hit }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -193,7 +194,7 @@ jobs:
 
       - name: 📦 Cache node_modules
         id: cache-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -222,7 +223,7 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 📤 Upload dependencies artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: node-modules-${{ github.run_id }}
           path: |
@@ -246,11 +247,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -300,11 +302,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -339,11 +342,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -378,11 +382,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -424,11 +429,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -489,11 +495,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -554,11 +561,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -619,7 +627,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for Maestro API key
         id: check_maestro
@@ -735,11 +743,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -791,7 +800,7 @@ jobs:
       - name: 💾 Restore Expo build cache
         if: steps.check_playwright.outputs.has_config == 'true' && inputs.cache_build == true
         id: expo_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ inputs.working_directory || '.' }}/dist
@@ -832,7 +841,7 @@ jobs:
       # the same downstream artifact name — `playwright-report-<run-id>`.
       - name: 📤 Upload Playwright blob
         if: steps.check_playwright.outputs.has_config == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-blob-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: ${{ inputs.working_directory || '.' }}/blob-report
@@ -861,7 +870,7 @@ jobs:
     if: ${{ always() && !contains(inputs.skip_jobs, 'playwright_e2e') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for Playwright config
         id: check_playwright
@@ -877,8 +886,9 @@ jobs:
 
       - name: 🔧 Setup Node.js
         if: steps.check_playwright.outputs.has_config == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -902,7 +912,7 @@ jobs:
 
       - name: 📥 Download all shard blob reports
         if: steps.check_playwright.outputs.has_config == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ inputs.working_directory || '.' }}/all-blob-reports
           pattern: playwright-blob-${{ github.run_id }}-shard-*
@@ -918,7 +928,7 @@ jobs:
       # viewers) don't need to change when a repo opts into sharding.
       - name: 📤 Upload merged Playwright report
         if: steps.check_playwright.outputs.has_config == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ github.run_id }}
           path: ${{ inputs.working_directory || '.' }}/playwright-report
@@ -958,11 +968,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -997,11 +1008,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1032,7 +1044,7 @@ jobs:
       - name: 💾 Restore build cache
         if: inputs.cache_build == true
         id: build_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ inputs.working_directory || '.' }}/dist
@@ -1058,7 +1070,7 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 📤 Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success()
         with:
           name: build-output-${{ github.run_id }}
@@ -1078,11 +1090,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1115,11 +1128,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1192,11 +1206,12 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'npm_security_scan') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1340,7 +1355,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'sonarcloud') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full depth for proper analysis
 
@@ -1430,7 +1445,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'snyk') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for Snyk token
         id: check_snyk
@@ -1447,8 +1462,9 @@ jobs:
 
       - name: 🔧 Setup Node.js
         if: steps.check_snyk.outputs.has_token == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1480,7 +1496,7 @@ jobs:
 
       - name: 📤 Upload Snyk results
         if: steps.check_snyk.outputs.has_token == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: snyk-results
           path: snyk-results.json
@@ -1499,7 +1515,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'secret_scanning') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full depth for scanning history
 
@@ -1537,7 +1553,7 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'license_compliance') }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔍 Check for FOSSA API key
         id: check_fossa
@@ -1573,11 +1589,12 @@ jobs:
     if: ${{ !contains(inputs.skip_jobs, 'zap_baseline') && inputs.zap_target_url != '' }}
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -1619,7 +1636,7 @@ jobs:
 
       - name: 📤 Upload ZAP report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap-baseline-report-${{ github.run_id }}
           path: |
@@ -2002,7 +2019,7 @@ jobs:
       ]
     steps:
       - name: 📝 Generate audit log
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const auditLog = {
@@ -2079,7 +2096,7 @@ jobs:
             core.setOutput('filename', filename);
 
       - name: 📤 Upload audit log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audit-log-${{ github.run_id }}
           path: audit-log-*.json
@@ -2127,7 +2144,7 @@ jobs:
 
       - name: 📤 Upload evidence package
         if: ${{ inputs.generate_evidence_package == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compliance-evidence-${{ github.run_id }}
           path: evidence-package/
@@ -2180,7 +2197,7 @@ jobs:
           EOF
 
       - name: 📤 Upload approval record
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: approval-record-${{ github.run_id }}
           path: approval-record-*.json

--- a/.github/workflows/release-rails.yml
+++ b/.github/workflows/release-rails.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
@@ -66,9 +66,10 @@ jobs:
 
           echo "skip=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.skip.outputs.skip != 'true'
         with:
+          package-manager-cache: false
           node-version: '22'
 
       - name: Configure Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
       is_promotion: ${{ steps.check.outputs.is_promotion }}
       skip_reason: ${{ steps.check.outputs.skip_reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 10 # Need some history to analyze merge commits
 
@@ -387,7 +387,7 @@ jobs:
     steps:
       # Use SSH deploy key for pushing to protected branches
       # Setup: Add DEPLOY_KEY secret and add the deploy key to ruleset bypass list
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
@@ -474,8 +474,9 @@ jobs:
             "signatures_required" "${{ inputs.require_signatures }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -659,7 +660,7 @@ jobs:
             "components" "$(jq '.components | length' sbom.json)"
 
       - name: Upload Version Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: version-artifacts-${{ github.run_id }}
           path: |
@@ -679,13 +680,13 @@ jobs:
       signed: ${{ steps.sign.outputs.signed }}
       signature_files: ${{ steps.sign.outputs.files }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
       - name: Download Version Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: version-artifacts-${{ github.run_id }}
 
@@ -840,7 +841,7 @@ jobs:
 
       - name: Upload Signed Artifacts
         if: steps.sign.outputs.signed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: signed-artifacts-${{ github.run_id }}
           path: |
@@ -995,7 +996,7 @@ jobs:
           echo "url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" >> $GITHUB_OUTPUT
 
       - name: Store Attestations
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-attestations-${{ needs.version.outputs.version }}
           path: |
@@ -1019,12 +1020,12 @@ jobs:
       release_id: ${{ steps.create_release.outputs.id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: '*-${{ github.run_id }}'
 
@@ -1185,7 +1186,7 @@ jobs:
       sentry_release_created: ${{ steps.set_outputs.outputs.created }}
       sentry_release_url: ${{ steps.set_outputs.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -1257,7 +1258,7 @@ jobs:
       has_jira_setup: ${{ steps.check.outputs.has_jira_setup }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: JIRA_AUTOMATION_WEBHOOK
@@ -1296,7 +1297,7 @@ jobs:
       jira_release_url: ${{ steps.create.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: JIRA_AUTOMATION_WEBHOOK
@@ -1349,7 +1350,7 @@ jobs:
       report_url: ${{ steps.compliance.outputs.report_url }}
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: '*-${{ github.run_id }}'
 
@@ -1515,7 +1516,7 @@ jobs:
           tar -czf compliance-evidence-${{ needs.version.outputs.version }}.tar.gz compliance-evidence/
 
       - name: Store Compliance Evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compliance-evidence-${{ needs.version.outputs.version }}
           path: compliance-evidence-${{ needs.version.outputs.version }}.tar.gz

--- a/.github/workflows/reusable-auto-update-pr-branches.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch auto-update via repository_dispatch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createDispatchEvent({
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch auto-update via repository_dispatch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createDispatchEvent({

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -91,8 +91,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun
@@ -130,7 +131,7 @@ jobs:
       - name: Fetch failure details
         if: steps.loop-guard.outputs.skip != 'true'
         id: failure-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runId = ${{ inputs.run_id }};

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -92,8 +92,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -93,8 +93,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun
@@ -132,7 +133,7 @@ jobs:
       - name: Fetch failure details
         if: steps.loop-guard.outputs.skip != 'true'
         id: failure-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runId = ${{ inputs.run_id }};

--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check for existing PR
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -65,8 +65,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun
@@ -87,7 +88,7 @@ jobs:
 
       - name: Check for existing PR
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({
@@ -107,7 +108,7 @@ jobs:
       - name: Read complexity thresholds
         if: steps.check-pr.outputs.has_existing_pr != 'true'
         id: thresholds
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Check for existing PR
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({
@@ -128,7 +128,7 @@ jobs:
       - name: Read coverage thresholds
         if: steps.check-pr.outputs.has_existing_pr != 'true'
         id: thresholds
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -336,7 +336,7 @@ jobs:
 
       - name: Check for existing PR
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({
@@ -356,7 +356,7 @@ jobs:
       - name: Read coverage thresholds
         if: steps.check-pr.outputs.has_existing_pr != 'true'
         id: thresholds
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -70,8 +70,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun
@@ -92,7 +93,7 @@ jobs:
 
       - name: Check for existing PR
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({
@@ -112,7 +113,7 @@ jobs:
       - name: Read coverage thresholds
         if: steps.check-pr.outputs.has_existing_pr != 'true'
         id: thresholds
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Check for existing PR
         if: steps.changes.outputs.skip != 'true'
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -71,8 +71,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Setup Bun
@@ -116,7 +117,7 @@ jobs:
       - name: Check for existing PR
         if: steps.changes.outputs.skip != 'true'
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/reusable-claude-sync-down-branches.yml
+++ b/.github/workflows/reusable-claude-sync-down-branches.yml
@@ -158,8 +158,9 @@ jobs:
 
       - name: Setup Node.js (for Claude)
         if: steps.merge.outputs.conflicts == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
       - name: Run Claude to resolve conflicts

--- a/.github/workflows/zap-baseline-expo.yml
+++ b/.github/workflows/zap-baseline-expo.yml
@@ -35,11 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -97,7 +98,7 @@ jobs:
 
       - name: Upload ZAP report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap-baseline-report-expo-${{ github.run_id }}
           path: |

--- a/.github/workflows/zap-baseline-nestjs.yml
+++ b/.github/workflows/zap-baseline-nestjs.yml
@@ -35,11 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
@@ -113,7 +114,7 @@ jobs:
 
       - name: Upload ZAP report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap-baseline-report-nestjs-${{ github.run_id }}
           path: |

--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -76,11 +76,12 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: '22.21.1'
 
       - name: 📦 Install dependencies

--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
       app_config_changed: ${{ steps.check_changes.outputs.app_config_changed }}
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -151,12 +151,13 @@ jobs:
       needs.release.result == 'success'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }} # Use branch HEAD to include version bump from release job
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: '22.21.1'
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
       has_aws_credentials: ${{ steps.check.outputs.has_aws_credentials }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: AWS_ACCOUNT_ID
@@ -110,7 +110,7 @@ jobs:
       requires_migration: ${{ steps.check.outputs.requires_migration }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: check
         run: |
           if [[ -z "${SKIP_MIGRATIONS}" ]]; then
@@ -132,7 +132,7 @@ jobs:
       has_vpn_setup: ${{ steps.check.outputs.has_vpn_setup }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: OVPN_CONFIG
@@ -155,7 +155,7 @@ jobs:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint.
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: AWS_ACCOUNT_ID
@@ -205,11 +205,12 @@ jobs:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js 22.21.1
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 22.21.1
+          package-manager-cache: false
       - uses: noliran/branch-based-secrets@v1
         with:
           secrets: AWS_ACCOUNT_ID

--- a/npm-package/create-only/.github/workflows/publish-to-npm.yml
+++ b/npm-package/create-only/.github/workflows/publish-to-npm.yml
@@ -62,7 +62,7 @@ jobs:
           echo "✅ Inputs validated: tag=${{ inputs.tag }}, version=${{ inputs.version }}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -93,8 +93,9 @@ jobs:
           bun-version: '1.3.8'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}

--- a/plugins/lisa-wiki/ci/lisa-wiki-validate.yml
+++ b/plugins/lisa-wiki/ci/lisa-wiki-validate.yml
@@ -20,10 +20,11 @@ jobs:
     env:
       LISA_WIKI_SCRIPTS: ${{ vars.LISA_WIKI_SCRIPTS || '.lisa-wiki/scripts' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Validate config
         run: node "$LISA_WIKI_SCRIPTS/validate-config.mjs" wiki/lisa-wiki.config.json

--- a/plugins/src/wiki/ci/lisa-wiki-validate.yml
+++ b/plugins/src/wiki/ci/lisa-wiki-validate.yml
@@ -20,10 +20,11 @@ jobs:
     env:
       LISA_WIKI_SCRIPTS: ${{ vars.LISA_WIKI_SCRIPTS || '.lisa-wiki/scripts' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Validate config
         run: node "$LISA_WIKI_SCRIPTS/validate-config.mjs" wiki/lisa-wiki.config.json

--- a/rails/create-only/.github/workflows/deploy.yml
+++ b/rails/create-only/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}


### PR DESCRIPTION
## Why

GitHub forces all Actions onto the **Node.js 24 runtime on 2026-06-02**; actions still pinned to Node 20 will stop working. The Lisa release pipeline (and most other workflows) were emitting the deprecation warning. Because Lisa distributes workflow templates to downstream projects, this fixes both the repo's own CI **and** the templates so consumers become Node-24-ready on their next update.

## What changed

Bumped every first-party action that ran on Node 20 to its current Node-24 major, across `.github/workflows/`, the stack templates (`*/create-only/.github`, `harper-fabric/copy-overwrite/.github`), and the lisa-wiki plugin CI:

| Action | Before | After | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | unifies the prior v4/v6 split (73 files now v6) |
| `actions/setup-node` | v4 | **v6** | + `package-manager-cache: false` (see below) |
| `actions/upload-artifact` | v4 | **v7** | v5 was still node20 |
| `actions/download-artifact` | v4 | **v8** | v5/v6 were still node20 |
| `actions/cache` | v4 | **v5** | |
| `actions/github-script` | v7 | **v8** | **not v9** — see below |

Also brought the nestjs deploy template's stale first-party actions up to v6 (`checkout@v2`, `checkout@v3`, `setup-node@v3`).

## Decisions / risk notes

- **github-script pinned to v8, not v9.** v9 ships `@actions/github` v9 (ESM-only), which breaks `require('@actions/github')` and `const/let getOctokit` redeclaration in inline scripts. v8 already runs on Node 24, so it clears the deprecation without that risk. (Audited all 19 inline scripts — none use the risky patterns today, but v9's octokit-v7 jump is unnecessary risk for this change.)
- **`package-manager-cache: false` on every setup-node step.** setup-node v5+ added automatic package-manager caching triggered by the `packageManager` field in `package.json`. These workflows install bun via `oven-sh/setup-bun` *after* setup-node and disable node-side caching for bun, so the new auto-cache would run before bun exists. Disabling it preserves existing behavior. (setup-node@v6 ↔ `package-manager-cache: false` counts match: 40/40.)
- **download-artifact v8** now errors on hash mismatch by default and is Content-Type-aware about unzipping. Safe here — artifacts are zips passed within the same workflow run.
- **Left `aws-actions/configure-aws-credentials@v1`** (nestjs deploy template) untouched — its v1→v4 jump has breaking OIDC/role-assumption changes that warrant a separate, careful PR.

## Verification

- No first-party Node-20 actions remain anywhere in the repo.
- `actionlint` reports **no new issues** vs the pre-change baseline.
- All 32 changed workflow files parse as valid YAML.
- Plugin artifact regenerated from source; `check:plugins` passes (artifacts in sync, marketplace complete).

🤖 Generated with Claude Code