### PR TITLE
feat(github): document project validation modes

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -183,11 +183,19 @@ Each vendor section is **conditionally required**: required only when that vendo
 | `github.projects.v2.owner.kind` | GitHub Project coordination is enabled | Owner type for the shared ProjectV2. Supported values are `organization` and `user`. |
 | `github.projects.v2.owner.slug` | GitHub Project coordination is enabled | Owner login for the shared ProjectV2. In v1 it MUST match the tracked repository namespace (`github.org`); cross-namespace coordination is rejected. |
 | `github.projects.v2.number` | GitHub Project coordination is enabled | Human-facing ProjectV2 number from the GitHub UI / URL. Later utilities resolve the opaque node id from this owner + number pair. |
-| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. |
+| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. Setup/doctor/runtime validation reads Project ownership + access and branches on this flag: best-effort failures warn, required-mode failures stop the write. |
 
 When `tracker = "github"` AND `source = "github"` (self-host), both reads and writes hit the same GitHub repo. Label namespaces are kept separate so the two flows don't collide — see "Self-host edge case" below.
 
 `github.projects.v2` is optional. When absent, GitHub issue / PR writes remain repository-local exactly as they work today. When present, the shared Project is a coordination view layered on top of real issues and pull requests; it does not replace lifecycle labels, comments, dependencies, or native issue / PR state as Lisa's durable source of truth.
+
+When `github.projects.v2` is present, later setup/doctor and writer preflight validation MUST read the referenced Project's owner + access level before any membership write depends on it. The validation contract is:
+
+- Resolve the Project from `owner.kind`, `owner.slug`, and `number`.
+- Confirm the owner namespace still matches `github.org`; cross-namespace Project ownership is a configuration error.
+- Confirm the authenticated identity can read the Project and has sufficient access for membership coordination.
+- If `required = false`, surface Project-validation failures as warnings and continue repository-local issue / PR writes without Project membership.
+- If `required = true`, surface the same failures as blocking errors and stop the write before mutating issue / PR membership.
 
 #### `notion`
 

--- a/plugins/lisa/skills/setup-github/SKILL.md
+++ b/plugins/lisa/skills/setup-github/SKILL.md
@@ -172,6 +172,8 @@ If this project later enables shared GitHub Project coordination, store it under
 
 That block is optional and coordination-only: real issues and pull requests stay the durable source of truth. In v1, `github.projects.v2.owner.slug` MUST match the tracked repository namespace (`github.org`) — user-owned repos use a user-owned Project, org-owned repos use an org-owned Project, and cross-namespace Project ownership is rejected. `required` defaults to `false`, meaning Project membership is best-effort unless a later setup/doctor flow explicitly opts into strict mode.
 
+When that block is present, later setup/doctor and runtime validation must read the shared Project's owner + access before membership writes depend on it. Best-effort mode (`required: false`) reports warning-level validation failures and continues repository-local writes without Project membership; strict mode (`required: true`) reports the same failures as blocking errors and stops the write.
+
 No secrets go in config — the GitHub token lives in `gh`'s own store (`~/.config/gh/`) or the `GH_TOKEN` env var, never in `.lisa.config.json`.
 
 ### Step 5 — Offer to set top-level `tracker` / `source`

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -183,11 +183,19 @@ Each vendor section is **conditionally required**: required only when that vendo
 | `github.projects.v2.owner.kind` | GitHub Project coordination is enabled | Owner type for the shared ProjectV2. Supported values are `organization` and `user`. |
 | `github.projects.v2.owner.slug` | GitHub Project coordination is enabled | Owner login for the shared ProjectV2. In v1 it MUST match the tracked repository namespace (`github.org`); cross-namespace coordination is rejected. |
 | `github.projects.v2.number` | GitHub Project coordination is enabled | Human-facing ProjectV2 number from the GitHub UI / URL. Later utilities resolve the opaque node id from this owner + number pair. |
-| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. |
+| `github.projects.v2.required` | no | Coordination strictness flag. Default `false` keeps Project membership best-effort; `true` makes Project membership failures block the write. Setup/doctor/runtime validation reads Project ownership + access and branches on this flag: best-effort failures warn, required-mode failures stop the write. |
 
 When `tracker = "github"` AND `source = "github"` (self-host), both reads and writes hit the same GitHub repo. Label namespaces are kept separate so the two flows don't collide — see "Self-host edge case" below.
 
 `github.projects.v2` is optional. When absent, GitHub issue / PR writes remain repository-local exactly as they work today. When present, the shared Project is a coordination view layered on top of real issues and pull requests; it does not replace lifecycle labels, comments, dependencies, or native issue / PR state as Lisa's durable source of truth.
