### PR TITLE
feat(doctor): validate GitHub Project readiness

### DIFF
--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -140,6 +140,59 @@ every vendor Lisa supports.
    - `FAIL` when no supported substrate can prove read access for the configured tracker/source, or
      when the configured vendor target is unreadable from the current runtime.
 
+### Minimum GitHub Project coordination checks
+
+When `github.projects.v2` is configured, doctor must run one additional read-only coordination
+check instead of treating the config block as implicitly ready.
+
+1. **Delegate through the shared chokepoint**
+   - Call `lisa:github-project-v2` in read-only resolution mode:
+
+     ```text
+     operation: resolve-project
+     ```
+
+   - Do not inline ad-hoc Project GraphQL in doctor. Setup, doctor, writers, and linked-PR flows
+     must all read the same owner/access contract from the shared utility.
+2. **Preserve exact namespace + access failures**
+   - Enforce the v1 namespace rule exactly as documented by the shared utility. If
+     `github.projects.v2.owner.slug` does not match `github.org`, report:
+
+     ```yaml
+     code: project_namespace_mismatch
+     message: "github.projects.v2.owner.slug must match github.org in v1"
+     remediation: "Use a Project owned by <github.org> or remove github.projects.v2."
+     ```
+
+   - For owner-access or GraphQL failures, preserve the exact GitHub / GraphQL failure text in the
+     observed output. Examples include missing Project, `Resource not accessible by integration`,
+     unsupported owner kind, or a wrong owner/number pair.
+3. **Report exact remediation paths**
+   - Doctor must make the next operator action explicit. At minimum, say whether they need to:
+     1. choose a Project owned by the tracked repo namespace,
+     2. grant the token Project read/write access,
+     3. correct the configured Project number/owner, or
+     4. remove `github.projects.v2` when coordination is not required.
+4. **Map shared utility outcomes into doctor severity**
+   - `required: false` => doctor `WARN`. Repository-local GitHub issue/PR flows remain usable while
+     Project coordination is degraded.
+   - `required: true` => doctor `FAIL`. The same Project validation failure blocks Lisa readiness
+     because coordination was configured as required.
+
+Good output examples:
+
+```text
+WARN github.projects.v2: Resource not accessible by integration
+Observed: exact GitHub / GraphQL failure text preserved from resolve-project.
+Remediation: grant the token Project read/write access or remove github.projects.v2.required.
+Repository-local GitHub issue/PR flows remain usable; Project coordination is disabled.
+```
+
+```text
+FAIL github.projects.v2: github.projects.v2.owner.slug must match github.org in v1
+Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
+```
+
 ## Output contract
 
 The final report must:

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -140,6 +140,59 @@ every vendor Lisa supports.
    - `FAIL` when no supported substrate can prove read access for the configured tracker/source, or
      when the configured vendor target is unreadable from the current runtime.
 
+### Minimum GitHub Project coordination checks
+
+When `github.projects.v2` is configured, doctor must run one additional read-only coordination
+check instead of treating the config block as implicitly ready.
+
+1. **Delegate through the shared chokepoint**
+   - Call `lisa:github-project-v2` in read-only resolution mode:
+
+     ```text
+     operation: resolve-project
+     ```
+
+   - Do not inline ad-hoc Project GraphQL in doctor. Setup, doctor, writers, and linked-PR flows
+     must all read the same owner/access contract from the shared utility.
+2. **Preserve exact namespace + access failures**
+   - Enforce the v1 namespace rule exactly as documented by the shared utility. If
+     `github.projects.v2.owner.slug` does not match `github.org`, report:
+
+     ```yaml
+     code: project_namespace_mismatch
+     message: "github.projects.v2.owner.slug must match github.org in v1"
+     remediation: "Use a Project owned by <github.org> or remove github.projects.v2."
+     ```
+
+   - For owner-access or GraphQL failures, preserve the exact GitHub / GraphQL failure text in the
+     observed output. Examples include missing Project, `Resource not accessible by integration`,
+     unsupported owner kind, or a wrong owner/number pair.
+3. **Report exact remediation paths**
+   - Doctor must make the next operator action explicit. At minimum, say whether they need to:
+     1. choose a Project owned by the tracked repo namespace,
+     2. grant the token Project read/write access,
+     3. correct the configured Project number/owner, or
+     4. remove `github.projects.v2` when coordination is not required.
+4. **Map shared utility outcomes into doctor severity**
+   - `required: false` => doctor `WARN`. Repository-local GitHub issue/PR flows remain usable while
+     Project coordination is degraded.
+   - `required: true` => doctor `FAIL`. The same Project validation failure blocks Lisa readiness
+     because coordination was configured as required.
+
+Good output examples:
+
+```text
+WARN github.projects.v2: Resource not accessible by integration
+Observed: exact GitHub / GraphQL failure text preserved from resolve-project.
+Remediation: grant the token Project read/write access or remove github.projects.v2.required.
+Repository-local GitHub issue/PR flows remain usable; Project coordination is disabled.
+```
+
+```text
+FAIL github.projects.v2: github.projects.v2.owner.slug must match github.org in v1
+Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
+```
+
 ## Output contract
 
 The final report must:

