### PR TITLE
feat(doctor): add doctor command scaffold

### DIFF
--- a/plugins/lisa/commands/doctor.md
+++ b/plugins/lisa/commands/doctor.md
@@ -1,0 +1,6 @@
+---
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
+argument-hint: "[--fix=false]"
+---
+
+Use the /lisa:doctor skill to audit whether the current repository is ready to use Lisa, report grouped PASS/WARN/FAIL/SKIP checks, and emit an overall readiness verdict. $ARGUMENTS

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: doctor
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only checks across project detection, Lisa config, runtime distribution surfaces, tracker/source preflight access, automation prerequisites, optional GitHub Project coordination, and optional wiki delegation, then reports PASS/WARN/FAIL/SKIP results plus an overall readiness verdict (`READY`, `READY_WITH_WARNINGS`, or `NOT_READY`)."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Doctor: $ARGUMENTS
+
+Run a read-only Lisa readiness audit for the current repository.
+
+## Purpose
+
+`/lisa:doctor` is the deterministic answer to "is this repo actually ready to use Lisa?" It audits
+the repository in grouped sections, reports each check as `PASS`, `WARN`, `FAIL`, or `SKIP`, and
+emits one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
+
+The command is repository-scoped. It validates only what can be observed from the current repo,
+current machine, and current runtime. It does **not** create automations, labels, tracker items, or
+other external state as part of the default audit path.
+
+## Inputs
+
+- Optional flags in `$ARGUMENTS` that narrow or tune read-only validation.
+- The current repository root and its Lisa config files (`.lisa.config.json`,
+  `.lisa.config.local.json`) when present.
+
+## Confirmation policy
+
+Do **not** ask whether to proceed. Once invoked, run the read-only audit, print the grouped
+results, emit the overall verdict, and stop.
+
+Specifically forbidden:
+
+- Previewing the number of checks and asking whether to continue.
+- Offering "run a few checks first" or "dry-run vs real run" choices. This skill is already the
+  read-only path.
+- Performing setup mutations just because a failing check discovered something missing.
+
+The only legitimate reasons to stop early are:
+
+- The current working directory cannot be resolved to a repository/root the audit can inspect.
+- The runtime blocks all required local reads needed to even classify the repo.
+
+## Audit contract
+
+Doctor reports grouped checks in a stable, human-readable structure. The grouped sections include,
+as applicable to the current repo:
+
+1. **Project detection and runtime basics** — detect the project root, package/runtime surface, and
+   whether Lisa is installed where the repo expects it.
+2. **Lisa config readiness** — read `.lisa.config.json` and `.lisa.config.local.json` using the
+   same local-overrides-global semantics defined by `config-resolution`; report missing required
+   keys, incompatible combinations, and committed-vs-local locality problems as findings rather
+   than mutating config.
+3. **Tracker/source preflight** — perform read-only readiness checks for the configured `tracker`
+   and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
+   runtime, report that explicitly instead of pretending the repo is ready.
+4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
+   prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
+6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate
+   the shared validation read to `github-project-v2` instead of reimplementing ad-hoc GraphQL
+   checks. Honor the `required=false` vs `required=true` semantics documented by
+   `config-resolution`: best-effort failures are `WARN`, required-mode failures are `FAIL`.
+7. **Optional wiki delegation** — when a repo-local `wiki/` exists, either summarize the
+   specialized `lisa-wiki-doctor` verdict or explicitly report that deeper wiki checks are
+   available there. The base doctor stays narrower than full wiki migration enforcement.
+
+If a check family is not applicable to the current repo, report `SKIP` with the reason.
+
+## Output contract
+
+The final report must:
+
+- Separate observed facts from remediation advice.
+- Print every check with one of `PASS`, `WARN`, `FAIL`, or `SKIP`.
+- Emit exactly one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
+- Stay read-only by default.
+
+The verdict ladder is:
+
+- `READY` — no `FAIL` and no `WARN`.
+- `READY_WITH_WARNINGS` — no `FAIL`, but one or more `WARN`.
+- `NOT_READY` — one or more `FAIL`.
+
+## Delegation and reuse
+
+- Reuse `config-resolution` for config and lifecycle role defaults instead of inventing a second
+  schema.
+- Reuse the existing `github-project-v2` chokepoint for GitHub Project coordination checks instead
+  of inlining bespoke access logic.
+- Reuse ideas from `lisa-wiki-doctor` for grouped verdict rendering where they fit, while keeping
+  the Lisa-wide doctor narrower than the wiki-specific migration/readiness workflow.
+
+## Rules
+
+- Never mutate repository, tracker, or automation state on the default doctor path.
+- Never hardcode tracker/source label names outside the documented defaults plus configured
+  overrides from `config-resolution`.
+- Never silently treat an unavailable check surface as success; report `WARN`, `FAIL`, or `SKIP`
+  with the explicit missing dependency.
+- Never turn wiki-specific checks into a requirement for non-wiki repos.

