### PR TITLE
feat(github): coordinate writer project membership

### DIFF
--- a/plugins/lisa/skills/github-write-issue/SKILL.md
+++ b/plugins/lisa/skills/github-write-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-write-issue
-description: "Creates or updates a GitHub Issue following the same organizational best practices as lisa:jira-write-ticket — three-audience description, Gherkin acceptance criteria, parent sub-issue (Epic/Story hierarchy), explicit relationship discovery, remote links, labels for status/components/priority/story-points, and Validation Journey. Uses the `gh` CLI exclusively (no MCP). Rejects thin issues. The GitHub counterpart of lisa:jira-write-ticket."
+description: "Creates or updates a GitHub Issue following the same organizational best practices as lisa:jira-write-ticket — three-audience description, Gherkin acceptance criteria, parent sub-issue (Epic/Story hierarchy), explicit relationship discovery, remote links, labels for status/components/priority/story-points, Validation Journey, and optional GitHub ProjectV2 coordination through lisa:github-project-v2 while keeping the Issue as the lifecycle source of truth. Uses the `gh` CLI exclusively (no MCP). Rejects thin issues. The GitHub counterpart of lisa:jira-write-ticket."
 allowed-tools: ["Bash", "Skill", "Read"]
 ---
 
@@ -268,6 +268,11 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
    If the GraphQL mutation isn't available on the repo (older GHES, sub-issues feature off), fall back to text linkage in the body (`Parent: #<parent>`) and surface a warning to the caller. Do NOT silently proceed without recording the parent.
 4. Phase 4b relationship lines (`Blocks #...`, `Blocked by #...`, etc.) are already in the body. No separate API call is needed — `lisa:github-read-issue` parses them on read.
 5. If the issue changes runtime behavior, invoke the `lisa:github-add-journey` skill to append the Validation Journey section.
+6. If `github.projects.v2` is enabled, resolve the created issue's node id and invoke `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <issue-node-id>`. This is membership coordination only — the GitHub Issue remains the lifecycle source of truth for labels, body, comments, and parentage.
+   - `outcome: disabled` → continue normally; no shared Project is configured.
+   - `outcome: reused` or `added` → continue normally; the issue is now present in the Project.
+   - `outcome: warning` (`required: false`) → preserve the exact warning and continue the issue write as success.
+   - `outcome: blocked` (`required: true`) → surface the exact failure and stop returning success; do not claim Project coordination succeeded silently.
 
 ### UPDATE
 
@@ -278,6 +283,7 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
    ```
 3. Add labels: `gh issue edit <number> --add-label "<new-label>"`. Remove labels: `--remove-label`.
 4. Add new relationship lines to `## Links` if needed. Existing links are not touched unless explicitly removed.
+5. Re-resolve the live issue node id and invoke `lisa:github-project-v2` with `operation: ensure-item` so updates keep the issue present in the configured shared Project without duplicating membership writes. Branch on `disabled` / `added` / `reused` / `warning` / `blocked` exactly as in CREATE.
 
 ## Phase 7 — Verify
 
@@ -328,3 +334,4 @@ The mapping below is the single source of truth for how JIRA concepts translate 
 - All writes go through this skill (or the `tracker-write` shim). Other vendor-neutral skills must NEVER call `gh issue create` directly.
 - The gate logic lives in `lisa:github-validate-issue`, NOT here. This skill calls the validator at Phase 5.5 and Phase 7. When a gate needs to change, change it in `lisa:github-validate-issue`.
 - Never bypass the sub-issue mutation by encoding the parent only in the body. The native sub-issue link is what `lisa:github-read-issue` and the GitHub UI use to render the hierarchy.
+- When GitHub Project coordination is enabled, always delegate membership to `lisa:github-project-v2`; never inline separate ProjectV2 GraphQL from this skill.

