### PR TITLE
fix: wire setup:deploy-key script into host project package.json

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -1,6 +1,7 @@
 {
   "force": {
     "scripts": {
+      "setup:deploy-key": "setup-deploy-key",
       "watch": "tsc -w",
       "cdk": "cdk",
       "build": "tsc --noEmit",

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -1,6 +1,7 @@
 {
   "force": {
     "scripts": {
+      "setup:deploy-key": "setup-deploy-key",
       "lighthouse:check": "lhci autorun --collect.settings.chromeFlags='--no-sandbox --disable-gpu --headless'",
       "playwright:build": "expo export --platform web",
       "playwright:test": "bun run playwright:build && playwright test",

--- a/harper-fabric/package-lisa/package.lisa.json
+++ b/harper-fabric/package-lisa/package.lisa.json
@@ -2,6 +2,7 @@
   "force": {
     "scripts": {
       "bootstrap": "bash scripts/bootstrap.sh",
+      "setup:deploy-key": "setup-deploy-key",
       "typecheck": "tsc --noEmit",
       "test": "vitest run",
       "test:cov": "vitest run --coverage",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -11,6 +11,7 @@
   },
   "force": {
     "scripts": {
+      "setup:deploy-key": "setup-deploy-key",
       "k6": "./scripts/k6-run.sh",
       "k6:smoke": "./scripts/k6-run.sh --scenario smoke",
       "k6:load": "./scripts/k6-run.sh --scenario load",

--- a/npm-package/package-lisa/package.lisa.json
+++ b/npm-package/package-lisa/package.lisa.json
@@ -2,6 +2,7 @@
   "force": {
     "scripts": {
       "prepublishOnly": "$npm_execpath run build",
+      "setup:deploy-key": "setup-deploy-key",
       "prepare": "$npm_execpath run build || husky install || true"
     },
     "devDependencies": {

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -1,6 +1,7 @@
 {
   "force": {
     "scripts": {
+      "setup:deploy-key": "setup-deploy-key",
       "lint": "oxlint && eslint . --quiet",
       "format:check": "prettier --check .",
       "format": "prettier --check . --write",


### PR DESCRIPTION
## What

Adds `"setup:deploy-key": "setup-deploy-key"` to the `force.scripts` of every project-type `package.lisa.json` (harper-fabric, typescript, nestjs, expo, cdk, npm-package).

## Why

The `setup-deploy-key` bin and `scripts/setup-deploy-key.sh` were shipped, and old per-project copies of the script were removed from host projects via `all/deletions.json`. But the matching `setup:deploy-key` **script entry** was never added to any `package.lisa.json` `force.scripts`. As a result, host projects ended up with an orphan bin (`node_modules/.bin/setup-deploy-key`) and no `bun run setup:deploy-key` script — so the command failed.

This completes the wiring described in the plan (`plans/swirling-forging-shore.md`, Step 6b item 5) that was missed. On the next install/sync, host projects get the script entry pointing at the published bin.

## Impact

Purely additive — adds one script entry per project type. `force.scripts` overwrites any pre-existing `setup:deploy-key` (no host project currently defines one).

🤖 Generated with Claude Code