### PR TITLE
feat: add harness parity council skill scaffold

### DIFF
--- a/.agents/skills/harness-parity-council/SKILL.md
+++ b/.agents/skills/harness-parity-council/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: harness-parity-council
+description: Lisa-only advisory workflow for consulting external coding-agent CLIs about runtime parity without bundling this skill into host projects
+---
+
+# Harness Parity Council
+
+Use this skill inside the Lisa repository when Claude needs structured parity advice from external coding-agent CLIs before changing Lisa behavior.
+
+This skill is Lisa-only. Keep it under `.agents/skills/` and do not move or mirror it into `plugins/`, generated plugin artifacts, host-project templates, install output, or marketplace bundles.
+
+## Use Cases
+
+- Research a new runtime-support PRD before decomposition or implementation.
+- Review a design sketch, branch diff, or issue for Claude/Codex/Cursor/Copilot/Antigravity parity risks.
+- Collect runtime-specific naming, packaging, permission, testing, or migration advice before editing Lisa features.
+
+## Invocation Contract
+
+Run this skill from Claude as the lead orchestrator. Claude remains the final decision-maker. External CLI output is evidence, not authority.
+
+Base invocation shape:
+
+```text
+/harness-parity-council <topic-or-artifact> [--runtime <name>] [--second-round] [--dry-run] [--write-mode <mode>]
+```
+
+Examples:
+
+```text
+/harness-parity-council "Codex parity for install-time hooks"
+/harness-parity-council https://github.com/CodySwannGT/lisa/issues/721 --runtime codex
+/harness-parity-council "review current diff for Cursor/Codex parity gaps" --second-round
+/harness-parity-council "plan Antigravity support" --dry-run
+```
+
+## Arguments
+
+- `<topic-or-artifact>`: Required. Plain-language feature prompt, issue URL, PRD URL, branch/diff summary, or other Lisa-local context to review.
+- `--runtime <name>`: Optional. Narrow to one runtime. Supported names: `cursor`, `codex`, `copilot`, `antigravity`.
+- `--second-round`: Optional. After the first advisory round, share Claude's sanitized synthesis back to available runtimes for critique.
+- `--dry-run`: Optional. Print planned adapter invocations and safety settings without calling external CLIs.
+- `--write-mode <mode>`: Optional and opt-in only. Reserved for guarded future use. Default behavior is read-only advisory mode.
+
+## Runtime Adapters
+
+The skill is designed around these configurable CLI command slots:
+
+- `cursor` via `LISA_CURSOR_CLI`, default candidate `cursor-agent`
+- `codex` via `LISA_CODEX_CLI`, default candidate `codex`
+- `copilot` via `LISA_COPILOT_CLI`, default candidate `copilot`
+- `antigravity` via `LISA_ANTIGRAVITY_CLI`, default candidate `agy`
+
+Adapter implementation details, safe flags, timeout handling, auth detection, and output capture are handled by follow-on council tickets. This scaffold defines the contract they must satisfy.
+
+## Operating Rules
+
+- Default to read-only advisory execution.
+- Do not let external CLIs edit files, install dependencies, commit, push, or open PRs unless the user explicitly requests a guarded write mode.
+- Do not send secrets, token files, `.env` contents, private keys, or MCP auth artifacts to external CLIs.
+- Treat missing or unauthenticated CLIs as non-fatal. Record them as unavailable and continue.
+- Keep Claude's final synthesis separate from raw runtime responses.
+- Prefer inline summaries or gitignored Lisa-local temp artifacts over durable repo files unless a later ticket explicitly adds storage.
+
+## Expected Output
+
+Each run should produce a concise synthesis with:
+
+- runtimes consulted and runtimes unavailable
+- native feature surfaces each runtime claims to support
+- parity gaps or risks
+- testing and documentation implications
+- open questions Claude should resolve before implementation
+
+## Notes For Maintainers
+
+- This skill intentionally lives only in `.agents/skills/`.
+- The follow-on implementation tickets should add adapter execution, safety enforcement, redaction, packaging checks, and fixture-backed verification without changing this Lisa-only placement.

--- a/tests/unit/strategies/harness-parity-council-skill.test.ts
+++ b/tests/unit/strategies/harness-parity-council-skill.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.resolve(
+  ".agents/skills/harness-parity-council/SKILL.md"
+);
+const skill = readFileSync(SKILL_PATH, "utf8");
+
+describe("harness-parity-council internal skill contract", () => {
+  it("stays in the Lisa-only internal skill tree", () => {
+    expect(skill).toMatch(/Lisa-only/i);
+    expect(skill).toContain(".agents/skills/");
+    expect(skill).toMatch(/do not move or mirror it into `plugins\/`/i);
+  });
+
+  it("defines the maintainer-facing invocation surface", () => {
+    expect(skill).toContain("/harness-parity-council <topic-or-artifact>");
+    expect(skill).toContain("--runtime <name>");
+    expect(skill).toContain("--second-round");
+    expect(skill).toContain("--dry-run");
+    expect(skill).toContain("--write-mode <mode>");
+  });
+
+  it("documents the supported advisory runtimes and env overrides", () => {
+    expect(skill).toContain("LISA_CURSOR_CLI");
+    expect(skill).toContain("LISA_CODEX_CLI");
+    expect(skill).toContain("LISA_COPILOT_CLI");
+    expect(skill).toContain("LISA_ANTIGRAVITY_CLI");
+  });
+
+  it("locks the default mode to read-only advisory behavior", () => {
+    expect(skill).toMatch(/Default to read-only advisory execution/i);
+    expect(skill).toMatch(/Do not let external CLIs edit files/i);
+    expect(skill).toMatch(/record them as unavailable and continue/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add the Lisa-only `harness-parity-council` internal skill scaffold under `.agents/skills/`
- define the invocation contract, runtime slots, and read-only advisory guardrails for future council work
- add a static unit test covering the Lisa-only placement and contract surface

## Testing
- bun test tests/unit/strategies/harness-parity-council-skill.test.ts
- bun run typecheck
- bun run lint:slow
- bun run knip
- bun run test:unit --coverage
- bun run test:integration

Fixes #768