### PR TITLE
feat(doctor): add grouped report renderer

### DIFF
--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Shared doctor report helpers for the base Lisa doctor surface.
+ *
+ * The first doctor milestone needs a stable grouped output contract before the
+ * repo adds real readiness probes. Keep this file dependency-free so future
+ * doctor scripts can reuse it from plugin distributions and downstream repos.
+ */
+
+export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
+export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
+
+/**
+ * @typedef {"PASS" | "WARN" | "FAIL" | "SKIP"} DoctorStatus
+ * @typedef {"READY" | "READY_WITH_WARNINGS" | "NOT_READY"} DoctorVerdict
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly status: DoctorStatus
+ *   readonly summary: string
+ *   readonly observed?: string
+ *   readonly remediation?: string
+ * }} DoctorCheck
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly title: string
+ *   readonly checks: readonly DoctorCheck[]
+ * }} DoctorGroup
+ *
+ * @typedef {{
+ *   readonly generatedAt?: string
+ *   readonly groups: readonly DoctorGroup[]
+ * }} DoctorReportInput
+ */
+
+/**
+ * @param {readonly DoctorGroup[]} groups
+ * @returns {DoctorVerdict}
+ */
+export function computeDoctorVerdict(groups) {
+  const checks = groups.flatMap(group => group.checks);
+  if (checks.some(check => check.status === "FAIL")) {
+    return "NOT_READY";
+  }
+  if (checks.some(check => check.status === "WARN")) {
+    return "READY_WITH_WARNINGS";
+  }
+  return "READY";
+}
+
+/**
+ * @param {readonly DoctorGroup[]} groups
+ * @returns {Record<DoctorStatus, number>}
+ */
+export function countDoctorStatuses(groups) {
+  return groups
+    .flatMap(group => group.checks)
+    .reduce(
+      (counts, check) => ({
+        ...counts,
+        [check.status]: counts[check.status] + 1,
+      }),
+      { PASS: 0, WARN: 0, FAIL: 0, SKIP: 0 }
+    );
+}
+
+/**
+ * @param {DoctorReportInput} input
+ * @returns {{ readonly verdict: DoctorVerdict, readonly counts: Record<DoctorStatus, number>, readonly text: string }}
+ */
+export function renderDoctorReport(input) {
+  const groups = input.groups.map(normalizeGroup);
+  const verdict = computeDoctorVerdict(groups);
+  const counts = countDoctorStatuses(groups);
+  const lines = [
+    `Overall verdict: ${verdict}`,
+    `Counts: ${DOCTOR_STATUSES.map(status => `${counts[status]} ${status}`).join(", ")}`,
+  ];
+
+  if (input.generatedAt) {
+    lines.push(`Generated at: ${input.generatedAt}`);
+  }
+
+  for (const group of groups) {
+    lines.push("", `${group.id}. ${group.title}`);
+    if (group.checks.length === 0) {
+      lines.push("- SKIP empty-group: no checks registered yet");
+      continue;
+    }
+    for (const check of group.checks) {
+      lines.push(`- ${check.status} ${check.id}: ${check.summary}`);
+      if (check.observed) {
+        lines.push(`  Observed: ${check.observed}`);
+      }
+      if (check.remediation) {
+        lines.push(`  Remediation: ${check.remediation}`);
+      }
+    }
+  }
+
+  return {
+    verdict,
+    counts,
+    text: `${lines.join("\n")}\n`,
+  };
+}
+
+/**
+ * @param {DoctorGroup} group
+ * @returns {DoctorGroup}
+ */
+function normalizeGroup(group) {
+  return {
+    ...group,
+    checks: group.checks.map(normalizeCheck),
+  };
+}
+
+/**
+ * @param {DoctorCheck} check
+ * @returns {DoctorCheck}
+ */
+function normalizeCheck(check) {
+  const normalizedStatus = DOCTOR_STATUSES.includes(check.status)
+    ? check.status
+    : "FAIL";
+  return {
+    ...check,
+    status: normalizedStatus,
+  };
+}

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -78,6 +78,17 @@ The final report must:
 - Emit exactly one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
 - Stay read-only by default.
 