--- a/plugins/lisa/skills/github-write-prd/SKILL.md
+++ b/plugins/lisa/skills/github-write-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-write-prd
-description: "Creates or idempotently updates a PRD as a GitHub Issue in the configured source repo, carrying exactly one PRD lifecycle label (`prd-draft` by default, or `prd-ready` when initial_role is ready so lisa:github-prd-intake auto-claims it). The GitHub PRD-source writer behind lisa:prd-source-write — the source-side counterpart of lisa:github-write-issue. Dedupes by a stable marker embedded in the issue body (matched by marker, never by title) so re-running ideation references the existing PRD instead of opening a duplicate. Uses the `gh` CLI exclusively."
+description: "Creates or idempotently updates a PRD as a GitHub Issue in the configured source repo, carrying exactly one PRD lifecycle label (`prd-draft` by default, or `prd-ready` when initial_role is ready so lisa:github-prd-intake auto-claims it). The GitHub PRD-source writer behind lisa:prd-source-write — the source-side counterpart of lisa:github-write-issue. Dedupes by a stable marker embedded in the issue body (matched by marker, never by title) so re-running ideation references the existing PRD instead of opening a duplicate, and when `github.projects.v2` is enabled it coordinates PRD issue membership through `lisa:github-project-v2` without replacing the issue as the lifecycle source of truth. Uses the `gh` CLI exclusively."
 allowed-tools: ["Skill", "Bash"]
 ---
 
@@ -67,6 +67,12 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
    gh issue create --repo "$ORG/$REPO" --title "$TITLE" --body-file /tmp/prd-body.md --label "$ROLE_LABEL"
    ```
 3. Capture the returned issue number/URL.
+4. If `github.projects.v2` is enabled, resolve the created PRD issue node id and invoke
+   `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <issue-node-id>`.
+   - `outcome: disabled` → continue normally.
+   - `outcome: added` or `reused` → continue normally; membership is now present.
+   - `outcome: warning` (`required: false`) → preserve the exact warning and keep the PRD issue write as the durable success.
+   - `outcome: blocked` (`required: true`) → surface the exact failure and stop returning success; do not report Project coordination as completed.
 
 **UPDATE** (existing issue or `source_ref`):
 
@@ -77,6 +83,10 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
    `gh issue edit <n> --add-label / --remove-label`. Never leave a PRD carrying two lifecycle labels.
    - Exception: do **not** down-rank a PRD whose current label is in the resolved `${PROGRESSED[@]}`
      set (already past `ready`). If so, leave it and report `reused (already past ready)`.
+3. Re-resolve the live PRD issue node id and invoke `lisa:github-project-v2` with
+   `operation: ensure-item` so updates keep the PRD present in the configured shared Project without
+   duplicating membership writes. Branch on `disabled` / `added` / `reused` / `warning` / `blocked`
+   exactly as in CREATE.
 
 ## Phase 4 — Return
 
@@ -98,3 +108,4 @@ outcome: created | reused
 - A *closed* prior PRD does not suppress a new one — a recurrence after closure is a genuine new PRD.
 - This is a source-side writer (`prd-*` labels). It never touches build labels (`status:*`) — that is
   `lisa:github-write-issue`'s lane. See `config-resolution` "Self-host edge case".
+- When GitHub Project coordination is enabled, always delegate membership to `lisa:github-project-v2`; never inline separate ProjectV2 GraphQL from this skill.

--- a/plugins/src/base/skills/github-write-issue/SKILL.md
+++ b/plugins/src/base/skills/github-write-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-write-issue
-description: "Creates or updates a GitHub Issue following the same organizational best practices as lisa:jira-write-ticket — three-audience description, Gherkin acceptance criteria, parent sub-issue (Epic/Story hierarchy), explicit relationship discovery, remote links, labels for status/components/priority/story-points, and Validation Journey. Uses the `gh` CLI exclusively (no MCP). Rejects thin issues. The GitHub counterpart of lisa:jira-write-ticket."
+description: "Creates or updates a GitHub Issue following the same organizational best practices as lisa:jira-write-ticket — three-audience description, Gherkin acceptance criteria, parent sub-issue (Epic/Story hierarchy), explicit relationship discovery, remote links, labels for status/components/priority/story-points, Validation Journey, and optional GitHub ProjectV2 coordination through lisa:github-project-v2 while keeping the Issue as the lifecycle source of truth. Uses the `gh` CLI exclusively (no MCP). Rejects thin issues. The GitHub counterpart of lisa:jira-write-ticket."
 allowed-tools: ["Bash", "Skill", "Read"]
 ---
 
@@ -268,6 +268,11 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
    If the GraphQL mutation isn't available on the repo (older GHES, sub-issues feature off), fall back to text linkage in the body (`Parent: #<parent>`) and surface a warning to the caller. Do NOT silently proceed without recording the parent.
 4. Phase 4b relationship lines (`Blocks #...`, `Blocked by #...`, etc.) are already in the body. No separate API call is needed — `lisa:github-read-issue` parses them on read.
 5. If the issue changes runtime behavior, invoke the `lisa:github-add-journey` skill to append the Validation Journey section.
