### PR TITLE
feat(sync): implement parent status rollup across GitHub/JIRA/Linear (#544)

### DIFF
--- a/plugins/lisa/skills/github-sync/SKILL.md
+++ b/plugins/lisa/skills/github-sync/SKILL.md
@@ -62,11 +62,57 @@ Based on the milestone, suggest (but do NOT automatically perform) a label trans
 
 The actual `status:in-progress` flip is owned by `lisa:github-build-intake` (claim) and `lisa:github-agent`. The `status:code-review` flip is owned by `lisa:github-evidence`. The `status:done` flip is typically owned by merge automation or PM. This skill never relabels.
 
+### Step 5: Parent Status Rollup (`--rollup`)
+
+When invoked with `--rollup`, this skill **derives a parent/container issue's `status:*` label from the roll-up of its child sub-issues** instead of posting a milestone update on a leaf. This implements the GitHub sub-issue-completion arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy. It is the sync-side complement to the write-time labeling (`lisa:github-write-issue`), the validate-time S15 gate (`lisa:github-validate-issue`), and the claim-time gate (`lisa:github-build-intake`); all four cite the same rule so the classification never drifts.
+
+**Resolve the child set the same way `lisa:github-read-issue` does** — native sub-issues via GraphQL, each with its `status:*` label and open/closed state:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){
+      issue(number:$number){
+        number title state
+        subIssues(first:100){ nodes { number state labels(first:20){ nodes { name } } } }
+      }
+    }
+  }' -F owner=<org> -F repo=<repo> -F number=<parent-number>
+```
+
+If the `subIssues` field is unavailable (older GHES), fall back to body parentage exactly as `lisa:github-read-issue` does. If the issue has **no** children it is a leaf, not a parent — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; the GitHub label map is `status:blocked`, `status:in-progress`, `status:code-review`, `status:done`):
+
+| If among the required child leaves… | Derived parent role | GitHub label |
+|---|---|---|
+| any child carries `status:blocked` (or is otherwise blocked) | `blocked` | `status:blocked` |
+| else any child carries `status:in-progress` **or** `status:code-review` | `claimed` | `status:in-progress` |
+| else **all** required children are terminal (closed / `status:done`) | `done` | the configured terminal `done` label |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container label |
+
+- **Blocked dominates** — a single blocked child surfaces `status:blocked` on the parent even while siblings progress, so a human sees the parent needs attention.
+- **"Required" children only** — a child labelled won't-do / optional does not hold the parent open; only leaves that must ship count toward the all-terminal check.
+- **Recursive** — a parent reaches `done` only when its children are all terminal; an Epic reaches `done` only when its Stories have themselves rolled up to `done`. Evaluate bottom-up.
+- **Never set the parent to `status:ready`** — `ready` is leaf-only (the human "claim this" signal). Rollup only moves the parent between non-ready container labels.
+
+**Single-environment collapse (this repo).** `.lisa.config.json` `deploy.branches` declares only `production: main`, so the terminal `done` resolves to the single label `status:done` — there is no `status:on-dev` / `status:on-stg` and **no dev → staging → prod promotion chain**. Resolve the terminal via the env-keyed `done` logic in `config-resolution`, but in the single-environment case it collapses to the one `status:done` value; the rollup never attempts to resolve a dev or staging `done`. Projects that DO have multiple environments keep the env-keyed map and roll the parent up to whichever `done` matches the environment its leaves shipped to.
+
+**Apply the derived label** (only when it differs from the parent's current `status:*`): remove the parent's existing `status:*` label and add the derived one, keeping exactly one `status:*` label so the build-queue invariant holds. Post an idempotent `[claude-sync] rollup` comment naming the derived state and the child tally (e.g. `3/4 leaves terminal, 1 blocked → status:blocked`); skip the comment if an identical one is already the most recent rollup comment.
+
+```bash
+gh issue edit <parent-number> --repo <org>/<repo> \
+  --remove-label "<current status:*>" --add-label "<derived status:*>"
+```
+
+**Safe default.** If rollup cannot be applied automatically (e.g. ambiguous required-set, GraphQL hierarchy unavailable, or a derived terminal that the env logic cannot resolve), this skill does **not** guess — it posts the derived suggestion as a comment and leaves the parent's label untouched. No unsafe transition is ever made.
+
 ## Important Notes
 
-- **Never auto-transition labels** — always suggest and let the user / pipeline confirm.
-- **Idempotent updates** — the `[claude-sync] <milestone>` prefix on the most-recent comment is the dedupe key.
+- **Never auto-transition labels** — always suggest and let the user / pipeline confirm. The one exception is the explicit `--rollup` parent derivation (Step 5), which moves a *parent's* `status:*` label as the `leaf-only-lifecycle` rule mandates — never a leaf's, and never to `status:ready`.
+- **Idempotent updates** — the `[claude-sync] <milestone>` prefix on the most-recent comment is the dedupe key; the rollup path uses `[claude-sync] rollup`.
 - **Comment format** — use GitHub-flavored markdown (`##` headings, fenced code blocks). The same template is used for the JIRA path (rendered as wiki markup there); keep the markdown source canonical.
+- **Rollup cites the rule by slug** — parent state derivation follows the `leaf-only-lifecycle` rule's state machine; this skill does not restate the policy.
 
 ## Execution
 