+Render the report in grouped sections using the shared `scripts/doctor-report.mjs` contract:
+
+- Start with `Overall verdict: <VERDICT>` and one `Counts:` line covering `PASS`, `WARN`, `FAIL`,
+  and `SKIP`.
+- Then print each group as `<group-id>. <group-title>`.
+- Under each group, print one line per check as `- <STATUS> <check-id>: <summary>`.
+- When available, print `Observed:` and `Remediation:` lines beneath the check so the report keeps
+  facts separate from advice.
+- If a group has no applicable checks yet, render it as a grouped `SKIP` with the reason instead of
+  silently omitting the section.
+
 The verdict ladder is:
 
 - `READY` — no `FAIL` and no `WARN`.

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Shared doctor report helpers for the base Lisa doctor surface.
+ *
+ * The first doctor milestone needs a stable grouped output contract before the
+ * repo adds real readiness probes. Keep this file dependency-free so future
+ * doctor scripts can reuse it from plugin distributions and downstream repos.
+ */
+
+export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
+export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
+
+/**
+ * @typedef {"PASS" | "WARN" | "FAIL" | "SKIP"} DoctorStatus
+ * @typedef {"READY" | "READY_WITH_WARNINGS" | "NOT_READY"} DoctorVerdict
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly status: DoctorStatus
+ *   readonly summary: string
+ *   readonly observed?: string
+ *   readonly remediation?: string
+ * }} DoctorCheck
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly title: string
+ *   readonly checks: readonly DoctorCheck[]
+ * }} DoctorGroup
+ *
+ * @typedef {{
+ *   readonly generatedAt?: string
+ *   readonly groups: readonly DoctorGroup[]
+ * }} DoctorReportInput
+ */
+
+/**
+ * @param {readonly DoctorGroup[]} groups
+ * @returns {DoctorVerdict}
+ */
+export function computeDoctorVerdict(groups) {
+  const checks = groups.flatMap(group => group.checks);
+  if (checks.some(check => check.status === "FAIL")) {
+    return "NOT_READY";
+  }
+  if (checks.some(check => check.status === "WARN")) {
+    return "READY_WITH_WARNINGS";
+  }
+  return "READY";
+}
+
+/**
+ * @param {readonly DoctorGroup[]} groups
+ * @returns {Record<DoctorStatus, number>}
+ */
+export function countDoctorStatuses(groups) {
+  return groups
+    .flatMap(group => group.checks)
+    .reduce(
+      (counts, check) => ({
+        ...counts,
+        [check.status]: counts[check.status] + 1,
+      }),
+      { PASS: 0, WARN: 0, FAIL: 0, SKIP: 0 }
+    );
+}
+
+/**
+ * @param {DoctorReportInput} input
+ * @returns {{ readonly verdict: DoctorVerdict, readonly counts: Record<DoctorStatus, number>, readonly text: string }}
+ */
+export function renderDoctorReport(input) {
+  const groups = input.groups.map(normalizeGroup);
+  const verdict = computeDoctorVerdict(groups);
+  const counts = countDoctorStatuses(groups);
+  const lines = [
+    `Overall verdict: ${verdict}`,
+    `Counts: ${DOCTOR_STATUSES.map(status => `${counts[status]} ${status}`).join(", ")}`,
+  ];
+
+  if (input.generatedAt) {
+    lines.push(`Generated at: ${input.generatedAt}`);
+  }
+
+  for (const group of groups) {
+    lines.push("", `${group.id}. ${group.title}`);
+    if (group.checks.length === 0) {
+      lines.push("- SKIP empty-group: no checks registered yet");
+      continue;
+    }
+    for (const check of group.checks) {
+      lines.push(`- ${check.status} ${check.id}: ${check.summary}`);
+      if (check.observed) {
+        lines.push(`  Observed: ${check.observed}`);
+      }
+      if (check.remediation) {
+        lines.push(`  Remediation: ${check.remediation}`);
+      }
+    }
+  }
+
+  return {
+    verdict,
+    counts,
+    text: `${lines.join("\n")}\n`,
+  };
+}
+
+/**
+ * @param {DoctorGroup} group
+ * @returns {DoctorGroup}
+ */
+function normalizeGroup(group) {
+  return {
+    ...group,
+    checks: group.checks.map(normalizeCheck),
+  };
+}
+
+/**
+ * @param {DoctorCheck} check
+ * @returns {DoctorCheck}
+ */
+function normalizeCheck(check) {
+  const normalizedStatus = DOCTOR_STATUSES.includes(check.status)
+    ? check.status
+    : "FAIL";
+  return {
+    ...check,
+    status: normalizedStatus,
+  };
+}

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -78,6 +78,17 @@ The final report must:
 - Emit exactly one overall verdict: `READY`, `READY_WITH_WARNINGS`, or `NOT_READY`.
 - Stay read-only by default.
 
