### PR TITLE
feat(github): coordinate linked PR project membership

### DIFF
--- a/plugins/lisa/skills/git-submit-pr/SKILL.md
+++ b/plugins/lisa/skills/git-submit-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-submit-pr
-description: This skill should be used when pushing changes and creating or updating a pull request. It verifies the branch state, pushes to remote, creates or updates a PR with a comprehensive description, and enables auto-merge.
-allowed-tools: ["Bash", "mcp__github__create_pull_request", "mcp__github__get_pull_request", "mcp__github__update_pull_request"]
+description: This skill should be used when pushing changes and creating or updating a pull request. It verifies the branch state, pushes to remote, creates or updates a PR with a comprehensive description, optionally coordinates the resulting Pull Request into the configured GitHub ProjectV2, and enables auto-merge.
+allowed-tools: ["Bash", "Skill", "mcp__github__create_pull_request", "mcp__github__get_pull_request", "mcp__github__update_pull_request"]
 ---
 
 # Submit Pull Request Workflow
@@ -31,6 +31,7 @@ Recognized optional hints:
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
    - Include native development linkage for the source work item when `work_item_ref` can be inferred from `$ARGUMENTS`, the current branch name, an existing PR body, or the issue/ticket context passed by the caller.
+   - After the PR exists, re-resolve the live Pull Request node id and, when `github.projects.v2` is enabled, invoke `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <pull-request-node-id>` so linked pull requests join the configured shared Project without replacing the PR as the durable review/merge surface.
 5. **Auto-merge**: Choose merge strategy by PR type:
    - **Promotion PRs** (env → env, e.g. `dev` → `staging`): use `gh pr merge --auto --merge` (never squash). Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
    - **Feature PRs** (anything → `dev`): use `gh pr merge --auto --merge`.
@@ -60,6 +61,30 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 - **No supported provider**: Skip this section without error; do not invent references.
 
 When updating an existing PR, preserve any existing linkage line unless the new `work_item_ref` is more specific. Do not duplicate equivalent references.
+
+### GitHub ProjectV2 Coordination
+
+After PR creation or update, resolve the live Pull Request node id:
+
+```bash
+gh pr view <pr-number> --json id,url --jq '{ id, url }'
+```
+
+When `github.projects.v2` is enabled, delegate membership to `lisa:github-project-v2`:
+
+```text
+operation: ensure-item
+content_node_id: <pull-request-node-id>
+```
+
+Branch on the shared utility outcome exactly as GitHub Issue writers do:
+
+- `outcome: disabled` — no Project configured; continue normally.
+- `outcome: added` or `outcome: reused` — PR membership is now present; continue normally.
+- `outcome: warning` with `required: false` — preserve the exact Project error, keep the underlying PR creation/update as the durable success, and continue the normal auto-merge/watch flow.
+- `outcome: blocked` with `required: true` — surface the exact Project failure and treat the submit flow as blocked even if the PR already exists, so operators can fix Project access/config before reporting full success.
+
+Never inline separate `gh api graphql` ProjectV2 mutations here. All Pull Request membership coordination goes through `lisa:github-project-v2` so linked-PR flows and Issue writers stay in parity.
 
 ### PR Description Format
 

--- a/plugins/lisa/skills/github-project-v2/SKILL.md
+++ b/plugins/lisa/skills/github-project-v2/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: github-project-v2
-description: "Shared GitHub ProjectV2 coordination utility. Every GitHub writer or evidence flow that needs Project membership MUST delegate through this skill instead of inlining GraphQL. Resolves the configured ProjectV2 id from `github.projects.v2`, validates namespace + access, adds Issue or Pull Request node ids to the Project, optionally updates Project field values, and returns exact failures with best-effort vs required-mode branching."
+description: "Shared GitHub ProjectV2 coordination utility. Every GitHub writer or linked pull request flow that needs Project membership MUST delegate through this skill instead of inlining GraphQL. Resolves the configured ProjectV2 id from `github.projects.v2`, validates namespace + access, adds Issue or Pull Request node ids to the Project, optionally updates Project field values, and returns exact failures with best-effort vs required-mode branching."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
 # GitHub ProjectV2: $ARGUMENTS
 
 Single chokepoint for GitHub ProjectV2 coordination. Caller skills (`github-write-prd`,
-`github-write-issue`, linked-PR / evidence flows, later doctor/setup checks) MUST go through
+`github-write-issue`, `git-submit-pr`, later linked-PR flows, later doctor/setup checks) MUST go through
 this skill rather than duplicating `gh api graphql` calls.
 
 The utility never invents policy. It applies the config + validation contract already defined in

