### PR TITLE
feat(github-to-tracker): apply build-ready label only to leaf sub-tasks

### DIFF
--- a/plugins/lisa/skills/github-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/github-to-tracker/SKILL.md
@@ -198,6 +198,8 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` shim** (d
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The Epic is the canonical hub.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic ref — Phase 4 needs it as the parent for Stories.
 
 ### Phase 4: Create Stories
@@ -225,6 +227,8 @@ For each Story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story ref — Phase 5 needs it.
 
 ### Phase 5: Create Sub-tasks
@@ -236,6 +240,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`.
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking.
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:github-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:github-write-issue` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent Story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/lisa/skills/github-write-issue/SKILL.md
+++ b/plugins/lisa/skills/github-write-issue/SKILL.md
@@ -206,6 +206,12 @@ Milestones map to `fix-version:<value>` labels OR native GitHub Milestones — p
 
 Create labels lazily — call `gh label create` if a referenced label doesn't exist. Use a stable color palette per category so the issue board reads cleanly.
 
+### Build-ready label is leaf-only
+
+The build-ready status label (`status:ready`) is governed by the `leaf-only-lifecycle` rule. **Apply `status:ready` only when the issue is a leaf work unit** — an individually implementable issue type (`Bug`, `Task`, `Sub-task`, `Improvement`) that has **no child work**. A container (`Epic`, `Story`, `Spike`, or *any* issue that has sub-issues) is **never** written with `status:ready`; its lifecycle state rolls up from its children. The classification is structural: an item is a container if it has child work, regardless of its declared type (see the childless-parent exception in the rule). Do not hand-apply `status:ready` to a parent.
+
+For non-build-ready issues created fresh (Epics, Stories, and other containers), omit the status label entirely; the container's rollup state is derived, not set directly.
+
 ## Phase 5.5 — Validate (Pre-write Gate)
 
 Before any write, invoke `lisa:github-validate-issue` with the full proposed spec assembled from Phases 2 / 3 / 4 / 5. Pass it as a YAML block per the `lisa:github-validate-issue` schema, including `runtime_behavior_change`, `authenticated_surface`, and `artifacts_attached` flags so the right gates run.
@@ -218,13 +224,24 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
 
 ### CREATE
 
-1. Compose the body markdown from Phases 2/3/4 in a temp file (avoid quoting hell):
+1. Compose the body markdown from Phases 2/3/4 in a temp file (avoid quoting hell). Apply `status:ready` **only for a leaf work unit** per the Phase 5 leaf-only rule (`leaf-only-lifecycle`) — omit it for `Epic` / `Story` / `Spike` and any issue that has child work:
    ```bash
+   # Leaf work unit (Bug / Task / Sub-task / Improvement with no children):
    gh issue create \
      --repo <org>/<repo> \
      --title "<summary>" \
      --body-file /tmp/issue-body.md \
      --label "type:<type>" --label "status:ready" --label "priority:<priority>" \
