### PR TITLE
feat(skills): add project ideation examples

### DIFF
--- a/plugins/lisa/skills/project-ideation/SKILL.md
+++ b/plugins/lisa/skills/project-ideation/SKILL.md
@@ -116,3 +116,12 @@ When the user wants to act on an idea, preserve its feasibility and verification
 - Turn a PRD into tickets → `/lisa:plan`
 - Build a ticket end-to-end → `/lisa:implement`
 - Lock in the verification so it never regresses → `/lisa:codify-verification`
+
+## Example outputs
+
+Use the markdown examples in `examples/` as shape references when composing reports:
+
+- `host-project-only.md` shows ideas grounded only in the current repository.
+- `public-external-inspiration.md` shows how public, no-login external sources can inspire ideas without becoming hidden requirements.
+- `unavailable-data-rejection.md` shows how to name missing private, paid, or unavailable data sources when demoting ideas.
+- `evidence-card-format.md` shows the required evidence fields every Practical Idea card must carry.

--- a/plugins/lisa/skills/project-ideation/examples/evidence-card-format.md
+++ b/plugins/lisa/skills/project-ideation/examples/evidence-card-format.md
@@ -1,0 +1,21 @@
+# Evidence Card Formatting Example Output
+
+## What Already Exists
+- Lisa work items already use Validation Journey evidence markers.
+- Skill reports can be saved as markdown artifacts and reviewed by humans.
+
+## Practical Ideas
+### 1. Evidence-First Idea Cards
+- User value: A reviewer can decide whether an idea is ready without asking how it will be proven.
+- Existing fit: Uses the project-ideation report shape and Lisa's evidence-first verification rules.
+- Data/source path: Existing local project files plus any public URLs cited in the report.
+- Practical slice: Require each practical idea to include `Empirical verification` and `Evidence` lines before it can remain in the practical list.
+- Empirical verification: Render this example and confirm every practical idea card includes the two evidence fields.
+- Evidence: Text output showing all practical cards pass the field check.
+- Confidence: high because the check is structural and does not require external services.
+
+## Discovery Spikes
+- Evidence attachments inside generated reports: needs a storage and retention decision for binary artifacts.
+
+## Rejected / Not Practical Yet
+- Treating lint, typecheck, or unit tests as the only proof for a user-facing idea: rejected because quality gates are prerequisites, not empirical evidence artifacts.

--- a/plugins/lisa/skills/project-ideation/examples/host-project-only.md
+++ b/plugins/lisa/skills/project-ideation/examples/host-project-only.md
@@ -1,0 +1,22 @@
+# Host Project Only Example Output
+
+## What Already Exists
+- CLI command registration is documented in the repository README.
+- Skill sources live under `plugins/src/base/skills/` and are copied into the generated Lisa plugin.
+- The project already has unit tests that verify generated plugin artifacts.
+
+## Practical Ideas
+### 1. Plugin Surface Drift Report
+- User value: Maintainers can see which source skills are not represented in the generated plugin before publishing.
+- Existing fit: Builds on the existing plugin source tree and generated plugin artifact tests.
+- Data/source path: Local files under `plugins/src/base/skills/` and `plugins/lisa/skills/`.
+- Practical slice: Emit a markdown report listing source-only, generated-only, and mismatched skill directories.
+- Empirical verification: Run the report command in a clean checkout after intentionally adding one fixture-only source skill.
+- Evidence: CLI output showing the mismatched skill and the generated markdown report path.
+- Confidence: high because the required data is already local and deterministic.
+
+## Discovery Spikes
+- Skill usage frequency ranking: needs a bounded source of invocation telemetry before it can be recommended.
+
+## Rejected / Not Practical Yet
+- Personalized skill suggestions from private user history: rejected because the repository does not have access to private Codex usage history.

