### PR TITLE
feat(rules): add vendor-neutral prd-lifecycle-rollup rule and wire config schema

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -57,7 +57,8 @@ fi
       "shipped":   "<page-id>"
     },
     "dashboardPageId": "<page-id>",
-    "feedbackPageId":  "<page-id>"
+    "feedbackPageId":  "<page-id>",
+    "rollup": { "closeOnShipped": false }
   },
   "github": {
     "org": "<org-or-user>",
@@ -75,7 +76,8 @@ fi
         "ready": "prd-ready", "in_review": "prd-in-review",
         "blocked": "prd-blocked", "ticketed": "prd-ticketed",
         "shipped": "prd-shipped",
-        "sentinel": "prd-intake-feedback"
+        "sentinel": "prd-intake-feedback",
+        "rollup": { "closeOnShipped": false }
       }
     }
   },
@@ -86,7 +88,8 @@ fi
     "values": {
       "draft": "Draft", "ready": "Ready", "in_review": "In Review",
       "blocked": "Blocked", "ticketed": "Ticketed", "shipped": "Shipped"
-    }
+    },
+    "rollup": { "closeOnShipped": false }
   },
   "linear": {
     "workspace": "<workspace-slug>",
@@ -104,7 +107,8 @@ fi
         "ready": "prd-ready", "in_review": "prd-in-review",
         "blocked": "prd-blocked", "ticketed": "prd-ticketed",
         "shipped": "prd-shipped",
-        "sentinel": "prd-intake-feedback"
+        "sentinel": "prd-intake-feedback",
+        "rollup": { "closeOnShipped": false }
       }
     }
   },
