### PR TITLE
[lisa] Audit automation and exploratory-job readiness without mutating state

### DIFF
--- a/plugins/lisa/rules/config-resolution.md
+++ b/plugins/lisa/rules/config-resolution.md
@@ -459,6 +459,38 @@ preflight for those configured vendors only.
      unreadable after all supported probes, is a doctor `FAIL`.
    - A reachable vendor with only auxiliary-substrate degradation is a doctor `WARN`.
 
+### Doctor automation readiness
+
+Doctor's automation-readiness group is also read-only. It answers "could this repo safely support
+Lisa's recurring automations from the current runtime?" without creating, editing, deleting, or
+reconciling any automation state.
+
+1. **Resolve the automation queues from merged config**
+   - Resolve the PRD automation queue from merged `source`.
+   - Resolve the build automation queue from merged `tracker`.
+   - Resolve repair-intake from the same queue-detection contract `lisa:intake` /
+     `lisa:repair-intake` already use; doctor should not invent a second queue schema.
+   - If an automation's queue cannot be resolved because `source`, `tracker`, or the selected
+     vendor's required keys are still missing after merge, that automation is a doctor `FAIL`.
+     Unattended runs would be ambiguous before the scheduler is even involved.
+2. **Check native scheduler availability by runtime, read-only**
+   - Codex automation support means the runtime exposes the native automations surface
+     (`automation_update`) that `setup-automations` depends on.
+   - Claude automation support means `/schedule` is available.
+   - Other runtimes should be reported explicitly as having no known native Lisa scheduler unless a
+     supported surface is observable.
+   - Doctor must not create a throwaway automation just to prove the scheduler exists.
+3. **Match exploratory automation support to the repo's shipped stack**
+   - `exploratory-bugs` exists only for stacks that ship `exploratory-qa` (`expo`, `rails`,
+     `harper-fabric`). If the repo lacks that command surface, doctor reports the automation as
+     `SKIP`, not `FAIL`.
+   - `exploratory-prds` follows the normal queue-resolution rules; if its prerequisites are
+     unresolved, preserve the exact blocking config fact.
+4. **Severity**
+   - Queue resolution failure is a doctor `FAIL`.
+   - Missing native scheduler support in an otherwise manually-usable repo is a doctor `WARN`.
+   - Intentional absence of an optional exploratory automation surface is a doctor `SKIP`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -193,6 +193,47 @@ FAIL github.projects.v2: github.projects.v2.owner.slug must match github.org in 
 Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
 ```
 
+### Minimum automation-readiness checks
+
+Doctor's automation-readiness group stays read-only: it audits whether this repo and runtime could
+support `/lisa:setup-automations` and the resulting recurring jobs, but it does **not** create,
+edit, delete, or reconcile automations on the default doctor path.
+
+1. **Resolve the queue inputs exactly as setup-automations would**
+   - Resolve the PRD queue from merged `source`.
+   - Resolve the build queue from merged `tracker`.
+   - Resolve the repair queue from the same queue-detection rules as `lisa:repair-intake`
+     (identical source-dispatch contract to `lisa:intake`).
+   - If any automation would require guessing because `source`, `tracker`, or their vendor keys are
+     still unresolved after the config-readiness audit, report that automation as `FAIL` rather
+     than pretending scheduling can proceed safely.
+2. **Audit the current runtime's native scheduler surface without mutating it**
+   - Codex: doctor should report whether the runtime exposes the native automations surface
+     (`automation_update`) needed by `/lisa:setup-automations`.
+   - Claude: doctor should report whether the runtime exposes `/schedule`.
+   - Other runtimes: doctor should explicitly say that no native Lisa scheduler is known for the
+     current runtime.
+   - This is observability only. Never create a placeholder automation just to prove the scheduler
+     works.
+3. **Check exploratory-automation support by shipped stack surface**
+   - `exploratory-bugs` is supported only when the project ships an `exploratory-qa` command
+     surface (the `expo`, `rails`, or `harper-fabric` stacks today). Reuse the same stack/support
+     rule documented by `setup-automations`; do not invent exploratory jobs for stacks that do not
+     ship that command.
+   - When the repo does not ship `exploratory-qa`, report `exploratory-bugs` as `SKIP` with the
+     reason.
+   - `exploratory-prds` remains applicable when the repo can run `/lisa:project-ideation`; if its
+     queue/config prerequisites are unresolved, report the exact blocking config fact.
+4. **Severity ladder**
+   - `PASS` when an automation's queue inputs are resolvable and the runtime exposes the required
+     native scheduler surface for that automation.
+   - `WARN` when Lisa remains usable manually, but the current runtime has no native scheduler
+     surface for unattended runs, so automation setup would be unavailable from here.
+   - `SKIP` when an optional automation is intentionally unsupported for this repo surface (for
+     example, `exploratory-bugs` on a stack with no `exploratory-qa` command).
+   - `FAIL` when the repo's config cannot resolve the queue that an automation needs, because that
+     would make unattended runs ambiguous or broken before scheduling even starts.
+
 ## Output contract
 
 The final report must:

--- a/plugins/src/base/rules/config-resolution.md
+++ b/plugins/src/base/rules/config-resolution.md
@@ -459,6 +459,38 @@ preflight for those configured vendors only.
      unreadable after all supported probes, is a doctor `FAIL`.
    - A reachable vendor with only auxiliary-substrate degradation is a doctor `WARN`.
 
+### Doctor automation readiness
+
+Doctor's automation-readiness group is also read-only. It answers "could this repo safely support
+Lisa's recurring automations from the current runtime?" without creating, editing, deleting, or
+reconciling any automation state.
+
+1. **Resolve the automation queues from merged config**
+   - Resolve the PRD automation queue from merged `source`.
+   - Resolve the build automation queue from merged `tracker`.
+   - Resolve repair-intake from the same queue-detection contract `lisa:intake` /
+     `lisa:repair-intake` already use; doctor should not invent a second queue schema.
+   - If an automation's queue cannot be resolved because `source`, `tracker`, or the selected
+     vendor's required keys are still missing after merge, that automation is a doctor `FAIL`.
+     Unattended runs would be ambiguous before the scheduler is even involved.
+2. **Check native scheduler availability by runtime, read-only**
+   - Codex automation support means the runtime exposes the native automations surface
+     (`automation_update`) that `setup-automations` depends on.
+   - Claude automation support means `/schedule` is available.
+   - Other runtimes should be reported explicitly as having no known native Lisa scheduler unless a
+     supported surface is observable.
+   - Doctor must not create a throwaway automation just to prove the scheduler exists.
+3. **Match exploratory automation support to the repo's shipped stack**
+   - `exploratory-bugs` exists only for stacks that ship `exploratory-qa` (`expo`, `rails`,
+     `harper-fabric`). If the repo lacks that command surface, doctor reports the automation as
+     `SKIP`, not `FAIL`.
+   - `exploratory-prds` follows the normal queue-resolution rules; if its prerequisites are
+     unresolved, preserve the exact blocking config fact.
+4. **Severity**
+   - Queue resolution failure is a doctor `FAIL`.
+   - Missing native scheduler support in an otherwise manually-usable repo is a doctor `WARN`.
+   - Intentional absence of an optional exploratory automation surface is a doctor `SKIP`.
+
 ## Skill mapping
 
 The shim → vendor mapping is fixed:

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -193,6 +193,47 @@ FAIL github.projects.v2: github.projects.v2.owner.slug must match github.org in 
 Remediation: use a Project owned by CodySwannGT or remove github.projects.v2.
 ```
 
