### PR TITLE
feat(wiki): schedule wiki ingest via /lisa-wiki:setup-automations

### DIFF
--- a/plugins/lisa-wiki/commands/setup-automations.md
+++ b/plugins/lisa-wiki/commands/setup-automations.md
@@ -1,0 +1,6 @@
+---
+description: "Set up the recurring LLM Wiki ingest automation on the local workstation using the runtime's native scheduler (Codex automations / Claude /schedule): wiki-ingest, a full /lisa-wiki:ingest cycle, once a day by default (override with cadence). A declarative spec — it states what to schedule and how often; the runtime's native automation mechanism does the creating. Named lisa-wiki-auto-<project>-* so it never collides with the base /lisa:setup-automations set. The wiki counterpart of /lisa:setup-automations, separate because the wiki plugin is standalone."
+argument-hint: "[cadence=daily|weekly|every-<n>-hours]"
+---
+
+Use the lisa-wiki-setup-automations skill to create the recurring wiki-ingest automation via this runtime's native scheduler (Codex automations / Claude /schedule), running a full /lisa-wiki:ingest cycle on the resolved cadence (default daily) and naming it lisa-wiki-auto-<project>-ingest so teardown stays precise. $ARGUMENTS

--- a/plugins/lisa-wiki/commands/tear-down-automations.md
+++ b/plugins/lisa-wiki/commands/tear-down-automations.md
@@ -1,0 +1,6 @@
+---
+description: "Remove the recurring LLM Wiki ingest automation /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-* set) using the runtime's native scheduler (Codex automations / Claude /schedule). A declarative spec — it states which automation to remove; the runtime's native mechanism does the removing. Removes only this project's wiki automation, never the base set or other projects'."
+argument-hint: ""
+---
+
+Use the lisa-wiki-tear-down-automations skill to remove this project's lisa-wiki-auto-<project>-* automation via this runtime's native scheduler (Codex automations / Claude /schedule), leaving the base /lisa:setup-automations set, other projects', and non-Lisa automations untouched. $ARGUMENTS