@@ -207,6 +211,18 @@ Every lifecycle skill operates on a fixed set of **roles** (`ready`, `claimed`, 
 | `ticketed` | Validated and tickets created | `Ticketed` (status) | `prd-ticketed` (label) |
 | `shipped` | All child tickets shipped | `Shipped` (status) | `prd-shipped` (label) |
 | `sentinel` | (PRD-intake feedback issue marker, GitHub/Linear self-host only) | — | `prd-intake-feedback` |
+
+### PRD rollup config (`prd.rollup`)
+
+PRD lifecycle completion is **derived** from the PRD's generated top-level work, not set independently — see the `prd-lifecycle-rollup` rule for the full contract (generated-top-level-work definition, per-vendor terminal-state predicate, the `shipped` transition, and the child-ref idempotency key). When all required generated top-level children are terminal, rollup transitions the PRD to its `shipped` role; the `prd.rollup` block configures the optional close/archive step that follows.
+
+The `rollup` object lives in each PRD-source vendor section (`github.labels.prd.rollup`, `linear.labels.prd.rollup`, `notion.rollup`, `confluence.rollup`):
+
+| Key | Required | Default | Notes |
+|-----|----------|---------|-------|
+| `closeOnShipped` | no | `false` | When `true`, rollup closes/archives the PRD after the `shipped` transition (GitHub: close the issue; Linear: move to a closed/archived state; JIRA: transition to Done; Confluence/Notion: archive where supported). When `false` (the default), the PRD is set to `shipped` but left open for a human to close. Closure never happens before all generated top-level work is terminal. |
+
+Like every other vocabulary key, `prd.rollup` is **optional** — a missing block inherits `closeOnShipped: false`. The `shipped` transition itself is unconditional on the all-terminal condition; only the close/archive step is gated by this flag.
 
 ### Env-keyed `done`
 

--- a/plugins/lisa/rules/prd-lifecycle-rollup.md
+++ b/plugins/lisa/rules/prd-lifecycle-rollup.md
@@ -1,0 +1,109 @@
+# PRD Lifecycle Rollup & Generated-Top-Level-Work Contract
+
+This is the single vendor-neutral source of truth for how a PRD owns the work it generates and how its lifecycle rolls up to `shipped` from that work. Every PRD-source and PRD-intake skill (`prd-backlink`, `prd-ticket-coverage`, `*-prd-intake`, `*-to-tracker`) cites this rule by slug rather than restating it, so PRD→child linking and PRD closure rollup behave identically across GitHub, Linear, JIRA/Atlassian, Confluence, and Notion instead of drifting per vendor.
+
+It defines four coupled things:
+
+1. **Generated top-level work** — what a PRD owns as children (its created Epics / top-level Stories), explicitly **excluding** leaf Sub-tasks.
+2. **Per-vendor terminal-state predicate** — how "this generated child is done" is decided for each source/tracker.
+3. **PRD `shipped` transition + config-gated close/archive** — when and how a PRD rolls up to its terminal state and is closed/archived.
+4. **Idempotency dedupe key** — the child-ref identity that makes linking and rollup safe to re-run.
+
+This is the PRD-level companion to `leaf-only-lifecycle`: that rule governs the *build* lifecycle of leaf work units and how a **parent container** rolls up from its leaf children; this rule governs the *PRD* lifecycle and how the **PRD** rolls up from its generated top-level children. The two share the rollup shape (terminal children → parent advances) and the multi-env terminal handling, applied at different levels of the hierarchy.
+
+## Why this exists
+
+PRD intake currently comments back with created ticket links, but the PRD is not necessarily the structural parent of the work it generated. That makes lifecycle rollup weaker than it should be: humans cannot always navigate from PRD to generated top-level work using the host tool's hierarchy UI, agents must parse free-form comments instead of reading a first-class relationship, and PRD shipped/closed state is not automatically derived from whether its generated work is done. Worst of all, cross-vendor implementations drift in how they record the PRD-to-work relationship and when they close a PRD.
+
+The desired model is vendor-neutral: **the PRD is the source-of-truth parent for the top-level work it generated, and PRD lifecycle completion rolls up from that child set.** That belongs here, in a cross-vendor rule, and every backlink / intake / coverage path enforces it.
+
+This surfaced in real GitHub-backed PRD intake (`CodySwannGT/advisory-rankings`): PRD issue #64 generated top-level Epic #65 plus child Stories/Sub-tasks. #65 should be a child/sub-issue of #64, and #64 should eventually transition/close when #65 and its descendants are complete — not before, and not twice.
+
+## Generated top-level work (the contract)
+
+**Generated top-level work** is the set of work units a PRD's intake/decomposition *directly created at the top of the hierarchy* and now owns as children:
+
+| Class | Examples by type | Owned by the PRD as a child? |
+|---|---|---|
+| **Generated top-level work** | the created **Epic(s)**, and any **top-level Story** created directly under the PRD (a Story with no parent Epic) | **Yes** — these are the PRD's children for rollup |
+| **Descendant work** | **Sub-tasks**, and **Stories that hang under a generated Epic**, and any leaf (Bug/Task/Improvement) under a top-level unit | **No** — owned by their top-level parent, not by the PRD directly |
+
+The boundary is **structural, mirroring `leaf-only-lifecycle`'s container/leaf taxonomy but one level up**:
+
+- A PRD owns its **top-level** generated units. Those top-level units own their own descendants (per `leaf-only-lifecycle`'s parent-status-rollup state machine).
+- Leaf Sub-tasks are **never** direct children of the PRD when a top-level Epic/Story hierarchy exists (PRD #525 non-goal: "Do not make leaf implementation tasks direct children of the PRD when a top-level Epic/Story hierarchy exists"). The PRD owns top-level generated work; those top-level work units own their descendants.
+- When a PRD decomposes into a flat set with no Epic (e.g. a few top-level Stories or a single leaf Task and nothing under it), the **top-level** items it created are its generated top-level work, whatever their type. The rule is "what the PRD created at the top," not "only Epics."
+
+### How each vendor records the PRD→child relationship
+
+The relationship is recorded with the source tool's **native hierarchy first**, falling back to a **durable documented section** in the PRD where native hierarchy is unavailable or the source and destination are different systems (PRD #525: vendors need not all expose identical native hierarchy):
+
+- **GitHub Issues** — native **sub-issues**: the generated Epic issue becomes a sub-issue of the PRD issue when the repo supports sub-issues and source and tracker are the same repo. Otherwise a documented `## Tickets` / generated-work section.
+- **Linear** — native **parent / project** relationships: a generated top-level Issue uses `parentId`, or a generated Project groups generated Issues; the PRD's relationship to its top-level Project/Issues is recorded natively where the PRD also lives in Linear.
+- **JIRA** — native **Epic link / parent field** or a documented issue-link type for the PRD→Epic relationship where available.
+- **Confluence / Notion** — no native issue hierarchy for tracker work: the PRD page carries a stable, machine-readable **generated-work section** (e.g. `## Tickets` / `## Generated Work`) listing the top-level refs and URLs.
+- **Cross-vendor** (e.g. Notion PRD → JIRA tracker) — the destination ticket cannot become a native child of the PRD, so the relationship is **always** recorded in the PRD source artifact's documented section.
+
+The documented-section fallback is always written so the generated child set is readable later without relying only on free-form comments. Comment summaries are still useful human-facing audit trails and are not removed (PRD #525 non-goal).
+
+## Per-vendor terminal-state predicate
+
+A generated top-level child is **terminal** (counts as done for rollup) when it reaches the source/tracker's done/shipped state. The predicate is vendor-specific; the *semantics* ("this child has shipped") are not:
+
+| Vendor | A generated top-level child is terminal when… |
+|---|---|
+| **GitHub Issues** | the issue is **closed** *and* (where the build-status label is used) carries the resolved `done` role label (`status:done` by default — env-keyed; see below). A closed-as-not-planned issue is terminal-but-dropped: it does not hold the PRD open but is excluded from "shipped" (treated like a won't-do leaf). |
+| **Linear** | the Issue/Project is in a **completed** workflow state (`done`-category), **or** a **canceled** state (terminal-but-dropped, like not-planned — does not hold the PRD open, excluded from shipped). |
+| **JIRA** | the issue's status is in the **Done status category** (`statusCategory.key == "done"`). |
+| **Confluence / Notion** | the documented generated-work entry is marked **done** in the PRD's machine-readable section (the durable equivalent of a closed ticket, since these sources have no native ticket state). |
+
+Notes:
+
+- **Required vs. optional children.** Only the generated top-level children that must ship for the PRD to be complete are counted toward the all-terminal check. Won't-do / canceled / not-planned children are terminal-but-dropped: they do not hold the PRD open and are excluded from the shipped set. This mirrors `leaf-only-lifecycle`'s "required leaves" qualifier.
+- **Recursion is delegated, not duplicated.** A generated Epic is terminal only when *it* has rolled up to its own terminal state per `leaf-only-lifecycle`'s parent-status-rollup (all its required Stories/Sub-tasks terminal). This rule does not re-derive an Epic's state from its leaves — it reads the top-level child's own resolved state and trusts `leaf-only-lifecycle` to have rolled that up bottom-up.
+- **Blocked dominates at the report level.** If any required generated top-level child is blocked or incomplete, rollup leaves the PRD open and reports the incomplete child set (PRD #525: "rollup leaving a PRD open when at least one generated top-level child is incomplete"). The PRD is only advanced when **all** required top-level children are terminal.
+
+### The terminal `done` is the configured, env-keyed value — multi-env capable
+
+Where a vendor's terminal predicate references the build-status `done` role (GitHub/Linear labels), that value is the project's configured `done` — which is **env-keyed** (`config-resolution` "Env-keyed `done`"): a map keyed by environment (`dev`, `staging`, `production`), resolved from the merged PR's base branch. This rule does **not** hardcode a `dev → staging → prod` promotion chain; a multi-env project counts a child as terminal when it reaches whichever `done` value matches the environment it shipped to.
+
+**Single-environment collapse (this repo).** Lisa's own deploy has only `main`/`production` (`deploy.branches = production: main`, no dev/staging), so `done` is a single value, not a map, and the build lifecycle collapses to one chain: `ready → claimed (in-progress) → review (code-review) → done`. A generated top-level child is terminal when it reaches the single `status:done`; rollup never resolves a `dev` or `staging` `done` in this repo. This is the *collapsed* case of the generic rule, not a different rule — projects with more environments keep the env-keyed map.
+
+## PRD `shipped` transition + config-gated close/archive
+
+When **all required** generated top-level children are terminal, the PRD rolls up to its terminal PRD-lifecycle state and, where configured, is closed/archived:
+
+1. **Transition to `shipped`.** Set the PRD to the configured `shipped` role (`config-resolution` PRD-lifecycle roles: `prd-shipped` label for GitHub/Linear, `Shipped` status for Notion, the shipped parent page for Confluence). The PRD lifecycle is `ready → in_review → (blocked | ticketed) → shipped`; rollup performs the `ticketed → shipped` hop only, and only on the all-terminal condition.
+2. **Config-gated close/archive.** When the source tool supports closure/archival *and* the project configures it, also close (GitHub: close the issue; Linear: move to a closed/archived state; JIRA: transition to Done; Confluence/Notion: archive where supported). Closure is **gated on configuration** via `prd.rollup.closeOnShipped` (`config-resolution`): when false (the default), the PRD is set to `shipped` but left open for a human to close; when true, rollup closes/archives it after the `shipped` transition. Never close a PRD before all generated top-level work is terminal (PRD #525 non-goal).
+3. **Partial completion is a no-op + report.** If only some required children are terminal, leave the PRD in its current state and report the incomplete/blocked child set. Do not advance, do not close.
+
+The PRD never advances to `shipped` on its own authority — it is **derived** from the generated-top-level-child set, exactly as a container's state is derived from its leaves in `leaf-only-lifecycle`.
+
+## Idempotency dedupe key
+
+Linking and rollup MUST be safe to re-run: re-running intake, backlink, or rollup never produces duplicate child links, duplicate sub-issues, duplicate generated-work entries, or a double `shipped` transition (PRD #525: "Re-running backlink or rollup is idempotent").
+
+The dedupe key is **child-ref identity** — the stable, vendor-native identifier of each generated top-level child:
+
+- **GitHub** — `owner/repo#number` (the issue ref).
+- **Linear** — the issue/project identifier (e.g. `TEAM-123`) or its UUID.
+- **JIRA** — the issue key (e.g. `PROJ-123`).
+- **Confluence / Notion** — the destination ticket ref recorded in the generated-work entry (the entry is keyed by that ref, not by list position).
+
+Apply it as follows:
+
+- **Linking** is keyed by child-ref: before adding a native child link or a documented generated-work entry, check whether that exact child-ref is already linked/listed; if so, it's a no-op. The documented generated-work section is **regenerated** from the current child set on each run rather than appended, so re-planning never accumulates stale or duplicate entries (the same regenerate-don't-append discipline `prd-backlink` already uses for its `## Tickets` section).
+- **Rollup** is keyed by the PRD's current state: a PRD already in `shipped` (and closed, when closure is configured) is a no-op — rollup does not re-transition or re-close it. Computing the all-terminal condition over the child-ref set is itself idempotent (a pure function of the children's current states).
+
+## Citation
+
+Skills that link generated work to a PRD or roll a PRD up cite this rule by slug (the `prd-lifecycle-rollup` rule) instead of restating it:
+
+- **PRD backlink / native linking** (`prd-backlink`) — record generated top-level work as native PRD children where supported; always write the documented generated-work fallback; dedupe by child-ref. *(LPC-1.1 #580, LPC-1.2 #582)*
+- **PRD coverage** (`prd-ticket-coverage`) — read the generated top-level child set deterministically from the recorded relationship, not from free-form comments.
+- **GitHub PRD closure rollup** (`github-prd-intake`) — detect terminal/incomplete/blocked child sets, transition to `prd-shipped`, and close the PRD issue when `prd.rollup.closeOnShipped` is configured. *(LPC-1.3 #583)*
+- **Linear / Confluence / Notion PRD rollup** (`linear-prd-intake`, `confluence-prd-intake`, `notion-prd-intake`) — mirror the GitHub closure rollup with each vendor's terminal predicate and close/archive support. *(LPC-1.3 #584)*
+- **Idempotency** (all of the above) — dedupe-by-ref linking and no-op already-shipped rollup. *(LPC-1.4 #585)*
+- **Vendor matrix documentation** — describe native-hierarchy vs documented-link fallback per supported vendor against this contract. *(LPC-1.5 #586)*
+
+This is the PRD-level companion to `leaf-only-lifecycle` (which governs the build lifecycle and parent-from-leaves rollup); together they define the full hierarchy: a PRD owns its generated top-level work, which owns its leaves, and terminal state rolls up bottom-to-top — leaf → top-level unit → PRD.

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -57,7 +57,8 @@ fi
       "shipped":   "<page-id>"
     },
     "dashboardPageId": "<page-id>",
-    "feedbackPageId":  "<page-id>"
+    "feedbackPageId":  "<page-id>",
+    "rollup": { "closeOnShipped": false }
   },
   "github": {
     "org": "<org-or-user>",
@@ -75,7 +76,8 @@ fi
         "ready": "prd-ready", "in_review": "prd-in-review",
         "blocked": "prd-blocked", "ticketed": "prd-ticketed",
         "shipped": "prd-shipped",
-        "sentinel": "prd-intake-feedback"
+        "sentinel": "prd-intake-feedback",
+        "rollup": { "closeOnShipped": false }
       }
     }
   },
@@ -86,7 +88,8 @@ fi
     "values": {
       "draft": "Draft", "ready": "Ready", "in_review": "In Review",
       "blocked": "Blocked", "ticketed": "Ticketed", "shipped": "Shipped"
-    }
+    },
+    "rollup": { "closeOnShipped": false }
   },
   "linear": {
     "workspace": "<workspace-slug>",
@@ -104,7 +107,8 @@ fi
         "ready": "prd-ready", "in_review": "prd-in-review",
         "blocked": "prd-blocked", "ticketed": "prd-ticketed",
         "shipped": "prd-shipped",
-        "sentinel": "prd-intake-feedback"
+        "sentinel": "prd-intake-feedback",
+        "rollup": { "closeOnShipped": false }
       }
     }
   },
@@ -207,6 +211,18 @@ Every lifecycle skill operates on a fixed set of **roles** (`ready`, `claimed`, 
 | `ticketed` | Validated and tickets created | `Ticketed` (status) | `prd-ticketed` (label) |
 | `shipped` | All child tickets shipped | `Shipped` (status) | `prd-shipped` (label) |
 | `sentinel` | (PRD-intake feedback issue marker, GitHub/Linear self-host only) | — | `prd-intake-feedback` |
+
+### PRD rollup config (`prd.rollup`)
+
+PRD lifecycle completion is **derived** from the PRD's generated top-level work, not set independently — see the `prd-lifecycle-rollup` rule for the full contract (generated-top-level-work definition, per-vendor terminal-state predicate, the `shipped` transition, and the child-ref idempotency key). When all required generated top-level children are terminal, rollup transitions the PRD to its `shipped` role; the `prd.rollup` block configures the optional close/archive step that follows.
+
+The `rollup` object lives in each PRD-source vendor section (`github.labels.prd.rollup`, `linear.labels.prd.rollup`, `notion.rollup`, `confluence.rollup`):
+
+| Key | Required | Default | Notes |
+|-----|----------|---------|-------|
+| `closeOnShipped` | no | `false` | When `true`, rollup closes/archives the PRD after the `shipped` transition (GitHub: close the issue; Linear: move to a closed/archived state; JIRA: transition to Done; Confluence/Notion: archive where supported). When `false` (the default), the PRD is set to `shipped` but left open for a human to close. Closure never happens before all generated top-level work is terminal. |
+
+Like every other vocabulary key, `prd.rollup` is **optional** — a missing block inherits `closeOnShipped: false`. The `shipped` transition itself is unconditional on the all-terminal condition; only the close/archive step is gated by this flag.
 
 ### Env-keyed `done`
 

--- a/plugins/src/base/rules/prd-lifecycle-rollup.md
+++ b/plugins/src/base/rules/prd-lifecycle-rollup.md
@@ -1,0 +1,109 @@
+# PRD Lifecycle Rollup & Generated-Top-Level-Work Contract
+
+This is the single vendor-neutral source of truth for how a PRD owns the work it generates and how its lifecycle rolls up to `shipped` from that work. Every PRD-source and PRD-intake skill (`prd-backlink`, `prd-ticket-coverage`, `*-prd-intake`, `*-to-tracker`) cites this rule by slug rather than restating it, so PRD→child linking and PRD closure rollup behave identically across GitHub, Linear, JIRA/Atlassian, Confluence, and Notion instead of drifting per vendor.
+
+It defines four coupled things:
+
+1. **Generated top-level work** — what a PRD owns as children (its created Epics / top-level Stories), explicitly **excluding** leaf Sub-tasks.
+2. **Per-vendor terminal-state predicate** — how "this generated child is done" is decided for each source/tracker.
+3. **PRD `shipped` transition + config-gated close/archive** — when and how a PRD rolls up to its terminal state and is closed/archived.
+4. **Idempotency dedupe key** — the child-ref identity that makes linking and rollup safe to re-run.
+
+This is the PRD-level companion to `leaf-only-lifecycle`: that rule governs the *build* lifecycle of leaf work units and how a **parent container** rolls up from its leaf children; this rule governs the *PRD* lifecycle and how the **PRD** rolls up from its generated top-level children. The two share the rollup shape (terminal children → parent advances) and the multi-env terminal handling, applied at different levels of the hierarchy.
+
+## Why this exists
+
+PRD intake currently comments back with created ticket links, but the PRD is not necessarily the structural parent of the work it generated. That makes lifecycle rollup weaker than it should be: humans cannot always navigate from PRD to generated top-level work using the host tool's hierarchy UI, agents must parse free-form comments instead of reading a first-class relationship, and PRD shipped/closed state is not automatically derived from whether its generated work is done. Worst of all, cross-vendor implementations drift in how they record the PRD-to-work relationship and when they close a PRD.
+
+The desired model is vendor-neutral: **the PRD is the source-of-truth parent for the top-level work it generated, and PRD lifecycle completion rolls up from that child set.** That belongs here, in a cross-vendor rule, and every backlink / intake / coverage path enforces it.
+
+This surfaced in real GitHub-backed PRD intake (`CodySwannGT/advisory-rankings`): PRD issue #64 generated top-level Epic #65 plus child Stories/Sub-tasks. #65 should be a child/sub-issue of #64, and #64 should eventually transition/close when #65 and its descendants are complete — not before, and not twice.
+
+## Generated top-level work (the contract)
+
+**Generated top-level work** is the set of work units a PRD's intake/decomposition *directly created at the top of the hierarchy* and now owns as children:
+
+| Class | Examples by type | Owned by the PRD as a child? |
+|---|---|---|
+| **Generated top-level work** | the created **Epic(s)**, and any **top-level Story** created directly under the PRD (a Story with no parent Epic) | **Yes** — these are the PRD's children for rollup |
+| **Descendant work** | **Sub-tasks**, and **Stories that hang under a generated Epic**, and any leaf (Bug/Task/Improvement) under a top-level unit | **No** — owned by their top-level parent, not by the PRD directly |
+
+The boundary is **structural, mirroring `leaf-only-lifecycle`'s container/leaf taxonomy but one level up**:
+
+- A PRD owns its **top-level** generated units. Those top-level units own their own descendants (per `leaf-only-lifecycle`'s parent-status-rollup state machine).
+- Leaf Sub-tasks are **never** direct children of the PRD when a top-level Epic/Story hierarchy exists (PRD #525 non-goal: "Do not make leaf implementation tasks direct children of the PRD when a top-level Epic/Story hierarchy exists"). The PRD owns top-level generated work; those top-level work units own their descendants.
+- When a PRD decomposes into a flat set with no Epic (e.g. a few top-level Stories or a single leaf Task and nothing under it), the **top-level** items it created are its generated top-level work, whatever their type. The rule is "what the PRD created at the top," not "only Epics."
+
+### How each vendor records the PRD→child relationship
+
+The relationship is recorded with the source tool's **native hierarchy first**, falling back to a **durable documented section** in the PRD where native hierarchy is unavailable or the source and destination are different systems (PRD #525: vendors need not all expose identical native hierarchy):
+
+- **GitHub Issues** — native **sub-issues**: the generated Epic issue becomes a sub-issue of the PRD issue when the repo supports sub-issues and source and tracker are the same repo. Otherwise a documented `## Tickets` / generated-work section.
+- **Linear** — native **parent / project** relationships: a generated top-level Issue uses `parentId`, or a generated Project groups generated Issues; the PRD's relationship to its top-level Project/Issues is recorded natively where the PRD also lives in Linear.
+- **JIRA** — native **Epic link / parent field** or a documented issue-link type for the PRD→Epic relationship where available.
+- **Confluence / Notion** — no native issue hierarchy for tracker work: the PRD page carries a stable, machine-readable **generated-work section** (e.g. `## Tickets` / `## Generated Work`) listing the top-level refs and URLs.
+- **Cross-vendor** (e.g. Notion PRD → JIRA tracker) — the destination ticket cannot become a native child of the PRD, so the relationship is **always** recorded in the PRD source artifact's documented section.
+
+The documented-section fallback is always written so the generated child set is readable later without relying only on free-form comments. Comment summaries are still useful human-facing audit trails and are not removed (PRD #525 non-goal).
+
+## Per-vendor terminal-state predicate
+
+A generated top-level child is **terminal** (counts as done for rollup) when it reaches the source/tracker's done/shipped state. The predicate is vendor-specific; the *semantics* ("this child has shipped") are not:
+
+| Vendor | A generated top-level child is terminal when… |
+|---|---|
+| **GitHub Issues** | the issue is **closed** *and* (where the build-status label is used) carries the resolved `done` role label (`status:done` by default — env-keyed; see below). A closed-as-not-planned issue is terminal-but-dropped: it does not hold the PRD open but is excluded from "shipped" (treated like a won't-do leaf). |
+| **Linear** | the Issue/Project is in a **completed** workflow state (`done`-category), **or** a **canceled** state (terminal-but-dropped, like not-planned — does not hold the PRD open, excluded from shipped). |
+| **JIRA** | the issue's status is in the **Done status category** (`statusCategory.key == "done"`). |
+| **Confluence / Notion** | the documented generated-work entry is marked **done** in the PRD's machine-readable section (the durable equivalent of a closed ticket, since these sources have no native ticket state). |
+
+Notes:
+
+- **Required vs. optional children.** Only the generated top-level children that must ship for the PRD to be complete are counted toward the all-terminal check. Won't-do / canceled / not-planned children are terminal-but-dropped: they do not hold the PRD open and are excluded from the shipped set. This mirrors `leaf-only-lifecycle`'s "required leaves" qualifier.
+- **Recursion is delegated, not duplicated.** A generated Epic is terminal only when *it* has rolled up to its own terminal state per `leaf-only-lifecycle`'s parent-status-rollup (all its required Stories/Sub-tasks terminal). This rule does not re-derive an Epic's state from its leaves — it reads the top-level child's own resolved state and trusts `leaf-only-lifecycle` to have rolled that up bottom-up.
+- **Blocked dominates at the report level.** If any required generated top-level child is blocked or incomplete, rollup leaves the PRD open and reports the incomplete child set (PRD #525: "rollup leaving a PRD open when at least one generated top-level child is incomplete"). The PRD is only advanced when **all** required top-level children are terminal.
+
+### The terminal `done` is the configured, env-keyed value — multi-env capable
+
+Where a vendor's terminal predicate references the build-status `done` role (GitHub/Linear labels), that value is the project's configured `done` — which is **env-keyed** (`config-resolution` "Env-keyed `done`"): a map keyed by environment (`dev`, `staging`, `production`), resolved from the merged PR's base branch. This rule does **not** hardcode a `dev → staging → prod` promotion chain; a multi-env project counts a child as terminal when it reaches whichever `done` value matches the environment it shipped to.
+
+**Single-environment collapse (this repo).** Lisa's own deploy has only `main`/`production` (`deploy.branches = production: main`, no dev/staging), so `done` is a single value, not a map, and the build lifecycle collapses to one chain: `ready → claimed (in-progress) → review (code-review) → done`. A generated top-level child is terminal when it reaches the single `status:done`; rollup never resolves a `dev` or `staging` `done` in this repo. This is the *collapsed* case of the generic rule, not a different rule — projects with more environments keep the env-keyed map.
+
+## PRD `shipped` transition + config-gated close/archive
+
+When **all required** generated top-level children are terminal, the PRD rolls up to its terminal PRD-lifecycle state and, where configured, is closed/archived:
+
+1. **Transition to `shipped`.** Set the PRD to the configured `shipped` role (`config-resolution` PRD-lifecycle roles: `prd-shipped` label for GitHub/Linear, `Shipped` status for Notion, the shipped parent page for Confluence). The PRD lifecycle is `ready → in_review → (blocked | ticketed) → shipped`; rollup performs the `ticketed → shipped` hop only, and only on the all-terminal condition.
+2. **Config-gated close/archive.** When the source tool supports closure/archival *and* the project configures it, also close (GitHub: close the issue; Linear: move to a closed/archived state; JIRA: transition to Done; Confluence/Notion: archive where supported). Closure is **gated on configuration** via `prd.rollup.closeOnShipped` (`config-resolution`): when false (the default), the PRD is set to `shipped` but left open for a human to close; when true, rollup closes/archives it after the `shipped` transition. Never close a PRD before all generated top-level work is terminal (PRD #525 non-goal).
+3. **Partial completion is a no-op + report.** If only some required children are terminal, leave the PRD in its current state and report the incomplete/blocked child set. Do not advance, do not close.
+
+The PRD never advances to `shipped` on its own authority — it is **derived** from the generated-top-level-child set, exactly as a container's state is derived from its leaves in `leaf-only-lifecycle`.
+
+## Idempotency dedupe key
+
+Linking and rollup MUST be safe to re-run: re-running intake, backlink, or rollup never produces duplicate child links, duplicate sub-issues, duplicate generated-work entries, or a double `shipped` transition (PRD #525: "Re-running backlink or rollup is idempotent").
+
+The dedupe key is **child-ref identity** — the stable, vendor-native identifier of each generated top-level child:
+
+- **GitHub** — `owner/repo#number` (the issue ref).
+- **Linear** — the issue/project identifier (e.g. `TEAM-123`) or its UUID.
+- **JIRA** — the issue key (e.g. `PROJ-123`).
+- **Confluence / Notion** — the destination ticket ref recorded in the generated-work entry (the entry is keyed by that ref, not by list position).
+
+Apply it as follows:
+
+- **Linking** is keyed by child-ref: before adding a native child link or a documented generated-work entry, check whether that exact child-ref is already linked/listed; if so, it's a no-op. The documented generated-work section is **regenerated** from the current child set on each run rather than appended, so re-planning never accumulates stale or duplicate entries (the same regenerate-don't-append discipline `prd-backlink` already uses for its `## Tickets` section).
+- **Rollup** is keyed by the PRD's current state: a PRD already in `shipped` (and closed, when closure is configured) is a no-op — rollup does not re-transition or re-close it. Computing the all-terminal condition over the child-ref set is itself idempotent (a pure function of the children's current states).
+
+## Citation
+
+Skills that link generated work to a PRD or roll a PRD up cite this rule by slug (the `prd-lifecycle-rollup` rule) instead of restating it:
+
+- **PRD backlink / native linking** (`prd-backlink`) — record generated top-level work as native PRD children where supported; always write the documented generated-work fallback; dedupe by child-ref. *(LPC-1.1 #580, LPC-1.2 #582)*
+- **PRD coverage** (`prd-ticket-coverage`) — read the generated top-level child set deterministically from the recorded relationship, not from free-form comments.
+- **GitHub PRD closure rollup** (`github-prd-intake`) — detect terminal/incomplete/blocked child sets, transition to `prd-shipped`, and close the PRD issue when `prd.rollup.closeOnShipped` is configured. *(LPC-1.3 #583)*
+- **Linear / Confluence / Notion PRD rollup** (`linear-prd-intake`, `confluence-prd-intake`, `notion-prd-intake`) — mirror the GitHub closure rollup with each vendor's terminal predicate and close/archive support. *(LPC-1.3 #584)*
+- **Idempotency** (all of the above) — dedupe-by-ref linking and no-op already-shipped rollup. *(LPC-1.4 #585)*
+- **Vendor matrix documentation** — describe native-hierarchy vs documented-link fallback per supported vendor against this contract. *(LPC-1.5 #586)*
+
+This is the PRD-level companion to `leaf-only-lifecycle` (which governs the build lifecycle and parent-from-leaves rollup); together they define the full hierarchy: a PRD owns its generated top-level work, which owns its leaves, and terminal state rolls up bottom-to-top — leaf → top-level unit → PRD.

--- a/tests/unit/strategies/prd-lifecycle-rollup.test.ts
+++ b/tests/unit/strategies/prd-lifecycle-rollup.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for the vendor-neutral PRD lifecycle rollup rule.
+ *
+ * Issue #579: add `plugins/src/base/rules/prd-lifecycle-rollup.md` — the single
+ * vendor-neutral source of truth for how a PRD owns its generated top-level work
+ * and rolls up to `shipped` from that child set, and wire the `prd.rollup.*`
+ * config schema into `config-resolution`. This is the foundation leaf of PRD
+ * #525; siblings #580–#586 (prd-backlink native linking, generated-work
+ * fallback, github/linear/confluence/notion PRD closure rollup, idempotency
+ * hardening, vendor matrix) cite the rule added here by slug.
+ *
+ * The rule must define four coupled things:
+ *   (a) "generated top-level work" = the PRD's created Epics / top-level Stories,
+ *       explicitly EXCLUDING leaf Sub-tasks;
+ *   (b) the per-vendor terminal-state predicate (GitHub closed/status:done;
+ *       Linear completed/canceled; JIRA Done-category; Confluence/Notion
+ *       documented done);
+ *   (c) the prd-shipped transition + config-gated close/archive
+ *       (`prd.rollup.closeOnShipped`);
+ *   (d) the idempotency dedupe key (child-ref identity).
+ * It must cross-reference `leaf-only-lifecycle` by slug and document the
+ * single-environment collapse while staying multi-env capable.
+ *
+ * Both the source (`plugins/src/base/rules`) and the generated artifact
+ * (`plugins/lisa/rules`) are asserted, so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/prd-lifecycle-rollup
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Both plugin roots: source of truth and generated artifact. */
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+
+/** The new rule's slug / filename stem. */
+const RULE_SLUG = "prd-lifecycle-rollup";
+/** The companion rule this one cross-references by slug. */
+const COMPANION_SLUG = "leaf-only-lifecycle";
+
+const readRule = (root: string, slug: string): string =>
+  readFileSync(path.resolve(root, `${slug}.md`), "utf8");
+
+describe("prd-lifecycle-rollup rule (#579)", () => {
+  describe.each(RULE_ROOTS)("%s/prd-lifecycle-rollup", root => {
+    const rulePath = path.resolve(root, `${RULE_SLUG}.md`);
+
+    it("exists in this plugin root", () => {
+      expect(existsSync(rulePath)).toBe(true);
+    });
+
+    const content = readRule(root, RULE_SLUG);
+
+    it("is the vendor-neutral source of truth for PRD rollup", () => {
+      expect(content).toMatch(/vendor-neutral/i);
+      expect(content).toMatch(/PRD/);
+      expect(content).toMatch(/rollup/i);
+    });
+
+    // (a) generated-top-level-work contract — excludes leaf Sub-tasks.
+    it("defines generated top-level work and excludes leaf Sub-tasks", () => {
+      expect(content).toMatch(/[Gg]enerated top-level work/);
+      // The PRD owns Epics / top-level Stories.
+      expect(content).toMatch(/Epic/);
+      expect(content).toMatch(/Story/);
+      // Sub-tasks are explicitly excluded from the PRD's direct children.
+      expect(content).toMatch(/Sub-tasks?/);
+      expect(content).toMatch(/exclud/i);
+      expect(content).toMatch(
+        /leaf implementation tasks direct children of the PRD|never.*direct children of the PRD/i
+      );
+    });
+
+    // (b) per-vendor terminal-state predicate across all five vendors.
+    it("defines the per-vendor terminal-state predicate", () => {
+      expect(content).toMatch(/terminal-state predicate|terminal predicate/i);
+      // GitHub: closed + done role label.
+      expect(content).toMatch(/closed/);
+      expect(content).toMatch(/status:done/);
+      // Linear: completed / canceled.
+      expect(content).toMatch(/completed/i);
+      expect(content).toMatch(/cancel/i);
+      // JIRA: Done status category.
+      expect(content).toMatch(/Done status category|statusCategory/);
+      // Confluence / Notion: documented done.
+      expect(content).toMatch(/Confluence/);
+      expect(content).toMatch(/Notion/);
+      expect(content).toMatch(/documented.*done|done.*documented/i);
+    });
+
+    // (c) prd-shipped transition + config-gated close/archive.
+    it("defines the prd-shipped transition and config-gated close/archive", () => {
+      expect(content).toMatch(/prd-shipped|`shipped`/);
+      expect(content).toMatch(/ticketed.*shipped|shipped/i);
+      expect(content).toMatch(/close\/archive|close\b|archive/i);
+      // Closure is gated on configuration via prd.rollup.closeOnShipped.
+      expect(content).toMatch(/closeOnShipped/);
+      // Never close before all top-level work is terminal.
+      expect(content).toMatch(
+        /[Nn]ever close.*before|before all generated top-level work is terminal/
+      );
+      // Only advances when ALL required children are terminal.
+      expect(content).toMatch(/all.*required.*terminal|all required/i);
+    });
+
+    // (d) idempotency dedupe key = child-ref identity.
+    it("defines the idempotency dedupe key as child-ref identity", () => {
+      expect(content).toMatch(/[Ii]dempoten/);
+      expect(content).toMatch(/dedupe key/i);
+      expect(content).toMatch(/child-ref identity|child-ref/i);
+      // The GitHub child ref form is named explicitly.
+      expect(content).toMatch(/owner\/repo#number|#number/);
+      // Already-shipped rollup is a no-op.
+      expect(content).toMatch(/no-op/i);
+      // Documented section is regenerated, not appended.
+      expect(content).toMatch(/regenerat/i);
+    });
+
+    it("cross-references the leaf-only-lifecycle rule by slug", () => {
+      expect(content).toContain(COMPANION_SLUG);
+    });
+
+    it("documents the single-environment collapse and stays multi-env capable", () => {
+      // Documents the collapse explicitly.
+      expect(content).toMatch(/[Ss]ingle-environment collapse/);
+      expect(content).toMatch(/production: main/);
+      // Never assumes a dev → staging → prod promotion chain for the rollup.
+      expect(content).toMatch(
+        /does \*\*not\*\* hardcode a `dev → staging → prod`|no.*dev.*staging.*prod/i
+      );
+      // Stays multi-env capable — env-keyed done logic is preserved.
+      expect(content).toMatch(/env-keyed `done`|multi-env capable/i);
+      // Never resolves a dev/staging done in this single-env repo.
+      expect(content).toMatch(
+        /never resolves a `dev` or `staging`|never.*dev/i
+      );
+    });
+
+    it("lists the downstream sibling skills that cite it (Citation section)", () => {
+      expect(content).toMatch(/## Citation/);
+      expect(content).toContain("prd-backlink");
+      expect(content).toContain("prd-ticket-coverage");
+      expect(content).toContain("github-prd-intake");
+      expect(content).toContain("linear-prd-intake");
+      expect(content).toContain("confluence-prd-intake");
+      expect(content).toContain("notion-prd-intake");
+    });
+  });
+});
+
+// config-resolution must wire the prd.rollup.* schema and reference the rule.
+describe("config-resolution wires prd.rollup (#579)", () => {
+  describe.each(["plugins/src/base/rules", "plugins/lisa/rules"] as const)(
+    "%s/config-resolution",
+    root => {
+      const content = readRule(root, "config-resolution");
+
+      it("references the prd-lifecycle-rollup rule by slug", () => {
+        expect(content).toContain(RULE_SLUG);
+      });
+
+      it("documents the prd.rollup.closeOnShipped config key", () => {
+        expect(content).toMatch(/prd\.rollup/);
+        expect(content).toContain("closeOnShipped");
+        // Default is false (set shipped, leave open for a human to close).
+        expect(content).toMatch(/`false`/);
+      });
+
+      it("adds the rollup block to the github and linear prd schema", () => {
+        // The JSON schema blocks for github + linear prd carry the rollup object.
+        const matches = content.match(
+          /"rollup":\s*\{\s*"closeOnShipped":\s*false\s*\}/g
+        );
+        expect(matches).not.toBeNull();
+        // github.labels.prd + linear.labels.prd + notion + confluence = 4.
+        expect((matches ?? []).length).toBeGreaterThanOrEqual(2);
+      });
+    }
+  );
+});


### PR DESCRIPTION
## What

Adds the **foundation leaf** of PRD #525 (link generated top-level work as PRD children + roll up PRD closure). Resolves #579.

### 1. New vendor-neutral rule — `plugins/src/base/rules/prd-lifecycle-rollup.md`

Single source of truth for how a PRD owns the work it generates and how its lifecycle rolls up to `shipped`. Modeled in structure/citation style on the existing `leaf-only-lifecycle` rule (#537). Defines the four elements required by #579's acceptance criteria:

- **(a) Generated top-level work** — the PRD's created Epics / top-level Stories, **explicitly excluding leaf Sub-tasks** (the PRD owns top-level units; those own their descendants, per `leaf-only-lifecycle`).
- **(b) Per-vendor terminal-state predicate** — GitHub closed + `status:done`; Linear completed/canceled; JIRA Done status category; Confluence/Notion documented done.
- **(c) `prd-shipped` transition + config-gated close/archive** — gated by `prd.rollup.closeOnShipped`; never closes before all top-level work is terminal.
- **(d) Idempotency dedupe key** — child-ref identity (e.g. `owner/repo#number`); no duplicate links, no double `shipped` transition; documented generated-work section is regenerated, not appended.

Kept generic/multi-env with the **single-environment collapse** documented for this repo (`deploy.branches = production: main` only). Cross-references `leaf-only-lifecycle` by slug. A Citation section names the downstream siblings (#580 prd-backlink native linking, #582 generated-work fallback, #583 github-prd-intake rollup, #584 linear/confluence/notion-prd-intake, #585 idempotency, #586 vendor matrix).

### 2. Config schema wiring — `plugins/src/base/rules/config-resolution.md`

- Added the `prd.rollup` block (`closeOnShipped`, default `false`) to the github/linear/notion/confluence PRD schema blocks.
- New **PRD rollup config (`prd.rollup`)** subsection documenting the key and referencing the `prd-lifecycle-rollup` rule.

### 3. Regression test — `tests/unit/strategies/prd-lifecycle-rollup.test.ts`

Modeled on `parent-status-rollup.test.ts`. Asserts the rule exists in **both** plugin roots (`plugins/src/base/rules` + the regenerated `plugins/lisa/rules`), defines the four required elements, cross-references `leaf-only-lifecycle`, documents the single-env collapse, and that `config-resolution` wires `prd.rollup`.

## Verification (empirical, CLI-based — no deploy)

- ✅ `bun run build:plugins` — rule regenerated into `plugins/lisa/rules/prd-lifecycle-rollup.md`, byte-identical to source (verified via `diff`).
- ✅ `bun run check:plugins` — `Plugin artifacts are in sync with plugins/src` + `Marketplace registers every built plugin` (no drift).
- ✅ `bun run typecheck` — clean.
- ✅ lint (oxlint + eslint) + prettier — clean on changed files.
- ✅ `bun run test:unit` — 55 files / 1136 tests pass, including the new `prd-lifecycle-rollup.test.ts`.

## Scope

Doc + config-schema + test only. Implementing the actual linking/rollup mechanics is out of scope (siblings #580+). `plugins/lisa` artifacts are generated and committed alongside source per the repo's plugin-sync guard.

🤖 Generated with Claude Code