--- a/plugins/lisa/skills/jira-sync/SKILL.md
+++ b/plugins/lisa/skills/jira-sync/SKILL.md
@@ -58,11 +58,37 @@ Based on the milestone, suggest (but don't automatically perform) a status trans
 | PR ready | "In Review" |
 | PR merged | "Done" |
 
+### Step 5: Parent Status Rollup (`--rollup`)
+
+When invoked with `--rollup`, this skill **derives a parent/container ticket's status from the roll-up of its children** (Stories under an Epic; Sub-tasks under a Story/Task) instead of posting a milestone update on a leaf. This implements the JIRA child/subtask-status arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy.
+
+**Resolve the child set the same way `lisa:jira-read-ticket` does** — the native Epic → Story → Sub-task hierarchy (Epic link / parent field for Stories, the subtask relationship for Sub-tasks), each with its current status. Fetch via `lisa:atlassian-access` (`operation: read-ticket` / `search-issues` with the parent's `"Epic Link" = <KEY>` or `parent = <KEY>` JQL). If the ticket has **no** children it is a leaf — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; the JIRA status map defaults to `Blocked`, `In Progress`, `Code Review`, env-keyed `done`):
+
+| If among the required child leaves… | Derived parent role | JIRA status |
+|---|---|---|
+| any child is **blocked** | `blocked` | `Blocked` |
+| else any child is **in progress** (`In Progress` or `Code Review`) | `claimed` | `In Progress` |
+| else **all** required children are terminal (`Done`) | `done` | the configured terminal `done` status |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container status |
+
+- **Blocked dominates** — a single blocked child surfaces `Blocked` on the parent even while siblings progress.
+- **"Required" children only** — won't-do / optional children do not hold the parent open.
+- **Recursive** — an Epic reaches `Done` only when its Stories have themselves rolled up to `Done`; a Story reaches `Done` only when its Sub-tasks are all terminal. Evaluate bottom-up.
+- **Never set the parent to the build-ready status** — `ready` is leaf-only. Rollup only moves the parent between non-ready container statuses.
+- **`review` is optional for JIRA** (`config-resolution`) — a project that omits `Code Review` keeps the parent in `In Progress` until terminal; skip the intermediate rollup hop rather than forcing a non-existent status (a `leaf-only-lifecycle` "vendor support varies" note).
+
+**Single-environment collapse (this repo).** The terminal `done` resolves via the env-keyed `done` logic in `config-resolution`. In this repo `deploy.branches` declares only `production: main`, so `done` collapses to a single status and the lifecycle is `Ready → In Progress → Code Review → Done` with **no** dev/staging promotion hops; the rollup never resolves a dev or staging `done`. Multi-environment projects keep the env-keyed map.
+
+**Apply the derived status** (only when it differs from the parent's current status) via `lisa:atlassian-access` `operation: transition`, and post an idempotent rollup comment naming the derived state and the child tally. **Safe default:** if the derived terminal cannot be resolved (ambiguous required-set or unresolvable env `done`), do not guess — post the derived suggestion as a comment and leave the parent's status untouched.
+
 ## Important Notes
 
-- **Never auto-transition ticket status** — always suggest and let the user confirm
+- **Never auto-transition ticket status** — always suggest and let the user confirm. The one exception is the explicit `--rollup` parent derivation (Step 5), which transitions a *parent's* status per the `leaf-only-lifecycle` rule — never a leaf's, and never to the build-ready status.
 - **Idempotent updates** — running sync multiple times at the same milestone should not create duplicate comments
 - **Comment format** — use JIRA markdown with clear headers and bullet points
+- **Rollup cites the rule by slug** — parent state derivation follows the `leaf-only-lifecycle` rule's state machine; this skill does not restate the policy.
 
 ## Execution
 

--- a/plugins/lisa/skills/linear-sync/SKILL.md
+++ b/plugins/lisa/skills/linear-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: linear-sync
 description: "Syncs plan progress to a linked Linear Issue. Posts plan contents, progress updates, branch links, and PR links at key milestones. Use this skill throughout the plan lifecycle to keep Linear Issues in sync. The Linear counterpart of lisa:jira-sync and lisa:github-sync."
-allowed-tools: ["Bash", "Skill", "mcp__linear-server__list_teams", "mcp__linear-server__get_issue", "mcp__linear-server__save_comment", "mcp__linear-server__list_issue_labels", "mcp__linear-server__create_issue_label", "mcp__linear-server__save_issue"]
+allowed-tools: ["Bash", "Skill", "mcp__linear-server__list_teams", "mcp__linear-server__get_issue", "mcp__linear-server__list_issues", "mcp__linear-server__save_comment", "mcp__linear-server__list_issue_labels", "mcp__linear-server__create_issue_label", "mcp__linear-server__save_issue"]
 ---
 
 # Sync Plan to Linear: $ARGUMENTS
@@ -81,9 +81,34 @@ Verify exactly one `status:*` label remains after the update — having two simu
 
 Without `--update-label`, this skill posts the comment only and does NOT touch labels.
 
+## Phase 5 — Parent Status Rollup (`--rollup`)
+
+When the caller passes `--rollup`, this skill **derives a parent/container's `status:*` label from the roll-up of its children** instead of acting on a leaf. A **Project** (the Epic equivalent) rolls up from its Issues; an **Issue** rolls up from its sub-Issues. This implements the Linear child-issue-status arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy.
+
+**Resolve the child set the same way `lisa:linear-read-issue` does** — `mcp__linear-server__list_issues({project: <id>})` for a Project's Issues, or `mcp__linear-server__get_issue` per child for an Issue's sub-Issues (via `parentId`). Capture each child's `status:*` label. If the item has **no** children it is a leaf — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; Linear label map is `status:blocked`, `status:in-progress`, `status:code-review`, `status:done`):
+
+| If among the required child leaves… | Derived parent role | Linear label |
+|---|---|---|
+| any child carries `status:blocked` | `blocked` | `status:blocked` |
+| else any child carries `status:in-progress` **or** `status:code-review` | `claimed` | `status:in-progress` |
+| else **all** required children carry `status:done` | `done` | the configured terminal `done` label |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container label |
+
+- **Blocked dominates** — one blocked child surfaces `status:blocked` on the parent even while siblings progress.
+- **"Required" children only** — won't-do / optional (e.g. `Canceled`) children do not hold the parent open.
+- **Recursive** — a Project reaches `status:done` only when its Issues have themselves rolled up to `status:done`. Evaluate bottom-up.
+- **Never set the parent to `status:ready`** — `ready` is leaf-only. Rollup only moves the parent between non-ready container labels.
+
+**Single-environment collapse (this repo).** The terminal `done` resolves via the env-keyed `done` logic in `config-resolution`. In this repo `deploy.branches` declares only `production: main`, so `done` collapses to the single `status:done` label and the lifecycle is `status:ready → status:in-progress → status:code-review → status:done` with **no** dev/staging promotion hops; the rollup never resolves a dev or staging `done`. Multi-environment projects keep the env-keyed map.
+
+**Apply the derived label** via `mcp__linear-server__save_issue` (Project or Issue), removing the parent's existing `status:*` and adding the derived one so exactly one `status:*` label remains. Post an idempotent rollup comment naming the derived state and the child tally. The native Linear `state` is **not** auto-transitioned — only the `status:*` label, mirroring the `--update-label` rule. **Safe default:** if the derived terminal cannot be resolved (ambiguous required-set or unresolvable env `done`), do not guess — post the derived suggestion as a comment and leave the parent's label untouched.
+
 ## Rules
 
-- Never auto-transition the native Linear `state` — only the label, and only when the caller explicitly asks.
+- Never auto-transition the native Linear `state` — only the label, and only when the caller explicitly asks (`--update-label`, or `--rollup` for parent derivation per the `leaf-only-lifecycle` rule).
+- Rollup derives a *parent's* `status:*` label from its children and never sets a parent to `status:ready`. It cites the `leaf-only-lifecycle` rule by slug rather than restating the state machine.
 - Never post empty or minimal comments — if a milestone has no meaningful content, skip the post.
 - Do not delete prior milestone comments. They are the audit trail.
 - If `save_comment` fails, retry once. If it fails again, surface the error.

--- a/plugins/lisa/skills/tracker-sync/SKILL.md
+++ b/plugins/lisa/skills/tracker-sync/SKILL.md
@@ -20,9 +20,32 @@ See the `config-resolution` rule for configuration and dispatch table.
    - Anything else → stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
 3. Pass through the output.
 
+`$ARGUMENTS` is forwarded verbatim, including the optional `--rollup` flag (see "Parent status rollup" below) and `--update-label`. The shim never interprets these — the vendor skill does.
+
 If `$ARGUMENTS` is empty, all vendor skills auto-detect a ticket reference from the active plan file (most recently modified `.md` in `plans/`).
+
+## Parent status rollup (`--rollup`)
+
+When the caller passes `--rollup` after the milestone, the dispatch target additionally **derives the parent/container's lifecycle state from its children** instead of acting on the work item directly. This is the vendor-neutral implementation of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy here. The shim is dispatch only; the rollup mechanics live in the vendor sync skill (`lisa:github-sync`, `lisa:jira-sync`, `lisa:linear-sync`), which resolves child membership via its `*-read-*` skill and evaluates the state machine below.
+
+The state machine (first match wins, evaluated over the **required** leaves only):
+
+| If among the required leaves… | …the parent rolls up to | Role |
+|---|---|---|
+| any leaf is **blocked** | blocked / attention-needed | `blocked` |
+| else any leaf is **in progress** (claimed or in review) | active / in-progress | `claimed` |
+| else **all** required leaves are **terminal** | the configured rollup terminal | `done` (or `review` where supported) |
+| else (leaves exist, none started) | unchanged | — |
+
+- **Blocked dominates** — one blocked leaf surfaces blocked on the parent even while others progress.
+- **The parent never carries `ready`** — `ready` is a human "claim this leaf" signal; rollup only moves a parent between non-ready container states.
+- **Rollup is recursive** — an Epic rolls up from its Stories, each of which rolls up from its own leaves. Evaluate bottom-up.
+- **The terminal is the configured env-keyed `done`** — multi-env projects roll up to whichever `done` value matches the env their leaves shipped to (see `config-resolution` "Env-keyed `done`"). **Single-environment collapse (this repo):** `deploy.branches` declares only `production: main`, so `done` is a single value and the lifecycle collapses to `ready → claimed (in-progress) → review (code-review) → done`; the rollup terminal is simply `done` (or the PRD-side `ticketed` for PRD containers), with **no** dev/staging promotion hops and **no** env-keyed multi-entry chain to resolve.
+
+**Safe-by-default when not yet supported.** A vendor sync path that has not implemented native rollup MUST be a documented no-op that surfaces the derived state as a suggestion/comment rather than guessing a transition — never an unsafe default. Without `--rollup`, the sync skills behave exactly as before (milestone comment on the work item; no parent derivation).
 
 ## Rules
 
 - Idempotent updates — running sync at the same milestone twice should not produce duplicate comments. Vendor skills enforce this.
 - Never auto-transition the underlying state. Linear's label-based transition (`status:*`) is the canonical signal and is updated only when the caller passes `--update-label`. Native states stay as suggestions.
+- Parent rollup derives state from children per the `leaf-only-lifecycle` rule; it never sets a parent to `ready` and never resolves a dev/staging `done` in this single-environment repo.

--- a/plugins/src/base/skills/github-sync/SKILL.md
+++ b/plugins/src/base/skills/github-sync/SKILL.md
@@ -62,11 +62,57 @@ Based on the milestone, suggest (but do NOT automatically perform) a label trans
 
 The actual `status:in-progress` flip is owned by `lisa:github-build-intake` (claim) and `lisa:github-agent`. The `status:code-review` flip is owned by `lisa:github-evidence`. The `status:done` flip is typically owned by merge automation or PM. This skill never relabels.
 
+### Step 5: Parent Status Rollup (`--rollup`)
+
+When invoked with `--rollup`, this skill **derives a parent/container issue's `status:*` label from the roll-up of its child sub-issues** instead of posting a milestone update on a leaf. This implements the GitHub sub-issue-completion arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy. It is the sync-side complement to the write-time labeling (`lisa:github-write-issue`), the validate-time S15 gate (`lisa:github-validate-issue`), and the claim-time gate (`lisa:github-build-intake`); all four cite the same rule so the classification never drifts.
+
+**Resolve the child set the same way `lisa:github-read-issue` does** — native sub-issues via GraphQL, each with its `status:*` label and open/closed state:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){
+      issue(number:$number){
+        number title state
+        subIssues(first:100){ nodes { number state labels(first:20){ nodes { name } } } }
+      }
+    }
+  }' -F owner=<org> -F repo=<repo> -F number=<parent-number>
+```
+
+If the `subIssues` field is unavailable (older GHES), fall back to body parentage exactly as `lisa:github-read-issue` does. If the issue has **no** children it is a leaf, not a parent — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; the GitHub label map is `status:blocked`, `status:in-progress`, `status:code-review`, `status:done`):
+
+| If among the required child leaves… | Derived parent role | GitHub label |
+|---|---|---|
+| any child carries `status:blocked` (or is otherwise blocked) | `blocked` | `status:blocked` |
+| else any child carries `status:in-progress` **or** `status:code-review` | `claimed` | `status:in-progress` |
+| else **all** required children are terminal (closed / `status:done`) | `done` | the configured terminal `done` label |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container label |
+
+- **Blocked dominates** — a single blocked child surfaces `status:blocked` on the parent even while siblings progress, so a human sees the parent needs attention.
+- **"Required" children only** — a child labelled won't-do / optional does not hold the parent open; only leaves that must ship count toward the all-terminal check.
+- **Recursive** — a parent reaches `done` only when its children are all terminal; an Epic reaches `done` only when its Stories have themselves rolled up to `done`. Evaluate bottom-up.
+- **Never set the parent to `status:ready`** — `ready` is leaf-only (the human "claim this" signal). Rollup only moves the parent between non-ready container labels.
+
+**Single-environment collapse (this repo).** `.lisa.config.json` `deploy.branches` declares only `production: main`, so the terminal `done` resolves to the single label `status:done` — there is no `status:on-dev` / `status:on-stg` and **no dev → staging → prod promotion chain**. Resolve the terminal via the env-keyed `done` logic in `config-resolution`, but in the single-environment case it collapses to the one `status:done` value; the rollup never attempts to resolve a dev or staging `done`. Projects that DO have multiple environments keep the env-keyed map and roll the parent up to whichever `done` matches the environment its leaves shipped to.
+
+**Apply the derived label** (only when it differs from the parent's current `status:*`): remove the parent's existing `status:*` label and add the derived one, keeping exactly one `status:*` label so the build-queue invariant holds. Post an idempotent `[claude-sync] rollup` comment naming the derived state and the child tally (e.g. `3/4 leaves terminal, 1 blocked → status:blocked`); skip the comment if an identical one is already the most recent rollup comment.
+
+```bash
+gh issue edit <parent-number> --repo <org>/<repo> \
+  --remove-label "<current status:*>" --add-label "<derived status:*>"
+```
+
+**Safe default.** If rollup cannot be applied automatically (e.g. ambiguous required-set, GraphQL hierarchy unavailable, or a derived terminal that the env logic cannot resolve), this skill does **not** guess — it posts the derived suggestion as a comment and leaves the parent's label untouched. No unsafe transition is ever made.
+
 ## Important Notes
 
-- **Never auto-transition labels** — always suggest and let the user / pipeline confirm.
-- **Idempotent updates** — the `[claude-sync] <milestone>` prefix on the most-recent comment is the dedupe key.
+- **Never auto-transition labels** — always suggest and let the user / pipeline confirm. The one exception is the explicit `--rollup` parent derivation (Step 5), which moves a *parent's* `status:*` label as the `leaf-only-lifecycle` rule mandates — never a leaf's, and never to `status:ready`.
+- **Idempotent updates** — the `[claude-sync] <milestone>` prefix on the most-recent comment is the dedupe key; the rollup path uses `[claude-sync] rollup`.
 - **Comment format** — use GitHub-flavored markdown (`##` headings, fenced code blocks). The same template is used for the JIRA path (rendered as wiki markup there); keep the markdown source canonical.
+- **Rollup cites the rule by slug** — parent state derivation follows the `leaf-only-lifecycle` rule's state machine; this skill does not restate the policy.
 
 ## Execution
 

--- a/plugins/src/base/skills/jira-sync/SKILL.md
+++ b/plugins/src/base/skills/jira-sync/SKILL.md
@@ -58,11 +58,37 @@ Based on the milestone, suggest (but don't automatically perform) a status trans
 | PR ready | "In Review" |
 | PR merged | "Done" |
 
+### Step 5: Parent Status Rollup (`--rollup`)
+
+When invoked with `--rollup`, this skill **derives a parent/container ticket's status from the roll-up of its children** (Stories under an Epic; Sub-tasks under a Story/Task) instead of posting a milestone update on a leaf. This implements the JIRA child/subtask-status arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy.
+
+**Resolve the child set the same way `lisa:jira-read-ticket` does** — the native Epic → Story → Sub-task hierarchy (Epic link / parent field for Stories, the subtask relationship for Sub-tasks), each with its current status. Fetch via `lisa:atlassian-access` (`operation: read-ticket` / `search-issues` with the parent's `"Epic Link" = <KEY>` or `parent = <KEY>` JQL). If the ticket has **no** children it is a leaf — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; the JIRA status map defaults to `Blocked`, `In Progress`, `Code Review`, env-keyed `done`):
+
+| If among the required child leaves… | Derived parent role | JIRA status |
+|---|---|---|
+| any child is **blocked** | `blocked` | `Blocked` |
+| else any child is **in progress** (`In Progress` or `Code Review`) | `claimed` | `In Progress` |
+| else **all** required children are terminal (`Done`) | `done` | the configured terminal `done` status |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container status |
+
+- **Blocked dominates** — a single blocked child surfaces `Blocked` on the parent even while siblings progress.
+- **"Required" children only** — won't-do / optional children do not hold the parent open.
+- **Recursive** — an Epic reaches `Done` only when its Stories have themselves rolled up to `Done`; a Story reaches `Done` only when its Sub-tasks are all terminal. Evaluate bottom-up.
+- **Never set the parent to the build-ready status** — `ready` is leaf-only. Rollup only moves the parent between non-ready container statuses.
+- **`review` is optional for JIRA** (`config-resolution`) — a project that omits `Code Review` keeps the parent in `In Progress` until terminal; skip the intermediate rollup hop rather than forcing a non-existent status (a `leaf-only-lifecycle` "vendor support varies" note).
+
+**Single-environment collapse (this repo).** The terminal `done` resolves via the env-keyed `done` logic in `config-resolution`. In this repo `deploy.branches` declares only `production: main`, so `done` collapses to a single status and the lifecycle is `Ready → In Progress → Code Review → Done` with **no** dev/staging promotion hops; the rollup never resolves a dev or staging `done`. Multi-environment projects keep the env-keyed map.
+
+**Apply the derived status** (only when it differs from the parent's current status) via `lisa:atlassian-access` `operation: transition`, and post an idempotent rollup comment naming the derived state and the child tally. **Safe default:** if the derived terminal cannot be resolved (ambiguous required-set or unresolvable env `done`), do not guess — post the derived suggestion as a comment and leave the parent's status untouched.
+
 ## Important Notes
 
-- **Never auto-transition ticket status** — always suggest and let the user confirm
+- **Never auto-transition ticket status** — always suggest and let the user confirm. The one exception is the explicit `--rollup` parent derivation (Step 5), which transitions a *parent's* status per the `leaf-only-lifecycle` rule — never a leaf's, and never to the build-ready status.
 - **Idempotent updates** — running sync multiple times at the same milestone should not create duplicate comments
 - **Comment format** — use JIRA markdown with clear headers and bullet points
+- **Rollup cites the rule by slug** — parent state derivation follows the `leaf-only-lifecycle` rule's state machine; this skill does not restate the policy.
 
 ## Execution
 

--- a/plugins/src/base/skills/linear-sync/SKILL.md
+++ b/plugins/src/base/skills/linear-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: linear-sync
 description: "Syncs plan progress to a linked Linear Issue. Posts plan contents, progress updates, branch links, and PR links at key milestones. Use this skill throughout the plan lifecycle to keep Linear Issues in sync. The Linear counterpart of lisa:jira-sync and lisa:github-sync."
-allowed-tools: ["Bash", "Skill", "mcp__linear-server__list_teams", "mcp__linear-server__get_issue", "mcp__linear-server__save_comment", "mcp__linear-server__list_issue_labels", "mcp__linear-server__create_issue_label", "mcp__linear-server__save_issue"]
+allowed-tools: ["Bash", "Skill", "mcp__linear-server__list_teams", "mcp__linear-server__get_issue", "mcp__linear-server__list_issues", "mcp__linear-server__save_comment", "mcp__linear-server__list_issue_labels", "mcp__linear-server__create_issue_label", "mcp__linear-server__save_issue"]
 ---
 
 # Sync Plan to Linear: $ARGUMENTS
@@ -81,9 +81,34 @@ Verify exactly one `status:*` label remains after the update — having two simu
 
 Without `--update-label`, this skill posts the comment only and does NOT touch labels.
 
+## Phase 5 — Parent Status Rollup (`--rollup`)
+
+When the caller passes `--rollup`, this skill **derives a parent/container's `status:*` label from the roll-up of its children** instead of acting on a leaf. A **Project** (the Epic equivalent) rolls up from its Issues; an **Issue** rolls up from its sub-Issues. This implements the Linear child-issue-status arm of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy.
+
+**Resolve the child set the same way `lisa:linear-read-issue` does** — `mcp__linear-server__list_issues({project: <id>})` for a Project's Issues, or `mcp__linear-server__get_issue` per child for an Issue's sub-Issues (via `parentId`). Capture each child's `status:*` label. If the item has **no** children it is a leaf — rollup is N/A; behave as a normal milestone sync.
+
+**Evaluate the required children in priority order and take the first match** (canonical roles from `config-resolution`; Linear label map is `status:blocked`, `status:in-progress`, `status:code-review`, `status:done`):
+
+| If among the required child leaves… | Derived parent role | Linear label |
+|---|---|---|
+| any child carries `status:blocked` | `blocked` | `status:blocked` |
+| else any child carries `status:in-progress` **or** `status:code-review` | `claimed` | `status:in-progress` |
+| else **all** required children carry `status:done` | `done` | the configured terminal `done` label |
+| else (children exist, none started) | — | unchanged — parent keeps its non-ready container label |
+
+- **Blocked dominates** — one blocked child surfaces `status:blocked` on the parent even while siblings progress.
+- **"Required" children only** — won't-do / optional (e.g. `Canceled`) children do not hold the parent open.
+- **Recursive** — a Project reaches `status:done` only when its Issues have themselves rolled up to `status:done`. Evaluate bottom-up.
+- **Never set the parent to `status:ready`** — `ready` is leaf-only. Rollup only moves the parent between non-ready container labels.
+
+**Single-environment collapse (this repo).** The terminal `done` resolves via the env-keyed `done` logic in `config-resolution`. In this repo `deploy.branches` declares only `production: main`, so `done` collapses to the single `status:done` label and the lifecycle is `status:ready → status:in-progress → status:code-review → status:done` with **no** dev/staging promotion hops; the rollup never resolves a dev or staging `done`. Multi-environment projects keep the env-keyed map.
+
+**Apply the derived label** via `mcp__linear-server__save_issue` (Project or Issue), removing the parent's existing `status:*` and adding the derived one so exactly one `status:*` label remains. Post an idempotent rollup comment naming the derived state and the child tally. The native Linear `state` is **not** auto-transitioned — only the `status:*` label, mirroring the `--update-label` rule. **Safe default:** if the derived terminal cannot be resolved (ambiguous required-set or unresolvable env `done`), do not guess — post the derived suggestion as a comment and leave the parent's label untouched.
+
 ## Rules
 
-- Never auto-transition the native Linear `state` — only the label, and only when the caller explicitly asks.
+- Never auto-transition the native Linear `state` — only the label, and only when the caller explicitly asks (`--update-label`, or `--rollup` for parent derivation per the `leaf-only-lifecycle` rule).
+- Rollup derives a *parent's* `status:*` label from its children and never sets a parent to `status:ready`. It cites the `leaf-only-lifecycle` rule by slug rather than restating the state machine.
 - Never post empty or minimal comments — if a milestone has no meaningful content, skip the post.
 - Do not delete prior milestone comments. They are the audit trail.
 - If `save_comment` fails, retry once. If it fails again, surface the error.

--- a/plugins/src/base/skills/tracker-sync/SKILL.md
+++ b/plugins/src/base/skills/tracker-sync/SKILL.md
@@ -20,9 +20,32 @@ See the `config-resolution` rule for configuration and dispatch table.
    - Anything else → stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
 3. Pass through the output.
 
+`$ARGUMENTS` is forwarded verbatim, including the optional `--rollup` flag (see "Parent status rollup" below) and `--update-label`. The shim never interprets these — the vendor skill does.
+
 If `$ARGUMENTS` is empty, all vendor skills auto-detect a ticket reference from the active plan file (most recently modified `.md` in `plans/`).
+
+## Parent status rollup (`--rollup`)
+
+When the caller passes `--rollup` after the milestone, the dispatch target additionally **derives the parent/container's lifecycle state from its children** instead of acting on the work item directly. This is the vendor-neutral implementation of the **Parent status rollup (the state machine)** section of the `leaf-only-lifecycle` rule — cite that rule, do not restate the policy here. The shim is dispatch only; the rollup mechanics live in the vendor sync skill (`lisa:github-sync`, `lisa:jira-sync`, `lisa:linear-sync`), which resolves child membership via its `*-read-*` skill and evaluates the state machine below.
+
+The state machine (first match wins, evaluated over the **required** leaves only):
+
+| If among the required leaves… | …the parent rolls up to | Role |
+|---|---|---|
+| any leaf is **blocked** | blocked / attention-needed | `blocked` |
+| else any leaf is **in progress** (claimed or in review) | active / in-progress | `claimed` |
+| else **all** required leaves are **terminal** | the configured rollup terminal | `done` (or `review` where supported) |
+| else (leaves exist, none started) | unchanged | — |
+
+- **Blocked dominates** — one blocked leaf surfaces blocked on the parent even while others progress.
+- **The parent never carries `ready`** — `ready` is a human "claim this leaf" signal; rollup only moves a parent between non-ready container states.
+- **Rollup is recursive** — an Epic rolls up from its Stories, each of which rolls up from its own leaves. Evaluate bottom-up.
+- **The terminal is the configured env-keyed `done`** — multi-env projects roll up to whichever `done` value matches the env their leaves shipped to (see `config-resolution` "Env-keyed `done`"). **Single-environment collapse (this repo):** `deploy.branches` declares only `production: main`, so `done` is a single value and the lifecycle collapses to `ready → claimed (in-progress) → review (code-review) → done`; the rollup terminal is simply `done` (or the PRD-side `ticketed` for PRD containers), with **no** dev/staging promotion hops and **no** env-keyed multi-entry chain to resolve.
+
+**Safe-by-default when not yet supported.** A vendor sync path that has not implemented native rollup MUST be a documented no-op that surfaces the derived state as a suggestion/comment rather than guessing a transition — never an unsafe default. Without `--rollup`, the sync skills behave exactly as before (milestone comment on the work item; no parent derivation).
 
 ## Rules
 
 - Idempotent updates — running sync at the same milestone twice should not produce duplicate comments. Vendor skills enforce this.
 - Never auto-transition the underlying state. Linear's label-based transition (`status:*`) is the canonical signal and is updated only when the caller passes `--update-label`. Native states stay as suggestions.
+- Parent rollup derives state from children per the `leaf-only-lifecycle` rule; it never sets a parent to `ready` and never resolves a dev/staging `done` in this single-environment repo.

--- a/tests/unit/strategies/parent-status-rollup.test.ts
+++ b/tests/unit/strategies/parent-status-rollup.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Regression tests for the parent status rollup state machine across the
+ * vendor status-transition (sync) surfaces.
+ *
+ * Issue #544: implement the **Parent status rollup (the state machine)** arm of
+ * the vendor-neutral `leaf-only-lifecycle` rule (merged in #537) across the
+ * surfaces that own status transitions — `lisa:github-sync` (GitHub sub-issue
+ * completion), `lisa:jira-sync` (JIRA child/subtask status), `lisa:linear-sync`
+ * (Linear child-issue status) — plus the vendor-neutral `lisa:tracker-sync`
+ * dispatcher that documents the contract once. A parent/container derives its
+ * lifecycle state from its children: any leaf blocked → parent blocked; any leaf
+ * in progress → parent active; all required leaves terminal → parent rolls up to
+ * the configured terminal `done`. Blocked dominates; the parent never carries
+ * `ready`.
+ *
+ * Single-environment collapse (this repo): `.lisa.config.json` `deploy.branches`
+ * declares only `production: main`, so the env-keyed `done` collapses to one
+ * `done` value and the lifecycle is `ready → in-progress → code-review → done`
+ * with no dev/staging promotion hops. The rule and skills stay multi-env
+ * capable; these tests assert the collapse is documented and that the rollup
+ * never resolves a dev/staging `done` in this repo.
+ *
+ * Both the source (`plugins/src/base/skills`) and the generated artifact
+ * (`plugins/lisa/skills`) are asserted, so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/parent-status-rollup
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+/** Vendor-neutral rule slug every rollup path cites. */
+const RULE_SLUG = "leaf-only-lifecycle";
+/** The rule section the rollup paths implement. */
+const STATE_MACHINE = "Parent status rollup (the state machine)";
+/** Shared test name reused for every skill that cites the rule by slug. */
+const CITES_SLUG = "cites the leaf-only-lifecycle rule by slug";
+/** Shared test name reused for every skill asserting the single-env collapse. */
+const COLLAPSE_TEST =
+  "documents the single-environment collapse and stays multi-env capable";
+/** Shared test name reused for every skill asserting the state machine. */
+const STATE_MACHINE_TEST =
+  "encodes the blocked-dominant priority state machine";
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+/**
+ * Assert a skill section documents the single-environment collapse while
+ * staying multi-environment capable.
+ * @param content - SKILL.md text (or the relevant rollup section) to assert.
+ */
+const assertSingleEnvCollapse = (content: string): void => {
+  // Documents the collapse explicitly.
+  expect(content).toMatch(/[Ss]ingle-environment collapse/);
+  expect(content).toMatch(/production: main/);
+  // Never assumes a dev → staging → prod promotion chain for the rollup.
+  expect(content).toMatch(
+    /no.*dev.*staging.*promotion|dev\/staging promotion/i
+  );
+  // Stays multi-env capable — env-keyed done logic is preserved.
+  expect(content).toMatch(/env-keyed `done`|multi-environment|multi-env/i);
+  // Never resolves a dev/staging done in this single-env repo.
+  expect(content).toMatch(/never.*resolve.*dev|never resolves a dev/i);
+};
+
+/**
+ * Assert a skill section encodes the four-row priority state machine
+ * (blocked → claimed → done → unchanged).
+ * @param section - The rollup section text to assert.
+ */
+const assertStateMachine = (section: string): void => {
+  // Blocked dominates.
+  expect(section).toMatch(/blocked/i);
+  expect(section).toMatch(/[Bb]locked dominates/);
+  // In-progress (claimed or in review) → active.
+  expect(section).toMatch(/in progress|in-progress/i);
+  // All required leaves terminal → done.
+  expect(section).toMatch(/all.*required.*terminal|all.*required.*done/i);
+  expect(section).toMatch(/terminal/i);
+  // Required-only qualifier.
+  expect(section).toMatch(/[Rr]equired/);
+  // Recursive evaluation bottom-up.
+  expect(section).toMatch(/[Rr]ecursive/);
+  expect(section).toMatch(/bottom-up/i);
+  // The parent never carries the build-ready role.
+  expect(section).toMatch(/never set the parent to.*ready|never.*ready/i);
+};
+
+describe("parent status rollup (#544)", () => {
+  // The vendor-neutral dispatcher documents the rollup contract once and
+  // forwards the --rollup flag to the resolved vendor sync skill.
+  describe.each(SKILL_ROOTS)("%s/tracker-sync", root => {
+    const content = readSkill(root, "tracker-sync");
+
+    it(CITES_SLUG, () => {
+      expect(content).toContain(RULE_SLUG);
+    });
+
+    it("names the rollup state-machine section of the rule", () => {
+      expect(content).toContain(STATE_MACHINE);
+    });
+
+    it("forwards the --rollup flag to the vendor sync skill", () => {
+      expect(content).toMatch(/--rollup/);
+    });
+
+    it("documents the four-row priority state machine", () => {
+      assertStateMachine(content);
+    });
+
+    it(COLLAPSE_TEST, () => {
+      assertSingleEnvCollapse(content);
+    });
+
+    it("requires a safe (no-op suggestion) default, never an unsafe guess", () => {
+      expect(content).toMatch(/[Ss]afe|no-op/);
+      expect(content).toMatch(/never.*unsafe|unsafe default/i);
+    });
+  });
+
+  // GitHub sub-issue-completion arm: derive the parent's status:* label from
+  // its child sub-issues, blocked-dominant, terminal = single status:done.
+  describe.each(SKILL_ROOTS)("%s/github-sync", root => {
+    const content = readSkill(root, "github-sync");
+    const heading = "### Step 5: Parent Status Rollup";
+
+    it(CITES_SLUG, () => {
+      expect(content).toContain(RULE_SLUG);
+    });
+
+    it("defines a parent status rollup step gated on --rollup", () => {
+      expect(content).toContain(heading);
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/--rollup/);
+    });
+
+    it("resolves children via the github-read-issue sub-issue graph", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/github-read-issue/);
+      expect(section).toMatch(/subIssues/);
+    });
+
+    it(STATE_MACHINE_TEST, () => {
+      assertStateMachine(content.slice(content.indexOf(heading)));
+    });
+
+    it("maps the derived roles to GitHub status labels", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/status:blocked/);
+      expect(section).toMatch(/status:in-progress/);
+      expect(section).toMatch(/status:done/);
+    });
+
+    it("never sets the parent to status:ready", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/status:ready/);
+      expect(section).toMatch(
+        /[Nn]ever set the parent to .*status:ready|ready.*leaf-only/
+      );
+    });
+
+    it("collapses the terminal to a single status:done in this repo", () => {
+      const section = content.slice(content.indexOf(heading));
+      assertSingleEnvCollapse(section);
+      // No per-environment label hops.
+      expect(section).toMatch(/status:on-dev|on-dev/);
+    });
+  });
+
+  // JIRA child/subtask-status arm: Epic ← Stories ← Sub-tasks, native hierarchy.
+  describe.each(SKILL_ROOTS)("%s/jira-sync", root => {
+    const content = readSkill(root, "jira-sync");
+    const heading = "### Step 5: Parent Status Rollup";
+
+    it(CITES_SLUG, () => {
+      expect(content).toContain(RULE_SLUG);
+    });
+
+    it("defines a parent status rollup step gated on --rollup", () => {
+      expect(content).toContain(heading);
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/--rollup/);
+    });
+
+    it("resolves children via the jira-read-ticket Epic/Story/Sub-task hierarchy", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/jira-read-ticket/);
+      expect(section).toMatch(/Epic/);
+      expect(section).toMatch(/Sub-task/);
+    });
+
+    it(STATE_MACHINE_TEST, () => {
+      assertStateMachine(content.slice(content.indexOf(heading)));
+    });
+
+    it("treats the review hop as optional for JIRA per config-resolution", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/review.*optional|optional for JIRA/i);
+    });
+
+    it(COLLAPSE_TEST, () => {
+      assertSingleEnvCollapse(content.slice(content.indexOf(heading)));
+    });
+  });
+
+  // Linear child-issue-status arm: Project ← Issues, Issue ← sub-Issues.
+  describe.each(SKILL_ROOTS)("%s/linear-sync", root => {
+    const content = readSkill(root, "linear-sync");
+    const heading = "## Phase 5 — Parent Status Rollup";
+
+    it(CITES_SLUG, () => {
+      expect(content).toContain(RULE_SLUG);
+    });
+
+    it("defines a parent status rollup phase gated on --rollup", () => {
+      expect(content).toContain(heading);
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/--rollup/);
+    });
+
+    it("resolves children via the linear-read-issue Project/sub-Issue hierarchy", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/linear-read-issue/);
+      expect(section).toMatch(/Project/);
+      expect(section).toMatch(/sub-Issue/i);
+    });
+
+    it(STATE_MACHINE_TEST, () => {
+      assertStateMachine(content.slice(content.indexOf(heading)));
+    });
+
+    it("updates only the status:* label, never the native Linear state", () => {
+      const section = content.slice(content.indexOf(heading));
+      expect(section).toMatch(/status:\*/);
+      expect(section).toMatch(/not.*auto-transition|native Linear `state`/i);
+    });
+
+    it(COLLAPSE_TEST, () => {
+      assertSingleEnvCollapse(content.slice(content.indexOf(heading)));
+    });
+  });
+});
+
+// The rule itself remains the single source of truth and documents both the
+// generic env-keyed terminal and the single-environment collapse.
+describe("leaf-only-lifecycle rule: rollup section (#544)", () => {
+  describe.each(["plugins/src/base/rules", "plugins/lisa/rules"] as const)(
+    "%s/leaf-only-lifecycle",
+    root => {
+      const content = readFileSync(
+        path.resolve(root, "leaf-only-lifecycle.md"),
+        "utf8"
+      );
+
+      it("defines the parent status rollup state machine", () => {
+        expect(content).toContain(STATE_MACHINE);
+      });
+
+      it("documents the env-keyed terminal AND the single-environment collapse", () => {
+        expect(content).toMatch(/env-keyed/i);
+        expect(content).toMatch(/[Ss]ingle-environment collapse/);
+        expect(content).toMatch(/ready.*claimed.*review.*done|ready → claimed/);
+      });
+
+      it("states blocked dominates and the parent never carries ready", () => {
+        expect(content).toMatch(/[Bb]locked dominates/);
+        expect(content).toMatch(/parent never carries.*ready/i);
+      });
+    }
+  );
+});