--- a/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-wiki-setup-automations
+description: "Set up the recurring LLM Wiki ingest automation on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automation to create, how often, and with which command; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates one automation: wiki-ingest, a full /lisa-wiki:ingest cycle, once a day by default (override with cadence). Named and scoped lisa-wiki-auto-<project>-* so it never collides with or clobbers the base /setup-automations set. The wiki counterpart of /lisa:setup-automations — it lives here because the wiki plugin is standalone and installable without the base plugin. Tear down with /lisa-wiki:tear-down-automations."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Set up LLM Wiki automations: $ARGUMENTS
+
+This skill is a **specification, not a script.** It tells the current runtime which recurring wiki
+automation to create, on what cadence, and with which command — and the runtime creates it with its
+**native** scheduling mechanism. Do **not** hand-template schedule files or write shell to create
+them; invoke the runtime's automation tool with the spec below.
+
+It is the wiki counterpart of the base `/lisa:setup-automations`. It is a **separate** skill because
+the wiki plugin (`lisa-wiki`) is standalone — it can be installed without the base Lisa plugin, in
+which case `/lisa:setup-automations` is not present to schedule ingest. The two skills are
+independent and use disjoint name prefixes, so running both is safe.
+
+## Runtime scheduler (branch on the current runtime)
+
+- **Codex** → create a Codex **automation** via the native automations mechanism (prefer the
+  `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
+  only its backing store). Set the execution environment to **local** so it runs on this
+  workstation, scoped to this project's working directory.
+- **Claude** → use **`/schedule`** to create a local recurring routine.
+- **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
+  state that scheduling is unavailable and stop.
+
+## Parameters
+
+- `cadence` (default **daily**) — how often the full ingest runs. Accepts `daily`, `weekly`, or an
+  `every-<n>-hours` form. Map to a Codex `rrule`: daily → `FREQ=DAILY;INTERVAL=1`; weekly →
+  `FREQ=WEEKLY;INTERVAL=1`; every N hours → `FREQ=HOURLY;INTERVAL=<n>`. On Claude, pass the
+  equivalent `/schedule` cadence. Default is **daily** (`FREQ=DAILY;INTERVAL=1`).
+
+## The automation to create
+
+The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
+and commit/PR policy (never ask before running; run a full ingest across every enabled
+non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
+
+| Automation | Command it runs | Cadence |
+|---|---|---|
+| **wiki-ingest** | `/lisa-wiki:ingest` (no argument → full ingest across all enabled sources) | once a day (or `cadence`) |
+
+**Naming + scope (so teardown is precise).** Name the automation with the stable prefix
+`lisa-wiki-auto-<project>-` (i.e. `lisa-wiki-auto-<project>-ingest`), where `<project>` identifies
+this repo, and scope it to this project's working directory. This prefix is deliberately distinct
+from the base `lisa-auto-<project>-` set so `/lisa-wiki:tear-down-automations` removes exactly this
+automation and never touches the base automations or any other project's. Use a project identifier
+stable across runs and distinct from other repos (qualify it, e.g. with the owner — don't rely on a
+bare repo basename that could collide).
+
+**Idempotent.** Re-running this skill updates the existing `lisa-wiki-auto-<project>-ingest`
+automation in place (same name) rather than creating a duplicate.
+
+## Conditions / guards
+
+- Create the automation only when this repo actually has an LLM Wiki — i.e. `wiki/` exists with a
+  `wiki/lisa-wiki.config.json`. If there is no configured wiki, **stop and report** that the wiki
+  must be set up first (run `/lisa-wiki:setup`); do not schedule ingest against a non-existent wiki.
+- If the runtime has no native scheduler, stop and report what's missing rather than guessing.
+
+## Report
+
+List the automation created or updated (name, the command it runs, the resolved cadence), or report
+that it was skipped and why (no configured wiki / no runtime scheduler).

--- a/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Lisa Wiki Setup Automations"
+short_description: "Set up the recurring LLM Wiki ingest automation on the local workstation using the CURRENT runtime's native scheduler — Codex automations…"
+default_prompt:
+  - "Use $lisa-wiki-setup-automations: Set up the recurring LLM Wiki ingest automation on the local workstation using the CURRENT runtime's native scheduler — Codex automations…."

--- a/plugins/lisa-wiki/skills/lisa-wiki-tear-down-automations/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-tear-down-automations/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: lisa-wiki-tear-down-automations
+description: "Remove the recurring LLM Wiki ingest automation that /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-* set) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automation to remove; it does not run teardown scripts. Removes only this project's wiki automations — never the base /setup-automations set, other projects' automations, or non-Lisa ones. The inverse of /lisa-wiki:setup-automations."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tear down LLM Wiki automations: $ARGUMENTS
+
+This skill is a **specification, not a script.** It tells the current runtime which recurring wiki
+automation to remove — the one `/lisa-wiki:setup-automations` created for THIS project — and the
+runtime removes it with its **native** scheduling mechanism.
+
+## Runtime scheduler (branch on the current runtime)
+
+- **Codex** → list Codex automations and delete the `lisa-wiki-auto-<project>-*` set via the native
+  automations mechanism (prefer the native delete over hand-removing
+  `~/.codex/automations/<id>/`, which is only the backing store).
+- **Claude** → use **`/schedule`** to list and remove the matching recurring routine.
+- **Other runtimes** → use the runtime's native recurring-task mechanism. If it has none, state that
+  and stop.
+
+## Scope (remove only what setup created)
+
+- Remove the wiki automation `/lisa-wiki:setup-automations` creates for the current project, matched
+  by the stable `lisa-wiki-auto-<project>-` name prefix: `wiki-ingest`.
+- **Never** remove the base `lisa-auto-<project>-*` automations, automations for a different project,
+  or any non-Lisa automation (e.g. unrelated crawlers/ingestors). Match strictly on the
+  `lisa-wiki-auto-<project>-` prefix for THIS project; when in doubt about an automation's ownership,
+  leave it and report it rather than deleting it.
+- **Idempotent** — an automation that is already absent is a no-op, not an error.
+
+## Report
+
+List the automation removed, or report it as already absent.

--- a/plugins/lisa-wiki/skills/lisa-wiki-tear-down-automations/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-tear-down-automations/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Lisa Wiki Tear Down Automations"
+short_description: "Remove the recurring LLM Wiki ingest automation that /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-*…"
+default_prompt:
+  - "Use $lisa-wiki-tear-down-automations: Remove the recurring LLM Wiki ingest automation that /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-*…."

--- a/plugins/src/wiki/commands/setup-automations.md
+++ b/plugins/src/wiki/commands/setup-automations.md
@@ -1,0 +1,6 @@
+---
+description: "Set up the recurring LLM Wiki ingest automation on the local workstation using the runtime's native scheduler (Codex automations / Claude /schedule): wiki-ingest, a full /lisa-wiki:ingest cycle, once a day by default (override with cadence). A declarative spec — it states what to schedule and how often; the runtime's native automation mechanism does the creating. Named lisa-wiki-auto-<project>-* so it never collides with the base /lisa:setup-automations set. The wiki counterpart of /lisa:setup-automations, separate because the wiki plugin is standalone."
+argument-hint: "[cadence=daily|weekly|every-<n>-hours]"
+---
+
+Use the lisa-wiki-setup-automations skill to create the recurring wiki-ingest automation via this runtime's native scheduler (Codex automations / Claude /schedule), running a full /lisa-wiki:ingest cycle on the resolved cadence (default daily) and naming it lisa-wiki-auto-<project>-ingest so teardown stays precise. $ARGUMENTS

--- a/plugins/src/wiki/commands/tear-down-automations.md
+++ b/plugins/src/wiki/commands/tear-down-automations.md
@@ -1,0 +1,6 @@
+---
+description: "Remove the recurring LLM Wiki ingest automation /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-* set) using the runtime's native scheduler (Codex automations / Claude /schedule). A declarative spec — it states which automation to remove; the runtime's native mechanism does the removing. Removes only this project's wiki automation, never the base set or other projects'."
+argument-hint: ""
+---
+
+Use the lisa-wiki-tear-down-automations skill to remove this project's lisa-wiki-auto-<project>-* automation via this runtime's native scheduler (Codex automations / Claude /schedule), leaving the base /lisa:setup-automations set, other projects', and non-Lisa automations untouched. $ARGUMENTS

--- a/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-wiki-setup-automations
+description: "Set up the recurring LLM Wiki ingest automation on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automation to create, how often, and with which command; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates one automation: wiki-ingest, a full /lisa-wiki:ingest cycle, once a day by default (override with cadence). Named and scoped lisa-wiki-auto-<project>-* so it never collides with or clobbers the base /setup-automations set. The wiki counterpart of /lisa:setup-automations — it lives here because the wiki plugin is standalone and installable without the base plugin. Tear down with /lisa-wiki:tear-down-automations."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Set up LLM Wiki automations: $ARGUMENTS
+
+This skill is a **specification, not a script.** It tells the current runtime which recurring wiki
+automation to create, on what cadence, and with which command — and the runtime creates it with its
+**native** scheduling mechanism. Do **not** hand-template schedule files or write shell to create
+them; invoke the runtime's automation tool with the spec below.
+
+It is the wiki counterpart of the base `/lisa:setup-automations`. It is a **separate** skill because
+the wiki plugin (`lisa-wiki`) is standalone — it can be installed without the base Lisa plugin, in
+which case `/lisa:setup-automations` is not present to schedule ingest. The two skills are
+independent and use disjoint name prefixes, so running both is safe.
+
+## Runtime scheduler (branch on the current runtime)
+
+- **Codex** → create a Codex **automation** via the native automations mechanism (prefer the
+  `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
+  only its backing store). Set the execution environment to **local** so it runs on this
+  workstation, scoped to this project's working directory.
+- **Claude** → use **`/schedule`** to create a local recurring routine.
+- **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
+  state that scheduling is unavailable and stop.
+
+## Parameters
+
+- `cadence` (default **daily**) — how often the full ingest runs. Accepts `daily`, `weekly`, or an
+  `every-<n>-hours` form. Map to a Codex `rrule`: daily → `FREQ=DAILY;INTERVAL=1`; weekly →
+  `FREQ=WEEKLY;INTERVAL=1`; every N hours → `FREQ=HOURLY;INTERVAL=<n>`. On Claude, pass the
+  equivalent `/schedule` cadence. Default is **daily** (`FREQ=DAILY;INTERVAL=1`).
+
+## The automation to create
+
+The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
+and commit/PR policy (never ask before running; run a full ingest across every enabled
+non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
+
+| Automation | Command it runs | Cadence |
+|---|---|---|
+| **wiki-ingest** | `/lisa-wiki:ingest` (no argument → full ingest across all enabled sources) | once a day (or `cadence`) |
+
+**Naming + scope (so teardown is precise).** Name the automation with the stable prefix
+`lisa-wiki-auto-<project>-` (i.e. `lisa-wiki-auto-<project>-ingest`), where `<project>` identifies
+this repo, and scope it to this project's working directory. This prefix is deliberately distinct
+from the base `lisa-auto-<project>-` set so `/lisa-wiki:tear-down-automations` removes exactly this
+automation and never touches the base automations or any other project's. Use a project identifier
+stable across runs and distinct from other repos (qualify it, e.g. with the owner — don't rely on a
+bare repo basename that could collide).
+
+**Idempotent.** Re-running this skill updates the existing `lisa-wiki-auto-<project>-ingest`
+automation in place (same name) rather than creating a duplicate.
+
+## Conditions / guards
+
+- Create the automation only when this repo actually has an LLM Wiki — i.e. `wiki/` exists with a
+  `wiki/lisa-wiki.config.json`. If there is no configured wiki, **stop and report** that the wiki
+  must be set up first (run `/lisa-wiki:setup`); do not schedule ingest against a non-existent wiki.
+- If the runtime has no native scheduler, stop and report what's missing rather than guessing.
+
+## Report
+
+List the automation created or updated (name, the command it runs, the resolved cadence), or report
+that it was skipped and why (no configured wiki / no runtime scheduler).

--- a/plugins/src/wiki/skills/lisa-wiki-tear-down-automations/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-tear-down-automations/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: lisa-wiki-tear-down-automations
+description: "Remove the recurring LLM Wiki ingest automation that /lisa-wiki:setup-automations created for this project (the lisa-wiki-auto-<project>-* set) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automation to remove; it does not run teardown scripts. Removes only this project's wiki automations — never the base /setup-automations set, other projects' automations, or non-Lisa ones. The inverse of /lisa-wiki:setup-automations."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tear down LLM Wiki automations: $ARGUMENTS
+
+This skill is a **specification, not a script.** It tells the current runtime which recurring wiki
+automation to remove — the one `/lisa-wiki:setup-automations` created for THIS project — and the
+runtime removes it with its **native** scheduling mechanism.
+
+## Runtime scheduler (branch on the current runtime)
+
+- **Codex** → list Codex automations and delete the `lisa-wiki-auto-<project>-*` set via the native
+  automations mechanism (prefer the native delete over hand-removing
+  `~/.codex/automations/<id>/`, which is only the backing store).
+- **Claude** → use **`/schedule`** to list and remove the matching recurring routine.
+- **Other runtimes** → use the runtime's native recurring-task mechanism. If it has none, state that
+  and stop.
+
+## Scope (remove only what setup created)
+
+- Remove the wiki automation `/lisa-wiki:setup-automations` creates for the current project, matched
+  by the stable `lisa-wiki-auto-<project>-` name prefix: `wiki-ingest`.
+- **Never** remove the base `lisa-auto-<project>-*` automations, automations for a different project,
+  or any non-Lisa automation (e.g. unrelated crawlers/ingestors). Match strictly on the
+  `lisa-wiki-auto-<project>-` prefix for THIS project; when in doubt about an automation's ownership,
+  leave it and report it rather than deleting it.
+- **Idempotent** — an automation that is already absent is a no-op, not an error.
+
+## Report
+
+List the automation removed, or report it as already absent.


### PR DESCRIPTION
## What

Adds the ability to **schedule the wiki ingest** as a recurring automation — and puts it in the right place.

The base `/lisa:setup-automations` (in `plugins/src/base`) can't own this: the **wiki plugin (`lisa-wiki`) is standalone** and installable without the base Lisa plugin, so base isn't always present, and base shouldn't reach across a plugin boundary into wiki. So this adds a wiki-owned pair, mirroring the base automation skills exactly.

### New skills/commands (in `plugins/src/wiki`)
- **`/lisa-wiki:setup-automations`** — schedules one automation, **`wiki-ingest`**: a full `/lisa-wiki:ingest` cycle, **daily by default** (`cadence=daily|weekly|every-<n>-hours` to override), via the runtime's native scheduler (Codex automations / Claude `/schedule`). Named/scoped **`lisa-wiki-auto-<project>-*`** so it never collides with or clobbers the base `lisa-auto-<project>-*` set. Guards on a configured wiki (`wiki/lisa-wiki.config.json`) and on the runtime having a scheduler.
- **`/lisa-wiki:tear-down-automations`** — removes exactly this project's `lisa-wiki-auto-<project>-*` automation; never the base set, other projects', or non-Lisa automations.

Both are **declarative specs** (no scheduling code), matching the base pair's design.

## Files
- `plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md`, `…/lisa-wiki-tear-down-automations/SKILL.md`
- `plugins/src/wiki/commands/setup-automations.md`, `…/tear-down-automations.md`
- Regenerated `plugins/lisa-wiki` artifacts (`SKILL.md` + Codex `agents/openai.yaml` + commands) committed alongside source, per the plugins-build rule.

## Validation
- Regenerated `plugins/lisa-wiki` via the codex artifact generator → **byte-identical** to the committed artifacts (deterministic); no other plugin touched, no deletions. Plugins Sync will match.
- `.codex-plugin/plugin.json` uses a `./skills/` directory pointer, so adding skills needs no manifest change.

🤖 Generated with Claude Code
