### PR TITLE
feat: add local intake assignee filter

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -123,6 +123,7 @@ fi
   },
 
   "intake": {
+    "assignee": "<vendor-user-id-or-login>",
     "repair": {
       "staleAfterHours": 24,
       "maxCandidates": 100
@@ -243,6 +244,26 @@ documented defaults, so existing projects need no config change.
 |-----|----------|---------|-------|
 | `intake.repair.staleAfterHours` | no | `24` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
+
+### Intake assignee filter (`intake.assignee`)
+
+The optional intake assignee filter narrows **ready-item selection only**. It never assigns or
+reassigns tickets; it simply tells build-intake to consider only ready items that are already
+assigned to the resolved person for this local run.
+
+Resolution order:
+
+1. `$ARGUMENTS` `assignee=<vendor-user-id-or-login>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default (no filtering)
+
+The setting is intentionally **local-only**: personal or machine-specific intake lanes belong in
+`.lisa.config.local.json`, not the committed project config. An empty resolved value disables the
+filter and preserves the shared ready-queue behavior.
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `intake.assignee` | no | empty | Local ready-queue filter for build intake. When non-empty, vendor build-intake skills query only ready items already assigned to that vendor-specific user id or login. When empty, no assignee filter is applied. Runtime `$ARGUMENTS` `assignee=<...>` always wins over config for that invocation. |
 
 Resolution order matches every other key: `$ARGUMENTS` override → `.lisa.config.local.json` →
 `.lisa.config.json` → built-in default. The role SEMANTICS repair-intake operates on (which

--- a/plugins/lisa/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/github-build-intake/SKILL.md
@@ -14,6 +14,17 @@ allowed-tools: ["Skill", "Bash"]
 
 Run one build-intake cycle. The first eligible issue in the configured `ready` build label is claimed, built via the `lisa:github-agent` flow, relabeled to the configured `done` label (env-aware — see Workflow resolution), then the cycle exits. Remaining ready issues stay queued for later scheduler invocations.
 
+This skill also accepts an optional `assignee=<github-login>` queue filter. Resolve it in this
+order:
+
+1. `$ARGUMENTS` `assignee=<login>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default
+
+When the resolved assignee is empty, scan the shared ready queue exactly as before. When it is
+non-empty, filter the ready-item query to issues already assigned to that login. This filter is
+selection-only: never assign or reassign issues as part of build intake.
+
 ## Workflow resolution
 
 Build-queue label names are read from `.lisa.config.json` `github.labels.build.*`, falling back to defaults documented in the `config-resolution` rule. Bash pattern:
@@ -30,6 +41,15 @@ read_role() {
 
 READY=$(read_role ready "status:ready")
 CLAIMED=$(read_role claimed "status:in-progress")
+
+read_intake_assignee() {
+  local cli_value local_v
+  cli_value=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*assignee=\([^[:space:]]*\).*/\1/p' | head -1)
+  local_v=$(jq -r '.intake.assignee // empty' .lisa.config.local.json 2>/dev/null)
+  echo "${cli_value:-${local_v:-}}"
+}
+
+ASSIGNEE=$(read_intake_assignee)
 ```
 
 For env-keyed `done`, resolve the env first, then look up `done[<env>]`:
@@ -120,7 +140,13 @@ A "transition" means: remove the old role label and add the new one, in two `gh 
 ### Phase 2 — Find ready issues
 
 ```bash
-gh issue list --repo <org>/<repo> --label "$READY" --state open --json number,title,labels,assignees,milestone,createdAt --limit 100
+if [ -n "$ASSIGNEE" ]; then
+  gh issue list --repo <org>/<repo> --label "$READY" --assignee "$ASSIGNEE" --state open \
+    --json number,title,labels,assignees,milestone,createdAt --limit 100
+else
+  gh issue list --repo <org>/<repo> --label "$READY" --state open \
+    --json number,title,labels,assignees,milestone,createdAt --limit 100
+fi
 ```
 
 If empty, run a secondary check to distinguish a genuinely empty queue from an unconfigured repo:
@@ -131,7 +157,7 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
 ### Phase 3 — Process the first eligible ready issue
 

--- a/plugins/lisa/skills/intake/SKILL.md
+++ b/plugins/lisa/skills/intake/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: ["Skill", "Bash", "mcp__claude_ai_Notion__notion-fetch", "mcp__cl
 
 Run one intake cycle against the queue identified by `$ARGUMENTS`. Scans for `Status = Ready`, claims the first eligible item, dispatches it to the appropriate single-item lifecycle skill, then exits. Remaining Ready items are left for later scheduler invocations.
 
+For build-queue runs, Intake also accepts an optional `assignee=<vendor-user-id-or-login>` filter.
+Resolution order is:
+
+1. `$ARGUMENTS` `assignee=<...>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default
+
+When the resolved assignee is empty, Intake keeps the shared queue behavior and scans any ready
+item. When non-empty, it forwards the filter to the vendor build-intake skill so that only ready
+items already assigned to that assignee are considered. Intake never assigns or reassigns tickets
+as part of this filter.
+
 ## Confirmation policy
 
 Do NOT ask the caller whether to proceed. Once invoked with a queue, run the cycle to completion. The caller (a human at the CLI or a scheduled cron) has already authorized the run by invoking the skill; re-prompting defeats the purpose of a background batch.
@@ -58,7 +70,7 @@ Detect the queue type from `$ARGUMENTS` and route:
 | A JIRA project key (e.g. `SE`) | Work queue (JIRA) | Invoke `lisa:jira-build-intake` (which scans the project for Status=Ready, claims the first eligible ticket via In Progress, runs `lisa:implement`, transitions to On Dev on success, then exits) |
 | A full JQL filter (e.g. `project = SE AND component = "frontend"`) | Work queue (JIRA, narrowed) | Invoke `lisa:jira-build-intake` with the JQL |
 | A GitHub **repository** URL or `org/repo` token (e.g. `https://github.com/acme/product-prds` or `acme/product-prds`) when used for **PRDs** | PRD queue (GitHub) | Invoke `lisa:github-prd-intake` (which queries `gh issue list --label prd-ready`, claims the first eligible PRD by relabeling to `prd-in-review`, runs the dry-run validate → branch → write pipeline, then exits). PRD discovery is independent of the destination tracker — the resulting tickets land wherever `.lisa.config.json` `tracker` says. |
-| A GitHub **repository** URL or `org/repo` token when `tracker = github` is configured (build-queue mode) | Work queue (GitHub) | Invoke `lisa:tracker-build-intake` which dispatches to `lisa:github-build-intake` (which queries `gh issue list --label status:ready`, claims the first eligible issue via `status:in-progress`, runs `lisa:implement`, relabels to `status:on-dev` on success, then exits). |
+| A GitHub **repository** URL or `org/repo` token when `tracker = github` is configured (build-queue mode) | Work queue (GitHub) | Invoke `lisa:tracker-build-intake` which dispatches to `lisa:github-build-intake` (which queries `gh issue list --label status:ready`, optionally narrows by the resolved assignee filter, claims the first eligible issue via `status:in-progress`, runs `lisa:implement`, relabels to `status:on-dev` on success, then exits). |
 | The literal token `github` | Defaults to `.lisa.config.json` `github.org` / `github.repo`. Routes by **the `intake_mode` flag** in `$ARGUMENTS` (`prd` or `build`); if the flag is absent, prefer the PRD queue when both label namespaces are present, otherwise pick whichever exists. | Invoke the matching skill (`lisa:github-prd-intake` or `lisa:tracker-build-intake`). |
 
 Disambiguation rules:
@@ -87,7 +99,7 @@ The single-item skills (`lisa:plan`, `lisa:implement`) and the per-vendor batch 
    - Linear PRDs → `lisa:linear-prd-intake` handles per-item: claim (relabel project to `prd-in-review`), dry-run validate, branch to `prd-blocked` or `prd-ticketed` (with a sentinel feedback issue under each project hosting clarifying-question comments), coverage audit
    - GitHub PRDs → `lisa:github-prd-intake` handles per-item: claim (relabel issue to `prd-in-review`), dry-run validate, branch to `prd-blocked` or `prd-ticketed` (with clarifying-question comments posted directly on the PRD issue), coverage audit
    - JIRA tickets → `lisa:jira-build-intake` handles per-item: claim, dispatch to `lisa:jira-agent`, transition to On Dev on success
-   - GitHub build issues (when `tracker = github`) → `lisa:tracker-build-intake` → `lisa:github-build-intake` handles per-item: claim (relabel to `status:in-progress`), dispatch to `lisa:github-agent`, relabel to `status:on-dev` on success
+   - GitHub build issues (when `tracker = github`) → `lisa:tracker-build-intake` → `lisa:github-build-intake` handles per-item: optional ready-queue assignee filtering, claim (relabel to `status:in-progress`), dispatch to `lisa:github-agent`, relabel to `status:on-dev` on success
    - **Closing the PRD loop:** beyond claiming one Ready PRD, every PRD scanner also runs the closure rollup (`ticketed → shipped`, Phase 3f) and **dispatches `lisa:verify-prd` for one shipped PRD** (Phase 3g) each cycle — so a shipped PRD does not sit unverified. On pass the PRD goes `shipped → verified`; on fail it is re-opened `shipped → ticketed` with **build-ready fix tickets** that auto-build and trigger a re-verify (never `blocked`). The scanner only dispatches; `lisa:verify-prd` owns the transition (per the `prd-lifecycle-rollup` rule's "Closing the loop" section), and the self-healing loop continues until the PRD verifies.
 5. **Stop after one item** — a claimed Ready item, a safe-blocked container, or a per-item error ends the *ready-claim* portion of the cycle. The per-vendor PRD scanner still runs its rollup and one verify-prd dispatch. Remaining Ready items stay untouched for later scheduler invocations.
 6. **Summary report** — the single processed/skipped/error item, total processed, total errors.
@@ -103,6 +115,7 @@ The single-item skills (`lisa:plan`, `lisa:implement`) and the per-vendor batch 
 /schedule "every 30 minutes" /lisa:intake acme/product-prds
 /schedule "every 30 minutes" /lisa:intake SE
 /schedule "every 30 minutes" /lisa:intake acme/frontend-v2 intake_mode=build
+/schedule "every 30 minutes" /lisa:intake acme/frontend-v2 intake_mode=build assignee=codyswanngt
 /schedule "every hour" /lisa:intake "project = SE AND component = 'frontend'"
 ```
 

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -123,6 +123,7 @@ fi
   },
 
   "intake": {
+    "assignee": "<vendor-user-id-or-login>",
     "repair": {
       "staleAfterHours": 24,
       "maxCandidates": 100
@@ -243,6 +244,26 @@ documented defaults, so existing projects need no config change.
 |-----|----------|---------|-------|
 | `intake.repair.staleAfterHours` | no | `24` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
+
+### Intake assignee filter (`intake.assignee`)
+
+The optional intake assignee filter narrows **ready-item selection only**. It never assigns or
+reassigns tickets; it simply tells build-intake to consider only ready items that are already
+assigned to the resolved person for this local run.
+
+Resolution order:
+
+1. `$ARGUMENTS` `assignee=<vendor-user-id-or-login>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default (no filtering)
+
+The setting is intentionally **local-only**: personal or machine-specific intake lanes belong in
+`.lisa.config.local.json`, not the committed project config. An empty resolved value disables the
+filter and preserves the shared ready-queue behavior.
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `intake.assignee` | no | empty | Local ready-queue filter for build intake. When non-empty, vendor build-intake skills query only ready items already assigned to that vendor-specific user id or login. When empty, no assignee filter is applied. Runtime `$ARGUMENTS` `assignee=<...>` always wins over config for that invocation. |
 
 Resolution order matches every other key: `$ARGUMENTS` override → `.lisa.config.local.json` →
 `.lisa.config.json` → built-in default. The role SEMANTICS repair-intake operates on (which

--- a/plugins/src/base/skills/github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/github-build-intake/SKILL.md
@@ -14,6 +14,17 @@ allowed-tools: ["Skill", "Bash"]
 
 Run one build-intake cycle. The first eligible issue in the configured `ready` build label is claimed, built via the `lisa:github-agent` flow, relabeled to the configured `done` label (env-aware — see Workflow resolution), then the cycle exits. Remaining ready issues stay queued for later scheduler invocations.
 
+This skill also accepts an optional `assignee=<github-login>` queue filter. Resolve it in this
+order:
+
+1. `$ARGUMENTS` `assignee=<login>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default
+
+When the resolved assignee is empty, scan the shared ready queue exactly as before. When it is
+non-empty, filter the ready-item query to issues already assigned to that login. This filter is
+selection-only: never assign or reassign issues as part of build intake.
+
 ## Workflow resolution
 
 Build-queue label names are read from `.lisa.config.json` `github.labels.build.*`, falling back to defaults documented in the `config-resolution` rule. Bash pattern:
@@ -30,6 +41,15 @@ read_role() {
 
 READY=$(read_role ready "status:ready")
 CLAIMED=$(read_role claimed "status:in-progress")
+
+read_intake_assignee() {
+  local cli_value local_v
+  cli_value=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*assignee=\([^[:space:]]*\).*/\1/p' | head -1)
+  local_v=$(jq -r '.intake.assignee // empty' .lisa.config.local.json 2>/dev/null)
+  echo "${cli_value:-${local_v:-}}"
+}
+
+ASSIGNEE=$(read_intake_assignee)
 ```
 
 For env-keyed `done`, resolve the env first, then look up `done[<env>]`:
@@ -120,7 +140,13 @@ A "transition" means: remove the old role label and add the new one, in two `gh 
 ### Phase 2 — Find ready issues
 
 ```bash
-gh issue list --repo <org>/<repo> --label "$READY" --state open --json number,title,labels,assignees,milestone,createdAt --limit 100
+if [ -n "$ASSIGNEE" ]; then
+  gh issue list --repo <org>/<repo> --label "$READY" --assignee "$ASSIGNEE" --state open \
+    --json number,title,labels,assignees,milestone,createdAt --limit 100
+else
+  gh issue list --repo <org>/<repo> --label "$READY" --state open \
+    --json number,title,labels,assignees,milestone,createdAt --limit 100
+fi
 ```
 
 If empty, run a secondary check to distinguish a genuinely empty queue from an unconfigured repo:
@@ -131,7 +157,7 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
 ### Phase 3 — Process the first eligible ready issue
 

--- a/plugins/src/base/skills/intake/SKILL.md
+++ b/plugins/src/base/skills/intake/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: ["Skill", "Bash", "mcp__claude_ai_Notion__notion-fetch", "mcp__cl
 
 Run one intake cycle against the queue identified by `$ARGUMENTS`. Scans for `Status = Ready`, claims the first eligible item, dispatches it to the appropriate single-item lifecycle skill, then exits. Remaining Ready items are left for later scheduler invocations.
 
+For build-queue runs, Intake also accepts an optional `assignee=<vendor-user-id-or-login>` filter.
+Resolution order is:
+
+1. `$ARGUMENTS` `assignee=<...>`
+2. `.lisa.config.local.json` `intake.assignee`
+3. empty default
+
+When the resolved assignee is empty, Intake keeps the shared queue behavior and scans any ready
+item. When non-empty, it forwards the filter to the vendor build-intake skill so that only ready
+items already assigned to that assignee are considered. Intake never assigns or reassigns tickets
+as part of this filter.
+
 ## Confirmation policy
 
 Do NOT ask the caller whether to proceed. Once invoked with a queue, run the cycle to completion. The caller (a human at the CLI or a scheduled cron) has already authorized the run by invoking the skill; re-prompting defeats the purpose of a background batch.
@@ -58,7 +70,7 @@ Detect the queue type from `$ARGUMENTS` and route:
 | A JIRA project key (e.g. `SE`) | Work queue (JIRA) | Invoke `lisa:jira-build-intake` (which scans the project for Status=Ready, claims the first eligible ticket via In Progress, runs `lisa:implement`, transitions to On Dev on success, then exits) |
 | A full JQL filter (e.g. `project = SE AND component = "frontend"`) | Work queue (JIRA, narrowed) | Invoke `lisa:jira-build-intake` with the JQL |
 | A GitHub **repository** URL or `org/repo` token (e.g. `https://github.com/acme/product-prds` or `acme/product-prds`) when used for **PRDs** | PRD queue (GitHub) | Invoke `lisa:github-prd-intake` (which queries `gh issue list --label prd-ready`, claims the first eligible PRD by relabeling to `prd-in-review`, runs the dry-run validate → branch → write pipeline, then exits). PRD discovery is independent of the destination tracker — the resulting tickets land wherever `.lisa.config.json` `tracker` says. |
-| A GitHub **repository** URL or `org/repo` token when `tracker = github` is configured (build-queue mode) | Work queue (GitHub) | Invoke `lisa:tracker-build-intake` which dispatches to `lisa:github-build-intake` (which queries `gh issue list --label status:ready`, claims the first eligible issue via `status:in-progress`, runs `lisa:implement`, relabels to `status:on-dev` on success, then exits). |
+| A GitHub **repository** URL or `org/repo` token when `tracker = github` is configured (build-queue mode) | Work queue (GitHub) | Invoke `lisa:tracker-build-intake` which dispatches to `lisa:github-build-intake` (which queries `gh issue list --label status:ready`, optionally narrows by the resolved assignee filter, claims the first eligible issue via `status:in-progress`, runs `lisa:implement`, relabels to `status:on-dev` on success, then exits). |
 | The literal token `github` | Defaults to `.lisa.config.json` `github.org` / `github.repo`. Routes by **the `intake_mode` flag** in `$ARGUMENTS` (`prd` or `build`); if the flag is absent, prefer the PRD queue when both label namespaces are present, otherwise pick whichever exists. | Invoke the matching skill (`lisa:github-prd-intake` or `lisa:tracker-build-intake`). |
 
 Disambiguation rules:
@@ -87,7 +99,7 @@ The single-item skills (`lisa:plan`, `lisa:implement`) and the per-vendor batch 
    - Linear PRDs → `lisa:linear-prd-intake` handles per-item: claim (relabel project to `prd-in-review`), dry-run validate, branch to `prd-blocked` or `prd-ticketed` (with a sentinel feedback issue under each project hosting clarifying-question comments), coverage audit
    - GitHub PRDs → `lisa:github-prd-intake` handles per-item: claim (relabel issue to `prd-in-review`), dry-run validate, branch to `prd-blocked` or `prd-ticketed` (with clarifying-question comments posted directly on the PRD issue), coverage audit
    - JIRA tickets → `lisa:jira-build-intake` handles per-item: claim, dispatch to `lisa:jira-agent`, transition to On Dev on success
-   - GitHub build issues (when `tracker = github`) → `lisa:tracker-build-intake` → `lisa:github-build-intake` handles per-item: claim (relabel to `status:in-progress`), dispatch to `lisa:github-agent`, relabel to `status:on-dev` on success
+   - GitHub build issues (when `tracker = github`) → `lisa:tracker-build-intake` → `lisa:github-build-intake` handles per-item: optional ready-queue assignee filtering, claim (relabel to `status:in-progress`), dispatch to `lisa:github-agent`, relabel to `status:on-dev` on success
    - **Closing the PRD loop:** beyond claiming one Ready PRD, every PRD scanner also runs the closure rollup (`ticketed → shipped`, Phase 3f) and **dispatches `lisa:verify-prd` for one shipped PRD** (Phase 3g) each cycle — so a shipped PRD does not sit unverified. On pass the PRD goes `shipped → verified`; on fail it is re-opened `shipped → ticketed` with **build-ready fix tickets** that auto-build and trigger a re-verify (never `blocked`). The scanner only dispatches; `lisa:verify-prd` owns the transition (per the `prd-lifecycle-rollup` rule's "Closing the loop" section), and the self-healing loop continues until the PRD verifies.
 5. **Stop after one item** — a claimed Ready item, a safe-blocked container, or a per-item error ends the *ready-claim* portion of the cycle. The per-vendor PRD scanner still runs its rollup and one verify-prd dispatch. Remaining Ready items stay untouched for later scheduler invocations.
 6. **Summary report** — the single processed/skipped/error item, total processed, total errors.
@@ -103,6 +115,7 @@ The single-item skills (`lisa:plan`, `lisa:implement`) and the per-vendor batch 
 /schedule "every 30 minutes" /lisa:intake acme/product-prds
 /schedule "every 30 minutes" /lisa:intake SE
 /schedule "every 30 minutes" /lisa:intake acme/frontend-v2 intake_mode=build
+/schedule "every 30 minutes" /lisa:intake acme/frontend-v2 intake_mode=build assignee=codyswanngt
 /schedule "every hour" /lisa:intake "project = SE AND component = 'frontend'"
 ```
 

--- a/tests/unit/strategies/intake-assignee-filter.test.ts
+++ b/tests/unit/strategies/intake-assignee-filter.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression tests for the optional local assignee filter on build-intake.
+ *
+ * Intake may narrow the ready queue to items already assigned to one person for
+ * a local automation lane, but the default shared queue behavior must remain
+ * unchanged when no assignee is resolved. Both source and generated plugin
+ * roots are asserted.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string, slug: string): string =>
+  readFileSync(path.resolve(root, slug, "SKILL.md"), "utf8");
+
+describe("intake assignee filter", () => {
+  describe.each(ROOTS)("%s/intake", root => {
+    const content = readSkill(root, "intake");
+
+    it("documents the assignee argument and local config resolution order", () => {
+      expect(content).toContain("assignee=<vendor-user-id-or-login>");
+      expect(content).toContain(".lisa.config.local.json` `intake.assignee`");
+      expect(content).toMatch(/empty default/i);
+    });
+
+    it("states that the filter is selection-only", () => {
+      expect(content).toMatch(/never assigns or reassigns tickets/i);
+      expect(content).toMatch(
+        /ready[\s\S]*already assigned to that assignee are considered/i
+      );
+    });
+  });
+
+  describe.each(ROOTS)("%s/github-build-intake", root => {
+    const content = readSkill(root, "github-build-intake");
+
+    it("documents assignee resolution for github build intake", () => {
+      expect(content).toContain("assignee=<github-login>");
+      expect(content).toContain(".lisa.config.local.json` `intake.assignee`");
+      expect(content).toMatch(/empty default/i);
+    });
+
+    it("uses --assignee only when the resolved filter is non-empty", () => {
+      expect(content).toMatch(/if \[ -n "\$ASSIGNEE" \]; then/);
+      expect(content).toMatch(/--assignee "\$ASSIGNEE"/);
+      expect(content).toMatch(
+        /else\s+gh issue list --repo <org>\/<repo> --label "\$READY" --state open/s
+      );
+    });
+
+    it("preserves shared-queue behavior when no assignee is resolved", () => {
+      expect(content).toMatch(/scan the shared ready queue exactly as before/i);
+      expect(content).toMatch(
+        /filter the ready-item query to issues already assigned/i
+      );
+    });
+  });
+});
+
+describe("config-resolution intake.assignee docs", () => {
+  const content = readFileSync(
+    path.resolve("plugins/src/base/rules/config-resolution.md"),
+    "utf8"
+  );
+
+  it("documents intake.assignee as a local-only override", () => {
+    expect(content).toContain("### Intake assignee filter (`intake.assignee`)");
+    expect(content).toMatch(/local-only/i);
+    expect(content).toMatch(/\.lisa\.config\.local\.json/);
+  });
+
+  it("documents argument override and empty default behavior", () => {
+    expect(content).toContain(
+      "$ARGUMENTS` `assignee=<vendor-user-id-or-login>`"
+    );
+    expect(content).toMatch(/empty default/i);
+    expect(content).toMatch(
+      /empty resolved value disables the[\s\S]*shared ready-queue behavior/i
+    );
+  });
+});

--- a/tests/unit/strategies/intake-assignee-filter.test.ts
+++ b/tests/unit/strategies/intake-assignee-filter.test.ts
@@ -60,25 +60,32 @@ describe("intake assignee filter", () => {
   });
 });
 
