### PR TITLE
feat: preserve usage ledgers in writers

### DIFF
--- a/plugins/lisa/skills/confluence-write-prd/SKILL.md
+++ b/plugins/lisa/skills/confluence-write-prd/SKILL.md
@@ -65,7 +65,10 @@ else → **create**.
 format** (XHTML): `#`/`##`/`###` → `<h1>/<h2>/<h3>`, paragraphs → `<p>`, lists → `<ul>/<ol><li>`,
 fenced code → `<ac:structured-macro ac:name="code">`. Embed the marker as a storage comment
 (`<!-- $MARKER -->`) or a small `<p>` so future CQL dedupe finds it. The body must always contain
-**exactly one** marker; never write a markerless page (CREATE or UPDATE).
+**exactly one** marker; never write a markerless page (CREATE or UPDATE). If the live page body
+already contains the canonical managed `## Lisa Usage` section, preserve it verbatim unless the
+caller intentionally supplied an updated canonical section; use the shared `usage-accounting`
+serializer/merge path rather than hand-editing ledger rows in storage XHTML.
 
 **CREATE:** `lisa:atlassian-access` `operation: write-page` (create form) with a payload that sets:
 - `title`: `$TITLE`
@@ -77,7 +80,8 @@ fenced code → `<ac:structured-macro ac:name="code">`. Embed the marker as a st
 1. **GET-then-PUT** (load-bearing, as `confluence-prd-intake` documents): first `operation: read-page
    id: <page-id>` to read the current `version.number`, then `operation: write-page` (edit form) with
    the marker-normalized storage body and `version.number` bumped to current+1. A PUT without the
-   current version is rejected; never drop the marker on the edit.
+   current version is rejected; never drop the marker or an existing managed `## Lisa Usage` section
+   on the edit.
 2. Re-parent to the target lifecycle parent if the role changed — **unless** the page's current
    parent is in the resolved `${PROGRESSED_PARENTS[@]}` set (already past `ready`). If so, leave it
    and report `reused (already past ready)`. Reverse-lookup the current parent in
@@ -99,5 +103,7 @@ outcome: created | reused
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never re-parent a PRD already past `ready` down to draft/ready.
 - Resolve parents from config (`confluence.parents.{draft,ready}`) — never hardcode page ids.

--- a/plugins/lisa/skills/github-write-issue/SKILL.md
+++ b/plugins/lisa/skills/github-write-issue/SKILL.md
@@ -276,7 +276,7 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
 
 ### UPDATE
 
-1. Re-read the current body via `gh issue view <number> --repo <org>/<repo> --json body --jq '.body'`. Edit only the sections being changed; preserve everything else verbatim.
+1. Re-read the current body via `gh issue view <number> --repo <org>/<repo> --json body --jq '.body'`. Edit only the sections being changed; preserve everything else verbatim, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 2. Apply the edit:
    ```bash
    gh issue edit <number> --repo <org>/<repo> --body-file /tmp/updated-body.md
@@ -331,6 +331,8 @@ The mapping below is the single source of truth for how JIRA concepts translate 
 - Never create a Bug, Task, or Sub-task whose AC references work in a different repo. GitHub Issues already live in one repo; reject AC bullets that span others — split into per-repo issues under a shared Epic.
 - Never include a runtime-behavior issue without a target backend environment, and never include an authenticated-surface issue without sign-in credentials.
 - Never overwrite an issue body without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All writes go through this skill (or the `tracker-write` shim). Other vendor-neutral skills must NEVER call `gh issue create` directly.
 - The gate logic lives in `lisa:github-validate-issue`, NOT here. This skill calls the validator at Phase 5.5 and Phase 7. When a gate needs to change, change it in `lisa:github-validate-issue`.
 - Never bypass the sub-issue mutation by encoding the parent only in the body. The native sub-issue link is what `lisa:github-read-issue` and the GitHub UI use to render the hierarchy.

--- a/plugins/lisa/skills/github-write-prd/SKILL.md
+++ b/plugins/lisa/skills/github-write-prd/SKILL.md
@@ -55,10 +55,13 @@ EXISTING=$(gh issue list --repo "$ORG/$REPO" --state open --search "\"$MARKER\" 
 
 ## Phase 3 — Create or update
 
-**Marker normalization (both paths).** Before writing any body, ensure it contains **exactly one**
-marker line — inject `<!-- $MARKER -->` if the caller's synthesized body doesn't already carry it.
-**Never write a markerless body** (including on UPDATE or when `source_ref` is passed): a body without
-the marker breaks future dedupe. If the body already has the marker, leave the single instance.
+**Marker + usage-ledger preservation (both paths).** Before writing any body, ensure it contains
+**exactly one** marker line — inject `<!-- $MARKER -->` if the caller's synthesized body doesn't
+already carry it. **Never write a markerless body** (including on UPDATE or when `source_ref` is
+passed): a body without the marker breaks future dedupe. If the body already has the marker, leave
+the single instance. If the live issue body already contains the canonical managed `## Lisa Usage`
+section, preserve it verbatim unless the caller intentionally supplied an updated canonical section;
+use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **CREATE** (no existing issue):
 
