### PR TITLE
feat(verify-prd): FAIL path (shipped->blocked + failure report + linked fix issues)

### DIFF
--- a/plugins/lisa/skills/verify-prd/SKILL.md
+++ b/plugins/lisa/skills/verify-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-prd
-description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. When the guard passes, it runs the PASS path: spec-conformance against the original PRD requirements (via the spec-conformance skill) plus empirical verification appropriate to the shipped surface (via verification-lifecycle), and on a CONFORMS verdict with all empirical checks passing transitions the PRD shipped → verified and posts verification evidence. The FAIL path (shipped → blocked + fix issues) and idempotency are handled by sibling work."
+description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. When the guard passes, it runs spec-conformance against the original PRD requirements (via the spec-conformance skill) plus empirical verification appropriate to the shipped surface (via verification-lifecycle). On a CONFORMS verdict with all empirical checks passing it runs the PASS path: transitions the PRD shipped → verified and posts verification evidence. On a PARTIAL/DIVERGES conformance verdict or any failing empirical check it runs the FAIL path: transitions the PRD shipped → blocked (reusing the existing blocked role — no new failure state), posts a product-readable failure report naming which requirements/ACs failed with observed-vs-expected evidence, and creates linked fix issues (via tracker-write) back-linked to the PRD and the failure report, each carrying the captured evidence and acceptance criteria. Re-run idempotency is handled by sibling work."
 allowed-tools: ["Skill", "Bash", "Read", "mcp__claude_ai_Notion__notion-fetch", "mcp__claude_ai_Notion__notion-get-comments", "mcp__atlassian__getConfluencePage", "mcp__atlassian__getConfluencePageDescendants", "mcp__atlassian__getJiraIssue", "mcp__atlassian__searchJiraIssuesUsingJql", "mcp__atlassian__getAccessibleAtlassianResources", "mcp__linear-server__get_project", "mcp__linear-server__list_issues", "mcp__linear-server__get_issue", "mcp__linear-server__list_documents", "mcp__linear-server__get_document"]
 ---
 
@@ -18,7 +18,7 @@ Do **not** re-prompt once invoked. Like the `*-prd-intake` skills, the caller ha
 
 ## Scope of this skill
 
-This skill covers the **read/guard front-half** plus the **PASS path** of PRD-level verification:
+This skill covers the **read/guard front-half** plus **both verdict branches** (PASS and FAIL) of PRD-level verification:
 
 1. Resolve the PRD ref and detect its source vendor.
 2. Read the PRD body and its **generated top-level child work set** via the `prd-lifecycle-rollup` contract.
@@ -26,13 +26,13 @@ This skill covers the **read/guard front-half** plus the **PASS path** of PRD-le
 4. **Spec conformance** — when the guard passes, invoke the `spec-conformance` skill with the PRD as the spec source to build a section-by-section coverage matrix against the shipped product (never reimplementing the matrix).
 5. **Empirical verification** — invoke `verification-lifecycle` to run empirical checks appropriate to the PRD's surface (browser/computer-use, API, CLI, DB, screenshots, logs), honoring the `verification` rule. Quality gates (test/typecheck/lint) are **not** verification.
 6. **PASS transition + evidence** — when spec conformance is `CONFORMS` **and** every applicable empirical check passes, transition the PRD lifecycle from the resolved `shipped` role to the resolved `verified` role (vendor-neutral via `config-resolution`) and post verification evidence (the coverage matrix + empirical proof artifacts) back on the PRD.
+7. **FAIL transition + failure report + fix issues** — when spec conformance is `PARTIAL`/`DIVERGES`, or any applicable empirical check fails (or a required surface is unavailable), transition the PRD from the resolved `shipped` role to the resolved `blocked` role (reusing the existing `blocked` role — **no new failure state**, vendor-neutral via `config-resolution`), post a product-readable failure report on the PRD, and create linked fix issues via `tracker-write` for each missing/incorrect/divergent behavior.
 
-The remaining phases of PRD-level verification are **out of scope** here and are delivered by sibling work:
+The only remaining phase of PRD-level verification is **out of scope** here and is delivered by sibling work:
 
