### PR TITLE
feat(setup-notion): map/create the Verified PRD status value idempotently

### DIFF
--- a/plugins/lisa/skills/setup-notion/SKILL.md
+++ b/plugins/lisa/skills/setup-notion/SKILL.md
@@ -259,9 +259,11 @@ STATUS_PROP=$(jq -r '.properties | to_entries[] | select(.value.type == "status"
 STATUS_VALUES=$(jq -r --arg p "$STATUS_PROP" '.properties[$p] | (.status.options // .select.options) | .[].name' <<<"$DB_SCHEMA")
 ```
 
-For each lisa role (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`), check if its default name (`Draft`, `Ready`, etc.) appears in `$STATUS_VALUES`. If a role's default is missing but a similar-looking value exists, prompt the user to map it via `AskUserQuestion`. If a role has no plausible match, prompt to either create the value in Notion or accept that the lifecycle stage is unrepresented.
+For each lisa role (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, `verified`), check if its default name (`Draft`, `Ready`, etc.; `Verified` for `verified`) appears in `$STATUS_VALUES`. If a role's default is missing but a similar-looking value exists, prompt the user to map it via `AskUserQuestion`. If a role has no plausible match, prompt to either create the value in Notion or accept that the lifecycle stage is unrepresented. This find-or-create-or-accept path is idempotent per role: a value already present (default or mapped) is reused untouched, so re-running never duplicates a status option.
 