--- a/tests/unit/strategies/doctor-project-readiness.test.ts
+++ b/tests/unit/strategies/doctor-project-readiness.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for doctor verification of optional GitHub ProjectV2
+ * coordination.
+ *
+ * Issue #753 (Story #746, PRD #741): `/lisa:doctor` must route GitHub Project
+ * readiness through the shared `github-project-v2` resolve-project chokepoint,
+ * preserve exact namespace/access failures, and map the same failure into WARN
+ * vs FAIL based on `github.projects.v2.required`.
+ *
+ * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
+ * suite.
+ * @module tests/unit/strategies/doctor-project-readiness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "doctor", "SKILL.md"), "utf8");
+
+describe.each(ROOTS)("doctor Project readiness contract (%s)", root => {
+  const content = readSkill(root);
+
+  it("routes GitHub Project checks through resolve-project", () => {
+    expect(content).toMatch(/Minimum GitHub Project coordination checks/i);
+    expect(content).toMatch(/operation:\s*resolve-project/i);
+    expect(content).toMatch(/Do not inline ad-hoc Project GraphQL in doctor/i);
+    expect(content).toMatch(/same owner\/access contract/i);
+  });
+
+  it("documents exact namespace-mismatch failure text and remediation", () => {
+    expect(content).toMatch(/code:\s*project_namespace_mismatch/i);
+    expect(content).toMatch(
+      /message:\s*"github\.projects\.v2\.owner\.slug must match github\.org in v1"/i
+    );
+    expect(content).toMatch(/Use a Project owned by <github\.org>/i);
+  });
+
+  it("preserves exact owner-access failures with explicit remediation branches", () => {
+    expect(content).toMatch(/exact GitHub \/ GraphQL failure text/i);
+    expect(content).toMatch(/Resource not accessible by integration/i);
+    expect(content).toMatch(/grant the token Project read\/write access/i);
+    expect(content).toMatch(/correct the configured Project number\/owner/i);
+  });
+
+  it("maps required=false to WARN and required=true to FAIL", () => {
+    expect(content).toMatch(/required:\s*false.*doctor `WARN`/i);
+    expect(content).toMatch(/required:\s*true.*doctor `FAIL`/i);
+    expect(content).toMatch(
+      /Repository-local GitHub issue\/PR flows remain usable/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- require `/lisa:doctor` to delegate optional GitHub ProjectV2 checks through `github-project-v2` in `resolve-project` mode
- document exact namespace and access failure preservation plus required-vs-warning readiness semantics
- add regression coverage for the doctor Project readiness contract across source and generated plugin roots

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/doctor-project-readiness.test.ts tests/unit/strategies/doctor-scaffold.test.ts tests/unit/strategies/doctor-config-readiness.test.ts tests/unit/strategies/doctor-vendor-preflight.test.ts tests/unit/strategies/setup-github-project-verification.test.ts tests/unit/strategies/github-project-config-resolution.test.ts

Closes #753