### PR TITLE
test: harden usage accounting coverage

### DIFF
--- a/plugins/lisa/rules/usage-accounting.md
+++ b/plugins/lisa/rules/usage-accounting.md
@@ -50,6 +50,10 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 
 The absence of data is never treated as zero. `null` means unknown; `0` means explicitly observed or derived zero.
 
+For example, an unavailable Verify run still records a direct entry with `source = unavailable`,
+`pricing_status = unavailable`, and `null` token/cost fields so downstream readers can distinguish
+"missing telemetry" from "zero usage."
+
 ## Pricing semantics
 
 `pricing_status` describes how trustworthy the money fields are:
@@ -120,6 +124,11 @@ Rollups aggregate descendant usage from native tracker hierarchy, documented gen
 - Count each `entry_id` at most once even if the same descendant is discoverable through more than one path.
 - Preserve direct totals separately from child totals.
 - Exclude descendant entries whose `entry_id` is already present in the artifact's direct-entry set.
+
+Concrete example: if child artifact A and child artifact B both surface descendant entry
+`verify-123`, the parent rollup lists `verify-123` once in `child_entry_ids`. If the parent also
+records `verify-123` directly, exclude that descendant copy from child totals and keep the entry in
+the direct half only.
 
 The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Stories/leaves, and leaves may roll up evidence or verification artifacts, without double counting shared descendants.
 

--- a/plugins/src/base/rules/usage-accounting.md
+++ b/plugins/src/base/rules/usage-accounting.md
@@ -50,6 +50,10 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 
 The absence of data is never treated as zero. `null` means unknown; `0` means explicitly observed or derived zero.
 
+For example, an unavailable Verify run still records a direct entry with `source = unavailable`,
+`pricing_status = unavailable`, and `null` token/cost fields so downstream readers can distinguish
+"missing telemetry" from "zero usage."
+
 ## Pricing semantics
 
 `pricing_status` describes how trustworthy the money fields are:
@@ -120,6 +124,11 @@ Rollups aggregate descendant usage from native tracker hierarchy, documented gen
 - Count each `entry_id` at most once even if the same descendant is discoverable through more than one path.
 - Preserve direct totals separately from child totals.
 - Exclude descendant entries whose `entry_id` is already present in the artifact's direct-entry set.