--- a/plugins/src/base/skills/git-submit-pr/SKILL.md
+++ b/plugins/src/base/skills/git-submit-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-submit-pr
-description: This skill should be used when pushing changes and creating or updating a pull request. It verifies the branch state, pushes to remote, creates or updates a PR with a comprehensive description, and enables auto-merge.
-allowed-tools: ["Bash", "mcp__github__create_pull_request", "mcp__github__get_pull_request", "mcp__github__update_pull_request"]
+description: This skill should be used when pushing changes and creating or updating a pull request. It verifies the branch state, pushes to remote, creates or updates a PR with a comprehensive description, optionally coordinates the resulting Pull Request into the configured GitHub ProjectV2, and enables auto-merge.
+allowed-tools: ["Bash", "Skill", "mcp__github__create_pull_request", "mcp__github__get_pull_request", "mcp__github__update_pull_request"]
 ---
 
 # Submit Pull Request Workflow
@@ -31,6 +31,7 @@ Recognized optional hints:
    - If exists: Update description with latest changes
    - If not: Create PR with comprehensive description (not a draft)
    - Include native development linkage for the source work item when `work_item_ref` can be inferred from `$ARGUMENTS`, the current branch name, an existing PR body, or the issue/ticket context passed by the caller.
+   - After the PR exists, re-resolve the live Pull Request node id and, when `github.projects.v2` is enabled, invoke `lisa:github-project-v2` with `operation: ensure-item` and `content_node_id: <pull-request-node-id>` so linked pull requests join the configured shared Project without replacing the PR as the durable review/merge surface.
 5. **Auto-merge**: Choose merge strategy by PR type:
    - **Promotion PRs** (env → env, e.g. `dev` → `staging`): use `gh pr merge --auto --merge` (never squash). Squashing flattens the constituent `chore(release): X.Y.Z [skip ci]` commits into one commit titled with the PR title, stripping the `[skip ci]` markers and breaking the release workflow's promotion-detection regex — the destination branch then double-bumps its version. `--merge` keeps each `chore(release)` commit (and its `[skip ci]` marker) intact under a clean merge commit subject the workflow can recognize.
    - **Feature PRs** (anything → `dev`): use `gh pr merge --auto --merge`.
@@ -60,6 +61,30 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 - **No supported provider**: Skip this section without error; do not invent references.
 
 When updating an existing PR, preserve any existing linkage line unless the new `work_item_ref` is more specific. Do not duplicate equivalent references.
+
+### GitHub ProjectV2 Coordination
+
+After PR creation or update, resolve the live Pull Request node id:
+
+```bash
+gh pr view <pr-number> --json id,url --jq '{ id, url }'
+```
+
+When `github.projects.v2` is enabled, delegate membership to `lisa:github-project-v2`:
+
+```text
+operation: ensure-item
+content_node_id: <pull-request-node-id>
+```
+
+Branch on the shared utility outcome exactly as GitHub Issue writers do:
+
+- `outcome: disabled` — no Project configured; continue normally.
+- `outcome: added` or `outcome: reused` — PR membership is now present; continue normally.
+- `outcome: warning` with `required: false` — preserve the exact Project error, keep the underlying PR creation/update as the durable success, and continue the normal auto-merge/watch flow.
+- `outcome: blocked` with `required: true` — surface the exact Project failure and treat the submit flow as blocked even if the PR already exists, so operators can fix Project access/config before reporting full success.
+
+Never inline separate `gh api graphql` ProjectV2 mutations here. All Pull Request membership coordination goes through `lisa:github-project-v2` so linked-PR flows and Issue writers stay in parity.
 
 ### PR Description Format
 