### PR DESCRIPTION
## What

Implements the **Parent status rollup (the state machine)** arm of the vendor-neutral `leaf-only-lifecycle` rule across the surfaces that own status transitions. A parent/container derives its lifecycle state from the roll-up of its children instead of being set independently. Closes #544.

| Surface | Rollup arm | Child resolution |
|---|---|---|
| `github-sync` (Step 5) | GitHub sub-issue completion → parent `status:*` label | `github-read-issue` GraphQL `subIssues` graph |
| `jira-sync` (Step 5) | JIRA child/subtask status → Epic/Story status | native Epic → Story → Sub-task hierarchy |
| `linear-sync` (Phase 5) | Linear child-issue status → Project/Issue `status:*` label | `linear-read-issue` Project/sub-Issue hierarchy |
| `tracker-sync` | documents the contract once, forwards `--rollup` | dispatch only |

All four **cite the rule by slug** rather than restating it, matching the write/validate/build-intake gates from #538/#540/#542.

## State machine (first match wins, required leaves only)

1. any leaf **blocked** → parent `blocked` (**blocked dominates**)
2. else any leaf **in progress** (claimed or in review) → parent `claimed`/active
3. else **all** required leaves **terminal** → parent rolls up to the configured terminal `done`
4. else (leaves exist, none started) → parent unchanged

