### PR TITLE
[lisa] Render and preserve Lisa Usage sections idempotently

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./fibonacci.js";
 export * from "./file-operations.js";
 export * from "./json-utils.js";
 export * from "./path-utils.js";
+export * from "./usage-accounting.js";
 // Intentionally narrow: the reconciliation trampoline's dist-path resolver and
 // detached-spawn primitive are only consumed by src/core/lisa.ts directly; keeping
 // them out of the barrel prevents leaking internal reconciliation plumbing as a

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -1,0 +1,416 @@
+export const LISA_USAGE_HEADING = "## Lisa Usage";
+
+/**
+ *
+ */
+export interface LisaUsageEntry {
+  artifactRef: string;
+  cachedInputTokens: number | null;
+  cost: number | null;
+  currency: string | null;
+  entryId: string;
+  flow: string;
+  inputTokens: number | null;
+  model: string;
+  outputTokens: number | null;
+  parentArtifactRef: string | null;
+  pricingSource: string | null;
+  pricingStatus: string;
+  provider: string;
+  reasoningTokens: number | null;
+  runId: string;
+  source: string;
+  totalTokens: number | null;
+}
+
+/**
+ *
+ */
+export interface LisaUsageRollup {
+  childCost: number | null;
+  childEntryIds: readonly string[];
+  childRefs: readonly string[];
+  childTokens: number | null;
+  currency: string | null;
+  directCost: number | null;
+  directEntryIds: readonly string[];
+  directTokens: number | null;
+  totalCost: number | null;
+  totalTokens: number | null;
+}
+
+/**
+ *
+ */
+export interface ParsedLisaUsageSection {
+  entries: readonly LisaUsageEntry[];
+  range: { end: number; start: number } | null;
+  rollup: LisaUsageRollup | null;
+}
+
+const ENTRY_PATTERN =
+  /<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=(\S+) provider=(\S+) model=(\S+) source=(\S+) input_tokens=(\S+) cached_input_tokens=(\S+) output_tokens=(\S+) reasoning_tokens=(\S+) total_tokens=(\S+) cost=(\S+) currency=(\S+) pricing_status=(\S+) pricing_source=(\S+) artifact_ref=(\S+) parent_artifact_ref=(\S*) -->/g;
+
+const ROLLUP_PATTERN =
+  /<!-- lisa:usage-rollup direct_entry_ids=(\S*) child_entry_ids=(\S*) child_refs=(\S*) direct_tokens=(\S+) child_tokens=(\S+) total_tokens=(\S+) direct_cost=(\S+) child_cost=(\S+) total_cost=(\S+) currency=(\S+) -->/;
+
+/**
+ * Parse a nullable numeric token field.
+ *
+ * @param value Serialized numeric token value.
+ * @returns The parsed number or null when the token is empty.
+ */
+function parseNullableNumber(value: string): number | null {
+  if (value === "null" || value.length === 0) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Parse a nullable string token field.
+ *
+ * @param value Serialized string token value.
+ * @returns The parsed string or null when the token is empty.
+ */
+function parseNullableString(value: string): string | null {
+  if (value === "null" || value.length === 0) {
+    return null;
+  }
+
+  return value;
+}
+
+/**
+ * Serialize a nullable token field.
+ *
+ * @param value Primitive token value to render.
+ * @returns The canonical string form used inside usage tokens.
+ */
+function renderNullable(value: number | string | null): string {
+  return value === null ? "null" : String(value);
+}
+
+/**
+ * Parse a comma-separated token field into stable document order.
+ *
+ * @param value Serialized CSV token field.
+ * @returns The parsed item list.
+ */
+function parseCsv(value: string): readonly string[] {
+  if (value.length === 0) {
+    return [];
+  }
+
+  return value.split(",");
+}
+
+/**
+ * Sum nullable numeric values while preserving null when nothing was recorded.
+ *
+ * @param values Numeric values to aggregate.
+ * @returns The sum of present values, or null when all are missing.
+ */
+function sumNullable(values: readonly (number | null)[]): number | null {
+  const present = values.filter((value): value is number => value !== null);
+  if (present.length === 0) {
+    return null;
+  }
+
+  return present.reduce((total, value) => total + value, 0);
+}
+
+/**
+ * Locate the current managed usage-section boundaries inside an artifact body.
+ *
+ * @param document Artifact markdown to inspect.
+ * @returns The start/end character offsets for the section, if present.
+ */
+function findUsageSectionRange(
+  document: string
+): { end: number; start: number } | null {
+  const heading = `${LISA_USAGE_HEADING}\n`;
+  const start = document.indexOf(heading);
+  if (start === -1) {
+    if (!document.endsWith(LISA_USAGE_HEADING)) {
+      return null;
+    }
+
+    return {
+      start: document.length - LISA_USAGE_HEADING.length,
+      end: document.length,
+    };
+  }
+
+  const afterHeading = start + heading.length;
+  const nextHeadingOffset = document.slice(afterHeading).search(/^##\s+/m);
+  const end =
+    nextHeadingOffset === -1
+      ? document.length
+      : afterHeading + nextHeadingOffset;
+  return { start, end };
+}
+
+/**
+ * Split an artifact body around the managed usage section.
+ *
+ * @param document Artifact markdown to split.
+ * @param range Located managed-section boundaries, if present.
+ * @returns The trimmed content before and after the managed section.
+ */
+function splitDocumentAroundRange(
+  document: string,
+  range: { end: number; start: number } | null
+): { after: string; before: string } {
+  if (!range) {
+    const before = document.trimEnd();
+    return { before, after: "" };
+  }
+
+  const before = document.slice(0, range.start).trimEnd();
+  const after = document.slice(range.end).trimStart();
+  return { before, after };
+}
+
+/**
+ * Render a token-count value for the human-readable table.
+ *
+ * @param value Token count to format.
+ * @returns A deterministic display string.
+ */
+function formatTokens(value: number | null): string {
+  return value === null ? "null" : String(value);
+}
+
+/**
+ * Render a cost value for the human-readable table.
+ *
+ * @param value Cost amount to format.
+ * @param currency Currency code paired with the cost, when known.
+ * @returns A deterministic display string.
+ */
+function formatCost(value: number | null, currency: string | null): string {
+  if (value === null) {
+    return "null";
+  }
+
+  return currency ? `${value} ${currency}` : String(value);
+}
+
+/**
+ * Merge new usage entries into an existing ledger while keeping stable order for
+ * previously recorded entries and replacing matching `entry_id` rows in place.
+ *
+ * @param existingEntries Previously recorded direct usage entries.
+ * @param nextEntries Newly observed direct usage entries to apply.
+ * @returns The merged direct-entry set in deterministic document order.
+ */
+export function mergeLisaUsageEntries(
+  existingEntries: readonly LisaUsageEntry[],
+  nextEntries: readonly LisaUsageEntry[]
+): readonly LisaUsageEntry[] {
+  const incoming = new Map(
+    nextEntries.map(entry => [entry.entryId, entry] as const)
+  );
+  const mergedExisting = existingEntries.map(
+    entry => incoming.get(entry.entryId) ?? entry
+  );
+  const appended = nextEntries.filter(
+    entry =>
+      !existingEntries.some(existing => existing.entryId === entry.entryId)
+  );
+
+  return [...mergedExisting, ...appended];
+}
+
+/**
+ * Build a default rollup token from direct entries while preserving any prior
+ * child-work totals supplied by callers from later lifecycle stages.
+ *
+ * @param entries Direct usage entries that should appear in the section.
+ * @param previousRollup Existing rollup token parsed from the artifact, if any.
+ * @returns A deterministic rollup token payload for the managed section.
+ */
+export function createLisaUsageRollup(
+  entries: readonly LisaUsageEntry[],
+  previousRollup?: LisaUsageRollup | null
+): LisaUsageRollup {
+  const directEntryIds = entries.map(entry => entry.entryId);
+  const directTokens = sumNullable(entries.map(entry => entry.totalTokens));
+  const directCost = sumNullable(entries.map(entry => entry.cost));
+  const childEntryIds = previousRollup?.childEntryIds ?? [];
+  const childRefs = previousRollup?.childRefs ?? [];
+  const childTokens = previousRollup?.childTokens ?? 0;
+  const childCost = previousRollup?.childCost ?? 0;
+  const totalTokens =
+    directTokens === null && childTokens === null
+      ? null
+      : (directTokens ?? 0) + (childTokens ?? 0);
+  const totalCost =
+    directCost === null && childCost === null
+      ? null
+      : (directCost ?? 0) + (childCost ?? 0);
+  const currency =
+    entries.find(entry => entry.currency !== null)?.currency ??
+    previousRollup?.currency ??
+    null;
+
+  return {
+    directEntryIds,
+    childEntryIds,
+    childRefs,
+    directTokens,
+    childTokens,
+    totalTokens,
+    directCost,
+    childCost,
+    totalCost,
+    currency,
+  };
+}
+
+/**
+ * Render the machine-readable token for a single direct usage row.
+ *
+ * @param entry Direct usage entry to serialize.
+ * @returns The canonical `lisa:usage-entry` token line.
+ */
+export function renderLisaUsageEntryToken(entry: LisaUsageEntry): string {
+  return `<!-- lisa:usage-entry entry_id=${entry.entryId} flow=${entry.flow} run_id=${entry.runId} provider=${entry.provider} model=${entry.model} source=${entry.source} input_tokens=${renderNullable(entry.inputTokens)} cached_input_tokens=${renderNullable(entry.cachedInputTokens)} output_tokens=${renderNullable(entry.outputTokens)} reasoning_tokens=${renderNullable(entry.reasoningTokens)} total_tokens=${renderNullable(entry.totalTokens)} cost=${renderNullable(entry.cost)} currency=${renderNullable(entry.currency)} pricing_status=${entry.pricingStatus} pricing_source=${renderNullable(entry.pricingSource)} artifact_ref=${entry.artifactRef} parent_artifact_ref=${entry.parentArtifactRef ?? ""} -->`;
+}
+
+/**
+ * Render the machine-readable rollup token for a managed usage section.
+ *
+ * @param rollup Rollup values to serialize.
+ * @returns The canonical `lisa:usage-rollup` token line.
+ */
+export function renderLisaUsageRollupToken(rollup: LisaUsageRollup): string {
+  return `<!-- lisa:usage-rollup direct_entry_ids=${rollup.directEntryIds.join(",")} child_entry_ids=${rollup.childEntryIds.join(",")} child_refs=${rollup.childRefs.join(",")} direct_tokens=${renderNullable(rollup.directTokens)} child_tokens=${renderNullable(rollup.childTokens)} total_tokens=${renderNullable(rollup.totalTokens)} direct_cost=${renderNullable(rollup.directCost)} child_cost=${renderNullable(rollup.childCost)} total_cost=${renderNullable(rollup.totalCost)} currency=${renderNullable(rollup.currency)} -->`;
+}
+
+/**
+ * Render the canonical `## Lisa Usage` section body from direct entries and a
+ * rollup token.
+ *
+ * @param input Section payload containing direct entries and rollup totals.
+ * @param input.entries Direct entries to render in document order.
+ * @param input.rollup Rollup token to end the section with.
+ * @returns The managed section text, terminated with a trailing newline.
+ */
+export function renderLisaUsageSection(input: {
+  entries: readonly LisaUsageEntry[];
+  rollup: LisaUsageRollup;
+}): string {
+  const { entries, rollup } = input;
+  const entryLines =
+    entries.length === 0
+      ? ["| _No direct entries recorded_ | | | | |"]
+      : entries.map(
+          entry =>
+            `| ${entry.flow} | ${entry.source} | ${entry.provider}/${entry.model} | ${formatTokens(entry.totalTokens)} | ${formatCost(entry.cost, entry.currency)} | ${renderLisaUsageEntryToken(entry)}`
+        );
+  const lines = [
+    LISA_USAGE_HEADING,
+    "",
+    "_This section is managed by Lisa. Rewrites update matching usage entries in place and preserve older rows._",
+    "",
+    "| Flow | Source | Model | Tokens | Cost |",
+    "| --- | --- | --- | ---: | ---: |",
+    ...entryLines,
+    "",
+    renderLisaUsageRollupToken(rollup),
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Parse the managed usage section out of an artifact body or comment.
+ *
+ * @param document Artifact markdown to inspect.
+ * @returns Parsed direct entries, rollup token, and the located section range.
+ */
+export function parseLisaUsageSection(
+  document: string
+): ParsedLisaUsageSection {
+  const range = findUsageSectionRange(document);
+  const section = range ? document.slice(range.start, range.end) : "";
+  const entries = Array.from(section.matchAll(ENTRY_PATTERN), match => ({
+    entryId: match[1] ?? "",
+    flow: match[2] ?? "",
+    runId: match[3] ?? "",
+    provider: match[4] ?? "",
+    model: match[5] ?? "",
+    source: match[6] ?? "",
+    inputTokens: parseNullableNumber(match[7] ?? ""),
+    cachedInputTokens: parseNullableNumber(match[8] ?? ""),
+    outputTokens: parseNullableNumber(match[9] ?? ""),
+    reasoningTokens: parseNullableNumber(match[10] ?? ""),
+    totalTokens: parseNullableNumber(match[11] ?? ""),
+    cost: parseNullableNumber(match[12] ?? ""),
+    currency: parseNullableString(match[13] ?? ""),
+    pricingStatus: match[14] ?? "",
+    pricingSource: parseNullableString(match[15] ?? ""),
+    artifactRef: match[16] ?? "",
+    parentArtifactRef: parseNullableString(match[17] ?? ""),
+  }));
+
+  const rollupMatch = ROLLUP_PATTERN.exec(section);
+  const rollup = rollupMatch
+    ? {
+        directEntryIds: parseCsv(rollupMatch[1] ?? ""),
+        childEntryIds: parseCsv(rollupMatch[2] ?? ""),
+        childRefs: parseCsv(rollupMatch[3] ?? ""),
+        directTokens: parseNullableNumber(rollupMatch[4] ?? ""),
+        childTokens: parseNullableNumber(rollupMatch[5] ?? ""),
+        totalTokens: parseNullableNumber(rollupMatch[6] ?? ""),
+        directCost: parseNullableNumber(rollupMatch[7] ?? ""),
+        childCost: parseNullableNumber(rollupMatch[8] ?? ""),
+        totalCost: parseNullableNumber(rollupMatch[9] ?? ""),
+        currency: parseNullableString(rollupMatch[10] ?? ""),
+      }
+    : null;
+
+  return { entries, rollup, range };
+}
+
+/**
+ * Append or replace the canonical `## Lisa Usage` section in a markdown
+ * artifact while preserving prior entries that are not being refreshed.
+ *
+ * @param document Existing artifact markdown or comment body.
+ * @param input New usage content to merge into the managed section.
+ * @param input.entries Newly observed direct usage entries.
+ * @param input.rollup Optional explicit rollup payload to serialize.
+ * @returns The updated artifact markdown with exactly one managed usage block.
+ */
+export function upsertLisaUsageSection(
+  document: string,
+  input: {
+    entries: readonly LisaUsageEntry[];
+    rollup?: LisaUsageRollup | null;
+  }
+): string {
+  const parsed = parseLisaUsageSection(document);
+  const mergedEntries = mergeLisaUsageEntries(parsed.entries, input.entries);
+  const rollup =
+    input.rollup ?? createLisaUsageRollup(mergedEntries, parsed.rollup);
+  const usageSection = renderLisaUsageSection({
+    entries: mergedEntries,
+    rollup,
+  }).trimEnd();
+  const { before, after } = splitDocumentAroundRange(document, parsed.range);
+
+  if (!before) {
+    return after ? `${usageSection}\n\n${after}\n` : `${usageSection}\n`;
+  }
+
+  if (!after) {
+    return `${before}\n\n${usageSection}\n`;
+  }
+
+  return `${before}\n\n${usageSection}\n\n${after}\n`;
+}

--- a/tests/unit/utils/usage-accounting.test.ts
+++ b/tests/unit/utils/usage-accounting.test.ts
@@ -1,0 +1,159 @@
+import {
+  createLisaUsageRollup,
+  LISA_USAGE_HEADING,
+  parseLisaUsageSection,
+  type LisaUsageEntry,
+  upsertLisaUsageSection,
+} from "../../../src/utils/usage-accounting.js";
+
+const USAGE_HEADING_COUNT = 1;
+const USAGE_HEADING_MATCHER = /## Lisa Usage/g;
+const ARTIFACT_HEADING = "# Artifact";
+const ARTIFACT_DOCUMENT = `${ARTIFACT_HEADING}\n`;
+
+/**
+ * Create a deterministic direct usage entry for unit tests.
+ *
+ * @param overrides Test-specific field overrides.
+ * @returns A complete usage entry payload.
+ */
+function makeEntry(
+  overrides: Partial<LisaUsageEntry> & Pick<LisaUsageEntry, "entryId" | "runId">
+): LisaUsageEntry {
+  return {
+    artifactRef: "github:issue:718",
+    cachedInputTokens: null,
+    cost: 0.12,
+    currency: "USD",
+    entryId: overrides.entryId,
+    flow: "plan",
+    inputTokens: 100,
+    model: "gpt-5",
+    outputTokens: 20,
+    parentArtifactRef: null,
+    pricingSource: "catalog",
+    pricingStatus: "estimated",
+    provider: "openai",
+    reasoningTokens: null,
+    runId: overrides.runId,
+    source: "prompt",
+    totalTokens: 120,
+    ...overrides,
+  };
+}
+
+describe("usage-accounting utilities", () => {
+  it("appends the managed Lisa Usage section when none exists", () => {
+    const original = [ARTIFACT_HEADING, "", "Body content."].join("\n");
+    const entry = makeEntry({ entryId: "entry-1", runId: "run-1" });
+
+    const updated = upsertLisaUsageSection(original, {
+      entries: [entry],
+      rollup: createLisaUsageRollup([entry]),
+    });
+
+    expect(updated).toContain(LISA_USAGE_HEADING);
+    expect(updated.match(USAGE_HEADING_MATCHER)).toHaveLength(
+      USAGE_HEADING_COUNT
+    );
+    expect(updated).toContain("Body content.");
+    expect(updated).toContain("entry_id=entry-1");
+  });
+
+  it("rewrites the existing section in place instead of duplicating it", () => {
+    const firstEntry = makeEntry({ entryId: "entry-1", runId: "run-1" });
+    const original = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [firstEntry],
+      rollup: createLisaUsageRollup([firstEntry]),
+    });
+    const secondEntry = makeEntry({ entryId: "entry-2", runId: "run-2" });
+
+    const updated = upsertLisaUsageSection(original, {
+      entries: [secondEntry],
+      rollup: createLisaUsageRollup([firstEntry, secondEntry]),
+    });
+
+    expect(updated.match(USAGE_HEADING_MATCHER)).toHaveLength(
+      USAGE_HEADING_COUNT
+    );
+    expect(updated).toContain("entry_id=entry-1");
+    expect(updated).toContain("entry_id=entry-2");
+  });
+
+  it("preserves surrounding sections when replacing the usage block", () => {
+    const entry = makeEntry({ entryId: "entry-1", runId: "run-1" });
+    const original = [
+      ARTIFACT_HEADING,
+      "",
+      "intro",
+      "",
+      "## Lisa Usage",
+      "",
+      "stale body",
+      "",
+      "## Next Section",
+      "",
+      "keep me",
+    ].join("\n");
+
+    const updated = upsertLisaUsageSection(original, {
+      entries: [entry],
+      rollup: createLisaUsageRollup([entry]),
+    });
+
+    expect(updated).toContain("## Next Section");
+    expect(updated).toContain("keep me");
+    expect(updated).not.toContain("stale body");
+  });
+
+  it("updates an existing entry in place by stable entry_id", () => {
+    const initialEntry = makeEntry({ entryId: "entry-1", runId: "run-1" });
+    const original = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [initialEntry],
+      rollup: createLisaUsageRollup([initialEntry]),
+    });
+    const refreshedEntry = makeEntry({
+      entryId: "entry-1",
+      runId: "run-1",
+      totalTokens: 240,
+      cost: 0.24,
+    });
+
+    const updated = upsertLisaUsageSection(original, {
+      entries: [refreshedEntry],
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0]?.totalTokens).toBe(240);
+    expect(updated).not.toContain("total_tokens=120");
+  });
+
+  it("preserves prior entries when appending a new run", () => {
+    const firstEntry = makeEntry({ entryId: "entry-1", runId: "run-1" });
+    const secondEntry = makeEntry({
+      entryId: "entry-2",
+      runId: "run-2",
+      flow: "implement",
+      totalTokens: 80,
+      cost: 0.08,
+    });
+    const original = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [firstEntry],
+      rollup: createLisaUsageRollup([firstEntry]),
+    });
+
+    const updated = upsertLisaUsageSection(original, {
+      entries: [secondEntry],
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(parsed.entries.map(entry => entry.entryId)).toEqual([
+      "entry-1",
+      "entry-2",
+    ]);
+    expect(parsed.rollup?.directEntryIds).toEqual(["entry-1", "entry-2"]);
+    expect(parsed.rollup?.directTokens).toBe(200);
+    expect(parsed.rollup?.totalCost).toBeCloseTo(0.2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared usage-accounting utility for parsing, merging, rendering, and upserting managed Lisa Usage sections
- preserve existing usage rows by stable entry_id while replacing matching rows in place
- cover append, replace, and surrounding-section preservation behavior with focused unit tests

## Testing
- bun test tests/unit/utils/usage-accounting.test.ts
- bun run typecheck
- bun run build:plugins
- push hook: bun audit, eslint slow config, knip, vitest --coverage, vitest run tests/integration

Closes #728