### PR TITLE
fix(harper-fabric): stop creating Jest local config

### DIFF
--- a/harper-fabric/copy-overwrite/knip.json
+++ b/harper-fabric/copy-overwrite/knip.json
@@ -17,7 +17,7 @@
     "harper-app/web/**/*.js"
   ],
   "ignoreDependencies": ["@types/node", "@vitest/coverage-v8"],
-  "ignoreBinaries": ["harperdb", "playwright", "tsx"],
+  "ignoreBinaries": ["audit", "harperdb", "knip", "playwright", "tsx"],
   "rules": {
     "devDependencies": "off"
   }

--- a/harper-fabric/copy-overwrite/tsconfig.eslint.json
+++ b/harper-fabric/copy-overwrite/tsconfig.eslint.json
@@ -12,6 +12,7 @@
     "tests/**/*.ts",
     "eslint.config.ts",
     "eslint.config.local.ts",
+    "eslint.slow.config.ts",
     "vitest.config.ts",
     "vitest.config.local.ts"
   ],

--- a/harper-fabric/deletions.json
+++ b/harper-fabric/deletions.json
@@ -1,0 +1,3 @@
+{
+  "paths": ["jest.config.local.ts"]
+}

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -36,6 +36,7 @@ const CREATE_ONLY = "create-only";
 const COPY_OVERWRITE = "copy-overwrite";
 const HARPER_FABRIC_TYPE = "harper-fabric";
 const HARPER_FABRIC_TXT = "harper-fabric.txt";
+const JEST_CONFIG_LOCAL = "jest.config.local.ts";
 
 describe("Lisa Integration Tests", () => {
   let tempDir: string;
@@ -177,11 +178,10 @@ describe("Lisa Integration Tests", () => {
       // jest config via create-only, CDK's deletions.json removes it. Without
       // the pending-deletion gate, Lisa creates-then-deletes, which races with
       // any concurrent file-watcher/linter.
-      const JEST_CONFIG_LOCAL = "jest.config.local.ts";
       await createCDKProject(destDir);
 
       // Add a file to typescript/create-only that CDK's deletions.json removes
-      const tsCreateOnly = path.join(lisaDir, "typescript", "create-only");
+      const tsCreateOnly = path.join(lisaDir, "typescript", CREATE_ONLY);
       await fs.ensureDir(tsCreateOnly);
       await fs.writeFile(
         path.join(tsCreateOnly, JEST_CONFIG_LOCAL),
@@ -207,6 +207,32 @@ describe("Lisa Integration Tests", () => {
       // *skipped* (never written to disk) rather than *deleted* (written then
       // removed).  If the gate were absent, deleted would be 1 and skipped
       // would be 0 for this file.
+      expect(result.counters.skipped).toBeGreaterThan(0);
+      expect(result.counters.deleted).toBe(0);
+    });
+
+    it("skips inherited Jest local config for Harper/Fabric projects", async () => {
+      await createHarperFabricProject(destDir);
+
+      const tsCreateOnly = path.join(lisaDir, "typescript", CREATE_ONLY);
+      await fs.ensureDir(tsCreateOnly);
+      await fs.writeFile(
+        path.join(tsCreateOnly, JEST_CONFIG_LOCAL),
+        "export default {};\n"
+      );
+
+      const harperDir = path.join(lisaDir, HARPER_FABRIC_TYPE);
+      await fs.ensureDir(harperDir);
+      await fs.writeJson(path.join(harperDir, "deletions.json"), {
+        paths: [JEST_CONFIG_LOCAL],
+      });
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      expect(await fs.pathExists(path.join(destDir, JEST_CONFIG_LOCAL))).toBe(
+        false
+      );
       expect(result.counters.skipped).toBeGreaterThan(0);
       expect(result.counters.deleted).toBe(0);
     });
@@ -267,11 +293,7 @@ describe("Lisa Integration Tests", () => {
 
       await createHarperFabricProject(destDir);
 
-      const tsCopyOverwrite = path.join(
-        lisaDir,
-        "typescript",
-        "copy-overwrite"
-      );
+      const tsCopyOverwrite = path.join(lisaDir, "typescript", COPY_OVERWRITE);
       await fs.ensureDir(tsCopyOverwrite);
       await fs.writeFile(path.join(tsCopyOverwrite, SHARED_CONFIG), TS_CONFIG);
 

--- a/tests/unit/config/harper-fabric-template.test.ts
+++ b/tests/unit/config/harper-fabric-template.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression guards for Harper/Fabric stack templates.
+ */
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/**
+ * Read a JSON template from the Lisa repository.
+ * @param relativePath - Repo-relative JSON path
+ * @returns Parsed template content
+ */
+function readJson(relativePath: string): unknown {
+  return JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8")
+  );
+}
+
+describe("Harper/Fabric templates", () => {
+  it("delete inherited Jest local config from the TypeScript parent stack", () => {
+    const deletions = readJson("harper-fabric/deletions.json") as {
+      readonly paths?: readonly string[];
+    };
+
+    expect(deletions.paths).toContain("jest.config.local.ts");
+  });
+
+  it("ignore hook-invoked binaries in Knip", () => {
+    const knip = readJson("harper-fabric/copy-overwrite/knip.json") as {
+      readonly ignoreBinaries?: readonly string[];
+    };
+
+    expect(knip.ignoreBinaries).toEqual(
+      expect.arrayContaining(["audit", "knip"])
+    );
+  });
+
+  it("includes slow lint config but not Jest config in the ESLint project", () => {
+    const tsconfig = readJson(
+      "harper-fabric/copy-overwrite/tsconfig.eslint.json"
+    ) as {
+      readonly include?: readonly string[];
+    };
+
+    expect(tsconfig.include).toContain("eslint.slow.config.ts");
+    expect(tsconfig.include).not.toContain("jest.config.local.ts");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Harper/Fabric deletion rule so inherited TypeScript Jest local config is skipped/removed.
- Updates Harper/Fabric templates for slow lint and Knip hook binaries.
- Adds regression tests for the template behavior.

## Test plan
- bun test tests/unit/config/harper-fabric-template.test.ts tests/integration/lisa.test.ts
- bun run typecheck
- pre-push hook: audit, slow lint, knip, coverage, integration tests
