### PR TITLE
feat(to-tracker): mirror leaf-only build-ready labeling into notion/confluence/linear (#539)

### DIFF
--- a/plugins/lisa/skills/confluence-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/confluence-to-tracker/SKILL.md
@@ -214,6 +214,8 @@ For each PRD epic, **invoke the `lisa:tracker-write` skill** (do not invoke `lis
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub. No filtering at the epic level.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -242,6 +244,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 ### Phase 5: Create Sub-tasks
@@ -253,6 +257,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/lisa/skills/linear-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/linear-to-tracker/SKILL.md
@@ -195,6 +195,8 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` skill** (
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub. No filtering at the epic level.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -223,6 +225,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 ### Phase 5: Create Sub-tasks
@@ -234,6 +238,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/lisa/skills/notion-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/notion-to-tracker/SKILL.md
@@ -186,6 +186,8 @@ For each PRD epic, **invoke the `lisa:tracker-write` skill** (do not call `creat
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub, and anyone working on the epic or its descendants must be able to reach the full set from one place. No filtering at the epic level. `lisa:tracker-write` Phase 4c attaches them as remote links.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -216,6 +218,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 - `artifacts`: the Phase 1.5 artifacts filtered by domain per the inheritance table below — `lisa:tracker-write` Phase 4c attaches them as remote links
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 **Inherit domain-matching artifacts as story remote links**. For each story, the artifact set passed to `lisa:tracker-write` should be the Phase 1.5 artifacts whose domain matches the story's scope:
@@ -238,6 +242,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`. `lisa:tracker-write` enforces single-repo scope on Sub-task; cross-repo sub-tasks will be rejected and must be split before delegation.
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 **Verification plan examples by stack:**
 - **Backend APIs**: curl GraphQL/REST calls with auth token, database queries, checking audit entries

--- a/plugins/src/base/skills/confluence-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/confluence-to-tracker/SKILL.md
@@ -214,6 +214,8 @@ For each PRD epic, **invoke the `lisa:tracker-write` skill** (do not invoke `lis
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub. No filtering at the epic level.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -242,6 +244,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 ### Phase 5: Create Sub-tasks
@@ -253,6 +257,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/src/base/skills/linear-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/linear-to-tracker/SKILL.md
@@ -195,6 +195,8 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` skill** (
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub. No filtering at the epic level.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -223,6 +225,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 ### Phase 5: Create Sub-tasks
@@ -234,6 +238,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 Sub-tasks inherit their parent story's artifacts by reference (the parent link). Do not pass the same artifact list to every sub-task.
 

--- a/plugins/src/base/skills/notion-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/notion-to-tracker/SKILL.md
@@ -186,6 +186,8 @@ For each PRD epic, **invoke the `lisa:tracker-write` skill** (do not call `creat
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The epic is the canonical hub, and anyone working on the epic or its descendants must be able to reach the full set from one place. No filtering at the epic level. `lisa:tracker-write` Phase 4c attaches them as remote links.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+
 Capture the returned epic key — Phase 4 needs it as the parent for stories.
 
 ### Phase 4: Create Stories
@@ -216,6 +218,8 @@ For each story, **invoke `lisa:tracker-write`** with:
 - `artifacts`: the Phase 1.5 artifacts filtered by domain per the inheritance table below — `lisa:tracker-write` Phase 4c attaches them as remote links
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+
 Capture each returned story key — Phase 5 needs it as the parent for sub-tasks.
 
 **Inherit domain-matching artifacts as story remote links**. For each story, the artifact set passed to `lisa:tracker-write` should be the Phase 1.5 artifacts whose domain matches the story's scope:
@@ -238,6 +242,8 @@ Delegate sub-task creation to **parallel agents** (one per epic or batch of stor
 Each sub-task MUST:
 1. **Be scoped to exactly ONE repo** — indicated in brackets in the summary: `[repo-name]`. `lisa:tracker-write` enforces single-repo scope on Sub-task; cross-repo sub-tasks will be rejected and must be split before delegation.
 2. **Include an Empirical Verification Plan** — real user-like verification, NOT unit tests, linting, or typechecking
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: Sub-tasks are the **leaf work units** of the decomposition — they are the ONLY items in the hierarchy that receive the build-ready label. `lisa:tracker-write` applies `status:ready` here so downstream build intake (`lisa:tracker-build-intake`) claims the leaves and never the Epic or Stories. Apply `status:ready` to each Sub-task; never to its parent Story or Epic (Phases 3–4). `lisa:tracker-write` enforces the same invariant on the write side, so a Sub-task split into per-repo children (the cross-repo case above) carries build-ready on the children, not on any intermediate parent that gains child work.
 
 **Verification plan examples by stack:**
 - **Backend APIs**: curl GraphQL/REST calls with auth token, database queries, checking audit entries

--- a/tests/unit/strategies/leaf-only-build-ready.test.ts
+++ b/tests/unit/strategies/leaf-only-build-ready.test.ts
@@ -15,6 +15,12 @@
  * with open child work (or a childless Epic/Story/Spike) carrying a stale
  * build-ready label, while a childless leaf is claimed normally.
  *
+ * Issue #539: mirrors the #538 decomposition-side change into the other three
+ * PRD-to-tracker skills — `notion-to-tracker`, `confluence-to-tracker`,
+ * `linear-to-tracker` — so all four PRD sources are behaviorally identical:
+ * Phase 3 (Epics) and Phase 4 (Stories) never pass `status:ready`; Phase 5
+ * (Sub-tasks) is the only phase that applies it.
+ *
  * The invariant itself is the vendor-neutral `leaf-only-lifecycle` rule (merged
  * in #537); these tests assert that the writer, decomposition, validator, and
  * build-intake skills encode it so the label is never hard-applied to — nor
@@ -239,6 +245,78 @@ describe("leaf-only build-ready invariant (#538)", () => {
 
     it("lists a Skipped (container) bucket in the summary report", () => {
       expect(content).toMatch(/Skipped \(container/);
+    });
+  });
+
+  // Issue #539: the three non-GitHub PRD-to-tracker skills must mirror the #538
+  // decomposition-side change so all four PRD sources are behaviorally
+  // identical — Phase 3 (Epics) and Phase 4 (Stories) never pass status:ready;
+  // Phase 5 (Sub-tasks) is the only phase that applies it. Asserting both roots
+  // catches an artifact-only edit or a missed `bun run build:plugins`.
+  const TO_TRACKER_SKILLS = [
+    "notion-to-tracker",
+    "confluence-to-tracker",
+    "linear-to-tracker",
+  ] as const;
+  /** Phase headings used to slice each to-tracker skill into phase windows. */
+  const PHASE_3_HEADING = "### Phase 3: Create Epics";
+  const PHASE_4_HEADING = "### Phase 4: Create Stories";
+  const PHASE_5_HEADING = "### Phase 5: Create Sub-tasks";
+  const PHASE_55_HEADING = "### Phase 5.5: Artifact Preservation Gate";
+
+  describe.each(TO_TRACKER_SKILLS)("%s (#539)", skill => {
+    describe.each(SKILL_ROOTS)("%s", root => {
+      const content = readSkill(root, skill);
+      /**
+       * Slice the skill content to the window for a single phase.
+       * @param from heading that opens the phase window (inclusive)
+       * @param to heading that opens the next phase (exclusive bound)
+       * @returns the content between the two headings
+       */
+      const phaseWindow = (from: string, to: string): string => {
+        const fromIndex = content.indexOf(from);
+        const toIndex = content.indexOf(to);
+        expect(fromIndex).toBeGreaterThan(-1);
+        expect(toIndex).toBeGreaterThan(fromIndex);
+        return content.slice(fromIndex, toIndex);
+      };
+
+      it(CITES_SLUG, () => {
+        expect(content).toContain(RULE_SLUG);
+      });
+
+      it("states Epics (Phase 3) are never marked build-ready", () => {
+        const phase3 = phaseWindow(PHASE_3_HEADING, PHASE_4_HEADING);
+        // The Epic block must carry the leaf-only guidance and forbid the label.
+        expect(phase3).toContain(RULE_SLUG);
+        expect(phase3).toMatch(/container, not a leaf work unit/);
+        expect(phase3).toMatch(/status:ready/);
+      });
+
+      it("states Stories (Phase 4) are never marked build-ready", () => {
+        const phase4 = phaseWindow(PHASE_4_HEADING, PHASE_5_HEADING);
+        expect(phase4).toContain(RULE_SLUG);
+        expect(phase4).toMatch(/a Story is a container/);
+        expect(phase4).toMatch(/status:ready/);
+      });
+
+      it("applies the build-ready label only to Sub-tasks (Phase 5)", () => {
+        const phase5 = phaseWindow(PHASE_5_HEADING, PHASE_55_HEADING);
+        expect(phase5).toContain(RULE_SLUG);
+        expect(phase5).toMatch(/leaf work units/);
+        // Sub-tasks are the ONLY items that receive the label.
+        expect(phase5).toMatch(/the ONLY items in the hierarchy/);
+        expect(phase5).toMatch(/status:ready/);
+      });
+
+      it("cites the vendor-neutral build intake, not the GitHub one", () => {
+        const phase5 = phaseWindow(PHASE_5_HEADING, PHASE_55_HEADING);
+        // These are vendor-neutral PRD sources: the destination tracker is
+        // resolved by lisa:tracker-write, so the leaf-only guidance must point
+        // at lisa:tracker-build-intake rather than lisa:github-build-intake.
+        expect(phase5).toContain("lisa:tracker-build-intake");
+        expect(phase5).not.toContain("lisa:github-build-intake");
+      });
     });
   });
 });


### PR DESCRIPTION
## What

Mirrors the #538 leaf-only build-ready labeling change from `github-to-tracker` into the other three PRD-to-tracker skills so all four PRD sources are behaviorally identical.

Closes #539.

## Why

`github-to-tracker` (#538) made build-ready labeling **leaf-only**: Epics (Phase 3) and Stories (Phase 4) are containers and never receive `status:ready`; only Sub-tasks (Phase 5) — the leaf work units — do. The other three PRD-to-tracker skills still implied the label could land on any level, so a downstream build pass could claim and "implement" an Epic or Story container, which is the wrong lifecycle boundary.

## Changes

- **`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`** (`plugins/src/base/skills/.../SKILL.md`): added the "Leaf-only build-ready" guidance block to Phase 3 (Epics), Phase 4 (Stories), and Phase 5 (Sub-tasks). Cites the vendor-neutral `leaf-only-lifecycle` rule by slug rather than restating it.
- Because these are vendor-neutral PRD sources whose destination tracker is resolved by `lisa:tracker-write`, the Phase 5 block points at the vendor-neutral `lisa:tracker-build-intake` (not `lisa:github-build-intake`) and at `lisa:tracker-write`'s write-side enforcement — matching #538's intent while staying tracker-agnostic.
- Regenerated `plugins/lisa/skills/...` artifacts via `bun run build:plugins`.
- Extended `tests/unit/strategies/leaf-only-build-ready.test.ts` with a #539 block asserting the invariant over all three skills in **both** `plugins/src/base` and the generated `plugins/lisa` artifact (catches artifact-only edits / missed `build:plugins`).

## Verification

- **Empirical**: each of the three skills now carries exactly 3 leaf-only blocks (Phase 3/4/5) in both source and artifact; Phase 3/4 forbid `status:ready` ("Do NOT mark it build-ready"), Phase 5 is the only phase that applies it ("the ONLY items in the hierarchy that receive the build-ready label") — identical to `github-to-tracker`.
- `bunx vitest run tests/unit/strategies/leaf-only-build-ready.test.ts` → **80 passed**.
- `bun run check:plugins` → **artifacts in sync; marketplace registers every built plugin**.

## Acceptance Criteria

> Given the leaf-only labeling change landed in github-to-tracker, when notion/confluence/linear-to-tracker are diffed, then each contains the equivalent leaf-only labeling guidance. ✅

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build-ready status assignment rules: only Sub-tasks (leaf work items) can receive the build-ready label; Epics and Stories cannot be marked build-ready. Applies across Confluence, Linear, and Notion integrations.

* **Tests**
  * Added test coverage to validate build-ready status rules and phase assignments across multiple integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->