+6. If `github.projects.v2` is enabled, resolve the created issue's node id and invoke `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <issue-node-id>`. This is membership coordination only — the GitHub Issue remains the lifecycle source of truth for labels, body, comments, and parentage.
+   - `outcome: disabled` → continue normally; no shared Project is configured.
+   - `outcome: reused` or `added` → continue normally; the issue is now present in the Project.
+   - `outcome: warning` (`required: false`) → preserve the exact warning and continue the issue write as success.
+   - `outcome: blocked` (`required: true`) → surface the exact failure and stop returning success; do not claim Project coordination succeeded silently.
 
 ### UPDATE
 
@@ -278,6 +283,7 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
    ```
 3. Add labels: `gh issue edit <number> --add-label "<new-label>"`. Remove labels: `--remove-label`.
 4. Add new relationship lines to `## Links` if needed. Existing links are not touched unless explicitly removed.
+5. Re-resolve the live issue node id and invoke `lisa:github-project-v2` with `operation: ensure-item` so updates keep the issue present in the configured shared Project without duplicating membership writes. Branch on `disabled` / `added` / `reused` / `warning` / `blocked` exactly as in CREATE.
 
 ## Phase 7 — Verify
 
@@ -328,3 +334,4 @@ The mapping below is the single source of truth for how JIRA concepts translate 
 - All writes go through this skill (or the `tracker-write` shim). Other vendor-neutral skills must NEVER call `gh issue create` directly.
 - The gate logic lives in `lisa:github-validate-issue`, NOT here. This skill calls the validator at Phase 5.5 and Phase 7. When a gate needs to change, change it in `lisa:github-validate-issue`.
 - Never bypass the sub-issue mutation by encoding the parent only in the body. The native sub-issue link is what `lisa:github-read-issue` and the GitHub UI use to render the hierarchy.
+- When GitHub Project coordination is enabled, always delegate membership to `lisa:github-project-v2`; never inline separate ProjectV2 GraphQL from this skill.

--- a/plugins/src/base/skills/github-write-prd/SKILL.md
+++ b/plugins/src/base/skills/github-write-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-write-prd
-description: "Creates or idempotently updates a PRD as a GitHub Issue in the configured source repo, carrying exactly one PRD lifecycle label (`prd-draft` by default, or `prd-ready` when initial_role is ready so lisa:github-prd-intake auto-claims it). The GitHub PRD-source writer behind lisa:prd-source-write — the source-side counterpart of lisa:github-write-issue. Dedupes by a stable marker embedded in the issue body (matched by marker, never by title) so re-running ideation references the existing PRD instead of opening a duplicate. Uses the `gh` CLI exclusively."
+description: "Creates or idempotently updates a PRD as a GitHub Issue in the configured source repo, carrying exactly one PRD lifecycle label (`prd-draft` by default, or `prd-ready` when initial_role is ready so lisa:github-prd-intake auto-claims it). The GitHub PRD-source writer behind lisa:prd-source-write — the source-side counterpart of lisa:github-write-issue. Dedupes by a stable marker embedded in the issue body (matched by marker, never by title) so re-running ideation references the existing PRD instead of opening a duplicate, and when `github.projects.v2` is enabled it coordinates PRD issue membership through `lisa:github-project-v2` without replacing the issue as the lifecycle source of truth. Uses the `gh` CLI exclusively."
 allowed-tools: ["Skill", "Bash"]
 ---
 
