### PR TITLE
[codex] Add documentation source path rules

### DIFF
--- a/.claude/rules/documentation-source-paths.md
+++ b/.claude/rules/documentation-source-paths.md
@@ -1,0 +1,13 @@
+# Documentation Source Paths
+
+Do not treat `docs/`, `research/`, `transcripts/`, or other source-material directories as disposable duplicates just because the Lisa monorepo also has `wiki/`.
+
+Before moving, absorbing, or deleting documentation-like paths:
+
+1. Classify each path as one of: durable wiki content, reader-safe source note, executable test fixture, runtime scratch/input path, generated output, or obsolete material.
+2. Use `rg` to find every code, test, script, config, README, rule, skill, agent, and wiki reference to the path.
+3. Preserve executable fixtures and runtime inputs outside the wiki. They are project behavior, not documentation.
+4. When absorbing documentation into `wiki/`, also update source notes, indexes, logs, README links, rule references, and any runtime defaults that pointed at the old path.
+5. Delete a source path only after references are updated and verification proves the project no longer reads it.
+
+For Lisa wiki work specifically, `wiki/` is the durable knowledge source, but `docs/`, `research/`, `docs/wiki-inbox/`, and `transcripts/` may still be ingestion inputs, historical source evidence, fixtures, or runtime scratch locations. Preserve reader-safe evidence under `wiki/sources/` and record successful ingestions in `wiki/log.md`.

--- a/plugins/lisa/rules/documentation-source-paths.md
+++ b/plugins/lisa/rules/documentation-source-paths.md
@@ -1,0 +1,13 @@
+# Documentation Source Paths
+
+Do not treat `docs/`, `research/`, `transcripts/`, or other source-material directories as disposable duplicates just because a project also has a `wiki/`.
+
+Before moving, absorbing, or deleting documentation-like paths:
+
+1. Classify each path as one of: durable wiki content, reader-safe source note, executable test fixture, runtime scratch/input path, generated output, or obsolete material.
+2. Use `rg` to find every code, test, script, config, README, rule, skill, agent, and wiki reference to the path.
+3. Preserve executable fixtures and runtime inputs outside the wiki. They are project behavior, not documentation.
+4. When absorbing documentation into `wiki/`, also update source notes, indexes, logs, README links, rule references, and any runtime defaults that pointed at the old path.
+5. Delete a source path only after references are updated and verification proves the project no longer reads it.
+
+For Lisa wiki work specifically, `wiki/` is the durable knowledge source, but `docs/`, `research/`, `docs/wiki-inbox/`, and `transcripts/` may still be ingestion inputs, historical source evidence, fixtures, or runtime scratch locations. Preserve reader-safe evidence under `wiki/sources/` and record successful ingestions in `wiki/log.md`.

--- a/plugins/src/base/rules/documentation-source-paths.md
+++ b/plugins/src/base/rules/documentation-source-paths.md
@@ -1,0 +1,13 @@
+# Documentation Source Paths
+
+Do not treat `docs/`, `research/`, `transcripts/`, or other source-material directories as disposable duplicates just because a project also has a `wiki/`.
+
+Before moving, absorbing, or deleting documentation-like paths:
+
+1. Classify each path as one of: durable wiki content, reader-safe source note, executable test fixture, runtime scratch/input path, generated output, or obsolete material.
+2. Use `rg` to find every code, test, script, config, README, rule, skill, agent, and wiki reference to the path.
+3. Preserve executable fixtures and runtime inputs outside the wiki. They are project behavior, not documentation.
+4. When absorbing documentation into `wiki/`, also update source notes, indexes, logs, README links, rule references, and any runtime defaults that pointed at the old path.
+5. Delete a source path only after references are updated and verification proves the project no longer reads it.
+
+For Lisa wiki work specifically, `wiki/` is the durable knowledge source, but `docs/`, `research/`, `docs/wiki-inbox/`, and `transcripts/` may still be ingestion inputs, historical source evidence, fixtures, or runtime scratch locations. Preserve reader-safe evidence under `wiki/sources/` and record successful ingestions in `wiki/log.md`.


### PR DESCRIPTION
## Summary

- add a modular Lisa repo rule for documentation/source-material paths
- add the shared base plugin rule so downstream Claude sessions receive it from plugin rules
- rebuild the generated `plugins/lisa` rule artifact so Codex installs mirror it into `.codex/lisa-rules/`

## Why

Agents were treating `docs/` and `research/` as disposable duplicate documentation even though these paths may still contain ingestion inputs, source evidence, executable fixtures, or runtime scratch/input data.

## Validation

- `bunx vitest run tests/unit/codex/hooks-installer.test.ts tests/unit/codex/agents-md-installer.test.ts`
- `bun run build`
- pre-push hook: `bun audit`, slow lint, `knip`, unit coverage, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation governance rules for managing documentation sources and references. These rules establish processes for classifying documentation paths, verifying cross-references, and designating wiki as the primary knowledge repository while preserving other documentation inputs appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->