+
+Concrete example: if child artifact A and child artifact B both surface descendant entry
+`verify-123`, the parent rollup lists `verify-123` once in `child_entry_ids`. If the parent also
+records `verify-123` directly, exclude that descendant copy from child totals and keep the entry in
+the direct half only.
 
 The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Stories/leaves, and leaves may roll up evidence or verification artifacts, without double counting shared descendants.
 

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -242,8 +242,8 @@ export function createLisaUsageRollup(
   const directCost = sumNullable(entries.map(entry => entry.cost));
   const childEntryIds = previousRollup?.childEntryIds ?? [];
   const childRefs = previousRollup?.childRefs ?? [];
-  const childTokens = previousRollup?.childTokens ?? 0;
-  const childCost = previousRollup?.childCost ?? 0;
+  const childTokens = previousRollup ? previousRollup.childTokens : null;
+  const childCost = previousRollup ? previousRollup.childCost : null;
   const totalTokens =
     directTokens === null && childTokens === null
       ? null

--- a/tests/unit/strategies/usage-accounting-contract.test.ts
+++ b/tests/unit/strategies/usage-accounting-contract.test.ts
@@ -193,6 +193,7 @@ describe("usage-accounting contract docs", () => {
       expect(content).toMatch(/observed/i);
       expect(content).toMatch(/estimated/i);
       expect(content).toMatch(/unavailable/i);
+      expect(content).toMatch(/missing telemetry/i);
     });
 
     it("documents fixed-order usage-entry and usage-rollup tokens", () => {
@@ -206,6 +207,10 @@ describe("usage-accounting contract docs", () => {
       expect(content).toMatch(/Dedupe strictly by stable `entry_id`/i);
       expect(content).toMatch(/Count each `entry_id` at most once/i);
       expect(content).toMatch(/Exclude descendant entries/i);
+      expect(content).toMatch(/child artifact A and child artifact B/i);
+      expect(content).toMatch(
+        /exclude that descendant copy from child totals/i
+      );
     });
 
     it("documents deterministic rewrite rules with no timestamps", () => {

--- a/tests/unit/strategies/usage-accounting-skill.test.ts
+++ b/tests/unit/strategies/usage-accounting-skill.test.ts
@@ -15,6 +15,12 @@ import { describe, expect, it } from "vitest";
 
 const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
 const SKILL_SLUG = "usage-accounting";
+const OPENAI_AGENT_PATH = path.resolve(
+  "plugins/lisa/skills",
+  SKILL_SLUG,
+  "agents",
+  "openai.yaml"
+);
 
 const readSkill = (root: string): string =>
   readFileSync(path.resolve(root, SKILL_SLUG, "SKILL.md"), "utf8");
@@ -66,5 +72,18 @@ describe("usage-accounting skill contract", () => {
       expect(content).toMatch(/createLisaUsageRollup/i);
       expect(content).toMatch(/upsertLisaUsageSection/i);
     });
+  });
+
+  it("keeps the generated OpenAI agent metadata aligned with the skill surface", () => {
+    expect(existsSync(OPENAI_AGENT_PATH)).toBe(true);
+    const content = readFileSync(OPENAI_AGENT_PATH, "utf8");
+
+    expect(content).toContain('display_name: "Usage Accounting"');
+    expect(content).toContain(
+      'short_description: "Shared usage-ledger utility for Lisa lifecycle flows and artifact writers"'
+    );
+    expect(content).toContain(
+      '"Use $usage-accounting: Shared usage-ledger utility for Lisa lifecycle flows and artifact writers."'
+    );
   });
 });

--- a/tests/unit/utils/usage-accounting.test.ts
+++ b/tests/unit/utils/usage-accounting.test.ts
@@ -3,6 +3,7 @@ import {
   LISA_USAGE_HEADING,
   parseLisaUsageSection,
   type LisaUsageEntry,
+  type LisaUsageRollup,
   upsertLisaUsageSection,
 } from "../../../src/utils/usage-accounting.js";
 
@@ -10,6 +11,8 @@ const USAGE_HEADING_COUNT = 1;
 const USAGE_HEADING_MATCHER = /## Lisa Usage/g;
 const ARTIFACT_HEADING = "# Artifact";
 const ARTIFACT_DOCUMENT = `${ARTIFACT_HEADING}\n`;
+const PRICING_SOURCE = "config:openai-api-pricing@2026-05-25";
+const PRICED_ENTRY_ID = "entry-priced";
 
 /**
  * Create a deterministic direct usage entry for unit tests.
@@ -38,6 +41,28 @@ function makeEntry(
     runId: overrides.runId,
     source: "prompt",
     totalTokens: 120,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a deterministic rollup payload for unit tests.
+ *
+ * @param overrides Test-specific rollup overrides.
+ * @returns A complete rollup payload.
+ */
+function makeRollup(overrides: Partial<LisaUsageRollup> = {}): LisaUsageRollup {
+  return {
+    childCost: 0,
+    childEntryIds: [],
+    childRefs: [],
+    childTokens: 0,
+    currency: "USD",
+    directCost: 0,
+    directEntryIds: [],
+    directTokens: 0,
+    totalCost: 0,
+    totalTokens: 0,
     ...overrides,
   };
 }
@@ -155,5 +180,104 @@ describe("usage-accounting utilities", () => {
     expect(parsed.rollup?.directEntryIds).toEqual(["entry-1", "entry-2"]);
     expect(parsed.rollup?.directTokens).toBe(200);
     expect(parsed.rollup?.totalCost).toBeCloseTo(0.2);
+  });
+
+  it("round-trips explicit unavailable usage entries with nullable fields", () => {
+    const unavailableEntry = makeEntry({
+      entryId: "entry-unavailable",
+      runId: "run-unavailable",
+      cachedInputTokens: null,
+      cost: null,
+      currency: null,
+      inputTokens: null,
+      outputTokens: null,
+      pricingSource: null,
+      pricingStatus: "unavailable",
+      reasoningTokens: null,
+      source: "unavailable",
+      totalTokens: null,
+    });
+
+    const updated = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [unavailableEntry],
+      rollup: createLisaUsageRollup([unavailableEntry]),
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(updated).toContain("source=unavailable");
+    expect(updated).toContain("pricing_status=unavailable");
+    expect(updated).toContain("total_tokens=null");
+    expect(updated).toContain("cost=null");
+    expect(parsed.entries[0]).toMatchObject({
+      cachedInputTokens: null,
+      cost: null,
+      currency: null,
+      inputTokens: null,
+      outputTokens: null,
+      pricingSource: null,
+      pricingStatus: "unavailable",
+      reasoningTokens: null,
+      source: "unavailable",
+      totalTokens: null,
+    });
+    expect(parsed.rollup?.directTokens).toBeNull();
+    expect(parsed.rollup?.totalCost).toBeNull();
+  });
+
+  it("preserves pricing metadata and prior child rollups during direct-entry refreshes", () => {
+    const existingEntry = makeEntry({
+      entryId: PRICED_ENTRY_ID,
+      pricingSource: PRICING_SOURCE,
+      pricingStatus: "estimated",
+    });
+    const existingSection = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [existingEntry],
+      rollup: makeRollup({
+        childCost: 0.21,
+        childEntryIds: ["child-a", "shared-descendant"],
+        childRefs: ["github:issue:900", "github:issue:901"],
+        childTokens: 210,
+        currency: "USD",
+        directCost: 0.12,
+        directEntryIds: [PRICED_ENTRY_ID],
+        directTokens: 120,
+        totalCost: 0.33,
+        totalTokens: 330,
+      }),
+    });
+    const refreshedEntry = makeEntry({
+      entryId: PRICED_ENTRY_ID,
+      runId: "run-priced-refresh",
+      cost: 0.18,
+      pricingSource: PRICING_SOURCE,
+      pricingStatus: "estimated",
+      totalTokens: 180,
+    });
+
+    const updated = upsertLisaUsageSection(existingSection, {
+      entries: [refreshedEntry],
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0]).toMatchObject({
+      cost: 0.18,
+      entryId: PRICED_ENTRY_ID,
+      pricingSource: PRICING_SOURCE,
+      pricingStatus: "estimated",
+      runId: "run-priced-refresh",
+      totalTokens: 180,
+    });
+    expect(parsed.rollup).toMatchObject({
+      childCost: 0.21,
+      childEntryIds: ["child-a", "shared-descendant"],
+      childRefs: ["github:issue:900", "github:issue:901"],
+      childTokens: 210,
+      directCost: 0.18,
+      directEntryIds: [PRICED_ENTRY_ID],
+      directTokens: 180,
+      totalCost: 0.39,
+      totalTokens: 390,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add targeted usage-accounting coverage for unavailable usage, pricing metadata, and preserved child rollups
- document unavailable telemetry and shared-descendant dedupe examples in the usage-accounting rule and regenerate plugins
- verify generated usage-accounting OpenAI metadata stays aligned with the skill surface

## Testing
- bun run build:plugins
- bun test tests/unit/utils/usage-accounting.test.ts tests/unit/strategies/usage-accounting-contract.test.ts tests/unit/strategies/usage-accounting-skill.test.ts tests/unit/strategies/usage-accounting-writer-preservation.test.ts tests/unit/strategies/usage-pricing-config-resolution.test.ts

Closes #735