+Render the report in grouped sections using the shared `scripts/doctor-report.mjs` contract:
+
+- Start with `Overall verdict: <VERDICT>` and one `Counts:` line covering `PASS`, `WARN`, `FAIL`,
+  and `SKIP`.
+- Then print each group as `<group-id>. <group-title>`.
+- Under each group, print one line per check as `- <STATUS> <check-id>: <summary>`.
+- When available, print `Observed:` and `Remediation:` lines beneath the check so the report keeps
+  facts separate from advice.
+- If a group has no applicable checks yet, render it as a grouped `SKIP` with the reason instead of
+  silently omitting the section.
+
 The verdict ladder is:
 
 - `READY` — no `FAIL` and no `WARN`.

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression coverage for the shared doctor report renderer.
+ *
+ * Issue #750 (Story #745, PRD #741): doctor needs a concrete grouped output
+ * contract rather than prose-only instructions. This suite proves the shared
+ * renderer emits grouped PASS/WARN/FAIL/SKIP checks, keeps observed facts
+ * separate from remediation text, and computes the overall verdict ladder.
+ * @module tests/unit/strategies/doctor-report-rendering
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDoctorVerdict,
+  countDoctorStatuses,
+  renderDoctorReport,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+describe("doctor report rendering (#750)", () => {
+  it("renders grouped sections with PASS, WARN, FAIL, and SKIP checks", () => {
+    const report = renderDoctorReport({
+      generatedAt: "2026-05-25T22:30:00.000Z",
+      groups: [
+        {
+          id: "1",
+          title: "Project detection and runtime basics",
+          checks: [
+            {
+              id: "repo-root",
+              status: "PASS",
+              summary: "repository root resolved",
+              observed:
+                "package.json and .git are present at the working root.",
+            },
+            {
+              id: "codex-runtime",
+              status: "WARN",
+              summary:
+                "Codex runtime detected without downstream plugin install",
+              observed: "The repo exposes source plugin assets only.",
+              remediation:
+                "Run `bun run build:plugins` before downstream smoke checks.",
+            },
+          ],
+        },
+        {
+          id: "2",
+          title: "Lisa config readiness",
+          checks: [
+            {
+              id: "tracker-config",
+              status: "FAIL",
+              summary: "configured tracker keys are incomplete",
+              observed: "tracker=github but github.repo is missing.",
+              remediation:
+                "Add `github.repo` to .lisa.config.json or .lisa.config.local.json.",
+            },
+          ],
+        },
+        {
+          id: "3",
+          title: "Optional wiki delegation",
+          checks: [
+            {
+              id: "wiki-checks",
+              status: "SKIP",
+              summary: "no wiki/ directory detected",
+              observed:
+                "This repository does not carry the wiki plugin surface.",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(report.verdict).toBe("NOT_READY");
+    expect(report.counts).toEqual({ PASS: 1, WARN: 1, FAIL: 1, SKIP: 1 });
+    expect(report.text).toContain("Overall verdict: NOT_READY");
+    expect(report.text).toContain("Counts: 1 PASS, 1 WARN, 1 FAIL, 1 SKIP");
+    expect(report.text).toContain("1. Project detection and runtime basics");
+    expect(report.text).toContain("- PASS repo-root: repository root resolved");
+    expect(report.text).toContain(
+      "- WARN codex-runtime: Codex runtime detected without downstream plugin install"
+    );
+    expect(report.text).toContain(
+      "- FAIL tracker-config: configured tracker keys are incomplete"
+    );
+    expect(report.text).toContain(
+      "- SKIP wiki-checks: no wiki/ directory detected"
+    );
+    expect(report.text).toContain(
+      "Observed: tracker=github but github.repo is missing."
+    );
+    expect(report.text).toContain(
+      "Remediation: Add `github.repo` to .lisa.config.json or .lisa.config.local.json."
+    );
+  });
+
+  it("returns READY when there are no warnings or failures", () => {
+    expect(
+      computeDoctorVerdict([
+        {
+          id: "1",
+          title: "Runtime distribution surfaces",
+          checks: [
+            {
+              id: "doctor-command",
+              status: "PASS",
+              summary: "doctor command surface is installed",
+            },
+            {
+              id: "doctor-skill",
+              status: "SKIP",
+              summary: "runtime-specific subagent check not applicable here",
+            },
+          ],
+        },
+      ])
+    ).toBe("READY");
+  });
+
+  it("returns READY_WITH_WARNINGS when warnings exist without failures", () => {
+    expect(
+      computeDoctorVerdict([
+        {
+          id: "1",
+          title: "Automation readiness",
+          checks: [
+            {
+              id: "schedule-surface",
+              status: "WARN",
+              summary: "scheduler runtime not observable from this shell",
+            },
+          ],
+        },
+      ])
+    ).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("counts statuses across all groups", () => {
+    expect(
+      countDoctorStatuses([
+        {
+          id: "1",
+          title: "A",
+          checks: [
+            { id: "one", status: "PASS", summary: "ok" },
+            { id: "two", status: "WARN", summary: "warn" },
+          ],
+        },
+        {
+          id: "2",
+          title: "B",
+          checks: [
+            { id: "three", status: "FAIL", summary: "fail" },
+            { id: "four", status: "SKIP", summary: "skip" },
+          ],
+        },
+      ])
+    ).toEqual({ PASS: 1, WARN: 1, FAIL: 1, SKIP: 1 });
+  });
+
+  it("renders empty groups as grouped skips instead of omitting them", () => {
+    const report = renderDoctorReport({
+      groups: [{ id: "7", title: "Optional wiki delegation", checks: [] }],
+    });
+
+    expect(report.verdict).toBe("READY");
+    expect(report.text).toContain("7. Optional wiki delegation");
+    expect(report.text).toContain(
+      "- SKIP empty-group: no checks registered yet"
+    );
+  });
+});

--- a/tests/unit/strategies/doctor-scaffold.test.ts
+++ b/tests/unit/strategies/doctor-scaffold.test.ts
@@ -27,6 +27,7 @@ const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
 
 const COMMAND_REL = "commands/doctor.md";
 const SKILL_REL = "skills/doctor/SKILL.md";
+const SCRIPT_REL = "scripts/doctor-report.mjs";
 
 const read = (root: string, rel: string): string =>
   readFileSync(path.resolve(root, rel), "utf8");
@@ -35,10 +36,12 @@ describe("doctor scaffold (#749)", () => {
   describe.each(PLUGIN_ROOTS)("%s", root => {
     const commandPath = path.resolve(root, COMMAND_REL);
     const skillPath = path.resolve(root, SKILL_REL);
+    const scriptPath = path.resolve(root, SCRIPT_REL);
 
-    it("ships both the command and the skill in this plugin root", () => {
+    it("ships the command, skill, and shared report script in this plugin root", () => {
       expect(existsSync(commandPath)).toBe(true);
       expect(existsSync(skillPath)).toBe(true);
+      expect(existsSync(scriptPath)).toBe(true);
     });
 
     describe(COMMAND_REL, () => {
@@ -89,10 +92,34 @@ describe("doctor scaffold (#749)", () => {
         expect(skill).toMatch(/The verdict ladder is:/);
       });
 
+      it("documents the shared grouped report rendering contract", () => {
+        expect(skill).toContain("scripts/doctor-report.mjs");
+        expect(skill).toMatch(/Overall verdict: <VERDICT>/);
+        expect(skill).toMatch(/Counts:/);
+        expect(skill).toMatch(/Observed:/);
+        expect(skill).toMatch(/Remediation:/);
+      });
+
       it("reuses existing contracts for GitHub Project and wiki checks", () => {
         expect(skill).toContain("config-resolution");
         expect(skill).toContain("github-project-v2");
         expect(skill).toContain("lisa-wiki-doctor");
+      });
+    });
+
+    describe(SCRIPT_REL, () => {
+      const script = read(root, SCRIPT_REL);
+
+      it("exports the verdict helpers for later doctor checks", () => {
+        expect(script).toContain("computeDoctorVerdict");
+        expect(script).toContain("countDoctorStatuses");
+        expect(script).toContain("renderDoctorReport");
+      });
+
+      it("keeps observed facts separate from remediation advice", () => {
+        expect(script).toMatch(/Observed:/);
+        expect(script).toMatch(/Remediation:/);
+        expect(script).toContain("Overall verdict:");
       });
     });
   });


### PR DESCRIPTION
## Summary
- add a shared dependency-free `doctor-report.mjs` renderer for grouped PASS/WARN/FAIL/SKIP output
- document the concrete doctor report shape in both source and generated doctor skills
- add targeted regression coverage for verdict aggregation and built plugin parity

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/doctor-scaffold.test.ts tests/unit/strategies/doctor-report-rendering.test.ts
- git push -u origin codex/issue-750-github-build-intake

Closes #750