### PR TITLE
feat(verify-prd): scaffold command+skill, child-set read, and terminal-child guard (#597)

### DIFF
--- a/plugins/lisa/commands/verify-prd.md
+++ b/plugins/lisa/commands/verify-prd.md
@@ -1,0 +1,6 @@
+---
+description: "Initiative-level PRD acceptance gate. Reads a shipped PRD and its generated child work, confirms all generated top-level work is terminal, then (sibling tickets) runs spec-conformance + empirical verification and transitions the PRD shipped → verified | blocked."
+argument-hint: "<prd>"
+---
+
+Use the /lisa:verify-prd skill to read the PRD, confirm its generated top-level work is terminal, and run initiative-level acceptance verification. $ARGUMENTS

--- a/plugins/lisa/skills/verify-prd/SKILL.md
+++ b/plugins/lisa/skills/verify-prd/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: verify-prd
+description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any empirical verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. The entry point of the PRD-level verification flow; the PASS path (spec-conformance + empirical verification + shipped → verified), the FAIL path (shipped → blocked + fix issues), and idempotency are handled by sibling work."
+allowed-tools: ["Skill", "Bash", "Read", "mcp__claude_ai_Notion__notion-fetch", "mcp__claude_ai_Notion__notion-get-comments", "mcp__atlassian__getConfluencePage", "mcp__atlassian__getConfluencePageDescendants", "mcp__atlassian__getJiraIssue", "mcp__atlassian__searchJiraIssuesUsingJql", "mcp__atlassian__getAccessibleAtlassianResources", "mcp__linear-server__get_project", "mcp__linear-server__list_issues", "mcp__linear-server__get_issue", "mcp__linear-server__list_documents", "mcp__linear-server__get_document"]
+---
+
+# PRD-level Verification: $ARGUMENTS
+
+`/lisa:verify-prd <prd>` is the **initiative-level acceptance gate**. It runs *after* a PRD is `shipped` (all generated top-level work terminal, per `prd-lifecycle-rollup`'s rollup phase) and proves the shipped product actually matches the PRD — not merely that every ticket is closed. `shipped` is **necessary but not sufficient** for `verified`: a PRD can have every child ticket closed while still missing a requirement, diverging from its acceptance criteria, or failing a real user workflow.
+
+This is distinct from `/lisa:verify`, which empirically verifies a **single work item** (a ticket / story / sub-task) in its target environment as part of that item's Build/Fix/Improve flow. `/lisa:verify` drives a build ticket to `done` at the leaf/build level; it does not read the PRD or judge initiative-level acceptance. `/lisa:verify-prd` operates one level up, over the whole initiative. See the `prd-lifecycle-rollup` rule's "PRD-level verification vs ticket verification" section for the full distinction.
+
+`$ARGUMENTS` is a single PRD reference: a **GitHub issue URL** (or `<org>/<repo>#<n>`), a **Linear project/issue URL**, a **Notion page URL**, a **Confluence page URL**, or a **JIRA issue key/URL**.
+
+## Confirmation policy
+
+Do **not** re-prompt once invoked. Like the `*-prd-intake` skills, the caller has already authorized the run by invoking the skill; asking the user to confirm before reading or before applying the guard defeats the purpose of a batchable acceptance gate. Run the front-half (resolve → read child set → guard) to completion and report.
+
+## Scope of this skill
+
+This skill is the **read/guard front-half** of PRD-level verification:
+
+1. Resolve the PRD ref and detect its source vendor.
+2. Read the PRD body and its **generated top-level child work set** via the `prd-lifecycle-rollup` contract.
+3. Apply the per-vendor terminal predicate to the generated top-level work and run the **terminal-child guard**: if any required top-level child is non-terminal, report the incomplete set and STOP — do not run empirical verification, do not transition the PRD.
+
+The remaining phases of PRD-level verification are **out of scope** here and are delivered by sibling work (this skill is their entry point):
+
+- **PASS path** — spec-conformance against the PRD's requirements + empirical verification of the shipped surface, then the `shipped → verified` transition with evidence.
+- **FAIL path** — on verification failure, the `shipped → blocked` transition, a product-readable failure report, and linked fix issues for the missing/incorrect behavior.
+- **Idempotency** — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
+
+When the terminal-child guard passes (all required generated top-level work is terminal), this front-half hands off to the PASS/FAIL phases. Until those phases land, a passing guard means "ready for verification"; this skill does not itself transition the PRD to `verified` or `blocked`.
+
+## Phase 1 — Resolve the PRD ref and detect the source vendor
+
+Detect the vendor from `$ARGUMENTS` the same way `prd-ticket-coverage` / `prd-backlink` do — from the host (or key shape for JIRA), never by guessing:
+
+| Input shape | Vendor | Read surface |
+|---|---|---|
+| `github.com/<org>/<repo>/issues/<n>` or `<org>/<repo>#<n>` | **GitHub Issues** | `gh` CLI (Lisa uses the CLI exclusively for GitHub — no GitHub MCP) |
+| `linear.app/...` | **Linear** | `mcp__linear-server__get_project` / `get_issue` |
+| `notion.so` / `notion.site` | **Notion** | `mcp__claude_ai_Notion__notion-fetch` (`include_discussions: true`) |
+| `*.atlassian.net/wiki/...` | **Confluence** | `mcp__atlassian__getConfluencePage` (+ descendants) |
+| JIRA issue key (e.g. `PROJ-123`) or `*.atlassian.net/browse/...` | **JIRA** | `mcp__atlassian__getJiraIssue` |
+
+Read the PRD body via the vendor-appropriate surface. The vendor that owns the PRD source is what Phase 2 reads the child set from; it is independent of which tracker hosts the generated tickets (a Notion PRD can own JIRA tickets — the cross-vendor case is handled by the documented generated-work section in Phase 2).
+
+Where the PRD lives in the same vendor as the configured `tracker` (`.lisa.config.json`), prefer reading the PRD ticket through `lisa:tracker-read` so this skill stays agnostic of which tracker hosts the work — `tracker-read` dispatches to `lisa:github-read-issue` / `lisa:jira-read-ticket` / `lisa:linear-read-issue` per config and returns the consolidated context bundle (PRD body, native children, links). For PRD sources with no tracker counterpart (Notion / Confluence / cross-vendor), read the PRD body directly via the vendor surface above.
+
+## Phase 2 — Read the generated top-level child work set
+
+**Do NOT reimplement child enumeration.** Consume the PRD→generated-top-level-work relationship recorded by the merged child-linking work (`prd-backlink` native linking + its always-written machine-readable generated-work section), exactly as `github-prd-intake`'s rollup phase consumes it. Read the **generated top-level work** only — the PRD's created Epics and any top-level Story created directly under it — and **exclude** leaf Sub-tasks and any Story nested under a generated Epic, per the `prd-lifecycle-rollup` rule's generated-top-level-work contract.
+
+Use two sources, **native first**, deduped by child-ref identity:
+
+1. **Native hierarchy (primary).** Read the PRD's direct native children — these are its top-level children:
+   - **GitHub** — the PRD issue's direct `subIssues` nodes (the GraphQL `subIssues` query `lisa:github-read-issue` Phase 3 uses; capture `number title state url stateReason labels`).
+   - **Linear** — for a PRD Project, its member Issues (`list_issues({project})`); for a PRD Issue, its sub-Issues (`get_issue` children). Capture each child's `state` (workflow state + category).
+   - **JIRA** — the PRD's children via the epic-link/parent JQL `lisa:jira-read-ticket` Phase 5 uses (`"Epic Link" = <PRD-KEY>` or `parent = <PRD-KEY>`). Capture each child's `statusCategory`.
+   - **Notion / Confluence** — no native issue hierarchy; use the documented section below.
+
+2. **Documented generated-work section (fallback / cross-vendor).** When native hierarchy is unavailable (older host, cross-vendor PRD→tracker, or the relationship was only recorded in the PRD body), parse the machine-readable generated-work section `prd-backlink` writes to the PRD body (`## Tickets`, alias `## Generated Work`). Enumerate the `<!-- lisa:gw ref=… url=… type=… parent=… -->` tokens; the **generated top-level child set is every token whose `parent` is empty** (top-level), exactly as `prd-backlink` documents. Tokens with a non-empty `parent` are descendants — skip them. For GitHub, this is the same `awk` extraction `github-prd-intake` Phase 3f.2 uses.
+
+**Dedupe by child-ref identity** (`owner/repo#number` for GitHub, the issue/project identifier for Linear, the issue key for JIRA, the recorded ref for Notion/Confluence — the `prd-lifecycle-rollup` idempotency dedupe key) so a child appearing in both the native graph and the documented section is counted once. **Match by stable ref, never by title.**
+
+If neither source yields any generated top-level child (the PRD generated nothing, or the relationship was never recorded), report `no generated top-level children — cannot verify an empty PRD` and STOP. Do not transition the PRD.
+
+## Phase 3 — Terminal-child guard
+
+Apply the **per-vendor terminal-state predicate from the `prd-lifecycle-rollup` rule** to every generated **top-level** work item (cite the rule by slug — do not restate its predicate table here). In summary, a top-level child is:
+
+- **Terminal** — it has reached its source/tracker's done/shipped state (GitHub: closed + the resolved build `done` role label where used; Linear: a `done`-category completed state; JIRA: `statusCategory.key == "done"`; Notion/Confluence: the documented generated-work entry marked done). A generated Epic is terminal only when *it* has rolled up to its own terminal state per `leaf-only-lifecycle` — read the child's own resolved state; do not re-derive it from its leaves.
+- **Terminal-but-dropped** — closed-as-not-planned (GitHub `stateReason == "not_planned"`) / canceled (Linear) / won't-do. It does **not** hold the PRD open and is excluded from the required set.
+- **Incomplete / blocked** — anything else (still open, or closed without the `done` role). It holds the PRD open.
+
+The **required** set is the top-level children minus the terminal-but-dropped ones. Branch:
+
+**Any required top-level child is non-terminal** (the "Given a PRD has generated child work that is not terminal" scenario):
+
+1. **STOP.** Do **not** run empirical verification or spec-conformance.
+2. **Leave the PRD lifecycle untouched** — it stays at `shipped`. Do not transition it to `verified` or `blocked`; do not close or archive it.
+3. **Report the incomplete child set** — list each non-terminal required top-level child as `- <ref> "<title>" — <state>`, so product can see exactly what is blocking PRD-level verification.
+
+This guard exists because PRD-level acceptance is only meaningful once the work graph is actually complete. `shipped` is the precondition; verifying a PRD whose generated work is still in flight would produce a false PASS or FAIL against an incomplete product.
+
+**All required top-level children are terminal** (at least one required child exists): the guard passes. Hand off to the PASS/FAIL verification phases (sibling work, out of scope here — see [Scope of this skill](#scope-of-this-skill)). Until those phases land, report `terminal-child guard PASSED — <n> required top-level children terminal; ready for PRD-level verification` and stop.
+
+## Output
+
+Emit a single fenced text block so callers can parse it.
+
+```text
+## verify-prd: <PRD title>
+
+PRD: <ref/URL>  (vendor: <github|linear|notion|confluence|jira>)
+PRD lifecycle state: shipped
+Generated top-level children read: <n>  (source: native | documented | both)
+
+### Terminal-child guard
+- <ref> "<title>" — <terminal|terminal-but-dropped|incomplete>: <state>
+- ...
+
+Required top-level children: <n>   Terminal: <n>   Incomplete: <n>
+
+### Verdict: GUARD_PASSED | GUARD_BLOCKED | NO_CHILDREN
+```
+
+- `GUARD_BLOCKED` — one or more required top-level children are non-terminal; verification did not run; the PRD was left at `shipped`.
+- `GUARD_PASSED` — all required top-level children are terminal; ready to hand off to PRD-level verification (PASS/FAIL phases — sibling work).
+- `NO_CHILDREN` — no generated top-level children found; cannot verify; the PRD was left untouched.
+
+## Rules
+
+- **Read-only in this front-half.** This skill resolves the PRD, reads the child set, and applies the guard. It never transitions the PRD lifecycle — neither the guard-blocked path (leave at `shipped`) nor the guard-passed path (hand off; the `shipped → verified | blocked` hops are owned by the PASS/FAIL sibling work, not by this scaffold).
+- **Never reimplement child enumeration.** Consume the recorded PRD→child relationship (`prd-lifecycle-rollup` native linking + machine-readable generated-work section). The two-source read here mirrors `github-prd-intake` Phase 3f.2 — same sources, same dedupe-by-child-ref, same top-level-only boundary.
+- **Top-level only.** Exclude leaf Sub-tasks and Stories nested under a generated Epic. The PRD owns its top-level work; those top-level units own their descendants (`prd-lifecycle-rollup` generated-top-level-work contract).
+- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, and the dedupe-by-child-ref idempotency key all come from the `prd-lifecycle-rollup` rule. This skill is a consumer of that contract, not a second source of truth.
+
+## Related rules
+
+- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, and the child-ref idempotency dedupe key. This skill consumes that contract; it cites the rule by slug rather than restating its taxonomy.
+- `leaf-only-lifecycle` — governs the build lifecycle of leaf work units and how a generated Epic rolls up from its own children; this skill trusts that bottom-up rollup when reading a top-level child's resolved state.
+- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`) and the env-keyed `done` map the terminal predicate resolves against.

--- a/plugins/lisa/skills/verify-prd/agents/openai.yaml
+++ b/plugins/lisa/skills/verify-prd/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Verify PRD"
+short_description: "Initiative-level PRD acceptance gate"
+default_prompt:
+  - "Use $verify-prd: Initiative-level PRD acceptance gate."

--- a/plugins/src/base/commands/verify-prd.md
+++ b/plugins/src/base/commands/verify-prd.md
@@ -1,0 +1,6 @@
+---
+description: "Initiative-level PRD acceptance gate. Reads a shipped PRD and its generated child work, confirms all generated top-level work is terminal, then (sibling tickets) runs spec-conformance + empirical verification and transitions the PRD shipped → verified | blocked."
+argument-hint: "<prd>"
+---
+
+Use the /lisa:verify-prd skill to read the PRD, confirm its generated top-level work is terminal, and run initiative-level acceptance verification. $ARGUMENTS

--- a/plugins/src/base/skills/verify-prd/SKILL.md
+++ b/plugins/src/base/skills/verify-prd/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: verify-prd
+description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any empirical verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. The entry point of the PRD-level verification flow; the PASS path (spec-conformance + empirical verification + shipped → verified), the FAIL path (shipped → blocked + fix issues), and idempotency are handled by sibling work."
+allowed-tools: ["Skill", "Bash", "Read", "mcp__claude_ai_Notion__notion-fetch", "mcp__claude_ai_Notion__notion-get-comments", "mcp__atlassian__getConfluencePage", "mcp__atlassian__getConfluencePageDescendants", "mcp__atlassian__getJiraIssue", "mcp__atlassian__searchJiraIssuesUsingJql", "mcp__atlassian__getAccessibleAtlassianResources", "mcp__linear-server__get_project", "mcp__linear-server__list_issues", "mcp__linear-server__get_issue", "mcp__linear-server__list_documents", "mcp__linear-server__get_document"]
+---
+
+# PRD-level Verification: $ARGUMENTS
+
+`/lisa:verify-prd <prd>` is the **initiative-level acceptance gate**. It runs *after* a PRD is `shipped` (all generated top-level work terminal, per `prd-lifecycle-rollup`'s rollup phase) and proves the shipped product actually matches the PRD — not merely that every ticket is closed. `shipped` is **necessary but not sufficient** for `verified`: a PRD can have every child ticket closed while still missing a requirement, diverging from its acceptance criteria, or failing a real user workflow.
+
+This is distinct from `/lisa:verify`, which empirically verifies a **single work item** (a ticket / story / sub-task) in its target environment as part of that item's Build/Fix/Improve flow. `/lisa:verify` drives a build ticket to `done` at the leaf/build level; it does not read the PRD or judge initiative-level acceptance. `/lisa:verify-prd` operates one level up, over the whole initiative. See the `prd-lifecycle-rollup` rule's "PRD-level verification vs ticket verification" section for the full distinction.
+
+`$ARGUMENTS` is a single PRD reference: a **GitHub issue URL** (or `<org>/<repo>#<n>`), a **Linear project/issue URL**, a **Notion page URL**, a **Confluence page URL**, or a **JIRA issue key/URL**.
+
+## Confirmation policy
+
+Do **not** re-prompt once invoked. Like the `*-prd-intake` skills, the caller has already authorized the run by invoking the skill; asking the user to confirm before reading or before applying the guard defeats the purpose of a batchable acceptance gate. Run the front-half (resolve → read child set → guard) to completion and report.
+
+## Scope of this skill
+
+This skill is the **read/guard front-half** of PRD-level verification:
+
+1. Resolve the PRD ref and detect its source vendor.
+2. Read the PRD body and its **generated top-level child work set** via the `prd-lifecycle-rollup` contract.
+3. Apply the per-vendor terminal predicate to the generated top-level work and run the **terminal-child guard**: if any required top-level child is non-terminal, report the incomplete set and STOP — do not run empirical verification, do not transition the PRD.
+
+The remaining phases of PRD-level verification are **out of scope** here and are delivered by sibling work (this skill is their entry point):
+
+- **PASS path** — spec-conformance against the PRD's requirements + empirical verification of the shipped surface, then the `shipped → verified` transition with evidence.
+- **FAIL path** — on verification failure, the `shipped → blocked` transition, a product-readable failure report, and linked fix issues for the missing/incorrect behavior.
+- **Idempotency** — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
+
+When the terminal-child guard passes (all required generated top-level work is terminal), this front-half hands off to the PASS/FAIL phases. Until those phases land, a passing guard means "ready for verification"; this skill does not itself transition the PRD to `verified` or `blocked`.
+
+## Phase 1 — Resolve the PRD ref and detect the source vendor
+
+Detect the vendor from `$ARGUMENTS` the same way `prd-ticket-coverage` / `prd-backlink` do — from the host (or key shape for JIRA), never by guessing:
+
+| Input shape | Vendor | Read surface |
+|---|---|---|
+| `github.com/<org>/<repo>/issues/<n>` or `<org>/<repo>#<n>` | **GitHub Issues** | `gh` CLI (Lisa uses the CLI exclusively for GitHub — no GitHub MCP) |
+| `linear.app/...` | **Linear** | `mcp__linear-server__get_project` / `get_issue` |
+| `notion.so` / `notion.site` | **Notion** | `mcp__claude_ai_Notion__notion-fetch` (`include_discussions: true`) |
+| `*.atlassian.net/wiki/...` | **Confluence** | `mcp__atlassian__getConfluencePage` (+ descendants) |
+| JIRA issue key (e.g. `PROJ-123`) or `*.atlassian.net/browse/...` | **JIRA** | `mcp__atlassian__getJiraIssue` |
+
+Read the PRD body via the vendor-appropriate surface. The vendor that owns the PRD source is what Phase 2 reads the child set from; it is independent of which tracker hosts the generated tickets (a Notion PRD can own JIRA tickets — the cross-vendor case is handled by the documented generated-work section in Phase 2).
+
+Where the PRD lives in the same vendor as the configured `tracker` (`.lisa.config.json`), prefer reading the PRD ticket through `lisa:tracker-read` so this skill stays agnostic of which tracker hosts the work — `tracker-read` dispatches to `lisa:github-read-issue` / `lisa:jira-read-ticket` / `lisa:linear-read-issue` per config and returns the consolidated context bundle (PRD body, native children, links). For PRD sources with no tracker counterpart (Notion / Confluence / cross-vendor), read the PRD body directly via the vendor surface above.
+
+## Phase 2 — Read the generated top-level child work set
+
+**Do NOT reimplement child enumeration.** Consume the PRD→generated-top-level-work relationship recorded by the merged child-linking work (`prd-backlink` native linking + its always-written machine-readable generated-work section), exactly as `github-prd-intake`'s rollup phase consumes it. Read the **generated top-level work** only — the PRD's created Epics and any top-level Story created directly under it — and **exclude** leaf Sub-tasks and any Story nested under a generated Epic, per the `prd-lifecycle-rollup` rule's generated-top-level-work contract.
+
+Use two sources, **native first**, deduped by child-ref identity:
+
+1. **Native hierarchy (primary).** Read the PRD's direct native children — these are its top-level children:
+   - **GitHub** — the PRD issue's direct `subIssues` nodes (the GraphQL `subIssues` query `lisa:github-read-issue` Phase 3 uses; capture `number title state url stateReason labels`).
+   - **Linear** — for a PRD Project, its member Issues (`list_issues({project})`); for a PRD Issue, its sub-Issues (`get_issue` children). Capture each child's `state` (workflow state + category).
+   - **JIRA** — the PRD's children via the epic-link/parent JQL `lisa:jira-read-ticket` Phase 5 uses (`"Epic Link" = <PRD-KEY>` or `parent = <PRD-KEY>`). Capture each child's `statusCategory`.
+   - **Notion / Confluence** — no native issue hierarchy; use the documented section below.
+
+2. **Documented generated-work section (fallback / cross-vendor).** When native hierarchy is unavailable (older host, cross-vendor PRD→tracker, or the relationship was only recorded in the PRD body), parse the machine-readable generated-work section `prd-backlink` writes to the PRD body (`## Tickets`, alias `## Generated Work`). Enumerate the `<!-- lisa:gw ref=… url=… type=… parent=… -->` tokens; the **generated top-level child set is every token whose `parent` is empty** (top-level), exactly as `prd-backlink` documents. Tokens with a non-empty `parent` are descendants — skip them. For GitHub, this is the same `awk` extraction `github-prd-intake` Phase 3f.2 uses.
+
+**Dedupe by child-ref identity** (`owner/repo#number` for GitHub, the issue/project identifier for Linear, the issue key for JIRA, the recorded ref for Notion/Confluence — the `prd-lifecycle-rollup` idempotency dedupe key) so a child appearing in both the native graph and the documented section is counted once. **Match by stable ref, never by title.**
+
+If neither source yields any generated top-level child (the PRD generated nothing, or the relationship was never recorded), report `no generated top-level children — cannot verify an empty PRD` and STOP. Do not transition the PRD.
+
+## Phase 3 — Terminal-child guard
+
+Apply the **per-vendor terminal-state predicate from the `prd-lifecycle-rollup` rule** to every generated **top-level** work item (cite the rule by slug — do not restate its predicate table here). In summary, a top-level child is:
+
+- **Terminal** — it has reached its source/tracker's done/shipped state (GitHub: closed + the resolved build `done` role label where used; Linear: a `done`-category completed state; JIRA: `statusCategory.key == "done"`; Notion/Confluence: the documented generated-work entry marked done). A generated Epic is terminal only when *it* has rolled up to its own terminal state per `leaf-only-lifecycle` — read the child's own resolved state; do not re-derive it from its leaves.
+- **Terminal-but-dropped** — closed-as-not-planned (GitHub `stateReason == "not_planned"`) / canceled (Linear) / won't-do. It does **not** hold the PRD open and is excluded from the required set.
+- **Incomplete / blocked** — anything else (still open, or closed without the `done` role). It holds the PRD open.
+
+The **required** set is the top-level children minus the terminal-but-dropped ones. Branch:
+
+**Any required top-level child is non-terminal** (the "Given a PRD has generated child work that is not terminal" scenario):
+
+1. **STOP.** Do **not** run empirical verification or spec-conformance.
+2. **Leave the PRD lifecycle untouched** — it stays at `shipped`. Do not transition it to `verified` or `blocked`; do not close or archive it.
+3. **Report the incomplete child set** — list each non-terminal required top-level child as `- <ref> "<title>" — <state>`, so product can see exactly what is blocking PRD-level verification.
+
+This guard exists because PRD-level acceptance is only meaningful once the work graph is actually complete. `shipped` is the precondition; verifying a PRD whose generated work is still in flight would produce a false PASS or FAIL against an incomplete product.
+
+**All required top-level children are terminal** (at least one required child exists): the guard passes. Hand off to the PASS/FAIL verification phases (sibling work, out of scope here — see [Scope of this skill](#scope-of-this-skill)). Until those phases land, report `terminal-child guard PASSED — <n> required top-level children terminal; ready for PRD-level verification` and stop.
+
+## Output
+
+Emit a single fenced text block so callers can parse it.
+
+```text
+## verify-prd: <PRD title>
+
+PRD: <ref/URL>  (vendor: <github|linear|notion|confluence|jira>)
+PRD lifecycle state: shipped
+Generated top-level children read: <n>  (source: native | documented | both)
+
+### Terminal-child guard
+- <ref> "<title>" — <terminal|terminal-but-dropped|incomplete>: <state>
+- ...
+
+Required top-level children: <n>   Terminal: <n>   Incomplete: <n>
+
+### Verdict: GUARD_PASSED | GUARD_BLOCKED | NO_CHILDREN
+```
+
+- `GUARD_BLOCKED` — one or more required top-level children are non-terminal; verification did not run; the PRD was left at `shipped`.
+- `GUARD_PASSED` — all required top-level children are terminal; ready to hand off to PRD-level verification (PASS/FAIL phases — sibling work).
+- `NO_CHILDREN` — no generated top-level children found; cannot verify; the PRD was left untouched.
+
+## Rules
+
+- **Read-only in this front-half.** This skill resolves the PRD, reads the child set, and applies the guard. It never transitions the PRD lifecycle — neither the guard-blocked path (leave at `shipped`) nor the guard-passed path (hand off; the `shipped → verified | blocked` hops are owned by the PASS/FAIL sibling work, not by this scaffold).
+- **Never reimplement child enumeration.** Consume the recorded PRD→child relationship (`prd-lifecycle-rollup` native linking + machine-readable generated-work section). The two-source read here mirrors `github-prd-intake` Phase 3f.2 — same sources, same dedupe-by-child-ref, same top-level-only boundary.
+- **Top-level only.** Exclude leaf Sub-tasks and Stories nested under a generated Epic. The PRD owns its top-level work; those top-level units own their descendants (`prd-lifecycle-rollup` generated-top-level-work contract).
+- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, and the dedupe-by-child-ref idempotency key all come from the `prd-lifecycle-rollup` rule. This skill is a consumer of that contract, not a second source of truth.
+
+## Related rules
+
+- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, and the child-ref idempotency dedupe key. This skill consumes that contract; it cites the rule by slug rather than restating its taxonomy.
+- `leaf-only-lifecycle` — governs the build lifecycle of leaf work units and how a generated Epic rolls up from its own children; this skill trusts that bottom-up rollup when reading a top-level child's resolved state.
+- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`) and the env-keyed `done` map the terminal predicate resolves against.

--- a/tests/unit/strategies/verify-prd-scaffold.test.ts
+++ b/tests/unit/strategies/verify-prd-scaffold.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Regression tests for the `/lisa:verify-prd` command + skill scaffold — the
+ * read/guard front-half of initiative-level PRD verification.
+ *
+ * Issue #597 (PRD #553, Story #590, Epic #587): create the verify-prd command +
+ * skill scaffold and its read/guard front-half — resolve the PRD across vendors,
+ * read its generated top-level child work set by CONSUMING the
+ * `prd-lifecycle-rollup` contract (native hierarchy first, machine-readable
+ * generated-work section fallback — never reimplementing child enumeration), and
+ * confirm every required generated top-level work item is terminal before any
+ * empirical verification begins. If any required top-level child is non-terminal,
+ * the terminal-child guard STOPS, reports the incomplete child set, and leaves
+ * the PRD at `shipped`.
+ *
+ * The guarantees under test:
+ *   (1) commands/verify-prd.md is a pass-through with `argument-hint: "<prd>"`
+ *       that delegates to the /lisa:verify-prd skill;
+ *   (2) the skill resolves the PRD vendor and reads the generated child set via
+ *       the #525/#562 child-linking + machine-readable generated-work section,
+ *       and explicitly does NOT reimplement child enumeration;
+ *   (3) the terminal-child guard applies the per-vendor terminal predicate to
+ *       generated TOP-LEVEL work only (excluding leaf sub-tasks), and on any
+ *       non-terminal required child STOPS, reports the incomplete set, runs no
+ *       verification, and leaves the PRD at `shipped`;
+ *   (4) the scaffold cites `prd-lifecycle-rollup` by slug and scopes the PASS
+ *       path / FAIL path / idempotency to sibling work (#598/#599/#600);
+ *   (5) the front-half is read-only and does not re-prompt once invoked.
+ *
+ * Beyond asserting the scaffold documents these guarantees, this suite proves
+ * the guard's selection + verdict logic is genuinely derivable from the contract
+ * verify-prd consumes: it parses a `lisa:gw` generated-work section, selects the
+ * generated TOP-LEVEL child set (empty `parent`), applies the GitHub terminal
+ * predicate, and computes GUARD_BLOCKED vs GUARD_PASSED — the empirical trace
+ * #597's terminal-child-guard evidence required (PRD #525 → top-level Epic #562
+ * OPEN → GUARD_BLOCKED).
+ *
+ * Both plugin roots are asserted (`plugins/src/base` source of truth and the
+ * generated `plugins/lisa` artifact), so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite — the same discipline the
+ * prd-verified-lifecycle-docs (#592) and prd-backlink (#582) suites use.
+ * @module tests/unit/strategies/verify-prd-scaffold
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Both plugin roots: source of truth and generated artifact. */
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+/** The vendor-neutral rule the scaffold cites by slug. */
+const RULE_SLUG = "prd-lifecycle-rollup";
+
+/** Relative path of the pass-through command within a plugin root. */
+const COMMAND_REL = "commands/verify-prd.md";
+/** Relative path of the skill within a plugin root. */
+const SKILL_REL = "skills/verify-prd/SKILL.md";
+
+/** Source vendors the skill resolves, the same set prd-ticket-coverage lists. */
+const SOURCE_VENDORS = [
+  "GitHub",
+  "Linear",
+  "Notion",
+  "Confluence",
+  "JIRA",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("verify-prd scaffold (#597)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const commandPath = path.resolve(root, COMMAND_REL);
+    const skillPath = path.resolve(root, SKILL_REL);
+
+    it("ships both the command and the skill in this plugin root", () => {
+      expect(existsSync(commandPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    describe("commands/verify-prd.md", () => {
+      const command = read(root, COMMAND_REL);
+
+      it("is a pass-through with argument-hint that delegates to the skill", () => {
+        // Pass-through command frontmatter: description + argument-hint "<prd>".
+        expect(command).toMatch(/^---/);
+        expect(command).toMatch(/description:/);
+        expect(command).toContain('argument-hint: "<prd>"');
+        // Body delegates to the /lisa:verify-prd skill and forwards $ARGUMENTS.
+        expect(command).toMatch(/Use the \/lisa:verify-prd skill/);
+        expect(command).toContain("$ARGUMENTS");
+      });
+    });
+
+    describe("skills/verify-prd/SKILL.md", () => {
+      const skill = read(root, SKILL_REL);
+
+      it("declares frontmatter name, description, and allowed-tools", () => {
+        expect(skill).toMatch(/^---/);
+        expect(skill).toMatch(/name:\s*verify-prd/);
+        expect(skill).toMatch(/description:/);
+        expect(skill).toMatch(/allowed-tools:/);
+        // The vendor read surfaces it resolves (Skill/Bash plus MCP readers).
+        expect(skill).toContain("Skill");
+        expect(skill).toContain("Bash");
+      });
+
+      // (2) resolves the PRD vendor the same way prd-ticket-coverage does.
+      it("resolves the PRD ref and detects the source vendor", () => {
+        expect(skill).toMatch(/detect (the )?(source )?vendor/i);
+        // Resolves the same way prd-ticket-coverage / prd-backlink do.
+        expect(skill).toMatch(/prd-ticket-coverage/);
+        expect(skill).toMatch(/prd-backlink/);
+      });
+
+      it.each(SOURCE_VENDORS)("names the %s source vendor", vendor => {
+        expect(skill).toContain(vendor);
+      });
+
+      // (2) reads the child set via the #525/#562 child-linking + generated-work
+      //     section, and does NOT reimplement enumeration.
+      it("reads the generated child set via the rollup contract without reimplementing it", () => {
+        // Consumes the always-written machine-readable generated-work tokens.
+        expect(skill).toContain("lisa:gw");
+        expect(skill).toMatch(/## Tickets|## Generated Work/);
+        // Two-source read: native hierarchy primary, documented section fallback.
+        expect(skill).toMatch(/native (hierarchy|sub-issues)/i);
+        // Explicitly forbids reimplementing child enumeration.
+        expect(skill).toMatch(
+          /(do|does) not reimplement (child )?enumeration/i
+        );
+        // Dedupe by child-ref identity (the rollup idempotency key).
+        expect(skill).toMatch(/child-ref/i);
+      });
+
+      it("consumes tracker-read for the PRD/ticket read", () => {
+        expect(skill).toMatch(/tracker-read/);
+      });
+
+      // (3) terminal predicate applies to generated TOP-LEVEL work only.
+      it("applies the terminal predicate to top-level work, excluding leaf sub-tasks", () => {
+        expect(skill).toMatch(/terminal/i);
+        // Top-level only — leaf sub-tasks are excluded per the rollup contract.
+        expect(skill).toMatch(/top-level/i);
+        expect(skill).toMatch(/exclud(e|ing)[^]*sub-task/i);
+        // Terminal-but-dropped (not-planned / canceled) is excluded from required.
+        expect(skill).toMatch(/terminal-but-dropped/i);
+        expect(skill).toMatch(/not.?planned|not_planned|canceled/i);
+      });
+
+      // (3) terminal-child guard: STOP, report, no verification, leave at shipped.
+      it("the terminal-child guard stops without verifying and leaves the PRD at shipped", () => {
+        expect(skill).toContain("STOP");
+        // Reports the incomplete child set.
+        expect(skill).toMatch(/incomplete child set/i);
+        // Does NOT run empirical verification.
+        expect(skill).toMatch(/do(es)? not run empirical verification/i);
+        // Leaves the PRD lifecycle untouched — stays at shipped.
+        expect(skill).toMatch(/stays at .?shipped.?|left at .?shipped.?/i);
+        expect(skill).toMatch(/untouched|do not transition/i);
+      });
+
+      // (4) cites the rule by slug; PASS/FAIL/idempotency are sibling work.
+      it("cites prd-lifecycle-rollup by slug and scopes the rest to siblings", () => {
+        expect(skill).toContain(RULE_SLUG);
+        expect(skill).toMatch(/cite[^]*by slug|cites the rule by slug/i);
+        expect(skill).toMatch(/out of scope/i);
+        // The PASS path, FAIL path, and idempotency are sibling work.
+        expect(skill).toMatch(/PASS path/i);
+        expect(skill).toMatch(/FAIL path/i);
+        expect(skill).toMatch(/idempoten/i);
+        expect(skill).toMatch(/shipped → verified/);
+        expect(skill).toMatch(/shipped → blocked/);
+      });
+
+      // (5) read-only front-half that does not re-prompt.
+      it("is a read-only front-half and does not re-prompt once invoked", () => {
+        // Tolerate markdown emphasis around "not" (e.g. "Do **not** re-prompt").
+        expect(skill).toMatch(/do(es)?\s+\**not\**\s+re-prompt/i);
+        expect(skill).toMatch(/read-only/i);
+      });
+    });
+  });
+});
+
+/**
+ * A generated top-level child as the guard reads it: its child-ref, GitHub
+ * issue state, and close reason (for the terminal-but-dropped distinction).
+ * Mirrors the fields the skill's two-source read captures per child.
+ */
+type TopLevelChild = {
+  readonly ref: string;
+  readonly title: string;
+  /** GitHub issue state. */
+  readonly state: "OPEN" | "CLOSED";
+  /** Close reason — `not_planned` is terminal-but-dropped. */
+  readonly stateReason: "completed" | "not_planned" | null;
+  /** Whether the resolved build `done` role label is present. */
+  readonly hasDoneLabel: boolean;
+};
+
+/** A `lisa:gw` token parsed from a rendered generated-work section. */
+type GeneratedWorkEntry = {
+  readonly ref: string;
+  readonly type: string;
+  readonly parent: string;
+};
+
+/**
+ * Enumerate the generated child set from a rendered generated-work section by
+ * matching only the machine-readable `lisa:gw` tokens — never prose, headings,
+ * links, or indentation. This is the read the skill consumes (it does not
+ * reimplement enumeration); the parser proves the contract is consumable.
+ * @param section - A rendered generated-work (`## Tickets`) section.
+ * @returns Every `lisa:gw` entry, in document order.
+ */
+const parseEntries = (section: string): readonly GeneratedWorkEntry[] => {
+  const tokenPattern =
+    /<!-- lisa:gw ref=(\S+) url=\S+ type=(\S+) parent=(\S*) -->/g;
+  const entries: GeneratedWorkEntry[] = [];
+  let match = tokenPattern.exec(section);
+  while (match !== null) {
+    entries.push({
+      ref: match[1] ?? "",
+      type: match[2] ?? "",
+      parent: match[3] ?? "",
+    });
+    match = tokenPattern.exec(section);
+  }
+  return entries;
+};
+
+/**
+ * Apply the `prd-lifecycle-rollup` GitHub terminal-state predicate to one
+ * generated top-level child.
+ * @param child - The top-level child's current resolved state.
+ * @returns Its rollup classification.
+ */
+const classifyChild = (
+  child: TopLevelChild
+): "terminal" | "terminal-but-dropped" | "incomplete" => {
+  if (child.state === "CLOSED" && child.stateReason === "not_planned") {
+    return "terminal-but-dropped";
+  }
+  if (child.state === "CLOSED" && child.hasDoneLabel) {
+    return "terminal";
+  }
+  return "incomplete";
+};
+
+/**
+ * Compute the terminal-child guard verdict over a generated top-level child set,
+ * exactly as the skill's Phase 3 prescribes: required = top-level minus
+ * terminal-but-dropped; GUARD_BLOCKED if any required child is incomplete,
+ * GUARD_PASSED if all required children are terminal (and at least one exists),
+ * NO_CHILDREN if the set is empty.
+ * @param children - The generated top-level child set.
+ * @returns The verdict plus the incomplete required child refs.
+ */
+const guardVerdict = (
+  children: readonly TopLevelChild[]
+): {
+  readonly verdict: "GUARD_PASSED" | "GUARD_BLOCKED" | "NO_CHILDREN";
+  readonly incompleteRefs: readonly string[];
+} => {
+  if (children.length === 0) {
+    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
+  }
+  const required = children.filter(
+    child => classifyChild(child) !== "terminal-but-dropped"
+  );
+  const incompleteRefs = required
+    .filter(child => classifyChild(child) === "incomplete")
+    .map(child => child.ref);
+  if (required.length === 0) {
+    // Every child was dropped — nothing required ships the PRD.
+    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
+  }
+  return {
+    verdict: incompleteRefs.length > 0 ? "GUARD_BLOCKED" : "GUARD_PASSED",
+    incompleteRefs,
+  };
+};
+
+/**
+ * Stable child-refs for the guard fixtures (hoisted to satisfy
+ * sonarjs/no-duplicate-string and keep fixtures and expectations DRY).
+ */
+const EPIC_REF = "CodySwannGT/lisa#100";
+const STORY2_REF = "CodySwannGT/lisa#200";
+
+describe("terminal-child guard logic is derivable from the rollup contract", () => {
+  it("selects generated TOP-LEVEL children by empty parent, excluding descendants", () => {
+    // Epic E (top-level) → Story S → Sub-task T, plus top-level Story S2.
+    const section = [
+      "## Tickets",
+      "",
+      `- [${EPIC_REF}](https://x/100) — Epic <!-- lisa:gw ref=${EPIC_REF} url=https://x/100 type=Epic parent= -->`,
+      `  - [CodySwannGT/lisa#101](https://x/101) — Story: s <!-- lisa:gw ref=CodySwannGT/lisa#101 url=https://x/101 type=Story parent=${EPIC_REF} -->`,
+      "    - [CodySwannGT/lisa#102](https://x/102) — Sub-task: t <!-- lisa:gw ref=CodySwannGT/lisa#102 url=https://x/102 type=Sub-task parent=CodySwannGT/lisa#101 -->",
+      `- [${STORY2_REF}](https://x/200) — Story: s2 <!-- lisa:gw ref=${STORY2_REF} url=https://x/200 type=Story parent= -->`,
+      "",
+    ].join("\n");
+    const topLevel = parseEntries(section)
+      .filter(entry => entry.parent === "")
+      .map(entry => entry.ref);
+    // Only the top-level Epic and the top-level Story — never the nested Story
+    // or the leaf Sub-task (those are owned by their own parent).
+    expect(topLevel).toEqual([EPIC_REF, STORY2_REF]);
+  });
+
+  it("blocks when a required top-level child is open (the #525 → #562 trace)", () => {
+    // The empirical [terminal-child-guard] evidence: PRD #525's one generated
+    // top-level child is Epic #562, OPEN → incomplete → GUARD_BLOCKED.
+    const result = guardVerdict([
+      {
+        ref: "CodySwannGT/lisa#562",
+        title: "Link generated top-level work as PRD children",
+        state: "OPEN",
+        stateReason: null,
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_BLOCKED");
+    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#562"]);
+  });
+
+  it("blocks when a closed child lacks the done role label", () => {
+    const result = guardVerdict([
+      {
+        ref: "CodySwannGT/lisa#300",
+        title: "closed but not done-labelled",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_BLOCKED");
+    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#300"]);
+  });
+
+  it("passes when every required top-level child is terminal", () => {
+    const result = guardVerdict([
+      {
+        ref: EPIC_REF,
+        title: "done epic",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+      {
+        ref: STORY2_REF,
+        title: "done story",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_PASSED");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+
+  it("excludes terminal-but-dropped (not_planned) children from the required set", () => {
+    // One done child + one closed-as-not-planned child → all required terminal.
+    const result = guardVerdict([
+      {
+        ref: EPIC_REF,
+        title: "done epic",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+      {
+        ref: "CodySwannGT/lisa#400",
+        title: "dropped epic",
+        state: "CLOSED",
+        stateReason: "not_planned",
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_PASSED");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+
+  it("reports NO_CHILDREN for an empty generated top-level set", () => {
+    const result = guardVerdict([]);
+    expect(result.verdict).toBe("NO_CHILDREN");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #597 — the `/lisa:verify-prd` command + skill **scaffold** and its read/guard **front-half**. This is the entry point of initiative-level PRD verification (PRD #553, Story #590, Epic #587); the PASS path (#598), FAIL path (#599), and idempotency (#600) are sibling work that extends this scaffold.

## What changed

- **`plugins/src/base/commands/verify-prd.md`** — pass-through command mirroring `commands/verify.md`: frontmatter `description` + `argument-hint: "<prd>"`, body delegates to the `/lisa:verify-prd` skill, forwarding `$ARGUMENTS`.
- **`plugins/src/base/skills/verify-prd/SKILL.md`** — the read/guard front-half:
  - **Resolve + detect vendor** (GitHub / Linear / Notion / Confluence / JIRA) the same way `prd-ticket-coverage` / `prd-backlink` do.
  - **Read the generated top-level child set** by CONSUMING the merged child-linking + machine-readable generated-work section (`<!-- lisa:gw ... -->`) via `lisa:tracker-read` and the `prd-lifecycle-rollup` contract — native hierarchy primary, documented section fallback, deduped by child-ref identity. Does **not** reimplement child enumeration (same two-source read as `github-prd-intake` Phase 3f.2).
  - **Terminal predicate on top-level work only** (excludes leaf Sub-tasks and Stories nested under a generated Epic, per the rollup contract). Required = top-level minus terminal-but-dropped (not-planned / canceled).
  - **Terminal-child guard**: any non-terminal required top-level child → STOP, report the incomplete child set, run no empirical verification, leave the PRD at `shipped`.
  - Cites `prd-lifecycle-rollup` by slug; no re-prompt; read-only front-half.
- **`tests/unit/strategies/verify-prd-scaffold.test.ts`** — regression test (codify-verification) following the `prd-verified-lifecycle-docs` / `prd-backlink` convention: asserts the scaffold's invariants across **both** plugin roots (so an artifact-only edit / missed `build:plugins` fails), and **programmatically reproduces the guard logic** — top-level selection by empty parent, the `#525 → top-level Epic #562 OPEN → GUARD_BLOCKED` trace, terminal-but-dropped exclusion, GUARD_PASSED, NO_CHILDREN.
- Regenerated `plugins/lisa/**` artifacts (incl. derived Codex `agents/openai.yaml`), committed alongside source.

## Acceptance criteria

- [x] command delegates to the skill (pass-through + `argument-hint`)
- [x] skill reads the PRD + generated child set via #525/#562 child-linking, without reimplementing enumeration
- [x] incomplete child set blocks verification (report + no verification + PRD stays at shipped)
- [x] built artifacts stay in sync (`check:plugins` reports no drift; verify-prd present in `plugins/lisa`)

## Verification

- **[verify-prd-files]** new command + skill present with correct frontmatter (✓).
- **[terminal-child-guard]** traced the skill's two-source read + terminal predicate against real merged data — PRD #525 → generated top-level Epic #562 (OPEN) → classified incomplete → **GUARD_BLOCKED** → STOP / report / leave PRD untouched. (Disposable-repo `gh` teardown not possible: token lacks `delete_repo` scope; traced against production-linked data instead, which exercises the exact queries + predicate.)
- **[build-plugins-sync]** `bun run build:plugins && bun run check:plugins` → in sync, marketplace registers every plugin, no drift.
- `bun run test:unit` → **1491 passed** (incl. the new 36-test suite); lint + `tsc --noEmit` clean.

## Scope

Front-half only, per #597 Out of Scope. PASS path / FAIL path / idempotency are #598 / #599 / #600.

Closes #597

🤖 Generated with Claude Code