### PR TITLE
docs(setup-github): validate project coordination setup

### DIFF
--- a/plugins/lisa/skills/setup-github/SKILL.md
+++ b/plugins/lisa/skills/setup-github/SKILL.md
@@ -202,6 +202,55 @@ gh label list --repo "$ORG/$REPO" --limit 200 --json name --jq '.[].name' \
   | grep -E 'status:|prd-' || true   # show the scaffolded namespaces
 ```
 
+If `github.projects.v2` is configured, setup verification MUST also run the shared Project utility in
+read-only resolution mode before declaring success:
+
+```text
+operation: resolve-project
+```
+
+This is the setup/doctor chokepoint for GitHub Project coordination. Do not inline ad-hoc GraphQL
+here; delegate to `lisa:github-project-v2` so setup, doctor, writers, and linked-PR flows all read
+the same owner/access contract and surface the same exact failure text.
+
+Verification contract when `github.projects.v2` is present:
+
+- First enforce the v1 namespace rule locally: `github.projects.v2.owner.slug` MUST equal
+  `github.org`. If not, report the exact configuration failure and remediation:
+
+  ```yaml
+  code: project_namespace_mismatch
+  message: "github.projects.v2.owner.slug must match github.org in v1"
+  remediation: "Use a Project owned by <github.org> or remove github.projects.v2."
+  ```
+
+- Then resolve the configured Project owner + number through `lisa:github-project-v2`.
+- Preserve the exact GitHub / GraphQL failure text for inaccessible or unsupported Project
+  configurations. Examples: missing Project, `Resource not accessible by integration`, unsupported
+  owner kind, or any other Project read failure.
+- Report the exact remediation path. At minimum, say whether the operator must:
+  1. choose a Project owned by the tracked repo namespace,
+  2. grant the token Project read/write access,
+  3. correct the configured Project number/owner, or
+  4. remove `github.projects.v2` if coordination is not required.
+- Branch severity on `required` exactly the same way the shared utility does:
+  `required: false` => warning-level validation failure, continue repository-local setup success;
+  `required: true` => blocking verification failure, stop setup/doctor before claiming coordination
+  is usable.
+
+The verify output should make the operator's next step obvious. Good examples:
+
+```text
+WARNING github.projects.v2: Resource not accessible by integration
+Remediation: grant the token Project read/write access or remove github.projects.v2.required.
+Repository-local GitHub issue/PR flows remain usable; Project coordination is disabled.
+```
+
+```text
+ERROR github.projects.v2: github.projects.v2.owner.slug must match github.org in v1
+Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
+```
+
 Report success with the resolved `org/repo`, which label namespaces were scaffolded (and which labels already existed vs. were created), any non-default label overrides written, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency

--- a/plugins/src/base/skills/setup-github/SKILL.md
+++ b/plugins/src/base/skills/setup-github/SKILL.md
@@ -202,6 +202,55 @@ gh label list --repo "$ORG/$REPO" --limit 200 --json name --jq '.[].name' \
   | grep -E 'status:|prd-' || true   # show the scaffolded namespaces
 ```
 