Recursive (Epic ← Stories ← Sub-tasks, evaluated bottom-up). The parent **never** carries `ready` (leaf-only signal).

## Single-environment collapse (this repo)

`.lisa.config.json` `deploy.branches` declares only `production: main`, so the env-keyed `done` resolves to a single `status:done` and the lifecycle collapses to `ready → in-progress → code-review → done` — **no** dev/staging promotion hops, and the rollup **never** resolves a dev/staging `done`. The rule and skills stay multi-environment capable for downstream projects that keep the env-keyed map. Safe-by-default: an unresolvable rollup posts a suggestion comment and leaves the parent untouched (no unsafe guess).

## Tests / verification

- `tests/unit/strategies/parent-status-rollup.test.ts` — 56 cases asserting the rollup sections in **both** `plugins/src/base` and the generated `plugins/lisa` artifacts (artifact-only edits / missed `build:plugins` fail the suite).
- Empirical dry-run simulated a parent with children in every leaf-state combination and confirmed the derived parent state (all-terminal → `status:done`; one blocked → `status:blocked`; one in-progress → `status:in-progress`; none-started → unchanged; optional non-terminal does not hold the parent open; never `status:ready`; refuses to resolve a staging `done`).
- `bun run build:plugins` rebuilt artifacts; `bun run check:plugins` ✓ in sync; typecheck + lint + commitlint pass via pre-commit.

## Out of scope

Decomposition labeling (1.1), validator gate (1.2), build-intake skipping (1.3) — already shipped in #538/#540/#542. Removing env-keyed `done` support for multi-environment projects.

🤖 Generated with Claude Code