@@ -77,7 +80,7 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
 **UPDATE** (existing issue or `source_ref`):
 
 1. `gh issue edit <n> --repo "$ORG/$REPO" --body-file /tmp/prd-body.md` with the **marker-normalized**
-   body (regenerate in place; never drop the marker).
+   body (regenerate in place; never drop the marker or an existing managed `## Lisa Usage` section).
 2. Reconcile the lifecycle label to **exactly one**: add `$ROLE_LABEL`, remove every other label in
    the resolved `${ALL_PRD_LABELS[@]}` set (the config-resolved names — not a hard-coded list) via
    `gh issue edit <n> --add-label / --remove-label`. Never leave a PRD carrying two lifecycle labels.
@@ -104,6 +107,8 @@ outcome: created | reused
 
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a PRD already past `ready`.
 - A *closed* prior PRD does not suppress a new one — a recurrence after closure is a genuine new PRD.
 - This is a source-side writer (`prd-*` labels). It never touches build labels (`status:*`) — that is

--- a/plugins/lisa/skills/jira-write-ticket/SKILL.md
+++ b/plugins/lisa/skills/jira-write-ticket/SKILL.md
@@ -235,7 +235,7 @@ If the validator reports `PASS`, continue to Phase 6.
 
 1. Invoke `lisa:atlassian-access` with `operation: write-ticket payload: {key: <K>, ...fields-being-changed}`. Do NOT resend fields that weren't in the change set — it blows away history.
 2. Add new relationships via `lisa:atlassian-access` `operation: link from: <K1> to: <K2> type: "<link-type>"`. Existing links are not touched unless explicitly removed.
-3. If description changes, preserve sections you are not editing. Re-read via `/jira-read-ticket` first.
+3. If description changes, preserve sections you are not editing. Re-read via `/jira-read-ticket` first, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 
 ## Phase 7 — Verify
 
@@ -259,5 +259,7 @@ Skip this step only on UPDATE when no material change was made.
 - Never include a runtime-behavior ticket without a target backend environment, and never include an authenticated-surface ticket without sign-in credentials in the description.
 - Never invent custom field values. If the project requires a field you don't have, stop and ask.
 - Never overwrite a description without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All writes go through this skill so best practices are enforced uniformly. Downstream skills (e.g. `lisa:jira-create`) should delegate here rather than invoking `lisa:atlassian-access` write operations directly.
 - The gate logic (what makes a valid ticket) lives in `lisa:jira-validate-ticket`, NOT in this skill. This skill calls the validator at Phase 5.5 (pre-write) and Phase 7 (via `lisa:jira-verify` post-write). When a gate needs to change, change it in `lisa:jira-validate-ticket` — every caller (write path, dry-run path, post-write verify) picks it up automatically.

--- a/plugins/lisa/skills/linear-write-issue/SKILL.md
+++ b/plugins/lisa/skills/linear-write-issue/SKILL.md
@@ -260,7 +260,7 @@ If the validator reports `PASS`, continue to Phase 6.
 ### UPDATE
 
 1. Call `mcp__linear-server__save_project` or `mcp__linear-server__save_issue` with **only the fields being changed**. Do NOT resend fields that weren't in the change set — Linear treats the call as a full overwrite of the listed fields.
-2. Preserve description sections you are not editing — re-read via `/linear-read-issue` first.
+2. Preserve description sections you are not editing — re-read via `/linear-read-issue` first, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 
 ## Phase 7 — Verify
 