+### Minimum automation-readiness checks
+
+Doctor's automation-readiness group stays read-only: it audits whether this repo and runtime could
+support `/lisa:setup-automations` and the resulting recurring jobs, but it does **not** create,
+edit, delete, or reconcile automations on the default doctor path.
+
+1. **Resolve the queue inputs exactly as setup-automations would**
+   - Resolve the PRD queue from merged `source`.
+   - Resolve the build queue from merged `tracker`.
+   - Resolve the repair queue from the same queue-detection rules as `lisa:repair-intake`
+     (identical source-dispatch contract to `lisa:intake`).
+   - If any automation would require guessing because `source`, `tracker`, or their vendor keys are
+     still unresolved after the config-readiness audit, report that automation as `FAIL` rather
+     than pretending scheduling can proceed safely.
+2. **Audit the current runtime's native scheduler surface without mutating it**
+   - Codex: doctor should report whether the runtime exposes the native automations surface
+     (`automation_update`) needed by `/lisa:setup-automations`.
+   - Claude: doctor should report whether the runtime exposes `/schedule`.
+   - Other runtimes: doctor should explicitly say that no native Lisa scheduler is known for the
+     current runtime.
+   - This is observability only. Never create a placeholder automation just to prove the scheduler
+     works.
+3. **Check exploratory-automation support by shipped stack surface**
+   - `exploratory-bugs` is supported only when the project ships an `exploratory-qa` command
+     surface (the `expo`, `rails`, or `harper-fabric` stacks today). Reuse the same stack/support
+     rule documented by `setup-automations`; do not invent exploratory jobs for stacks that do not
+     ship that command.
+   - When the repo does not ship `exploratory-qa`, report `exploratory-bugs` as `SKIP` with the
+     reason.
+   - `exploratory-prds` remains applicable when the repo can run `/lisa:project-ideation`; if its
+     queue/config prerequisites are unresolved, report the exact blocking config fact.
+4. **Severity ladder**
+   - `PASS` when an automation's queue inputs are resolvable and the runtime exposes the required
+     native scheduler surface for that automation.
+   - `WARN` when Lisa remains usable manually, but the current runtime has no native scheduler
+     surface for unattended runs, so automation setup would be unavailable from here.
+   - `SKIP` when an optional automation is intentionally unsupported for this repo surface (for
+     example, `exploratory-bugs` on a stack with no `exploratory-qa` command).
+   - `FAIL` when the repo's config cannot resolve the queue that an automation needs, because that
+     would make unattended runs ambiguous or broken before scheduling even starts.
+
 ## Output contract
 
 The final report must:

