### PR TITLE
fix(harper-fabric): ignore per-resource generated files; exclude .codex from prettier

### DIFF
--- a/harper-fabric/copy-contents/.gitignore
+++ b/harper-fabric/copy-contents/.gitignore
@@ -1,5 +1,6 @@
 # BEGIN: AI GUARDRAILS HARPER-FABRIC
 harper-app/resources.js
+harper-app/resource-*.js
 harper-app/web/**/*.js
 harper-app/web/**/*.js.map
 .lisabak/

--- a/harper-fabric/copy-overwrite/knip.json
+++ b/harper-fabric/copy-overwrite/knip.json
@@ -14,6 +14,7 @@
     "**/coverage/**",
     "**/node_modules/**",
     "harper-app/resources.js",
+    "harper-app/resource-*.js",
     "harper-app/web/**/*.js"
   ],
   "ignoreDependencies": ["@types/node", "@vitest/coverage-v8"],

--- a/harper-fabric/copy-overwrite/tsconfig.eslint.json
+++ b/harper-fabric/copy-overwrite/tsconfig.eslint.json
@@ -21,6 +21,7 @@
     "dist",
     "coverage",
     "harper-app/resources.js",
+    "harper-app/resource-*.js",
     "harper-app/web/**/*.js"
   ]
 }

--- a/harper-fabric/merge/.oxlintrc.json
+++ b/harper-fabric/merge/.oxlintrc.json
@@ -11,6 +11,7 @@
     "**/__generated__/**",
     "**/generated/**",
     "harper-app/resources.js",
+    "harper-app/resource-*.js",
     "harper-app/web/**/*.js"
   ]
 }

--- a/oxlint/harper-fabric.json
+++ b/oxlint/harper-fabric.json
@@ -6,6 +6,7 @@
     "coverage/**",
     "node_modules/**",
     "harper-app/resources.js",
+    "harper-app/resource-*.js",
     "harper-app/web/**/*.js"
   ]
 }

--- a/src/configs/eslint/harper-fabric.ts
+++ b/src/configs/eslint/harper-fabric.ts
@@ -24,6 +24,7 @@ export const defaultHarperFabricIgnores = [
   "**/*.toml",
   "*.config.local.ts",
   "harper-app/resources.js",
+  "harper-app/resource-*.js",
   "harper-app/web/**/*.js",
   "harper-app/web/**/*.js.map",
 ];

--- a/tests/unit/config/harper-fabric-template.test.ts
+++ b/tests/unit/config/harper-fabric-template.test.ts
@@ -65,4 +65,43 @@ describe("Harper/Fabric templates", () => {
     expect(prettierIgnore).toContain("harper-app/web/");
     expect(prettierIgnore).toContain("research/articles/");
   });
+
+  it("ignores per-resource generated Harper deploy artifacts everywhere", () => {
+    // The Harper build emits one `harper-app/resource-<name>.js` per resource
+    // alongside the `harper-app/resources.js` barrel. Every ignore surface must
+    // cover the per-resource glob or lint/knip/oxlint break after a Lisa update.
+    const oxlint = readJson("oxlint/harper-fabric.json") as {
+      readonly ignorePatterns?: readonly string[];
+    };
+    const oxlintMerge = readJson("harper-fabric/merge/.oxlintrc.json") as {
+      readonly ignorePatterns?: readonly string[];
+    };
+    const knip = readJson("harper-fabric/copy-overwrite/knip.json") as {
+      readonly ignore?: readonly string[];
+    };
+    const tsconfigEslint = readJson(
+      "harper-fabric/copy-overwrite/tsconfig.eslint.json"
+    ) as { readonly exclude?: readonly string[] };
+    const gitignore = readText("harper-fabric/copy-contents/.gitignore");
+    const eslintConfigSource = readText("src/configs/eslint/harper-fabric.ts");
+    const perResourceGlob = "harper-app/resource-*.js";
+
+    expect(oxlint.ignorePatterns).toContain(perResourceGlob);
+    expect(oxlintMerge.ignorePatterns).toContain(perResourceGlob);
+    expect(knip.ignore).toContain(perResourceGlob);
+    expect(tsconfigEslint.exclude).toContain(perResourceGlob);
+    expect(gitignore).toContain(perResourceGlob);
+    expect(eslintConfigSource).toContain(`"${perResourceGlob}"`);
+  });
+
+  it("keeps the generated Codex distribution mirror out of Prettier", () => {
+    // Lisa regenerates `.codex/` on every run with generated YAML/markdown that
+    // does not satisfy the project's Prettier config. It must be excluded from
+    // format gates in the TypeScript base inherited by every stack.
+    const prettierIgnore = readText(
+      "typescript/copy-overwrite/.prettierignore"
+    );
+
+    expect(prettierIgnore).toContain(".codex");
+  });
 });

--- a/typescript/copy-overwrite/.prettierignore
+++ b/typescript/copy-overwrite/.prettierignore
@@ -29,3 +29,9 @@ coverage
 # no trailing newline). Keep its scaffolding out of format gates.
 # No-op for projects that don't use Amplify.
 amplify
+
+# Lisa regenerates the Codex distribution mirror (.codex/) on every run.
+# Those agent/skill artifacts are generated output (e.g. double-quoted YAML
+# scalars) and are not source formatting inputs. Keep them out of format gates.
+# No-op for projects without a Codex mirror.
+.codex


### PR DESCRIPTION
## What

Two upstream harper-fabric template gaps, found while updating the **advisory-rankings** project during the 2.62.1 rollout and reproduced against the Lisa source:

1. **Per-resource generated files weren't ignored.** The harper-fabric ignore surfaces covered only the `harper-app/resources.js` barrel and `harper-app/web/**`, but the Harper build also emits per-resource files (`harper-app/resource-mcp.js`, etc.). Those generated files leaked into ESLint / oxlint / knip / `tsconfig.eslint` scope and failed lint + dead-code gates in harper-fabric projects.
   → Add `harper-app/resource-*.js` to every harper-fabric ignore surface and to `defaultHarperFabricIgnores`.

2. **The Codex mirror `.codex/` wasn't excluded from prettier.** Lisa regenerates `.codex/` on every run as generated output (e.g. double-quoted YAML scalars) that prettier rejects, failing `format:check`.
   → Exclude `.codex` in the base `typescript/copy-overwrite/.prettierignore` (no-op for projects without a Codex mirror).

## Files
- `src/configs/eslint/harper-fabric.ts` — `defaultHarperFabricIgnores` += `harper-app/resource-*.js`
- `oxlint/harper-fabric.json`, `harper-fabric/merge/.oxlintrc.json`, `harper-fabric/copy-overwrite/knip.json`, `harper-fabric/copy-overwrite/tsconfig.eslint.json`, `harper-fabric/copy-contents/.gitignore` — same ignore added
- `typescript/copy-overwrite/.prettierignore` — exclude `.codex`
- `tests/unit/config/harper-fabric-template.test.ts` — regression tests for both patterns

## Validation
- `tsc --noEmit` ✅
- `vitest run tests/unit/config/harper-fabric-template.test.ts` ✅ (6 passed)
- No `plugins/` or `plugins/src/` changes — Plugins Sync unaffected.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configurations for linting, formatting, and type-checking tools to exclude generated resource files from processing.
  * Extended ignore patterns to also exclude Amplify and Codex generated artifacts.

* **Tests**
  * Added regression tests to verify generated artifacts remain properly excluded across all tooling configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->