### PR TITLE
feat(setup-linear): scaffold prd-verified PRD project label idempotently

### DIFF
--- a/plugins/lisa/skills/setup-linear/SKILL.md
+++ b/plugins/lisa/skills/setup-linear/SKILL.md
@@ -168,7 +168,9 @@ Probe with `mcp__linear-server__list_issue_labels` (scoped to the team). For eac
 
 #### 3b. PRD-lifecycle labels — PROJECT labels (only if Linear is the PRD source)
 
-Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `mcp__linear-server__create_project_label`. These are a **separate label kind** from issue labels — creating an issue label of the same name will NOT work for the PRD flow.
+Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `mcp__linear-server__create_project_label`. This probe-then-create is find-or-create per label: a label already present is reused untouched, so re-running never duplicates `prd-*`. These are a **separate label kind** from issue labels — creating an issue label of the same name will NOT work for the PRD flow.
+
+`prd-verified` is the terminal lifecycle state after `prd-shipped` (the `verified` role from config-resolution, #591): `/lisa:verify-prd` transitions a Linear PRD project into it once the shipped product has been empirically verified against the PRD. Scaffold it through the same find-or-create path as every other `prd-*` row.
 
 | Role | Default | Kind |
 |------|---------|------|
@@ -178,6 +180,7 @@ Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `m
 | `blocked` | `prd-blocked` | project label |
 | `ticketed` | `prd-ticketed` | project label |
 | `shipped` | `prd-shipped` | project label |
+| `verified` | `prd-verified` | project label |
 | `sentinel` | `prd-intake-feedback` | **issue** label (marks the sentinel feedback issue — create via `create_issue_label`) |
 
 #### 3c. Handle name collisions / renames
@@ -230,7 +233,7 @@ jq -e '.linear.workspace' .lisa.config.json >/dev/null
 [ "$(jq -r '.tracker // empty' .lisa.config.json)" = "linear" ] && jq -e '.linear.teamKey' .lisa.config.json >/dev/null
 ```
 
-Confirm the scaffolded labels are present (`list_issue_labels` for `status:*` + the sentinel; `list_project_labels` for `prd-*`). Report success with the resolved workspace, team key (if any), which namespaces were scaffolded (created vs. already existed), any non-default overrides, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
+Confirm the scaffolded labels are present (`list_issue_labels` for `status:*` + the sentinel; `list_project_labels` for `prd-*`, including the terminal `prd-verified`). Report success with the resolved workspace, team key (if any), which namespaces were scaffolded (created vs. already existed), any non-default overrides, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency
 

--- a/plugins/src/base/skills/setup-linear/SKILL.md
+++ b/plugins/src/base/skills/setup-linear/SKILL.md
@@ -168,7 +168,9 @@ Probe with `mcp__linear-server__list_issue_labels` (scoped to the team). For eac
 
 #### 3b. PRD-lifecycle labels — PROJECT labels (only if Linear is the PRD source)
 
-Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `mcp__linear-server__create_project_label`. These are a **separate label kind** from issue labels — creating an issue label of the same name will NOT work for the PRD flow.
+Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `mcp__linear-server__create_project_label`. This probe-then-create is find-or-create per label: a label already present is reused untouched, so re-running never duplicates `prd-*`. These are a **separate label kind** from issue labels — creating an issue label of the same name will NOT work for the PRD flow.
+
+`prd-verified` is the terminal lifecycle state after `prd-shipped` (the `verified` role from config-resolution, #591): `/lisa:verify-prd` transitions a Linear PRD project into it once the shipped product has been empirically verified against the PRD. Scaffold it through the same find-or-create path as every other `prd-*` row.
 
 | Role | Default | Kind |
 |------|---------|------|
@@ -178,6 +180,7 @@ Probe with `mcp__linear-server__list_project_labels`. Create missing ones via `m
 | `blocked` | `prd-blocked` | project label |
 | `ticketed` | `prd-ticketed` | project label |
 | `shipped` | `prd-shipped` | project label |
+| `verified` | `prd-verified` | project label |
 | `sentinel` | `prd-intake-feedback` | **issue** label (marks the sentinel feedback issue — create via `create_issue_label`) |
 
 #### 3c. Handle name collisions / renames
@@ -230,7 +233,7 @@ jq -e '.linear.workspace' .lisa.config.json >/dev/null
 [ "$(jq -r '.tracker // empty' .lisa.config.json)" = "linear" ] && jq -e '.linear.teamKey' .lisa.config.json >/dev/null
 ```
 
-Confirm the scaffolded labels are present (`list_issue_labels` for `status:*` + the sentinel; `list_project_labels` for `prd-*`). Report success with the resolved workspace, team key (if any), which namespaces were scaffolded (created vs. already existed), any non-default overrides, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
+Confirm the scaffolded labels are present (`list_issue_labels` for `status:*` + the sentinel; `list_project_labels` for `prd-*`, including the terminal `prd-verified`). Report success with the resolved workspace, team key (if any), which namespaces were scaffolded (created vs. already existed), any non-default overrides, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency
 

--- a/tests/unit/strategies/setup-linear-prd-verified-label.test.ts
+++ b/tests/unit/strategies/setup-linear-prd-verified-label.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for the `prd-verified` PRD-lifecycle project-label scaffolding
+ * in the `setup-linear` skill.
+ *
+ * Issue #594 (Story #589, Epic #587, PRD #553): when Linear is the PRD source,
+ * `setup-linear` must scaffold the new terminal `prd-verified` PROJECT label so
+ * `/lisa:verify-prd` has a label to transition a Linear PRD project into once the
+ * shipped product has been empirically verified against the PRD. The label must
+ * be scaffolded idempotently — through the same `list_project_labels` (probe) →
+ * `create_project_label` (create-missing) find-or-create path the rest of the
+ * `prd-*` namespace uses — so reruns reuse the existing label instead of
+ * duplicating.
+ *
+ * This is the Linear counterpart of merged #593 (setup-github prd-verified) and
+ * aligns with sibling #591 (config-resolution `verified` role). Unlike
+ * setup-github (bash `ensure_label`), setup-linear drives scaffolding from a
+ * role->label table plus MCP probe/create, so the assertions target that idiom:
+ * the `verified | prd-verified | project label` table row and the project-label
+ * tooling.
+ *
+ * Linear splits labels into two kinds: `prd-verified` MUST be a PROJECT label
+ * (the PRD lifecycle lives on Projects), never an issue label.
+ *
+ * Both plugin roots are asserted (`plugins/src/base` source of truth and the
+ * generated `plugins/lisa` artifact), so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/setup-linear-prd-verified-label
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Both plugin roots: source of truth and generated artifact. */
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("setup-linear scaffolds prd-verified idempotently (#594)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const content = read(root, "skills/setup-linear/SKILL.md");
+
+    it("adds the verified role row to the PRD role->label table", () => {
+      // Mirrors the rest of the prd-* table: `| <role> | <default> | <kind> |`.
+      expect(content).toMatch(
+        /\|\s*`verified`\s*\|\s*`prd-verified`\s*\|\s*project label\s*\|/
+      );
+    });
+
+    it("scaffolds prd-verified as a PROJECT label, not an issue label", () => {
+      // Target the role->label table row specifically (begins with `| `verified`).
+      const verifiedRow = content
+        .split("\n")
+        .find(line => /^\|\s*`verified`\s*\|/.test(line));
+      expect(verifiedRow).toBeDefined();
+      // PRD lifecycle lives on Linear Projects — the row must say project label.
+      expect(verifiedRow).toMatch(/project label/);
+      expect(verifiedRow).not.toMatch(/\*\*issue\*\* label/);
+    });
+
+    it("orders the prd-verified table row after the prd-shipped table row", () => {
+      // Compare the table ROWS (anchored on `| `<role>`), not prose mentions,
+      // so the terminal-state prose paragraph does not perturb ordering.
+      const lines = content.split("\n");
+      const shippedRowIdx = lines.findIndex(line =>
+        /^\|\s*`shipped`\s*\|/.test(line)
+      );
+      const verifiedRowIdx = lines.findIndex(line =>
+        /^\|\s*`verified`\s*\|/.test(line)
+      );
+      expect(shippedRowIdx).toBeGreaterThanOrEqual(0);
+      expect(verifiedRowIdx).toBeGreaterThan(shippedRowIdx);
+    });
+
+    it("drives prd-* creation through the find-or-create MCP project-label path", () => {
+      // The probe-then-create that makes reruns non-duplicating.
+      expect(content).toMatch(/list_project_labels/);
+      expect(content).toMatch(/create_project_label/);
+      expect(content).toMatch(/find-or-create/);
+    });
+
+    it("documents prd-verified as the terminal state after prd-shipped", () => {
+      expect(content).toMatch(
+        /`prd-verified` is the terminal lifecycle state after `prd-shipped`/
+      );
+    });
+
+    it("confirms prd-verified is present in the Step 6 verification prose", () => {
+      expect(content).toMatch(/including the terminal `prd-verified`/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #594. Mirrors merged #593 (setup-github `prd-verified`) into the **setup-linear** skill so that when Linear is the PRD source, `/lisa:verify-prd` has a `prd-verified` PROJECT label to transition a Linear PRD project into once the shipped product has been empirically verified against the PRD.

Linear splits labels into two kinds — `prd-verified` is a **project** label (the PRD lifecycle lives on Projects), never an issue label.

## Changes

`plugins/src/base/skills/setup-linear/SKILL.md` (source of truth; `plugins/lisa` regenerated via `bun run build:plugins`):

1. **Role->label table (Step 3b):** added `| verified | prd-verified | project label |` after `prd-shipped`, before the sentinel issue label.
2. **Scaffolding prose:** documented `prd-verified` as the terminal lifecycle state after `prd-shipped` (the `verified` role from config-resolution, #591), scaffolded through the same find-or-create path (`list_project_labels` probe → `create_project_label` for missing) the rest of the `prd-*` namespace uses — reruns reuse the existing label rather than duplicating.
3. **Step 6 verify prose:** the `list_project_labels` confirmation now calls out the terminal `prd-verified`.

## Test

`tests/unit/strategies/setup-linear-prd-verified-label.test.ts` — vitest regression asserting, across **both** plugin roots (`plugins/src/base` source + generated `plugins/lisa`):
- the `verified | prd-verified | project label` table row exists;
- `prd-verified` is a PROJECT label (not an issue label);
- it is ordered after `prd-shipped` in the table;
- the find-or-create MCP project-label path is documented;
- the terminal-state + Step 6 confirmation prose is present.

## Verification (empirical)

CLI/doc-based per the issue's plan (Lisa has no Linear workspace wired for E2E; the skill is prose+config):

- `bunx vitest run tests/unit/strategies/setup-linear-prd-verified-label.test.ts` → **12 passed** (6 assertions × 2 plugin roots).
- `bun run check:plugins` → **✓ Plugin artifacts are in sync with plugins/src** / **✓ Marketplace registers every built plugin.**
- `grep -n "prd-verified" plugins/src/base/skills/setup-linear/SKILL.md` and the generated `plugins/lisa/...` show identical table row + scaffolding + verify lines.

Aligns with the verified vendor-map (#591), the setup-github pattern (#593), and the `prd-lifecycle-rollup` rule.

🤖 Generated with Claude Code