### PR TITLE
[codex] Soft-fail GitGuardian quota exhaustion

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -227,11 +227,29 @@ jobs:
 
       - name: 🔐 GitGuardian scan
         if: steps.check_gitguardian.outputs.has_token == 'true'
-        uses: GitGuardian/ggshield-action@master
+        shell: bash
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-        with:
-          args: --show-secrets --all-policies
+        run: |
+          python -m pip install --user 'ggshield==1.50.3'
+          export PATH="$HOME/.local/bin:$PATH"
+
+          set +e
+          ggshield secret scan ci --show-secrets --all-policies 2>&1 | tee ggshield.log
+          scan_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$scan_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -qiE 'no more API calls available|quota.*exhaust|exhaust.*quota|quota.*exceed|rate limit' ggshield.log; then
+            echo "::warning::GitGuardian secret detection skipped because API quota is exhausted"
+            echo "GitGuardian quota exhaustion is treated as non-blocking; real secret findings still fail this job."
+            exit 0
+          fi
+
+          exit "$scan_status"
 
       - name: 🔐 GitGuardian Scan Skipped
         if: steps.check_gitguardian.outputs.has_token != 'true'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1534,11 +1534,29 @@ jobs:
 
       - name: 🔐 GitGuardian scan
         if: steps.check_gitguardian.outputs.has_token == 'true'
-        uses: GitGuardian/ggshield-action@master
+        shell: bash
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-        with:
-          args: --show-secrets --all-policies
+        run: |
+          python -m pip install --user 'ggshield==1.50.3'
+          export PATH="$HOME/.local/bin:$PATH"
+
+          set +e
+          ggshield secret scan ci --show-secrets --all-policies 2>&1 | tee ggshield.log
+          scan_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$scan_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -qiE 'no more API calls available|quota.*exhaust|exhaust.*quota|quota.*exceed|rate limit' ggshield.log; then
+            echo "::warning::GitGuardian secret detection skipped because API quota is exhausted"
+            echo "GitGuardian quota exhaustion is treated as non-blocking; real secret findings still fail this job."
+            exit 0
+          fi
+
+          exit "$scan_status"
 
       - name: 🔐 GitGuardian Scan Skipped
         if: steps.check_gitguardian.outputs.has_token != 'true'

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -8,6 +8,12 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const QUALITY_YML = path.join(REPO_ROOT, ".github", "workflows", "quality.yml");
+const QUALITY_RAILS_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "quality-rails.yml"
+);
 
 /** Shape of a single `workflow_call` input declaration. */
 interface WorkflowInput {
@@ -166,6 +172,24 @@ describe("quality.yml reusable workflow", () => {
       // per-shard checks that coexist with the aggregator's unsuffixed
       // context under the same display name.
       expect(workflow.jobs.playwright_e2e.name).toBe("🎭 Playwright E2E Tests");
+    });
+  });
+
+  describe("GitGuardian quota exhaustion", () => {
+    it.each([
+      ["quality.yml", QUALITY_YML],
+      ["quality-rails.yml", QUALITY_RAILS_YML],
+    ])("%s soft-fails only quota exhaustion", (_label, workflowPath) => {
+      const raw = fs.readFileSync(workflowPath, "utf8");
+      const parsed = yaml.load(raw) as QualityWorkflow;
+      const steps = parsed.jobs.secret_scanning.steps ?? [];
+      const scan = steps.find(s => s.name === "🔐 GitGuardian scan");
+
+      expect(scan).toBeDefined();
+      expect(scan?.uses).toBeUndefined();
+      expect(scan?.run).toContain("ggshield secret scan ci");
+      expect(scan?.run).toContain("no more API calls available");
+      expect(scan?.run).toContain('exit "$scan_status"');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace the GitGuardian action wrapper with a pinned `ggshield` CLI invocation so the workflow can inspect scanner output.
- Treat GitGuardian API quota/rate-limit exhaustion as a warning instead of blocking CI or release publishing.
- Keep real GitGuardian scan failures blocking by exiting with the original `ggshield` status for non-quota failures.
- Add integration coverage for both reusable quality workflows.

## Validation

- `bunx vitest run tests/integration/quality-workflow.test.ts`
- `bunx prettier --check .github/workflows/quality.yml .github/workflows/quality-rails.yml tests/integration/quality-workflow.test.ts`
- `git diff --check`
- pre-push: `bun audit`, slow lint, `knip`, unit tests with coverage, integration tests

## Notes

This is an upstream Lisa reusable-workflow fix. Downstream projects can still disable the entire scanner with `skip_jobs: secret_scanning`, but quota exhaustion no longer needs a full scanner disable.