+     [--label "component:<name>" ...] [--milestone "<milestone>"] \
+     [--assignee "<login>"]
+
+   # Container (Epic / Story / Spike / any issue with child work):
+   # identical, but WITHOUT --label "status:ready" — its state rolls up from children.
+   gh issue create \
+     --repo <org>/<repo> \
+     --title "<summary>" \
+     --body-file /tmp/issue-body.md \
+     --label "type:<type>" --label "priority:<priority>" \
      [--label "component:<name>" ...] [--milestone "<milestone>"] \
      [--assignee "<login>"]
    ```

--- a/plugins/src/base/skills/github-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/github-to-tracker/SKILL.md
@@ -198,6 +198,8 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` shim** (d
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The Epic is the canonical hub.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic ref — Phase 4 needs it as the parent for Stories.
 
 ### Phase 4: Create Stories
@@ -225,6 +227,8 @@ For each Story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story ref — Phase 5 needs it.
 
 ### Phase 5: Create Sub-tasks
@@ -236,6 +240,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`.
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking.
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:github-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:github-write-issue` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent Story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/src/base/skills/github-write-issue/SKILL.md
+++ b/plugins/src/base/skills/github-write-issue/SKILL.md
@@ -206,6 +206,12 @@ Milestones map to `fix-version:<value>` labels OR native GitHub Milestones — p
 
 Create labels lazily — call `gh label create` if a referenced label doesn't exist. Use a stable color palette per category so the issue board reads cleanly.
 
+### Build-ready label is leaf-only
+
+The build-ready status label (`status:ready`) is governed by the `leaf-only-lifecycle` rule. **Apply `status:ready` only when the issue is a leaf work unit** — an individually implementable issue type (`Bug`, `Task`, `Sub-task`, `Improvement`) that has **no child work**. A container (`Epic`, `Story`, `Spike`, or *any* issue that has sub-issues) is **never** written with `status:ready`; its lifecycle state rolls up from its children. The classification is structural: an item is a container if it has child work, regardless of its declared type (see the childless-parent exception in the rule). Do not hand-apply `status:ready` to a parent.
+
+For non-build-ready issues created fresh (Epics, Stories, and other containers), omit the status label entirely; the container's rollup state is derived, not set directly.
+
 ## Phase 5.5 — Validate (Pre-write Gate)
 
 Before any write, invoke `lisa:github-validate-issue` with the full proposed spec assembled from Phases 2 / 3 / 4 / 5. Pass it as a YAML block per the `lisa:github-validate-issue` schema, including `runtime_behavior_change`, `authenticated_surface`, and `artifacts_attached` flags so the right gates run.
@@ -218,13 +224,24 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
 
 ### CREATE
 
-1. Compose the body markdown from Phases 2/3/4 in a temp file (avoid quoting hell):
+1. Compose the body markdown from Phases 2/3/4 in a temp file (avoid quoting hell). Apply `status:ready` **only for a leaf work unit** per the Phase 5 leaf-only rule (`leaf-only-lifecycle`) — omit it for `Epic` / `Story` / `Spike` and any issue that has child work:
    ```bash
+   # Leaf work unit (Bug / Task / Sub-task / Improvement with no children):
    gh issue create \
      --repo <org>/<repo> \
      --title "<summary>" \
      --body-file /tmp/issue-body.md \
      --label "type:<type>" --label "status:ready" --label "priority:<priority>" \
+     [--label "component:<name>" ...] [--milestone "<milestone>"] \
+     [--assignee "<login>"]
+
+   # Container (Epic / Story / Spike / any issue with child work):
+   # identical, but WITHOUT --label "status:ready" — its state rolls up from children.
+   gh issue create \
+     --repo <org>/<repo> \
+     --title "<summary>" \
+     --body-file /tmp/issue-body.md \
+     --label "type:<type>" --label "priority:<priority>" \
      [--label "component:<name>" ...] [--milestone "<milestone>"] \
      [--assignee "<login>"]
    ```

--- a/tests/unit/strategies/leaf-only-build-ready.test.ts
+++ b/tests/unit/strategies/leaf-only-build-ready.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for the leaf-only build-ready invariant in the GitHub
+ * write path.
+ *
+ * Issue #538: `lisa:github-to-tracker` must apply the build-ready label
+ * (`status:ready`) ONLY to leaf sub-tasks when writing a decomposed
+ * hierarchy — never to the Epic or Stories. The invariant itself is the
+ * vendor-neutral `leaf-only-lifecycle` rule (merged in #537); these tests
+ * assert that the GitHub writer and decomposition skill encode it so the
+ * label is never hard-applied to a container.
+ *
+ * Both the source (`plugins/src/base/skills`) and the generated artifact
+ * (`plugins/lisa/skills`) are asserted, so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/leaf-only-build-ready
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+describe("leaf-only build-ready invariant (#538)", () => {
+  describe.each(SKILL_ROOTS)("%s/github-write-issue", root => {
+    const content = readSkill(root, "github-write-issue");
+
+    it("cites the leaf-only-lifecycle rule by slug", () => {
+      expect(content).toContain("leaf-only-lifecycle");
+    });
+
+    it("documents a container create path that omits status:ready", () => {
+      // The previous skill applied `--label "status:ready"` on the single
+      // CREATE example regardless of type. After the fix there must be a
+      // container path whose create command omits the build-ready label.
+      expect(content).toMatch(/WITHOUT --label "status:ready"/);
+    });
+
+    it("makes the build-ready label conditional on a leaf work unit", () => {
+      // The skill must describe the conditional: only Bug/Task/Sub-task/
+      // Improvement leaves receive status:ready; containers do not.
+      expect(content).toMatch(/leaf work unit/i);
+      expect(content).toMatch(/status:ready/);
+      expect(content).toMatch(/only.*leaf work unit/i);
+    });
+
+    it("names the container types that never receive build-ready", () => {
+      expect(content).toMatch(/Epic/);
+      expect(content).toMatch(/Story/);
+    });
+  });
+
+  describe.each(SKILL_ROOTS)("%s/github-to-tracker", root => {
+    const content = readSkill(root, "github-to-tracker");
+
+    it("cites the leaf-only-lifecycle rule by slug", () => {
+      expect(content).toContain("leaf-only-lifecycle");
+    });
+
+    it("states Epics (Phase 3) never receive the build-ready label", () => {
+      // Phase 3 creates Epics; it must not mark them build-ready.
+      expect(content).toMatch(/leaf/i);
+      expect(content).toMatch(/status:ready/);
+    });
+
+    it("states only Sub-tasks (Phase 5) receive the build-ready label", () => {
+      // Phase 5 creates the leaf Sub-tasks — the only items that may be ready.
+      const phase5Index = content.indexOf("### Phase 5: Create Sub-tasks");
+      expect(phase5Index).toBeGreaterThan(-1);
+      const phase5Onward = content.slice(phase5Index);
+      expect(phase5Onward).toMatch(/status:ready/);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

`lisa:github-to-tracker` decomposes a GitHub-Issue PRD into Epic → Story → Sub-task, but `lisa:github-write-issue` hard-coded `status:ready` on **every** issue it created. A subsequent build pass (`lisa:github-build-intake`) would then claim and try to "implement" an Epic or Story container — the wrong lifecycle/permission boundary. This is the exact failure the `leaf-only-lifecycle` rule (merged in #537) documents.

Implements #538: apply the build-ready label (`status:ready`) **only to leaf sub-tasks**, never to Epics or Stories.

## Changes

- **`github-write-issue`** — `status:ready` is now conditional on the issue being a **leaf work unit** (`Bug` / `Task` / `Sub-task` / `Improvement` with no child work). The CREATE block documents two paths: a leaf path that carries the label and a container path (`Epic` / `Story` / `Spike` or any issue with child work) that omits it. Cites `leaf-only-lifecycle` by slug.
- **`github-to-tracker`** — Phase 3 (Epics) and Phase 4 (Stories) explicitly never pass `status:ready`; Phase 5 (Sub-tasks) is the only phase that applies it.
- Both edits made in `plugins/src/base/` and regenerated into `plugins/lisa/` via `bun run build:plugins` — `check:plugins` is green.
- **Regression test** `tests/unit/strategies/leaf-only-build-ready.test.ts` asserts the invariant over **both** the source and the generated artifact, so an artifact-only edit or a missed `build:plugins` fails CI.

## Empirical verification

Parsed the documented `gh issue create` paths in the built artifact:
- Leaf path → carries `--label "status:ready"`.
- Container path → explicitly `WITHOUT --label "status:ready"`.
- Decomposition phases: Epic (P3) and Story (P4) → not build-ready; Sub-tasks (P5) → the only items marked `status:ready`.

Codified as the regression test above (the `lisa:codify-verification` step).

## Out of scope (separate sub-tasks)

The other three `*-to-tracker` skills, the `*-validate-*` container gate, and build-intake claim-time skipping — per #538.

Closes #538

🤖 Generated with Claude Code