### PR TITLE
feat(codex): walk skills and emit per-skill agents/openai.yaml (#547)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,13 @@ src/graphql-generated
 *.sh
 *.json
 coverage
+
+# Generated Codex plugin artifacts. plugins/lisa and plugins/lisa-* are built
+# from plugins/src by scripts/build-plugins.sh and must stay byte-identical to
+# the deterministic serializer output (scripts/generate-codex-plugin-artifacts.mjs),
+# or the Plugins Sync CI gate (bun run check:plugins) fails. Prettier's YAML
+# single-quote style would rewrite the serializer's double-quoted scalars, so the
+# generated openai.yaml files are excluded here. plugins/src (source of truth)
+# stays formatted.
+plugins/lisa/**/openai.yaml
+plugins/lisa-*/**/openai.yaml

--- a/plugins/lisa-expo/skills/apollo-client/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/apollo-client/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "apollo-client"
+short_description: "This skill should be used when writing or modifying GraphQL operations, hooks, or mutations using Apollo Client 3.10. It enforces best practices for optimistic responses, cache updates, and TypeScript type generation. Use this skill when creating new queries/mutations, reviewing Apollo code, or troubleshooting cache issues."
+default_prompt:
+  - "Use $apollo-client"

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "atomic-design-gluestack"
+short_description: "|"
+default_prompt:
+  - "Use $atomic-design-gluestack"

--- a/plugins/lisa-expo/skills/container-view-pattern/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/container-view-pattern/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "container-view-pattern"
+short_description: "This skill enforces the Container/View pattern for React components. It should be used when creating new components, validating existing components, or refactoring components to follow the separation of concerns pattern where Container handles logic and View handles presentation."
+default_prompt:
+  - "Use $container-view-pattern"

--- a/plugins/lisa-expo/skills/cross-platform-compatibility/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/cross-platform-compatibility/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "cross-platform-compatibility"
+short_description: "This skill enforces cross-platform compatibility best practices for Expo apps targeting iOS, Android, and web. It should be used when creating new features, components, or screens to ensure they work correctly on all platforms. Use this skill when writing platform-specific code, using Platform.OS checks, creating platform-specific files (.web.tsx, .native.tsx, .ios.tsx, .android.tsx), or reviewing code for cross-platform issues."
+default_prompt:
+  - "Use $cross-platform-compatibility"

--- a/plugins/lisa-expo/skills/directory-structure/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/directory-structure/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "directory-structure"
+short_description: "This skill enforces the project's directory structure standards when creating or moving files. Use this skill when creating new components, screens, features, hooks, utilities, or any other code files to ensure they are placed in the correct location with proper naming conventions. Also use when reviewing file placement or restructuring code."
+default_prompt:
+  - "Use $directory-structure"

--- a/plugins/lisa-expo/skills/exploratory-qa/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/exploratory-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "exploratory-qa"
+short_description: "Playwright-backed exploratory QA workflow for web apps. Use when asked to audit an app or project with Playwright/e2e tests, find human-noticeable bugs, identify gaps in automated test coverage, test responsive breakpoints, observe slow or unclear load states, exercise mutable workflows with cleanup, or produce a QA gaps report."
+default_prompt:
+  - "Use $exploratory-qa"

--- a/plugins/lisa-expo/skills/expo-env-config/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/expo-env-config/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "expo-env-config"
+short_description: "This skill should be used when creating, modifying, or accessing environment variables in this Expo/React Native codebase. It enforces type-safe, validated environment configuration using Zod schemas. Use this skill when adding new environment variables, setting up env validation, or writing code that reads from process.env."
+default_prompt:
+  - "Use $expo-env-config"

--- a/plugins/lisa-expo/skills/expo-router-best-practices/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/expo-router-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "expo-router-best-practices"
+short_description: "This skill should be used when creating new routes, configuring navigation layouts, implementing deep linking, or organizing the app/ directory structure in Expo Router projects. It provides best practices for file-based routing patterns."
+default_prompt:
+  - "Use $expo-router-best-practices"

--- a/plugins/lisa-expo/skills/gluestack-nativewind/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "gluestack-nativewind"
+short_description: "This skill enforces Gluestack UI v3 and NativeWind v4 design patterns for consistent, performant, and maintainable styling. It should be used when creating or reviewing components, fixing styling issues, or refactoring styles to follow the constrained design system."
+default_prompt:
+  - "Use $gluestack-nativewind"

--- a/plugins/lisa-expo/skills/jira-add-journey/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/jira-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-add-journey"
+short_description: "Add a Validation Journey section to an existing JIRA ticket by reading the ticket description, understanding the feature, and generating the journey steps, viewports, and assertions."
+default_prompt:
+  - "Use $jira-add-journey"

--- a/plugins/lisa-expo/skills/jira-create/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/jira-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-create"
+short_description: "This skill should be used when creating JIRA epics, stories, and tasks from code files or descriptions. It analyzes the provided input, determines the appropriate issue hierarchy, and creates issues with comprehensive quality requirements including test-first development and documentation."
+default_prompt:
+  - "Use $jira-create"

--- a/plugins/lisa-expo/skills/jira-evidence/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/jira-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-evidence"
+short_description: "Upload screenshots to GitHub pr-assets release, update PR description with evidence, upload attachments to JIRA, post wiki markup comment, and move ticket to Code Review. Reusable by any skill that captures screenshots and generates evidence/comment.txt + evidence/comment.md."
+default_prompt:
+  - "Use $jira-evidence"

--- a/plugins/lisa-expo/skills/jira-journey/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/jira-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-journey"
+short_description: "Read a JIRA ticket's Validation Journey section, execute the steps using Playwright MCP browser tools across all defined viewports, capture screenshots at each marker, generate evidence templates, and post to JIRA + GitHub PR using the jira-evidence skill."
+default_prompt:
+  - "Use $jira-journey"

--- a/plugins/lisa-expo/skills/jira-verify/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/jira-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-verify"
+short_description: "This skill should be used when verifying that a JIRA ticket meets organizational standards for epic relationships, description quality, and (for UI tickets) Validation Journey presence. It fetches the live ticket and delegates the gate checks to jira-validate-ticket so the bar matches what jira-write-ticket enforces pre-write."
+default_prompt:
+  - "Use $jira-verify"

--- a/plugins/lisa-expo/skills/local-state/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/local-state/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "local-state"
+short_description: "This skill should be used when implementing local state management in this React Native/Expo codebase. It covers Apollo Client Reactive Variables for in-memory reactive state and React Native AsyncStorage for persistent storage. Use this skill when creating feature flags, user preferences, session state, or any client-only state that needs to survive component unmounts or app restarts."
+default_prompt:
+  - "Use $local-state"

--- a/plugins/lisa-expo/skills/ops-browser-uat/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-browser-uat/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-browser-uat"
+short_description: "Browser-based user acceptance testing via Playwright MCP tools. Logs into the application, navigates through features, and captures visual proof with screenshots."
+default_prompt:
+  - "Use $ops-browser-uat"

--- a/plugins/lisa-expo/skills/ops-check-logs/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-check-logs/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-check-logs"
+short_description: "Check application logs from local processes, browser console, React Native device logs, or remote AWS CloudWatch. Supports log tailing, filtering, and error searching across all platforms."
+default_prompt:
+  - "Use $ops-check-logs"

--- a/plugins/lisa-expo/skills/ops-db-ops/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-db-ops/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-db-ops"
+short_description: "Database migrations, reverts, schema generation, and GraphQL codegen for Expo + serverless backend projects. Operates on the backend (TypeORM) and frontend (GraphQL code generation)."
+default_prompt:
+  - "Use $ops-db-ops"

--- a/plugins/lisa-expo/skills/ops-deploy/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-deploy"
+short_description: "Deploy Expo frontend (EAS Update/Build) or serverless backend (Serverless Framework) to dev, staging, or production environments."
+default_prompt:
+  - "Use $ops-deploy"

--- a/plugins/lisa-expo/skills/ops-monitor-errors/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-monitor-errors/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-monitor-errors"
+short_description: "Monitor Sentry for unresolved errors in frontend and backend projects. Supports filtering by project, environment, and time range."
+default_prompt:
+  - "Use $ops-monitor-errors"

--- a/plugins/lisa-expo/skills/ops-performance/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-performance/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-performance"
+short_description: "Performance analysis for Expo + serverless backend projects. Runs Lighthouse audits, bundle size analysis, and k6 load tests."
+default_prompt:
+  - "Use $ops-performance"

--- a/plugins/lisa-expo/skills/ops-run-local/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-run-local/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-run-local"
+short_description: "Manage the local development environment for Expo + serverless backend projects. Supports start, stop, restart, and status for the full stack or individual services."
+default_prompt:
+  - "Use $ops-run-local"

--- a/plugins/lisa-expo/skills/ops-verify-health/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/ops-verify-health/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-verify-health"
+short_description: "Health check all services across environments. Checks frontend URLs, backend GraphQL endpoints, and reports response times."
+default_prompt:
+  - "Use $ops-verify-health"

--- a/plugins/lisa-expo/skills/owasp-zap/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/owasp-zap/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "owasp-zap"
+short_description: ""
+default_prompt:
+  - "Use $owasp-zap"

--- a/plugins/lisa-expo/skills/playwright-ci-debugging/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/playwright-ci-debugging/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "playwright-ci-debugging"
+short_description: "Debug Playwright E2E tests that pass locally but fail in CI (or vice versa) in Expo web projects. Covers local reproduction, network interception, CI environment discovery, commit SHA verification, and robust interaction patterns that eliminate flake. Use this skill when a Playwright test is failing in CI, a test is flaky, a PR is blocked by E2E checks, or you need to investigate CI-specific test behavior. Trigger on mentions of CI failure, failing Playwright test, flaky E2E test, or debugging E2E in CI."
+default_prompt:
+  - "Use $playwright-ci-debugging"

--- a/plugins/lisa-expo/skills/playwright-selectors/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/playwright-selectors/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "playwright-selectors"
+short_description: "Best practices for writing reliable Playwright E2E tests and adding testID/aria-label selectors in Expo web applications using GlueStack UI and NativeWind. Use this skill when creating, debugging, or modifying Playwright tests, adding E2E test coverage, creating components that need test selectors, reviewing code for testability, or troubleshooting testID/data-testid issues. Trigger on any mention of Playwright, E2E tests, end-to-end tests, testID, data-testid, or GlueStack testing in an Expo web context."
+default_prompt:
+  - "Use $playwright-selectors"

--- a/plugins/lisa-expo/skills/reduce-complexity/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/reduce-complexity/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "reduce-complexity"
+short_description: "This skill provides strategies and patterns for reducing cognitive complexity in React components. It should be used when ESLint reports sonarjs/cognitive-complexity violations, when refactoring complex View components, or when planning how to break down large components. The skill enforces this project's Container/View pattern requirements when extracting components."
+default_prompt:
+  - "Use $reduce-complexity"

--- a/plugins/lisa-expo/skills/testing-library/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/testing-library/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "testing-library"
+short_description: "Enforces best practices for unit testing with Jest, @testing-library/react-native, and jest-expo in Expo projects. This skill should be used when writing, reviewing, or debugging unit tests to ensure tests are accessible, maintainable, and follow Testing Library guiding principles. Use this skill for test file creation, query selection, async handling, mocking patterns, and Expo Router testing."
+default_prompt:
+  - "Use $testing-library"

--- a/plugins/lisa-harper-fabric/skills/exploratory-qa/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/exploratory-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "exploratory-qa"
+short_description: "Playwright-backed exploratory QA workflow for web apps. Use when asked to audit an app or project with Playwright/e2e tests, find human-noticeable bugs, identify gaps in automated test coverage, test responsive breakpoints, observe slow or unclear load states, exercise mutable workflows with cleanup, or produce a QA gaps report."
+default_prompt:
+  - "Use $exploratory-qa"

--- a/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "harper-build-and-deploy"
+short_description: "This skill should be used when building, running locally, or deploying a Harper (HarperDB/Fabric) component — running harper dev/run, producing the generated resources.js and web/** from TypeScript via the project build, packaging the harper-app component, deploying to Harper Fabric, or handling deploy-time secrets. Use it for any change that affects the deployable surface or the dev loop. Pairs with harper-component-model, harper-config-yaml, and harper-resources."
+default_prompt:
+  - "Use $harper-build-and-deploy"

--- a/plugins/lisa-harper-fabric/skills/harper-component-model/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-component-model/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "harper-component-model"
+short_description: "This skill should be used when reasoning about how a Harper (formerly HarperDB) Fabric application is structured — what a component, application, extension, or plugin is, where code and assets belong, and how the pieces depend on each other. Use it before adding a new capability, wiring an extension, deciding where a file should live, or explaining the runtime to someone. Pairs with harper-config-yaml, harper-resources, harper-schema-graphql, and harper-build-and-deploy."
+default_prompt:
+  - "Use $harper-component-model"

--- a/plugins/lisa-harper-fabric/skills/harper-config-yaml/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-config-yaml/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "harper-config-yaml"
+short_description: "This skill should be used when creating or editing a Harper (HarperDB/Fabric) component's config.yaml — enabling a built-in extension (graphqlSchema, jsResource, rest, static, roles, loadEnv, dataLoader, fastifyRoutes), wiring an external component, or troubleshooting why an extension is not loading. Critical: it documents the no-merge footgun where a custom config.yaml replaces Harper's default config entirely. Pairs with harper-component-model, harper-resources, and harper-schema-graphql."
+default_prompt:
+  - "Use $harper-config-yaml"

--- a/plugins/lisa-harper-fabric/skills/harper-resources/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-resources/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "harper-resources"
+short_description: "This skill should be used when writing or editing Harper (HarperDB/Fabric) resources — the classes in resources.js (built from TypeScript under src/) that expose custom data logic over REST and GraphQL. Use it when adding an endpoint, overriding table behavior, wrapping an external API, or wiring real-time subscriptions. Covers the Resource method-to-HTTP mapping and the TS-is-source build convention. Pairs with harper-schema-graphql, harper-config-yaml, and harper-build-and-deploy."
+default_prompt:
+  - "Use $harper-resources"

--- a/plugins/lisa-harper-fabric/skills/harper-schema-graphql/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-schema-graphql/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "harper-schema-graphql"
+short_description: "This skill should be used when editing a Harper (HarperDB/Fabric) schema.graphql — defining or changing database tables, types, fields, relationships, or indexes that the graphqlSchema extension turns into Harper tables and API surface. Use it when adding a table, changing the data model, or when a resource/verify path depends on schema shape. Pairs with harper-resources, harper-config-yaml, and harper-component-model."
+default_prompt:
+  - "Use $harper-schema-graphql"

--- a/plugins/lisa-nestjs/skills/nestjs-graphql/agents/openai.yaml
+++ b/plugins/lisa-nestjs/skills/nestjs-graphql/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "nestjs-graphql"
+short_description: "Comprehensive guide for NestJS GraphQL development using Apollo and code-first approach. This skill should be used when writing GraphQL resolvers, mutations, queries, types, subscriptions, or implementing advanced features like field middleware, complexity limits, and custom scalars. Also covers project-specific patterns including zero-trust auth decorators and DataLoader integration."
+default_prompt:
+  - "Use $nestjs-graphql"

--- a/plugins/lisa-nestjs/skills/nestjs-rules/agents/openai.yaml
+++ b/plugins/lisa-nestjs/skills/nestjs-rules/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "nestjs-rules"
+short_description: "Procedural rules and patterns for NestJS backend development. This skill should be used when creating new NestJS modules, services, resolvers, or controllers. It covers component generation with NestJS CLI, TDD patterns, module structure conventions, Lambda handler patterns, and configuration standards. Use this skill alongside nestjs-graphql for GraphQL-specific patterns."
+default_prompt:
+  - "Use $nestjs-rules"

--- a/plugins/lisa-nestjs/skills/typeorm-patterns/agents/openai.yaml
+++ b/plugins/lisa-nestjs/skills/typeorm-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "typeorm-patterns"
+short_description: "Enforces TypeORM implementation patterns for this NestJS backend project. This skill should be used when creating or modifying TypeORM entities, repositories, database configuration, migrations, or any database-related code. It covers configuration patterns (TypeOrmModule.forRootAsync, replication, naming strategy), entity patterns (base entity, comments, indexes), and observability (X-Ray logging)."
+default_prompt:
+  - "Use $typeorm-patterns"

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/agents/openai.yaml
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-openclaw-connect-repo-topic"
+short_description: "Bind a Telegram forum topic to an OpenClaw dispatcher+worker agent pair that runs a coding CLI against a repo, so you can drive code work from chat. Supports single-repo topics and folder-scoped topics (multiple repos with repo-confirmation). Creates/validates the agent pair, ensures the bot is a group admin, captures real group/topic ids, wires the route in ~/.openclaw/openclaw.json, validates the gateway, and runs a no-change self-test. Requires lisa-openclaw-setup first."
+default_prompt:
+  - "Use $lisa-openclaw-connect-repo-topic"

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/agents/openai.yaml
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-openclaw-connect-staff"
+short_description: "Connect staff roles to a human chat surface (Telegram or Slack) via OpenClaw using a facilitator/specialist hub-and-spoke model. Registers bots/apps, creates or reuses the human-facing surface, wires routes in ~/.openclaw/openclaw.json, writes facilitator/specialist agent prompts, validates the gateway, resets stale sessions, and runs an end-to-end route test. Use when you want a \"chief of staff\" facilitator and its specialists reachable from chat. Requires lisa-openclaw-setup first."
+default_prompt:
+  - "Use $lisa-openclaw-connect-staff"

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-setup/agents/openai.yaml
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-openclaw-setup"
+short_description: "Set up OpenClaw as the chat-surface runtime for this project's staff roles. Verifies the openclaw CLI, the ~/.openclaw/openclaw.json config, a secret provider, and the required gateway capabilities (sessions_spawn, native-reply session scoping, the NO_REPLY sentinel), then writes a lean `openclaw` section to .lisa.config.json. Prerequisite for lisa-openclaw-connect-staff and lisa-openclaw-connect-repo-topic. Use when a project wants its facilitator/specialist staff reachable from Telegram or Slack."
+default_prompt:
+  - "Use $lisa-openclaw-setup"

--- a/plugins/lisa-rails/skills/action-controller-best-practices/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/action-controller-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "action-controller-best-practices"
+short_description: "Build or Refactor large Rails controller files into clean, maintainable code. Use when a controller action exceeds ~10 lines, a controller has custom non-RESTful actions, or when the user asks to refactor, slim down, clean up, or organize a Rails controller. Applies patterns: service objects, query objects, form objects, controller concerns, presenters/decorators, and RESTful resource extraction."
+default_prompt:
+  - "Use $action-controller-best-practices"

--- a/plugins/lisa-rails/skills/action-view-best-practices/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/action-view-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "action-view-best-practices"
+short_description: "Build or Refactor Rails views, partials, and templates into clean, maintainable code. Use when views have inline Ruby logic, deeply nested partials, jQuery or legacy JavaScript, helper methods returning HTML, or when the user asks to modernize, refactor, or clean up Rails views. Applies patterns - Turbo Frames, Turbo Streams, Stimulus controllers, ViewComponent, presenters, strict locals, and proper partial extraction."
+default_prompt:
+  - "Use $action-view-best-practices"

--- a/plugins/lisa-rails/skills/active-record-model-best-practices/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/active-record-model-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "active-record-model-best-practices"
+short_description: "Best practices for Ruby on Rails models, splitting code into well-organized, maintainable code. Use when a model exceeds ~100 lines, has mixed responsibilities, or when the user asks to refactor, extract, clean up, or organize a Rails model. Applies patterns: concerns, service objects, query objects, form objects, and value objects."
+default_prompt:
+  - "Use $active-record-model-best-practices"

--- a/plugins/lisa-rails/skills/exploratory-qa/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/exploratory-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "exploratory-qa"
+short_description: "Playwright-backed exploratory QA workflow for web apps. Use when asked to audit an app or project with Playwright/e2e tests, find human-noticeable bugs, identify gaps in automated test coverage, test responsive breakpoints, observe slow or unclear load states, exercise mutable workflows with cleanup, or produce a QA gaps report."
+default_prompt:
+  - "Use $exploratory-qa"

--- a/plugins/lisa-rails/skills/fix-linter-error/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/fix-linter-error/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "fix-linter-error"
+short_description: "This skill should be used when fixing all violations of one or more RuboCop cops across the codebase. It runs RuboCop, groups violations by cop and file, generates a brief with fix strategies, and creates a plan with tasks to implement the fixes."
+default_prompt:
+  - "Use $fix-linter-error"

--- a/plugins/lisa-rails/skills/improve-code-complexity/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/improve-code-complexity/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-code-complexity"
+short_description: "This skill should be used when reducing the code complexity threshold of the codebase. It lowers the CyclomaticComplexity threshold by 2, identifies methods that exceed the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to fix all violations."
+default_prompt:
+  - "Use $improve-code-complexity"

--- a/plugins/lisa-rails/skills/improve-max-lines-per-function/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/improve-max-lines-per-function/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-max-lines-per-function"
+short_description: "This skill should be used when reducing the maximum lines per method threshold and fixing all violations. It updates the RuboCop configuration, identifies methods exceeding the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to split oversized methods."
+default_prompt:
+  - "Use $improve-max-lines-per-function"

--- a/plugins/lisa-rails/skills/improve-max-lines/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/improve-max-lines/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-max-lines"
+short_description: "This skill should be used when reducing the maximum class/module lines threshold and fixing all violations. It updates the RuboCop configuration, identifies classes and modules exceeding the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to split oversized files."
+default_prompt:
+  - "Use $improve-max-lines"

--- a/plugins/lisa-rails/skills/improve-test-coverage/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/improve-test-coverage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-test-coverage"
+short_description: "This skill should be used when increasing test coverage to a specified threshold percentage. It runs the test suite with SimpleCov, identifies files with the lowest coverage, generates a brief with coverage gaps, and creates a plan with tasks to add the missing tests."
+default_prompt:
+  - "Use $improve-test-coverage"

--- a/plugins/lisa-rails/skills/jira-add-journey/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/jira-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-add-journey"
+short_description: "Add a Validation Journey section to an existing JIRA ticket by reading the ticket description, understanding the feature, and generating the journey steps and assertions."
+default_prompt:
+  - "Use $jira-add-journey"

--- a/plugins/lisa-rails/skills/jira-create/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/jira-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-create"
+short_description: "This skill should be used when creating JIRA epics, stories, and tasks from code files or descriptions. It analyzes the provided input, determines the appropriate issue hierarchy, and creates issues with comprehensive quality requirements including test-first development and documentation."
+default_prompt:
+  - "Use $jira-create"

--- a/plugins/lisa-rails/skills/jira-evidence/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/jira-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-evidence"
+short_description: "Upload evidence to GitHub pr-assets release, update PR description, upload attachments to JIRA, post comment, and move ticket to Code Review. Reusable by any skill that captures evidence and generates evidence/comment.txt + evidence/comment.md."
+default_prompt:
+  - "Use $jira-evidence"

--- a/plugins/lisa-rails/skills/jira-journey/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/jira-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-journey"
+short_description: "Parse a JIRA ticket's Validation Journey section, execute the verification steps, capture evidence, and post to JIRA + GitHub PR using the jira-evidence skill."
+default_prompt:
+  - "Use $jira-journey"

--- a/plugins/lisa-rails/skills/jira-verify/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/jira-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-verify"
+short_description: "This skill should be used when verifying that a JIRA ticket meets organizational standards for epic relationships and description quality. It fetches the live ticket and delegates the gate checks to jira-validate-ticket so the bar matches what jira-write-ticket enforces pre-write."
+default_prompt:
+  - "Use $jira-verify"

--- a/plugins/lisa-rails/skills/ops-check-logs/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/ops-check-logs/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-check-logs"
+short_description: "Check application logs from local Docker Compose or remote AWS CloudWatch for Rails applications. Supports log tailing, filtering, and error searching."
+default_prompt:
+  - "Use $ops-check-logs"

--- a/plugins/lisa-rails/skills/ops-deploy/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/ops-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-deploy"
+short_description: "Deploy Rails applications via Kamal or CI/CD branch push to staging or production environments."
+default_prompt:
+  - "Use $ops-deploy"

--- a/plugins/lisa-rails/skills/ops-run-local/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/ops-run-local/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-run-local"
+short_description: "Manage the local Docker Compose development environment for Rails applications. Supports start, stop, restart, and status for the full stack or individual services."
+default_prompt:
+  - "Use $ops-run-local"

--- a/plugins/lisa-rails/skills/ops-verify-jobs/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/ops-verify-jobs/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-verify-jobs"
+short_description: "Verify Solid Queue background jobs are running in Rails applications. Check worker health, queue depth, failed jobs, recurring job execution, and retry stuck jobs."
+default_prompt:
+  - "Use $ops-verify-jobs"

--- a/plugins/lisa-rails/skills/ops-verify-telemetry/agents/openai.yaml
+++ b/plugins/lisa-rails/skills/ops-verify-telemetry/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ops-verify-telemetry"
+short_description: "Verify OpenTelemetry traces are being collected and exported to AWS X-Ray for Rails applications. Check collector health, trace export, and CloudWatch metrics."
+default_prompt:
+  - "Use $ops-verify-telemetry"

--- a/plugins/lisa-wiki/skills/lisa-wiki-add-ingest/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-add-ingest/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-add-ingest"
+short_description: "Scaffold a project-specific \"front-door\" ingest skill that does something unique (classify a source, fetch from a special system, stamp domain frontmatter) and then chains into /ingest. Use when a project needs a bespoke ingestion path that the core connectors do not cover — instead of forking the kernel. The generated skill enriches and delegates; the kernel still owns synthesis, index, log, verify, state, and PR."
+default_prompt:
+  - "Use $lisa-wiki-add-ingest"

--- a/plugins/lisa-wiki/skills/lisa-wiki-add-role/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-add-role/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-add-role"
+short_description: "Scaffold a domain-expert \"digital staff\" role over the wiki — a dual-runtime subagent (Claude + Codex) plus a staff doc page — from a config.staff[] entry. Use when a project wants a role-scoped expert (e.g. Legal, Finance, Sales) whose knowledge is a slice of the wiki. The plugin only SETS UP the subagent; whether it is ever invoked, scheduled, or routed is out of scope."
+default_prompt:
+  - "Use $lisa-wiki-add-role"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-confluence/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-confluence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-confluence"
+short_description: "Produce sanitized Confluence source notes for lisa-wiki ingest via the Atlassian MCP. Use only when lisa-wiki-ingest routes to the confluence connector. Read-only; tenant-guarded."
+default_prompt:
+  - "Use $lisa-wiki-connector-confluence"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-docs/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-docs"
+short_description: "Ingest a local document (PDF, DOCX, Markdown, text) into a sanitized source note for lisa-wiki ingest. Use only when lisa-wiki-ingest routes to the docs connector (a file-path input). Uses available local converters; no heavy bundled dependency."
+default_prompt:
+  - "Use $lisa-wiki-connector-docs"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-git/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-git/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-git"
+short_description: "Produce sanitized git/PR-history source notes for lisa-wiki ingest. Use only when lisa-wiki-ingest routes to the git connector (self repo or a registered project). Read-only — never checks out, fetches, or mutates the target repo."
+default_prompt:
+  - "Use $lisa-wiki-connector-git"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-jira/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-jira/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-jira"
+short_description: "Produce sanitized JIRA source notes for lisa-wiki ingest via the Atlassian MCP. Use only when lisa-wiki-ingest routes to the jira connector. Read-only; tenant-guarded."
+default_prompt:
+  - "Use $lisa-wiki-connector-jira"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-memory/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-memory"
+short_description: "Ingest the agent's PROJECT-SCOPED memory into a sanitized source note. Use only when lisa-wiki-ingest routes to the memory connector. NEVER ingests global or unrelated memory — global Codex memory and the Chronicle store are refused."
+default_prompt:
+  - "Use $lisa-wiki-connector-memory"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-notion/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-notion/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-notion"
+short_description: "Produce sanitized Notion source notes for lisa-wiki ingest via the Notion MCP. Use only when lisa-wiki-ingest routes to the notion connector. Read-only; teamspace-guarded."
+default_prompt:
+  - "Use $lisa-wiki-connector-notion"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-roles/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-roles/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-roles"
+short_description: "Ingest the wiki's own digital-staff roster (config.staff[] + wiki/staff/*) into a sanitized source note. Use only when lisa-wiki-ingest routes to the roles connector. Does not run any subagent."
+default_prompt:
+  - "Use $lisa-wiki-connector-roles"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-slack/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-slack/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-slack"
+short_description: "Ingest a Slack channel into sanitized source notes via a user token. Use only when lisa-wiki-ingest routes to the slack connector AND the run carries explicit external-write intent (Slack OAuth opens a browser and stores a token file). Centralized stdlib-Python scripts; secrets are redacted."
+default_prompt:
+  - "Use $lisa-wiki-connector-slack"

--- a/plugins/lisa-wiki/skills/lisa-wiki-connector-web/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-connector-web/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-connector-web"
+short_description: "Ingest a public URL into a sanitized source note for lisa-wiki ingest (via WebFetch). Use only when lisa-wiki-ingest routes to the web connector (a URL input). Read-only."
+default_prompt:
+  - "Use $lisa-wiki-connector-web"

--- a/plugins/lisa-wiki/skills/lisa-wiki-doctor/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-doctor/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-doctor"
+short_description: "Verify that a wiki is correctly set up and (after migration) fully functional. Runs the deterministic checks plus functional smoke tests, writes a doctor report, and returns an overall verdict. Use as the final gate of /migrate, after /setup, or anytime to confirm wiki health. A repo is not \"migrated\" until its doctor verdict is READY."
+default_prompt:
+  - "Use $lisa-wiki-doctor"

--- a/plugins/lisa-wiki/skills/lisa-wiki-ingest/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-ingest/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-ingest"
+short_description: "Ingest source material into the LLM Wiki. With an argument (URL, file path, or prompt) it ingests that one source; with no argument it runs a full ingest across every enabled non-external-write source. Routes to the right connector, then runs the ordered pipeline (source note → synthesis → index → log → verify → state → commit/PR). Use whenever new knowledge should enter the wiki."
+default_prompt:
+  - "Use $lisa-wiki-ingest"

--- a/plugins/lisa-wiki/skills/lisa-wiki-lint/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-lint/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-lint"
+short_description: "Health-check the LLM Wiki. Reports orphan pages, contradictions, stale claims, broken internal links, missing index/log coverage, structure-manifest violations, and secret/tenant leaks. Use periodically or before hardening a wiki. Read-only — it reports findings, it does not fix them."
+default_prompt:
+  - "Use $lisa-wiki-lint"

--- a/plugins/lisa-wiki/skills/lisa-wiki-migrate/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-migrate/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-migrate"
+short_description: "Migrate an existing, hand-rolled wiki implementation onto the lisa-wiki kernel — phased and compatibility-first, with a strict no-loss guarantee. Use when adopting lisa-wiki in a repo that already has its own wiki/, ingest skills, docs, or roles. Renaming things into the canonical shape is fine; losing functionality or data is not. Ends by running /doctor."
+default_prompt:
+  - "Use $lisa-wiki-migrate"

--- a/plugins/lisa-wiki/skills/lisa-wiki-onboard-me/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-onboard-me/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-onboard-me"
+short_description: "Onboard a user to the project via its LLM Wiki. Interviews the user about themselves in relation to the project, captures that to project-scoped memory only, then gives a guided tour of what the project is and sample questions they can ask. Use when someone is new to the project or asks to be onboarded. Read-mostly — it does not open PRs or write PII into the wiki."
+default_prompt:
+  - "Use $lisa-wiki-onboard-me"

--- a/plugins/lisa-wiki/skills/lisa-wiki-query/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-query/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-query"
+short_description: "Answer a question from the LLM Wiki with citations. Reads the index, drills into relevant pages, and synthesizes a cited answer. Read-only by default; only files new synthesis back into the wiki when the user explicitly asks. Use when someone asks a question the wiki should be able to answer, or wants to explore what the wiki knows."
+default_prompt:
+  - "Use $lisa-wiki-query"

--- a/plugins/lisa-wiki/skills/lisa-wiki-setup/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-setup"
+short_description: "Scaffold, repair, verify, or upgrade a project's LLM Wiki from its config. Use when setting up the wiki in a new repo, fixing a broken/incomplete structure, or upgrading to a newer kernel version. Asks the wiki's purpose and README mode, renders the contract snapshot, scaffolds the canonical folders, and seeds the staff roster. Idempotent and non-destructive."
+default_prompt:
+  - "Use $lisa-wiki-setup"

--- a/plugins/lisa-wiki/skills/lisa-wiki-usage/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-usage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-wiki-usage"
+short_description: "Explain how to browse, query, and contribute to this project's LLM Wiki. Use when a user asks how the wiki works, where knowledge lives, how to find something, or how to add to it — the read/navigation path, not an ingestion or write workflow."
+default_prompt:
+  - "Use $lisa-wiki-usage"

--- a/plugins/lisa/skills/acceptance-criteria/agents/openai.yaml
+++ b/plugins/lisa/skills/acceptance-criteria/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "acceptance-criteria"
+short_description: "Acceptance criteria definition. Gherkin user flows (Given/When/Then), error states, UX concerns, and empirical verification from the user perspective."
+default_prompt:
+  - "Use $acceptance-criteria"

--- a/plugins/lisa/skills/agent-design-best-practices/agents/openai.yaml
+++ b/plugins/lisa/skills/agent-design-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "agent-design-best-practices"
+short_description: "Best practices for designing Claude Code agent files (.claude/agents/*.md). This skill should be used when writing or reviewing agent markdown files to ensure proper design with focused domains, correct tool access, reusable definitions, and separation of capabilities from lifecycle. Combines Anthropic's official guidance with battle-tested patterns from agent team usage."
+default_prompt:
+  - "Use $agent-design-best-practices"

--- a/plugins/lisa/skills/atlassian-access/agents/openai.yaml
+++ b/plugins/lisa/skills/atlassian-access/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "atlassian-access"
+short_description: "Vendor-neutral access layer for Atlassian (JIRA + Confluence). Every jira-* and confluence-* skill MUST delegate through this skill rather than calling Atlassian directly. Resolves a substrate per operation in this order: (1) acli if installed and its active profile matches the configured site, (2) Atlassian MCP if authenticated and the configured cloudId is in its accessible resources, (3) curl + API-token Basic auth. Verifies the active connection matches `.lisa.config.json` before every operation — substrates authenticated as a different Atlassian account are skipped, not used."
+default_prompt:
+  - "Use $atlassian-access"

--- a/plugins/lisa/skills/bug-triage/agents/openai.yaml
+++ b/plugins/lisa/skills/bug-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "bug-triage"
+short_description: "8-step bug triage and implementation workflow. Ensures bugs are reproducible, root-caused, and fixable before implementation begins."
+default_prompt:
+  - "Use $bug-triage"

--- a/plugins/lisa/skills/codebase-research/agents/openai.yaml
+++ b/plugins/lisa/skills/codebase-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "codebase-research"
+short_description: "Codebase exploration and architecture analysis. Read files, trace data flow, identify modification points, map dependencies, find reusable code, evaluate design patterns."
+default_prompt:
+  - "Use $codebase-research"

--- a/plugins/lisa/skills/codify-verification/agents/openai.yaml
+++ b/plugins/lisa/skills/codify-verification/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "codify-verification"
+short_description: "Convert empirical verification into a regression test so it never has to be re-proven manually. Runs after a verification passes — picks the appropriate test framework for the verification type (Playwright for UI/browser, integration test for API/DB/auth, benchmark for performance, etc.), generates the test, wires it into the project's test runner, and confirms it executes. Mandatory step in the verification lifecycle and in the Build/Fix/Improve flows."
+default_prompt:
+  - "Use $codify-verification"

--- a/plugins/lisa/skills/confluence-prd-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/confluence-prd-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "confluence-prd-intake"
+short_description: "Scans a Confluence space (or a parent page) for PRD pages currently parented under the configured `ready` lifecycle page and runs each one through the dry-run validation pipeline. PRDs that pass every gate get tickets written and are re-parented under the `ticketed` lifecycle page; PRDs that fail get clarifying-question comments and are re-parented under the `blocked` lifecycle page. Confluence counterpart of `lisa:notion-prd-intake` — the workflow is identical; only the source-of-truth tools and the state encoding differ (parent-page re-parenting instead of a status property). Composes existing skills (confluence-to-tracker, tracker-validate, tracker-source-artifacts, product-walkthrough)."
+default_prompt:
+  - "Use $confluence-prd-intake"

--- a/plugins/lisa/skills/confluence-to-tracker/agents/openai.yaml
+++ b/plugins/lisa/skills/confluence-to-tracker/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "confluence-to-tracker"
+short_description: ">"
+default_prompt:
+  - "Use $confluence-to-tracker"

--- a/plugins/lisa/skills/debrief-apply/agents/openai.yaml
+++ b/plugins/lisa/skills/debrief-apply/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "debrief-apply"
+short_description: "Apply human-marked dispositions from a Debrief triage document. Reads the triage doc produced by lisa:debrief, parses each row's disposition (Accept / Reject / Defer), and routes Accepted items to their persistence destination. Deterministic and idempotent — safe to re-run if dispositions are added incrementally."
+default_prompt:
+  - "Use $debrief-apply"

--- a/plugins/lisa/skills/debrief/agents/openai.yaml
+++ b/plugins/lisa/skills/debrief/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "debrief"
+short_description: "Run the Debrief flow over a shipped initiative. Input: a PRD URL (Notion / Confluence / Linear / GitHub Issue / file), a JIRA epic key, or a GitHub epic issue URL. Output: a triage-ready learnings document covering every work item in the initiative — edge cases, gotchas, process friction, tooling gaps, convention drift — each with structured evidence and a human-disposition field. Persistence is deferred to lisa:debrief-apply."
+default_prompt:
+  - "Use $debrief"

--- a/plugins/lisa/skills/epic-triage/agents/openai.yaml
+++ b/plugins/lisa/skills/epic-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "epic-triage"
+short_description: "9-step epic triage and 5-step implementation workflow. Ensures epics are fully scoped, broken down, and ordered before execution begins."
+default_prompt:
+  - "Use $epic-triage"

--- a/plugins/lisa/skills/fix-linter-error/agents/openai.yaml
+++ b/plugins/lisa/skills/fix-linter-error/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "fix-linter-error"
+short_description: "This skill should be used when fixing all violations of one or more ESLint rules across the codebase. It runs the linter, groups violations by rule and file, generates a brief with fix strategies, and creates a plan with tasks to implement the fixes."
+default_prompt:
+  - "Use $fix-linter-error"

--- a/plugins/lisa/skills/git-commit/agents/openai.yaml
+++ b/plugins/lisa/skills/git-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "git-commit"
+short_description: "This skill should be used when creating conventional commits for current changes. It groups related changes into logical commits, ensures all files are committed, and verifies the working directory is clean afterward."
+default_prompt:
+  - "Use $git-commit"

--- a/plugins/lisa/skills/git-prune/agents/openai.yaml
+++ b/plugins/lisa/skills/git-prune/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "git-prune"
+short_description: "This skill should be used when pruning local branches that have been deleted on the remote. It fetches remote changes, identifies stale local branches, and safely deletes them."
+default_prompt:
+  - "Use $git-prune"

--- a/plugins/lisa/skills/git-submit-pr/agents/openai.yaml
+++ b/plugins/lisa/skills/git-submit-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "git-submit-pr"
+short_description: "This skill should be used when pushing changes and creating or updating a pull request. It verifies the branch state, pushes to remote, creates or updates a PR with a comprehensive description, and enables auto-merge."
+default_prompt:
+  - "Use $git-submit-pr"

--- a/plugins/lisa/skills/github-add-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/github-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-add-journey"
+short_description: "Add a Validation Journey section to an existing GitHub Issue by analyzing the change type and generating appropriate verification steps with evidence markers. The GitHub counterpart of lisa:jira-add-journey."
+default_prompt:
+  - "Use $github-add-journey"

--- a/plugins/lisa/skills/github-build-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/github-build-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-build-intake"
+short_description: "GitHub counterpart to lisa:jira-build-intake. Scans a GitHub repository for issues carrying the configured `ready` build label, claims each leaf work unit by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:github-agent, and relabels to the configured `done` label on completion. Enforces the claim-time arm of the `leaf-only-lifecycle` rule: a parent/container with open child work (or a childless Epic/Story/Spike) that still carries a stale build-ready label is skipped or safe-blocked with a lifecycle-repair comment, never claimed. The `ready` label is the human-flipped signal that an issue is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
+default_prompt:
+  - "Use $github-build-intake"

--- a/plugins/lisa/skills/github-create/agents/openai.yaml
+++ b/plugins/lisa/skills/github-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-create"
+short_description: "This skill should be used when creating GitHub Issue Epics, Stories, and Sub-tasks from code files or descriptions. It analyzes the provided input, determines the appropriate issue hierarchy, and creates issues with comprehensive quality requirements including test-first development and documentation. The GitHub counterpart of lisa:jira-create."
+default_prompt:
+  - "Use $github-create"

--- a/plugins/lisa/skills/github-evidence/agents/openai.yaml
+++ b/plugins/lisa/skills/github-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-evidence"
+short_description: "Upload text evidence to the GitHub `pr-assets` release, update PR description, post a GitHub Issue comment with code blocks, and relabel the issue to the configured `review` label (default `status:code-review`). Reusable by any skill that captures evidence and generates evidence/comment.md (and optionally evidence/comment.txt). The GitHub counterpart of lisa:jira-evidence."
+default_prompt:
+  - "Use $github-evidence"

--- a/plugins/lisa/skills/github-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/github-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-journey"
+short_description: "Parse a GitHub Issue's Validation Journey section, execute the verification steps using appropriate tools (curl, test commands, database queries), capture evidence at each marker, and post results via lisa:github-evidence. The GitHub counterpart of lisa:jira-journey."
+default_prompt:
+  - "Use $github-journey"

--- a/plugins/lisa/skills/github-prd-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/github-prd-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-prd-intake"
+short_description: "Scans a GitHub repository for issues carrying the configured `ready` PRD label and runs each one through the dry-run validation pipeline. PRDs that pass every gate get tickets written (to whatever destination tracker is configured — JIRA, GitHub Issues itself, or Linear) and the label flipped to the configured `ticketed` label; PRDs that fail get clarifying-question comments and the label flipped to the configured `blocked` label. The GitHub counterpart of lisa:notion-prd-intake / lisa:confluence-prd-intake / lisa:linear-prd-intake. Composes existing skills (github-to-tracker, tracker-validate, tracker-source-artifacts, product-walkthrough)."
+default_prompt:
+  - "Use $github-prd-intake"

--- a/plugins/lisa/skills/github-read-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/github-read-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-read-issue"
+short_description: "Fetches the full scope of a GitHub Issue — metadata, body sections, all comments, native sub-issue parent and children, linked PRs, related issues parsed from `Blocks/Blocked by/Relates to/Duplicates/Cloned from` lines, and any cross-repo references. Produces a consolidated context bundle that downstream agents consume so they never act on an issue in isolation. The GitHub counterpart of lisa:jira-read-ticket."
+default_prompt:
+  - "Use $github-read-issue"

--- a/plugins/lisa/skills/github-sync/agents/openai.yaml
+++ b/plugins/lisa/skills/github-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-sync"
+short_description: "Syncs plan progress to a linked GitHub Issue. Posts plan contents, progress updates, branch links, and PR links at key milestones. Use this skill throughout the plan lifecycle to keep issues in sync. The GitHub counterpart of lisa:jira-sync."
+default_prompt:
+  - "Use $github-sync"

--- a/plugins/lisa/skills/github-to-tracker/agents/openai.yaml
+++ b/plugins/lisa/skills/github-to-tracker/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-to-tracker"
+short_description: ">"
+default_prompt:
+  - "Use $github-to-tracker"

--- a/plugins/lisa/skills/github-validate-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/github-validate-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-validate-issue"
+short_description: "Validates a proposed GitHub Issue spec (or an existing issue) against the organizational quality gates without writing anything. Returns a structured PASS/FAIL report per gate with concrete remediation. The GitHub counterpart of lisa:jira-validate-ticket — same gate definitions, translated to the GitHub Issues data model. Single source of truth for what makes a valid GitHub Issue. Both the write path (github-write-issue runs it pre-write) and the dry-run path (github-to-tracker runs it during PRD intake) call this skill."
+default_prompt:
+  - "Use $github-validate-issue"

--- a/plugins/lisa/skills/github-verify/agents/openai.yaml
+++ b/plugins/lisa/skills/github-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-verify"
+short_description: "This skill should be used when verifying that a GitHub Issue meets organizational standards for parent-sub-issue relationships and description quality. It fetches the live issue and delegates the gate checks to github-validate-issue so the bar matches what github-write-issue enforces pre-write. The GitHub counterpart of lisa:jira-verify."
+default_prompt:
+  - "Use $github-verify"

--- a/plugins/lisa/skills/github-write-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/github-write-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "github-write-issue"
+short_description: "Creates or updates a GitHub Issue following the same organizational best practices as lisa:jira-write-ticket — three-audience description, Gherkin acceptance criteria, parent sub-issue (Epic/Story hierarchy), explicit relationship discovery, remote links, labels for status/components/priority/story-points, and Validation Journey. Uses the `gh` CLI exclusively (no MCP). Rejects thin issues. The GitHub counterpart of lisa:jira-write-ticket."
+default_prompt:
+  - "Use $github-write-issue"

--- a/plugins/lisa/skills/implement/agents/openai.yaml
+++ b/plugins/lisa/skills/implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "implement"
+short_description: "This skill should be used for any non-trivial request — features, bugs, stories, epics, spikes, or multi-step tasks. It accepts a ticket URL (Jira, Linear, GitHub), a file path containing a spec, or a plain-text prompt. It assembles an agent team, breaks the work into structured tasks, and manages the full lifecycle from research through implementation, code review, deploy, and empirical verification."
+default_prompt:
+  - "Use $implement"

--- a/plugins/lisa/skills/improve-code-complexity/agents/openai.yaml
+++ b/plugins/lisa/skills/improve-code-complexity/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-code-complexity"
+short_description: "This skill should be used when reducing the cognitive complexity threshold of the codebase. It lowers the threshold by 2, identifies functions that exceed the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to fix all violations."
+default_prompt:
+  - "Use $improve-code-complexity"

--- a/plugins/lisa/skills/improve-max-lines-per-function/agents/openai.yaml
+++ b/plugins/lisa/skills/improve-max-lines-per-function/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-max-lines-per-function"
+short_description: "This skill should be used when reducing the maximum lines per function threshold and fixing all violations. It updates the eslint threshold configuration, identifies functions exceeding the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to split oversized functions."
+default_prompt:
+  - "Use $improve-max-lines-per-function"

--- a/plugins/lisa/skills/improve-max-lines/agents/openai.yaml
+++ b/plugins/lisa/skills/improve-max-lines/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-max-lines"
+short_description: "This skill should be used when reducing the maximum file lines threshold and fixing all violations. It updates the eslint threshold configuration, identifies files exceeding the new limit, generates a brief with refactoring strategies, and creates a plan with tasks to split oversized files."
+default_prompt:
+  - "Use $improve-max-lines"

--- a/plugins/lisa/skills/improve-test-coverage/agents/openai.yaml
+++ b/plugins/lisa/skills/improve-test-coverage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-test-coverage"
+short_description: "This skill should be used when increasing test coverage to a specified threshold percentage. It runs the coverage report, identifies files with the lowest coverage, generates a brief with coverage gaps, and creates a plan with tasks to add the missing tests."
+default_prompt:
+  - "Use $improve-test-coverage"

--- a/plugins/lisa/skills/improve-tests/agents/openai.yaml
+++ b/plugins/lisa/skills/improve-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "improve-tests"
+short_description: "This skill should be used when improving test quality. It scans the test suite for weak, brittle, or poorly-written tests, generates a brief with improvement opportunities, and creates a plan with tasks to strengthen the tests."
+default_prompt:
+  - "Use $improve-tests"

--- a/plugins/lisa/skills/intake/agents/openai.yaml
+++ b/plugins/lisa/skills/intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "intake"
+short_description: "Vendor-agnostic batch scanner for Ready queues. Given a Notion PRD database URL → finds Ready PRDs and runs lisa:plan per item. Given a Confluence space or parent page URL → finds prd-ready PRDs and runs lisa:plan per item. Given a Linear workspace URL or team key → finds prd-ready Linear projects and runs lisa:plan per item. Given a GitHub repo URL or `org/repo` token → finds prd-ready GitHub issues and runs lisa:plan per item. Given a JIRA project key or JQL filter → finds Ready tickets and runs lisa:implement per item. Given a GitHub repo URL or `org/repo` token when `tracker = github` → finds `status:ready` issues and runs lisa:implement per item. Designed as the cron target for /schedule — one cycle per invocation, processes everything currently Ready, exits cleanly on empty. Symmetric counterpart to the single-item lisa:plan and lisa:implement skills."
+default_prompt:
+  - "Use $intake"

--- a/plugins/lisa/skills/jira-add-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-add-journey"
+short_description: "Add a Validation Journey section to an existing JIRA ticket by analyzing the change type and generating appropriate verification steps with evidence markers."
+default_prompt:
+  - "Use $jira-add-journey"

--- a/plugins/lisa/skills/jira-build-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-build-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-build-intake"
+short_description: "Symmetric counterpart to notion-prd-intake on the JIRA side. Scans a JIRA project (or JQL filter) for tickets in the configured `ready` status, claims each by transitioning to the configured `claimed` status, runs the implementation/build flow via jira-agent, and transitions to the configured `done` status on completion. Enforces the claim-time arm of the `leaf-only-lifecycle` rule: a parent/container with open child work (or a childless Epic/Story/Spike) that still carries a stale build-ready status is skipped or safe-blocked with a lifecycle-repair comment, never claimed. The `ready` status is the human-flipped signal that a TODO ticket is truly ready for development — mirroring how Notion PRDs work product Draft → Ready → (us) In Review → Blocked|Ticketed."
+default_prompt:
+  - "Use $jira-build-intake"

--- a/plugins/lisa/skills/jira-create/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-create"
+short_description: "This skill should be used when creating JIRA epics, stories, and tasks from code files or descriptions. It analyzes the provided input, determines the appropriate issue hierarchy, and creates issues with comprehensive quality requirements including test-first development and documentation."
+default_prompt:
+  - "Use $jira-create"

--- a/plugins/lisa/skills/jira-evidence/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-evidence"
+short_description: "Upload text evidence to GitHub pr-assets release, update PR description, post JIRA comment with code blocks, and move ticket to the configured code-review status. Reusable by any skill that captures evidence and generates evidence/comment.txt + evidence/comment.md."
+default_prompt:
+  - "Use $jira-evidence"

--- a/plugins/lisa/skills/jira-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-journey"
+short_description: "Parse a JIRA ticket's Validation Journey section, execute the verification steps using appropriate tools (curl, test commands, database queries), capture evidence, and post to JIRA + GitHub PR using the jira-evidence skill."
+default_prompt:
+  - "Use $jira-journey"

--- a/plugins/lisa/skills/jira-read-ticket/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-read-ticket/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-read-ticket"
+short_description: "Fetches the full scope of a JIRA ticket — metadata, description, acceptance criteria, all comments, remote links (PRs, Confluence, dashboards), issue links (blocks/is blocked by/relates to/duplicates/clones), epic parent with siblings, and subtasks. Produces a consolidated context bundle that downstream agents consume so they never act on a single ticket in isolation."
+default_prompt:
+  - "Use $jira-read-ticket"

--- a/plugins/lisa/skills/jira-sync/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-sync"
+short_description: "Syncs plan progress to a linked JIRA ticket. Posts plan contents, progress updates, branch links, and PR links at key milestones. Use this skill throughout the plan lifecycle to keep tickets in sync."
+default_prompt:
+  - "Use $jira-sync"

--- a/plugins/lisa/skills/jira-validate-ticket/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-validate-ticket/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-validate-ticket"
+short_description: "Validates a proposed JIRA ticket spec (or an existing ticket) against the organizational quality gates without writing anything. Returns a structured PASS/FAIL report per gate with concrete remediation. This is the single source of truth for what makes a valid ticket — both the write path (jira-write-ticket runs it pre-write) and the dry-run path (notion-to-tracker runs it during PRD intake) call this skill so the bar can never drift."
+default_prompt:
+  - "Use $jira-validate-ticket"

--- a/plugins/lisa/skills/jira-verify/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-verify"
+short_description: "This skill should be used when verifying that a JIRA ticket meets organizational standards for epic relationships and description quality. It fetches the live ticket and delegates the gate checks to jira-validate-ticket so the bar matches what jira-write-ticket enforces pre-write."
+default_prompt:
+  - "Use $jira-verify"

--- a/plugins/lisa/skills/jira-write-ticket/agents/openai.yaml
+++ b/plugins/lisa/skills/jira-write-ticket/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jira-write-ticket"
+short_description: "Creates or updates a JIRA ticket following organizational best practices. Enforces description quality (coding assistant / developer / stakeholder sections), Gherkin acceptance criteria, epic parent relationship, explicit link discovery (blocks / is blocked by / relates to / duplicates / clones), remote links (PRs, Confluence, dashboards), labels, components, fix version, priority, story points, and Validation Journey. Rejects thin tickets — use this skill any time a ticket is created or significantly edited."
+default_prompt:
+  - "Use $jira-write-ticket"

--- a/plugins/lisa/skills/jsdoc-best-practices/agents/openai.yaml
+++ b/plugins/lisa/skills/jsdoc-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "jsdoc-best-practices"
+short_description: "Enforces JSDoc documentation standards for this TypeScript project. This skill should be used when writing or reviewing TypeScript code to ensure proper documentation with file preambles, function docs, interface docs, and the critical distinction between documenting \"what\" vs \"why\". Use this skill to understand the project's JSDoc ESLint rules and established patterns."
+default_prompt:
+  - "Use $jsdoc-best-practices"

--- a/plugins/lisa/skills/linear-add-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-add-journey"
+short_description: "Add a Validation Journey section to an existing Linear Issue by analyzing the change type and generating appropriate verification steps with evidence markers. Linear counterpart of lisa:jira-add-journey."
+default_prompt:
+  - "Use $linear-add-journey"

--- a/plugins/lisa/skills/linear-build-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-build-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-build-intake"
+short_description: "Symmetric counterpart to lisa:jira-build-intake on the Linear side. Scans a Linear team for Issues carrying the configured `ready` build label, claims each by relabeling to the configured `claimed` label, runs the implementation/build flow via lisa:linear-agent, and relabels to the configured `done` label on completion. Enforces the claim-time arm of the `leaf-only-lifecycle` rule: a parent/container with open child work (or a childless Epic/Story/Spike) that still carries a stale build-ready label is skipped or safe-blocked with a lifecycle-repair comment, never claimed. The `ready` label is the human-flipped signal that an Issue is truly ready for development — mirroring how Notion PRDs work Draft → Ready → (us) In Review → Blocked|Ticketed."
+default_prompt:
+  - "Use $linear-build-intake"

--- a/plugins/lisa/skills/linear-create/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-create"
+short_description: "Creates Linear Projects (Epic-equivalent), Issues (Story / Task / Bug / Spike), and sub-Issues (Sub-task) from code files or descriptions. Analyzes the input, determines the appropriate hierarchy, and creates items with comprehensive quality requirements including test-first development and Validation Journey. The Linear counterpart of lisa:jira-create — delegates every write to lisa:linear-write-issue."
+default_prompt:
+  - "Use $linear-create"

--- a/plugins/lisa/skills/linear-evidence/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-evidence"
+short_description: "Uploads text evidence to the GitHub `pr-assets` release, updates the PR description, posts a comment on the originating Linear Issue with code blocks, and transitions the Issue from the configured `claimed` label to the configured `review` label. Reusable by any skill that captures evidence and generates evidence/comment.txt + evidence/code-blocks.md. Linear counterpart of lisa:jira-evidence and lisa:github-evidence."
+default_prompt:
+  - "Use $linear-evidence"

--- a/plugins/lisa/skills/linear-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-journey"
+short_description: "Parse a Linear Issue's Validation Journey section, execute the verification steps using appropriate tools (curl, test commands, database queries, Playwright), capture evidence at each [EVIDENCE: name] marker, and post to Linear + GitHub PR using the linear-evidence skill. Linear counterpart of lisa:jira-journey."
+default_prompt:
+  - "Use $linear-journey"

--- a/plugins/lisa/skills/linear-prd-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-prd-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-prd-intake"
+short_description: "Scans a Linear workspace (or a specific team) for projects carrying the configured `ready` PRD label and runs each one through the dry-run validation pipeline. Projects that pass every gate get tickets written and the label flipped to the configured `ticketed` label; projects that fail get clarifying-question comments (on a sentinel feedback issue under the project) and the label flipped to the configured `blocked` label. Linear counterpart of `lisa:notion-prd-intake` and `lisa:confluence-prd-intake` — the workflow is identical; only the source-of-truth tools differ. Composes existing skills (linear-to-tracker, tracker-validate, tracker-source-artifacts, product-walkthrough)."
+default_prompt:
+  - "Use $linear-prd-intake"

--- a/plugins/lisa/skills/linear-read-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-read-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-read-issue"
+short_description: "Fetches the full scope of a Linear work item — Issue or Project — including metadata, description, acceptance criteria, all comments, attachments, native relations (blocks/blocked_by/relates_to/duplicates), Project parent (if any) with siblings, and sub-Issues. Produces a consolidated context bundle that downstream agents consume so they never act on a single item in isolation."
+default_prompt:
+  - "Use $linear-read-issue"

--- a/plugins/lisa/skills/linear-sync/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-sync"
+short_description: "Syncs plan progress to a linked Linear Issue. Posts plan contents, progress updates, branch links, and PR links at key milestones. Use this skill throughout the plan lifecycle to keep Linear Issues in sync. The Linear counterpart of lisa:jira-sync and lisa:github-sync."
+default_prompt:
+  - "Use $linear-sync"

--- a/plugins/lisa/skills/linear-to-tracker/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-to-tracker/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-to-tracker"
+short_description: ">"
+default_prompt:
+  - "Use $linear-to-tracker"

--- a/plugins/lisa/skills/linear-validate-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-validate-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-validate-issue"
+short_description: "Validates a proposed Linear work item spec (Project, Issue, or sub-Issue) — or an existing Linear item — against the organizational quality gates without writing anything. Returns a structured PASS/FAIL report per gate with concrete remediation. Single source of truth for what makes a valid Linear item — both the write path (linear-write-issue runs it pre-write) and the dry-run path (linear-to-tracker runs it during PRD intake) call this skill so the bar can never drift."
+default_prompt:
+  - "Use $linear-validate-issue"

--- a/plugins/lisa/skills/linear-verify/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-verify"
+short_description: "Verifies a Linear work item meets organizational standards by fetching the live item and running it through lisa:linear-validate-issue. Catches anything dropped or reformatted on write — same gates as the pre-write check, but applied to what Linear actually stored. Read-only."
+default_prompt:
+  - "Use $linear-verify"

--- a/plugins/lisa/skills/linear-write-issue/agents/openai.yaml
+++ b/plugins/lisa/skills/linear-write-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "linear-write-issue"
+short_description: "Creates or updates a Linear work item — Project (Epic), Issue (Story), or sub-Issue (Sub-task) — following organizational best practices. Polymorphic: dispatches internally on issue_type to save_project (Epic) or save_issue (Story / Sub-task). Enforces description quality (three audiences), Gherkin acceptance criteria, project-as-parent for Stories, parentId for Sub-tasks, explicit relationship discovery (blocks / is blocked by / relates to / duplicates), labels, components-as-labels, project milestones for fix versions, native priority and estimate fields, and Validation Journey. Rejects thin items — use this skill any time a Linear work item is created or significantly edited."
+default_prompt:
+  - "Use $linear-write-issue"

--- a/plugins/lisa/skills/lisa-review-implementation/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-review-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "lisa-review-implementation"
+short_description: "This skill should be used when comparing a project's Lisa-managed files against Lisa's source templates to identify drift. It reads the project manifest, locates source templates, generates diffs for drifted files, and offers to upstream improvements back to Lisa."
+default_prompt:
+  - "Use $lisa-review-implementation"

--- a/plugins/lisa/skills/monitor/agents/openai.yaml
+++ b/plugins/lisa/skills/monitor/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "monitor"
+short_description: "Monitor application health across environments. Checks health endpoints, recent logs (CloudWatch / Sentry / browser console), error-rate spikes, performance hotspots, pending migrations, and runs Playwright smoke flows when relevant. Routes to the stack-specific ops-specialist agent (Expo, Rails, etc.). Also invoked as the post-deploy step of the lisa:verify skill."
+default_prompt:
+  - "Use $monitor"

--- a/plugins/lisa/skills/nightly-add-test-coverage/agents/openai.yaml
+++ b/plugins/lisa/skills/nightly-add-test-coverage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "nightly-add-test-coverage"
+short_description: "Nightly direct-execution skill for increasing test coverage. Receives pre-computed threshold data, writes tests targeting coverage gaps, updates thresholds, commits, and creates a PR."
+default_prompt:
+  - "Use $nightly-add-test-coverage"

--- a/plugins/lisa/skills/nightly-improve-tests/agents/openai.yaml
+++ b/plugins/lisa/skills/nightly-improve-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "nightly-improve-tests"
+short_description: "Nightly direct-execution skill for improving test quality. In nightly mode, focuses on tests for recently changed files. In general mode, scans all tests for the weakest ones. Commits and creates a PR."
+default_prompt:
+  - "Use $nightly-improve-tests"

--- a/plugins/lisa/skills/nightly-lower-code-complexity/agents/openai.yaml
+++ b/plugins/lisa/skills/nightly-lower-code-complexity/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "nightly-lower-code-complexity"
+short_description: "Nightly direct-execution skill for reducing code complexity thresholds. Receives pre-computed threshold data, refactors violations, updates thresholds, commits, and creates a PR."
+default_prompt:
+  - "Use $nightly-lower-code-complexity"

--- a/plugins/lisa/skills/notion-access/agents/openai.yaml
+++ b/plugins/lisa/skills/notion-access/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "notion-access"
+short_description: "Vendor-neutral access layer for Notion. Every notion-* skill MUST delegate through this skill rather than invoking the Notion REST API or any Notion MCP directly. Resolves a substrate per operation in this order: (1) Notion MCP if authenticated and the configured prdDatabaseId is fetchable through it (identity-match), (2) curl + Bearer auth + internal-integration token. Verifies the active connection matches `.lisa.config.json` before every operation — substrates authenticated as a different Notion workspace are skipped, not used."
+default_prompt:
+  - "Use $notion-access"

--- a/plugins/lisa/skills/notion-prd-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/notion-prd-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "notion-prd-intake"
+short_description: "Scans a Notion PRD database for pages in the configured `ready` status and runs each one through the dry-run validation pipeline. PRDs that pass every gate get tickets written and the status flipped to the configured `ticketed` value; PRDs that fail get clarifying-question comments and the status flipped to the configured `blocked` value. The skill is the runtime for the ready → in_review → blocked|ticketed lifecycle. Composes existing skills (notion-to-tracker, tracker-validate, tracker-source-artifacts, product-walkthrough); does not reimplement their logic."
+default_prompt:
+  - "Use $notion-prd-intake"

--- a/plugins/lisa/skills/notion-to-tracker/agents/openai.yaml
+++ b/plugins/lisa/skills/notion-to-tracker/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "notion-to-tracker"
+short_description: ">"
+default_prompt:
+  - "Use $notion-to-tracker"

--- a/plugins/lisa/skills/performance-review/agents/openai.yaml
+++ b/plugins/lisa/skills/performance-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "performance-review"
+short_description: "Performance review methodology. N+1 queries, inefficient algorithms, memory leaks, missing indexes, unnecessary re-renders, bundle size issues. Evidence-based recommendations."
+default_prompt:
+  - "Use $performance-review"

--- a/plugins/lisa/skills/plan/agents/openai.yaml
+++ b/plugins/lisa/skills/plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "plan"
+short_description: "Decompose a single PRD or specification into ordered work items in the configured tracker. Vendor-agnostic — the source can be a Notion PRD URL, a Confluence PRD URL, a Linear project URL, a GitHub Issue URL, an existing JIRA epic key, a markdown file, or a free-form description; the destination tracker is whatever the project is configured to use via `.lisa.config.json` `tracker` (JIRA, GitHub Issues, or Linear). Single-PRD mode only — for batch scanning of all Ready PRDs in a queue, use the lisa:intake skill."
+default_prompt:
+  - "Use $plan"

--- a/plugins/lisa/skills/prd-backlink/agents/openai.yaml
+++ b/plugins/lisa/skills/prd-backlink/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "prd-backlink"
+short_description: "Update a source PRD with a `## Tickets` section linking back to every work item created from it. Vendor-aware on the source side (Notion / Confluence / Linear / GitHub Issue / file) and tracker-agnostic on the ticket side. Idempotent — regenerates the section on each run rather than appending, so re-planning never accumulates stale links. Invoked by the *-to-tracker skills at the end of their pipeline and standalone if a PRD's Tickets section needs to be refreshed."
+default_prompt:
+  - "Use $prd-backlink"

--- a/plugins/lisa/skills/prd-ticket-coverage/agents/openai.yaml
+++ b/plugins/lisa/skills/prd-ticket-coverage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "prd-ticket-coverage"
+short_description: "Verifies that every requirement in a PRD (Notion, Confluence, Linear, or GitHub Issues) is covered by at least one created destination ticket (JIRA, GitHub Issues, or Linear) — no silent drops. Parses the PRD into atomic items (goals, user stories, functional/non-functional requirements, acceptance criteria, important notes), maps each to the created tickets, and produces a coverage matrix and verdict (COMPLETE / COMPLETE_WITH_SCOPE_CREEP / GAPS_FOUND / NO_TICKETS_FOUND). Used by notion-prd-intake / confluence-prd-intake / linear-prd-intake / github-prd-intake post-write to gate the Ticketed transition; can also be invoked standalone for after-the-fact audits."
+default_prompt:
+  - "Use $prd-ticket-coverage"

--- a/plugins/lisa/skills/product-walkthrough/agents/openai.yaml
+++ b/plugins/lisa/skills/product-walkthrough/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "product-walkthrough"
+short_description: "Methodology for evaluating the live product via a real browser (Playwright MCP) when planning work or evaluating a PRD. Reading a PRD or a mock without seeing the current product produces tickets that misjudge the change — this skill grounds the analysis in what actually exists today. Invoke this skill from notion-to-tracker (Phase 2b live-product walkthrough), jira-create, and any PRD intake flow whose work touches existing user-facing surfaces."
+default_prompt:
+  - "Use $product-walkthrough"

--- a/plugins/lisa/skills/pull-request-review/agents/openai.yaml
+++ b/plugins/lisa/skills/pull-request-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "pull-request-review"
+short_description: "This skill should be used when checking for code review comments on a pull request and implementing them if required. It fetches PR metadata and comments, generates a brief from unresolved feedback, and bootstraps a project to address the review comments."
+default_prompt:
+  - "Use $pull-request-review"

--- a/plugins/lisa/skills/quality-review/agents/openai.yaml
+++ b/plugins/lisa/skills/quality-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "quality-review"
+short_description: "Code quality review checklist. Correctness, coding philosophy compliance, test coverage, documentation quality. Findings ranked by severity in plain English."
+default_prompt:
+  - "Use $quality-review"

--- a/plugins/lisa/skills/reproduce-bug/agents/openai.yaml
+++ b/plugins/lisa/skills/reproduce-bug/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "reproduce-bug"
+short_description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+default_prompt:
+  - "Use $reproduce-bug"

--- a/plugins/lisa/skills/research/agents/openai.yaml
+++ b/plugins/lisa/skills/research/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "research"
+short_description: "Research a problem space and produce a PRD. Investigates the codebase, defines user flows, assesses technical feasibility, and outputs a specification ready to hand to the Plan flow. Vendor-agnostic — the resulting PRD lands wherever the configured destination is (Notion, Confluence, file, etc.)."
+default_prompt:
+  - "Use $research"

--- a/plugins/lisa/skills/review-local/agents/openai.yaml
+++ b/plugins/lisa/skills/review-local/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "review-local"
+short_description: "This skill should be used when performing a code review on local changes on the current branch compared to the main branch. It uses multiple parallel agents to check for bugs, CLAUDE.md compliance, git history context, previous PR comments, and code comment adherence, then scores and filters findings by confidence level."
+default_prompt:
+  - "Use $review-local"

--- a/plugins/lisa/skills/root-cause-analysis/agents/openai.yaml
+++ b/plugins/lisa/skills/root-cause-analysis/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "root-cause-analysis"
+short_description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+default_prompt:
+  - "Use $root-cause-analysis"

--- a/plugins/lisa/skills/security-review/agents/openai.yaml
+++ b/plugins/lisa/skills/security-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "security-review"
+short_description: "Security review methodology. STRIDE threat modeling, OWASP Top 10 vulnerability checks, auth/validation/secrets handling review, and mitigation recommendations."
+default_prompt:
+  - "Use $security-review"

--- a/plugins/lisa/skills/security-zap-scan/agents/openai.yaml
+++ b/plugins/lisa/skills/security-zap-scan/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "security-zap-scan"
+short_description: "Run an OWASP ZAP baseline security scan locally using Docker. Checks for the ZAP baseline script, executes the scan, and summarizes findings by risk level with remediation recommendations."
+default_prompt:
+  - "Use $security-zap-scan"

--- a/plugins/lisa/skills/setup-atlassian/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-atlassian/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-atlassian"
+short_description: "Configure Atlassian access for this project. Installs acli if missing, runs the OAuth or API-token login, optionally enables the Atlassian MCP, resolves the cloudId for the active site, and writes the `atlassian` section into `.lisa.config.json`. Prerequisite for /lisa:setup:jira and /lisa:setup:confluence (both need atlassian.cloudId). Idempotent — re-running updates the existing section rather than duplicating it."
+default_prompt:
+  - "Use $setup-atlassian"

--- a/plugins/lisa/skills/setup-confluence/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-confluence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-confluence"
+short_description: "Configure Confluence as the PRD source for this project. Writes `confluence.spaceKey` and/or `confluence.parentPageId` into `.lisa.config.json` and offers to set top-level `source: \\\"confluence\\\"`. Depends on /lisa:setup:atlassian — atlassian.cloudId must already be present. Idempotent."
+default_prompt:
+  - "Use $setup-confluence"

--- a/plugins/lisa/skills/setup-github/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-github/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-github"
+short_description: "Configure GitHub Issues as the destination tracker and/or the PRD source for this project. Verifies the gh CLI is installed and authenticated, resolves `org/repo`, scaffolds the build-queue label namespace (`status:*`) when GitHub is the tracker and/or the PRD-lifecycle label namespace (`prd-*` + sentinel) when GitHub is the PRD source, writes the `github` section into `.lisa.config.json`, and offers to set top-level `tracker: \\\"github\\\"` and/or `source: \\\"github\\\"`. Idempotent — re-running updates the existing section and reuses existing labels rather than duplicating. No /lisa:setup:atlassian prerequisite (GitHub auth is standalone)."
+default_prompt:
+  - "Use $setup-github"

--- a/plugins/lisa/skills/setup-jira/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-jira/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-jira"
+short_description: "Configure JIRA as the destination tracker for this project. Writes `jira.project` into `.lisa.config.json` and offers to set top-level `tracker: \\\"jira\\\"`. Depends on /lisa:setup:atlassian — atlassian.cloudId must already be present, otherwise this skill stops and instructs the user to run setup-atlassian first. Idempotent."
+default_prompt:
+  - "Use $setup-jira"

--- a/plugins/lisa/skills/setup-linear/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-linear/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-linear"
+short_description: "Configure Linear as the destination tracker and/or the PRD source for this project. Verifies Linear access (MCP OAuth or a personal API key in OS keychain), resolves the workspace slug and team key, scaffolds the build-queue issue-label namespace (`status:*`) when Linear is the tracker and/or the PRD-lifecycle project-label namespace (`prd-*` + issue-level sentinel) when Linear is the PRD source, writes the `linear` section into `.lisa.config.json`, and offers to set top-level `tracker: \\\"linear\\\"` and/or `source: \\\"linear\\\"`. Idempotent — re-running updates the existing section and reuses existing labels. No /lisa:setup:atlassian prerequisite."
+default_prompt:
+  - "Use $setup-linear"

--- a/plugins/lisa/skills/setup-notion/agents/openai.yaml
+++ b/plugins/lisa/skills/setup-notion/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "setup-notion"
+short_description: "Configure Notion as the PRD source for this project. Walks the user through creating an internal integration in the target workspace, sharing the PRD database with it, stores the resulting `ntn_*` token in OS keychain (multi-workspace-safe — keyed by workspaceId), validates against the Notion API, and writes `notion.workspaceId`, `notion.prdDatabaseId`, and `notion.values` into `.lisa.config.json`. Idempotent — re-runs update the existing section rather than duplicating it. Offers to set top-level `source: \\\"notion\\\"`."
+default_prompt:
+  - "Use $setup-notion"

--- a/plugins/lisa/skills/spec-conformance/agents/openai.yaml
+++ b/plugins/lisa/skills/spec-conformance/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "spec-conformance"
+short_description: "Verifies that shipped work matches its spec section-by-section — acceptance criteria, Out of Scope, Technical Approach, Validation Journey assertions, and any explicit deliverables. Builds a coverage matrix mapping each requirement to evidence, flags scope creep separately from misses, and produces a verdict (CONFORMS / PARTIAL / DIVERGES). Runs during the verification phase alongside empirical system verification."
+default_prompt:
+  - "Use $spec-conformance"

--- a/plugins/lisa/skills/task-decomposition/agents/openai.yaml
+++ b/plugins/lisa/skills/task-decomposition/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "task-decomposition"
+short_description: "Methodology for breaking work into ordered tasks. Each task gets a single-repo scope, acceptance criteria, verification type, dependencies, and skills required."
+default_prompt:
+  - "Use $task-decomposition"

--- a/plugins/lisa/skills/task-triage/agents/openai.yaml
+++ b/plugins/lisa/skills/task-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "task-triage"
+short_description: "8-step task triage and implementation workflow. Ensures tasks have clear requirements, dependencies, and verification plans before implementation begins."
+default_prompt:
+  - "Use $task-triage"

--- a/plugins/lisa/skills/tdd-implementation/agents/openai.yaml
+++ b/plugins/lisa/skills/tdd-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tdd-implementation"
+short_description: "Test-Driven Development implementation workflow. RED: write failing test, GREEN: minimum code to pass, REFACTOR: clean up. Includes task metadata requirements, verification, and atomic commit practices."
+default_prompt:
+  - "Use $tdd-implementation"

--- a/plugins/lisa/skills/test-strategy/agents/openai.yaml
+++ b/plugins/lisa/skills/test-strategy/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "test-strategy"
+short_description: "Test strategy design. Coverage matrix, edge cases, TDD sequence planning, test quality review. Behavior-focused testing over implementation details."
+default_prompt:
+  - "Use $test-strategy"

--- a/plugins/lisa/skills/ticket-triage/agents/openai.yaml
+++ b/plugins/lisa/skills/ticket-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "ticket-triage"
+short_description: "Analytical triage gate for tickets in the configured destination tracker (JIRA, GitHub Issues, or Linear). Detects requirement ambiguities, identifies edge cases from codebase analysis, and plans verification methodology. Posts findings to the ticket and produces a verdict (BLOCKED/PASSED_WITH_FINDINGS/PASSED) that gates whether implementation can proceed. Vendor-neutral: the caller (jira-agent or github-agent) is responsible for fetching the ticket via lisa:tracker-read, running the pre-flight gate via lisa:tracker-verify, and posting findings via the matching vendor comment tool."
+default_prompt:
+  - "Use $ticket-triage"

--- a/plugins/lisa/skills/tracker-add-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-add-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-add-journey"
+short_description: "Vendor-neutral wrapper for appending a Validation Journey section to an existing ticket/issue. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-add-journey, lisa:github-add-journey, or lisa:linear-add-journey."
+default_prompt:
+  - "Use $tracker-add-journey"

--- a/plugins/lisa/skills/tracker-build-intake/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-build-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-build-intake"
+short_description: "Vendor-neutral wrapper for the build-queue batch scanner. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-build-intake (JQL/project-key queue), lisa:github-build-intake (GitHub repo queue keyed off the `status:ready` label), or lisa:linear-build-intake (Linear team queue keyed off the `status:ready` label). Every vendor scanner enforces the claim-time arm of the `leaf-only-lifecycle` rule — claim leaf work units only; skip or safe-block a container with open child work (or a childless Epic/Story/Spike) that carries a stale build-ready role. Counterpart to lisa:intake's PRD-side dispatchers."
+default_prompt:
+  - "Use $tracker-build-intake"

--- a/plugins/lisa/skills/tracker-create/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-create"
+short_description: "Vendor-neutral wrapper for creating tickets/issues from code files or descriptions. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-create, lisa:github-create, or lisa:linear-create. Plans hierarchy structure (epic / story / sub-task), then delegates each individual write through the tracker-write shim."
+default_prompt:
+  - "Use $tracker-create"

--- a/plugins/lisa/skills/tracker-evidence/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-evidence"
+short_description: "Vendor-neutral wrapper for posting verification evidence. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-evidence, lisa:github-evidence, or lisa:linear-evidence. Uploads evidence to the GitHub `pr-assets` release, updates the PR description, posts a comment on the originating ticket/issue, and transitions the ticket/issue to its post-build review state."
+default_prompt:
+  - "Use $tracker-evidence"

--- a/plugins/lisa/skills/tracker-journey/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-journey/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-journey"
+short_description: "Vendor-neutral wrapper for executing a ticket/issue's Validation Journey end-to-end. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-journey, lisa:github-journey, or lisa:linear-journey. Parses the journey, satisfies prerequisites, executes the steps, captures evidence at each marker, and posts results via tracker-evidence."
+default_prompt:
+  - "Use $tracker-journey"

--- a/plugins/lisa/skills/tracker-read/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-read/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-read"
+short_description: "Vendor-neutral wrapper for fetching the full scope of a ticket/issue and its related graph. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-read-ticket, lisa:github-read-issue, or lisa:linear-read-issue. Returns a consolidated context bundle so downstream agents never act on a single ticket in isolation."
+default_prompt:
+  - "Use $tracker-read"

--- a/plugins/lisa/skills/tracker-source-artifacts/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-source-artifacts/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-source-artifacts"
+short_description: "Canonical, vendor-neutral taxonomy and rules for handling source artifacts (Figma, Lovable, Loom, screenshots, design docs, data samples) when generating or evaluating tracker tickets (JIRA, GitHub Issues, Linear). Defines: (1) artifact domains, (2) classification rules per tool, (3) source precedence (which artifact is authoritative for which question), (4) inheritance from epic to story to sub-task, (5) cross-axis conflict handling. Invoke this skill from any flow that extracts, attaches, or reasons about external design/UX/data artifacts so the rules don't drift across skills."
+default_prompt:
+  - "Use $tracker-source-artifacts"

--- a/plugins/lisa/skills/tracker-sync/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-sync"
+short_description: "Vendor-neutral wrapper for posting milestone updates to the linked ticket/issue. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-sync, lisa:github-sync, or lisa:linear-sync. Posts at: plan created, implementation in progress, PR ready, PR merged. Suggests (never auto-transitions) the next status."
+default_prompt:
+  - "Use $tracker-sync"

--- a/plugins/lisa/skills/tracker-validate/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-validate/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-validate"
+short_description: "Vendor-neutral wrapper for the pre-write quality gate. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-validate-ticket, lisa:github-validate-issue, or lisa:linear-validate-issue. Read-only — never writes to any tracker. Used by tracker-write Phase 5.5 (pre-write gate), tracker-verify (post-write checks), and the *-to-tracker dry-run paths. Output is structured PASS/FAIL per gate so callers can parse it."
+default_prompt:
+  - "Use $tracker-validate"

--- a/plugins/lisa/skills/tracker-verify/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-verify"
+short_description: "Vendor-neutral wrapper for the post-write verification gate. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-verify, lisa:github-verify, or lisa:linear-verify. Fetches the live ticket/issue and runs the validator gates against the stored state — catches anything dropped or reformatted on write. Read-only."
+default_prompt:
+  - "Use $tracker-verify"

--- a/plugins/lisa/skills/tracker-write/agents/openai.yaml
+++ b/plugins/lisa/skills/tracker-write/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "tracker-write"
+short_description: "Vendor-neutral wrapper for ticket creation and updates. Reads `tracker` from .lisa.config.json (default: jira) and dispatches to lisa:jira-write-ticket, lisa:github-write-issue, or lisa:linear-write-issue. Callers in vendor-neutral skills (notion-to-tracker, linear-to-tracker, confluence-to-tracker, github-to-tracker, implement, verify) MUST invoke this skill instead of the vendor-specific ones — that is what makes the tracker switchable per project. The Phase-5.5 validate-pre-write gate, post-write verify, and Phase-8 announce-comment behavior live in the vendor skills; this shim is dispatch only."
+default_prompt:
+  - "Use $tracker-write"

--- a/plugins/lisa/skills/verification-lifecycle/agents/openai.yaml
+++ b/plugins/lisa/skills/verification-lifecycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "verification-lifecycle"
+short_description: "Verification lifecycle: confirm quality gates, classify types, discover tools, fail fast, plan, execute, codify (turn each passing verification into a regression test), spec conformance (verify shipped work matches the spec), loop. Quality gates (tests/typecheck/lint) are prerequisites, NOT verification. Verification means running the actual system and observing results."
+default_prompt:
+  - "Use $verification-lifecycle"

--- a/plugins/lisa/skills/verify/agents/openai.yaml
+++ b/plugins/lisa/skills/verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "verify"
+short_description: "Ship and verify code. Commits any pending changes, opens or updates the PR, handles the review loop, merges when green, monitors the deploy, and runs remote verification (health checks, Validation Journey replay, Sentry/log inspection) in the target environment. Folds in the legacy /ship alias."
+default_prompt:
+  - "Use $verify"

--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -123,6 +123,84 @@ export function serializeInterfaceToYaml(iface) {
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Derive a Codex `interface` object from a skill's SKILL.md frontmatter.
+ *
+ * NOTE ON DERIVATION RULES: this is the minimal/placeholder derivation that the
+ * walk-and-emit shell (issue #547) needs to produce a valid `interface` block.
+ * The richer humanization/summarization rules — title-casing `display_name`,
+ * trimming `short_description`, and the `$<name>` starter prompt — are issue
+ * #548's responsibility and will refine these defaults. Until then we fall back
+ * to the raw frontmatter values (and the skill directory name when frontmatter
+ * is missing) so every skill still emits a well-formed file.
+ *
+ * @param {{ name?: string, description?: string } | null} frontmatter Parsed
+ *   SKILL.md frontmatter (or `null` when the file has no frontmatter block).
+ * @param {string} skillName The skill directory name, used as a fallback.
+ * @returns {{ display_name: string, short_description: string, default_prompt: string[] }}
+ *   The normalized interface object the serializer consumes. Pure.
+ */
+export function deriveSkillInterface(frontmatter, skillName) {
+  const name = frontmatter?.name?.trim() || skillName;
+  const description = frontmatter?.description?.trim() || "";
+  return {
+    display_name: name,
+    short_description: description,
+    default_prompt: [`Use $${name}`],
+  };
+}
+
+/**
+ * Walk every `skills/<name>/SKILL.md` in a built plugin and emit a per-skill
+ * `skills/<name>/agents/openai.yaml` (issue #547).
+ *
+ * For each skill directory containing a SKILL.md, the frontmatter is parsed
+ * (#545), an interface object is derived (#548 refines the rules), and the
+ * deterministic serializer (#546) writes `agents/openai.yaml`, creating the
+ * `agents/` directory when missing. Behavior boundaries:
+ *
+ *  - No-op when the plugin has no `skills/` directory.
+ *  - Never clobber a hand-authored `agents/openai.yaml` that already exists in
+ *    source (that is issue #550's surface — but we must not overwrite it here
+ *    regardless).
+ *  - The `commands/` directory is left untouched — Codex does not consume Claude
+ *    `commands/`.
+ *
+ * @param {string} pluginDir Absolute path to a built plugin directory.
+ * @returns {void} Writes files as a side effect.
+ */
+export function writeSkillAgents(pluginDir) {
+  const skillsDir = path.join(pluginDir, "skills");
+  if (!fs.existsSync(skillsDir)) {
+    return;
+  }
+
+  const entries = fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
+
+  for (const skillName of entries) {
+    const skillDir = path.join(skillsDir, skillName);
+    const skillMdPath = path.join(skillDir, "SKILL.md");
+    if (!fs.existsSync(skillMdPath)) {
+      continue;
+    }
+
+    const openaiYamlPath = path.join(skillDir, "agents", "openai.yaml");
+    // Don't clobber a hand-authored openai.yaml carried over from source.
+    if (fs.existsSync(openaiYamlPath)) {
+      continue;
+    }
+
+    const frontmatter = parseSkillFrontmatter(skillMdPath);
+    const iface = deriveSkillInterface(frontmatter, skillName);
+    fs.mkdirSync(path.dirname(openaiYamlPath), { recursive: true });
+    fs.writeFileSync(openaiYamlPath, serializeInterfaceToYaml(iface));
+  }
+}
+
 function main() {
   const [pluginDirArg, versionArg] = process.argv.slice(2);
   if (!pluginDirArg || !versionArg) {
@@ -148,6 +226,7 @@ function main() {
   const pluginName = claudeManifest.name;
 
   writeCodexManifest(pluginDir, claudeManifest, pluginName, versionArg);
+  writeSkillAgents(pluginDir);
 }
 
 function writeCodexManifest(pluginDir, claudeManifest, pluginName, version) {

--- a/tests/unit/codex/skill-agents-walk.test.ts
+++ b/tests/unit/codex/skill-agents-walk.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the per-skill agents/openai.yaml walk used by the Codex
+ * artifact generator (scripts/generate-codex-plugin-artifacts.mjs).
+ *
+ * Covers the acceptance-criteria scenarios from issue #547:
+ *  - every skill with a SKILL.md gets a skills/<name>/agents/openai.yaml that
+ *    carries an interface block
+ *  - the agents/ directory is created when missing
+ *
+ * Plus the boundaries declared by the parent PRD (#521):
+ *  - no-op when the plugin has no skills/ directory
+ *  - never clobber a hand-authored openai.yaml already present in the dir
+ *  - leave the commands/ directory untouched
+ */
+import { load as parseYaml } from "js-yaml";
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  deriveSkillInterface,
+  writeSkillAgents,
+} from "../../../scripts/generate-codex-plugin-artifacts.mjs";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+/** The per-skill artifact filename the walk emits. */
+const OPENAI_YAML = "openai.yaml";
+/** A representative skill name used by the derivation tests. */
+const EXPLORATORY_QA = "exploratory-qa";
+
+describe("codex/skill-agents-walk", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Resolve the emitted openai.yaml path for a skill in the test plugin dir.
+   * @param name Skill directory name.
+   * @returns Absolute path to skills/<name>/agents/openai.yaml.
+   */
+  function openaiYamlPath(name: string): string {
+    return path.join(tempDir, "skills", name, "agents", OPENAI_YAML);
+  }
+
+  /**
+   * Write a SKILL.md into skills/<name>/ inside the test plugin dir.
+   * @param name Skill directory name.
+   * @param contents Raw SKILL.md body.
+   */
+  async function writeSkill(name: string, contents: string): Promise<void> {
+    const skillDir = path.join(tempDir, "skills", name);
+    await fs.ensureDir(skillDir);
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), contents);
+  }
+
+  /**
+   * Standard frontmatter block for a skill.
+   * @param name Frontmatter name value.
+   * @param description Frontmatter description value.
+   * @returns A SKILL.md body string.
+   */
+  function frontmatter(name: string, description: string): string {
+    return `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`;
+  }
+
+  it("emits one openai.yaml per skill, each with an interface block", async () => {
+    await writeSkill("alpha", frontmatter("alpha", "First skill"));
+    await writeSkill("beta", frontmatter("beta", "Second skill"));
+    await writeSkill("gamma", frontmatter("gamma", "Third skill"));
+
+    writeSkillAgents(tempDir);
+
+    for (const name of ["alpha", "beta", "gamma"]) {
+      const yamlPath = openaiYamlPath(name);
+      expect(await fs.pathExists(yamlPath)).toBe(true);
+      const parsed = parseYaml(await fs.readFile(yamlPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.display_name).toBe(name);
+      expect(parsed).toHaveProperty("short_description");
+      expect(parsed).toHaveProperty("default_prompt");
+    }
+  });
+
+  it("creates the agents/ directory when missing", async () => {
+    await writeSkill("solo", frontmatter("solo", "Only skill"));
+    const agentsDir = path.join(tempDir, "skills", "solo", "agents");
+    expect(await fs.pathExists(agentsDir)).toBe(false);
+
+    writeSkillAgents(tempDir);
+
+    expect(await fs.pathExists(agentsDir)).toBe(true);
+    expect(await fs.pathExists(path.join(agentsDir, OPENAI_YAML))).toBe(true);
+  });
+
+  it("is a no-op when the plugin has no skills/ directory", async () => {
+    expect(() => writeSkillAgents(tempDir)).not.toThrow();
+    expect(await fs.pathExists(path.join(tempDir, "skills"))).toBe(false);
+  });
+
+  it("does not clobber a hand-authored openai.yaml", async () => {
+    await writeSkill(
+      "kept",
+      frontmatter("kept", "Has hand-authored interface")
+    );
+    const yamlPath = openaiYamlPath("kept");
+    await fs.ensureDir(path.dirname(yamlPath));
+    const handAuthored =
+      'display_name: "HAND AUTHORED"\nshort_description: "keep me"\ndefault_prompt: []\n';
+    await fs.writeFile(yamlPath, handAuthored);
+
+    writeSkillAgents(tempDir);
+
+    expect(await fs.readFile(yamlPath, "utf8")).toBe(handAuthored);
+  });
+
+  it("leaves the commands/ directory untouched", async () => {
+    await writeSkill("withcmd", frontmatter("withcmd", "Skill with command"));
+    const commandsDir = path.join(tempDir, "commands");
+    await fs.ensureDir(commandsDir);
+    await fs.writeFile(path.join(commandsDir, "withcmd.md"), "# command\n");
+
+    writeSkillAgents(tempDir);
+
+    // commands/ must not gain an agents/openai.yaml or any generated artifact.
+    expect(await fs.pathExists(path.join(commandsDir, "agents"))).toBe(false);
+    expect(
+      await fs.readFile(path.join(commandsDir, "withcmd.md"), "utf8")
+    ).toBe("# command\n");
+  });
+
+  it("skips directories that have no SKILL.md", async () => {
+    await fs.ensureDir(path.join(tempDir, "skills", "not-a-skill"));
+
+    writeSkillAgents(tempDir);
+
+    expect(await fs.pathExists(openaiYamlPath("not-a-skill"))).toBe(false);
+  });
+
+  describe("deriveSkillInterface", () => {
+    it("uses frontmatter name and description", () => {
+      const iface = deriveSkillInterface(
+        { name: EXPLORATORY_QA, description: "QA workflow" },
+        EXPLORATORY_QA
+      );
+      expect(iface.display_name).toBe(EXPLORATORY_QA);
+      expect(iface.short_description).toBe("QA workflow");
+      expect(iface.default_prompt).toEqual([`Use $${EXPLORATORY_QA}`]);
+    });
+
+    it("falls back to the directory name when frontmatter is null", () => {
+      const iface = deriveSkillInterface(null, "fallback-skill");
+      expect(iface.display_name).toBe("fallback-skill");
+      expect(iface.short_description).toBe("");
+      expect(iface.default_prompt).toEqual(["Use $fallback-skill"]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Closes #547 (sub-task of Story #534, PRD #521).

Teaches `scripts/generate-codex-plugin-artifacts.mjs` to walk every `skills/<name>/SKILL.md` in each built plugin and emit `skills/<name>/agents/openai.yaml`, wiring together the two helpers merged earlier in the epic:

- `parseSkillFrontmatter` (#545) — reads `name`/`description` from SKILL.md frontmatter.
- `serializeInterfaceToYaml` (#546) — deterministic, byte-stable YAML.

New `writeSkillAgents(pluginDir)` runs after the manifest write in `main()`. A minimal `deriveSkillInterface(frontmatter, skillName)` produces the interface object (raw frontmatter `name`/`description` + a `Use $<name>` starter prompt). The richer humanization/summarization rules are **#548** and will refine `deriveSkillInterface` — this PR is the walk-and-emit shell per the ticket's scope split.

## Boundaries honored (per PRD #521)

- **No-op when a plugin has no `skills/` directory** — `lisa-cdk` and `lisa-typescript` emit nothing.
- **Never clobber a hand-authored `agents/openai.yaml`** carried over from `plugins/src` (that surface is #550 — but we don't overwrite regardless).
- **`commands/` left untouched** — Codex does not consume Claude `commands/`.

## Generated output

This changes generated artifacts. `bun run build:plugins` now emits **181** `openai.yaml` files across the seven plugins that ship skills:

| plugin | files |
| --- | --- |
| lisa | 103 |
| lisa-expo | 28 |
| lisa-rails | 19 |
| lisa-wiki | 19 |
| lisa-harper-fabric | 6 |
| lisa-nestjs | 3 |
| lisa-openclaw | 3 |
| lisa-cdk / lisa-typescript | 0 (no skills/) |

The script change and **all** regenerated `plugins/lisa*` artifacts are committed together so `bun run check:plugins` (🧩 Plugins Sync) stays green.

### .prettierignore

The serializer emits double-quoted YAML scalars (its #546 contract). The repo's `.prettierrc.json` has a `*.yaml` override (`singleQuote: true`), so the `prettier --write` pre-commit step would rewrite the generated files to single quotes — making them diverge from a fresh build and breaking `check:plugins`. The generated `plugins/lisa*/**/openai.yaml` are now excluded in `.prettierignore` (consistent with how generated `.json`/`.md`/`.sh` plugin artifacts already escape prettier). `plugins/src` (source of truth) stays formatted. The exclusion is Lisa-repo-specific (downstream projects have no `plugins/`), so it is not added to the downstream `.prettierignore` template.

## Verification (empirical, CLI)

- `bun run build:plugins` → 181 openai.yaml emitted; `find plugins/lisa-expo/skills -name openai.yaml | wc -l` = **28** (matches skill count, the AC example).
- Sample file `plugins/lisa-expo/skills/exploratory-qa/agents/openai.yaml` contains the `display_name` / `short_description` / `default_prompt` interface fields.
- **Byte-stable**: ran the build twice; aggregate `shasum` of all openai.yaml identical across runs; `check:plugins` rebuilds and finds no diff.
- **No-clobber**: planted a sentinel `openai.yaml` in `plugins/src/expo/skills/exploratory-qa/agents/`, rebuilt — the sentinel survived unmodified; removed it and rebuilt — generated version restored.
- **commands/ untouched**: 0 `openai.yaml` emitted under any `commands/` dir.
- `bun run check:plugins` → **in sync** + marketplace coverage OK.
- `bun run typecheck` → pass. `bun run lint` → 0 errors. `bun run test:unit` → **905 passed** (incl. 8 new tests in `tests/unit/codex/skill-agents-walk.test.ts`).

🤖 Generated with Claude Code