### PR TITLE
docs(doctor): define vendor preflight readiness contract

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -429,6 +429,36 @@ Doctor must validate config in three layers:
 Doctor's severity rule is simple: unusable merged config is `FAIL`; locality drift with a still
 usable merged config is `WARN`.
 
+### Doctor vendor preflight
+
+Once doctor can resolve the merged `tracker` and optional `source`, it must run a read-only vendor
+preflight for those configured vendors only.
+
+1. **Audit only the configured vendors**
+   - Always audit the merged `tracker`.
+   - Audit `source` when present and when it is not already covered by the tracker check.
+   - Every other vendor is a doctor `SKIP`, not an implicit pass.
+2. **Read-capable substrate requirement**
+   - `github` requires `gh` CLI, a passing `gh auth status`, and read access to the configured
+     repo (`github.org` + `github.repo`).
+   - `jira` / `confluence` must reuse the `atlassian-access` substrate ladder. Doctor passes when
+     at least one supported read-capable substrate (`acli`, Atlassian MCP, or validated curl/API
+     token) can prove visibility to the configured `atlassian.cloudId` and target scope.
+   - `linear` passes when either the Linear MCP or a validated API-key probe can read the
+     configured workspace; tracker mode also requires visibility to `linear.teamKey`.
+   - `notion` passes when either the Notion MCP identity matches `notion.workspaceId` or a valid
+     internal-integration token does, and the configured `notion.prdDatabaseId` is readable.
+3. **Observed-fact discipline**
+   - Missing executable / MCP availability and failed auth/scope probes must be reported
+     separately.
+   - Preserve the exact probe failure text or status code when a read attempt fails; doctor should
+     not collapse repo-not-found, wrong-workspace, and unauthenticated cases into one generic
+     readiness error.
+4. **Severity**
+   - No read-capable substrate for the configured vendor, or a configured target that remains
+     unreadable after all supported probes, is a doctor `FAIL`.
+   - A reachable vendor with only auxiliary-substrate degradation is a doctor `WARN`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -104,6 +104,42 @@ this order:
 Locality findings are advisory unless the merged config is unusable. Missing shared keys after the
 merge are `FAIL`; shared keys that exist only locally are `WARN`.
 
+### Minimum tracker/source preflight checks
+
+After config readiness passes far enough to resolve the merged `tracker` and optional `source`,
+doctor must perform read-only preflight checks for the configured vendors only. It does not probe
+every vendor Lisa supports.
+
+1. **Scope the audit to configured vendors**
+   - Audit the merged `tracker`.
+   - Audit the merged `source` only when present and distinct from the tracker.
+   - Report every non-configured vendor as `SKIP` rather than pretending it was checked.
+2. **Prove a readable substrate exists**
+   - `tracker=github` or `source=github`: require `gh` CLI availability, a passing `gh auth status`,
+     and a read probe against the configured repo such as `gh repo view <org>/<repo>`.
+   - `tracker=jira`, `source=jira`, or `source=confluence`: follow the `atlassian-access`
+     substrate ladder and prove at least one read-capable path can see the configured
+     `atlassian.cloudId` and vendor scope. Acceptable substrates are `acli`, Atlassian MCP, or the
+     validated API-token/curl path documented by `config-resolution`.
+   - `tracker=linear` or `source=linear`: require either readable Linear MCP access or a valid
+     personal API-key probe against the configured workspace. When Linear is the tracker, doctor
+     must also prove the configured `linear.teamKey` is visible.
+   - `source=notion`: require either a Notion MCP identity match for `notion.workspaceId` or a
+     valid internal-integration token probe, plus read visibility to `notion.prdDatabaseId`.
+3. **Separate missing tooling from missing auth or scope**
+   - Missing executable / MCP substrate availability is a distinct observed fact, not the same as
+     "auth failed."
+   - When a probe runs and fails, preserve the exact read-only failure text or HTTP/GraphQL status
+     in the observed output so the operator can distinguish wrong workspace/site/repo from missing
+     credentials.
+4. **Severity ladder**
+   - `PASS` when at least one supported read-only substrate proves the configured vendor is
+     reachable with the required scope.
+   - `WARN` when the configured vendor is reachable, but an additional optional substrate is
+     unavailable and later Lisa flows would need to fall back.
+   - `FAIL` when no supported substrate can prove read access for the configured tracker/source, or
+     when the configured vendor target is unreadable from the current runtime.
+
 ## Output contract
 
 The final report must:

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -429,6 +429,36 @@ Doctor must validate config in three layers:
 Doctor's severity rule is simple: unusable merged config is `FAIL`; locality drift with a still
 usable merged config is `WARN`.
 