--- a/plugins/lisa/skills/project-ideation/examples/public-external-inspiration.md
+++ b/plugins/lisa/skills/project-ideation/examples/public-external-inspiration.md
@@ -1,0 +1,22 @@
+# Public External Inspiration Example Output
+
+## What Already Exists
+- The host project already has a command catalog and source-authored skill files.
+- The host project can inspect public documentation pages without sign-in.
+- Existing verification can run through CLI commands and generated markdown artifacts.
+
+## Practical Ideas
+### 1. Public Pattern Checklist Import
+- User value: Maintainers can compare their command guidance against public best-practice pages without copying private or paid content.
+- Existing fit: Builds on the current docs and skill authoring workflow.
+- Data/source path: A public, no-login documentation URL supplied by the user, plus local `README.md` and skill files.
+- Practical slice: Generate a checklist of public patterns found in the external page and mark whether each is already represented locally.
+- Empirical verification: Run the ideation workflow against a fixed public URL and inspect the generated checklist.
+- Evidence: Generated markdown containing source URLs, matched local file paths, and unmatched public patterns.
+- Confidence: medium because public pages can change, but the source path is accessible and citeable.
+
+## Discovery Spikes
+- Automated freshness checks for public pages: needs a policy for when external pages may be re-fetched and cached.
+
+## Rejected / Not Practical Yet
+- Importing examples from a sign-in-only competitor workspace: rejected because the data source is not publicly obtainable.

--- a/plugins/lisa/skills/project-ideation/examples/unavailable-data-rejection.md
+++ b/plugins/lisa/skills/project-ideation/examples/unavailable-data-rejection.md
@@ -1,0 +1,22 @@
+# Unavailable Data Rejection Example Output
+
+## What Already Exists
+- The host project can read local source files, docs, scripts, and generated artifacts.
+- The host project does not expose customer analytics, private support tickets, or paid market datasets.
+
+## Practical Ideas
+### 1. Local Verification Gap Finder
+- User value: Maintainers can identify skills that describe empirical verification but do not name an evidence artifact.
+- Existing fit: Builds on local skill markdown files and existing unit tests.
+- Data/source path: Local `SKILL.md` files under the plugin source tree.
+- Practical slice: Scan skill files for verification sections and report entries that mention tests but no observable artifact.
+- Empirical verification: Run the scanner against a fixture skill with one missing evidence line.
+- Evidence: CLI output naming the fixture skill and the missing evidence field.
+- Confidence: high because the input is local and fully inspectable.
+
+## Discovery Spikes
+- Prioritize gaps by real-world usage: needs an obtainable telemetry source or a manually approved usage export before it can rank by frequency.
+
+## Rejected / Not Practical Yet
+- Recommend ideas from private customer support pain points: rejected because the missing source is a legitimate support-ticket export or configured support integration.
+- Recommend ideas from paid analyst reports: rejected because the missing source is a licensed data feed available to the agent at runtime.

--- a/plugins/src/base/skills/project-ideation/SKILL.md
+++ b/plugins/src/base/skills/project-ideation/SKILL.md
@@ -116,3 +116,12 @@ When the user wants to act on an idea, preserve its feasibility and verification
 - Turn a PRD into tickets → `/lisa:plan`
 - Build a ticket end-to-end → `/lisa:implement`
 - Lock in the verification so it never regresses → `/lisa:codify-verification`
+
+## Example outputs
+
+Use the markdown examples in `examples/` as shape references when composing reports:
+
+- `host-project-only.md` shows ideas grounded only in the current repository.
+- `public-external-inspiration.md` shows how public, no-login external sources can inspire ideas without becoming hidden requirements.
+- `unavailable-data-rejection.md` shows how to name missing private, paid, or unavailable data sources when demoting ideas.
+- `evidence-card-format.md` shows the required evidence fields every Practical Idea card must carry.

