### PR TITLE
[lisa] Extend config resolution with usage pricing fields

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -132,6 +132,22 @@ fi
     }
   },
 
+  "usage": {
+    "pricing": {
+      "currency": "USD",
+      "source": "openai-api-pricing",
+      "snapshot": "2026-05-25",
+      "models": {
+        "openai/gpt-5": {
+          "inputPer1M": 1.25,
+          "cachedInputPer1M": 0.125,
+          "outputPer1M": 10.0,
+          "reasoningPer1M": 10.0
+        }
+      }
+    }
+  },
+
   "intake": {
     "assignee": "<vendor-user-id-or-login>",
     "repair": {
@@ -212,6 +228,34 @@ When `github.projects.v2` is present, later setup/doctor and writer preflight va
 |-------|---------------|-------|
 | `linear.workspace` | `tracker = "linear"`, `source = "linear"`, or any `linear-*` skill is invoked | Linear workspace slug (e.g. `acme`). |
 | `linear.teamKey` | `tracker = "linear"` | Linear team key (e.g. `ENG`). The team owns the destination Issues. For source mode, projects are workspace-scoped or team-scoped per the URL passed. |
+
+#### `usage`
+
+`usage` is optional. It carries non-secret pricing metadata Lisa may use when runtime token counts are trustworthy but runtime monetary cost is absent.
+
+| Field | Required when | Where it lives | Notes |
+|-------|---------------|----------------|-------|
+| `usage.pricing.currency` | estimating cost from config | **committed** | ISO currency code paired with the configured rates (for example `USD`). |
+| `usage.pricing.source` | estimating cost from config | **committed** | Human-readable source label for the configured pricing schedule (for example `openai-api-pricing`). This is metadata, not a URL requirement. |
+| `usage.pricing.snapshot` | no | **committed** | Version/date/hash describing when the pricing schedule was captured. Use it to make estimated-cost provenance durable across later vendor price changes. |
+| `usage.pricing.models` | estimating cost from config | **committed** | Map of `<provider>/<model>` to per-million-token rates. Lisa has **no built-in provider rates**; every estimated-cost model must be declared here explicitly. |
+
+Each `usage.pricing.models["<provider>/<model>"]` value supports these numeric keys:
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `inputPer1M` | yes | Price per 1M non-cached input tokens. |
+| `cachedInputPer1M` | no | Price per 1M cached input tokens when the runtime exposes them separately. If absent, cached tokens cannot be priced and the entry falls back to `pricing_status=missing` unless the runtime already supplied cost. |
+| `outputPer1M` | yes | Price per 1M output/completion tokens. |
+| `reasoningPer1M` | no | Price per 1M reasoning/internal tokens when the provider bills them separately. If absent, treat reasoning tokens as unpriceable rather than folding them into another bucket. |
+
+Resolution rules for estimated pricing:
+
+- Resolve `usage.pricing.*` with the same per-key local-overrides-global precedence as every other config section.
+- Estimates are allowed only when trustworthy token counts exist and a matching `usage.pricing.models["<provider>/<model>"]` entry supplies every rate needed for the exposed token buckets.
+- Missing model entries or missing required bucket rates do **not** trigger built-in defaults. Preserve the token counts, leave `cost = null`, and emit `pricing_status = missing`.
+- When an estimate is produced from config, write `pricing_source` as `config:<source>@<snapshot>` when both fields exist, `config:<source>` when only `source` exists, or `config` when neither metadata field is available.
+- Runtime-observed monetary cost always wins over config estimates; config pricing is fallback-only.
 
 ## Workflow & vocabulary roles
 

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -132,6 +132,22 @@ fi
     }
   },
 
