### PR TITLE
feat(codex): add SKILL.md frontmatter parser to artifact generator

### DIFF
--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -18,32 +18,86 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const [pluginDirArg, versionArg] = process.argv.slice(2);
-if (!pluginDirArg || !versionArg) {
-  console.error(
-    "Usage: generate-codex-plugin-artifacts.mjs <plugin-dir> <version>"
+/**
+ * Parse the leading YAML frontmatter block of a SKILL.md file.
+ *
+ * The frontmatter is the simple `key: value` YAML between the first two `---`
+ * fences at the very top of the file (the shape every `plugins/*\/skills/*\/SKILL.md`
+ * uses). Values are read verbatim as strings (trimmed); nested structures and
+ * arrays are not interpreted because skill frontmatter does not use them.
+ *
+ * @param {string} skillMdPath Absolute or relative path to a SKILL.md file.
+ * @returns {{ name?: string, description?: string } & Record<string, string> | null}
+ *   The parsed key/value pairs, or `null` (skip sentinel) when the file has no
+ *   leading `---`-delimited frontmatter block. Pure: never writes.
+ */
+export function parseSkillFrontmatter(skillMdPath) {
+  const raw = fs.readFileSync(skillMdPath, "utf8");
+  // Frontmatter must be the very first thing in the file. Normalize CRLF so a
+  // Windows-authored SKILL.md parses identically to a LF one.
+  const normalized = raw.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return null;
+  }
+  const closingIndex = normalized.indexOf("\n---", 3);
+  if (closingIndex === -1) {
+    return null;
+  }
+  const block = normalized.slice(4, closingIndex);
+  const frontmatter = {};
+  for (const line of block.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = trimmed.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    const key = trimmed.slice(0, separator).trim();
+    if (key === "") {
+      continue;
+    }
+    const value = trimmed
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    frontmatter[key] = value;
+  }
+  return frontmatter;
+}
+
+function main() {
+  const [pluginDirArg, versionArg] = process.argv.slice(2);
+  if (!pluginDirArg || !versionArg) {
+    console.error(
+      "Usage: generate-codex-plugin-artifacts.mjs <plugin-dir> <version>"
+    );
+    process.exit(1);
+  }
+
+  const pluginDir = path.resolve(pluginDirArg);
+  const claudeManifestPath = path.join(
+    pluginDir,
+    ".claude-plugin",
+    "plugin.json"
   );
-  process.exit(1);
+  if (!fs.existsSync(claudeManifestPath)) {
+    process.exit(0);
+  }
+
+  const claudeManifest = JSON.parse(
+    fs.readFileSync(claudeManifestPath, "utf8")
+  );
+  const pluginName = claudeManifest.name;
+
+  writeCodexManifest(pluginDir, claudeManifest, pluginName, versionArg);
 }
 
-const pluginDir = path.resolve(pluginDirArg);
-const claudeManifestPath = path.join(
-  pluginDir,
-  ".claude-plugin",
-  "plugin.json"
-);
-if (!fs.existsSync(claudeManifestPath)) {
-  process.exit(0);
-}
-
-const claudeManifest = JSON.parse(fs.readFileSync(claudeManifestPath, "utf8"));
-const pluginName = claudeManifest.name;
-
-writeCodexManifest(pluginName, versionArg);
-
-function writeCodexManifest(pluginName, version) {
-  const metadata = metadataFor(pluginName);
+function writeCodexManifest(pluginDir, claudeManifest, pluginName, version) {
+  const metadata = metadataFor(pluginName, claudeManifest);
   const manifest = {
     name: pluginName,
     version,
@@ -53,7 +107,7 @@ function writeCodexManifest(pluginName, version) {
     ...(claudeManifest.dependencies
       ? { dependencies: claudeManifest.dependencies }
       : {}),
-    ...componentPointers(),
+    ...componentPointers(pluginDir),
     interface: {
       displayName: metadata.displayName,
       shortDescription: metadata.shortDescription,
@@ -73,7 +127,7 @@ function writeCodexManifest(pluginName, version) {
   );
 }
 
-function componentPointers() {
+function componentPointers(pluginDir) {
   return {
     ...(fs.existsSync(path.join(pluginDir, "skills"))
       ? { skills: "./skills/" }
@@ -84,7 +138,7 @@ function componentPointers() {
   };
 }
 
-function metadataFor(pluginName) {
+function metadataFor(pluginName, claudeManifest) {
   const map = {
     lisa: {
       displayName: "Lisa",
@@ -235,4 +289,10 @@ function metadataFor(pluginName) {
       defaultPrompt: [`Use ${pluginName}`],
     }
   );
+}
+
+// Run the generator only when invoked directly (e.g. via build-plugins.sh),
+// not when this module is imported (e.g. by unit tests for the parser).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
 }

--- a/tests/unit/codex/skill-frontmatter-parser.test.ts
+++ b/tests/unit/codex/skill-frontmatter-parser.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the SKILL.md YAML-frontmatter parser used by the Codex
+ * artifact generator (scripts/generate-codex-plugin-artifacts.mjs).
+ *
+ * Covers the two acceptance-criteria scenarios from issue #545:
+ *  - extracting name + description from a frontmatter block
+ *  - returning the skip sentinel (null) when no frontmatter is present
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseSkillFrontmatter } from "../../../scripts/generate-codex-plugin-artifacts.mjs";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+describe("codex/skill-frontmatter-parser", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a SKILL.md file with the given contents into the test's temp dir.
+   * @param contents Raw file body to write.
+   * @returns Absolute path to the written SKILL.md.
+   */
+  async function writeSkill(contents: string): Promise<string> {
+    const skillPath = path.join(tempDir, "SKILL.md");
+    await fs.writeFile(skillPath, contents);
+    return skillPath;
+  }
+
+  it("extracts name and description from frontmatter", async () => {
+    const skillPath = await writeSkill(
+      "---\n" +
+        "name: exploratory-qa\n" +
+        "description: Playwright-backed exploratory QA workflow for web apps.\n" +
+        "---\n\n" +
+        "# Exploratory QA\n\nBody text.\n"
+    );
+
+    const result = parseSkillFrontmatter(skillPath);
+
+    expect(result).toEqual({
+      name: "exploratory-qa",
+      description: "Playwright-backed exploratory QA workflow for web apps.",
+    });
+  });
+
+  it("returns the skip sentinel (null) when there is no frontmatter block", () => {
+    const noFrontmatter = path.join(tempDir, "SKILL.md");
+    fs.writeFileSync(
+      noFrontmatter,
+      "# Just a heading\n\nNo frontmatter here.\n"
+    );
+
+    expect(parseSkillFrontmatter(noFrontmatter)).toBeNull();
+  });
+
+  it("does not throw and returns null for a file with no frontmatter", () => {
+    const noFrontmatter = path.join(tempDir, "SKILL.md");
+    fs.writeFileSync(noFrontmatter, "plain content, no fences");
+
+    expect(() => parseSkillFrontmatter(noFrontmatter)).not.toThrow();
+    expect(parseSkillFrontmatter(noFrontmatter)).toBeNull();
+  });
+
+  it("returns null when the opening fence is never closed", async () => {
+    const skillPath = await writeSkill(
+      "---\nname: unterminated\ndescription: missing closing fence\n"
+    );
+
+    expect(parseSkillFrontmatter(skillPath)).toBeNull();
+  });
+
+  it("preserves all key/value pairs and strips surrounding quotes", async () => {
+    const skillPath = await writeSkill(
+      "---\n" +
+        'name: "quoted-name"\n' +
+        "description: A description with: an embedded colon.\n" +
+        "argument-hint: <url>\n" +
+        "---\n\n# Body\n"
+    );
+
+    const result = parseSkillFrontmatter(skillPath);
+
+    expect(result).toEqual({
+      name: "quoted-name",
+      description: "A description with: an embedded colon.",
+      "argument-hint": "<url>",
+    });
+  });
+
+  it("ignores blank lines and comment lines inside the block", async () => {
+    const skillPath = await writeSkill(
+      "---\n" +
+        "# a leading comment\n" +
+        "\n" +
+        "name: with-comments\n" +
+        "\n" +
+        "description: clean value\n" +
+        "---\n\n# Body\n"
+    );
+
+    expect(parseSkillFrontmatter(skillPath)).toEqual({
+      name: "with-comments",
+      description: "clean value",
+    });
+  });
+
+  it("parses CRLF-authored frontmatter identically to LF", async () => {
+    const skillPath = await writeSkill(
+      "---\r\nname: crlf-skill\r\ndescription: windows line endings\r\n---\r\n\r\n# Body\r\n"
+    );
+
+    expect(parseSkillFrontmatter(skillPath)).toEqual({
+      name: "crlf-skill",
+      description: "windows line endings",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #545 (sub-task of PRD #521 / Story #533). Adds a SKILL.md YAML-frontmatter parser to `scripts/generate-codex-plugin-artifacts.mjs` so later sub-tasks (#546/#547/#548) can derive per-skill `agents/openai.yaml` fields from each skill's identity.

## What changed

- **`scripts/generate-codex-plugin-artifacts.mjs`**
  - New exported pure helper `parseSkillFrontmatter(skillMdPath)` — reads the leading `---`-delimited YAML frontmatter and returns its `key: value` pairs (notably `name` and `description`), or `null` (skip sentinel) when no frontmatter block is present. Never writes. Tolerates CRLF, blank lines, comment lines, quoted values, and values containing colons.
  - CLI entrypoint moved into a guarded `main()` (`import.meta.url` vs `process.argv[1]`) so importing the module is side-effect-free and the parser is unit-testable. The generator's existing helpers were threaded their previously-module-level state (`pluginDir`, `claudeManifest`) as parameters.
  - **Generated artifacts are byte-identical** — no behavior change to the CLI output (`bun run check:plugins` green).
- **`tests/unit/codex/skill-frontmatter-parser.test.ts`** (new) — vitest tests encoding both acceptance-criteria scenarios plus edge cases (unterminated fence, quotes, embedded colons, comments/blanks, CRLF).

## Acceptance criteria

| Scenario | Status |
| --- | --- |
| Extract `name` + `description` from frontmatter | ✅ |
| No frontmatter returns the skip sentinel (no throw) | ✅ |

## Verification (empirical)

- `parseSkillFrontmatter` run against the real `exploratory-qa` SKILL.md → `name: "exploratory-qa"` + description text.
- Sweep over all 362 built `SKILL.md` files → parsed without throwing (360 with frontmatter, 2 skip sentinel).
- `bun run build:plugins` exits 0; `bun run check:plugins` reports artifacts in sync.
- Quality gates: `lint` ✅ · `typecheck` ✅ · `format:check` ✅ · full vitest suite (934 tests) ✅.

## Out of scope (separate sub-tasks)

Writing `openai.yaml`, serialization, and the directory walk (#546/#547/#548).

Closes #545

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata parser for plugin documentation files.

* **Refactor**
  * Made plugin artifact generator modular and importable for testing and reusability.

* **Tests**
  * Added comprehensive test suite for documentation metadata parsing with edge case coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->