+### Doctor vendor preflight
+
+Once doctor can resolve the merged `tracker` and optional `source`, it must run a read-only vendor
+preflight for those configured vendors only.
+
+1. **Audit only the configured vendors**
+   - Always audit the merged `tracker`.
+   - Audit `source` when present and when it is not already covered by the tracker check.
+   - Every other vendor is a doctor `SKIP`, not an implicit pass.
+2. **Read-capable substrate requirement**
+   - `github` requires `gh` CLI, a passing `gh auth status`, and read access to the configured
+     repo (`github.org` + `github.repo`).
+   - `jira` / `confluence` must reuse the `atlassian-access` substrate ladder. Doctor passes when
+     at least one supported read-capable substrate (`acli`, Atlassian MCP, or validated curl/API
+     token) can prove visibility to the configured `atlassian.cloudId` and target scope.
+   - `linear` passes when either the Linear MCP or a validated API-key probe can read the
+     configured workspace; tracker mode also requires visibility to `linear.teamKey`.
+   - `notion` passes when either the Notion MCP identity matches `notion.workspaceId` or a valid
+     internal-integration token does, and the configured `notion.prdDatabaseId` is readable.
+3. **Observed-fact discipline**
+   - Missing executable / MCP availability and failed auth/scope probes must be reported
+     separately.
+   - Preserve the exact probe failure text or status code when a read attempt fails; doctor should
+     not collapse repo-not-found, wrong-workspace, and unauthenticated cases into one generic
+     readiness error.
+4. **Severity**
+   - No read-capable substrate for the configured vendor, or a configured target that remains
+     unreadable after all supported probes, is a doctor `FAIL`.
+   - A reachable vendor with only auxiliary-substrate degradation is a doctor `WARN`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -104,6 +104,42 @@ this order:
 Locality findings are advisory unless the merged config is unusable. Missing shared keys after the
 merge are `FAIL`; shared keys that exist only locally are `WARN`.
 
+### Minimum tracker/source preflight checks
+
+After config readiness passes far enough to resolve the merged `tracker` and optional `source`,
+doctor must perform read-only preflight checks for the configured vendors only. It does not probe
+every vendor Lisa supports.
+
+1. **Scope the audit to configured vendors**
+   - Audit the merged `tracker`.
+   - Audit the merged `source` only when present and distinct from the tracker.
+   - Report every non-configured vendor as `SKIP` rather than pretending it was checked.
+2. **Prove a readable substrate exists**
+   - `tracker=github` or `source=github`: require `gh` CLI availability, a passing `gh auth status`,
+     and a read probe against the configured repo such as `gh repo view <org>/<repo>`.
+   - `tracker=jira`, `source=jira`, or `source=confluence`: follow the `atlassian-access`
+     substrate ladder and prove at least one read-capable path can see the configured
+     `atlassian.cloudId` and vendor scope. Acceptable substrates are `acli`, Atlassian MCP, or the
+     validated API-token/curl path documented by `config-resolution`.
+   - `tracker=linear` or `source=linear`: require either readable Linear MCP access or a valid
+     personal API-key probe against the configured workspace. When Linear is the tracker, doctor
+     must also prove the configured `linear.teamKey` is visible.
+   - `source=notion`: require either a Notion MCP identity match for `notion.workspaceId` or a
+     valid internal-integration token probe, plus read visibility to `notion.prdDatabaseId`.
+3. **Separate missing tooling from missing auth or scope**
+   - Missing executable / MCP substrate availability is a distinct observed fact, not the same as
+     "auth failed."
+   - When a probe runs and fails, preserve the exact read-only failure text or HTTP/GraphQL status
+     in the observed output so the operator can distinguish wrong workspace/site/repo from missing
+     credentials.
+4. **Severity ladder**
+   - `PASS` when at least one supported read-only substrate proves the configured vendor is
+     reachable with the required scope.
+   - `WARN` when the configured vendor is reachable, but an additional optional substrate is
+     unavailable and later Lisa flows would need to fall back.
+   - `FAIL` when no supported substrate can prove read access for the configured tracker/source, or
+     when the configured vendor target is unreadable from the current runtime.
+
 ## Output contract
 
 The final report must:

--- a/tests/unit/strategies/doctor-vendor-preflight.test.ts
+++ b/tests/unit/strategies/doctor-vendor-preflight.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression tests for the doctor tracker/source preflight contract.
+ *
+ * Issue #752 (Story #746, PRD #741): `/lisa:doctor` must describe how it
+ * proves tracker/source readiness without mutating state. The contract needs to
+ * stay explicit about which vendors are checked, which read-only substrates
+ * count, and how missing tooling differs from missing auth or scope.
+ *
+ * Both plugin roots and both rules roots are asserted so source-only or
+ * artifact-only edits fail fast.
+ * @module tests/unit/strategies/doctor-vendor-preflight
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+
+const readDoctorSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "doctor", "SKILL.md"), "utf8");
+
+describe.each(SKILL_ROOTS)("doctor vendor preflight contract (%s)", root => {
+  const content = readDoctorSkill(root);
+
+  it("checks only the configured tracker and source vendors", () => {
+    expect(content).toContain("### Minimum tracker/source preflight checks");
+    expect(content).toMatch(/configured vendors only/i);
+    expect(content).toMatch(/Audit the merged `tracker`/);
+    expect(content).toMatch(
+      /merged `source` only when present and distinct from the tracker/i
+    );
+    expect(content).toMatch(/non-configured vendors? as `SKIP`/i);
+  });
+
+  it("documents the vendor-specific read-only substrates", () => {
+    expect(content).toMatch(/`tracker=github`.*`source=github`/s);
+    expect(content).toMatch(/`gh` CLI availability/i);
+    expect(content).toMatch(/gh auth status/i);
+    expect(content).toMatch(/gh repo view <org>\/<repo>/i);
+    expect(content).toMatch(
+      /`tracker=jira`, `source=jira`, or `source=confluence`/
+    );
+    expect(content).toMatch(
+      /`acli`, Atlassian MCP, or the\s+validated API-token\/curl path/i
+    );
+    expect(content).toMatch(/`tracker=linear` or `source=linear`/);
+    expect(content).toMatch(
+      /readable Linear MCP access or a valid\s+personal API-key probe/i
+    );
+    expect(content).toMatch(/`source=notion`/);
+    expect(content).toMatch(/Notion MCP identity match/i);
+    expect(content).toMatch(/`notion\.prdDatabaseId`/i);
+  });
+
+  it("separates missing tooling from auth or scope failures and defines severity", () => {
+    expect(content).toMatch(
+      /Missing executable \/ MCP substrate availability is a distinct observed fact/i
+    );
+    expect(content).toMatch(
+      /exact read-only failure text or HTTP\/GraphQL status/i
+    );
+    expect(content).toMatch(
+      /`PASS` when at least one supported read-only substrate proves/i
+    );
+    expect(content).toMatch(
+      /`WARN` when the configured vendor is reachable, but an additional optional substrate is\s+unavailable/i
+    );
+    expect(content).toMatch(
+      /`FAIL` when no supported substrate can prove read access/i
+    );
+  });
+});
+
+describe.each(RULE_ROOTS)(
+  "config-resolution doctor vendor preflight docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
+
+    it("defines one shared doctor vendor-preflight section", () => {
+      expect(content).toContain("### Doctor vendor preflight");
+      expect(content).toMatch(/read-only vendor\s+preflight/i);
+      expect(content).toMatch(/configured vendors only/i);
+      expect(content).toMatch(/Every other vendor is a doctor `SKIP`/i);
+    });
+
+    it("documents the vendor substrate ladder expectations", () => {
+      expect(content).toMatch(
+        /`github` requires `gh` CLI, a passing `gh auth status`/i
+      );
+      expect(content).toMatch(
+        /`jira` \/ `confluence` must reuse the `atlassian-access` substrate ladder/i
+      );
+      expect(content).toMatch(
+        /`acli`, Atlassian MCP, or\s+validated curl\/API\s+token/i
+      );
+      expect(content).toMatch(
+        /`linear` passes when either the Linear MCP or a validated\s+API-key probe/i
+      );
+      expect(content).toMatch(
+        /`notion` passes when either the Notion MCP identity matches\s+`notion\.workspaceId`/i
+      );
+    });
+
+    it("documents exact-failure preservation and WARN vs FAIL branching", () => {
+      expect(content).toMatch(
+        /Preserve the exact probe failure text or status code/i
+      );
+      expect(content).toMatch(
+        /No read-capable substrate for the configured vendor.*doctor `FAIL`/s
+      );
+      expect(content).toMatch(
+        /reachable vendor with only auxiliary-substrate degradation is a doctor `WARN`/i
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary\n- define the  tracker/source vendor preflight contract in the shared doctor skill\n- add the matching  rule section for read-only vendor readiness semantics\n- cover the source and generated plugin roots with a dedicated vendor-preflight regression suite\n\n## Testing\n- bun run build:plugins\n- bun test tests/unit/strategies/doctor-scaffold.test.ts tests/unit/strategies/doctor-report-rendering.test.ts tests/unit/strategies/doctor-config-readiness.test.ts tests/unit/strategies/doctor-vendor-preflight.test.ts