### PR TITLE
feat: record lifecycle usage on research plan and debrief artifacts

### DIFF
--- a/plugins/lisa/rules/intent-routing.md
+++ b/plugins/lisa/rules/intent-routing.md
@@ -70,7 +70,8 @@ Sequence:
 5. Synthesize findings into a PRD containing: problem statement, user stories, acceptance criteria, technical constraints, open questions, and proposed scope
 6. **Plan Phase Tooling** -- review all available skills and agents (project-defined, plugin-provided, and built-in) and determine which ones the Plan phase will need. For each recommended skill or agent, state why it is needed. If no skills or agents beyond the defaults are identified, explicitly justify why the standard set is sufficient. Include this as a "Recommended Tooling for Plan Phase" section in the PRD.
 7. **Create the PRD in the configured source** -- invoke `lisa:prd-source-write` with the synthesized PRD (`title`, `body`, `initial_role` resolved from the caller's `prd_ready` flag — `draft` by default, `ready` when `prd_ready=true`, plus any `dedupe_key`/`marker`/`source_ref` the caller passed). The PRD **lives in the source** (Notion page / Confluence page / GitHub issue / Linear project per `.lisa.config.json` `source`); there is no separate document artifact. A `source` must be configured — if it is not, stop and report it. `prd-source-write` dedupes by marker, so re-running against the same idea references the existing PRD instead of creating a duplicate.
-8. `learner` -- capture discoveries for future sessions
+8. **Record Research usage on the PRD artifact** -- invoke `lisa:usage-accounting` against the created PRD/source artifact so it gains a direct `research` usage entry in the canonical `## Lisa Usage` section at creation time. If the runtime cannot provide trustworthy usage, still write the row with `source: unavailable` and nullable token/cost fields; missing usage is never treated as zero or silently omitted.
+9. `learner` -- capture discoveries for future sessions
 
 Output: A PRD created in the configured source, carrying a "Recommended Tooling for Plan Phase" section, in the `draft` role by default (or `ready` when `prd_ready=true`, so `lisa:intake` auto-claims it). If there is not enough context to produce a complete PRD, stop and report what is missing rather than creating an incomplete one. If no `source` is configured, stop and report it rather than emitting a loose document.
 
@@ -97,8 +98,10 @@ Sequence:
    - Dependencies
    - Skills and agents required (from step 5)
 7. Create work items in the tracker (JIRA, Linear, GitHub) with acceptance criteria, dependencies, and recommended skills/agents
-8. **PRD back-link** -- update the source PRD with a `## Tickets` section listing every created work item (key, title, type, link), so the PRD becomes the canonical anchor for downstream flows (notably **Debrief**). Invoke `lisa:prd-backlink` with the PRD source and the created ticket list. The section is regenerated on each run, not appended, so re-planning never produces stale links.
-9. `learner` -- capture discoveries for future sessions
+8. **Record Plan usage on the PRD and created work items** -- route all direct usage writes through `lisa:usage-accounting`: attach a `plan` entry to the source PRD/spec artifact and to each created work item. If runtime usage is unavailable, still write an explicit `source: unavailable` row with nullable token/cost fields instead of omitting the entry.
+9. **PRD back-link** -- update the source PRD with a `## Tickets` section listing every created work item (key, title, type, link), so the PRD becomes the canonical anchor for downstream flows (notably **Debrief**). Invoke `lisa:prd-backlink` with the PRD source and the created ticket list. The section is regenerated on each run, not appended, so re-planning never produces stale links.
+10. **Refresh the PRD usage rollup** -- re-invoke `lisa:usage-accounting` on the source PRD after `lisa:prd-backlink` regenerates child refs so the PRD `## Lisa Usage` rollup reflects the created ticket set.
+11. `learner` -- capture discoveries for future sessions
 
 Output: Work items in a tracker with acceptance criteria and recommended skills/agents, ordered by dependency. The source PRD carries a `## Tickets` section linking back to every created item. If the specification cannot be decomposed without further clarification, stop and report what is missing.
 
@@ -215,7 +218,8 @@ Sequence:
    - **Tooling gap** — missing skill, wrong agent assignment, broken hook, missing automation
    - **Convention drift** — an unwritten rule revealed by review comments that should be codified
 4. **Produce the human-triage document** — a markdown file with one row per candidate learning showing: category, summary, evidence (links to the source ticket comment / PR comment / commit), recommended persistence destination, and a checkbox-style disposition field the human will mark (Accept / Reject / Defer). Surface step-1 anomalies (work items missing PRs, etc.) in a separate section. The document is exhaustive — it lists every candidate, even ones the synthesizer rates low confidence — because the human, not the agent, decides what is worth keeping.
-5. **Stop and hand the document to the human.** Debrief does NOT persist accepted learnings itself. The human triages, marks dispositions, and runs the **`/lisa:debrief:apply`** command (skill: `debrief-apply`) to route the accepted items to their destinations.
+5. **Record Debrief usage on the triage document** — invoke `lisa:usage-accounting` against the generated markdown artifact so the document carries its own direct `debrief` usage entry in the canonical `## Lisa Usage` section. If runtime usage is unavailable, write the entry with `source: unavailable` and nullable token/cost fields rather than skipping it.
+6. **Stop and hand the document to the human.** Debrief does NOT persist accepted learnings itself. The human triages, marks dispositions, and runs the **`/lisa:debrief:apply`** command (skill: `debrief-apply`) to route the accepted items to their destinations.
 
 Output: A triage-ready learnings document covering every work item and PR in the initiative, with structured evidence and disposition fields. Persistence is deferred to `debrief-apply`, which the human invokes after triage.
 

--- a/plugins/lisa/skills/debrief/SKILL.md
+++ b/plugins/lisa/skills/debrief/SKILL.md
@@ -69,6 +69,11 @@ A markdown triage document at `./debrief/<initiative-slug>-<YYYY-MM-DD>.md` (or 
    - `Disposition` — empty checkbox-style field the human will fill: `[ ] Accept` / `[ ] Reject` / `[ ] Defer` plus a free-text reason
 4. **Source map** — appendix listing every work item and PR walked, so the human can verify completeness.
 
+Before returning, write the Debrief run's direct usage onto the triage document through
+`lisa:usage-accounting` so the markdown artifact carries its own `## Lisa Usage` section separate
+from delivery-time usage. If runtime usage is unavailable, record a debrief entry with
+`source: unavailable` and nullable token/cost fields instead of skipping the row.
+
 The skill's terminal output is the path to the triage document and a one-line summary of counts per category. Persistence does not happen here — that is `lisa:debrief-apply`'s job.
 
 ## Hand-off

--- a/plugins/lisa/skills/plan/SKILL.md
+++ b/plugins/lisa/skills/plan/SKILL.md
@@ -52,4 +52,4 @@ Execute the **Plan** flow as defined in the `intent-routing` rule (loaded via th
 
 ## Output
 
-Work items in the configured tracker (JIRA, GitHub Issues, or Linear, per `.lisa.config.json` `tracker`) with acceptance criteria, dependencies, and recommended skills/agents per item. Ordered by dependency. If the specification cannot be decomposed without further clarification, stop and report what is missing.
+Work items in the configured tracker (JIRA, GitHub Issues, or Linear, per `.lisa.config.json` `tracker`) with acceptance criteria, dependencies, and recommended skills/agents per item. Ordered by dependency. Before finishing, route usage writes through `lisa:usage-accounting`: record the Plan run as a direct entry on the source PRD/spec artifact, attach a plan usage entry (or an explicit `source: unavailable` entry with nullable token/cost fields) to each created work item, and refresh the PRD rollup after `lisa:prd-backlink` regenerates the `## Tickets` child refs. Do not invent plan-specific ledger formats or omit missing usage silently. If the specification cannot be decomposed without further clarification, stop and report what is missing.

--- a/plugins/lisa/skills/research/SKILL.md
+++ b/plugins/lisa/skills/research/SKILL.md
@@ -45,5 +45,10 @@ feasibility notes, open questions, and the "Recommended Tooling for Plan Phase" 
 flow step invokes `lisa:prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the
-source — there is no loose document artifact.** A `source` must be configured; if it is not, stop and
-report it rather than emitting a document. The Plan flow consumes the created PRD next.
+source — there is no loose document artifact.** Before handing the synthesized PRD to
+`lisa:prd-source-write`, record the Research run's direct usage on that artifact through
+`lisa:usage-accounting` so the PRD body carries the canonical `## Lisa Usage` ledger from creation
+time onward. If the runtime does not expose trustworthy usage, the direct entry must still be
+written with `source: unavailable` and nullable token/cost fields rather than silently omitting the
+Research row. A `source` must be configured; if it is not, stop and report it rather than emitting
+a document. The Plan flow consumes the created PRD next.

--- a/plugins/src/base/rules/intent-routing.md
+++ b/plugins/src/base/rules/intent-routing.md
@@ -70,7 +70,8 @@ Sequence:
 5. Synthesize findings into a PRD containing: problem statement, user stories, acceptance criteria, technical constraints, open questions, and proposed scope
 6. **Plan Phase Tooling** -- review all available skills and agents (project-defined, plugin-provided, and built-in) and determine which ones the Plan phase will need. For each recommended skill or agent, state why it is needed. If no skills or agents beyond the defaults are identified, explicitly justify why the standard set is sufficient. Include this as a "Recommended Tooling for Plan Phase" section in the PRD.
 7. **Create the PRD in the configured source** -- invoke `lisa:prd-source-write` with the synthesized PRD (`title`, `body`, `initial_role` resolved from the caller's `prd_ready` flag — `draft` by default, `ready` when `prd_ready=true`, plus any `dedupe_key`/`marker`/`source_ref` the caller passed). The PRD **lives in the source** (Notion page / Confluence page / GitHub issue / Linear project per `.lisa.config.json` `source`); there is no separate document artifact. A `source` must be configured — if it is not, stop and report it. `prd-source-write` dedupes by marker, so re-running against the same idea references the existing PRD instead of creating a duplicate.
-8. `learner` -- capture discoveries for future sessions
+8. **Record Research usage on the PRD artifact** -- invoke `lisa:usage-accounting` against the created PRD/source artifact so it gains a direct `research` usage entry in the canonical `## Lisa Usage` section at creation time. If the runtime cannot provide trustworthy usage, still write the row with `source: unavailable` and nullable token/cost fields; missing usage is never treated as zero or silently omitted.
+9. `learner` -- capture discoveries for future sessions
 
 Output: A PRD created in the configured source, carrying a "Recommended Tooling for Plan Phase" section, in the `draft` role by default (or `ready` when `prd_ready=true`, so `lisa:intake` auto-claims it). If there is not enough context to produce a complete PRD, stop and report what is missing rather than creating an incomplete one. If no `source` is configured, stop and report it rather than emitting a loose document.
 
@@ -97,8 +98,10 @@ Sequence:
    - Dependencies
    - Skills and agents required (from step 5)
 7. Create work items in the tracker (JIRA, Linear, GitHub) with acceptance criteria, dependencies, and recommended skills/agents
-8. **PRD back-link** -- update the source PRD with a `## Tickets` section listing every created work item (key, title, type, link), so the PRD becomes the canonical anchor for downstream flows (notably **Debrief**). Invoke `lisa:prd-backlink` with the PRD source and the created ticket list. The section is regenerated on each run, not appended, so re-planning never produces stale links.
-9. `learner` -- capture discoveries for future sessions
+8. **Record Plan usage on the PRD and created work items** -- route all direct usage writes through `lisa:usage-accounting`: attach a `plan` entry to the source PRD/spec artifact and to each created work item. If runtime usage is unavailable, still write an explicit `source: unavailable` row with nullable token/cost fields instead of omitting the entry.
+9. **PRD back-link** -- update the source PRD with a `## Tickets` section listing every created work item (key, title, type, link), so the PRD becomes the canonical anchor for downstream flows (notably **Debrief**). Invoke `lisa:prd-backlink` with the PRD source and the created ticket list. The section is regenerated on each run, not appended, so re-planning never produces stale links.
+10. **Refresh the PRD usage rollup** -- re-invoke `lisa:usage-accounting` on the source PRD after `lisa:prd-backlink` regenerates child refs so the PRD `## Lisa Usage` rollup reflects the created ticket set.
+11. `learner` -- capture discoveries for future sessions
 
 Output: Work items in a tracker with acceptance criteria and recommended skills/agents, ordered by dependency. The source PRD carries a `## Tickets` section linking back to every created item. If the specification cannot be decomposed without further clarification, stop and report what is missing.
 
@@ -215,7 +218,8 @@ Sequence:
    - **Tooling gap** — missing skill, wrong agent assignment, broken hook, missing automation
    - **Convention drift** — an unwritten rule revealed by review comments that should be codified
 4. **Produce the human-triage document** — a markdown file with one row per candidate learning showing: category, summary, evidence (links to the source ticket comment / PR comment / commit), recommended persistence destination, and a checkbox-style disposition field the human will mark (Accept / Reject / Defer). Surface step-1 anomalies (work items missing PRs, etc.) in a separate section. The document is exhaustive — it lists every candidate, even ones the synthesizer rates low confidence — because the human, not the agent, decides what is worth keeping.
-5. **Stop and hand the document to the human.** Debrief does NOT persist accepted learnings itself. The human triages, marks dispositions, and runs the **`/lisa:debrief:apply`** command (skill: `debrief-apply`) to route the accepted items to their destinations.
+5. **Record Debrief usage on the triage document** — invoke `lisa:usage-accounting` against the generated markdown artifact so the document carries its own direct `debrief` usage entry in the canonical `## Lisa Usage` section. If runtime usage is unavailable, write the entry with `source: unavailable` and nullable token/cost fields rather than skipping it.
+6. **Stop and hand the document to the human.** Debrief does NOT persist accepted learnings itself. The human triages, marks dispositions, and runs the **`/lisa:debrief:apply`** command (skill: `debrief-apply`) to route the accepted items to their destinations.
 
 Output: A triage-ready learnings document covering every work item and PR in the initiative, with structured evidence and disposition fields. Persistence is deferred to `debrief-apply`, which the human invokes after triage.
 

--- a/plugins/src/base/skills/debrief/SKILL.md
+++ b/plugins/src/base/skills/debrief/SKILL.md
@@ -69,6 +69,11 @@ A markdown triage document at `./debrief/<initiative-slug>-<YYYY-MM-DD>.md` (or 
    - `Disposition` — empty checkbox-style field the human will fill: `[ ] Accept` / `[ ] Reject` / `[ ] Defer` plus a free-text reason
 4. **Source map** — appendix listing every work item and PR walked, so the human can verify completeness.
 
+Before returning, write the Debrief run's direct usage onto the triage document through
+`lisa:usage-accounting` so the markdown artifact carries its own `## Lisa Usage` section separate
+from delivery-time usage. If runtime usage is unavailable, record a debrief entry with
+`source: unavailable` and nullable token/cost fields instead of skipping the row.
+
 The skill's terminal output is the path to the triage document and a one-line summary of counts per category. Persistence does not happen here — that is `lisa:debrief-apply`'s job.
 
 ## Hand-off

--- a/plugins/src/base/skills/plan/SKILL.md
+++ b/plugins/src/base/skills/plan/SKILL.md
@@ -52,4 +52,4 @@ Execute the **Plan** flow as defined in the `intent-routing` rule (loaded via th
 
 ## Output
 
-Work items in the configured tracker (JIRA, GitHub Issues, or Linear, per `.lisa.config.json` `tracker`) with acceptance criteria, dependencies, and recommended skills/agents per item. Ordered by dependency. If the specification cannot be decomposed without further clarification, stop and report what is missing.
+Work items in the configured tracker (JIRA, GitHub Issues, or Linear, per `.lisa.config.json` `tracker`) with acceptance criteria, dependencies, and recommended skills/agents per item. Ordered by dependency. Before finishing, route usage writes through `lisa:usage-accounting`: record the Plan run as a direct entry on the source PRD/spec artifact, attach a plan usage entry (or an explicit `source: unavailable` entry with nullable token/cost fields) to each created work item, and refresh the PRD rollup after `lisa:prd-backlink` regenerates the `## Tickets` child refs. Do not invent plan-specific ledger formats or omit missing usage silently. If the specification cannot be decomposed without further clarification, stop and report what is missing.

--- a/plugins/src/base/skills/research/SKILL.md
+++ b/plugins/src/base/skills/research/SKILL.md
@@ -45,5 +45,10 @@ feasibility notes, open questions, and the "Recommended Tooling for Plan Phase" 
 flow step invokes `lisa:prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the
-source — there is no loose document artifact.** A `source` must be configured; if it is not, stop and
-report it rather than emitting a document. The Plan flow consumes the created PRD next.
+source — there is no loose document artifact.** Before handing the synthesized PRD to
+`lisa:prd-source-write`, record the Research run's direct usage on that artifact through
+`lisa:usage-accounting` so the PRD body carries the canonical `## Lisa Usage` ledger from creation
+time onward. If the runtime does not expose trustworthy usage, the direct entry must still be
+written with `source: unavailable` and nullable token/cost fields rather than silently omitting the
+Research row. A `source` must be configured; if it is not, stop and report it rather than emitting
+a document. The Plan flow consumes the created PRD next.

--- a/tests/unit/strategies/usage-accounting-lifecycle-artifacts.test.ts
+++ b/tests/unit/strategies/usage-accounting-lifecycle-artifacts.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression coverage for issue #731: research, plan, and debrief must attach
+ * direct usage entries to the artifacts they create or update.
+ *
+ * Assert both the upstream source skills/rules and the generated plugin copies
+ * so plugin parity stays enforced.
+ * @module tests/unit/strategies/usage-accounting-lifecycle-artifacts
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const RULES = [
+  "plugins/src/base/rules/intent-routing.md",
+  "plugins/lisa/rules/intent-routing.md",
+] as const;
+const USAGE_SKILL = "lisa:usage-accounting";
+const USAGE_SECTION = "## Lisa Usage";
+const UNAVAILABLE_USAGE = /source:\s*unavailable/i;
+
+const readSkill = (root: string, skill: string): string =>
+  readFileSync(path.resolve(root, skill, "SKILL.md"), "utf8");
+
+describe("research/plan/debrief usage-accounting integration", () => {
+  describe.each(ROOTS)("%s", root => {
+    it("records research usage on the PRD artifact", () => {
+      const content = readSkill(root, "research");
+
+      expect(content).toContain(USAGE_SKILL);
+      expect(content).toContain(USAGE_SECTION);
+      expect(content).toMatch(/Research run's direct usage/i);
+      expect(content).toMatch(UNAVAILABLE_USAGE);
+    });
+
+    it("records plan usage on the PRD and created work items", () => {
+      const content = readSkill(root, "plan");
+
+      expect(content).toContain(USAGE_SKILL);
+      expect(content).toMatch(/direct entry on the source PRD/i);
+      expect(content).toMatch(/each created work item/i);
+      expect(content).toMatch(UNAVAILABLE_USAGE);
+      expect(content).toMatch(/prd-backlink/i);
+      expect(content).toMatch(/rollup/i);
+    });
+
+    it("records debrief usage on the generated triage document", () => {
+      const content = readSkill(root, "debrief");
+
+      expect(content).toContain(USAGE_SKILL);
+      expect(content).toContain(USAGE_SECTION);
+      expect(content).toMatch(/Debrief run's direct usage/i);
+      expect(content).toMatch(UNAVAILABLE_USAGE);
+    });
+  });
+});
+
+describe("intent-routing lifecycle flows include usage writes", () => {
+  describe.each(RULES)("%s", rulePath => {
+    const content = readFileSync(path.resolve(rulePath), "utf8");
+
+    it("adds Research usage recording after PRD creation", () => {
+      expect(content).toMatch(/Record Research usage on the PRD artifact/i);
+      expect(content).toContain(USAGE_SKILL);
+      expect(content).toMatch(UNAVAILABLE_USAGE);
+    });
+
+    it("adds Plan usage recording plus PRD rollup refresh", () => {
+      expect(content).toMatch(
+        /Record Plan usage on the PRD and created work items/i
+      );
+      expect(content).toMatch(/Refresh the PRD usage rollup/i);
+      expect(content).toMatch(/prd-backlink/i);
+    });
+
+    it("adds Debrief usage recording on the triage document", () => {
+      expect(content).toMatch(/Record Debrief usage on the triage document/i);
+      expect(content).toContain(USAGE_SECTION);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- record usage-accounting expectations on research, plan, and debrief artifact outputs
- update the shared intent-routing flow definitions so lifecycle usage recording stays canonical
- add regression coverage for source/generated skill parity and lifecycle usage hooks

## Testing
- bun test tests/unit/strategies/usage-accounting-lifecycle-artifacts.test.ts
- bun run build:plugins