-Collect overrides as a partial values map. Only write keys that differ from defaults.
+`verified` is the terminal lifecycle state after `shipped` (the `verified` role from the `config-resolution` rule, #591): `/lisa:verify-prd` transitions a Notion PRD into it once the shipped product has been empirically verified against the PRD. Notion models the PRD lifecycle as `Status` (or `select`) property options rather than labels, so `verified` is mapped or created through the exact same path as every other role above — and, like them, persisted to `notion.values.verified` when the workspace uses a non-default option name.
+
+Collect overrides as a partial values map. Only write keys that differ from defaults — `verified` included, so a non-default `Verified` option name lands in `notion.values.verified`.
 
 ### Step 7 — Write `.lisa.config.json`
 
@@ -298,7 +300,7 @@ jq -e '.notion.workspaceId and .notion.prdDatabaseId' .lisa.config.json >/dev/nu
 echo "Token validated (${#TOKEN} chars). Workspace: $ME_WORKSPACE. Database: $DATABASE_ID."
 ```
 
-Report success with the resolved workspace, database, status property name, and value overrides (if any). Direct the user to `/lisa:intake` to test.
+Report success with the resolved workspace, database, status property name, and value overrides (if any), confirming all lifecycle roles — including the terminal `verified` — were detected, mapped, or flagged for creation. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency
 

--- a/plugins/src/base/skills/setup-notion/SKILL.md
+++ b/plugins/src/base/skills/setup-notion/SKILL.md
@@ -259,9 +259,11 @@ STATUS_PROP=$(jq -r '.properties | to_entries[] | select(.value.type == "status"
 STATUS_VALUES=$(jq -r --arg p "$STATUS_PROP" '.properties[$p] | (.status.options // .select.options) | .[].name' <<<"$DB_SCHEMA")
 ```
 
-For each lisa role (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`), check if its default name (`Draft`, `Ready`, etc.) appears in `$STATUS_VALUES`. If a role's default is missing but a similar-looking value exists, prompt the user to map it via `AskUserQuestion`. If a role has no plausible match, prompt to either create the value in Notion or accept that the lifecycle stage is unrepresented.
+For each lisa role (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, `verified`), check if its default name (`Draft`, `Ready`, etc.; `Verified` for `verified`) appears in `$STATUS_VALUES`. If a role's default is missing but a similar-looking value exists, prompt the user to map it via `AskUserQuestion`. If a role has no plausible match, prompt to either create the value in Notion or accept that the lifecycle stage is unrepresented. This find-or-create-or-accept path is idempotent per role: a value already present (default or mapped) is reused untouched, so re-running never duplicates a status option.
 
-Collect overrides as a partial values map. Only write keys that differ from defaults.
+`verified` is the terminal lifecycle state after `shipped` (the `verified` role from the `config-resolution` rule, #591): `/lisa:verify-prd` transitions a Notion PRD into it once the shipped product has been empirically verified against the PRD. Notion models the PRD lifecycle as `Status` (or `select`) property options rather than labels, so `verified` is mapped or created through the exact same path as every other role above — and, like them, persisted to `notion.values.verified` when the workspace uses a non-default option name.
+
+Collect overrides as a partial values map. Only write keys that differ from defaults — `verified` included, so a non-default `Verified` option name lands in `notion.values.verified`.
 
 ### Step 7 — Write `.lisa.config.json`
 
@@ -298,7 +300,7 @@ jq -e '.notion.workspaceId and .notion.prdDatabaseId' .lisa.config.json >/dev/nu
 echo "Token validated (${#TOKEN} chars). Workspace: $ME_WORKSPACE. Database: $DATABASE_ID."
 ```
 
-Report success with the resolved workspace, database, status property name, and value overrides (if any). Direct the user to `/lisa:intake` to test.
+Report success with the resolved workspace, database, status property name, and value overrides (if any), confirming all lifecycle roles — including the terminal `verified` — were detected, mapped, or flagged for creation. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency
 

--- a/tests/unit/strategies/setup-notion-prd-verified-status.test.ts
+++ b/tests/unit/strategies/setup-notion-prd-verified-status.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for the `verified` PRD-lifecycle status-value mapping in the
+ * `setup-notion` skill.
+ *
+ * Issue #595 (Story #589, Epic #587, PRD #553): when Notion is the PRD source,
+ * `setup-notion` must detect/map/create the new terminal `Verified` status value
+ * so `/lisa:verify-prd` has a status option to transition a Notion PRD into once
+ * the shipped product has been empirically verified against the PRD. The value
+ * must be handled idempotently — through the same find-or-create-or-accept path
+ * (default-name probe against `$STATUS_VALUES` → map similar value → create or
+ * accept-unrepresented) the rest of the lifecycle roles use — so reruns reuse the
+ * existing status option instead of duplicating.
+ *
+ * This is the Notion counterpart of merged #593 (setup-github prd-verified) and
+ * #594 (setup-linear prd-verified), and aligns with sibling #591
+ * (config-resolution `verified` role / `notion.values.verified` default
+ * `Verified`). Unlike GitHub (bash `ensure_label`) and Linear (project-label
+ * role->label table), Notion models the PRD lifecycle as `Status`/`select`
+ * property options mapped via `notion.values`, so the assertions target that
+ * idiom: the `verified` role appearing in the Step 6 role loop and the
+ * `notion.values.verified` persistence.
+ *
+ * Both plugin roots are asserted (`plugins/src/base` source of truth and the
+ * generated `plugins/lisa` artifact), so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/setup-notion-prd-verified-status
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Both plugin roots: source of truth and generated artifact. */
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("setup-notion maps/creates the verified status idempotently (#595)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const content = read(root, "skills/setup-notion/SKILL.md");
+
+    it("includes verified in the Step 6 role list", () => {
+      // The role loop iterates draft..shipped, now extended with verified.
+      expect(content).toMatch(
+        /`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, `verified`/
+      );
+    });
+
+    it("names Verified as the default option for the verified role", () => {
+      expect(content).toMatch(/`Verified` for `verified`/);
+    });
+
+    it("documents verified as the terminal state after shipped", () => {
+      expect(content).toMatch(
+        /`verified` is the terminal lifecycle state after `shipped`/
+      );
+    });
+
+    it("cites the config-resolution rule and the #591 verified role", () => {
+      expect(content).toMatch(/`config-resolution` rule, #591/);
+    });
+
+    it("persists a non-default verified option to notion.values.verified", () => {
+      expect(content).toMatch(/notion\.values\.verified/);
+    });
+
+    it("describes the per-role mapping as idempotent (no duplicate options)", () => {
+      expect(content).toMatch(/idempotent/);
+      expect(content).toMatch(/re-running never duplicates a status option/);
+    });
+
+    it("confirms verified in the Step 9 success-report prose", () => {
+      expect(content).toMatch(/including the terminal `verified`/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #595. Notion counterpart of merged #593 (setup-github `prd-verified`) and #594 (setup-linear `prd-verified`), part of PRD #553 (verified PRD state).

When Notion is the PRD source, `/lisa:verify-prd` needs a terminal `Verified` Status value to transition a Notion PRD into once the shipped product has been empirically verified against the PRD. Notion models the PRD lifecycle as a `Status` (or `select`) property's options mapped via `notion.values` — not as labels — so unlike GitHub (bash `ensure_label`) and Linear (project-label table), the new role is added to the **Step 6 status-value detection loop**.

## What changed

`plugins/src/base/skills/setup-notion/SKILL.md` (source of truth; `plugins/lisa` regenerated via `bun run build:plugins`):

- **Step 6** — added `verified` (default `Verified`) to the lifecycle role list the mapping loop iterates over (`draft, ready, in_review, blocked, ticketed, shipped`). It reuses the existing find-or-create-or-accept path (default-name probe against `$STATUS_VALUES` → map a similar value via `AskUserQuestion` → create the option or accept-unrepresented). Made the idempotency explicit: a value already present is reused untouched, so re-running never duplicates a status option.
- Documented `verified` as the terminal state after `shipped` (the `verified` role from the **`config-resolution`** rule, #591), and made the Step 6/Step 7 prose explicit that a non-default option name persists to `notion.values.verified`.
- **Step 9** — success-report prose now confirms the terminal `verified` role was detected, mapped, or flagged for creation.

## Tests

Added `tests/unit/strategies/setup-notion-prd-verified-status.test.ts` — a vitest regression test asserting the mapping across **both plugin roots** (`plugins/src/base` source + generated `plugins/lisa`), so an artifact-only edit or a missed `bun run build:plugins` fails the suite.

## Acceptance criteria

- [x] `verified` detected/mapped/flagged-for-creation exactly like the other roles (Step 6 loop)
- [x] non-default name persists to `notion.values.verified` (Step 7 partial values map; prose explicit)
- [x] built artifacts stay in sync — `bun run build:plugins && bun run check:plugins` reports no drift

## Verification (doc/CLI-based; Lisa has no Notion workspace wired for E2E)

- `grep` confirms `verified` in the Step 6 role loop, the `notion.values.verified` write, and the Step 9 report across both plugin roots.
- `bun run check:plugins` → `✓ Plugin artifacts are in sync with plugins/src.`
- `bunx vitest run tests/unit/strategies/setup-notion-prd-verified-status.test.ts` → 14 passed (7 assertions × 2 roots).

🤖 Generated with Claude Code