+  "usage": {
+    "pricing": {
+      "currency": "USD",
+      "source": "openai-api-pricing",
+      "snapshot": "2026-05-25",
+      "models": {
+        "openai/gpt-5": {
+          "inputPer1M": 1.25,
+          "cachedInputPer1M": 0.125,
+          "outputPer1M": 10.0,
+          "reasoningPer1M": 10.0
+        }
+      }
+    }
+  },
+
   "intake": {
     "assignee": "<vendor-user-id-or-login>",
     "repair": {
@@ -212,6 +228,34 @@ When `github.projects.v2` is present, later setup/doctor and writer preflight va
 |-------|---------------|-------|
 | `linear.workspace` | `tracker = "linear"`, `source = "linear"`, or any `linear-*` skill is invoked | Linear workspace slug (e.g. `acme`). |
 | `linear.teamKey` | `tracker = "linear"` | Linear team key (e.g. `ENG`). The team owns the destination Issues. For source mode, projects are workspace-scoped or team-scoped per the URL passed. |
+
+#### `usage`
+
+`usage` is optional. It carries non-secret pricing metadata Lisa may use when runtime token counts are trustworthy but runtime monetary cost is absent.
+
+| Field | Required when | Where it lives | Notes |
+|-------|---------------|----------------|-------|
+| `usage.pricing.currency` | estimating cost from config | **committed** | ISO currency code paired with the configured rates (for example `USD`). |
+| `usage.pricing.source` | estimating cost from config | **committed** | Human-readable source label for the configured pricing schedule (for example `openai-api-pricing`). This is metadata, not a URL requirement. |
+| `usage.pricing.snapshot` | no | **committed** | Version/date/hash describing when the pricing schedule was captured. Use it to make estimated-cost provenance durable across later vendor price changes. |
+| `usage.pricing.models` | estimating cost from config | **committed** | Map of `<provider>/<model>` to per-million-token rates. Lisa has **no built-in provider rates**; every estimated-cost model must be declared here explicitly. |
+
+Each `usage.pricing.models["<provider>/<model>"]` value supports these numeric keys:
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `inputPer1M` | yes | Price per 1M non-cached input tokens. |
+| `cachedInputPer1M` | no | Price per 1M cached input tokens when the runtime exposes them separately. If absent, cached tokens cannot be priced and the entry falls back to `pricing_status=missing` unless the runtime already supplied cost. |
+| `outputPer1M` | yes | Price per 1M output/completion tokens. |
+| `reasoningPer1M` | no | Price per 1M reasoning/internal tokens when the provider bills them separately. If absent, treat reasoning tokens as unpriceable rather than folding them into another bucket. |
+
+Resolution rules for estimated pricing:
+
+- Resolve `usage.pricing.*` with the same per-key local-overrides-global precedence as every other config section.
+- Estimates are allowed only when trustworthy token counts exist and a matching `usage.pricing.models["<provider>/<model>"]` entry supplies every rate needed for the exposed token buckets.
+- Missing model entries or missing required bucket rates do **not** trigger built-in defaults. Preserve the token counts, leave `cost = null`, and emit `pricing_status = missing`.
+- When an estimate is produced from config, write `pricing_source` as `config:<source>@<snapshot>` when both fields exist, `config:<source>` when only `source` exists, or `config` when neither metadata field is available.
+- Runtime-observed monetary cost always wins over config estimates; config pricing is fallback-only.
 
 ## Workflow & vocabulary roles
 

--- a/tests/unit/strategies/usage-pricing-config-resolution.test.ts
+++ b/tests/unit/strategies/usage-pricing-config-resolution.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression tests for the optional usage-pricing config contract.
+ *
+ * Issue #733 extends the canonical config-resolution docs with a committed,
+ * non-secret `usage.pricing` block so Lisa can estimate cost from trustworthy
+ * token counts without inventing built-in provider rates.
+ * @module tests/unit/strategies/usage-pricing-config-resolution
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+
+describe.each(RULE_ROOTS)(
+  "config-resolution usage pricing docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
+
+    it("documents the usage.pricing schema and per-model rate shape", () => {
+      expect(content).toContain('"usage": {');
+      expect(content).toContain('"pricing": {');
+      expect(content).toContain('"currency": "USD"');
+      expect(content).toContain('"source": "openai-api-pricing"');
+      expect(content).toContain('"snapshot": "2026-05-25"');
+      expect(content).toContain('"openai/gpt-5"');
+      expect(content).toContain('"inputPer1M": 1.25');
+      expect(content).toContain('"cachedInputPer1M": 0.125');
+      expect(content).toContain('"outputPer1M": 10.0');
+    });
+
+    it("forbids built-in provider defaults and preserves missing pricing", () => {
+      expect(content).toMatch(/no built-in provider rates/i);
+      expect(content).toMatch(/do \*\*not\*\* trigger built-in defaults/i);
+      expect(content).toMatch(/pricing_status = missing/i);
+      expect(content).toMatch(/cost = null/i);
+    });
+
+    it("documents pricing source provenance from config metadata", () => {
+      expect(content).toMatch(/config:<source>@<snapshot>/i);
+      expect(content).toMatch(/config:<source>/i);
+      expect(content).toMatch(/Runtime-observed monetary cost always wins/i);
+      expect(content).toMatch(/per-key local-overrides-global precedence/i);
+    });
+  }
+);


### PR DESCRIPTION
## Summary\n- add the canonical \ schema to config-resolution with explicit per-model rate fields\n- document provenance and fallback rules for estimated pricing, including no built-in provider defaults\n- add regression coverage for both source and generated config-resolution docs\n\nCloses #733