+If `github.projects.v2` is configured, setup verification MUST also run the shared Project utility in
+read-only resolution mode before declaring success:
+
+```text
+operation: resolve-project
+```
+
+This is the setup/doctor chokepoint for GitHub Project coordination. Do not inline ad-hoc GraphQL
+here; delegate to `lisa:github-project-v2` so setup, doctor, writers, and linked-PR flows all read
+the same owner/access contract and surface the same exact failure text.
+
+Verification contract when `github.projects.v2` is present:
+
+- First enforce the v1 namespace rule locally: `github.projects.v2.owner.slug` MUST equal
+  `github.org`. If not, report the exact configuration failure and remediation:
+
+  ```yaml
+  code: project_namespace_mismatch
+  message: "github.projects.v2.owner.slug must match github.org in v1"
+  remediation: "Use a Project owned by <github.org> or remove github.projects.v2."
+  ```
+
+- Then resolve the configured Project owner + number through `lisa:github-project-v2`.
+- Preserve the exact GitHub / GraphQL failure text for inaccessible or unsupported Project
+  configurations. Examples: missing Project, `Resource not accessible by integration`, unsupported
+  owner kind, or any other Project read failure.
+- Report the exact remediation path. At minimum, say whether the operator must:
+  1. choose a Project owned by the tracked repo namespace,
+  2. grant the token Project read/write access,
+  3. correct the configured Project number/owner, or
+  4. remove `github.projects.v2` if coordination is not required.
+- Branch severity on `required` exactly the same way the shared utility does:
+  `required: false` => warning-level validation failure, continue repository-local setup success;
+  `required: true` => blocking verification failure, stop setup/doctor before claiming coordination
+  is usable.
+
+The verify output should make the operator's next step obvious. Good examples:
+
+```text
+WARNING github.projects.v2: Resource not accessible by integration
+Remediation: grant the token Project read/write access or remove github.projects.v2.required.
+Repository-local GitHub issue/PR flows remain usable; Project coordination is disabled.
+```
+
+```text
+ERROR github.projects.v2: github.projects.v2.owner.slug must match github.org in v1
+Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
+```
+
 Report success with the resolved `org/repo`, which label namespaces were scaffolded (and which labels already existed vs. were created), any non-default label overrides written, and whether `tracker` / `source` were set. Direct the user to `/lisa:intake` to test.
 
 ## Idempotency

--- a/tests/unit/strategies/setup-github-project-verification.test.ts
+++ b/tests/unit/strategies/setup-github-project-verification.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for setup/doctor verification of optional GitHub ProjectV2
+ * coordination.
+ *
+ * Issue #705 extends `setup-github` so setup-time validation does not stop at
+ * writing config and labels. When `github.projects.v2` is configured, setup
+ * verification must run the shared `github-project-v2` utility in
+ * `resolve-project` mode, preserve exact owner/access failures, and branch
+ * severity on `required` so operators get an exact remediation path before they
+ * rely on Project coordination.
+ *
+ * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
+ * suite.
+ * @module tests/unit/strategies/setup-github-project-verification
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "setup-github", "SKILL.md"), "utf8");
+
+describe.each(ROOTS)("setup-github Project verification (%s)", root => {
+  const content = readSkill(root);
+
+  it("runs shared Project resolution during setup verification", () => {
+    expect(content).toMatch(/Step 6 .*Verify/s);
+    expect(content).toMatch(/operation:\s*resolve-project/i);
+    expect(content).toMatch(/delegate to `lisa:github-project-v2`/i);
+  });
+
+  it("documents exact namespace-mismatch failure text and remediation", () => {
+    expect(content).toMatch(/code:\s*project_namespace_mismatch/i);
+    expect(content).toMatch(
+      /message:\s*"github\.projects\.v2\.owner\.slug must match github\.org in v1"/i
+    );
+    expect(content).toMatch(/Use a Project owned by <github\.org>/i);
+  });
+
+  it("requires exact owner-access failures and remediation paths", () => {
+    expect(content).toMatch(/exact GitHub \/ GraphQL failure text/i);
+    expect(content).toMatch(/Resource not accessible by integration/i);
+    expect(content).toMatch(/grant the token Project read\/write access/i);
+    expect(content).toMatch(/correct the configured Project number\/owner/i);
+  });
+
+  it("branches setup verification severity on required mode", () => {
+    expect(content).toMatch(
+      /required:\s*false.*warning-level validation failure/i
+    );
+    expect(content).toMatch(/required:\s*true.*blocking verification failure/i);
+    expect(content).toMatch(
+      /Repository-local GitHub issue\/PR flows remain usable/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- require setup-github verification to run shared GitHub ProjectV2 resolution when coordination is configured
- document exact namespace, access, and remediation failures plus required-vs-warning behavior
- add a regression test covering the setup/doctor Project verification contract

## Testing
- bun test tests/unit/strategies/setup-github-project-verification.test.ts tests/unit/strategies/github-project-config-resolution.test.ts tests/unit/strategies/github-project-v2-utility.test.ts
- pre-push hooks: bun audit, eslint slow config, knip, vitest run --coverage, vitest run tests/integration

Closes #705