@@ -285,6 +285,8 @@ Skip this step only on UPDATE when no material change was made.
 - Never include a runtime-behavior item without a target backend environment, and never include an authenticated-surface item without sign-in credentials in the description.
 - Never invent custom field values. If the team requires a field you don't have, stop and ask.
 - Never overwrite a description without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All Linear writes go through this skill so best practices are enforced uniformly. Downstream skills (e.g. `lisa:linear-create`) should delegate here rather than calling the MCP write tools directly.
 - The gate logic (what makes a valid item) lives in `lisa:linear-validate-issue`, NOT in this skill. This skill calls the validator at Phase 5.5 (pre-write) and Phase 7 (via `lisa:linear-verify` post-write). When a gate needs to change, change it in `lisa:linear-validate-issue` — every caller picks it up automatically.
 - This skill is the destination of the `lisa:tracker-write` shim when `tracker = "linear"`. Vendor-neutral callers (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST go through `lisa:tracker-write`, not call this skill directly.

--- a/plugins/lisa/skills/linear-write-prd/SKILL.md
+++ b/plugins/lisa/skills/linear-write-prd/SKILL.md
@@ -52,9 +52,12 @@ marker, **never** the project name:
 
 ## Phase 3 — Create or update
 
-**Marker normalization (both paths).** Before writing the `description`, ensure it contains
-**exactly one** marker line — inject the marker if the synthesized description lacks it. **Never write
-a markerless description** (including UPDATE / `source_ref`): that breaks future dedupe.
+**Marker + usage-ledger preservation (both paths).** Before writing the `description`, ensure it
+contains **exactly one** marker line — inject the marker if the synthesized description lacks it.
+**Never write a markerless description** (including UPDATE / `source_ref`): that breaks future
+dedupe. If the live Project description already contains the canonical managed `## Lisa Usage`
+section, preserve it verbatim unless the caller intentionally supplied an updated canonical section;
+use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **CREATE:** `mcp__linear-server__save_project` with:
 - `name`: `$TITLE`
@@ -64,8 +67,9 @@ a markerless description** (including UPDATE / `source_ref`): that breaks future
 - `state`: Linear Project default (e.g. `backlog`)
 
 **UPDATE** (existing project or `source_ref`): `save_project` with the project id and **only** the
-changed fields — regenerate the marker-normalized `description`, and reconcile labels to **exactly
-one** PRD lifecycle label: add the role label, remove every other label in the resolved
+changed fields — regenerate the marker-normalized `description` without dropping the managed
+`## Lisa Usage` section, and reconcile labels to **exactly one** PRD lifecycle label: add the role
+label, remove every other label in the resolved
 `${ALL_PRD_LABELS[@]}` set (config-resolved names, not a hard-coded list). Do **not** down-rank a
 Project whose current label is in the resolved `${PROGRESSED[@]}` set (already past `ready`) — leave
 it and report `reused (already past ready)`.
@@ -84,6 +88,8 @@ outcome: created | reused
 
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a Project already past `ready`.
 - Source-side writer (`prd-*` project labels) — never touches issue-level build labels (`status:*`),
   which are `lisa:linear-write-issue`'s lane (see `config-resolution` self-host separation).

--- a/plugins/lisa/skills/notion-write-prd/SKILL.md
+++ b/plugins/lisa/skills/notion-write-prd/SKILL.md
@@ -60,8 +60,12 @@ exceeds 100 blocks, create the page with the first ≤100 blocks then add the re
 accept the markdown content directly (it performs this conversion) — prefer that; the explicit block
 conversion is the curl-substrate path.
 
-**Marker normalization (both paths).** The page must always carry **exactly one** marker. On CREATE
-the marker is the first body block; on UPDATE never remove it. Never write a markerless page.
+**Marker + usage-ledger preservation (both paths).** The page must always carry **exactly one**
+marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a
+markerless page. If the existing page content already contains the canonical managed `## Lisa Usage`
+section, preserve that section when regenerating the page body unless the caller intentionally
+supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path
+rather than freehand block edits to ledger rows.
 
 **CREATE:**
 
@@ -86,7 +90,7 @@ the marker is the first body block; on UPDATE never remove it. Never write a mar
    (`operation: archive-page` is page-level, so for blocks delete via the blocks API through
    `notion-access` or, where block deletion isn't available, replace their text in place) and
    `operation: append-blocks` the regenerated blocks. Do not duplicate the whole spec as a dated
-   note, and never drop the marker.
+   note, and never drop the marker or an existing managed `## Lisa Usage` section.
 
 ## Phase 4 — Return
 
@@ -102,6 +106,8 @@ outcome: created | reused
 
 - All access via `lisa:notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a PRD whose Status is already past `ready`.
 - Resolve the Status vocabulary from config (`notion.statusProperty`, `notion.values.*`) — never
   hardcode value names.

--- a/plugins/lisa/skills/notion-write-prd/SKILL.md
+++ b/plugins/lisa/skills/notion-write-prd/SKILL.md
@@ -61,11 +61,7 @@ accept the markdown content directly (it performs this conversion) — prefer th
 conversion is the curl-substrate path.
 
 **Marker + usage-ledger preservation (both paths).** The page must always carry **exactly one**
-marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a
-markerless page. If the existing page content already contains the canonical managed `## Lisa Usage`
-section, preserve that section when regenerating the page body unless the caller intentionally
-supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path
-rather than freehand block edits to ledger rows.
+marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a markerless body. Never write a markerless page. If the existing page content already contains the canonical managed `## Lisa Usage` section, preserve that section when regenerating the page body unless the caller intentionally supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path rather than freehand block edits to ledger rows.
 
 **CREATE:**
 

--- a/plugins/lisa/skills/prd-source-write/SKILL.md
+++ b/plugins/lisa/skills/prd-source-write/SKILL.md
@@ -8,7 +8,9 @@ allowed-tools: ["Skill", "Bash", "Read"]
 
 Thin dispatcher. Resolves the configured PRD `source` and delegates to the matching vendor PRD
 writer, which owns the concrete create/update, the lifecycle-role application, and the marker-based
-dedupe. This skill only routes — it never talks to a source API itself.
+dedupe. When the supplied PRD body already contains the canonical `## Lisa Usage` ledger, the
+vendor writer must preserve that managed section on update instead of dropping it or reformatting it
+ad hoc. This skill only routes — it never talks to a source API itself.
 
 See the `config-resolution` rule for the full configuration schema and the PRD lifecycle roles.
 
@@ -74,6 +76,8 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
 
 - Never bypass dispatch — a vendor-neutral caller calling a `*-write-prd` skill directly defeats the
   per-project source switch (exactly the `tracker-write` discipline, mirrored).
+- Never drop or duplicate an existing managed `## Lisa Usage` section. Writer-specific preservation
+  and fallback behavior belongs in the vendor writers and follows the `usage-accounting` contract.
 - Never accept a source outside `{notion, confluence, github, linear}`. `jira` and `file` fail loudly.
 - Never mutate the spec between layers. The vendor writers define their own create/dedupe contract.
 - Never invent a PRD lifecycle role string — resolve every role from `config-resolution` per vendor.

--- a/plugins/lisa/skills/tracker-write/SKILL.md
+++ b/plugins/lisa/skills/tracker-write/SKILL.md
@@ -6,7 +6,12 @@ allowed-tools: ["Skill", "Bash", "Read"]
 
 # Tracker Write: $ARGUMENTS
 
-Thin dispatcher. Resolves the configured destination tracker and delegates to the matching vendor write skill.
+Thin dispatcher. Resolves the configured destination tracker and delegates to the matching vendor
+write skill.
+
+When the incoming description/body already contains the canonical `## Lisa Usage` ledger, the vendor
+writer must preserve that managed section on update and use the `usage-accounting` contract for any
+body-vs-comment fallback. This shim only routes — it never edits tracker artifacts itself.
 
 See the `config-resolution` rule for the full configuration schema and skill-mapping table.
 
@@ -40,6 +45,9 @@ See the `config-resolution` rule for the full configuration schema and skill-map
 ## Rules
 
 - Never bypass dispatch — calling the vendor skill directly from a vendor-neutral caller defeats the per-project switch.
+- Never drop, duplicate, or hand-rewrite an existing managed `## Lisa Usage` section in this shim.
+  Writer-specific preservation logic belongs in the vendor writers and follows the
+  `usage-accounting` contract.
 - Never accept a tracker value outside `{jira, github, linear}`.
 - Never mutate `$ARGUMENTS` between layers. The vendor skills define their own input contract.
 - Never inline gate logic here. All validation rules live in the vendor skills (`lisa:jira-validate-ticket` / `lisa:github-validate-issue` / `lisa:linear-validate-issue`); this skill only routes.

--- a/plugins/src/base/skills/confluence-write-prd/SKILL.md
+++ b/plugins/src/base/skills/confluence-write-prd/SKILL.md
@@ -65,7 +65,10 @@ else → **create**.
 format** (XHTML): `#`/`##`/`###` → `<h1>/<h2>/<h3>`, paragraphs → `<p>`, lists → `<ul>/<ol><li>`,
 fenced code → `<ac:structured-macro ac:name="code">`. Embed the marker as a storage comment
 (`<!-- $MARKER -->`) or a small `<p>` so future CQL dedupe finds it. The body must always contain
-**exactly one** marker; never write a markerless page (CREATE or UPDATE).
+**exactly one** marker; never write a markerless page (CREATE or UPDATE). If the live page body
+already contains the canonical managed `## Lisa Usage` section, preserve it verbatim unless the
+caller intentionally supplied an updated canonical section; use the shared `usage-accounting`
+serializer/merge path rather than hand-editing ledger rows in storage XHTML.
 
 **CREATE:** `lisa:atlassian-access` `operation: write-page` (create form) with a payload that sets:
 - `title`: `$TITLE`
@@ -77,7 +80,8 @@ fenced code → `<ac:structured-macro ac:name="code">`. Embed the marker as a st
 1. **GET-then-PUT** (load-bearing, as `confluence-prd-intake` documents): first `operation: read-page
    id: <page-id>` to read the current `version.number`, then `operation: write-page` (edit form) with
    the marker-normalized storage body and `version.number` bumped to current+1. A PUT without the
-   current version is rejected; never drop the marker on the edit.
+   current version is rejected; never drop the marker or an existing managed `## Lisa Usage` section
+   on the edit.
 2. Re-parent to the target lifecycle parent if the role changed — **unless** the page's current
    parent is in the resolved `${PROGRESSED_PARENTS[@]}` set (already past `ready`). If so, leave it
    and report `reused (already past ready)`. Reverse-lookup the current parent in
@@ -99,5 +103,7 @@ outcome: created | reused
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never re-parent a PRD already past `ready` down to draft/ready.
 - Resolve parents from config (`confluence.parents.{draft,ready}`) — never hardcode page ids.

--- a/plugins/src/base/skills/github-write-issue/SKILL.md
+++ b/plugins/src/base/skills/github-write-issue/SKILL.md
@@ -276,7 +276,7 @@ If the validator reports `FAIL`, do NOT proceed to Phase 6. Fix the spec and re-
 
 ### UPDATE
 
-1. Re-read the current body via `gh issue view <number> --repo <org>/<repo> --json body --jq '.body'`. Edit only the sections being changed; preserve everything else verbatim.
+1. Re-read the current body via `gh issue view <number> --repo <org>/<repo> --json body --jq '.body'`. Edit only the sections being changed; preserve everything else verbatim, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 2. Apply the edit:
    ```bash
    gh issue edit <number> --repo <org>/<repo> --body-file /tmp/updated-body.md
@@ -331,6 +331,8 @@ The mapping below is the single source of truth for how JIRA concepts translate 
 - Never create a Bug, Task, or Sub-task whose AC references work in a different repo. GitHub Issues already live in one repo; reject AC bullets that span others — split into per-repo issues under a shared Epic.
 - Never include a runtime-behavior issue without a target backend environment, and never include an authenticated-surface issue without sign-in credentials.
 - Never overwrite an issue body without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All writes go through this skill (or the `tracker-write` shim). Other vendor-neutral skills must NEVER call `gh issue create` directly.
 - The gate logic lives in `lisa:github-validate-issue`, NOT here. This skill calls the validator at Phase 5.5 and Phase 7. When a gate needs to change, change it in `lisa:github-validate-issue`.
 - Never bypass the sub-issue mutation by encoding the parent only in the body. The native sub-issue link is what `lisa:github-read-issue` and the GitHub UI use to render the hierarchy.

--- a/plugins/src/base/skills/github-write-prd/SKILL.md
+++ b/plugins/src/base/skills/github-write-prd/SKILL.md
@@ -55,10 +55,13 @@ EXISTING=$(gh issue list --repo "$ORG/$REPO" --state open --search "\"$MARKER\" 
 
 ## Phase 3 — Create or update
 
-**Marker normalization (both paths).** Before writing any body, ensure it contains **exactly one**
-marker line — inject `<!-- $MARKER -->` if the caller's synthesized body doesn't already carry it.
-**Never write a markerless body** (including on UPDATE or when `source_ref` is passed): a body without
-the marker breaks future dedupe. If the body already has the marker, leave the single instance.
+**Marker + usage-ledger preservation (both paths).** Before writing any body, ensure it contains
+**exactly one** marker line — inject `<!-- $MARKER -->` if the caller's synthesized body doesn't
+already carry it. **Never write a markerless body** (including on UPDATE or when `source_ref` is
+passed): a body without the marker breaks future dedupe. If the body already has the marker, leave
+the single instance. If the live issue body already contains the canonical managed `## Lisa Usage`
+section, preserve it verbatim unless the caller intentionally supplied an updated canonical section;
+use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **CREATE** (no existing issue):
 
@@ -77,7 +80,7 @@ the marker breaks future dedupe. If the body already has the marker, leave the s
 **UPDATE** (existing issue or `source_ref`):
 
 1. `gh issue edit <n> --repo "$ORG/$REPO" --body-file /tmp/prd-body.md` with the **marker-normalized**
-   body (regenerate in place; never drop the marker).
+   body (regenerate in place; never drop the marker or an existing managed `## Lisa Usage` section).
 2. Reconcile the lifecycle label to **exactly one**: add `$ROLE_LABEL`, remove every other label in
    the resolved `${ALL_PRD_LABELS[@]}` set (the config-resolved names — not a hard-coded list) via
    `gh issue edit <n> --add-label / --remove-label`. Never leave a PRD carrying two lifecycle labels.
@@ -104,6 +107,8 @@ outcome: created | reused
 
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a PRD already past `ready`.
 - A *closed* prior PRD does not suppress a new one — a recurrence after closure is a genuine new PRD.
 - This is a source-side writer (`prd-*` labels). It never touches build labels (`status:*`) — that is

--- a/plugins/src/base/skills/jira-write-ticket/SKILL.md
+++ b/plugins/src/base/skills/jira-write-ticket/SKILL.md
@@ -235,7 +235,7 @@ If the validator reports `PASS`, continue to Phase 6.
 
 1. Invoke `lisa:atlassian-access` with `operation: write-ticket payload: {key: <K>, ...fields-being-changed}`. Do NOT resend fields that weren't in the change set — it blows away history.
 2. Add new relationships via `lisa:atlassian-access` `operation: link from: <K1> to: <K2> type: "<link-type>"`. Existing links are not touched unless explicitly removed.
-3. If description changes, preserve sections you are not editing. Re-read via `/jira-read-ticket` first.
+3. If description changes, preserve sections you are not editing. Re-read via `/jira-read-ticket` first, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 
 ## Phase 7 — Verify
 
@@ -259,5 +259,7 @@ Skip this step only on UPDATE when no material change was made.
 - Never include a runtime-behavior ticket without a target backend environment, and never include an authenticated-surface ticket without sign-in credentials in the description.
 - Never invent custom field values. If the project requires a field you don't have, stop and ask.
 - Never overwrite a description without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All writes go through this skill so best practices are enforced uniformly. Downstream skills (e.g. `lisa:jira-create`) should delegate here rather than invoking `lisa:atlassian-access` write operations directly.
 - The gate logic (what makes a valid ticket) lives in `lisa:jira-validate-ticket`, NOT in this skill. This skill calls the validator at Phase 5.5 (pre-write) and Phase 7 (via `lisa:jira-verify` post-write). When a gate needs to change, change it in `lisa:jira-validate-ticket` — every caller (write path, dry-run path, post-write verify) picks it up automatically.

--- a/plugins/src/base/skills/linear-write-issue/SKILL.md
+++ b/plugins/src/base/skills/linear-write-issue/SKILL.md
@@ -260,7 +260,7 @@ If the validator reports `PASS`, continue to Phase 6.
 ### UPDATE
 
 1. Call `mcp__linear-server__save_project` or `mcp__linear-server__save_issue` with **only the fields being changed**. Do NOT resend fields that weren't in the change set — Linear treats the call as a full overwrite of the listed fields.
-2. Preserve description sections you are not editing — re-read via `/linear-read-issue` first.
+2. Preserve description sections you are not editing — re-read via `/linear-read-issue` first, including any existing canonical managed `## Lisa Usage` section unless the caller intentionally supplied an updated canonical section. Use the shared `usage-accounting` serializer/merge path rather than freehand edits to ledger rows.
 
 ## Phase 7 — Verify
 
@@ -285,6 +285,8 @@ Skip this step only on UPDATE when no material change was made.
 - Never include a runtime-behavior item without a target backend environment, and never include an authenticated-surface item without sign-in credentials in the description.
 - Never invent custom field values. If the team requires a field you don't have, stop and ask.
 - Never overwrite a description without reading the current version first.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - All Linear writes go through this skill so best practices are enforced uniformly. Downstream skills (e.g. `lisa:linear-create`) should delegate here rather than calling the MCP write tools directly.
 - The gate logic (what makes a valid item) lives in `lisa:linear-validate-issue`, NOT in this skill. This skill calls the validator at Phase 5.5 (pre-write) and Phase 7 (via `lisa:linear-verify` post-write). When a gate needs to change, change it in `lisa:linear-validate-issue` — every caller picks it up automatically.
 - This skill is the destination of the `lisa:tracker-write` shim when `tracker = "linear"`. Vendor-neutral callers (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST go through `lisa:tracker-write`, not call this skill directly.

--- a/plugins/src/base/skills/linear-write-prd/SKILL.md
+++ b/plugins/src/base/skills/linear-write-prd/SKILL.md
@@ -52,9 +52,12 @@ marker, **never** the project name:
 
 ## Phase 3 — Create or update
 
-**Marker normalization (both paths).** Before writing the `description`, ensure it contains
-**exactly one** marker line — inject the marker if the synthesized description lacks it. **Never write
-a markerless description** (including UPDATE / `source_ref`): that breaks future dedupe.
+**Marker + usage-ledger preservation (both paths).** Before writing the `description`, ensure it
+contains **exactly one** marker line — inject the marker if the synthesized description lacks it.
+**Never write a markerless description** (including UPDATE / `source_ref`): that breaks future
+dedupe. If the live Project description already contains the canonical managed `## Lisa Usage`
+section, preserve it verbatim unless the caller intentionally supplied an updated canonical section;
+use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **CREATE:** `mcp__linear-server__save_project` with:
 - `name`: `$TITLE`
@@ -64,8 +67,9 @@ a markerless description** (including UPDATE / `source_ref`): that breaks future
 - `state`: Linear Project default (e.g. `backlog`)
 
 **UPDATE** (existing project or `source_ref`): `save_project` with the project id and **only** the
-changed fields — regenerate the marker-normalized `description`, and reconcile labels to **exactly
-one** PRD lifecycle label: add the role label, remove every other label in the resolved
+changed fields — regenerate the marker-normalized `description` without dropping the managed
+`## Lisa Usage` section, and reconcile labels to **exactly one** PRD lifecycle label: add the role
+label, remove every other label in the resolved
 `${ALL_PRD_LABELS[@]}` set (config-resolved names, not a hard-coded list). Do **not** down-rank a
 Project whose current label is in the resolved `${PROGRESSED[@]}` set (already past `ready`) — leave
 it and report `reused (already past ready)`.
@@ -84,6 +88,8 @@ outcome: created | reused
 
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a Project already past `ready`.
 - Source-side writer (`prd-*` project labels) — never touches issue-level build labels (`status:*`),
   which are `lisa:linear-write-issue`'s lane (see `config-resolution` self-host separation).

--- a/plugins/src/base/skills/notion-write-prd/SKILL.md
+++ b/plugins/src/base/skills/notion-write-prd/SKILL.md
@@ -60,8 +60,12 @@ exceeds 100 blocks, create the page with the first ≤100 blocks then add the re
 accept the markdown content directly (it performs this conversion) — prefer that; the explicit block
 conversion is the curl-substrate path.
 
-**Marker normalization (both paths).** The page must always carry **exactly one** marker. On CREATE
-the marker is the first body block; on UPDATE never remove it. Never write a markerless page.
+**Marker + usage-ledger preservation (both paths).** The page must always carry **exactly one**
+marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a
+markerless page. If the existing page content already contains the canonical managed `## Lisa Usage`
+section, preserve that section when regenerating the page body unless the caller intentionally
+supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path
+rather than freehand block edits to ledger rows.
 
 **CREATE:**
 
@@ -86,7 +90,7 @@ the marker is the first body block; on UPDATE never remove it. Never write a mar
    (`operation: archive-page` is page-level, so for blocks delete via the blocks API through
    `notion-access` or, where block deletion isn't available, replace their text in place) and
    `operation: append-blocks` the regenerated blocks. Do not duplicate the whole spec as a dated
-   note, and never drop the marker.
+   note, and never drop the marker or an existing managed `## Lisa Usage` section.
 
 ## Phase 4 — Return
 
@@ -102,6 +106,8 @@ outcome: created | reused
 
 - All access via `lisa:notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
+- Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage
+  section or silently drop ledger rows.
 - Never down-rank a PRD whose Status is already past `ready`.
 - Resolve the Status vocabulary from config (`notion.statusProperty`, `notion.values.*`) — never
   hardcode value names.

--- a/plugins/src/base/skills/notion-write-prd/SKILL.md
+++ b/plugins/src/base/skills/notion-write-prd/SKILL.md
@@ -61,11 +61,7 @@ accept the markdown content directly (it performs this conversion) — prefer th
 conversion is the curl-substrate path.
 
 **Marker + usage-ledger preservation (both paths).** The page must always carry **exactly one**
-marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a
-markerless page. If the existing page content already contains the canonical managed `## Lisa Usage`
-section, preserve that section when regenerating the page body unless the caller intentionally
-supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path
-rather than freehand block edits to ledger rows.
+marker. On CREATE the marker is the first body block; on UPDATE never remove it. Never write a markerless body. Never write a markerless page. If the existing page content already contains the canonical managed `## Lisa Usage` section, preserve that section when regenerating the page body unless the caller intentionally supplied an updated canonical section; use the shared `usage-accounting` serializer/merge path rather than freehand block edits to ledger rows.
 
 **CREATE:**
 

--- a/plugins/src/base/skills/prd-source-write/SKILL.md
+++ b/plugins/src/base/skills/prd-source-write/SKILL.md
@@ -8,7 +8,9 @@ allowed-tools: ["Skill", "Bash", "Read"]
 
 Thin dispatcher. Resolves the configured PRD `source` and delegates to the matching vendor PRD
 writer, which owns the concrete create/update, the lifecycle-role application, and the marker-based
-dedupe. This skill only routes — it never talks to a source API itself.
+dedupe. When the supplied PRD body already contains the canonical `## Lisa Usage` ledger, the
+vendor writer must preserve that managed section on update instead of dropping it or reformatting it
+ad hoc. This skill only routes — it never talks to a source API itself.
 
 See the `config-resolution` rule for the full configuration schema and the PRD lifecycle roles.
 
@@ -74,6 +76,8 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
 
 - Never bypass dispatch — a vendor-neutral caller calling a `*-write-prd` skill directly defeats the
   per-project source switch (exactly the `tracker-write` discipline, mirrored).
+- Never drop or duplicate an existing managed `## Lisa Usage` section. Writer-specific preservation
+  and fallback behavior belongs in the vendor writers and follows the `usage-accounting` contract.
 - Never accept a source outside `{notion, confluence, github, linear}`. `jira` and `file` fail loudly.
 - Never mutate the spec between layers. The vendor writers define their own create/dedupe contract.
 - Never invent a PRD lifecycle role string — resolve every role from `config-resolution` per vendor.

--- a/plugins/src/base/skills/tracker-write/SKILL.md
+++ b/plugins/src/base/skills/tracker-write/SKILL.md
@@ -6,7 +6,12 @@ allowed-tools: ["Skill", "Bash", "Read"]
 
 # Tracker Write: $ARGUMENTS
 
-Thin dispatcher. Resolves the configured destination tracker and delegates to the matching vendor write skill.
+Thin dispatcher. Resolves the configured destination tracker and delegates to the matching vendor
+write skill.
+
+When the incoming description/body already contains the canonical `## Lisa Usage` ledger, the vendor
+writer must preserve that managed section on update and use the `usage-accounting` contract for any
+body-vs-comment fallback. This shim only routes — it never edits tracker artifacts itself.
 
 See the `config-resolution` rule for the full configuration schema and skill-mapping table.
 
@@ -40,6 +45,9 @@ See the `config-resolution` rule for the full configuration schema and skill-map
 ## Rules
 
 - Never bypass dispatch — calling the vendor skill directly from a vendor-neutral caller defeats the per-project switch.
+- Never drop, duplicate, or hand-rewrite an existing managed `## Lisa Usage` section in this shim.
+  Writer-specific preservation logic belongs in the vendor writers and follows the
+  `usage-accounting` contract.
 - Never accept a tracker value outside `{jira, github, linear}`.
 - Never mutate `$ARGUMENTS` between layers. The vendor skills define their own input contract.
 - Never inline gate logic here. All validation rules live in the vendor skills (`lisa:jira-validate-ticket` / `lisa:github-validate-issue` / `lisa:linear-validate-issue`); this skill only routes.

--- a/tests/unit/strategies/usage-accounting-writer-preservation.test.ts
+++ b/tests/unit/strategies/usage-accounting-writer-preservation.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression tests for issue #730: PRD writers and tracker writers must preserve
+ * the managed Lisa Usage ledger instead of dropping or duplicating it during
+ * updates.
+ *
+ * Assert both the upstream source skills and the generated plugin artifacts so
+ * `bun run build:plugins` remains a required parity step.
+ * @module tests/unit/strategies/usage-accounting-writer-preservation
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const USAGE_SECTION = "## Lisa Usage";
+const USAGE_RULE = "usage-accounting";
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+describe("writer shims preserve managed Lisa Usage ledgers", () => {
+  describe.each(ROOTS)("%s", root => {
+    it("threads PRD writes through usage-aware vendor writers", () => {
+      const content = readSkill(root, "prd-source-write");
+      expect(content).toContain(USAGE_SECTION);
+      expect(content).toMatch(/preserve/i);
+      expect(content).toMatch(new RegExp(USAGE_RULE, "i"));
+    });
+
+    it("threads tracker writes through usage-aware vendor writers", () => {
+      const content = readSkill(root, "tracker-write");
+      expect(content).toContain(USAGE_SECTION);
+      expect(content).toMatch(/preserve/i);
+      expect(content).toMatch(new RegExp(USAGE_RULE, "i"));
+    });
+  });
+});
+
+describe("per-vendor PRD writers preserve managed Lisa Usage ledgers", () => {
+  const writers = [
+    "github-write-prd",
+    "linear-write-prd",
+    "notion-write-prd",
+    "confluence-write-prd",
+  ] as const;
+
+  describe.each(writers)("%s", writer => {
+    describe.each(ROOTS)("%s", root => {
+      const content = readSkill(root, writer);
+
+      it("mentions preserving the canonical usage section on update", () => {
+        expect(content).toContain(USAGE_SECTION);
+        expect(content).toMatch(/preserve/i);
+        expect(content).toMatch(/update/i);
+      });
+
+      it("routes ledger rewrites through the shared usage-accounting contract", () => {
+        expect(content).toMatch(new RegExp(USAGE_RULE, "i"));
+        expect(content).toMatch(/serializer|merge path/i);
+      });
+    });
+  });
+});
+
+describe("per-vendor tracker writers preserve managed Lisa Usage ledgers", () => {
+  const writers = [
+    "github-write-issue",
+    "linear-write-issue",
+    "jira-write-ticket",
+  ] as const;
+
+  describe.each(writers)("%s", writer => {
+    describe.each(ROOTS)("%s", root => {
+      const content = readSkill(root, writer);
+
+      it("requires preserving the canonical usage section during updates", () => {
+        expect(content).toContain(USAGE_SECTION);
+        expect(content).toMatch(/preserve/i);
+        expect(content).toMatch(/update/i);
+      });
+
+      it("forbids duplicate or ad hoc ledger rewrites", () => {
+        expect(content).toMatch(
+          /never append a second usage section|silently drop ledger rows/i
+        );
+        expect(content).toMatch(new RegExp(USAGE_RULE, "i"));
+      });
+    });
+  });
+});

--- a/tests/unit/strategies/usage-accounting-writer-preservation.test.ts
+++ b/tests/unit/strategies/usage-accounting-writer-preservation.test.ts
@@ -8,6 +8,7 @@
  * @module tests/unit/strategies/usage-accounting-writer-preservation
  */
 import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -18,6 +19,9 @@ const USAGE_RULE = "usage-accounting";
 
 const readSkill = (root: string, skill: string): string =>
   readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+const skillRoots = (skill: string): string[] =>
+  ROOTS.filter(root => existsSync(path.resolve(root, skill, "SKILL.md")));
 
 describe("writer shims preserve managed Lisa Usage ledgers", () => {
   describe.each(ROOTS)("%s", root => {
@@ -46,7 +50,7 @@ describe("per-vendor PRD writers preserve managed Lisa Usage ledgers", () => {
   ] as const;
 
   describe.each(writers)("%s", writer => {
-    describe.each(ROOTS)("%s", root => {
+    describe.each(skillRoots(writer))("%s", root => {
       const content = readSkill(root, writer);
 
       it("mentions preserving the canonical usage section on update", () => {
@@ -71,7 +75,7 @@ describe("per-vendor tracker writers preserve managed Lisa Usage ledgers", () =>
   ] as const;
 
   describe.each(writers)("%s", writer => {
-    describe.each(ROOTS)("%s", root => {
+    describe.each(skillRoots(writer))("%s", root => {
       const content = readSkill(root, writer);
 
       it("requires preserving the canonical usage section during updates", () => {


### PR DESCRIPTION
## Summary
- require PRD and tracker writer contracts to preserve managed \ sections on update
- thread the usage-accounting contract through vendor-neutral shims and vendor-specific writer docs
- add regression coverage for source and generated writer skills, then rebuild plugin artifacts

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/usage-accounting-writer-preservation.test.ts