--- a/plugins/src/base/skills/project-ideation/examples/evidence-card-format.md
+++ b/plugins/src/base/skills/project-ideation/examples/evidence-card-format.md
@@ -1,0 +1,21 @@
+# Evidence Card Formatting Example Output
+
+## What Already Exists
+- Lisa work items already use Validation Journey evidence markers.
+- Skill reports can be saved as markdown artifacts and reviewed by humans.
+
+## Practical Ideas
+### 1. Evidence-First Idea Cards
+- User value: A reviewer can decide whether an idea is ready without asking how it will be proven.
+- Existing fit: Uses the project-ideation report shape and Lisa's evidence-first verification rules.
+- Data/source path: Existing local project files plus any public URLs cited in the report.
+- Practical slice: Require each practical idea to include `Empirical verification` and `Evidence` lines before it can remain in the practical list.
+- Empirical verification: Render this example and confirm every practical idea card includes the two evidence fields.
+- Evidence: Text output showing all practical cards pass the field check.
+- Confidence: high because the check is structural and does not require external services.
+
+## Discovery Spikes
+- Evidence attachments inside generated reports: needs a storage and retention decision for binary artifacts.
+
+## Rejected / Not Practical Yet
+- Treating lint, typecheck, or unit tests as the only proof for a user-facing idea: rejected because quality gates are prerequisites, not empirical evidence artifacts.

--- a/plugins/src/base/skills/project-ideation/examples/host-project-only.md
+++ b/plugins/src/base/skills/project-ideation/examples/host-project-only.md
@@ -1,0 +1,22 @@
+# Host Project Only Example Output
+
+## What Already Exists
+- CLI command registration is documented in the repository README.
+- Skill sources live under `plugins/src/base/skills/` and are copied into the generated Lisa plugin.
+- The project already has unit tests that verify generated plugin artifacts.
+
+## Practical Ideas
+### 1. Plugin Surface Drift Report
+- User value: Maintainers can see which source skills are not represented in the generated plugin before publishing.
+- Existing fit: Builds on the existing plugin source tree and generated plugin artifact tests.
+- Data/source path: Local files under `plugins/src/base/skills/` and `plugins/lisa/skills/`.
+- Practical slice: Emit a markdown report listing source-only, generated-only, and mismatched skill directories.
+- Empirical verification: Run the report command in a clean checkout after intentionally adding one fixture-only source skill.
+- Evidence: CLI output showing the mismatched skill and the generated markdown report path.
+- Confidence: high because the required data is already local and deterministic.
+
+## Discovery Spikes
+- Skill usage frequency ranking: needs a bounded source of invocation telemetry before it can be recommended.
+
+## Rejected / Not Practical Yet
+- Personalized skill suggestions from private user history: rejected because the repository does not have access to private Codex usage history.

--- a/plugins/src/base/skills/project-ideation/examples/public-external-inspiration.md
+++ b/plugins/src/base/skills/project-ideation/examples/public-external-inspiration.md
@@ -1,0 +1,22 @@
+# Public External Inspiration Example Output
+
+## What Already Exists
+- The host project already has a command catalog and source-authored skill files.
+- The host project can inspect public documentation pages without sign-in.
+- Existing verification can run through CLI commands and generated markdown artifacts.
+
+## Practical Ideas
+### 1. Public Pattern Checklist Import
+- User value: Maintainers can compare their command guidance against public best-practice pages without copying private or paid content.
+- Existing fit: Builds on the current docs and skill authoring workflow.
+- Data/source path: A public, no-login documentation URL supplied by the user, plus local `README.md` and skill files.
+- Practical slice: Generate a checklist of public patterns found in the external page and mark whether each is already represented locally.
+- Empirical verification: Run the ideation workflow against a fixed public URL and inspect the generated checklist.
+- Evidence: Generated markdown containing source URLs, matched local file paths, and unmatched public patterns.
+- Confidence: medium because public pages can change, but the source path is accessible and citeable.
+
+## Discovery Spikes
+- Automated freshness checks for public pages: needs a policy for when external pages may be re-fetched and cached.
+
+## Rejected / Not Practical Yet
+- Importing examples from a sign-in-only competitor workspace: rejected because the data source is not publicly obtainable.

