### PR TITLE
[lisa] Audit Lisa config presence, required keys, and local-vs-committed semantics

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -398,6 +398,37 @@ For batch skills that consume `source`:
 2. If `$ARGUMENTS` is the bare token `notion` / `confluence` / `linear` / `github` / `jira`, the source is that vendor; resolve location from the corresponding config section.
 3. If `$ARGUMENTS` is empty, fall back to `source` from config; if that's also empty, stop and report `"No source specified and no 'source' field in .lisa.config.json."`
 
+### Doctor config readiness
+
+`/lisa:doctor` reads the same config, but it audits readiness instead of dispatching a write.
+Doctor must validate config in three layers:
+
+1. **Parse and merge**
+   - Parse both config files as JSON. Missing or invalid `.lisa.config.json` is a blocking error.
+     `.lisa.config.local.json` is optional, but if present and invalid it is also a blocking error.
+   - Merge per key with the standard local-overrides-global rule. Doctor reports against the merged
+     effective config; it does not treat the local file as a full replacement for the committed
+     file.
+2. **Required-key correctness**
+   - Missing `tracker` after merge is a blocking error. Unknown merged `tracker` / `source` values
+     are also blocking errors.
+   - If the configured tracker/source vendor is missing its required keys after merge, doctor must
+     report a blocking readiness failure using the vendor tables above. Examples: `tracker=github`
+     requires `github.org` + `github.repo`; `tracker=jira` requires `atlassian.cloudId` +
+     `jira.project`; `source=notion` requires `notion.workspaceId` + `notion.prdDatabaseId`.
+3. **Field locality correctness**
+   - `atlassian.email`, `intake.assignee`, and `jira.verified_workflow_hash` are local-only. If
+     they appear in committed config, doctor warns that developer-specific state was checked into
+     the project file.
+   - Project-wide fields that exist only in `.lisa.config.local.json` should warn, not pass
+     silently. Current machine works, repository not durably configured for teammates and
+     automations. Common examples include `tracker`, `source`, `github.org`, `github.repo`,
+     `atlassian.cloudId`, `atlassian.site`, `jira.project`, `linear.workspace`, `linear.teamKey`,
+     and `deploy.branches`.
+
+Doctor's severity rule is simple: unusable merged config is `FAIL`; locality drift with a still
+usable merged config is `WARN`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -69,6 +69,41 @@ as applicable to the current repo:
 
 If a check family is not applicable to the current repo, report `SKIP` with the reason.
 
+### Minimum config-readiness checks
+
+The Lisa config group is not just "does a file exist?" Doctor must audit the config contract in
+this order:
+
+1. **Presence + parseability**
+   - `FAIL` when `.lisa.config.json` is missing, empty, or invalid JSON.
+   - Read `.lisa.config.local.json` only when present; if present but invalid JSON, `FAIL`.
+2. **Merged effective config**
+   - Resolve every key with the same per-key local-overrides-global semantics documented by
+     `config-resolution`. Doctor must describe findings against the effective merged value, not by
+     pretending one file fully replaces the other.
+3. **Required top-level dispatch keys**
+   - `FAIL` when merged `tracker` is missing or is not one of `jira`, `github`, or `linear`.
+   - `FAIL` when merged `source` is present but is not one of `notion`, `confluence`, `linear`,
+     `github`, or `jira`.
+4. **Vendor required-key audit**
+   - `FAIL` when the configured tracker/source points at a vendor whose required keys are absent
+     after merge. Examples: `tracker=github` requires `github.org` + `github.repo`;
+     `tracker=jira` requires `atlassian.cloudId` + `jira.project`; `source=notion` requires
+     `notion.workspaceId` + `notion.prdDatabaseId`.
+   - Reuse the `config-resolution` vendor tables rather than inventing a second required-key list.
+5. **Local-vs-committed locality audit**
+   - `WARN` when developer-specific fields appear in committed config. At minimum enforce the
+     documented local-only examples: `atlassian.email`, `intake.assignee`, and
+     `jira.verified_workflow_hash`.
+   - `WARN` when project-wide shared fields exist only in `.lisa.config.local.json` and are absent
+     from `.lisa.config.json`, because the current machine may work while the repository remains
+     under-configured for teammates and automations. Examples include `tracker`, `source`,
+     `github.org`, `github.repo`, `atlassian.cloudId`, `atlassian.site`, `jira.project`,
+     `linear.workspace`, `linear.teamKey`, and `deploy.branches`.
+
+Locality findings are advisory unless the merged config is unusable. Missing shared keys after the
+merge are `FAIL`; shared keys that exist only locally are `WARN`.
+
 ## Output contract
 
 The final report must:

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -398,6 +398,37 @@ For batch skills that consume `source`:
 2. If `$ARGUMENTS` is the bare token `notion` / `confluence` / `linear` / `github` / `jira`, the source is that vendor; resolve location from the corresponding config section.
 3. If `$ARGUMENTS` is empty, fall back to `source` from config; if that's also empty, stop and report `"No source specified and no 'source' field in .lisa.config.json."`
 