@@ -67,6 +67,12 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
    gh issue create --repo "$ORG/$REPO" --title "$TITLE" --body-file /tmp/prd-body.md --label "$ROLE_LABEL"
    ```
 3. Capture the returned issue number/URL.
+4. If `github.projects.v2` is enabled, resolve the created PRD issue node id and invoke
+   `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <issue-node-id>`.
+   - `outcome: disabled` → continue normally.
+   - `outcome: added` or `reused` → continue normally; membership is now present.
+   - `outcome: warning` (`required: false`) → preserve the exact warning and keep the PRD issue write as the durable success.
+   - `outcome: blocked` (`required: true`) → surface the exact failure and stop returning success; do not report Project coordination as completed.
 
 **UPDATE** (existing issue or `source_ref`):
 
@@ -77,6 +83,10 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
    `gh issue edit <n> --add-label / --remove-label`. Never leave a PRD carrying two lifecycle labels.
    - Exception: do **not** down-rank a PRD whose current label is in the resolved `${PROGRESSED[@]}`
      set (already past `ready`). If so, leave it and report `reused (already past ready)`.
+3. Re-resolve the live PRD issue node id and invoke `lisa:github-project-v2` with
+   `operation: ensure-item` so updates keep the PRD present in the configured shared Project without
+   duplicating membership writes. Branch on `disabled` / `added` / `reused` / `warning` / `blocked`
+   exactly as in CREATE.
 
 ## Phase 4 — Return
 
@@ -98,3 +108,4 @@ outcome: created | reused
 - A *closed* prior PRD does not suppress a new one — a recurrence after closure is a genuine new PRD.
 - This is a source-side writer (`prd-*` labels). It never touches build labels (`status:*`) — that is
   `lisa:github-write-issue`'s lane. See `config-resolution` "Self-host edge case".
+- When GitHub Project coordination is enabled, always delegate membership to `lisa:github-project-v2`; never inline separate ProjectV2 GraphQL from this skill.

--- a/tests/unit/strategies/github-writer-project-membership.test.ts
+++ b/tests/unit/strategies/github-writer-project-membership.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression tests for GitHub writer integration with the shared ProjectV2
+ * coordination utility.
+ *
+ * Issue #701 threads `github-write-prd` and `github-write-issue` through
+ * `github-project-v2` so real GitHub Issues are added to the configured shared
+ * Project without replacing GitHub Issues as the lifecycle source of truth.
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/github-writer-project-membership
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const WRITERS = ["github-write-issue", "github-write-prd"] as const;
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+describe("github writer project membership", () => {
+  describe.each(WRITERS)("%s", writer => {
+    describe.each(ROOTS)("%s", root => {
+      const content = readSkill(root, writer);
+
+      it("delegates project membership through the shared utility", () => {
+        expect(content).toMatch(/lisa:github-project-v2/);
+        expect(content).toMatch(/operation:\s*ensure-item/i);
+        expect(content).toMatch(/content_node_id/i);
+      });
+
+      it("keeps GitHub Issues as the lifecycle source of truth", () => {
+        expect(content).toMatch(/lifecycle source of truth/i);
+        expect(content).toMatch(
+          /labels, body, comments|durable success|report Project coordination as completed/i
+        );
+      });
+
+      it("branches by required vs best-effort project mode", () => {
+        expect(content).toMatch(/outcome:\s*warning/i);
+        expect(content).toMatch(/required:\s*false/i);
+        expect(content).toMatch(/outcome:\s*blocked/i);
+        expect(content).toMatch(/required:\s*true/i);
+      });
+
+      it("reuses membership idempotently on update", () => {
+        expect(content).toMatch(/outcome:\s*reused|added` or `reused`/i);
+        expect(content).toMatch(
+          /without duplicating membership writes|membership is now present/i
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- route `github-write-issue` through `lisa:github-project-v2` when Project coordination is enabled
- route `github-write-prd` through the same membership utility with required-vs-best-effort branching
- add regression coverage for writer membership coordination and regenerate Lisa plugin skill artifacts

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/github-writer-project-membership.test.ts
- bun test tests/unit/strategies/github-project-v2-utility.test.ts tests/unit/strategies/prd-source-write.test.ts

Closes #701