### PR TITLE
feat(config): document GitHub ProjectV2 coordination config

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -64,6 +64,16 @@ fi
   "github": {
     "org": "<org-or-user>",
     "repo": "<repo>",
+    "projects": {
+      "v2": {
+        "owner": {
+          "kind": "organization",
+          "slug": "<org-or-user>"
+        },
+        "number": 7,
+        "required": false
+      }
+    },
     "labels": {
       "build": {
         "ready":   "status:ready",
@@ -170,8 +180,14 @@ Each vendor section is **conditionally required**: required only when that vendo
 |-------|---------------|-------|
 | `github.org` | `tracker = "github"` or `source = "github"` or any `github-*` skill is invoked | GitHub organization or user name. |
 | `github.repo` | same as above | GitHub repository name. |
+| `github.projects.v2.owner.kind` | GitHub Project coordination is enabled | Owner type for the shared ProjectV2. Supported values are `organization` and `user`. |
+| `github.projects.v2.owner.slug` | GitHub Project coordination is enabled | Owner login for the shared ProjectV2. In v1 it MUST match the tracked repository namespace (`github.org`); cross-namespace coordination is rejected. |
+| `github.projects.v2.number` | GitHub Project coordination is enabled | Human-facing ProjectV2 number from the GitHub UI / URL. Later utilities resolve the opaque node id from this owner + number pair. |
+| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. |
 
 When `tracker = "github"` AND `source = "github"` (self-host), both reads and writes hit the same GitHub repo. Label namespaces are kept separate so the two flows don't collide — see "Self-host edge case" below.
+
+`github.projects.v2` is optional. When absent, GitHub issue / PR writes remain repository-local exactly as they work today. When present, the shared Project is a coordination view layered on top of real issues and pull requests; it does not replace lifecycle labels, comments, dependencies, or native issue / PR state as Lisa's durable source of truth.
 
 #### `notion`
 

--- a/plugins/lisa/skills/setup-github/SKILL.md
+++ b/plugins/lisa/skills/setup-github/SKILL.md
@@ -154,6 +154,24 @@ if [ -n "$LABEL_OVERRIDES_JSON" ] && [ "$LABEL_OVERRIDES_JSON" != "{}" ]; then
 fi
 ```
 
+If this project later enables shared GitHub Project coordination, store it under the same `github` block as:
+
+```json
+"github": {
+  "org": "<tracked-repo-owner>",
+  "repo": "<tracked-repo>",
+  "projects": {
+    "v2": {
+      "owner": { "kind": "organization", "slug": "<tracked-repo-owner>" },
+      "number": 7,
+      "required": false
+    }
+  }
+}
+```
+
+That block is optional and coordination-only: real issues and pull requests stay the durable source of truth. In v1, `github.projects.v2.owner.slug` MUST match the tracked repository namespace (`github.org`) — user-owned repos use a user-owned Project, org-owned repos use an org-owned Project, and cross-namespace Project ownership is rejected. `required` defaults to `false`, meaning Project membership is best-effort unless a later setup/doctor flow explicitly opts into strict mode.
+
 No secrets go in config — the GitHub token lives in `gh`'s own store (`~/.config/gh/`) or the `GH_TOKEN` env var, never in `.lisa.config.json`.
 
 ### Step 5 — Offer to set top-level `tracker` / `source`

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -64,6 +64,16 @@ fi
   "github": {
     "org": "<org-or-user>",
     "repo": "<repo>",
+    "projects": {
+      "v2": {
+        "owner": {
+          "kind": "organization",
+          "slug": "<org-or-user>"
+        },
+        "number": 7,
+        "required": false
+      }
+    },
     "labels": {
       "build": {
         "ready":   "status:ready",
@@ -170,8 +180,14 @@ Each vendor section is **conditionally required**: required only when that vendo
 |-------|---------------|-------|
 | `github.org` | `tracker = "github"` or `source = "github"` or any `github-*` skill is invoked | GitHub organization or user name. |
 | `github.repo` | same as above | GitHub repository name. |
+| `github.projects.v2.owner.kind` | GitHub Project coordination is enabled | Owner type for the shared ProjectV2. Supported values are `organization` and `user`. |
+| `github.projects.v2.owner.slug` | GitHub Project coordination is enabled | Owner login for the shared ProjectV2. In v1 it MUST match the tracked repository namespace (`github.org`); cross-namespace coordination is rejected. |
+| `github.projects.v2.number` | GitHub Project coordination is enabled | Human-facing ProjectV2 number from the GitHub UI / URL. Later utilities resolve the opaque node id from this owner + number pair. |
+| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. |
 
 When `tracker = "github"` AND `source = "github"` (self-host), both reads and writes hit the same GitHub repo. Label namespaces are kept separate so the two flows don't collide — see "Self-host edge case" below.
+
+`github.projects.v2` is optional. When absent, GitHub issue / PR writes remain repository-local exactly as they work today. When present, the shared Project is a coordination view layered on top of real issues and pull requests; it does not replace lifecycle labels, comments, dependencies, or native issue / PR state as Lisa's durable source of truth.
 
 #### `notion`
 

--- a/plugins/src/base/skills/setup-github/SKILL.md
+++ b/plugins/src/base/skills/setup-github/SKILL.md
@@ -154,6 +154,24 @@ if [ -n "$LABEL_OVERRIDES_JSON" ] && [ "$LABEL_OVERRIDES_JSON" != "{}" ]; then
 fi
 ```
 
+If this project later enables shared GitHub Project coordination, store it under the same `github` block as:
+
+```json
+"github": {
+  "org": "<tracked-repo-owner>",
+  "repo": "<tracked-repo>",
+  "projects": {
+    "v2": {
+      "owner": { "kind": "organization", "slug": "<tracked-repo-owner>" },
+      "number": 7,
+      "required": false
+    }
+  }
+}
+```
+
+That block is optional and coordination-only: real issues and pull requests stay the durable source of truth. In v1, `github.projects.v2.owner.slug` MUST match the tracked repository namespace (`github.org`) — user-owned repos use a user-owned Project, org-owned repos use an org-owned Project, and cross-namespace Project ownership is rejected. `required` defaults to `false`, meaning Project membership is best-effort unless a later setup/doctor flow explicitly opts into strict mode.
+
 No secrets go in config — the GitHub token lives in `gh`'s own store (`~/.config/gh/`) or the `GH_TOKEN` env var, never in `.lisa.config.json`.
 
 ### Step 5 — Offer to set top-level `tracker` / `source`

--- a/tests/unit/strategies/github-project-config-resolution.test.ts
+++ b/tests/unit/strategies/github-project-config-resolution.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for the optional GitHub ProjectV2 coordination config.
+ *
+ * Issue #698 extends the canonical config-resolution schema with an optional
+ * `github.projects.v2` block so later setup/doctor and writer utilities can
+ * resolve a shared GitHub Project without changing the repository-local issue
+ * model. V1 permits only namespace-matched ownership: the Project owner slug
+ * must match the tracked repository namespace (`github.org`).
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/github-project-config-resolution
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+describe.each(RULE_ROOTS)(
+  "config-resolution GitHub ProjectV2 docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
+
+    it("documents the optional github.projects.v2 schema", () => {
+      expect(content).toContain('"projects": {');
+      expect(content).toContain('"v2": {');
+      expect(content).toContain('"owner": {');
+      expect(content).toContain('"kind": "organization"');
+      expect(content).toContain('"slug": "<org-or-user>"');
+      expect(content).toContain('"number": 7');
+      expect(content).toContain('"required": false');
+    });
+
+    it("documents same-namespace ownership and best-effort default semantics", () => {
+      expect(content).toMatch(
+        /MUST match the tracked repository namespace \(`github\.org`\)/i
+      );
+      expect(content).toMatch(/cross-namespace coordination is rejected/i);
+      expect(content).toMatch(
+        /Default `false` keeps Project membership best-effort/i
+      );
+    });
+  }
+);
+
+describe.each(SKILL_ROOTS)(
+  "setup-github Project config docs (%s)",
+  skillRoot => {
+    const content = readFileSync(
+      path.resolve(skillRoot, "setup-github", "SKILL.md"),
+      "utf8"
+    );
+
+    it("shows the GitHub ProjectV2 config shape under the github block", () => {
+      expect(content).toContain('"projects": {');
+      expect(content).toContain('"v2": {');
+      expect(content).toContain('"owner": { "kind": "organization"');
+      expect(content).toContain('"number": 7');
+      expect(content).toContain('"required": false');
+    });
+
+    it("documents the v1 namespace rule and optional strict mode", () => {
+      expect(content).toMatch(
+        /MUST match the tracked repository namespace \(`github\.org`\)/i
+      );
+      expect(content).toMatch(/cross-namespace Project ownership is rejected/i);
+      expect(content).toMatch(/best-effort unless .* opts into strict mode/i);
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- add optional `github.projects.v2` config docs to the canonical config-resolution rule
- document same-namespace v1 ownership and default best-effort `required: false` semantics in setup-github
- add regression coverage for both source and generated plugin artifacts

## Validation
- bun run build:plugins
- bun test tests/unit/strategies/github-project-config-resolution.test.ts tests/unit/strategies/intake-assignee-filter.test.ts tests/unit/strategies/setup-github-prd-verified-label.test.ts
- pre-push hooks: eslint.slow, knip, vitest --coverage, vitest tests/integration

Closes #698