+### Doctor config readiness
+
+`/lisa:doctor` reads the same config, but it audits readiness instead of dispatching a write.
+Doctor must validate config in three layers:
+
+1. **Parse and merge**
+   - Parse both config files as JSON. Missing or invalid `.lisa.config.json` is a blocking error.
+     `.lisa.config.local.json` is optional, but if present and invalid it is also a blocking error.
+   - Merge per key with the standard local-overrides-global rule. Doctor reports against the merged
+     effective config; it does not treat the local file as a full replacement for the committed
+     file.
+2. **Required-key correctness**
+   - Missing `tracker` after merge is a blocking error. Unknown merged `tracker` / `source` values
+     are also blocking errors.
+   - If the configured tracker/source vendor is missing its required keys after merge, doctor must
+     report a blocking readiness failure using the vendor tables above. Examples: `tracker=github`
+     requires `github.org` + `github.repo`; `tracker=jira` requires `atlassian.cloudId` +
+     `jira.project`; `source=notion` requires `notion.workspaceId` + `notion.prdDatabaseId`.
+3. **Field locality correctness**
+   - `atlassian.email`, `intake.assignee`, and `jira.verified_workflow_hash` are local-only. If
+     they appear in committed config, doctor warns that developer-specific state was checked into
+     the project file.
+   - Project-wide fields that exist only in `.lisa.config.local.json` should warn, not pass
+     silently. Current machine works, repository not durably configured for teammates and
+     automations. Common examples include `tracker`, `source`, `github.org`, `github.repo`,
+     `atlassian.cloudId`, `atlassian.site`, `jira.project`, `linear.workspace`, `linear.teamKey`,
+     and `deploy.branches`.
+
+Doctor's severity rule is simple: unusable merged config is `FAIL`; locality drift with a still
+usable merged config is `WARN`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -69,6 +69,41 @@ as applicable to the current repo:
 
 If a check family is not applicable to the current repo, report `SKIP` with the reason.
 
+### Minimum config-readiness checks
+
+The Lisa config group is not just "does a file exist?" Doctor must audit the config contract in
+this order:
+
+1. **Presence + parseability**
+   - `FAIL` when `.lisa.config.json` is missing, empty, or invalid JSON.
+   - Read `.lisa.config.local.json` only when present; if present but invalid JSON, `FAIL`.
+2. **Merged effective config**
+   - Resolve every key with the same per-key local-overrides-global semantics documented by
+     `config-resolution`. Doctor must describe findings against the effective merged value, not by
+     pretending one file fully replaces the other.
+3. **Required top-level dispatch keys**
+   - `FAIL` when merged `tracker` is missing or is not one of `jira`, `github`, or `linear`.
+   - `FAIL` when merged `source` is present but is not one of `notion`, `confluence`, `linear`,
+     `github`, or `jira`.
+4. **Vendor required-key audit**
+   - `FAIL` when the configured tracker/source points at a vendor whose required keys are absent
+     after merge. Examples: `tracker=github` requires `github.org` + `github.repo`;
+     `tracker=jira` requires `atlassian.cloudId` + `jira.project`; `source=notion` requires
+     `notion.workspaceId` + `notion.prdDatabaseId`.
+   - Reuse the `config-resolution` vendor tables rather than inventing a second required-key list.
+5. **Local-vs-committed locality audit**
+   - `WARN` when developer-specific fields appear in committed config. At minimum enforce the
+     documented local-only examples: `atlassian.email`, `intake.assignee`, and
+     `jira.verified_workflow_hash`.
+   - `WARN` when project-wide shared fields exist only in `.lisa.config.local.json` and are absent
+     from `.lisa.config.json`, because the current machine may work while the repository remains
+     under-configured for teammates and automations. Examples include `tracker`, `source`,
+     `github.org`, `github.repo`, `atlassian.cloudId`, `atlassian.site`, `jira.project`,
+     `linear.workspace`, `linear.teamKey`, and `deploy.branches`.
+
+Locality findings are advisory unless the merged config is unusable. Missing shared keys after the
+merge are `FAIL`; shared keys that exist only locally are `WARN`.
+
 ## Output contract
 
 The final report must:

--- a/tests/unit/strategies/doctor-config-readiness.test.ts
+++ b/tests/unit/strategies/doctor-config-readiness.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for the doctor config-readiness contract.
+ *
+ * Issue #751 (Story #746, PRD #741): `/lisa:doctor` needs an explicit config
+ * audit contract before later runtime probes implement it. The skill must
+ * describe parse failures, merged effective-config semantics, vendor required
+ * keys, and local-vs-committed warnings using the same `config-resolution`
+ * rules every writer/intake flow already follows.
+ *
+ * Both plugin roots and both rules roots are asserted so source-only or
+ * artifact-only edits fail fast.
+ * @module tests/unit/strategies/doctor-config-readiness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+
+const readDoctorSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "doctor", "SKILL.md"), "utf8");
+
+describe.each(SKILL_ROOTS)("doctor config-readiness contract (%s)", root => {
+  const content = readDoctorSkill(root);
+
+  it("requires parseable committed and local config files", () => {
+    expect(content).toContain("Presence + parseability");
+    expect(content).toMatch(
+      /\.lisa\.config\.json` is missing, empty, or invalid JSON/i
+    );
+    expect(content).toMatch(/\.lisa\.config\.local\.json.*invalid JSON/i);
+  });
+
+  it("documents merged effective-config semantics and required dispatch keys", () => {
+    expect(content).toMatch(/per-key local-overrides-global semantics/i);
+    expect(content).toMatch(/effective merged value/i);
+    expect(content).toMatch(/merged `tracker` is missing/i);
+    expect(content).toMatch(/merged `source` is present but is not one of/i);
+  });
+
+  it("documents vendor required-key failures and locality warnings", () => {
+    expect(content).toMatch(/Vendor required-key audit/i);
+    expect(content).toMatch(/tracker=github.*github\.org.*github\.repo/s);
+    expect(content).toMatch(
+      /source=notion.*notion\.workspaceId.*notion\.prdDatabaseId/s
+    );
+    expect(content).toMatch(/Local-vs-committed locality audit/i);
+    expect(content).toMatch(
+      /atlassian\.email.*intake\.assignee.*jira\.verified_workflow_hash/s
+    );
+    expect(content).toMatch(
+      /project-wide shared fields exist only in `\.lisa\.config\.local\.json`/i
+    );
+  });
+});
+
+describe.each(RULE_ROOTS)(
+  "config-resolution doctor readiness docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
+
+    it("defines doctor's config-readiness audit in one shared section", () => {
+      expect(content).toContain("### Doctor config readiness");
+      expect(content).toMatch(/Doctor must validate config in three layers/i);
+      expect(content).toMatch(/parse both config files as JSON/i);
+      expect(content).toMatch(/merged[\s\S]*effective config/i);
+    });
+
+    it("documents required-key failures and local-only fields", () => {
+      expect(content).toMatch(
+        /Missing `tracker` after merge is a blocking error/i
+      );
+      expect(content).toMatch(
+        /configured tracker\/source vendor is missing its required keys/i
+      );
+      expect(content).toMatch(
+        /`atlassian\.email`, `intake\.assignee`, and `jira\.verified_workflow_hash` are local-only/i
+      );
+    });
+
+    it("documents shared-field-in-local warnings for doctor", () => {
+      expect(content).toMatch(
+        /project-wide fields that exist only in `\.lisa\.config\.local\.json`/i
+      );
+      expect(content).toMatch(
+        /`github\.org`, `github\.repo`[\s\S]*`atlassian\.cloudId`, `atlassian\.site`[\s\S]*`deploy\.branches`/i
+      );
+      expect(content).toMatch(
+        /Current machine works, repository not durably configured/i
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- tighten the `/lisa:doctor` config-readiness contract around parseability, merged config semantics, required tracker/source keys, and locality warnings
- add shared `config-resolution` guidance so doctor uses the same required-key and local-vs-committed rules as the rest of Lisa
- add regression coverage for both source and generated plugin roots

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/doctor-config-readiness.test.ts tests/unit/strategies/doctor-scaffold.test.ts tests/unit/strategies/doctor-report-rendering.test.ts