--- a/tests/unit/strategies/doctor-automation-readiness.test.ts
+++ b/tests/unit/strategies/doctor-automation-readiness.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression tests for the doctor automation-readiness contract.
+ *
+ * Issue #754 (Story #747, PRD #741): `/lisa:doctor` must explain how it audits
+ * automation readiness without mutating scheduler state. The contract needs to
+ * stay explicit about queue resolution, native scheduler availability, and the
+ * repo-surface rules for exploratory automations.
+ *
+ * Both plugin roots and both rules roots are asserted so source-only or
+ * artifact-only edits fail fast.
+ * @module tests/unit/strategies/doctor-automation-readiness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+const RULE_ROOTS = ["plugins/src/base/rules", "plugins/lisa/rules"] as const;
+
+const readDoctorSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "doctor", "SKILL.md"), "utf8");
+
+describe.each(SKILL_ROOTS)(
+  "doctor automation-readiness contract (%s)",
+  root => {
+    const content = readDoctorSkill(root);
+
+    it("documents read-only queue resolution for prd, build, and repair automations", () => {
+      expect(content).toContain("### Minimum automation-readiness checks");
+      expect(content).toMatch(
+        /automation-readiness group stays read-only|automation-readiness group is also read-only/i
+      );
+      expect(content).toMatch(/Resolve the PRD queue from merged `source`/i);
+      expect(content).toMatch(/Resolve the build queue from merged `tracker`/i);
+      expect(content).toMatch(
+        /Resolve the repair queue.*`lisa:repair-intake`/is
+      );
+      expect(content).toMatch(
+        /report that automation as `FAIL` rather\s+than pretending scheduling can proceed safely/i
+      );
+    });
+
+    it("checks native scheduler visibility without creating automations", () => {
+      expect(content).toMatch(/Codex[\s\S]*`automation_update`/i);
+      expect(content).toMatch(/Claude[\s\S]*`\/schedule`/i);
+      expect(content).toMatch(/Other runtimes[\s\S]*no native Lisa scheduler/i);
+      expect(content).toMatch(
+        /Never create a placeholder automation just to prove the scheduler\s+works/i
+      );
+    });
+
+    it("covers exploratory support and PASS WARN SKIP FAIL semantics", () => {
+      expect(content).toMatch(
+        /`exploratory-bugs`[\s\S]*`exploratory-qa`[\s\S]*`expo`[\s\S]*`rails`[\s\S]*`harper-fabric`/i
+      );
+      expect(content).toMatch(
+        /When the repo does not ship `exploratory-qa`, report `exploratory-bugs` as `SKIP`/i
+      );
+      expect(content).toMatch(/`exploratory-prds` remains applicable/i);
+      expect(content).toMatch(
+        /`PASS` when an automation's queue inputs are resolvable/i
+      );
+      expect(content).toMatch(
+        /`WARN` when Lisa remains usable manually, but the current runtime has no native scheduler\s+surface/i
+      );
+      expect(content).toMatch(
+        /`FAIL` when the repo's config cannot resolve the queue that an automation needs/i
+      );
+    });
+  }
+);
+
+describe.each(RULE_ROOTS)(
+  "config-resolution doctor automation-readiness docs (%s)",
+  rulesRoot => {
+    const content = readFileSync(
+      path.resolve(rulesRoot, "config-resolution.md"),
+      "utf8"
+    );
+
+    it("defines one shared doctor automation-readiness section", () => {
+      expect(content).toContain("### Doctor automation readiness");
+      expect(content).toMatch(
+        /recurring automations from the current runtime/i
+      );
+      expect(content).toMatch(
+        /without creating[\s\S]*editing[\s\S]*deleting[\s\S]*reconciling any automation state/i
+      );
+    });
+
+    it("documents queue resolution and runtime scheduler expectations", () => {
+      expect(content).toMatch(
+        /Resolve the PRD automation queue from merged `source`/i
+      );
+      expect(content).toMatch(
+        /Resolve the build automation queue from merged `tracker`/i
+      );
+      expect(content).toMatch(/`lisa:intake`\s*\/\s*`lisa:repair-intake`/i);
+      expect(content).toMatch(/Codex[\s\S]*`automation_update`/i);
+      expect(content).toMatch(/Claude[\s\S]*`\/schedule`/i);
+      expect(content).toMatch(/must not create a throwaway automation/i);
+    });
+
+    it("documents exploratory-support and severity mapping", () => {
+      expect(content).toMatch(
+        /`exploratory-bugs` exists only for stacks that ship `exploratory-qa`.*`expo`, `rails`,\s*`harper-fabric`/is
+      );
+      expect(content).toMatch(
+        /doctor reports the automation as\s+`SKIP`, not `FAIL`/i
+      );
+      expect(content).toMatch(/Queue resolution failure is a doctor `FAIL`/i);
+      expect(content).toMatch(
+        /Missing native scheduler support.*doctor `WARN`/i
+      );
+      expect(content).toMatch(
+        /optional exploratory automation surface is a doctor `SKIP`/i
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- document the doctor automation-readiness contract for queue resolution, scheduler visibility, and exploratory-job support
- add the shared config-resolution automation-readiness section so doctor and setup-automations follow the same rules
- add regression coverage across source and generated plugin roots

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/doctor-automation-readiness.test.ts tests/unit/strategies/doctor-config-readiness.test.ts tests/unit/strategies/doctor-vendor-preflight.test.ts tests/unit/strategies/doctor-project-readiness.test.ts tests/unit/strategies/doctor-scaffold.test.ts tests/unit/strategies/doctor-report-rendering.test.ts tests/unit/strategies/automations-skills.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new automation-readiness checks to doctor tool documentation, specifying how it validates queue resolution, native scheduler support, and exploratory automation availability with PASS/WARN/SKIP/FAIL severity outcomes.

* **Tests**
  * Added test suite to verify doctor automation-readiness contract documentation across plugin specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->