### PR TITLE
docs(github): preserve multi-repo containers

### DIFF
--- a/plugins/lisa/skills/github-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/github-to-tracker/SKILL.md
@@ -198,7 +198,9 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` shim** (d
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The Epic is the canonical hub.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
-**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+The source GitHub PRD may span multiple repositories, and the Epics created from it may stay cross-repo when they are coordination containers rather than buildable leaf work.
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. Epics may span repositories; only the leaf work created later must collapse to one repo each. The build-ready label is applied only in Phase 5.
 
 Capture the returned epic ref — Phase 4 needs it as the parent for Stories.
 
@@ -227,13 +229,13 @@ For each Story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
-**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. Stories may span repositories when they coordinate work across repos; the build-ready label is applied only in Phase 5 to the per-repo leaves.
 
 Capture each returned story ref — Phase 5 needs it.
 
 ### Phase 5: Create Sub-tasks
 
-**Auto-split cross-repo work before delegation.** For each candidate sub-task, apply `lisa:task-decomposition` step 1.5: if the work touches more than one repo, split it into one sub-task per repo under the same parent Story (e.g., `[backend-api] Add field` + `[mobile-app] Display field`), and encode the producer-before-consumer ordering via dependencies. Work units that may span repos (Epic, Story, Spike) stay as planned; work units that must be single-repo (Bug, Task, Sub-task, Improvement) are split now. Splitting is this skill's responsibility — the validator's S10 gate is `product_relevant: false` because cross-repo failures are decomposition errors caught here, not product questions sent back to the PRD.
+**Auto-split cross-repo work before delegation.** For each candidate sub-task, apply `lisa:task-decomposition` step 1.5: if the work touches more than one repo, split it into one sub-task per repo under the same parent Story (e.g., `[backend-api] Add field` + `[mobile-app] Display field`), and encode the producer-before-consumer ordering via dependencies. The source GitHub PRD and its coordination containers (Epic, Story, Spike) may remain cross-repo. Build-ready work units may not: every Bug, Task, Sub-task, or Improvement written from this phase must resolve to exactly one repository. Splitting is this skill's responsibility — the validator's S10 gate is `product_relevant: false` because cross-repo failures are decomposition errors caught here, not product questions sent back to the PRD.
 
 Delegate sub-task creation to **parallel agents** (one per epic or batch of stories) for efficiency. **Every spawned agent must invoke `lisa:tracker-write` for each sub-task — no agent may call `lisa:jira-write-ticket` / `lisa:github-write-issue` / `gh issue create` directly.**
 

--- a/plugins/lisa/skills/task-decomposition/SKILL.md
+++ b/plugins/lisa/skills/task-decomposition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-decomposition
-description: "Methodology for breaking work into ordered tasks. Each task gets a single-repo scope, acceptance criteria, verification type, dependencies, and skills required."
+description: "Methodology for breaking work into ordered tasks. Cross-repo source PRDs and coordination containers stay cross-repo; each buildable leaf task gets a single-repo scope, acceptance criteria, verification type, dependencies, and skills required."
 ---
 
 # Task Decomposition
@@ -16,16 +16,23 @@ Break work into ordered, well-scoped tasks that can be independently implemented
 - Avoid tasks that are too large to complete in a single session
 - Avoid tasks that are too small to be meaningful (e.g., "add an import statement")
 
-### 1.5. Scope Each Unit to a Single Repository
+### 1.5. Preserve Cross-Repo Containers, Split Leaf Work by Repository
 
-Work units must be implementable inside a single repository. This is a hard invariant — downstream validators (`jira-validate-ticket`, `github-validate-issue`, `linear-validate-issue`) gate writes on it, so a cross-repo task will fail to be created.
+Start from the right shape:
 
-Apply this rule by issue type:
+- A source PRD may span multiple repositories.
+- Coordination containers may also span multiple repositories.
+- Buildable leaf work units must be implementable inside exactly one repository.
 
-| Issue type | Repo scope |
-|------------|-----------|
+That last point is a hard invariant — downstream validators (`jira-validate-ticket`, `github-validate-issue`, `linear-validate-issue`) gate writes on it, so a cross-repo leaf will fail to be created.
+
+Apply this rule by layer:
+
+| Layer | Repo scope |
+|-------|------------|
+| **PRD / source initiative** | MAY span repos — it describes the full initiative |
 | **Epic, Story, Spike** | MAY span repos — these are coordination containers |
-| **Task, Bug, Sub-task, Improvement** | MUST name exactly one repo — these are work units |
+| **Task, Bug, Sub-task, Improvement** | MUST name exactly one repo — these are buildable leaf work units |
 
 If a candidate work unit naturally touches multiple repos (e.g., "add field to backend API and consume it in mobile app"), do not write it as one ticket. Instead:
 
@@ -36,7 +43,7 @@ If a candidate work unit naturally touches multiple repos (e.g., "add field to b
 
 Reject any work unit whose acceptance criteria reference behavior in a different repo from the one it's scoped to. If you find yourself writing "and the frontend should also...", that's a signal to split.
 
-This is the **decomposition-time** strategy (greenfield — you are creating the tickets now, so a parent Story + per-repo children is the natural shape). It is distinct from the **work-time** strategy in the `repo-scope-split` rule, which applies when an agent picks up an *already-existing* ticket to implement and discovers it spans repos: there it narrows the original in place and spins off sibling work units rather than introducing a new parent. Use the phase-appropriate one; do not mix them.
+This is the **decomposition-time** strategy (greenfield — you are creating the tickets now, so a cross-repo PRD can stay whole, its Epic/Story/Spike containers can stay cross-repo, and a parent Story + per-repo children is the natural shape). It is distinct from the **work-time** strategy in the `repo-scope-split` rule, which applies when an agent picks up an *already-existing leaf ticket* to implement and discovers it spans repos: there it narrows the original in place and spins off sibling work units rather than introducing a new parent. Use the phase-appropriate one; do not mix them.
 
 ### 2. Define Acceptance Criteria
 

--- a/plugins/src/base/skills/github-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/github-to-tracker/SKILL.md
@@ -198,7 +198,9 @@ For each epic identified in Phase 1, **invoke the `lisa:tracker-write` shim** (d
 - `artifacts`: the full Phase 1.5 artifact list — every artifact, regardless of domain. The Epic is the canonical hub.
 - `priority`, `labels`, `components`, `fix_version`: as appropriate
 
-**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. The build-ready label is applied only in Phase 5.
+The source GitHub PRD may span multiple repositories, and the Epics created from it may stay cross-repo when they are coordination containers rather than buildable leaf work.
+
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: an Epic is a container, not a leaf work unit. Do NOT mark it build-ready — `lisa:tracker-write` must not be passed `status:ready` for an Epic, and the Epic's lifecycle state rolls up from its children. Epics may span repositories; only the leaf work created later must collapse to one repo each. The build-ready label is applied only in Phase 5.
 
 Capture the returned epic ref — Phase 4 needs it as the parent for Stories.
 
@@ -227,13 +229,13 @@ For each Story, **invoke `lisa:tracker-write`** with:
 | Infrastructure | `ops`, `reference` |
 | Mixed / setup ("X.0") | All domains |
 
-**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. The build-ready label is applied only in Phase 5.
+**Leaf-only build-ready (`leaf-only-lifecycle`)**: a Story is a container (it has child Sub-tasks), not a leaf work unit. Do NOT mark it build-ready — never pass `status:ready` to `lisa:tracker-write` for a Story. Its lifecycle state rolls up from its Sub-tasks. Stories may span repositories when they coordinate work across repos; the build-ready label is applied only in Phase 5 to the per-repo leaves.
 
 Capture each returned story ref — Phase 5 needs it.
 
 ### Phase 5: Create Sub-tasks
 
-**Auto-split cross-repo work before delegation.** For each candidate sub-task, apply `lisa:task-decomposition` step 1.5: if the work touches more than one repo, split it into one sub-task per repo under the same parent Story (e.g., `[backend-api] Add field` + `[mobile-app] Display field`), and encode the producer-before-consumer ordering via dependencies. Work units that may span repos (Epic, Story, Spike) stay as planned; work units that must be single-repo (Bug, Task, Sub-task, Improvement) are split now. Splitting is this skill's responsibility — the validator's S10 gate is `product_relevant: false` because cross-repo failures are decomposition errors caught here, not product questions sent back to the PRD.
+**Auto-split cross-repo work before delegation.** For each candidate sub-task, apply `lisa:task-decomposition` step 1.5: if the work touches more than one repo, split it into one sub-task per repo under the same parent Story (e.g., `[backend-api] Add field` + `[mobile-app] Display field`), and encode the producer-before-consumer ordering via dependencies. The source GitHub PRD and its coordination containers (Epic, Story, Spike) may remain cross-repo. Build-ready work units may not: every Bug, Task, Sub-task, or Improvement written from this phase must resolve to exactly one repository. Splitting is this skill's responsibility — the validator's S10 gate is `product_relevant: false` because cross-repo failures are decomposition errors caught here, not product questions sent back to the PRD.
 
 Delegate sub-task creation to **parallel agents** (one per epic or batch of stories) for efficiency. **Every spawned agent must invoke `lisa:tracker-write` for each sub-task — no agent may call `lisa:jira-write-ticket` / `lisa:github-write-issue` / `gh issue create` directly.**
 

--- a/plugins/src/base/skills/task-decomposition/SKILL.md
+++ b/plugins/src/base/skills/task-decomposition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-decomposition
-description: "Methodology for breaking work into ordered tasks. Each task gets a single-repo scope, acceptance criteria, verification type, dependencies, and skills required."
+description: "Methodology for breaking work into ordered tasks. Cross-repo source PRDs and coordination containers stay cross-repo; each buildable leaf task gets a single-repo scope, acceptance criteria, verification type, dependencies, and skills required."
 ---
 
 # Task Decomposition
@@ -16,16 +16,23 @@ Break work into ordered, well-scoped tasks that can be independently implemented
 - Avoid tasks that are too large to complete in a single session
 - Avoid tasks that are too small to be meaningful (e.g., "add an import statement")
 
-### 1.5. Scope Each Unit to a Single Repository
+### 1.5. Preserve Cross-Repo Containers, Split Leaf Work by Repository
 
-Work units must be implementable inside a single repository. This is a hard invariant — downstream validators (`jira-validate-ticket`, `github-validate-issue`, `linear-validate-issue`) gate writes on it, so a cross-repo task will fail to be created.
+Start from the right shape:
 
-Apply this rule by issue type:
+- A source PRD may span multiple repositories.
+- Coordination containers may also span multiple repositories.
+- Buildable leaf work units must be implementable inside exactly one repository.
 
-| Issue type | Repo scope |
-|------------|-----------|
+That last point is a hard invariant — downstream validators (`jira-validate-ticket`, `github-validate-issue`, `linear-validate-issue`) gate writes on it, so a cross-repo leaf will fail to be created.
+
+Apply this rule by layer:
+
+| Layer | Repo scope |
+|-------|------------|
+| **PRD / source initiative** | MAY span repos — it describes the full initiative |
 | **Epic, Story, Spike** | MAY span repos — these are coordination containers |
-| **Task, Bug, Sub-task, Improvement** | MUST name exactly one repo — these are work units |
+| **Task, Bug, Sub-task, Improvement** | MUST name exactly one repo — these are buildable leaf work units |
 
 If a candidate work unit naturally touches multiple repos (e.g., "add field to backend API and consume it in mobile app"), do not write it as one ticket. Instead:
 
@@ -36,7 +43,7 @@ If a candidate work unit naturally touches multiple repos (e.g., "add field to b
 
 Reject any work unit whose acceptance criteria reference behavior in a different repo from the one it's scoped to. If you find yourself writing "and the frontend should also...", that's a signal to split.
 
-This is the **decomposition-time** strategy (greenfield — you are creating the tickets now, so a parent Story + per-repo children is the natural shape). It is distinct from the **work-time** strategy in the `repo-scope-split` rule, which applies when an agent picks up an *already-existing* ticket to implement and discovers it spans repos: there it narrows the original in place and spins off sibling work units rather than introducing a new parent. Use the phase-appropriate one; do not mix them.
+This is the **decomposition-time** strategy (greenfield — you are creating the tickets now, so a cross-repo PRD can stay whole, its Epic/Story/Spike containers can stay cross-repo, and a parent Story + per-repo children is the natural shape). It is distinct from the **work-time** strategy in the `repo-scope-split` rule, which applies when an agent picks up an *already-existing leaf ticket* to implement and discovers it spans repos: there it narrows the original in place and spins off sibling work units rather than introducing a new parent. Use the phase-appropriate one; do not mix them.
 
 ### 2. Define Acceptance Criteria
 

--- a/tests/unit/strategies/multi-repo-container-decomposition.test.ts
+++ b/tests/unit/strategies/multi-repo-container-decomposition.test.ts
@@ -20,27 +20,26 @@ const readSkill = (root: string, skill: string): string =>
   readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
 
 describe("task-decomposition preserves cross-repo containers", () => {
-  const content = readFileSync(
-    path.resolve("plugins/src/base/skills/task-decomposition/SKILL.md"),
-    "utf8"
-  );
+  describe.each(ROOTS)("%s", root => {
+    const content = readSkill(root, "task-decomposition");
 
-  it("allows the source PRD and containers to span repositories", () => {
-    expect(content).toMatch(/PRD.*MAY span repos/i);
-    expect(content).toMatch(/Epic, Story, Spike.*MAY span repos/i);
-  });
+    it("allows the source PRD and containers to span repositories", () => {
+      expect(content).toMatch(/PRD.*MAY span repos/i);
+      expect(content).toMatch(/Epic, Story, Spike.*MAY span repos/i);
+    });
 
-  it("requires every buildable leaf work unit to name exactly one repo", () => {
-    expect(content).toMatch(
-      /Task, Bug, Sub-task, Improvement.*MUST name exactly one repo/i
-    );
-    expect(content).toMatch(/buildable leaf work units/i);
-  });
+    it("requires every buildable leaf work unit to name exactly one repo", () => {
+      expect(content).toMatch(
+        /Task, Bug, Sub-task, Improvement.*MUST name exactly one repo/i
+      );
+      expect(content).toMatch(/buildable leaf work units/i);
+    });
 
-  it("keeps decomposition-time and work-time repo splitting distinct", () => {
-    expect(content).toMatch(/decomposition-time/i);
-    expect(content).toMatch(/work-time/i);
-    expect(content).toMatch(/already-existing leaf ticket/i);
+    it("keeps decomposition-time and work-time repo splitting distinct", () => {
+      expect(content).toMatch(/decomposition-time/i);
+      expect(content).toMatch(/work-time/i);
+      expect(content).toMatch(/already-existing leaf ticket/i);
+    });
   });
 });
 

--- a/tests/unit/strategies/multi-repo-container-decomposition.test.ts
+++ b/tests/unit/strategies/multi-repo-container-decomposition.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression tests for decomposition-time multi-repo container guidance.
+ *
+ * Issue #703 clarifies that a source PRD and coordination containers may span
+ * repositories, while every build-ready leaf work unit must still resolve to
+ * exactly one repository before ticket creation.
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/multi-repo-container-decomposition
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+describe("task-decomposition preserves cross-repo containers", () => {
+  const content = readFileSync(
+    path.resolve("plugins/src/base/skills/task-decomposition/SKILL.md"),
+    "utf8"
+  );
+
+  it("allows the source PRD and containers to span repositories", () => {
+    expect(content).toMatch(/PRD.*MAY span repos/i);
+    expect(content).toMatch(/Epic, Story, Spike.*MAY span repos/i);
+  });
+
+  it("requires every buildable leaf work unit to name exactly one repo", () => {
+    expect(content).toMatch(
+      /Task, Bug, Sub-task, Improvement.*MUST name exactly one repo/i
+    );
+    expect(content).toMatch(/buildable leaf work units/i);
+  });
+
+  it("keeps decomposition-time and work-time repo splitting distinct", () => {
+    expect(content).toMatch(/decomposition-time/i);
+    expect(content).toMatch(/work-time/i);
+    expect(content).toMatch(/already-existing leaf ticket/i);
+  });
+});
+
+describe("github-to-tracker keeps multi-repo containers but splits leaves", () => {
+  describe.each(ROOTS)("%s", root => {
+    const content = readSkill(root, "github-to-tracker");
+
+    it("allows the source PRD and containers to remain cross-repo", () => {
+      expect(content).toMatch(/PRD may span multiple repositories/i);
+      expect(content).toMatch(/Epics.*may stay cross-repo/i);
+      expect(content).toMatch(/Stories may span repositories/i);
+    });
+
+    it("restricts build-ready leaves to one repository each", () => {
+      expect(content).toMatch(
+        /every Bug, Task, Sub-task, or Improvement.*exactly one repository/i
+      );
+      expect(content).toMatch(/status:ready/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- clarify that source PRDs plus Epic/Story/Spike containers may stay cross-repo during decomposition\n- keep build-ready Bug/Task/Sub-task/Improvement leaves single-repo in github-to-tracker guidance\n- add regression coverage for the multi-repo container vs single-repo leaf contract\n\n## Testing\n- bun run build:plugins\n- bun test tests/unit/strategies/multi-repo-container-decomposition.test.ts\n- bun test tests/unit/strategies/leaf-only-build-ready.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified cross-repo rules for Epics, Stories, and Sub-tasks; coordination containers may span repos while build-ready is applied only to per-repo leaf work in Phase 5
  * Tightened guidance on splitting multi-repo work into per-repo leaf tasks, including layer-by-layer scoping and decomposition-time vs work-time rules

* **Tests**
  * Added regression tests covering multi-repo decomposition and enforcement that build-ready leaf units resolve to a single repository

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->