### PR TITLE
feat(github-build-intake): skip/safe-block parents with open child work (leaf-only claim gate)

### DIFF
--- a/plugins/lisa/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/github-build-intake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-build-intake
-description: "GitHub counterpart to lisa:jira-build-intake. Scans a GitHub repository for issues carrying the configured `ready` build label, claims each by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:github-agent, and relabels to the configured `done` label on completion. The `ready` label is the human-flipped signal that an issue is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
+description: "GitHub counterpart to lisa:jira-build-intake. Scans a GitHub repository for issues carrying the configured `ready` build label, claims each leaf work unit by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:github-agent, and relabels to the configured `done` label on completion. Enforces the claim-time arm of the `leaf-only-lifecycle` rule: a parent/container with open child work (or a childless Epic/Story/Spike) that still carries a stale build-ready label is skipped or safe-blocked with a lifecycle-repair comment, never claimed. The `ready` label is the human-flipped signal that an issue is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
 allowed-tools: ["Skill", "Bash"]
 ---
 
@@ -135,7 +135,54 @@ If none of the configured role labels exist on the repo → label convention not
 
 ### Phase 3 — Process each ready issue (serial)
 
-#### 3a. Claim
+#### 3a. Leaf-only claim gate (skip / safe-block containers)
+
+Build intake claims **only independently implementable leaf work units**. This enforces the claim-time arm of the vendor-neutral `leaf-only-lifecycle` rule: a parent/container that still carries a stale build-ready role (e.g. `status:ready` applied before this rule existed, or hand-applied to an Epic/Story) is **never claimed** — intake skips it or safe-blocks it with a clear lifecycle-repair message. It is the claim-time complement to the write-time labeling in `lisa:github-write-issue` and the validate-time S15 gate in `lisa:github-validate-issue`; all three cite the same rule so the classification never drifts. **Never silently implement a container.**
+
+Run this gate **before** the claim relabel, for every candidate issue. Do NOT relabel, comment "Claimed", or invoke `lisa:github-agent` for an issue that fails the gate.
+
+**Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an issue is a **container** if it has **open** child work, whatever its declared type; otherwise the **type label** decides. Resolve child work using the same hierarchy `lisa:github-read-issue` uses — native sub-issues first, then body parentage (task-list checkboxes referencing other issues, `Blocked by #<n>` / `Parent: #<n>` references):
+
+```bash
+# Native sub-issues via GraphQL (same query lisa:github-read-issue uses).
+SUBS=$(gh api graphql -f query='
+query($org:String!,$repo:String!,$number:Int!){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      subIssues(first: 100) {
+        nodes { number state }
+      }
+    }
+  }
+}' -F org=<org> -F repo=<repo> -F number=<number> 2>/dev/null)
+
+# Count children still OPEN — a parent whose children are all closed is no longer
+# holding open work and rolls up via lisa:github-read-issue's rollup, not here.
+OPEN_CHILDREN=$(echo "$SUBS" | jq -r '[.data.repository.issue.subIssues.nodes[]? | select(.state == "OPEN")] | length' 2>/dev/null)
+OPEN_CHILDREN=${OPEN_CHILDREN:-0}
+```
+
+If the GraphQL `subIssues` field is unavailable (older GHES), fall back to parsing the body for child references exactly as `lisa:github-read-issue` does, and treat the issue as a container if any referenced child issue is open. Note "GraphQL sub-issues unavailable" so the operator knows parentage was text-derived.
+
+Classify and act (first match wins). `type:` is read from the issue's labels (`type:Epic`, `type:Story`, `type:Spike`, `type:Bug`, `type:Task`, `type:Sub-task`, `type:Improvement`):
+
+| Condition | Class | Action |
+|---|---|---|
+| `OPEN_CHILDREN > 0` (open child work, any type) | **Container** | **Skip / safe-block — do NOT claim** |
+| no open children AND `type ∈ {Epic, Story, Spike}` | **Childless container-type** | **Skip / safe-block — do NOT claim** |
+| no open children AND `type ∈ {Bug, Task, Sub-task, Improvement}` (or no `type:` label) | **Leaf work unit** | **Proceed to 3b claim** |
+
+The childless-parent exception is narrow: childlessness enables a claim **only** for types that are leaf work units to begin with. A childless Epic/Story/Spike is an incomplete decomposition, not an implementable unit — it is never claimed.
+
+**Safe-block (default action for a flagged container).** Leave the build-ready role in place (don't silently strip it — that hides the lifecycle error), post a single lifecycle-repair comment, and record the issue under "Skipped (container)" in the summary. Do NOT relabel to `$CLAIMED`. Keep the comment idempotent — skip posting if an identical `[claude-build-intake]` lifecycle-repair comment already exists on the issue, so a re-entrant cycle doesn't spam it.
+
+```bash
+gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Not claimed: this issue carries the build-ready role ($READY) but is a container with open child work (or a childless Epic/Story/Spike), which violates the leaf-only-lifecycle rule. Build-ready is leaf-only — an agent claims and implements leaves, never a container. Repair: move $READY off this parent onto its leaf children (or, for a childless Epic/Story/Spike, decompose it into leaf children or reclassify it to a leaf type). A parent's lifecycle state rolls up from its children and is never set to ready directly."
+```
+
+This gate never blocks a legitimate flat Task/Bug: those have no open children and a leaf `type:`, so they fall straight through to the claim in 3b.
+
+#### 3b. Claim
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
@@ -146,7 +193,7 @@ This is the idempotency lock — a re-entrant cycle's `--label $READY` filter wi
 
 If the relabel fails (permission, race), log under "Errors" in the cycle summary and skip this issue. **Do not invoke the build flow on an issue you didn't successfully claim.**
 
-#### 3b. Run the build flow
+#### 3c. Run the build flow
 
 Invoke `lisa:github-agent` (the per-issue lifecycle agent) with the issue ref. `lisa:github-agent` owns:
 - Reading the full issue graph (`lisa:github-read-issue`)
@@ -163,7 +210,7 @@ Wait for `lisa:github-agent` to return. Capture its outcome:
 - **Blocked by ticket-triage ambiguities** — `lisa:github-agent` posts findings and stops. The issue stays in `$CLAIMED`. Surface to human; do not auto-relabel. Record under "Errors".
 - **Errored** — exception, missing config, etc. Leave the issue in `$CLAIMED` for human investigation. Record under "Errors".
 
-#### 3c. Transition to $DONE (only on Success)
+#### 3d. Transition to $DONE (only on Success)
 
 If `lisa:github-agent` returned Success:
 
@@ -176,7 +223,7 @@ gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Buil
 
 For any non-Success outcome, do NOT transition. The issue sits in `$CLAIMED` (or wherever `lisa:github-agent` left it) — humans take it from there.
 
-#### 3d. Continue
+#### 3e. Continue
 
 Move to the next ready issue. One issue failing does not stop others.
 
@@ -192,6 +239,8 @@ Cycle completed: <ISO timestamp>
 Issues processed: <n>
 - $DONE (build complete, PR ready): <n>
   - <org>/<repo>#<number> <title> → PR <URL>
+- Skipped (container — leaf-only-lifecycle): <n>
+  - <org>/<repo>#<number> <title> — build-ready on a parent with open child work; lifecycle-repair comment posted
 - Blocked (pre-flight verify failed): <n>
   - <org>/<repo>#<number> <title> — see issue comments
 - Held (triage found ambiguities): <n>
@@ -204,6 +253,7 @@ Total PRs opened: <n>
 
 ## Idempotency & safety
 
+- **Leaf-only claim gate runs first**: Phase 3a classifies each candidate before any claim; a container with open child work (or a childless Epic/Story/Spike) is skipped/safe-blocked, never claimed. The safe-block comment is idempotent — a re-entrant cycle does not re-post it.
 - **Claim-first ordering**: `$CLAIMED` set BEFORE `lisa:github-agent` invocation — no double-pickup.
 - **No writes outside the lifecycle**: this skill only relabels `$READY → $CLAIMED` and `$CLAIMED → $DONE`. Every other label change is owned by `lisa:github-agent`.
 - **Failure isolation**: per-issue exceptions caught and recorded; the cycle continues.
@@ -227,6 +277,7 @@ If the repo has not adopted the `status:*` label namespace, this skill cannot ru
 
 ## Rules
 
+- **Claim leaves only.** Per the `leaf-only-lifecycle` rule, never claim a container — an issue with open child work, or a childless Epic/Story/Spike — even if it carries the build-ready role. Skip or safe-block it (Phase 3a); never silently implement a container.
 - Never relabel an issue the cycle didn't claim. The `$CLAIMED` label is the signature of cycle ownership.
 - Never bypass `lisa:github-agent` to do build work directly. `lisa:github-agent` owns the per-issue lifecycle.
 - Never auto-transition past `$DONE`. Downstream labels (terminal `status:done`, etc.) are owned by QA / PM / merge automation.

--- a/plugins/src/base/skills/github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/github-build-intake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-build-intake
-description: "GitHub counterpart to lisa:jira-build-intake. Scans a GitHub repository for issues carrying the configured `ready` build label, claims each by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:github-agent, and relabels to the configured `done` label on completion. The `ready` label is the human-flipped signal that an issue is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
+description: "GitHub counterpart to lisa:jira-build-intake. Scans a GitHub repository for issues carrying the configured `ready` build label, claims each leaf work unit by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:github-agent, and relabels to the configured `done` label on completion. Enforces the claim-time arm of the `leaf-only-lifecycle` rule: a parent/container with open child work (or a childless Epic/Story/Spike) that still carries a stale build-ready label is skipped or safe-blocked with a lifecycle-repair comment, never claimed. The `ready` label is the human-flipped signal that an issue is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
 allowed-tools: ["Skill", "Bash"]
 ---
 
@@ -135,7 +135,54 @@ If none of the configured role labels exist on the repo → label convention not
 
 ### Phase 3 — Process each ready issue (serial)
 
-#### 3a. Claim
+#### 3a. Leaf-only claim gate (skip / safe-block containers)
+
+Build intake claims **only independently implementable leaf work units**. This enforces the claim-time arm of the vendor-neutral `leaf-only-lifecycle` rule: a parent/container that still carries a stale build-ready role (e.g. `status:ready` applied before this rule existed, or hand-applied to an Epic/Story) is **never claimed** — intake skips it or safe-blocks it with a clear lifecycle-repair message. It is the claim-time complement to the write-time labeling in `lisa:github-write-issue` and the validate-time S15 gate in `lisa:github-validate-issue`; all three cite the same rule so the classification never drifts. **Never silently implement a container.**
+
+Run this gate **before** the claim relabel, for every candidate issue. Do NOT relabel, comment "Claimed", or invoke `lisa:github-agent` for an issue that fails the gate.
+
+**Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an issue is a **container** if it has **open** child work, whatever its declared type; otherwise the **type label** decides. Resolve child work using the same hierarchy `lisa:github-read-issue` uses — native sub-issues first, then body parentage (task-list checkboxes referencing other issues, `Blocked by #<n>` / `Parent: #<n>` references):
+
+```bash
+# Native sub-issues via GraphQL (same query lisa:github-read-issue uses).
+SUBS=$(gh api graphql -f query='
+query($org:String!,$repo:String!,$number:Int!){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      subIssues(first: 100) {
+        nodes { number state }
+      }
+    }
+  }
+}' -F org=<org> -F repo=<repo> -F number=<number> 2>/dev/null)
+
+# Count children still OPEN — a parent whose children are all closed is no longer
+# holding open work and rolls up via lisa:github-read-issue's rollup, not here.
+OPEN_CHILDREN=$(echo "$SUBS" | jq -r '[.data.repository.issue.subIssues.nodes[]? | select(.state == "OPEN")] | length' 2>/dev/null)
+OPEN_CHILDREN=${OPEN_CHILDREN:-0}
+```
+
+If the GraphQL `subIssues` field is unavailable (older GHES), fall back to parsing the body for child references exactly as `lisa:github-read-issue` does, and treat the issue as a container if any referenced child issue is open. Note "GraphQL sub-issues unavailable" so the operator knows parentage was text-derived.
+
+Classify and act (first match wins). `type:` is read from the issue's labels (`type:Epic`, `type:Story`, `type:Spike`, `type:Bug`, `type:Task`, `type:Sub-task`, `type:Improvement`):
+
+| Condition | Class | Action |
+|---|---|---|
+| `OPEN_CHILDREN > 0` (open child work, any type) | **Container** | **Skip / safe-block — do NOT claim** |
+| no open children AND `type ∈ {Epic, Story, Spike}` | **Childless container-type** | **Skip / safe-block — do NOT claim** |
+| no open children AND `type ∈ {Bug, Task, Sub-task, Improvement}` (or no `type:` label) | **Leaf work unit** | **Proceed to 3b claim** |
+
+The childless-parent exception is narrow: childlessness enables a claim **only** for types that are leaf work units to begin with. A childless Epic/Story/Spike is an incomplete decomposition, not an implementable unit — it is never claimed.
+
+**Safe-block (default action for a flagged container).** Leave the build-ready role in place (don't silently strip it — that hides the lifecycle error), post a single lifecycle-repair comment, and record the issue under "Skipped (container)" in the summary. Do NOT relabel to `$CLAIMED`. Keep the comment idempotent — skip posting if an identical `[claude-build-intake]` lifecycle-repair comment already exists on the issue, so a re-entrant cycle doesn't spam it.
+
+```bash
+gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Not claimed: this issue carries the build-ready role ($READY) but is a container with open child work (or a childless Epic/Story/Spike), which violates the leaf-only-lifecycle rule. Build-ready is leaf-only — an agent claims and implements leaves, never a container. Repair: move $READY off this parent onto its leaf children (or, for a childless Epic/Story/Spike, decompose it into leaf children or reclassify it to a leaf type). A parent's lifecycle state rolls up from its children and is never set to ready directly."
+```
+
+This gate never blocks a legitimate flat Task/Bug: those have no open children and a leaf `type:`, so they fall straight through to the claim in 3b.
+
+#### 3b. Claim
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
@@ -146,7 +193,7 @@ This is the idempotency lock — a re-entrant cycle's `--label $READY` filter wi
 
 If the relabel fails (permission, race), log under "Errors" in the cycle summary and skip this issue. **Do not invoke the build flow on an issue you didn't successfully claim.**
 
-#### 3b. Run the build flow
+#### 3c. Run the build flow
 
 Invoke `lisa:github-agent` (the per-issue lifecycle agent) with the issue ref. `lisa:github-agent` owns:
 - Reading the full issue graph (`lisa:github-read-issue`)
@@ -163,7 +210,7 @@ Wait for `lisa:github-agent` to return. Capture its outcome:
 - **Blocked by ticket-triage ambiguities** — `lisa:github-agent` posts findings and stops. The issue stays in `$CLAIMED`. Surface to human; do not auto-relabel. Record under "Errors".
 - **Errored** — exception, missing config, etc. Leave the issue in `$CLAIMED` for human investigation. Record under "Errors".
 
-#### 3c. Transition to $DONE (only on Success)
+#### 3d. Transition to $DONE (only on Success)
 
 If `lisa:github-agent` returned Success:
 
@@ -176,7 +223,7 @@ gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Buil
 
 For any non-Success outcome, do NOT transition. The issue sits in `$CLAIMED` (or wherever `lisa:github-agent` left it) — humans take it from there.
 
-#### 3d. Continue
+#### 3e. Continue
 
 Move to the next ready issue. One issue failing does not stop others.
 
@@ -192,6 +239,8 @@ Cycle completed: <ISO timestamp>
 Issues processed: <n>
 - $DONE (build complete, PR ready): <n>
   - <org>/<repo>#<number> <title> → PR <URL>
+- Skipped (container — leaf-only-lifecycle): <n>
+  - <org>/<repo>#<number> <title> — build-ready on a parent with open child work; lifecycle-repair comment posted
 - Blocked (pre-flight verify failed): <n>
   - <org>/<repo>#<number> <title> — see issue comments
 - Held (triage found ambiguities): <n>
@@ -204,6 +253,7 @@ Total PRs opened: <n>
 
 ## Idempotency & safety
 
+- **Leaf-only claim gate runs first**: Phase 3a classifies each candidate before any claim; a container with open child work (or a childless Epic/Story/Spike) is skipped/safe-blocked, never claimed. The safe-block comment is idempotent — a re-entrant cycle does not re-post it.
 - **Claim-first ordering**: `$CLAIMED` set BEFORE `lisa:github-agent` invocation — no double-pickup.
 - **No writes outside the lifecycle**: this skill only relabels `$READY → $CLAIMED` and `$CLAIMED → $DONE`. Every other label change is owned by `lisa:github-agent`.
 - **Failure isolation**: per-issue exceptions caught and recorded; the cycle continues.
@@ -227,6 +277,7 @@ If the repo has not adopted the `status:*` label namespace, this skill cannot ru
 
 ## Rules
 
+- **Claim leaves only.** Per the `leaf-only-lifecycle` rule, never claim a container — an issue with open child work, or a childless Epic/Story/Spike — even if it carries the build-ready role. Skip or safe-block it (Phase 3a); never silently implement a container.
 - Never relabel an issue the cycle didn't claim. The `$CLAIMED` label is the signature of cycle ownership.
 - Never bypass `lisa:github-agent` to do build work directly. `lisa:github-agent` owns the per-issue lifecycle.
 - Never auto-transition past `$DONE`. Downstream labels (terminal `status:done`, etc.) are owned by QA / PM / merge automation.

--- a/tests/unit/strategies/leaf-only-build-ready.test.ts
+++ b/tests/unit/strategies/leaf-only-build-ready.test.ts
@@ -10,10 +10,15 @@
  * an S15 gate that FAILs a build-ready container (or a childless
  * Epic/Story/Spike) and PASSes a childless build-ready leaf work unit.
  *
+ * Issue #542: `lisa:github-build-intake` adds the claim-time arm — Phase 3a
+ * classifies each candidate before claiming and skips / safe-blocks any parent
+ * with open child work (or a childless Epic/Story/Spike) carrying a stale
+ * build-ready label, while a childless leaf is claimed normally.
+ *
  * The invariant itself is the vendor-neutral `leaf-only-lifecycle` rule (merged
- * in #537); these tests assert that the writer, decomposition, and validator
- * skills encode it so the label is never hard-applied to — nor accepted on — a
- * container.
+ * in #537); these tests assert that the writer, decomposition, validator, and
+ * build-intake skills encode it so the label is never hard-applied to — nor
+ * accepted on, nor claimed from — a container.
  *
  * Both the source (`plugins/src/base/skills`) and the generated artifact
  * (`plugins/lisa/skills`) are asserted, so an artifact-only edit or a missed
@@ -22,6 +27,8 @@
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
+
+import { describe, expect, it } from "vitest";
 
 const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
 
@@ -153,6 +160,85 @@ describe("leaf-only build-ready invariant (#538)", () => {
     it("documents the build_ready and child_refs spec inputs", () => {
       expect(content).toContain("build_ready");
       expect(content).toContain("child_refs");
+    });
+  });
+
+  // Issue #542: github-build-intake must skip / safe-block any parent that
+  // carries the build-ready label but has open child work (and any childless
+  // Epic/Story/Spike), claiming only leaf work units. The gate lives in
+  // Phase 3a, ahead of the claim relabel. Asserting both roots catches an
+  // artifact-only edit or a missed `bun run build:plugins`.
+  describe.each(SKILL_ROOTS)("%s/github-build-intake (#542)", root => {
+    const content = readSkill(root, "github-build-intake");
+    /** Heading that anchors the claim-time leaf-only gate. */
+    const gateHeading = "#### 3a. Leaf-only claim gate";
+
+    it(CITES_SLUG, () => {
+      expect(content).toContain(RULE_SLUG);
+    });
+
+    it("defines a Phase 3a leaf-only claim gate ahead of the claim", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const claimIndex = content.indexOf("#### 3b. Claim");
+      expect(gateIndex).toBeGreaterThan(-1);
+      expect(claimIndex).toBeGreaterThan(-1);
+      // The gate must precede the claim step so a container is never claimed.
+      expect(gateIndex).toBeLessThan(claimIndex);
+    });
+
+    it("skips / safe-blocks a parent with open child work", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const section = content.slice(gateIndex);
+      // Structural container detection via open sub-issues.
+      expect(section).toMatch(/open child work/i);
+      expect(section).toMatch(/do NOT claim|never claimed|not claimed/i);
+      expect(section).toMatch(/skip|safe-block/i);
+    });
+
+    it("queries native sub-issues to detect open children", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const section = content.slice(gateIndex);
+      // Same native hierarchy lisa:github-read-issue uses.
+      expect(section).toMatch(/subIssues/);
+      expect(section).toMatch(/graphql/i);
+      expect(section).toMatch(/OPEN/);
+    });
+
+    it("does not claim a childless Epic/Story/Spike", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const section = content.slice(gateIndex);
+      expect(section).toMatch(
+        /childless container-type|childless Epic\/Story\/Spike/i
+      );
+      expect(section).toMatch(/Epic/);
+      expect(section).toMatch(/Story/);
+      expect(section).toMatch(/Spike/);
+    });
+
+    it("claims a childless leaf work unit", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const section = content.slice(gateIndex);
+      // The childless-parent exception: flat Bug/Task/Sub-task/Improvement
+      // with no open children falls through to the claim.
+      expect(section).toMatch(/leaf work unit/i);
+      expect(section).toMatch(
+        /Bug, Task, Sub-task, Improvement|Bug \/ Task \/ Sub-task \/ Improvement/
+      );
+      expect(section).toMatch(/[Pp]roceed.*claim|claim/);
+    });
+
+    it("posts a lifecycle-repair comment when safe-blocking a container", () => {
+      const gateIndex = content.indexOf(gateHeading);
+      const section = content.slice(gateIndex);
+      expect(section).toMatch(/lifecycle-repair/i);
+      // The repair guidance points the label off the parent onto its leaves.
+      expect(section).toMatch(
+        /onto its leaf children|move .* off this parent/i
+      );
+    });
+
+    it("lists a Skipped (container) bucket in the summary report", () => {
+      expect(content).toMatch(/Skipped \(container/);
     });
   });
 });