--- a/plugins/lisa/skills/doctor/agents/openai.yaml
+++ b/plugins/lisa/skills/doctor/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Doctor"
+short_description: "Audit whether the current repository is ready to use Lisa"
+default_prompt:
+  - "Use $doctor: Audit whether the current repository is ready to use Lisa."

--- a/plugins/src/base/commands/doctor.md
+++ b/plugins/src/base/commands/doctor.md
@@ -1,0 +1,6 @@
+---
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
+argument-hint: "[--fix=false]"
+---
+
+Use the /lisa:doctor skill to audit whether the current repository is ready to use Lisa, report grouped PASS/WARN/FAIL/SKIP checks, and emit an overall readiness verdict. $ARGUMENTS

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: doctor
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only checks across project detection, Lisa config, runtime distribution surfaces, tracker/source preflight access, automation prerequisites, optional GitHub Project coordination, and optional wiki delegation, then reports PASS/WARN/FAIL/SKIP results plus an overall readiness verdict (`READY`, `READY_WITH_WARNINGS`, or `NOT_READY`)."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Doctor: $ARGUMENTS
+
+Run a read-only Lisa readiness audit for the current repository.
+
+## Purpose
+
+`/lisa:doctor` is the deterministic answer to "is this repo actually ready to use Lisa?" It audits
+the repository in grouped sections, reports each check as `PASS`, `WARN`, `FAIL`, or `SKIP`, and
+emits one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
+
+The command is repository-scoped. It validates only what can be observed from the current repo,
+current machine, and current runtime. It does **not** create automations, labels, tracker items, or
+other external state as part of the default audit path.
+
+## Inputs
+
+- Optional flags in `$ARGUMENTS` that narrow or tune read-only validation.
+- The current repository root and its Lisa config files (`.lisa.config.json`,
+  `.lisa.config.local.json`) when present.
+
+## Confirmation policy
+
+Do **not** ask whether to proceed. Once invoked, run the read-only audit, print the grouped
+results, emit the overall verdict, and stop.
+
+Specifically forbidden:
+
+- Previewing the number of checks and asking whether to continue.
+- Offering "run a few checks first" or "dry-run vs real run" choices. This skill is already the
+  read-only path.
+- Performing setup mutations just because a failing check discovered something missing.
+
+The only legitimate reasons to stop early are:
+
+- The current working directory cannot be resolved to a repository/root the audit can inspect.
+- The runtime blocks all required local reads needed to even classify the repo.
+
+## Audit contract
+
+Doctor reports grouped checks in a stable, human-readable structure. The grouped sections include,
+as applicable to the current repo:
+
+1. **Project detection and runtime basics** — detect the project root, package/runtime surface, and
+   whether Lisa is installed where the repo expects it.
+2. **Lisa config readiness** — read `.lisa.config.json` and `.lisa.config.local.json` using the
+   same local-overrides-global semantics defined by `config-resolution`; report missing required
+   keys, incompatible combinations, and committed-vs-local locality problems as findings rather
+   than mutating config.
+3. **Tracker/source preflight** — perform read-only readiness checks for the configured `tracker`
+   and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
+   runtime, report that explicitly instead of pretending the repo is ready.
+4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
+   prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
+6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate
+   the shared validation read to `github-project-v2` instead of reimplementing ad-hoc GraphQL
+   checks. Honor the `required=false` vs `required=true` semantics documented by
+   `config-resolution`: best-effort failures are `WARN`, required-mode failures are `FAIL`.
+7. **Optional wiki delegation** — when a repo-local `wiki/` exists, either summarize the
+   specialized `lisa-wiki-doctor` verdict or explicitly report that deeper wiki checks are
+   available there. The base doctor stays narrower than full wiki migration enforcement.
+
+If a check family is not applicable to the current repo, report `SKIP` with the reason.
+
+## Output contract
+
+The final report must:
+
+- Separate observed facts from remediation advice.
+- Print every check with one of `PASS`, `WARN`, `FAIL`, or `SKIP`.
+- Emit exactly one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
+- Stay read-only by default.
+
+The verdict ladder is:
+
+- `READY` — no `FAIL` and no `WARN`.
+- `READY_WITH_WARNINGS` — no `FAIL`, but one or more `WARN`.
+- `NOT_READY` — one or more `FAIL`.
+
+## Delegation and reuse
+
+- Reuse `config-resolution` for config and lifecycle role defaults instead of inventing a second
+  schema.
+- Reuse the existing `github-project-v2` chokepoint for GitHub Project coordination checks instead
+  of inlining bespoke access logic.
+- Reuse ideas from `lisa-wiki-doctor` for grouped verdict rendering where they fit, while keeping
+  the Lisa-wide doctor narrower than the wiki-specific migration/readiness workflow.
+
+## Rules
+
+- Never mutate repository, tracker, or automation state on the default doctor path.
+- Never hardcode tracker/source label names outside the documented defaults plus configured
+  overrides from `config-resolution`.
+- Never silently treat an unavailable check surface as success; report `WARN`, `FAIL`, or `SKIP`
+  with the explicit missing dependency.
+- Never turn wiki-specific checks into a requirement for non-wiki repos.