-- **FAIL path** — on verification failure (spec conformance not `CONFORMS`, or any empirical check failing), the `shipped → blocked` transition, a product-readable failure report, and linked fix issues for the missing/incorrect behavior.
-- **Idempotency** — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
+- **Idempotency** (#600) — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
 
-This skill implements only the **PASS** branch of Phase 6. When verification does not pass it stops at the verdict and **leaves the PRD at `shipped`** (it does not transition to `blocked`, does not open fix issues) — that is the FAIL sibling's job. Re-running before the idempotency sibling lands may re-post evidence or re-apply the (idempotent-by-label) transition; full no-duplicate guarantees are the idempotency sibling's job.
+When verification passes, this skill runs the **PASS** branch of Phase 6 (`shipped → verified`). When it does not pass — spec conformance not `CONFORMS`, or any empirical check failing — this skill runs the **FAIL** branch of Phase 7 (`shipped → blocked` + failure report + fix issues); it does **not** leave the PRD at `shipped`. Re-running before the idempotency sibling lands may re-post evidence/failure reports, re-create fix issues, or re-apply the (idempotent-by-label) transition; full no-duplicate guarantees are the idempotency sibling's job.
 
 ## Phase 1 — Resolve the PRD ref and detect the source vendor
 
@@ -113,7 +113,7 @@ Spec conformance at the PRD level differs from the leaf-ticket conformance run d
 **Branch on the verdict:**
 
 - **`CONFORMS`** — continue to Phase 5 (empirical verification).
-- **`PARTIAL` or `DIVERGES`** — verification has **not** passed. Stop the PASS path: record the verdict and the matrix in the output, **leave the PRD at `shipped`**, and do not transition or post a verified-evidence comment. Handing the `shipped → blocked` transition, the product-readable failure report, and the linked fix issues to the FAIL sibling is out of scope here (see [Scope of this skill](#scope-of-this-skill)).
+- **`PARTIAL` or `DIVERGES`** — verification has **not** passed. Do **not** run Phase 5 (empirical verification adds nothing once the spec already diverges) and do **not** enter the PASS path. Record the verdict and the matrix, then go to **Phase 7 — FAIL** with a `CONFORMANCE_FAILED` cause: the failed/missing/scope-crept requirements the matrix flagged become the failure report's findings and the seeds for the linked fix issues.
 
 ## Phase 5 — Empirical verification of the shipped surface
 
@@ -137,8 +137,8 @@ If a required surface or its tooling is unavailable, follow the lifecycle's Esca
 
 **Branch on the result:**
 
-- **Every applicable empirical check passes** (and is codified where the lifecycle requires) — continue to Phase 6.
-- **Any applicable empirical check fails, or a required surface is unavailable** — verification has **not** passed. Stop the PASS path: record what failed/was-blocked in the output, **leave the PRD at `shipped`**, and do not transition or post verified evidence. The `shipped → blocked` hop + fix issues are the FAIL sibling's job (out of scope here).
+- **Every applicable empirical check passes** (and is codified where the lifecycle requires) — continue to Phase 6 (PASS).
+- **Any applicable empirical check fails, or a required surface is unavailable** — verification has **not** passed. Record what failed/was-blocked (the check, the tool/command, observed vs expected, and any proof artifacts captured), then go to **Phase 7 — FAIL** with an `EMPIRICAL_FAILED` cause: each failed check (or unavailable required surface) becomes a failure-report finding and a seed for a linked fix issue.
 
 > **Single-environment note.** In a single-environment project (`main`/production only, no dev/staging), the shipped surface is whatever production exposes. A project with no deployed application, sign-in, or end-to-end environment variables (Lisa itself) verifies on its CLI/dry-run surface — running the documentation/skill build and drift check — which is the empirical surface the PRD's Validation Journey declares. The surface is always PRD-dependent: read the PRD's Empirical Verification Plan and verify what it says ships.
 
@@ -203,6 +203,83 @@ Post a verification-evidence comment back on the PRD, in the spirit of `tracker-
 
 Then emit the PASS output block (below).
 
+## Phase 7 — FAIL: transition `shipped → blocked`, post a failure report, and create fix issues
+
+Reach this phase when verification did **not** pass — i.e. **either** is true:
+
+- Phase 4 spec conformance returned **`PARTIAL`** or **`DIVERGES`** (`CONFORMANCE_FAILED` cause), or
+- Phase 5 had **any** applicable empirical check fail or a required surface unavailable (`EMPIRICAL_FAILED` cause).
+
+This is the FAIL counterpart of the Phase 6 PASS hop. It is the `shipped → blocked` FAIL hop the `prd-lifecycle-rollup` rule defines (cite it by slug; this skill is its FAIL-path implementation, not a second source of truth). It **reuses the existing `blocked` role** — it does **not** introduce a `prd-verification-failed` / `prd-verifying` state, per the "No extra failure states" rule in `prd-lifecycle-rollup`.
+
+Carry forward the verdict cause and the concrete **findings** that produced it: from `CONFORMANCE_FAILED`, the matrix's missed/divergent/scope-crept requirements; from `EMPIRICAL_FAILED`, each failing check (the requirement/AC it exercised, the tool/command, observed vs expected, and any captured artifacts). These findings drive both the failure report (7.3) and the fix issues (7.4).
+
+### 7.1 — Resolve the `blocked` and `shipped` roles
+
+Resolve the PRD-lifecycle roles from `.lisa.config.json` (then `.lisa.config.local.json` override) per the `config-resolution` rule — the same role-resolution Phase 6.1 and the `*-prd-intake` skills use. **Cite `config-resolution` for the role vocabulary; do not hardcode label strings except as the documented defaults.** Resolution per vendor:
+
+| Vendor | `shipped` role | `blocked` role | Default `blocked` |
+|---|---|---|---|
+| **GitHub** | `github.labels.prd.shipped` | `github.labels.prd.blocked` | `prd-blocked` (label) |
+| **Linear** | `linear.labels.prd.shipped` | `linear.labels.prd.blocked` | `prd-blocked` (project/issue label) |
+| **Notion** | `notion.values.shipped` | `notion.values.blocked` | `Blocked` (status value) |
+| **Confluence** | `confluence.parents.shipped` | `confluence.parents.blocked` | the `Blocked` parent page id |
+| **JIRA** | the configured shipped status | the configured blocked status | per `config-resolution` |
+
+For GitHub, resolve with the same helper Phase 6.1 / `github-prd-intake` use:
+
+```bash
+read_role() {  # role default → resolved value (local override wins)
+  local role="$1" default="$2" local_v global_v
+  local_v=$(jq -r ".github.labels.prd.${role} // empty" .lisa.config.local.json 2>/dev/null)
+  global_v=$(jq -r ".github.labels.prd.${role} // empty" .lisa.config.json 2>/dev/null)
+  echo "${local_v:-${global_v:-$default}}"
+}
+SHIPPED=$(read_role shipped prd-shipped)
+BLOCKED=$(read_role blocked prd-blocked)
+```
+
+### 7.2 — Transition the PRD `shipped → blocked`
+
+Apply the vendor-appropriate transition. This is the `shipped → blocked` FAIL hop from `prd-lifecycle-rollup` (cite it by slug):
+
+- **GitHub / Linear** — remove the `shipped` label and add the `blocked` label. For GitHub:
+  ```bash
+  gh issue edit <prd-num> --repo <org>/<repo> --remove-label "$SHIPPED" --add-label "$BLOCKED"
+  ```
+  Verify exactly **one** PRD-lifecycle label remains afterward (the single-label invariant `github-prd-intake` enforces). For Linear, set the project/issue label equivalently.
+- **Notion** — set the PRD page's `notion.statusProperty` (default `Status`) to the resolved `blocked` value (default `Blocked`).
+- **Confluence** — move the PRD page's `parentId` to `confluence.parents.blocked` (the parent-page-based lifecycle; Atlassian scoped tokens cannot write labels — see `config-resolution`).
+- **JIRA** — transition the PRD issue to the configured `blocked` status.
+
+Do **not** close or archive the PRD here — `blocked` signals "verification failed; human attention required," not "done." The PRD stays open so product can see it failed acceptance.
+
+### 7.3 — Post a product-readable failure report on the PRD
+
+Post a **failure report** comment back on the PRD, via the same vendor surface Phase 6.3 uses for evidence (`gh issue comment` for GitHub, the Linear comment API, the Notion/Confluence page comment surface, or a JIRA comment; dispatch through `tracker-evidence` where the PRD lives in the configured `tracker`). The report is written for a **non-engineer product owner** — plain language, no stack traces dumped raw. Capture its URL/anchor so the fix issues in 7.4 can back-link to it. It MUST include:
+
+1. **AI disclosure** — lead with "PRD-level verification by Claude (AI agent, not a human)."
+2. **Verdict line** — `shipped → blocked — FAIL` and the cause (`CONFORMANCE_FAILED` or `EMPIRICAL_FAILED`).
+3. **What failed, in plain language** — for each finding, name the **specific PRD requirement / acceptance criterion** that was not met, then **what was expected vs what was observed** (the empirical evidence: what was checked, what the shipped product did instead). One bullet per finding so product can follow each independently.
+4. **Spec-conformance coverage matrix** — for a `CONFORMANCE_FAILED` cause, the section-by-section matrix from Phase 4 verbatim with the `PARTIAL`/`DIVERGES` verdict, so the missed/divergent/scope-crept rows are visible.
+5. **Proof artifacts** — any captured empirical artifacts (screenshots uploaded via `gh release upload pr-assets <files> --clobber` and referenced as plain URLs per the `tracker-evidence` UI Evidence Checklist, request/response captures, query outputs, log excerpts).
+6. **Fix issues** — a list of the fix issues created in 7.4 (filled in after 7.4 runs, or posted as a brief follow-up edit), so the report is the single product-facing index of "what's wrong and where it's being fixed."
+
+### 7.4 — Create linked fix issues for the missing/incorrect behavior
+
+For **each** failed/missing/incorrect/divergent finding, create a **fix issue** via `tracker-write` (the vendor-neutral writer) — never by hand-rolling `gh issue create`, so each issue passes the same quality gates (`tracker-validate`) every Lisa ticket does: three-audience description, **Gherkin acceptance criteria**, labels, and explicit relationship discovery. Group findings that share one root cause into one fix issue; do not fan out one issue per matrix cell when several rows are the same defect. Each fix issue MUST:
+
+1. **Reference the specific failed requirement/AC** — quote or cite the exact PRD requirement / acceptance criterion the finding violated, so the fix is scoped to a real gap (not a vague "make it work").
+2. **Carry the captured evidence** — the observed-vs-expected from the failure report (what was checked, what was expected, what the shipped product did), so an implementer can reproduce without re-deriving it.
+3. **Back-link to the PRD and the failure report** — link to the PRD (so the fix rolls back up to the initiative) and to the failure-report comment from 7.3 (so the full context is one click away). On GitHub, reference the PRD issue number and the failure-report comment URL in the body and, where supported, as a sub-issue/`Relates to` link; on Linear, set the relation; on JIRA, add the issue link and remote link.
+4. **Have acceptance criteria** — Gherkin ACs describing the corrected behavior (what "fixed" looks like), enforced by `tracker-write` → the vendor `*-validate-issue` gate.
+
+Pass each fix issue's spec to `tracker-write` (which dispatches to `github-write-issue` / `jira-write-ticket` / `linear-write-issue` per config). Collect the created refs/URLs and fold them into the failure report's **Fix issues** list (7.3 item 6).
+
+> **Why not reopen children?** The generated top-level children are already terminal (that is the Phase 3 precondition for verification). A failed PRD-level acceptance is a **new** defect discovered against the shipped initiative, so it gets **new** fix issues linked to the PRD — not a reopen of closed build tickets, which would corrupt their build lifecycle (`leaf-only-lifecycle`).
+
+Then emit the FAIL output block (below).
+
 ## Output
 
 Emit a single fenced text block so callers can parse it.
@@ -228,28 +305,31 @@ Verdict: <CONFORMS | PARTIAL | DIVERGES>
 Surface: <browser | api | cli | db | logs | ...>  (PRD-dependent)
 <each check — tool/command → PASS/FAIL → artifact ref; codified test(s)>
 
-### Lifecycle transition   (only on PASS)
-shipped → verified   (role: <resolved verified role>)   evidence posted: <link>
+### Lifecycle transition   (PASS or FAIL)
+shipped → verified   (role: <resolved verified role>)   evidence posted: <link>          # on VERIFIED_PASS
+shipped → blocked    (role: <resolved blocked role>)    failure report: <link>   fix issues: <refs>   # on CONFORMANCE_FAILED | EMPIRICAL_FAILED
 
 ### Verdict: VERIFIED_PASS | CONFORMANCE_FAILED | EMPIRICAL_FAILED | GUARD_BLOCKED | NO_CHILDREN
 ```
 
 - `GUARD_BLOCKED` — one or more required top-level children are non-terminal; verification did not run; the PRD was left at `shipped`.
 - `NO_CHILDREN` — no generated top-level children found; cannot verify; the PRD was left untouched.
-- `CONFORMANCE_FAILED` — guard passed but spec conformance returned `PARTIAL`/`DIVERGES`; empirical verification did not run; the PRD was left at `shipped` (the `shipped → blocked` transition + fix issues are the FAIL sibling's job).
-- `EMPIRICAL_FAILED` — guard passed and conformance `CONFORMS`, but an applicable empirical check failed or a required surface was unavailable; the PRD was left at `shipped` (FAIL sibling owns the `blocked` path).
-- `VERIFIED_PASS` — guard passed, conformance `CONFORMS`, every applicable empirical check passed and was codified; the PRD was transitioned `shipped → verified` and verification evidence was posted.
+- `CONFORMANCE_FAILED` — guard passed but spec conformance returned `PARTIAL`/`DIVERGES`; empirical verification was skipped; the FAIL path ran — the PRD was transitioned `shipped → blocked` (reusing the `blocked` role), a product-readable failure report was posted, and linked fix issues were created (Phase 7).
+- `EMPIRICAL_FAILED` — guard passed and conformance `CONFORMS`, but an applicable empirical check failed or a required surface was unavailable; the FAIL path ran — the PRD was transitioned `shipped → blocked` (reusing the `blocked` role), a product-readable failure report was posted, and linked fix issues were created (Phase 7).
+- `VERIFIED_PASS` — guard passed, conformance `CONFORMS`, every applicable empirical check passed and was codified; the PRD was transitioned `shipped → verified` and verification evidence was posted (Phase 6).
 
 ## Rules
 
-- **The only lifecycle write is the PASS hop `shipped → verified`.** The front-half (resolve → read child set → guard) is read-only and never transitions the PRD. The only write this skill performs is the Phase 6 PASS hop — and **only** when spec conformance is `CONFORMS` and every applicable empirical check passes. The guard-blocked, no-children, conformance-failed, and empirical-failed paths all leave the PRD at `shipped` untouched. The `shipped → blocked` FAIL hop, fix issues, and re-run idempotency are sibling work (out of scope).
+- **The lifecycle writes are the PASS hop `shipped → verified` and the FAIL hop `shipped → blocked`.** The front-half (resolve → read child set → guard) is read-only and never transitions the PRD. After the guard passes and verification runs, this skill writes exactly one of two transitions: the Phase 6 PASS hop `shipped → verified` (when spec conformance is `CONFORMS` and every applicable empirical check passes), or the Phase 7 FAIL hop `shipped → blocked` (when conformance is `PARTIAL`/`DIVERGES` or any applicable empirical check fails). The FAIL hop **reuses the existing `blocked` role — it introduces no new failure state.** The guard-blocked and no-children paths run no verification and leave the PRD at `shipped` untouched. Re-run idempotency (no duplicate evidence/failure-reports/fix-issues/transitions) is sibling work (out of scope, #600).
+- **The FAIL path opens fix issues via `tracker-write`, never by hand.** Each fix issue is created through the vendor-neutral writer so it passes the same `tracker-validate` quality gate (three-audience description, Gherkin ACs, labels, relationships) every Lisa ticket does. Fix issues are **new** defects against the shipped initiative, back-linked to the PRD and the failure report — never reopens of the already-terminal generated children (`leaf-only-lifecycle`).
 - **Never reimplement child enumeration.** Consume the recorded PRD→child relationship (`prd-lifecycle-rollup` native linking + machine-readable generated-work section). The two-source read here mirrors `github-prd-intake` Phase 3f.2 — same sources, same dedupe-by-child-ref, same top-level-only boundary.
 - **Never reimplement spec conformance or verification.** Phase 4 invokes the `spec-conformance` skill (the single source of truth for the coverage matrix and the `CONFORMS`/`PARTIAL`/`DIVERGES` verdict); Phase 5 invokes `verification-lifecycle` (which in turn invokes `codify-verification` and, for UI, `product-walkthrough`). This skill orchestrates those skills against the PRD; it does not duplicate their logic.
 - **Quality gates are not verification.** Tests, typecheck, and lint are prerequisites enforced by hooks/CI. Phase 5 requires running the actual shipped system and observing results on a surface chosen from what the PRD delivered — never substituting a green test suite for empirical proof (`verification` rule).
 - **The verification surface is PRD-dependent.** Classify the empirical surface (browser/API/CLI/DB/logs/…) from what the PRD shipped; do not assume a fixed surface. A single-environment project with no deployed app verifies on its CLI/dry-run surface per the PRD's Empirical Verification Plan.
 - **`verified` is product-owned and terminal.** This skill is the only automated writer of the `verified` role; intake/rollup never set it. The PASS hop does not close or archive the PRD (closure is governed by `prd.rollup.closeOnShipped` at the `shipped` hop).
+- **`blocked` is reused, not invented, and is non-terminal.** The FAIL hop sets the existing `blocked` PRD role (`config-resolution`) — the same role intake uses for failed validation — so the lifecycle stays small (`prd-lifecycle-rollup` "No extra failure states"). `blocked` means "verification failed; human attention required"; the FAIL hop never closes or archives the PRD.
 - **Top-level only.** Exclude leaf Sub-tasks and Stories nested under a generated Epic. The PRD owns its top-level work; those top-level units own their descendants (`prd-lifecycle-rollup` generated-top-level-work contract).
-- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, the dedupe-by-child-ref idempotency key, and the `shipped → verified` PASS hop all come from the `prd-lifecycle-rollup` rule; the `verified`/`shipped` role vocabulary comes from `config-resolution`. This skill is a consumer of those contracts, not a second source of truth.
+- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, the dedupe-by-child-ref idempotency key, and the `shipped → verified | blocked` PRD-level verification hops all come from the `prd-lifecycle-rollup` rule; the `verified`/`shipped`/`blocked` role vocabulary comes from `config-resolution`. This skill is a consumer of those contracts, not a second source of truth.
 
 ## Related skills
 
@@ -257,11 +337,12 @@ shipped → verified   (role: <resolved verified role>)   evidence posted: <link
 - `verification-lifecycle` — Phase 5 invokes it to run empirical verification of the shipped surface (classify → check tooling → plan → execute → codify → loop). It in turn invokes `codify-verification` and, for UI surfaces, `product-walkthrough`.
 - `codify-verification` — turns each passing empirical verification into a regression test so the PRD's verified behavior cannot silently regress; invoked transitively via `verification-lifecycle`.
 - `product-walkthrough` — drives the live product through a real browser to ground UI-surface verification and the evidence comment in what actually renders.
-- `tracker-evidence` — the vendor-neutral evidence poster whose UI Evidence Checklist and `pr-assets` upload mechanics Phase 6.3 follows when posting the verification evidence comment on the PRD.
+- `tracker-evidence` — the vendor-neutral evidence poster whose UI Evidence Checklist and `pr-assets` upload mechanics Phase 6.3 (PASS evidence) and Phase 7.3 (FAIL failure report) follow when commenting on the PRD.
+- `tracker-write` — the vendor-neutral ticket writer Phase 7.4 invokes to create each linked fix issue (dispatching to `github-write-issue` / `jira-write-ticket` / `linear-write-issue` per config), so every fix issue clears the `tracker-validate` quality gate (Gherkin ACs, three-audience description, labels, relationships). This skill never hand-rolls issue creation.
 
 ## Related rules
 
-- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, and the child-ref idempotency dedupe key. This skill consumes that contract — including the `shipped → verified` PASS hop it implements — citing the rule by slug rather than restating its taxonomy.
+- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, the "no extra failure states" rule (the FAIL hop reuses `blocked`), and the child-ref idempotency dedupe key. This skill consumes that contract — implementing both the `shipped → verified` PASS hop and the `shipped → blocked` FAIL hop — citing the rule by slug rather than restating its taxonomy.
 - `verification` — defines what counts as empirical verification (the Verification Types table) and that quality gates (test/typecheck/lint) are prerequisites, not verification. Phase 5 honors it when classifying and running the surface-appropriate checks.
 - `leaf-only-lifecycle` — governs the build lifecycle of leaf work units and how a generated Epic rolls up from its own children; this skill trusts that bottom-up rollup when reading a top-level child's resolved state.
-- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`), the per-vendor `verified` role maps (`prd-verified` label for GitHub/Linear, `Verified` status for Notion, `confluence.parents.verified` parent page) Phase 6.1 resolves, and the env-keyed `done` map the terminal predicate resolves against.
+- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`), the per-vendor `verified` role maps (`prd-verified` label for GitHub/Linear, `Verified` status for Notion, `confluence.parents.verified` parent page) Phase 6.1 resolves, the per-vendor `blocked` role maps (`prd-blocked` label for GitHub/Linear, `Blocked` status for Notion, `confluence.parents.blocked` parent page) Phase 7.1 resolves, and the env-keyed `done` map the terminal predicate resolves against.

--- a/plugins/src/base/skills/verify-prd/SKILL.md
+++ b/plugins/src/base/skills/verify-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-prd
-description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. When the guard passes, it runs the PASS path: spec-conformance against the original PRD requirements (via the spec-conformance skill) plus empirical verification appropriate to the shipped surface (via verification-lifecycle), and on a CONFORMS verdict with all empirical checks passing transitions the PRD shipped → verified and posts verification evidence. The FAIL path (shipped → blocked + fix issues) and idempotency are handled by sibling work."
+description: "Initiative-level PRD acceptance gate. Given a PRD ref/URL (GitHub Issue, Linear project/issue, Notion page, Confluence page, or JIRA issue), resolves the source vendor, reads the PRD body and its generated top-level child work set via the prd-lifecycle-rollup contract (native hierarchy first, machine-readable generated-work section fallback — never reimplementing child enumeration), and confirms every required generated top-level work item is terminal before any verification runs. If any required top-level child is non-terminal, it reports the incomplete child set and STOPS without verifying or transitioning the PRD. When the guard passes, it runs spec-conformance against the original PRD requirements (via the spec-conformance skill) plus empirical verification appropriate to the shipped surface (via verification-lifecycle). On a CONFORMS verdict with all empirical checks passing it runs the PASS path: transitions the PRD shipped → verified and posts verification evidence. On a PARTIAL/DIVERGES conformance verdict or any failing empirical check it runs the FAIL path: transitions the PRD shipped → blocked (reusing the existing blocked role — no new failure state), posts a product-readable failure report naming which requirements/ACs failed with observed-vs-expected evidence, and creates linked fix issues (via tracker-write) back-linked to the PRD and the failure report, each carrying the captured evidence and acceptance criteria. Re-run idempotency is handled by sibling work."
 allowed-tools: ["Skill", "Bash", "Read", "mcp__claude_ai_Notion__notion-fetch", "mcp__claude_ai_Notion__notion-get-comments", "mcp__atlassian__getConfluencePage", "mcp__atlassian__getConfluencePageDescendants", "mcp__atlassian__getJiraIssue", "mcp__atlassian__searchJiraIssuesUsingJql", "mcp__atlassian__getAccessibleAtlassianResources", "mcp__linear-server__get_project", "mcp__linear-server__list_issues", "mcp__linear-server__get_issue", "mcp__linear-server__list_documents", "mcp__linear-server__get_document"]
 ---
 
@@ -18,7 +18,7 @@ Do **not** re-prompt once invoked. Like the `*-prd-intake` skills, the caller ha
 
 ## Scope of this skill
 
-This skill covers the **read/guard front-half** plus the **PASS path** of PRD-level verification:
+This skill covers the **read/guard front-half** plus **both verdict branches** (PASS and FAIL) of PRD-level verification:
 
 1. Resolve the PRD ref and detect its source vendor.
 2. Read the PRD body and its **generated top-level child work set** via the `prd-lifecycle-rollup` contract.
@@ -26,13 +26,13 @@ This skill covers the **read/guard front-half** plus the **PASS path** of PRD-le
 4. **Spec conformance** — when the guard passes, invoke the `spec-conformance` skill with the PRD as the spec source to build a section-by-section coverage matrix against the shipped product (never reimplementing the matrix).
 5. **Empirical verification** — invoke `verification-lifecycle` to run empirical checks appropriate to the PRD's surface (browser/computer-use, API, CLI, DB, screenshots, logs), honoring the `verification` rule. Quality gates (test/typecheck/lint) are **not** verification.
 6. **PASS transition + evidence** — when spec conformance is `CONFORMS` **and** every applicable empirical check passes, transition the PRD lifecycle from the resolved `shipped` role to the resolved `verified` role (vendor-neutral via `config-resolution`) and post verification evidence (the coverage matrix + empirical proof artifacts) back on the PRD.
+7. **FAIL transition + failure report + fix issues** — when spec conformance is `PARTIAL`/`DIVERGES`, or any applicable empirical check fails (or a required surface is unavailable), transition the PRD from the resolved `shipped` role to the resolved `blocked` role (reusing the existing `blocked` role — **no new failure state**, vendor-neutral via `config-resolution`), post a product-readable failure report on the PRD, and create linked fix issues via `tracker-write` for each missing/incorrect/divergent behavior.
 
-The remaining phases of PRD-level verification are **out of scope** here and are delivered by sibling work:
+The only remaining phase of PRD-level verification is **out of scope** here and is delivered by sibling work:
 
-- **FAIL path** — on verification failure (spec conformance not `CONFORMS`, or any empirical check failing), the `shipped → blocked` transition, a product-readable failure report, and linked fix issues for the missing/incorrect behavior.
-- **Idempotency** — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
+- **Idempotency** (#600) — re-runs producing no duplicate evidence, fix issues, or lifecycle transitions.
 
-This skill implements only the **PASS** branch of Phase 6. When verification does not pass it stops at the verdict and **leaves the PRD at `shipped`** (it does not transition to `blocked`, does not open fix issues) — that is the FAIL sibling's job. Re-running before the idempotency sibling lands may re-post evidence or re-apply the (idempotent-by-label) transition; full no-duplicate guarantees are the idempotency sibling's job.
+When verification passes, this skill runs the **PASS** branch of Phase 6 (`shipped → verified`). When it does not pass — spec conformance not `CONFORMS`, or any empirical check failing — this skill runs the **FAIL** branch of Phase 7 (`shipped → blocked` + failure report + fix issues); it does **not** leave the PRD at `shipped`. Re-running before the idempotency sibling lands may re-post evidence/failure reports, re-create fix issues, or re-apply the (idempotent-by-label) transition; full no-duplicate guarantees are the idempotency sibling's job.
 
 ## Phase 1 — Resolve the PRD ref and detect the source vendor
 
@@ -113,7 +113,7 @@ Spec conformance at the PRD level differs from the leaf-ticket conformance run d
 **Branch on the verdict:**
 
 - **`CONFORMS`** — continue to Phase 5 (empirical verification).
-- **`PARTIAL` or `DIVERGES`** — verification has **not** passed. Stop the PASS path: record the verdict and the matrix in the output, **leave the PRD at `shipped`**, and do not transition or post a verified-evidence comment. Handing the `shipped → blocked` transition, the product-readable failure report, and the linked fix issues to the FAIL sibling is out of scope here (see [Scope of this skill](#scope-of-this-skill)).
+- **`PARTIAL` or `DIVERGES`** — verification has **not** passed. Do **not** run Phase 5 (empirical verification adds nothing once the spec already diverges) and do **not** enter the PASS path. Record the verdict and the matrix, then go to **Phase 7 — FAIL** with a `CONFORMANCE_FAILED` cause: the failed/missing/scope-crept requirements the matrix flagged become the failure report's findings and the seeds for the linked fix issues.
 
 ## Phase 5 — Empirical verification of the shipped surface
 
@@ -137,8 +137,8 @@ If a required surface or its tooling is unavailable, follow the lifecycle's Esca
 
 **Branch on the result:**
 
-- **Every applicable empirical check passes** (and is codified where the lifecycle requires) — continue to Phase 6.
-- **Any applicable empirical check fails, or a required surface is unavailable** — verification has **not** passed. Stop the PASS path: record what failed/was-blocked in the output, **leave the PRD at `shipped`**, and do not transition or post verified evidence. The `shipped → blocked` hop + fix issues are the FAIL sibling's job (out of scope here).
+- **Every applicable empirical check passes** (and is codified where the lifecycle requires) — continue to Phase 6 (PASS).
+- **Any applicable empirical check fails, or a required surface is unavailable** — verification has **not** passed. Record what failed/was-blocked (the check, the tool/command, observed vs expected, and any proof artifacts captured), then go to **Phase 7 — FAIL** with an `EMPIRICAL_FAILED` cause: each failed check (or unavailable required surface) becomes a failure-report finding and a seed for a linked fix issue.
 
 > **Single-environment note.** In a single-environment project (`main`/production only, no dev/staging), the shipped surface is whatever production exposes. A project with no deployed application, sign-in, or end-to-end environment variables (Lisa itself) verifies on its CLI/dry-run surface — running the documentation/skill build and drift check — which is the empirical surface the PRD's Validation Journey declares. The surface is always PRD-dependent: read the PRD's Empirical Verification Plan and verify what it says ships.
 
@@ -203,6 +203,83 @@ Post a verification-evidence comment back on the PRD, in the spirit of `tracker-
 
 Then emit the PASS output block (below).
 
+## Phase 7 — FAIL: transition `shipped → blocked`, post a failure report, and create fix issues
+
+Reach this phase when verification did **not** pass — i.e. **either** is true:
+
+- Phase 4 spec conformance returned **`PARTIAL`** or **`DIVERGES`** (`CONFORMANCE_FAILED` cause), or
+- Phase 5 had **any** applicable empirical check fail or a required surface unavailable (`EMPIRICAL_FAILED` cause).
+
+This is the FAIL counterpart of the Phase 6 PASS hop. It is the `shipped → blocked` FAIL hop the `prd-lifecycle-rollup` rule defines (cite it by slug; this skill is its FAIL-path implementation, not a second source of truth). It **reuses the existing `blocked` role** — it does **not** introduce a `prd-verification-failed` / `prd-verifying` state, per the "No extra failure states" rule in `prd-lifecycle-rollup`.
+
+Carry forward the verdict cause and the concrete **findings** that produced it: from `CONFORMANCE_FAILED`, the matrix's missed/divergent/scope-crept requirements; from `EMPIRICAL_FAILED`, each failing check (the requirement/AC it exercised, the tool/command, observed vs expected, and any captured artifacts). These findings drive both the failure report (7.3) and the fix issues (7.4).
+
+### 7.1 — Resolve the `blocked` and `shipped` roles
+
+Resolve the PRD-lifecycle roles from `.lisa.config.json` (then `.lisa.config.local.json` override) per the `config-resolution` rule — the same role-resolution Phase 6.1 and the `*-prd-intake` skills use. **Cite `config-resolution` for the role vocabulary; do not hardcode label strings except as the documented defaults.** Resolution per vendor:
+
+| Vendor | `shipped` role | `blocked` role | Default `blocked` |
+|---|---|---|---|
+| **GitHub** | `github.labels.prd.shipped` | `github.labels.prd.blocked` | `prd-blocked` (label) |
+| **Linear** | `linear.labels.prd.shipped` | `linear.labels.prd.blocked` | `prd-blocked` (project/issue label) |
+| **Notion** | `notion.values.shipped` | `notion.values.blocked` | `Blocked` (status value) |
+| **Confluence** | `confluence.parents.shipped` | `confluence.parents.blocked` | the `Blocked` parent page id |
+| **JIRA** | the configured shipped status | the configured blocked status | per `config-resolution` |
+
+For GitHub, resolve with the same helper Phase 6.1 / `github-prd-intake` use:
+
+```bash
+read_role() {  # role default → resolved value (local override wins)
+  local role="$1" default="$2" local_v global_v
+  local_v=$(jq -r ".github.labels.prd.${role} // empty" .lisa.config.local.json 2>/dev/null)
+  global_v=$(jq -r ".github.labels.prd.${role} // empty" .lisa.config.json 2>/dev/null)
+  echo "${local_v:-${global_v:-$default}}"
+}
+SHIPPED=$(read_role shipped prd-shipped)
+BLOCKED=$(read_role blocked prd-blocked)
+```
+
+### 7.2 — Transition the PRD `shipped → blocked`
+
+Apply the vendor-appropriate transition. This is the `shipped → blocked` FAIL hop from `prd-lifecycle-rollup` (cite it by slug):
+
+- **GitHub / Linear** — remove the `shipped` label and add the `blocked` label. For GitHub:
+  ```bash
+  gh issue edit <prd-num> --repo <org>/<repo> --remove-label "$SHIPPED" --add-label "$BLOCKED"
+  ```
+  Verify exactly **one** PRD-lifecycle label remains afterward (the single-label invariant `github-prd-intake` enforces). For Linear, set the project/issue label equivalently.
+- **Notion** — set the PRD page's `notion.statusProperty` (default `Status`) to the resolved `blocked` value (default `Blocked`).
+- **Confluence** — move the PRD page's `parentId` to `confluence.parents.blocked` (the parent-page-based lifecycle; Atlassian scoped tokens cannot write labels — see `config-resolution`).
+- **JIRA** — transition the PRD issue to the configured `blocked` status.
+
+Do **not** close or archive the PRD here — `blocked` signals "verification failed; human attention required," not "done." The PRD stays open so product can see it failed acceptance.
+
+### 7.3 — Post a product-readable failure report on the PRD
+
+Post a **failure report** comment back on the PRD, via the same vendor surface Phase 6.3 uses for evidence (`gh issue comment` for GitHub, the Linear comment API, the Notion/Confluence page comment surface, or a JIRA comment; dispatch through `tracker-evidence` where the PRD lives in the configured `tracker`). The report is written for a **non-engineer product owner** — plain language, no stack traces dumped raw. Capture its URL/anchor so the fix issues in 7.4 can back-link to it. It MUST include:
+
+1. **AI disclosure** — lead with "PRD-level verification by Claude (AI agent, not a human)."
+2. **Verdict line** — `shipped → blocked — FAIL` and the cause (`CONFORMANCE_FAILED` or `EMPIRICAL_FAILED`).
+3. **What failed, in plain language** — for each finding, name the **specific PRD requirement / acceptance criterion** that was not met, then **what was expected vs what was observed** (the empirical evidence: what was checked, what the shipped product did instead). One bullet per finding so product can follow each independently.
+4. **Spec-conformance coverage matrix** — for a `CONFORMANCE_FAILED` cause, the section-by-section matrix from Phase 4 verbatim with the `PARTIAL`/`DIVERGES` verdict, so the missed/divergent/scope-crept rows are visible.
+5. **Proof artifacts** — any captured empirical artifacts (screenshots uploaded via `gh release upload pr-assets <files> --clobber` and referenced as plain URLs per the `tracker-evidence` UI Evidence Checklist, request/response captures, query outputs, log excerpts).
+6. **Fix issues** — a list of the fix issues created in 7.4 (filled in after 7.4 runs, or posted as a brief follow-up edit), so the report is the single product-facing index of "what's wrong and where it's being fixed."
+
+### 7.4 — Create linked fix issues for the missing/incorrect behavior
+
+For **each** failed/missing/incorrect/divergent finding, create a **fix issue** via `tracker-write` (the vendor-neutral writer) — never by hand-rolling `gh issue create`, so each issue passes the same quality gates (`tracker-validate`) every Lisa ticket does: three-audience description, **Gherkin acceptance criteria**, labels, and explicit relationship discovery. Group findings that share one root cause into one fix issue; do not fan out one issue per matrix cell when several rows are the same defect. Each fix issue MUST:
+
+1. **Reference the specific failed requirement/AC** — quote or cite the exact PRD requirement / acceptance criterion the finding violated, so the fix is scoped to a real gap (not a vague "make it work").
+2. **Carry the captured evidence** — the observed-vs-expected from the failure report (what was checked, what was expected, what the shipped product did), so an implementer can reproduce without re-deriving it.
+3. **Back-link to the PRD and the failure report** — link to the PRD (so the fix rolls back up to the initiative) and to the failure-report comment from 7.3 (so the full context is one click away). On GitHub, reference the PRD issue number and the failure-report comment URL in the body and, where supported, as a sub-issue/`Relates to` link; on Linear, set the relation; on JIRA, add the issue link and remote link.
+4. **Have acceptance criteria** — Gherkin ACs describing the corrected behavior (what "fixed" looks like), enforced by `tracker-write` → the vendor `*-validate-issue` gate.
+
+Pass each fix issue's spec to `tracker-write` (which dispatches to `github-write-issue` / `jira-write-ticket` / `linear-write-issue` per config). Collect the created refs/URLs and fold them into the failure report's **Fix issues** list (7.3 item 6).
+
+> **Why not reopen children?** The generated top-level children are already terminal (that is the Phase 3 precondition for verification). A failed PRD-level acceptance is a **new** defect discovered against the shipped initiative, so it gets **new** fix issues linked to the PRD — not a reopen of closed build tickets, which would corrupt their build lifecycle (`leaf-only-lifecycle`).
+
+Then emit the FAIL output block (below).
+
 ## Output
 
 Emit a single fenced text block so callers can parse it.
@@ -228,28 +305,31 @@ Verdict: <CONFORMS | PARTIAL | DIVERGES>
 Surface: <browser | api | cli | db | logs | ...>  (PRD-dependent)
 <each check — tool/command → PASS/FAIL → artifact ref; codified test(s)>
 
-### Lifecycle transition   (only on PASS)
-shipped → verified   (role: <resolved verified role>)   evidence posted: <link>
+### Lifecycle transition   (PASS or FAIL)
+shipped → verified   (role: <resolved verified role>)   evidence posted: <link>          # on VERIFIED_PASS
+shipped → blocked    (role: <resolved blocked role>)    failure report: <link>   fix issues: <refs>   # on CONFORMANCE_FAILED | EMPIRICAL_FAILED
 
 ### Verdict: VERIFIED_PASS | CONFORMANCE_FAILED | EMPIRICAL_FAILED | GUARD_BLOCKED | NO_CHILDREN
 ```
 
 - `GUARD_BLOCKED` — one or more required top-level children are non-terminal; verification did not run; the PRD was left at `shipped`.
 - `NO_CHILDREN` — no generated top-level children found; cannot verify; the PRD was left untouched.
-- `CONFORMANCE_FAILED` — guard passed but spec conformance returned `PARTIAL`/`DIVERGES`; empirical verification did not run; the PRD was left at `shipped` (the `shipped → blocked` transition + fix issues are the FAIL sibling's job).
-- `EMPIRICAL_FAILED` — guard passed and conformance `CONFORMS`, but an applicable empirical check failed or a required surface was unavailable; the PRD was left at `shipped` (FAIL sibling owns the `blocked` path).
-- `VERIFIED_PASS` — guard passed, conformance `CONFORMS`, every applicable empirical check passed and was codified; the PRD was transitioned `shipped → verified` and verification evidence was posted.
+- `CONFORMANCE_FAILED` — guard passed but spec conformance returned `PARTIAL`/`DIVERGES`; empirical verification was skipped; the FAIL path ran — the PRD was transitioned `shipped → blocked` (reusing the `blocked` role), a product-readable failure report was posted, and linked fix issues were created (Phase 7).
+- `EMPIRICAL_FAILED` — guard passed and conformance `CONFORMS`, but an applicable empirical check failed or a required surface was unavailable; the FAIL path ran — the PRD was transitioned `shipped → blocked` (reusing the `blocked` role), a product-readable failure report was posted, and linked fix issues were created (Phase 7).
+- `VERIFIED_PASS` — guard passed, conformance `CONFORMS`, every applicable empirical check passed and was codified; the PRD was transitioned `shipped → verified` and verification evidence was posted (Phase 6).
 
 ## Rules
 
-- **The only lifecycle write is the PASS hop `shipped → verified`.** The front-half (resolve → read child set → guard) is read-only and never transitions the PRD. The only write this skill performs is the Phase 6 PASS hop — and **only** when spec conformance is `CONFORMS` and every applicable empirical check passes. The guard-blocked, no-children, conformance-failed, and empirical-failed paths all leave the PRD at `shipped` untouched. The `shipped → blocked` FAIL hop, fix issues, and re-run idempotency are sibling work (out of scope).
+- **The lifecycle writes are the PASS hop `shipped → verified` and the FAIL hop `shipped → blocked`.** The front-half (resolve → read child set → guard) is read-only and never transitions the PRD. After the guard passes and verification runs, this skill writes exactly one of two transitions: the Phase 6 PASS hop `shipped → verified` (when spec conformance is `CONFORMS` and every applicable empirical check passes), or the Phase 7 FAIL hop `shipped → blocked` (when conformance is `PARTIAL`/`DIVERGES` or any applicable empirical check fails). The FAIL hop **reuses the existing `blocked` role — it introduces no new failure state.** The guard-blocked and no-children paths run no verification and leave the PRD at `shipped` untouched. Re-run idempotency (no duplicate evidence/failure-reports/fix-issues/transitions) is sibling work (out of scope, #600).
+- **The FAIL path opens fix issues via `tracker-write`, never by hand.** Each fix issue is created through the vendor-neutral writer so it passes the same `tracker-validate` quality gate (three-audience description, Gherkin ACs, labels, relationships) every Lisa ticket does. Fix issues are **new** defects against the shipped initiative, back-linked to the PRD and the failure report — never reopens of the already-terminal generated children (`leaf-only-lifecycle`).
 - **Never reimplement child enumeration.** Consume the recorded PRD→child relationship (`prd-lifecycle-rollup` native linking + machine-readable generated-work section). The two-source read here mirrors `github-prd-intake` Phase 3f.2 — same sources, same dedupe-by-child-ref, same top-level-only boundary.
 - **Never reimplement spec conformance or verification.** Phase 4 invokes the `spec-conformance` skill (the single source of truth for the coverage matrix and the `CONFORMS`/`PARTIAL`/`DIVERGES` verdict); Phase 5 invokes `verification-lifecycle` (which in turn invokes `codify-verification` and, for UI, `product-walkthrough`). This skill orchestrates those skills against the PRD; it does not duplicate their logic.
 - **Quality gates are not verification.** Tests, typecheck, and lint are prerequisites enforced by hooks/CI. Phase 5 requires running the actual shipped system and observing results on a surface chosen from what the PRD delivered — never substituting a green test suite for empirical proof (`verification` rule).
 - **The verification surface is PRD-dependent.** Classify the empirical surface (browser/API/CLI/DB/logs/…) from what the PRD shipped; do not assume a fixed surface. A single-environment project with no deployed app verifies on its CLI/dry-run surface per the PRD's Empirical Verification Plan.
 - **`verified` is product-owned and terminal.** This skill is the only automated writer of the `verified` role; intake/rollup never set it. The PASS hop does not close or archive the PRD (closure is governed by `prd.rollup.closeOnShipped` at the `shipped` hop).
+- **`blocked` is reused, not invented, and is non-terminal.** The FAIL hop sets the existing `blocked` PRD role (`config-resolution`) — the same role intake uses for failed validation — so the lifecycle stays small (`prd-lifecycle-rollup` "No extra failure states"). `blocked` means "verification failed; human attention required"; the FAIL hop never closes or archives the PRD.
 - **Top-level only.** Exclude leaf Sub-tasks and Stories nested under a generated Epic. The PRD owns its top-level work; those top-level units own their descendants (`prd-lifecycle-rollup` generated-top-level-work contract).
-- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, the dedupe-by-child-ref idempotency key, and the `shipped → verified` PASS hop all come from the `prd-lifecycle-rollup` rule; the `verified`/`shipped` role vocabulary comes from `config-resolution`. This skill is a consumer of those contracts, not a second source of truth.
+- **Cite, don't restate.** The generated-top-level-work boundary, the per-vendor terminal predicate, the env-keyed `done` resolution, the dedupe-by-child-ref idempotency key, and the `shipped → verified | blocked` PRD-level verification hops all come from the `prd-lifecycle-rollup` rule; the `verified`/`shipped`/`blocked` role vocabulary comes from `config-resolution`. This skill is a consumer of those contracts, not a second source of truth.
 
 ## Related skills
 
@@ -257,11 +337,12 @@ shipped → verified   (role: <resolved verified role>)   evidence posted: <link
 - `verification-lifecycle` — Phase 5 invokes it to run empirical verification of the shipped surface (classify → check tooling → plan → execute → codify → loop). It in turn invokes `codify-verification` and, for UI surfaces, `product-walkthrough`.
 - `codify-verification` — turns each passing empirical verification into a regression test so the PRD's verified behavior cannot silently regress; invoked transitively via `verification-lifecycle`.
 - `product-walkthrough` — drives the live product through a real browser to ground UI-surface verification and the evidence comment in what actually renders.
-- `tracker-evidence` — the vendor-neutral evidence poster whose UI Evidence Checklist and `pr-assets` upload mechanics Phase 6.3 follows when posting the verification evidence comment on the PRD.
+- `tracker-evidence` — the vendor-neutral evidence poster whose UI Evidence Checklist and `pr-assets` upload mechanics Phase 6.3 (PASS evidence) and Phase 7.3 (FAIL failure report) follow when commenting on the PRD.
+- `tracker-write` — the vendor-neutral ticket writer Phase 7.4 invokes to create each linked fix issue (dispatching to `github-write-issue` / `jira-write-ticket` / `linear-write-issue` per config), so every fix issue clears the `tracker-validate` quality gate (Gherkin ACs, three-audience description, labels, relationships). This skill never hand-rolls issue creation.
 
 ## Related rules
 
-- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, and the child-ref idempotency dedupe key. This skill consumes that contract — including the `shipped → verified` PASS hop it implements — citing the rule by slug rather than restating its taxonomy.
+- `prd-lifecycle-rollup` — the vendor-neutral source of truth for PRD→generated-top-level-work ownership, the per-vendor terminal predicate, the `shipped` rollup, the `shipped → verified | blocked` PRD-level verification hops, the "no extra failure states" rule (the FAIL hop reuses `blocked`), and the child-ref idempotency dedupe key. This skill consumes that contract — implementing both the `shipped → verified` PASS hop and the `shipped → blocked` FAIL hop — citing the rule by slug rather than restating its taxonomy.
 - `verification` — defines what counts as empirical verification (the Verification Types table) and that quality gates (test/typecheck/lint) are prerequisites, not verification. Phase 5 honors it when classifying and running the surface-appropriate checks.
 - `leaf-only-lifecycle` — governs the build lifecycle of leaf work units and how a generated Epic rolls up from its own children; this skill trusts that bottom-up rollup when reading a top-level child's resolved state.
-- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`), the per-vendor `verified` role maps (`prd-verified` label for GitHub/Linear, `Verified` status for Notion, `confluence.parents.verified` parent page) Phase 6.1 resolves, and the env-keyed `done` map the terminal predicate resolves against.
+- `config-resolution` — the PRD-lifecycle role vocabulary (`shipped`, `verified`, `blocked`), the per-vendor `verified` role maps (`prd-verified` label for GitHub/Linear, `Verified` status for Notion, `confluence.parents.verified` parent page) Phase 6.1 resolves, the per-vendor `blocked` role maps (`prd-blocked` label for GitHub/Linear, `Blocked` status for Notion, `confluence.parents.blocked` parent page) Phase 7.1 resolves, and the env-keyed `done` map the terminal predicate resolves against.

--- a/tests/unit/strategies/verify-prd-guard-logic.test.ts
+++ b/tests/unit/strategies/verify-prd-guard-logic.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Executable proof that the `/lisa:verify-prd` terminal-child guard's selection
+ * and verdict logic is genuinely derivable from the `prd-lifecycle-rollup`
+ * contract the skill CONSUMES (it does not reimplement child enumeration).
+ *
+ * Split out of verify-prd-scaffold.test.ts (#597/#598/#599 doc-presence suites)
+ * to keep each file within the project's max-lines budget. This file holds the
+ * behavioral guard logic: parse a `lisa:gw` generated-work section, select the
+ * generated TOP-LEVEL child set (empty `parent`), apply the GitHub terminal
+ * predicate, and compute GUARD_BLOCKED / GUARD_PASSED / NO_CHILDREN — the
+ * empirical trace #597's terminal-child-guard evidence required (PRD #525 →
+ * top-level Epic #562 OPEN → GUARD_BLOCKED).
+ * @module tests/unit/strategies/verify-prd-guard-logic
+ */
+import { describe, expect, it } from "vitest";
+
+/**
+ * A generated top-level child as the guard reads it: its child-ref, GitHub
+ * issue state, and close reason (for the terminal-but-dropped distinction).
+ * Mirrors the fields the skill's two-source read captures per child.
+ */
+type TopLevelChild = {
+  readonly ref: string;
+  readonly title: string;
+  /** GitHub issue state. */
+  readonly state: "OPEN" | "CLOSED";
+  /** Close reason — `not_planned` is terminal-but-dropped. */
+  readonly stateReason: "completed" | "not_planned" | null;
+  /** Whether the resolved build `done` role label is present. */
+  readonly hasDoneLabel: boolean;
+};
+
+/** A `lisa:gw` token parsed from a rendered generated-work section. */
+type GeneratedWorkEntry = {
+  readonly ref: string;
+  readonly type: string;
+  readonly parent: string;
+};
+
+/**
+ * Enumerate the generated child set from a rendered generated-work section by
+ * matching only the machine-readable `lisa:gw` tokens — never prose, headings,
+ * links, or indentation. This is the read the skill consumes (it does not
+ * reimplement enumeration); the parser proves the contract is consumable.
+ * @param section - A rendered generated-work (`## Tickets`) section.
+ * @returns Every `lisa:gw` entry, in document order.
+ */
+const parseEntries = (section: string): readonly GeneratedWorkEntry[] => {
+  const tokenPattern =
+    /<!-- lisa:gw ref=(\S+) url=\S+ type=(\S+) parent=(\S*) -->/g;
+  const entries: GeneratedWorkEntry[] = [];
+  let match = tokenPattern.exec(section);
+  while (match !== null) {
+    entries.push({
+      ref: match[1] ?? "",
+      type: match[2] ?? "",
+      parent: match[3] ?? "",
+    });
+    match = tokenPattern.exec(section);
+  }
+  return entries;
+};
+
+/**
+ * Apply the `prd-lifecycle-rollup` GitHub terminal-state predicate to one
+ * generated top-level child.
+ * @param child - The top-level child's current resolved state.
+ * @returns Its rollup classification.
+ */
+const classifyChild = (
+  child: TopLevelChild
+): "terminal" | "terminal-but-dropped" | "incomplete" => {
+  if (child.state === "CLOSED" && child.stateReason === "not_planned") {
+    return "terminal-but-dropped";
+  }
+  if (child.state === "CLOSED" && child.hasDoneLabel) {
+    return "terminal";
+  }
+  return "incomplete";
+};
+
+/**
+ * Compute the terminal-child guard verdict over a generated top-level child set,
+ * exactly as the skill's Phase 3 prescribes: required = top-level minus
+ * terminal-but-dropped; GUARD_BLOCKED if any required child is incomplete,
+ * GUARD_PASSED if all required children are terminal (and at least one exists),
+ * NO_CHILDREN if the set is empty.
+ * @param children - The generated top-level child set.
+ * @returns The verdict plus the incomplete required child refs.
+ */
+const guardVerdict = (
+  children: readonly TopLevelChild[]
+): {
+  readonly verdict: "GUARD_PASSED" | "GUARD_BLOCKED" | "NO_CHILDREN";
+  readonly incompleteRefs: readonly string[];
+} => {
+  if (children.length === 0) {
+    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
+  }
+  const required = children.filter(
+    child => classifyChild(child) !== "terminal-but-dropped"
+  );
+  const incompleteRefs = required
+    .filter(child => classifyChild(child) === "incomplete")
+    .map(child => child.ref);
+  if (required.length === 0) {
+    // Every child was dropped — nothing required ships the PRD.
+    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
+  }
+  return {
+    verdict: incompleteRefs.length > 0 ? "GUARD_BLOCKED" : "GUARD_PASSED",
+    incompleteRefs,
+  };
+};
+
+/**
+ * Stable child-refs for the guard fixtures (hoisted to satisfy
+ * sonarjs/no-duplicate-string and keep fixtures and expectations DRY).
+ */
+const EPIC_REF = "CodySwannGT/lisa#100";
+const STORY2_REF = "CodySwannGT/lisa#200";
+
+describe("terminal-child guard logic is derivable from the rollup contract", () => {
+  it("selects generated TOP-LEVEL children by empty parent, excluding descendants", () => {
+    // Epic E (top-level) → Story S → Sub-task T, plus top-level Story S2.
+    const section = [
+      "## Tickets",
+      "",
+      `- [${EPIC_REF}](https://x/100) — Epic <!-- lisa:gw ref=${EPIC_REF} url=https://x/100 type=Epic parent= -->`,
+      `  - [CodySwannGT/lisa#101](https://x/101) — Story: s <!-- lisa:gw ref=CodySwannGT/lisa#101 url=https://x/101 type=Story parent=${EPIC_REF} -->`,
+      "    - [CodySwannGT/lisa#102](https://x/102) — Sub-task: t <!-- lisa:gw ref=CodySwannGT/lisa#102 url=https://x/102 type=Sub-task parent=CodySwannGT/lisa#101 -->",
+      `- [${STORY2_REF}](https://x/200) — Story: s2 <!-- lisa:gw ref=${STORY2_REF} url=https://x/200 type=Story parent= -->`,
+      "",
+    ].join("\n");
+    const topLevel = parseEntries(section)
+      .filter(entry => entry.parent === "")
+      .map(entry => entry.ref);
+    // Only the top-level Epic and the top-level Story — never the nested Story
+    // or the leaf Sub-task (those are owned by their own parent).
+    expect(topLevel).toEqual([EPIC_REF, STORY2_REF]);
+  });
+
+  it("blocks when a required top-level child is open (the #525 → #562 trace)", () => {
+    // The empirical [terminal-child-guard] evidence: PRD #525's one generated
+    // top-level child is Epic #562, OPEN → incomplete → GUARD_BLOCKED.
+    const result = guardVerdict([
+      {
+        ref: "CodySwannGT/lisa#562",
+        title: "Link generated top-level work as PRD children",
+        state: "OPEN",
+        stateReason: null,
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_BLOCKED");
+    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#562"]);
+  });
+
+  it("blocks when a closed child lacks the done role label", () => {
+    const result = guardVerdict([
+      {
+        ref: "CodySwannGT/lisa#300",
+        title: "closed but not done-labelled",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_BLOCKED");
+    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#300"]);
+  });
+
+  it("passes when every required top-level child is terminal", () => {
+    const result = guardVerdict([
+      {
+        ref: EPIC_REF,
+        title: "done epic",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+      {
+        ref: STORY2_REF,
+        title: "done story",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_PASSED");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+
+  it("excludes terminal-but-dropped (not_planned) children from the required set", () => {
+    // One done child + one closed-as-not-planned child → all required terminal.
+    const result = guardVerdict([
+      {
+        ref: EPIC_REF,
+        title: "done epic",
+        state: "CLOSED",
+        stateReason: "completed",
+        hasDoneLabel: true,
+      },
+      {
+        ref: "CodySwannGT/lisa#400",
+        title: "dropped epic",
+        state: "CLOSED",
+        stateReason: "not_planned",
+        hasDoneLabel: false,
+      },
+    ]);
+    expect(result.verdict).toBe("GUARD_PASSED");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+
+  it("reports NO_CHILDREN for an empty generated top-level set", () => {
+    const result = guardVerdict([]);
+    expect(result.verdict).toBe("NO_CHILDREN");
+    expect(result.incompleteRefs).toEqual([]);
+  });
+});

--- a/tests/unit/strategies/verify-prd-scaffold.test.ts
+++ b/tests/unit/strategies/verify-prd-scaffold.test.ts
@@ -26,13 +26,11 @@
  *       path / FAIL path / idempotency to sibling work (#598/#599/#600);
  *   (5) the front-half is read-only and does not re-prompt once invoked.
  *
- * Beyond asserting the scaffold documents these guarantees, this suite proves
- * the guard's selection + verdict logic is genuinely derivable from the contract
- * verify-prd consumes: it parses a `lisa:gw` generated-work section, selects the
- * generated TOP-LEVEL child set (empty `parent`), applies the GitHub terminal
- * predicate, and computes GUARD_BLOCKED vs GUARD_PASSED — the empirical trace
- * #597's terminal-child-guard evidence required (PRD #525 → top-level Epic #562
- * OPEN → GUARD_BLOCKED).
+ * This suite asserts the scaffold + PASS-path (#598) + FAIL-path (#599)
+ * guarantees the skill documents. The executable proof that the guard's
+ * selection + verdict logic is derivable from the consumed `prd-lifecycle-rollup`
+ * contract lives in the sibling `verify-prd-guard-logic.test.ts` (split out to
+ * keep both files within the max-lines budget).
  *
  * Both plugin roots are asserted (`plugins/src/base` source of truth and the
  * generated `plugins/lisa` artifact), so an artifact-only edit or a missed
@@ -236,16 +234,20 @@ describe("verify-prd PASS path (#598)", () => {
         expect(skill).toMatch(/confluence\.parents\.verified/);
       });
 
-      // (4) The PASS verdict tokens and the not-passed branches that leave the
-      //     PRD at shipped (FAIL path stays sibling work).
-      it("declares the PASS verdict and leaves non-pass branches at shipped", () => {
+      // (4) The PASS verdict tokens are declared. The non-pass verdicts now
+      //     route to the FAIL path (#599) rather than being left at shipped;
+      //     only idempotency (#600) remains out of scope.
+      it("declares the PASS verdict tokens alongside the non-pass verdicts", () => {
         expect(skill).toContain("VERIFIED_PASS");
         expect(skill).toContain("CONFORMANCE_FAILED");
         expect(skill).toContain("EMPIRICAL_FAILED");
-        // Non-pass branches leave the PRD at shipped (FAIL path is out of scope).
-        expect(skill).toMatch(/left? (the PRD )?at .?shipped.?/i);
-        expect(skill).toMatch(/FAIL (path|sibling)/i);
+        // The guard/no-children branches still leave the PRD at shipped.
+        expect(skill).toMatch(
+          /left? (the PRD )?at .?shipped.?|stays at .?shipped.?/i
+        );
+        // Idempotency (#600) is the only phase still out of scope.
         expect(skill).toMatch(/out of scope/i);
+        expect(skill).toMatch(/idempoten/i);
       });
 
       // (5) Cites prd-lifecycle-rollup for the PASS hop; verified is product-owned.
@@ -259,208 +261,92 @@ describe("verify-prd PASS path (#598)", () => {
   });
 });
 
-/**
- * A generated top-level child as the guard reads it: its child-ref, GitHub
- * issue state, and close reason (for the terminal-but-dropped distinction).
- * Mirrors the fields the skill's two-source read captures per child.
- */
-type TopLevelChild = {
-  readonly ref: string;
-  readonly title: string;
-  /** GitHub issue state. */
-  readonly state: "OPEN" | "CLOSED";
-  /** Close reason — `not_planned` is terminal-but-dropped. */
-  readonly stateReason: "completed" | "not_planned" | null;
-  /** Whether the resolved build `done` role label is present. */
-  readonly hasDoneLabel: boolean;
-};
+describe("verify-prd FAIL path (#599)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    describe(SKILL_REL, () => {
+      const skill = read(root, SKILL_REL);
 
-/** A `lisa:gw` token parsed from a rendered generated-work section. */
-type GeneratedWorkEntry = {
-  readonly ref: string;
-  readonly type: string;
-  readonly parent: string;
-};
+      // AC scenario "fail transitions shipped to blocked": the FAIL path moves
+      // the PRD shipped → blocked, REUSING the existing blocked role (no new
+      // failure state), gated on the non-pass verdicts.
+      it("transitions shipped → blocked reusing the blocked role with no new failure state", () => {
+        expect(skill).toMatch(/shipped → blocked/);
+        // Triggered by either non-pass verdict cause.
+        expect(skill).toContain("CONFORMANCE_FAILED");
+        expect(skill).toContain("EMPIRICAL_FAILED");
+        // Reuses the existing blocked role — explicitly NO new failure state.
+        expect(skill).toMatch(/reus(e|ing|es)[^]*blocked role/i);
+        expect(skill).toMatch(/no new failure state/i);
+        // Does not invent a prd-verification-failed / prd-verifying state.
+        expect(skill).toMatch(
+          /no(t)?[^]*prd-verification-failed|prd-verification-failed[^]*prd-verifying/i
+        );
+        // Vendor-neutral blocked role vocabulary (config-resolution).
+        expect(skill).toContain("prd-blocked");
+        expect(skill).toMatch(/config-resolution/);
+        expect(skill).toMatch(/confluence\.parents\.blocked/);
+      });
 
-/**
- * Enumerate the generated child set from a rendered generated-work section by
- * matching only the machine-readable `lisa:gw` tokens — never prose, headings,
- * links, or indentation. This is the read the skill consumes (it does not
- * reimplement enumeration); the parser proves the contract is consumable.
- * @param section - A rendered generated-work (`## Tickets`) section.
- * @returns Every `lisa:gw` entry, in document order.
- */
-const parseEntries = (section: string): readonly GeneratedWorkEntry[] => {
-  const tokenPattern =
-    /<!-- lisa:gw ref=(\S+) url=\S+ type=(\S+) parent=(\S*) -->/g;
-  const entries: GeneratedWorkEntry[] = [];
-  let match = tokenPattern.exec(section);
-  while (match !== null) {
-    entries.push({
-      ref: match[1] ?? "",
-      type: match[2] ?? "",
-      parent: match[3] ?? "",
+      // AC scenario "failure report is posted": a product-readable report naming
+      // which requirements/ACs failed with observed-vs-expected evidence.
+      it("posts a product-readable failure report with observed-vs-expected evidence", () => {
+        expect(skill).toMatch(/failure report/i);
+        // Written for a non-engineer product owner, in plain language.
+        expect(skill).toMatch(/product-readable|non-engineer/i);
+        expect(skill).toMatch(/plain language/i);
+        // Names the specific failed requirement / acceptance criterion.
+        expect(skill).toMatch(
+          /requirement[^]*acceptance criterion|acceptance criteri/i
+        );
+        // Observed vs expected evidence is included.
+        expect(skill).toMatch(
+          /expected vs[^]*observed|observed vs[^]*expected/i
+        );
+        // Posted via the vendor-neutral evidence surface (tracker-evidence).
+        expect(skill).toMatch(/tracker-evidence/);
+      });
+
+      // AC scenario "linked fix issues are created": one or more fix issues via
+      // tracker-write, each back-linked to the PRD + failure report, each with
+      // captured evidence and acceptance criteria.
+      it("creates linked fix issues via tracker-write with evidence, ACs, and back-links", () => {
+        expect(skill).toMatch(/fix issue/i);
+        // Created via the vendor-neutral writer (so they pass tracker-validate).
+        expect(skill).toMatch(/tracker-write/);
+        // Each carries Gherkin acceptance criteria.
+        expect(skill).toMatch(/[Gg]herkin/);
+        expect(skill).toMatch(/acceptance criteria/i);
+        // Each back-links to BOTH the PRD and the failure report.
+        expect(skill).toMatch(/back-link[^]*PRD|PRD[^]*failure report/i);
+        // Each references the specific failed requirement / AC and carries evidence.
+        expect(skill).toMatch(
+          /specific failed requirement|failed requirement\/AC/i
+        );
+        expect(skill).toMatch(
+          /carry the captured evidence|carrying the captured evidence/i
+        );
+      });
+
+      // The FAIL path is implemented HERE — it must NOT be deferred to a sibling.
+      // Only idempotency (#600) remains out of scope.
+      it("implements the FAIL path here and scopes only idempotency to a sibling", () => {
+        // FAIL path is in scope (Phase 7 exists with the shipped → blocked hop).
+        expect(skill).toMatch(/Phase 7[^]*FAIL/i);
+        // Idempotency (#600) is the remaining sibling work / out of scope.
+        expect(skill).toMatch(/idempotency \(#600\)|idempoten[^]*sibling/i);
+        // Fix issues are NOT reopens of the already-terminal generated children.
+        expect(skill).toMatch(/never[^]*reopen|not[^]*reopen/i);
+        expect(skill).toMatch(/leaf-only-lifecycle/);
+      });
+
+      // Cites prd-lifecycle-rollup for the FAIL hop by slug (consumer, not a
+      // second source of truth for the shipped → blocked transition).
+      it("cites prd-lifecycle-rollup for the shipped → blocked FAIL hop", () => {
+        expect(skill).toContain(RULE_SLUG);
+        expect(skill).toMatch(/shipped → blocked/);
+        // The "no extra failure states" rule the FAIL hop honors.
+        expect(skill).toMatch(/no extra failure states|no new failure state/i);
+      });
     });
-    match = tokenPattern.exec(section);
-  }
-  return entries;
-};
-
-/**
- * Apply the `prd-lifecycle-rollup` GitHub terminal-state predicate to one
- * generated top-level child.
- * @param child - The top-level child's current resolved state.
- * @returns Its rollup classification.
- */
-const classifyChild = (
-  child: TopLevelChild
-): "terminal" | "terminal-but-dropped" | "incomplete" => {
-  if (child.state === "CLOSED" && child.stateReason === "not_planned") {
-    return "terminal-but-dropped";
-  }
-  if (child.state === "CLOSED" && child.hasDoneLabel) {
-    return "terminal";
-  }
-  return "incomplete";
-};
-
-/**
- * Compute the terminal-child guard verdict over a generated top-level child set,
- * exactly as the skill's Phase 3 prescribes: required = top-level minus
- * terminal-but-dropped; GUARD_BLOCKED if any required child is incomplete,
- * GUARD_PASSED if all required children are terminal (and at least one exists),
- * NO_CHILDREN if the set is empty.
- * @param children - The generated top-level child set.
- * @returns The verdict plus the incomplete required child refs.
- */
-const guardVerdict = (
-  children: readonly TopLevelChild[]
-): {
-  readonly verdict: "GUARD_PASSED" | "GUARD_BLOCKED" | "NO_CHILDREN";
-  readonly incompleteRefs: readonly string[];
-} => {
-  if (children.length === 0) {
-    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
-  }
-  const required = children.filter(
-    child => classifyChild(child) !== "terminal-but-dropped"
-  );
-  const incompleteRefs = required
-    .filter(child => classifyChild(child) === "incomplete")
-    .map(child => child.ref);
-  if (required.length === 0) {
-    // Every child was dropped — nothing required ships the PRD.
-    return { verdict: "NO_CHILDREN", incompleteRefs: [] };
-  }
-  return {
-    verdict: incompleteRefs.length > 0 ? "GUARD_BLOCKED" : "GUARD_PASSED",
-    incompleteRefs,
-  };
-};
-
-/**
- * Stable child-refs for the guard fixtures (hoisted to satisfy
- * sonarjs/no-duplicate-string and keep fixtures and expectations DRY).
- */
-const EPIC_REF = "CodySwannGT/lisa#100";
-const STORY2_REF = "CodySwannGT/lisa#200";
-
-describe("terminal-child guard logic is derivable from the rollup contract", () => {
-  it("selects generated TOP-LEVEL children by empty parent, excluding descendants", () => {
-    // Epic E (top-level) → Story S → Sub-task T, plus top-level Story S2.
-    const section = [
-      "## Tickets",
-      "",
-      `- [${EPIC_REF}](https://x/100) — Epic <!-- lisa:gw ref=${EPIC_REF} url=https://x/100 type=Epic parent= -->`,
-      `  - [CodySwannGT/lisa#101](https://x/101) — Story: s <!-- lisa:gw ref=CodySwannGT/lisa#101 url=https://x/101 type=Story parent=${EPIC_REF} -->`,
-      "    - [CodySwannGT/lisa#102](https://x/102) — Sub-task: t <!-- lisa:gw ref=CodySwannGT/lisa#102 url=https://x/102 type=Sub-task parent=CodySwannGT/lisa#101 -->",
-      `- [${STORY2_REF}](https://x/200) — Story: s2 <!-- lisa:gw ref=${STORY2_REF} url=https://x/200 type=Story parent= -->`,
-      "",
-    ].join("\n");
-    const topLevel = parseEntries(section)
-      .filter(entry => entry.parent === "")
-      .map(entry => entry.ref);
-    // Only the top-level Epic and the top-level Story — never the nested Story
-    // or the leaf Sub-task (those are owned by their own parent).
-    expect(topLevel).toEqual([EPIC_REF, STORY2_REF]);
-  });
-
-  it("blocks when a required top-level child is open (the #525 → #562 trace)", () => {
-    // The empirical [terminal-child-guard] evidence: PRD #525's one generated
-    // top-level child is Epic #562, OPEN → incomplete → GUARD_BLOCKED.
-    const result = guardVerdict([
-      {
-        ref: "CodySwannGT/lisa#562",
-        title: "Link generated top-level work as PRD children",
-        state: "OPEN",
-        stateReason: null,
-        hasDoneLabel: false,
-      },
-    ]);
-    expect(result.verdict).toBe("GUARD_BLOCKED");
-    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#562"]);
-  });
-
-  it("blocks when a closed child lacks the done role label", () => {
-    const result = guardVerdict([
-      {
-        ref: "CodySwannGT/lisa#300",
-        title: "closed but not done-labelled",
-        state: "CLOSED",
-        stateReason: "completed",
-        hasDoneLabel: false,
-      },
-    ]);
-    expect(result.verdict).toBe("GUARD_BLOCKED");
-    expect(result.incompleteRefs).toEqual(["CodySwannGT/lisa#300"]);
-  });
-
-  it("passes when every required top-level child is terminal", () => {
-    const result = guardVerdict([
-      {
-        ref: EPIC_REF,
-        title: "done epic",
-        state: "CLOSED",
-        stateReason: "completed",
-        hasDoneLabel: true,
-      },
-      {
-        ref: STORY2_REF,
-        title: "done story",
-        state: "CLOSED",
-        stateReason: "completed",
-        hasDoneLabel: true,
-      },
-    ]);
-    expect(result.verdict).toBe("GUARD_PASSED");
-    expect(result.incompleteRefs).toEqual([]);
-  });
-
-  it("excludes terminal-but-dropped (not_planned) children from the required set", () => {
-    // One done child + one closed-as-not-planned child → all required terminal.
-    const result = guardVerdict([
-      {
-        ref: EPIC_REF,
-        title: "done epic",
-        state: "CLOSED",
-        stateReason: "completed",
-        hasDoneLabel: true,
-      },
-      {
-        ref: "CodySwannGT/lisa#400",
-        title: "dropped epic",
-        state: "CLOSED",
-        stateReason: "not_planned",
-        hasDoneLabel: false,
-      },
-    ]);
-    expect(result.verdict).toBe("GUARD_PASSED");
-    expect(result.incompleteRefs).toEqual([]);
-  });
-
-  it("reports NO_CHILDREN for an empty generated top-level set", () => {
-    const result = guardVerdict([]);
-    expect(result.verdict).toBe("NO_CHILDREN");
-    expect(result.incompleteRefs).toEqual([]);
   });
 });


### PR DESCRIPTION
## What & why

Closes #599. Extends the `/lisa:verify-prd` skill (#597 scaffold + #598 PASS path / verification core, both merged) with the **FAIL path** of initiative-level PRD verification.

When the verification core returns a non-pass verdict, the skill now branches into the FAIL path instead of leaving the PRD at `shipped`:

- **`CONFORMANCE_FAILED`** — spec conformance returned `PARTIAL`/`DIVERGES`, or
- **`EMPIRICAL_FAILED`** — an applicable empirical check failed / a required surface was unavailable.

## What changed

`plugins/src/base/skills/verify-prd/SKILL.md` (source of truth) + regenerated `plugins/lisa/skills/verify-prd/SKILL.md` artifact:

- **Phase 4 / Phase 5 branches** now route the non-pass verdicts into the new Phase 7 (FAIL) instead of stopping at `shipped`.
- **New Phase 7 — FAIL**, mirroring the Phase 6 PASS structure:
  - **7.1/7.2** resolve the `shipped`/`blocked` roles via `config-resolution` and transition the PRD `shipped → blocked`, **reusing the existing `blocked` role** (`prd-blocked` for GitHub/Linear, `Blocked` for Notion, `confluence.parents.blocked` for Confluence) — **no new failure state**, per `prd-lifecycle-rollup`'s "No extra failure states" rule.
  - **7.3** posts a **product-readable failure report** on the PRD: AI disclosure, `shipped → blocked — FAIL` verdict line + cause, per-finding plain-language "what failed" naming the specific requirement/AC with observed-vs-expected evidence, the conformance matrix (for `CONFORMANCE_FAILED`), proof artifacts, and the fix-issue index.
  - **7.4** creates **linked fix issues via `tracker-write`** (never hand-rolled) — each with Gherkin ACs, captured evidence, a reference to the failed requirement/AC, and back-links to both the PRD and the failure report. Fix issues are **new** defects, not reopens of the already-terminal generated children (`leaf-only-lifecycle`).
- Description, Scope, Output verdicts, Rules, and Related skills/rules updated to reflect that the FAIL path is now implemented here; only **idempotency (#600)** remains out of scope.

## Tests

- Updated the #598 PASS-path doc-presence test that asserted non-pass branches stay at `shipped` (they now run the FAIL path).
- Added a **#599 FAIL-path block** covering all four acceptance scenarios across both plugin roots (source + generated artifact).
- Split the executable guard-logic proof into a sibling file (`verify-prd-guard-logic.test.ts`) to stay within the max-lines budget.

## Acceptance criteria verification

- **fail transitions shipped to blocked** — Phase 7.2 transitions `shipped → blocked` reusing the `blocked` role (no new state). ✓
- **failure report is posted** — Phase 7.3 posts a product-readable report naming failed requirements/ACs with observed-vs-expected evidence. ✓
- **linked fix issues are created** — Phase 7.4 creates fix issues via `tracker-write`, each linked to the PRD + failure report, with evidence and Gherkin ACs. ✓
- **built artifacts stay in sync** — `bun run build:plugins && bun run check:plugins` → "Plugin artifacts are in sync with plugins/src." (no drift) ✓

## Empirical verification (CLI/dry-run surface; Lisa has no deployed app)

- `bun run build:plugins` → all 9 plugins built.
- `bun run check:plugins` → no drift.
- `bun run typecheck` → clean.
- `bun run lint` → 0 errors / 0 warnings.
- `bun run test:unit` → 1526 passed; verify-prd suites → 56 passed across both roots.

Unblocks #600 (idempotency).

🤖 Generated with Claude Code