### PR DESCRIPTION
## What & why

Closes #542. Adds the **claim-time** arm of the vendor-neutral `leaf-only-lifecycle` rule (`plugins/src/base/rules/leaf-only-lifecycle.md`) to `lisa:github-build-intake`, so build intake only ever claims independently-implementable **leaf work units**.

This is the claim-time complement to:
- **#538** — write-time labeling (`github-write-issue` applies build-ready to leaves only)
- **#540** — validate-time S15 gate (`github-validate-issue` FAILs a build-ready container)

All three cite `leaf-only-lifecycle` by slug so the container-vs-leaf classification never drifts.

## Changes

- **`plugins/src/base/skills/github-build-intake/SKILL.md`** — new **Phase 3a "Leaf-only claim gate"**, ahead of the claim relabel. Before claiming, it:
  - Queries native sub-issues via GraphQL (the same hierarchy `lisa:github-read-issue` uses), with a body-parentage fallback for older GHES.
  - Counts **open** children and reads the `type:` label.
  - **Skips / safe-blocks** (does not claim) any container — an issue with open child work, or a childless Epic/Story/Spike — leaving the build-ready label in place and posting an *idempotent* lifecycle-repair comment.
  - **Proceeds to claim** a childless leaf work unit (Bug/Task/Sub-task/Improvement, or no `type:` label), so flat tickets are never stranded.
  - Subsequent phases renumbered (3b claim → 3c build → 3d done → 3e continue); summary report gains a "Skipped (container)" bucket; Rules + Idempotency sections updated.
- **`plugins/lisa/skills/github-build-intake/SKILL.md`** — regenerated artifact (`bun run build:plugins`).
- **`tests/unit/strategies/leaf-only-build-ready.test.ts`** — fixed a pre-existing convention deviation (added the missing `import { describe, expect, it } from "vitest";`) and extended the suite with 16 #542 assertions across both the `src` and generated artifact skill roots.

## Verification

- `bun run test:unit` — 704 passed (50 in the leaf-only suite). `pre-push` ran full unit + integration (46) green.
- `bun run check:plugins` — ✓ artifacts in sync; ✓ marketplace registers every plugin.
- `tsc --noEmit` clean; `eslint` clean on the test file.
- **Empirical (CLI dry-run of the Phase 3a classification against live issues):**
  - Parent Story **#531** (`type:Story`, 2 open children) → **CONTAINER → SKIP / SAFE-BLOCK, not claimed** ✓ (AC scenario 1)
  - Sub-task **#542** (`type:Sub-task`, 0 children) → **LEAF → PROCEED TO CLAIM** ✓ (AC scenario 2)
  - All 7 decision-table branches confirmed, including the structural override (a `type:Task` that acquired open children is treated as a container).

🤖 Generated with Claude Code