### PR TITLE
fix(harper-fabric): ignore generated web in prettier

### DIFF
--- a/harper-fabric/copy-contents/.prettierignore
+++ b/harper-fabric/copy-contents/.prettierignore
@@ -1,0 +1,8 @@
+# BEGIN: AI GUARDRAILS HARPER-FABRIC
+
+# Harper/Fabric generated web output and scraped research captures are not
+# source formatting inputs.
+harper-app/web/
+research/articles/
+
+# END: AI GUARDRAILS HARPER-FABRIC

--- a/tests/unit/config/harper-fabric-template.test.ts
+++ b/tests/unit/config/harper-fabric-template.test.ts
@@ -18,6 +18,15 @@ function readJson(relativePath: string): unknown {
   );
 }
 
+/**
+ * Read a text template from the Lisa repository.
+ * @param relativePath - Repo-relative text path
+ * @returns Template content
+ */
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
 describe("Harper/Fabric templates", () => {
   it("delete inherited Jest local config from the TypeScript parent stack", () => {
     const deletions = readJson("harper-fabric/deletions.json") as {
@@ -46,5 +55,14 @@ describe("Harper/Fabric templates", () => {
 
     expect(tsconfig.include).toContain("eslint.slow.config.ts");
     expect(tsconfig.include).not.toContain("jest.config.local.ts");
+  });
+
+  it("keeps generated web and scraped research captures out of Prettier", () => {
+    const prettierIgnore = readText(
+      "harper-fabric/copy-contents/.prettierignore"
+    );
+
+    expect(prettierIgnore).toContain("harper-app/web/");
+    expect(prettierIgnore).toContain("research/articles/");
   });
 });


### PR DESCRIPTION
## Summary\n- add a Harper/Fabric copy-contents block for .prettierignore\n- keep generated web assets and scraped research captures out of Prettier formatting gates\n- add a template regression test\n\n## Verification\n- bun test tests/unit/config/harper-fabric-template.test.ts\n- bun run typecheck\n- pre-push: audit, slow lint, knip, coverage, integration tests