-describe("config-resolution intake.assignee docs", () => {
-  const content = readFileSync(
-    path.resolve("plugins/src/base/rules/config-resolution.md"),
-    "utf8"
-  );
+const RULES_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
 
-  it("documents intake.assignee as a local-only override", () => {
-    expect(content).toContain("### Intake assignee filter (`intake.assignee`)");
-    expect(content).toMatch(/local-only/i);
-    expect(content).toMatch(/\.lisa\.config\.local\.json/);
-  });
+describe.each(RULES_ROOTS)(
+  "config-resolution intake.assignee docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
 
-  it("documents argument override and empty default behavior", () => {
-    expect(content).toContain(
-      "$ARGUMENTS` `assignee=<vendor-user-id-or-login>`"
-    );
-    expect(content).toMatch(/empty default/i);
-    expect(content).toMatch(
-      /empty resolved value disables the[\s\S]*shared ready-queue behavior/i
-    );
-  });
-});
+    it("documents intake.assignee as a local-only override", () => {
+      expect(content).toContain(
+        "### Intake assignee filter (`intake.assignee`)"
+      );
+      expect(content).toMatch(/local-only/i);
+      expect(content).toMatch(/\.lisa\.config\.local\.json/);
+    });
+
+    it("documents argument override and empty default behavior", () => {
+      expect(content).toContain(
+        "$ARGUMENTS` `assignee=<vendor-user-id-or-login>`"
+      );
+      expect(content).toMatch(/empty default/i);
+      expect(content).toMatch(
+        /empty resolved value disables the[\s\S]*shared ready-queue behavior/i
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- add local `intake.assignee` config and `assignee=<...>` intake contract docs
- document conditional GitHub build-intake `--assignee` queue filtering without assignment side effects
- add regression coverage for source and generated plugin outputs

## Testing
- bun test tests/unit/strategies/intake-assignee-filter.test.ts tests/unit/strategies/repo-scope-claim.test.ts tests/unit/strategies/leaf-only-build-ready.test.ts
- git push hook: bun audit, eslint slow, knip, vitest run --coverage, vitest run tests/integration

Closes #689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional assignee filter for build-queue intake runs, allowing users to narrow ready-queue scans to items already assigned to specific users. Configuration options include command-line arguments or local configuration files, and the filter affects only item selection without modifying assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->