--- a/tests/unit/strategies/doctor-scaffold.test.ts
+++ b/tests/unit/strategies/doctor-scaffold.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for the `/lisa:doctor` command + skill scaffold.
+ *
+ * Issue #749 (Story #745, PRD #741): add the top-level doctor command entrypoint
+ * and shared doctor skill surface to the base plugin, then prove the generated
+ * `plugins/lisa` artifact ships the same surface after `bun run build:plugins`.
+ *
+ * This suite asserts the scaffold only:
+ * 1. `commands/doctor.md` exists in both plugin roots and delegates to
+ *    `/lisa:doctor`.
+ * 2. `skills/doctor/SKILL.md` exists in both plugin roots with the expected
+ *    frontmatter and read-only readiness-audit contract.
+ * 3. The skill documents grouped `PASS` / `WARN` / `FAIL` / `SKIP` checks plus
+ *    the overall `READY` / `READY_WITH_WARNINGS` / `NOT_READY` verdict ladder.
+ *
+ * Both plugin roots are asserted (`plugins/src/base` source of truth and the
+ * generated `plugins/lisa` artifact), so an artifact-only edit or a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/doctor-scaffold
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const COMMAND_REL = "commands/doctor.md";
+const SKILL_REL = "skills/doctor/SKILL.md";
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("doctor scaffold (#749)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const commandPath = path.resolve(root, COMMAND_REL);
+    const skillPath = path.resolve(root, SKILL_REL);
+
+    it("ships both the command and the skill in this plugin root", () => {
+      expect(existsSync(commandPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    describe(COMMAND_REL, () => {
+      const command = read(root, COMMAND_REL);
+
+      it("is a pass-through command that delegates to /lisa:doctor", () => {
+        expect(command).toMatch(/^---/);
+        expect(command).toMatch(/description:/);
+        expect(command).toContain('argument-hint: "[--fix=false]"');
+        expect(command).toMatch(/Use the \/lisa:doctor skill/);
+        expect(command).toContain("$ARGUMENTS");
+      });
+    });
+
+    describe(SKILL_REL, () => {
+      const skill = read(root, SKILL_REL);
+
+      it("declares name, description, and allowed-tools in frontmatter", () => {
+        expect(skill).toMatch(/^---/);
+        expect(skill).toMatch(/name:\s*doctor/);
+        expect(skill).toMatch(/description:/);
+        expect(skill).toMatch(/allowed-tools:/);
+        expect(skill).toContain("Skill");
+        expect(skill).toContain("Bash");
+        expect(skill).toContain("Read");
+      });
+
+      it("documents a read-only readiness audit for the current repository", () => {
+        expect(skill).toMatch(/read-only Lisa readiness audit/i);
+        expect(skill).toMatch(/current repository/i);
+        expect(skill).toMatch(
+          /does \*\*not\*\* create automations, labels, tracker items/i
+        );
+      });
+
+      it("documents grouped PASS, WARN, FAIL, and SKIP checks", () => {
+        expect(skill).toContain("PASS");
+        expect(skill).toContain("WARN");
+        expect(skill).toContain("FAIL");
+        expect(skill).toContain("SKIP");
+        expect(skill).toMatch(/grouped sections/i);
+      });
+
+      it("documents the overall READY verdict ladder", () => {
+        expect(skill).toContain("READY");
+        expect(skill).toContain("READY_WITH_WARNINGS");
+        expect(skill).toContain("NOT_READY");
+        expect(skill).toMatch(/The verdict ladder is:/);
+      });
+
+      it("reuses existing contracts for GitHub Project and wiki checks", () => {
+        expect(skill).toContain("config-resolution");
+        expect(skill).toContain("github-project-v2");
+        expect(skill).toContain("lisa-wiki-doctor");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the base `/lisa:doctor` command pass-through and shared `doctor` skill scaffold
- document the read-only grouped readiness contract, verdict ladder, and reuse points for GitHub Project and wiki checks
- add parity coverage proving both `plugins/src/base` and generated `plugins/lisa` ship the new surface

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/doctor-scaffold.test.ts
- git push -u origin codex/issue-749-github-build-intake

Closes #749