--- a/plugins/src/base/skills/github-project-v2/SKILL.md
+++ b/plugins/src/base/skills/github-project-v2/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: github-project-v2
-description: "Shared GitHub ProjectV2 coordination utility. Every GitHub writer or evidence flow that needs Project membership MUST delegate through this skill instead of inlining GraphQL. Resolves the configured ProjectV2 id from `github.projects.v2`, validates namespace + access, adds Issue or Pull Request node ids to the Project, optionally updates Project field values, and returns exact failures with best-effort vs required-mode branching."
+description: "Shared GitHub ProjectV2 coordination utility. Every GitHub writer or linked pull request flow that needs Project membership MUST delegate through this skill instead of inlining GraphQL. Resolves the configured ProjectV2 id from `github.projects.v2`, validates namespace + access, adds Issue or Pull Request node ids to the Project, optionally updates Project field values, and returns exact failures with best-effort vs required-mode branching."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
 # GitHub ProjectV2: $ARGUMENTS
 
 Single chokepoint for GitHub ProjectV2 coordination. Caller skills (`github-write-prd`,
-`github-write-issue`, linked-PR / evidence flows, later doctor/setup checks) MUST go through
+`github-write-issue`, `git-submit-pr`, later linked-PR flows, later doctor/setup checks) MUST go through
 this skill rather than duplicating `gh api graphql` calls.
 
 The utility never invents policy. It applies the config + validation contract already defined in

--- a/tests/unit/strategies/github-linked-pr-project-membership.test.ts
+++ b/tests/unit/strategies/github-linked-pr-project-membership.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for linked pull request ProjectV2 coordination.
+ *
+ * Issue #702 extends `git-submit-pr` so the live Pull Request created or
+ * updated for a GitHub work item is also added to the configured shared
+ * Project through `github-project-v2`, preserving the PR as the durable review
+ * and merge surface.
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/github-linked-pr-project-membership
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+describe.each(ROOTS)("git-submit-pr Project membership (%s)", root => {
+  const content = readFileSync(
+    path.resolve(root, "git-submit-pr", "SKILL.md"),
+    "utf8"
+  );
+
+  it("delegates pull request membership through the shared utility", () => {
+    expect(content).toMatch(/lisa:github-project-v2/);
+    expect(content).toMatch(/operation:\s*ensure-item/i);
+    expect(content).toMatch(/content_node_id/i);
+    expect(content).toMatch(/Pull Request node id/i);
+  });
+
+  it("treats the pull request as the durable success surface", () => {
+    expect(content).toMatch(
+      /underlying PR creation\/update as the durable success|PR as the durable review\/merge surface/i
+    );
+    expect(content).toMatch(/continue the normal auto-merge\/watch flow/i);
+  });
+
+  it("branches linked pull request Project failures by required mode", () => {
+    expect(content).toMatch(/outcome:\s*warning/i);
+    expect(content).toMatch(/required:\s*false/i);
+    expect(content).toMatch(/outcome:\s*blocked/i);
+    expect(content).toMatch(/required:\s*true/i);
+  });
+
+  it("resolves the live pull request node id instead of inlining GraphQL", () => {
+    expect(content).toMatch(/gh pr view <pr-number> --json id,url/i);
+    expect(content).toMatch(
+      /Never inline separate .*ProjectV2 mutations here/i
+    );
+  });
+});

--- a/tests/unit/strategies/github-project-v2-utility.test.ts
+++ b/tests/unit/strategies/github-project-v2-utility.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for the shared GitHub ProjectV2 utility contract.
  *
  * Issue #700 introduces a single chokepoint skill for Project membership so
- * `github-write-prd`, `github-write-issue`, and linked-PR/evidence flows do
+ * `github-write-prd`, `github-write-issue`, and linked pull request flows do
  * not duplicate GraphQL handling. The utility must resolve the configured
  * Project, add Issue or Pull Request node ids, optionally update Project
  * fields, and preserve exact GitHub failures while branching by `required`.
@@ -28,7 +28,7 @@ describe.each(ROOTS)("github-project-v2 utility (%s)", root => {
     expect(content).toMatch(/single chokepoint/i);
     expect(content).toMatch(/github-write-prd/i);
     expect(content).toMatch(/github-write-issue/i);
-    expect(content).toMatch(/linked-PR/i);
+    expect(content).toMatch(/git-submit-pr|linked-PR/i);
   });
 
   it("documents project resolution from github.projects.v2 config", () => {


### PR DESCRIPTION
## Summary
- thread `git-submit-pr` through `lisa:github-project-v2` so created or updated pull requests can join the configured shared ProjectV2
- document required-vs-best-effort branching for linked PR membership while keeping the PR as the durable review surface
- add regression coverage for the linked PR path and shared utility callers

Closes #702

## Test plan
- bun run build:plugins
- bun test tests/unit/strategies/github-linked-pr-project-membership.test.ts tests/unit/strategies/github-project-v2-utility.test.ts tests/unit/strategies/github-writer-project-membership.test.ts
- pre-push hook: eslint slow config, knip, vitest --coverage, vitest integration