### PR TITLE
feat(codex): add deterministic openai.yaml serializer to artifact generator

### DIFF
--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -69,6 +69,60 @@ export function parseSkillFrontmatter(skillMdPath) {
   return frontmatter;
 }
 
+/**
+ * Encode a single string as a YAML double-quoted scalar.
+ *
+ * Double-quoting unconditionally is the deterministic choice: it round-trips
+ * every possible string — colons, leading `#`/`-`, quotes, indicators — without
+ * the branchy "is this plain-safe?" logic that risks emitting ambiguous YAML.
+ * Only the five escapes YAML's double-quoted style requires are applied, in a
+ * fixed order, so output is a pure function of the input.
+ *
+ * @param {string} value Raw string to encode.
+ * @returns {string} The value wrapped in double quotes with `\`, `"`, and the
+ *   C0 control characters (tab, newline, carriage return) escaped.
+ */
+function yamlQuote(value) {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\t/g, "\\t")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+  return `"${escaped}"`;
+}
+
+/**
+ * Serialize a Codex `interface` object to deterministic `openai.yaml` content.
+ *
+ * Emits exactly three keys in a fixed order — `display_name`,
+ * `short_description`, then `default_prompt` (a block sequence) — with every
+ * scalar double-quoted and a single trailing newline. The function is pure:
+ * given the same input it returns byte-identical output (no timestamps, no
+ * randomness, no filesystem), which is what keeps `bun run build:plugins`
+ * reproducible and the Plugins Sync CI gate stable.
+ *
+ * @param {{ display_name: string, short_description: string, default_prompt: readonly string[] }} iface
+ *   The normalized interface object. `default_prompt` is always rendered as a
+ *   block sequence (an empty array becomes `default_prompt: []`).
+ * @returns {string} Deterministic YAML, terminated by exactly one newline.
+ */
+export function serializeInterfaceToYaml(iface) {
+  const prompts = iface.default_prompt ?? [];
+  const promptBlock =
+    prompts.length === 0
+      ? "default_prompt: []"
+      : ["default_prompt:", ...prompts.map(p => `  - ${yamlQuote(p)}`)].join(
+          "\n"
+        );
+  const lines = [
+    `display_name: ${yamlQuote(iface.display_name)}`,
+    `short_description: ${yamlQuote(iface.short_description)}`,
+    promptBlock,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
 function main() {
   const [pluginDirArg, versionArg] = process.argv.slice(2);
   if (!pluginDirArg || !versionArg) {

--- a/tests/unit/codex/openai-yaml-serializer.test.ts
+++ b/tests/unit/codex/openai-yaml-serializer.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the deterministic openai.yaml serializer used by the Codex
+ * artifact generator (scripts/generate-codex-plugin-artifacts.mjs).
+ *
+ * Covers the two acceptance-criteria scenarios from issue #546:
+ *  - byte-stable output across invocations with fixed key order + trailing newline
+ *  - special characters (colons, quotes) quoted safely and round-tripping
+ *
+ * The serializer must be pure (a function of its input only — no timestamps,
+ * no filesystem, no randomness) so repeated `bun run build:plugins` runs emit
+ * byte-identical artifacts and the Plugins Sync CI gate never flakes.
+ */
+import { load as parseYaml } from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { serializeInterfaceToYaml } from "../../../scripts/generate-codex-plugin-artifacts.mjs";
+
+describe("codex/openai-yaml-serializer", () => {
+  /** A representative interface object matching the real generator shape. */
+  const sample = {
+    display_name: "Lisa",
+    short_description: "Universal project governance workflows",
+    default_prompt: [
+      "Plan this implementation with Lisa",
+      "Review this change with Lisa",
+    ],
+  };
+
+  it("is byte-stable across repeated invocations", () => {
+    const first = serializeInterfaceToYaml(sample);
+    const second = serializeInterfaceToYaml(sample);
+
+    expect(first).toBe(second);
+  });
+
+  it("does not mutate input between invocations (deep equality preserved)", () => {
+    const input = {
+      display_name: "Lisa",
+      short_description: "Universal project governance workflows",
+      default_prompt: ["Plan this implementation with Lisa"],
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    serializeInterfaceToYaml(input);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it("emits keys in the order display_name, short_description, default_prompt", () => {
+    const yaml = serializeInterfaceToYaml(sample);
+
+    const displayIndex = yaml.indexOf("display_name:");
+    const shortIndex = yaml.indexOf("short_description:");
+    const promptIndex = yaml.indexOf("default_prompt:");
+
+    expect(displayIndex).toBeGreaterThanOrEqual(0);
+    expect(shortIndex).toBeGreaterThan(displayIndex);
+    expect(promptIndex).toBeGreaterThan(shortIndex);
+  });
+
+  it("ends with exactly one trailing newline", () => {
+    const yaml = serializeInterfaceToYaml(sample);
+
+    expect(yaml.endsWith("\n")).toBe(true);
+    expect(yaml.endsWith("\n\n")).toBe(false);
+  });
+
+  it("round-trips a value containing a colon to the same string", () => {
+    const withColon = {
+      display_name: "Lisa: The Governor",
+      short_description: "key: value pairs everywhere",
+      default_prompt: ["Do this: then that"],
+    };
+
+    const yaml = serializeInterfaceToYaml(withColon);
+    const parsed = parseYaml(yaml);
+
+    expect(parsed).toEqual(withColon);
+  });
+
+  it("round-trips a value containing quotes to the same string", () => {
+    const withQuotes = {
+      display_name: 'The "Quoted" Plugin',
+      short_description: 'It\'s got an apostrophe and "double quotes"',
+      default_prompt: ['Say "hello"', "It's fine"],
+    };
+
+    const yaml = serializeInterfaceToYaml(withQuotes);
+    const parsed = parseYaml(yaml);
+
+    expect(parsed).toEqual(withQuotes);
+  });
+
+  it("round-trips special YAML indicator characters safely", () => {
+    const tricky = {
+      display_name: "#hashtag - @at & *star",
+      short_description: "value with | pipe and > gt and { brace }",
+      default_prompt: ["- looks like a list item", "[bracketed]", "yes"],
+    };
+
+    const yaml = serializeInterfaceToYaml(tricky);
+    const parsed = parseYaml(yaml);
+
+    expect(parsed).toEqual(tricky);
+  });
+
+  it("emits an empty default_prompt as an empty array, not null", () => {
+    const empty = {
+      display_name: "No Prompts",
+      short_description: "has no default prompts",
+      default_prompt: [],
+    };
+
+    const yaml = serializeInterfaceToYaml(empty);
+    const parsed = parseYaml(yaml);
+
+    expect(parsed.default_prompt).toEqual([]);
+  });
+
+  it("produces identical output for two structurally-equal inputs", () => {
+    const a = {
+      display_name: "Lisa",
+      short_description: "desc",
+      default_prompt: ["one", "two"],
+    };
+    const b = {
+      display_name: "Lisa",
+      short_description: "desc",
+      default_prompt: ["one", "two"],
+    };
+
+    expect(serializeInterfaceToYaml(a)).toBe(serializeInterfaceToYaml(b));
+  });
+});


### PR DESCRIPTION
## What

Adds a pure `serializeInterfaceToYaml` helper to `scripts/generate-codex-plugin-artifacts.mjs` (the Codex artifact generator). It serializes a Codex `interface` object to deterministic `openai.yaml` content:

- **Fixed key order**: `display_name`, `short_description`, `default_prompt`
- **Safe quoting**: every scalar is double-quoted, so colons, quotes, leading `#`/`-`, and other YAML indicators round-trip without ambiguity
- **`default_prompt`** rendered as a block sequence (empty array → `default_prompt: []`)
- **Pure / deterministic**: a function of its input only — no timestamps, randomness, or filesystem — so repeated `bun run build:plugins` runs are byte-identical and the Plugins Sync CI gate never flakes
- **Single trailing newline**

## Scope

Closes #546 (sub-task of Story #533, PRD #521). Scope is the serializer **only** — it is intentionally **not** wired into `main()`/emission yet. The directory walk and metadata derive are tracked separately in #547/#548. Because nothing in the generator's emitted output changed, generated artifacts are unchanged and `check:plugins` stays green.

This is a repo build script (not under `plugins/src`), so it is edited directly; no artifact regeneration was needed.

## Acceptance criteria

| Scenario | Covered by |
| --- | --- |
| Output byte-stable across invocations; keys in order; trailing newline | `is byte-stable across repeated invocations`, `emits keys in the order...`, `ends with exactly one trailing newline` |
| Special characters (colon/quote) quoted safely and round-trip | `round-trips a value containing a colon...`, `round-trips a value containing quotes...`, `round-trips special YAML indicator characters safely` |

## Verification

- **Empirical determinism**: serialized a sample interface object (with colons, embedded quotes, `#`, `|`, leading `-`) twice via CLI — output byte-identical, single trailing newline, correct key order, all special chars quoted safely.
- **Round-trip**: new vitest tests parse the emitted YAML with `js-yaml` and assert deep-equality back to the input.
- `npm run test:unit` → **897 passed** (incl. 9 new tests in `tests/unit/codex/openai-yaml-serializer.test.ts`)
- `npm run typecheck` → pass
- `npm run lint` → 0 errors, 0 warnings
- `npm run check:plugins` → **in sync** (no artifact drift)

🤖 Generated with Claude Code