### PR TITLE
feat: add usage accounting contract

### DIFF
--- a/plugins/lisa/rules/usage-accounting.md
+++ b/plugins/lisa/rules/usage-accounting.md
@@ -1,0 +1,135 @@
+# Usage Accounting
+
+Lisa usage accounting is a vendor-neutral contract for attaching AI usage and cost telemetry to the artifacts Lisa creates or updates. It governs the section shape, machine-readable tokens, source/pricing semantics, rollup behavior, and idempotent rewrite rules. Writer skills and lifecycle skills attach telemetry by following this contract; they do not invent artifact-local formats.
+
+## Managed section
+
+Artifacts that support inline body/description content use a single managed section:
+
+```markdown
+## Lisa Usage
+```
+
+The section is canonical. Rewrite it in place; never append a second usage section under a different heading. If an artifact host cannot safely edit the body, write the same section format in a comment instead and treat that comment body as the managed usage artifact for future rewrites.
+
+The visible body is for humans; the hidden tokens are for machines. Both are required.
+
+## Direct-entry schema
+
+Each direct usage entry records one logical Lisa run or sub-run on one artifact. The required semantic fields are:
+
+| Field | Meaning |
+|---|---|
+| `entry_id` | Stable dedupe key for this logical usage entry. Unique within the artifact graph. |
+| `flow` | `research`, `plan`, `implement`, `verify`, `debrief`, `intake`, `repair-intake`, `monitor`, or a command slug. |
+| `run_id` | Runtime/session identifier when available; empty only when the runtime exposes no stable run id. |
+| `provider` | Model provider name. |
+| `model` | Model identifier. |
+| `source` | `observed`, `estimated`, or `unavailable`. |
+| `input_tokens` | Prompt/input tokens, or `null` when unavailable. |
+| `cached_input_tokens` | Cached/reused input tokens, or `null` when unavailable/not exposed. |
+| `output_tokens` | Output/completion tokens, or `null` when unavailable. |
+| `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
+| `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
+| `cost` | Observed or estimated cost for this entry, or `null`. |
+| `currency` | ISO currency code when `cost` is known, otherwise `null`. |
+| `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
+| `pricing_source` | Runtime billing source, config/pricing snapshot ref, or `null`. |
+| `artifact_ref` | Canonical ref of the artifact carrying the entry. |
+| `parent_artifact_ref` | Canonical parent artifact ref when the entry is attached below a parent, otherwise empty. |
+
+`entry_id` must be stable across rewrites of the same logical run. Rewriting an existing entry with the same `entry_id` updates it in place. A different run gets a different `entry_id` and is appended as a new direct entry.
+
+## Source semantics
+
+`source` describes how trustworthy the token counts are:
+
+- `observed`: the runtime supplied the usage directly. Do not replace observed counts with estimates.
+- `estimated`: Lisa derived counts or cost from trustworthy runtime metadata plus an explicit pricing contract. Estimates are allowed only when the derivation inputs are real and attributable to the run.
+- `unavailable`: Lisa could not obtain trustworthy usage data. Write the entry anyway with `null` token/cost fields rather than silently omitting the row.
+
+The absence of data is never treated as zero. `null` means unknown; `0` means explicitly observed or derived zero.
+
+## Pricing semantics
+
+`pricing_status` describes how trustworthy the money fields are:
+
+- `observed`: runtime supplied a trustworthy monetary cost.
+- `estimated`: Lisa calculated cost from trustworthy token counts plus explicit pricing metadata.
+- `missing`: token counts are known but no trustworthy price source exists yet.
+- `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
+
+Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+
+## Machine-readable tokens
+
+Every visible direct entry row ends with exactly one machine-readable token:
+
+```text
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+```
+
+Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions.
+
+Every managed section also ends with exactly one rollup token:
+
+```text
+<!-- lisa:usage-rollup direct_entry_ids=<csv> child_entry_ids=<csv> child_refs=<csv> direct_tokens=<n|null> child_tokens=<n|null> total_tokens=<n|null> direct_cost=<decimal|null> child_cost=<decimal|null> total_cost=<decimal|null> currency=<code|null> -->
+```
+
+- `direct_entry_ids` enumerates the entries attached directly to the current artifact.
+- `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
+- `child_refs` enumerates the child artifacts consulted for the rollup.
+- `total_*` fields equal direct plus child totals over the deduped entry set.
+
+The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans.
+
+## Visible rendering contract
+
+The canonical body layout is:
+
+```markdown
+## Lisa Usage
+
+_Managed by Lisa. Regenerated on each usage update; do not edit by hand._
+
+### Direct Usage
+
+| Flow | Model | Source | Tokens | Cost |
+|---|---|---|---:|---:|
+| ...human-readable rows ending with `lisa:usage-entry` tokens... |
+
+### Rollup
+
+| Scope | Tokens | Cost |
+|---|---:|---:|
+| Direct | ... | ... |
+| Child | ... | ... |
+| Total | ... | ... |
+
+<!-- lisa:usage-rollup ... -->
+```
+
+Writers may add host-specific surrounding prose, but they must preserve the heading, the managed-note line, the direct-entry tokens, and the single rollup token.
+
+## Rollup and dedupe behavior
+
+Rollups aggregate descendant usage from native tracker hierarchy, documented generated-work references, and explicit `parent_artifact_ref` links. Within one artifact rollup:
+
+- Dedupe strictly by stable `entry_id`.
+- Count each `entry_id` at most once even if the same descendant is discoverable through more than one path.
+- Preserve direct totals separately from child totals.
+- Exclude descendant entries whose `entry_id` is already present in the artifact's direct-entry set.
+
+The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Stories/leaves, and leaves may roll up evidence or verification artifacts, without double counting shared descendants.
+
+## Idempotent rewrite rules
+
+- There is exactly one managed `## Lisa Usage` section per artifact body/comment.
+- Recompute the entire section on every write; never append ad hoc rows.
+- Sort direct entries deterministically by `(flow, run_id, entry_id)`.
+- Preserve existing entries with unchanged `entry_id` and refreshed field values.
+- Re-running with the same logical entry set must produce byte-identical output.
+- Do not include timestamps in the section preamble or token lines.
+
+Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/plugins/src/base/rules/usage-accounting.md
+++ b/plugins/src/base/rules/usage-accounting.md
@@ -1,0 +1,135 @@
+# Usage Accounting
+
+Lisa usage accounting is a vendor-neutral contract for attaching AI usage and cost telemetry to the artifacts Lisa creates or updates. It governs the section shape, machine-readable tokens, source/pricing semantics, rollup behavior, and idempotent rewrite rules. Writer skills and lifecycle skills attach telemetry by following this contract; they do not invent artifact-local formats.
+
+## Managed section
+
+Artifacts that support inline body/description content use a single managed section:
+
+```markdown
+## Lisa Usage
+```
+
+The section is canonical. Rewrite it in place; never append a second usage section under a different heading. If an artifact host cannot safely edit the body, write the same section format in a comment instead and treat that comment body as the managed usage artifact for future rewrites.
+
+The visible body is for humans; the hidden tokens are for machines. Both are required.
+
+## Direct-entry schema
+
+Each direct usage entry records one logical Lisa run or sub-run on one artifact. The required semantic fields are:
+
+| Field | Meaning |
+|---|---|
+| `entry_id` | Stable dedupe key for this logical usage entry. Unique within the artifact graph. |
+| `flow` | `research`, `plan`, `implement`, `verify`, `debrief`, `intake`, `repair-intake`, `monitor`, or a command slug. |
+| `run_id` | Runtime/session identifier when available; empty only when the runtime exposes no stable run id. |
+| `provider` | Model provider name. |
+| `model` | Model identifier. |
+| `source` | `observed`, `estimated`, or `unavailable`. |
+| `input_tokens` | Prompt/input tokens, or `null` when unavailable. |
+| `cached_input_tokens` | Cached/reused input tokens, or `null` when unavailable/not exposed. |
+| `output_tokens` | Output/completion tokens, or `null` when unavailable. |
+| `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
+| `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
+| `cost` | Observed or estimated cost for this entry, or `null`. |
+| `currency` | ISO currency code when `cost` is known, otherwise `null`. |
+| `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
+| `pricing_source` | Runtime billing source, config/pricing snapshot ref, or `null`. |
+| `artifact_ref` | Canonical ref of the artifact carrying the entry. |
+| `parent_artifact_ref` | Canonical parent artifact ref when the entry is attached below a parent, otherwise empty. |
+
+`entry_id` must be stable across rewrites of the same logical run. Rewriting an existing entry with the same `entry_id` updates it in place. A different run gets a different `entry_id` and is appended as a new direct entry.
+
+## Source semantics
+
+`source` describes how trustworthy the token counts are:
+
+- `observed`: the runtime supplied the usage directly. Do not replace observed counts with estimates.
+- `estimated`: Lisa derived counts or cost from trustworthy runtime metadata plus an explicit pricing contract. Estimates are allowed only when the derivation inputs are real and attributable to the run.
+- `unavailable`: Lisa could not obtain trustworthy usage data. Write the entry anyway with `null` token/cost fields rather than silently omitting the row.
+
+The absence of data is never treated as zero. `null` means unknown; `0` means explicitly observed or derived zero.
+
+## Pricing semantics
+
+`pricing_status` describes how trustworthy the money fields are:
+
+- `observed`: runtime supplied a trustworthy monetary cost.
+- `estimated`: Lisa calculated cost from trustworthy token counts plus explicit pricing metadata.
+- `missing`: token counts are known but no trustworthy price source exists yet.
+- `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
+
+Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+
+## Machine-readable tokens
+
+Every visible direct entry row ends with exactly one machine-readable token:
+
+```text
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+```
+
+Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions.
+
+Every managed section also ends with exactly one rollup token:
+
+```text
+<!-- lisa:usage-rollup direct_entry_ids=<csv> child_entry_ids=<csv> child_refs=<csv> direct_tokens=<n|null> child_tokens=<n|null> total_tokens=<n|null> direct_cost=<decimal|null> child_cost=<decimal|null> total_cost=<decimal|null> currency=<code|null> -->
+```
+
+- `direct_entry_ids` enumerates the entries attached directly to the current artifact.
+- `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
+- `child_refs` enumerates the child artifacts consulted for the rollup.
+- `total_*` fields equal direct plus child totals over the deduped entry set.
+
+The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans.
+
+## Visible rendering contract
+
+The canonical body layout is:
+
+```markdown
+## Lisa Usage
+
+_Managed by Lisa. Regenerated on each usage update; do not edit by hand._
+
+### Direct Usage
+
+| Flow | Model | Source | Tokens | Cost |
+|---|---|---|---:|---:|
+| ...human-readable rows ending with `lisa:usage-entry` tokens... |
+
+### Rollup
+
+| Scope | Tokens | Cost |
+|---|---:|---:|
+| Direct | ... | ... |
+| Child | ... | ... |
+| Total | ... | ... |
+
+<!-- lisa:usage-rollup ... -->
+```
+
+Writers may add host-specific surrounding prose, but they must preserve the heading, the managed-note line, the direct-entry tokens, and the single rollup token.
+
+## Rollup and dedupe behavior
+
+Rollups aggregate descendant usage from native tracker hierarchy, documented generated-work references, and explicit `parent_artifact_ref` links. Within one artifact rollup:
+
+- Dedupe strictly by stable `entry_id`.
+- Count each `entry_id` at most once even if the same descendant is discoverable through more than one path.
+- Preserve direct totals separately from child totals.
+- Exclude descendant entries whose `entry_id` is already present in the artifact's direct-entry set.
+
+The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Stories/leaves, and leaves may roll up evidence or verification artifacts, without double counting shared descendants.
+
+## Idempotent rewrite rules
+
+- There is exactly one managed `## Lisa Usage` section per artifact body/comment.
+- Recompute the entire section on every write; never append ad hoc rows.
+- Sort direct entries deterministically by `(flow, run_id, entry_id)`.
+- Preserve existing entries with unchanged `entry_id` and refreshed field values.
+- Re-running with the same logical entry set must produce byte-identical output.
+- Do not include timestamps in the section preamble or token lines.
+
+Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/tests/unit/strategies/usage-accounting-contract.test.ts
+++ b/tests/unit/strategies/usage-accounting-contract.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Regression tests for the upstream Lisa usage-accounting contract.
+ *
+ * Issue #727 defines the canonical usage ledger schema, source/pricing
+ * semantics, machine-readable token shapes, rollup dedupe contract, and
+ * deterministic rewrite rules before any writer integration lands. The rule is
+ * the durable source of truth; both source and generated plugin roots must stay
+ * in sync, and the token format must be parseable without reading prose.
+ * @module tests/unit/strategies/usage-accounting-contract
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+const RULE_NAME = "usage-accounting.md";
+const ARTIFACT_REF = "CodySwannGT/lisa#727";
+const MODEL_NAME = "gpt-5";
+const PROVIDER_NAME = "openai";
+const SOURCE_ESTIMATED = "estimated";
+const SOURCE_UNAVAILABLE = "unavailable";
+const DIRECT_COST = "0.60";
+const DIRECT_TOKENS = 400;
+const CHILD_COST = "0.65";
+const CHILD_TOKENS = 450;
+const IMPLEMENT_ENTRY_ID = "implement-1";
+const IMPLEMENT_FLOW = "implement";
+const IMPLEMENT_RUN_ID = "run-implement-1";
+const RESEARCH_ENTRY_ID = "research-1";
+const RESEARCH_FLOW = "research";
+const RESEARCH_RUN_ID = "run-research-1";
+const TOTAL_COST = "1.25";
+const TOTAL_TOKENS = 850;
+const ZERO_TOKENS = 0;
+
+/**
+ *
+ */
+type UsageEntry = {
+  readonly artifactRef: string;
+  readonly cachedInputTokens: number | null;
+  readonly cost: string | null;
+  readonly currency: string | null;
+  readonly entryId: string;
+  readonly flow: string;
+  readonly inputTokens: number | null;
+  readonly model: string;
+  readonly outputTokens: number | null;
+  readonly parentArtifactRef: string | null;
+  readonly pricingSource: string | null;
+  readonly pricingStatus: string;
+  readonly provider: string;
+  readonly reasoningTokens: number | null;
+  readonly runId: string;
+  readonly source: string;
+  readonly totalTokens: number | null;
+};
+
+/**
+ *
+ */
+type ParsedEntry = {
+  readonly entryId: string;
+  readonly flow: string;
+  readonly source: string;
+  readonly totalTokens: string;
+};
+
+/**
+ *
+ */
+type ParsedRollup = {
+  readonly childEntryIds: string;
+  readonly directEntryIds: string;
+  readonly totalCost: string;
+  readonly totalTokens: string;
+};
+
+const readRule = (root: string): string =>
+  readFileSync(path.resolve(root, RULE_NAME), "utf8");
+
+const renderValue = (value: number | string | null): string =>
+  value === null ? "null" : String(value);
+
+const renderEntryToken = (entry: UsageEntry): string =>
+  `<!-- lisa:usage-entry entry_id=${entry.entryId} flow=${entry.flow} run_id=${entry.runId} provider=${entry.provider} model=${entry.model} source=${entry.source} input_tokens=${renderValue(entry.inputTokens)} cached_input_tokens=${renderValue(entry.cachedInputTokens)} output_tokens=${renderValue(entry.outputTokens)} reasoning_tokens=${renderValue(entry.reasoningTokens)} total_tokens=${renderValue(entry.totalTokens)} cost=${renderValue(entry.cost)} currency=${renderValue(entry.currency)} pricing_status=${entry.pricingStatus} pricing_source=${renderValue(entry.pricingSource)} artifact_ref=${entry.artifactRef} parent_artifact_ref=${entry.parentArtifactRef ?? ""} -->`;
+
+const renderRollupToken = (
+  directEntryIds: readonly string[],
+  childEntryIds: readonly string[],
+  childRefs: readonly string[],
+  totalTokens: number | null,
+  totalCost: string | null
+): string =>
+  `<!-- lisa:usage-rollup direct_entry_ids=${directEntryIds.join(",")} child_entry_ids=${childEntryIds.join(",")} child_refs=${childRefs.join(",")} direct_tokens=${DIRECT_TOKENS} child_tokens=${CHILD_TOKENS} total_tokens=${renderValue(totalTokens)} direct_cost=${DIRECT_COST} child_cost=${CHILD_COST} total_cost=${renderValue(totalCost)} currency=USD -->`;
+
+const renderSection = (entries: readonly UsageEntry[]): string => {
+  const sorted = [...entries].sort((a, b) =>
+    `${a.flow}:${a.runId}:${a.entryId}`.localeCompare(
+      `${b.flow}:${b.runId}:${b.entryId}`
+    )
+  );
+  const directEntryIds = sorted.map(entry => entry.entryId);
+  const childEntryIds = ["verify-1", "shared-child"];
+  const childRefs = ["CodySwannGT/lisa#900", "CodySwannGT/lisa#901"];
+  return [
+    "## Lisa Usage",
+    "",
+    "_Managed by Lisa. Regenerated on each usage update; do not edit by hand._",
+    "",
+    "### Direct Usage",
+    "",
+    "| Flow | Model | Source | Tokens | Cost |",
+    "|---|---|---|---:|---:|",
+    ...sorted.map(
+      entry =>
+        `| ${entry.flow} | ${entry.provider}/${entry.model} | ${entry.source} | ${renderValue(entry.totalTokens)} | ${renderValue(entry.cost)} ${renderEntryToken(entry)} |`
+    ),
+    "",
+    "### Rollup",
+    "",
+    "| Scope | Tokens | Cost |",
+    "|---|---:|---:|",
+    `| Direct | ${DIRECT_TOKENS} | ${DIRECT_COST} |`,
+    `| Child | ${CHILD_TOKENS} | ${CHILD_COST} |`,
+    `| Total | ${TOTAL_TOKENS} | ${TOTAL_COST} |`,
+    "",
+    renderRollupToken(
+      directEntryIds,
+      childEntryIds,
+      childRefs,
+      TOTAL_TOKENS,
+      TOTAL_COST
+    ),
+    "",
+  ].join("\n");
+};
+
+const parseEntries = (section: string): readonly ParsedEntry[] => {
+  const tokenPattern =
+    /<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=\S+ provider=\S+ model=\S+ source=(\S+) input_tokens=\S+ cached_input_tokens=\S+ output_tokens=\S+ reasoning_tokens=\S+ total_tokens=(\S+) cost=\S+ currency=\S+ pricing_status=\S+ pricing_source=\S+ artifact_ref=\S+ parent_artifact_ref=\S* -->/g;
+  const entries: ParsedEntry[] = [];
+  let match = tokenPattern.exec(section);
+  while (match !== null) {
+    entries.push({
+      entryId: match[1] ?? "",
+      flow: match[2] ?? "",
+      source: match[3] ?? "",
+      totalTokens: match[4] ?? "",
+    });
+    match = tokenPattern.exec(section);
+  }
+  return entries;
+};
+
+const parseRollup = (section: string): ParsedRollup | null => {
+  const match =
+    /<!-- lisa:usage-rollup direct_entry_ids=(\S*) child_entry_ids=(\S*) child_refs=\S* direct_tokens=\S+ child_tokens=\S+ total_tokens=(\S+) direct_cost=\S+ child_cost=\S+ total_cost=(\S+) currency=\S+ -->/.exec(
+      section
+    );
+  if (match === null) {
+    return null;
+  }
+  return {
+    childEntryIds: match[2] ?? "",
+    directEntryIds: match[1] ?? "",
+    totalCost: match[4] ?? "",
+    totalTokens: match[3] ?? "",
+  };
+};
+
+describe("usage-accounting contract docs", () => {
+  describe.each(RULE_ROOTS)("%s/%s", root => {
+    const rulePath = path.resolve(root, RULE_NAME);
+
+    it("exists in this plugin root", () => {
+      expect(existsSync(rulePath)).toBe(true);
+    });
+
+    const content = readRule(root);
+
+    it("defines the canonical managed Lisa Usage section", () => {
+      expect(content).toContain("## Lisa Usage");
+      expect(content).toMatch(/rewrite it in place/i);
+      expect(content).toMatch(/never append a second usage section/i);
+    });
+
+    it("documents the direct-entry schema and source semantics", () => {
+      expect(content).toContain("entry_id");
+      expect(content).toContain("pricing_status");
+      expect(content).toContain("artifact_ref");
+      expect(content).toMatch(/observed/i);
+      expect(content).toMatch(/estimated/i);
+      expect(content).toMatch(/unavailable/i);
+    });
+
+    it("documents fixed-order usage-entry and usage-rollup tokens", () => {
+      expect(content).toContain("<!-- lisa:usage-entry entry_id=");
+      expect(content).toContain("<!-- lisa:usage-rollup");
+      expect(content).toMatch(/Field order is fixed/i);
+      expect(content).toMatch(/machine-readable summary/i);
+    });
+
+    it("documents rollup dedupe by stable entry_id", () => {
+      expect(content).toMatch(/Dedupe strictly by stable `entry_id`/i);
+      expect(content).toMatch(/Count each `entry_id` at most once/i);
+      expect(content).toMatch(/Exclude descendant entries/i);
+    });
+
+    it("documents deterministic rewrite rules with no timestamps", () => {
+      expect(content).toMatch(/byte-identical output/i);
+      expect(content).toMatch(/Do not include timestamps/i);
+      expect(content).toMatch(/Sort direct entries deterministically/i);
+    });
+  });
+});
+
+describe("usage-accounting token format is parseable and idempotent", () => {
+  const entries: readonly UsageEntry[] = [
+    {
+      artifactRef: ARTIFACT_REF,
+      cachedInputTokens: null,
+      cost: DIRECT_COST,
+      currency: "USD",
+      entryId: IMPLEMENT_ENTRY_ID,
+      flow: IMPLEMENT_FLOW,
+      inputTokens: 150,
+      model: MODEL_NAME,
+      outputTokens: 250,
+      parentArtifactRef: null,
+      pricingSource: "config:2026-05-25",
+      pricingStatus: SOURCE_ESTIMATED,
+      provider: PROVIDER_NAME,
+      reasoningTokens: ZERO_TOKENS,
+      runId: IMPLEMENT_RUN_ID,
+      source: SOURCE_ESTIMATED,
+      totalTokens: DIRECT_TOKENS,
+    },
+    {
+      artifactRef: ARTIFACT_REF,
+      cachedInputTokens: null,
+      cost: null,
+      currency: null,
+      entryId: RESEARCH_ENTRY_ID,
+      flow: RESEARCH_FLOW,
+      inputTokens: null,
+      model: MODEL_NAME,
+      outputTokens: null,
+      parentArtifactRef: null,
+      pricingSource: null,
+      pricingStatus: SOURCE_UNAVAILABLE,
+      provider: PROVIDER_NAME,
+      reasoningTokens: null,
+      runId: RESEARCH_RUN_ID,
+      source: SOURCE_UNAVAILABLE,
+      totalTokens: null,
+    },
+  ];
+
+  const section = renderSection(entries);
+
+  it("enumerates direct entries from tokens alone", () => {
+    const parsed = parseEntries(section);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.map(entry => entry.entryId)).toEqual([
+      IMPLEMENT_ENTRY_ID,
+      RESEARCH_ENTRY_ID,
+    ]);
+    expect(parsed[0]).toMatchObject({
+      entryId: IMPLEMENT_ENTRY_ID,
+      flow: IMPLEMENT_FLOW,
+      source: SOURCE_ESTIMATED,
+      totalTokens: String(DIRECT_TOKENS),
+    });
+  });
+
+  it("extracts direct and child entry ids from the rollup token", () => {
+    const parsedRollup = parseRollup(section);
+    expect(parsedRollup).not.toBeNull();
+    expect(parsedRollup).toMatchObject({
+      directEntryIds: `${IMPLEMENT_ENTRY_ID},${RESEARCH_ENTRY_ID}`,
+      childEntryIds: "verify-1,shared-child",
+      totalTokens: String(TOTAL_TOKENS),
+      totalCost: TOTAL_COST,
+    });
+  });
+
+  it("renders byte-identically for the same logical entry set", () => {
+    expect(renderSection([...entries].reverse())).toBe(section);
+  });
+});


### PR DESCRIPTION
## Summary\n- add the upstream usage-accounting rule covering the Lisa Usage section, direct-entry schema, token shapes, source/pricing semantics, rollup dedupe, and idempotent rewrites\n- regenerate the lisa plugin copy of the new rule\n- add regression coverage proving the contract docs stay in sync and the usage tokens are parseable and deterministic\n\n## Testing\n- bun test tests/unit/strategies/usage-accounting-contract.test.ts\n- git push -u https://github.com/CodySwannGT/lisa.git codex/issue-727-github-build-intake\n\nCloses #727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced vendor-neutral usage accounting contract specification detailing canonical section structure, direct-entry schema fields, machine-readable token formats, rendering requirements, and idempotent rewrite rules for consistent usage tracking.

* **Tests**
  * Added comprehensive test suite validating usage accounting contract compliance, including token rendering/parsing verification and idempotent regeneration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->