### PR TITLE
feat(codex): register lisa-wiki plugin in the marketplace installer

### DIFF
--- a/plugins/lisa-wiki/commands/setup/wiki.md
+++ b/plugins/lisa-wiki/commands/setup/wiki.md
@@ -1,0 +1,6 @@
+---
+description: "Scaffold, repair, verify, or upgrade the project's LLM Wiki from its config. Alias for lisa-wiki setup in the Lisa setup command family."
+argument-hint: "[--upgrade] [--with-ci]"
+---
+
+Use the lisa-wiki-setup skill to bring the wiki into conformance from wiki/lisa-wiki.config.json: validate config, ask purpose + README mode, scaffold the canonical structure, render the contract snapshot (stamping kernelVersion), seed the staff roster, then verify with /doctor. $ARGUMENTS

--- a/plugins/src/wiki/commands/setup/wiki.md
+++ b/plugins/src/wiki/commands/setup/wiki.md
@@ -1,0 +1,6 @@
+---
+description: "Scaffold, repair, verify, or upgrade the project's LLM Wiki from its config. Alias for lisa-wiki setup in the Lisa setup command family."
+argument-hint: "[--upgrade] [--with-ci]"
+---
+
+Use the lisa-wiki-setup skill to bring the wiki into conformance from wiki/lisa-wiki.config.json: validate config, ask purpose + README mode, scaffold the canonical structure, render the contract snapshot (stamping kernelVersion), seed the staff roster, then verify with /doctor. $ARGUMENTS

--- a/src/codex/plugin-marketplace-installer.ts
+++ b/src/codex/plugin-marketplace-installer.ts
@@ -25,6 +25,7 @@ const LISA_CODEX_PLUGINS = [
   "lisa-cdk",
   "lisa-harper-fabric",
   "lisa-rails",
+  "lisa-wiki",
 ] as const;
 
 /** Marketplace category should match each generated `.codex-plugin` manifest. */
@@ -36,6 +37,7 @@ const LISA_CODEX_PLUGIN_CATEGORIES: Readonly<Record<string, string>> = {
   "lisa-cdk": "Coding",
   "lisa-harper-fabric": "Coding",
   "lisa-rails": "Coding",
+  "lisa-wiki": "Productivity",
 };
 
 /** Result of a marketplace install pass */

--- a/tests/unit/codex/plugin-marketplace-installer.test.ts
+++ b/tests/unit/codex/plugin-marketplace-installer.test.ts
@@ -36,7 +36,7 @@ describe("codex/plugin-marketplace-installer", () => {
   it("creates a repo-local marketplace with Lisa plugin entries", async () => {
     const result = await installCodexMarketplace(lisaDir, destDir);
     expect(result.created).toBe(true);
-    expect(result.pluginEntries).toBe(7);
+    expect(result.pluginEntries).toBe(8);
 
     const marketplacePath = path.join(destDir, CODEX_MARKETPLACE_PATH);
     const parsed = JSON.parse(await fs.readFile(marketplacePath, "utf8"));
@@ -51,6 +51,7 @@ describe("codex/plugin-marketplace-installer", () => {
       "lisa-cdk",
       "lisa-harper-fabric",
       "lisa-rails",
+      "lisa-wiki",
     ]);
     expect(parsed.plugins[0].source.path).toBe(
       "./node_modules/@codyswann/lisa/plugins/lisa"
@@ -71,6 +72,7 @@ describe("codex/plugin-marketplace-installer", () => {
       "lisa-cdk": "Coding",
       "lisa-harper-fabric": "Coding",
       "lisa-rails": "Coding",
+      "lisa-wiki": "Productivity",
     });
   });
 

--- a/tests/unit/codex/skills-installer.test.ts
+++ b/tests/unit/codex/skills-installer.test.ts
@@ -182,6 +182,23 @@ describe("codex/skills-installer", () => {
       );
     });
 
+    it("converts the wiki setup command alias into lisa-setup-wiki", async () => {
+      await seedCommand("lisa-wiki", "setup/wiki.md", SAMPLE_COMMAND_MD);
+      const result = await installSkills(lisaDir, destDir, []);
+
+      const skillName = `${LISA_COMMAND_SKILL_PREFIX}setup-wiki`;
+      const skillPath = path.join(
+        destDir,
+        ".codex",
+        LISA_SKILLS_SUBDIR,
+        skillName,
+        SKILL_MD
+      );
+      expect(await fs.pathExists(skillPath)).toBe(true);
+      const skill = result.installed.find(s => s.name === skillName);
+      expect(skill?.source).toBe("command");
+    });
+
     it("ignores non-md files in the commands tree", async () => {
       await seedCommand("lisa", "fix.md", SAMPLE_COMMAND_MD);
       await seedCommand("lisa", "README.txt", "just a readme");


### PR DESCRIPTION
## What

Completes the half-landed `lisa-wiki` codex plugin by registering it in the installer source:

- Adds `lisa-wiki` to `LISA_CODEX_PLUGINS` and the category map (`Productivity`) in `src/codex/plugin-marketplace-installer.ts`.
- Adds the `plugins/src/wiki/commands/setup/wiki.md` alias command (and its built artifact under `plugins/lisa-wiki/`).
- Adds unit tests: marketplace now generates **8** entries incl. `lisa-wiki`; the `setup/wiki.md` command converts into the `lisa-setup-wiki` skill.

## Why

`main` already ships the built `lisa-wiki` plugin and lists it in `.agents/plugins/marketplace.json`, but the **installer source never registered it** — `LISA_CODEX_PLUGINS` still had 7 plugins. So `installCodexMarketplace` generated 7 entries, out of sync with the 8-entry committed marketplace, and the wiki setup-command alias was never wired into a skill.

These were uncommitted working-tree changes that hadn't been captured in any PR. This rescues them onto a clean branch off latest `main`. (The redundant `marketplace.json` edit was dropped — `main` already has the identical entry.)

## Verification

- `bunx vitest run tests/unit/codex/plugin-marketplace-installer.test.ts tests/unit/codex/skills-installer.test.ts` → all pass.
- `bash scripts/build-plugins.sh` reproduces `main`'s plugins byte-identically plus the new lisa-wiki setup command (version injection is a no-op at the current release).

🤖 Generated with Claude Code