### PR TITLE
fix(ci): use supported ggshield scan flags

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -235,7 +235,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
 
           set +e
-          ggshield secret scan ci --show-secrets --all-policies 2>&1 | tee ggshield.log
+          ggshield secret scan ci --show-secrets 2>&1 | tee ggshield.log
           scan_status=${PIPESTATUS[0]}
           set -e
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1542,7 +1542,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
 
           set +e
-          ggshield secret scan ci --show-secrets --all-policies 2>&1 | tee ggshield.log
+          ggshield secret scan ci --show-secrets 2>&1 | tee ggshield.log
           scan_status=${PIPESTATUS[0]}
           set -e
 

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -187,7 +187,8 @@ describe("quality.yml reusable workflow", () => {
 
       expect(scan).toBeDefined();
       expect(scan?.uses).toBeUndefined();
-      expect(scan?.run).toContain("ggshield secret scan ci");
+      expect(scan?.run).toContain("ggshield secret scan ci --show-secrets");
+      expect(scan?.run).not.toContain("--all-policies");
       expect(scan?.run).toContain("no more API calls available");
       expect(scan?.run).toContain('exit "$scan_status"');
     });


### PR DESCRIPTION
## Summary
- remove unsupported --all-policies flag from reusable GitGuardian scans
- keep quota exhaustion as a warning-only path while preserving failures for real scan findings
- assert the supported ggshield invocation in quality workflow integration coverage

## Tests
- bunx vitest run tests/integration/quality-workflow.test.ts
- git diff --check
- pre-push hook: bun audit, slow lint, knip, unit coverage, integration tests