--- a/plugins/src/base/skills/project-ideation/examples/unavailable-data-rejection.md
+++ b/plugins/src/base/skills/project-ideation/examples/unavailable-data-rejection.md
@@ -1,0 +1,22 @@
+# Unavailable Data Rejection Example Output
+
+## What Already Exists
+- The host project can read local source files, docs, scripts, and generated artifacts.
+- The host project does not expose customer analytics, private support tickets, or paid market datasets.
+
+## Practical Ideas
+### 1. Local Verification Gap Finder
+- User value: Maintainers can identify skills that describe empirical verification but do not name an evidence artifact.
+- Existing fit: Builds on local skill markdown files and existing unit tests.
+- Data/source path: Local `SKILL.md` files under the plugin source tree.
+- Practical slice: Scan skill files for verification sections and report entries that mention tests but no observable artifact.
+- Empirical verification: Run the scanner against a fixture skill with one missing evidence line.
+- Evidence: CLI output naming the fixture skill and the missing evidence field.
+- Confidence: high because the input is local and fully inspectable.
+
+## Discovery Spikes
+- Prioritize gaps by real-world usage: needs an obtainable telemetry source or a manually approved usage export before it can rank by frequency.
+
+## Rejected / Not Practical Yet
+- Recommend ideas from private customer support pain points: rejected because the missing source is a legitimate support-ticket export or configured support integration.
+- Recommend ideas from paid analyst reports: rejected because the missing source is a licensed data feed available to the agent at runtime.

--- a/tests/unit/codex/project-ideation-examples.test.ts
+++ b/tests/unit/codex/project-ideation-examples.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression coverage for issue #669: project-ideation ships concrete example
+ * outputs that demonstrate practical ideas, discovery spikes, unavailable-data
+ * rejection, and evidence-card formatting.
+ *
+ * @module tests/unit/codex/project-ideation-examples
+ */
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const EXAMPLE_ROOTS = [
+  "plugins/src/base/skills/project-ideation/examples",
+  "plugins/lisa/skills/project-ideation/examples",
+] as const;
+
+const EXAMPLE_FILES = [
+  "host-project-only.md",
+  "public-external-inspiration.md",
+  "unavailable-data-rejection.md",
+  "evidence-card-format.md",
+] as const;
+
+/**
+ * Read one committed project-ideation example from a source or generated root.
+ * @param root Example directory under source or built plugin artifacts.
+ * @param file Example markdown filename.
+ * @returns The example markdown contents.
+ */
+function readExample(root: string, file: string): string {
+  return readFileSync(path.resolve(root, file), "utf8");
+}
+
+describe("codex/project-ideation-examples (#669)", () => {
+  it.each(EXAMPLE_ROOTS)(
+    "%s ships the required project-ideation example outputs",
+    root => {
+      for (const file of EXAMPLE_FILES) {
+        const content = readExample(root, file);
+
+        expect(content).toContain("## What Already Exists");
+        expect(content).toContain("## Practical Ideas");
+        expect(content).toContain("## Discovery Spikes");
+        expect(content).toContain("## Rejected / Not Practical Yet");
+      }
+    }
+  );
+
+  it.each(EXAMPLE_ROOTS)(
+    "%s keeps Practical Ideas tied to empirical evidence fields",
+    root => {
+      for (const file of EXAMPLE_FILES) {
+        const content = readExample(root, file);
+
+        expect(content).toMatch(/- Empirical verification: .+/);
+        expect(content).toMatch(/- Evidence: .+/);
+      }
+    }
+  );
+
+  it.each(EXAMPLE_ROOTS)(
+    "%s names missing sources when rejecting unavailable-data ideas",
+    root => {
+      const content = readExample(root, "unavailable-data-rejection.md");
+
+      expect(content).toContain("missing source");
+      expect(content).toContain("support-ticket export");
+      expect(content).toContain("licensed data feed");
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Adds project-ideation example outputs for host-project-only ideas, public external inspiration, unavailable-data rejection, and evidence-card formatting.
- Documents the examples in the project-ideation skill and ships them through the generated Lisa plugin artifact.
- Adds regression coverage for the source and generated example files.

Closes #669.

## Verification
- bunx vitest run tests/unit/codex/project-ideation-examples.test.ts
- bunx eslint tests/unit/codex/project-ideation-examples.test.ts --quiet
- bunx prettier --check tests/unit/codex/project-ideation-examples.test.ts
- git diff --check
- bun run typecheck
- bun run build:plugins
- pre-push hook: bun audit, slow lint, knip, vitest run --coverage, integration tests

Note: `bun run check:plugins` refuses to run when plugin changes are uncommitted, so plugin artifact stability was verified by rerunning `bun run build:plugins` before commit and confirming the diff stayed scoped.