+
+When `github.projects.v2` is present, later setup/doctor and writer preflight validation MUST read the referenced Project's owner + access level before any membership write depends on it. The validation contract is:
+
+- Resolve the Project from `owner.kind`, `owner.slug`, and `number`.
+- Confirm the owner namespace still matches `github.org`; cross-namespace Project ownership is a configuration error.
+- Confirm the authenticated identity can read the Project and has sufficient access for membership coordination.
+- If `required = false`, surface Project-validation failures as warnings and continue repository-local issue / PR writes without Project membership.
+- If `required = true`, surface the same failures as blocking errors and stop the write before mutating issue / PR membership.
 
 #### `notion`
 

--- a/plugins/src/base/skills/setup-github/SKILL.md
+++ b/plugins/src/base/skills/setup-github/SKILL.md
@@ -172,6 +172,8 @@ If this project later enables shared GitHub Project coordination, store it under
 
 That block is optional and coordination-only: real issues and pull requests stay the durable source of truth. In v1, `github.projects.v2.owner.slug` MUST match the tracked repository namespace (`github.org`) — user-owned repos use a user-owned Project, org-owned repos use an org-owned Project, and cross-namespace Project ownership is rejected. `required` defaults to `false`, meaning Project membership is best-effort unless a later setup/doctor flow explicitly opts into strict mode.
 
+When that block is present, later setup/doctor and runtime validation must read the shared Project's owner + access before membership writes depend on it. Best-effort mode (`required: false`) reports warning-level validation failures and continues repository-local writes without Project membership; strict mode (`required: true`) reports the same failures as blocking errors and stops the write.
+
 No secrets go in config — the GitHub token lives in `gh`'s own store (`~/.config/gh/`) or the `GH_TOKEN` env var, never in `.lisa.config.json`.
 
 ### Step 5 — Offer to set top-level `tracker` / `source`

--- a/tests/unit/strategies/github-project-config-resolution.test.ts
+++ b/tests/unit/strategies/github-project-config-resolution.test.ts
@@ -1,11 +1,12 @@
 /**
  * Regression tests for the optional GitHub ProjectV2 coordination config.
  *
- * Issue #698 extends the canonical config-resolution schema with an optional
- * `github.projects.v2` block so later setup/doctor and writer utilities can
- * resolve a shared GitHub Project without changing the repository-local issue
- * model. V1 permits only namespace-matched ownership: the Project owner slug
- * must match the tracked repository namespace (`github.org`).
+ * Issues #698 and #699 extend the canonical GitHub ProjectV2 docs with an
+ * optional `github.projects.v2` block plus the validation semantics later
+ * setup/doctor and writer utilities must follow. V1 permits only
+ * namespace-matched ownership: the Project owner slug must match the tracked
+ * repository namespace (`github.org`). Validation reads owner/access and
+ * downgrades failures to warnings only when `required` remains false.
  *
  * Both source and generated plugin roots are asserted so a missed
  * `bun run build:plugins` fails the suite.
@@ -46,6 +47,15 @@ describe.each(RULE_ROOTS)(
         /Default `false` keeps Project membership best-effort/i
       );
     });
+
+    it("documents validation behavior for best-effort vs required mode", () => {
+      expect(content).toMatch(
+        /setup\/doctor and writer preflight validation MUST read/i
+      );
+      expect(content).toMatch(/owner \+ access/i);
+      expect(content).toMatch(/required = false.*warnings/i);
+      expect(content).toMatch(/required = true.*blocking errors/i);
+    });
   }
 );
 
@@ -71,6 +81,13 @@ describe.each(SKILL_ROOTS)(
       );
       expect(content).toMatch(/cross-namespace Project ownership is rejected/i);
       expect(content).toMatch(/best-effort unless .* opts into strict mode/i);
+    });
+
+    it("documents warning-vs-error validation behavior for project access", () => {
+      expect(content).toMatch(/setup\/doctor.*runtime validation.*must read/i);
+      expect(content).toMatch(/owner \+ access/i);
+      expect(content).toMatch(/required: false.*warning-level/i);
+      expect(content).toMatch(/required: true.*blocking errors/i);
     });
   }
 );


### PR DESCRIPTION
Closes #699

## Summary
- document GitHub ProjectV2 validation behavior for best-effort vs required mode
- clarify setup/doctor/runtime expectations for owner and access checks
- extend the regression test to assert the new validation contract in source and generated plugin docs

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/github-project-config-resolution.test.ts tests/unit/strategies/setup-github-prd-verified-label.test.ts tests/unit/strategies/repo-scope-claim.test.ts