### PR TITLE
test(doctor): add fixture smoke and parity coverage

### DIFF
--- a/tests/fixtures/doctor/not-ready-missing-config.json
+++ b/tests/fixtures/doctor/not-ready-missing-config.json
@@ -1,0 +1,50 @@
+{
+  "generatedAt": "2026-05-25T23:30:00.000Z",
+  "groups": [
+    {
+      "id": "1",
+      "title": "Project detection and runtime basics",
+      "checks": [
+        {
+          "id": "repo-root",
+          "status": "PASS",
+          "summary": "repository root resolved",
+          "observed": "package.json and .git are present at the working root."
+        }
+      ]
+    },
+    {
+      "id": "2",
+      "title": "Lisa config readiness",
+      "checks": [
+        {
+          "id": "config-json",
+          "status": "FAIL",
+          "summary": ".lisa.config.json is missing",
+          "observed": "No committed Lisa config file was found in the repository root.",
+          "remediation": "Create .lisa.config.json with at least tracker and vendor keys before running Lisa workflows."
+        },
+        {
+          "id": "locality",
+          "status": "WARN",
+          "summary": "developer-local overrides cannot be merged without committed config",
+          "observed": ".lisa.config.local.json exists, but the shared project config is absent.",
+          "remediation": "Move shared fields into .lisa.config.json and keep only developer-specific keys in .lisa.config.local.json."
+        }
+      ]
+    },
+    {
+      "id": "3",
+      "title": "Automation readiness",
+      "checks": [
+        {
+          "id": "intake-queue",
+          "status": "FAIL",
+          "summary": "build queue cannot be resolved",
+          "observed": "tracker is missing from merged config, so /lisa:intake build mode is ambiguous.",
+          "remediation": "Set tracker in .lisa.config.json before scheduling unattended intake."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/doctor/ready-with-warnings-github-self-host.json
+++ b/tests/fixtures/doctor/ready-with-warnings-github-self-host.json
@@ -1,0 +1,60 @@
+{
+  "generatedAt": "2026-05-25T23:31:00.000Z",
+  "groups": [
+    {
+      "id": "1",
+      "title": "Project detection and runtime basics",
+      "checks": [
+        {
+          "id": "repo-root",
+          "status": "PASS",
+          "summary": "repository root resolved",
+          "observed": "package.json, .git, and lisa distribution surfaces are present."
+        }
+      ]
+    },
+    {
+      "id": "2",
+      "title": "Lisa config readiness",
+      "checks": [
+        {
+          "id": "github-tracker",
+          "status": "PASS",
+          "summary": "merged tracker config resolves to GitHub self-host",
+          "observed": "tracker=github with github.org=CodySwannGT and github.repo=lisa."
+        }
+      ]
+    },
+    {
+      "id": "3",
+      "title": "Tracker/source preflight",
+      "checks": [
+        {
+          "id": "gh-access",
+          "status": "PASS",
+          "summary": "gh auth and repo read probe succeeded",
+          "observed": "gh auth status passed and gh repo view CodySwannGT/lisa is readable."
+        }
+      ]
+    },
+    {
+      "id": "4",
+      "title": "Automation readiness",
+      "checks": [
+        {
+          "id": "scheduler-surface",
+          "status": "WARN",
+          "summary": "manual Lisa usage is ready, but native scheduler support is unavailable in this runtime",
+          "observed": "Queue inputs are resolvable, but the current runtime cannot expose the scheduler surface here.",
+          "remediation": "Run doctor from a runtime with native automation support before configuring unattended jobs."
+        },
+        {
+          "id": "exploratory-bugs",
+          "status": "SKIP",
+          "summary": "exploratory-bugs is not shipped for this repo surface",
+          "observed": "This repository does not ship an exploratory-qa command surface."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
+++ b/tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Fixture-backed smoke coverage plus exact doctor artifact parity assertions.
+ *
+ * Issue #756 (Story #748, PRD #741): doctor already has contract-level tests,
+ * but it still needs representative readiness fixtures and a strict proof that
+ * the generated `plugins/lisa` doctor surfaces stay byte-for-byte aligned with
+ * the `plugins/src/base` source assets after `bun run build:plugins`.
+ * @module tests/unit/strategies/doctor-fixture-smoke-and-parity
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { renderDoctorReport } from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+/**
+ *
+ */
+type DoctorStatus = "PASS" | "WARN" | "FAIL" | "SKIP";
+/**
+ *
+ */
+type DoctorCheck = {
+  readonly id: string;
+  readonly status: DoctorStatus;
+  readonly summary: string;
+  readonly observed?: string;
+  readonly remediation?: string;
+};
+/**
+ *
+ */
+type DoctorGroup = {
+  readonly id: string;
+  readonly title: string;
+  readonly checks: readonly DoctorCheck[];
+};
+/**
+ *
+ */
+type DoctorReportFixture = {
+  readonly generatedAt?: string;
+  readonly groups: readonly DoctorGroup[];
+};
+
+const BASE_PLUGIN_ROOT = path.resolve("plugins/src/base");
+const GENERATED_PLUGIN_ROOT = path.resolve("plugins/lisa");
+const DOCTOR_FIXTURES = path.resolve("tests/fixtures/doctor");
+
+const readUtf8 = (filePath: string): string => readFileSync(filePath, "utf8");
+
+const readFixture = (name: string): DoctorReportFixture =>
+  JSON.parse(
+    readUtf8(path.join(DOCTOR_FIXTURES, `${name}.json`))
+  ) as DoctorReportFixture;
+
+describe("doctor fixture smoke coverage (#756)", () => {
+  it("renders a missing-config fixture as NOT_READY with actionable failures", () => {
+    const report = renderDoctorReport(readFixture("not-ready-missing-config"));
+
+    expect(report.verdict).toBe("NOT_READY");
+    expect(report.counts).toEqual({ PASS: 1, WARN: 1, FAIL: 2, SKIP: 0 });
+    expect(report.text).toContain("Overall verdict: NOT_READY");
+    expect(report.text).toContain(
+      "- FAIL config-json: .lisa.config.json is missing"
+    );
+    expect(report.text).toContain(
+      "Observed: No committed Lisa config file was found in the repository root."
+    );
+    expect(report.text).toContain(
+      "Remediation: Create .lisa.config.json with at least tracker and vendor keys before running Lisa workflows."
+    );
+    expect(report.text).toContain(
+      "- FAIL intake-queue: build queue cannot be resolved"
+    );
+  });
+
+  it("renders a minimally configured GitHub self-host fixture as READY_WITH_WARNINGS", () => {
+    const report = renderDoctorReport(
+      readFixture("ready-with-warnings-github-self-host")
+    );
+
+    expect(report.verdict).toBe("READY_WITH_WARNINGS");
+    expect(report.counts).toEqual({ PASS: 3, WARN: 1, FAIL: 0, SKIP: 1 });
+    expect(report.text).toContain("Overall verdict: READY_WITH_WARNINGS");
+    expect(report.text).toContain(
+      "- PASS github-tracker: merged tracker config resolves to GitHub self-host"
+    );
+    expect(report.text).toContain(
+      "- PASS gh-access: gh auth and repo read probe succeeded"
+    );
+    expect(report.text).toContain(
+      "- WARN scheduler-surface: manual Lisa usage is ready, but native scheduler support is unavailable in this runtime"
+    );
+    expect(report.text).toContain(
+      "- SKIP exploratory-bugs: exploratory-bugs is not shipped for this repo surface"
+    );
+  });
+});
+
+describe("doctor source/generated parity (#756)", () => {
+  it("keeps the distributed doctor command in lockstep with the source asset", () => {
+    expect(
+      readUtf8(path.join(GENERATED_PLUGIN_ROOT, "commands", "doctor.md"))
+    ).toBe(readUtf8(path.join(BASE_PLUGIN_ROOT, "commands", "doctor.md")));
+  });
+
+  it("keeps the distributed doctor skill in lockstep with the source asset", () => {
+    expect(
+      readUtf8(path.join(GENERATED_PLUGIN_ROOT, "skills", "doctor", "SKILL.md"))
+    ).toBe(
+      readUtf8(path.join(BASE_PLUGIN_ROOT, "skills", "doctor", "SKILL.md"))
+    );
+  });
+
+  it("keeps the distributed doctor report helper in lockstep with the source asset", () => {
+    expect(
+      readUtf8(path.join(GENERATED_PLUGIN_ROOT, "scripts", "doctor-report.mjs"))
+    ).toBe(
+      readUtf8(path.join(BASE_PLUGIN_ROOT, "scripts", "doctor-report.mjs"))
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add fixture-backed smoke coverage for representative doctor readiness outcomes
- assert exact parity for the distributed doctor command, skill, and report helper
- keep the new coverage focused on the remaining #756 verification gap

## Testing
- bun test tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
- bun test tests/unit/strategies/doctor-report-rendering.test.ts tests/unit/strategies/doctor-scaffold.test.ts
- push hook: eslint slow rules, knip, vitest --coverage, vitest integration

Fixes #756