### PR TITLE
feat(skills): add first-round council consultation flow

### DIFF
--- a/.agents/skills/harness-parity-council/SKILL.md
+++ b/.agents/skills/harness-parity-council/SKILL.md
@@ -55,6 +55,8 @@ Adapter implementation details, safe flags, timeout handling, auth detection, an
 
 The current adapter source of truth lives in `./runtime-adapters.mjs`. Run `node .agents/skills/harness-parity-council/runtime-adapters.mjs` to print the resolved command slots, read-only-safe base flags, timeout budget, and local help/version probe results for each runtime.
 
+The first-round consultation source of truth lives in `./first-round.mjs`. Run `node .agents/skills/harness-parity-council/first-round.mjs "<topic>"` to emit the structured runtime prompt, normalized first-round capture shape, and Claude-facing synthesis inputs for the currently available runtimes.
+
 ## Operating Rules
 
 - Default to read-only advisory execution.

--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -1,0 +1,440 @@
+import {
+  RUNTIME_ADAPTERS,
+  describeRuntimePlan,
+  probeRuntimeAdapter,
+} from "./runtime-adapters.mjs";
+
+export const FIRST_ROUND_REQUIRED_SECTIONS = Object.freeze([
+  "Supported native surfaces for this feature",
+  "Unsupported or partial parity areas",
+  "Recommended artifact locations and naming conventions",
+  "Permission and safety implications",
+  "Testing strategy",
+  "Migration risks",
+  "Documentation requirements",
+  "Questions Claude should resolve before implementation",
+]);
+
+export const DEFAULT_COUNCIL_CONTEXT = Object.freeze({
+  repository: "lisa",
+  sourceArtifacts: [],
+  targetEnvironment: "main",
+});
+
+const ANSI_ESCAPE_PATTERN =
+  // Strip common SGR color/style escape sequences without touching regular text.
+  /\u001B\[[0-9;]*m/gu;
+
+/**
+ * Normalize free-form context into a stable council input shape.
+ *
+ * @param {{
+ *   repository?: string;
+ *   sourceArtifacts?: string[];
+ *   targetEnvironment?: string;
+ * }} [context] Optional council context overrides.
+ * @returns {{
+ *   repository: string;
+ *   sourceArtifacts: string[];
+ *   targetEnvironment: string;
+ * }} Normalized council context.
+ */
+export function normalizeCouncilContext(context = {}) {
+  return {
+    repository:
+      context.repository?.trim() || DEFAULT_COUNCIL_CONTEXT.repository,
+    sourceArtifacts: Array.isArray(context.sourceArtifacts)
+      ? context.sourceArtifacts.map(value => `${value}`.trim()).filter(Boolean)
+      : [...DEFAULT_COUNCIL_CONTEXT.sourceArtifacts],
+    targetEnvironment:
+      context.targetEnvironment?.trim() ||
+      DEFAULT_COUNCIL_CONTEXT.targetEnvironment,
+  };
+}
+
+/**
+ * Build the structured first-round advisory prompt for one runtime.
+ *
+ * @param {{
+ *   topic: string;
+ *   runtime: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ * }} input Prompt inputs.
+ * @returns {string} Runtime-specific first-round advisory prompt.
+ */
+export function buildFirstRoundPrompt({ topic, runtime, context = {} }) {
+  const trimmedTopic = topic?.trim();
+  if (!trimmedTopic) {
+    throw new Error("First-round council prompt requires a non-empty topic.");
+  }
+
+  const normalizedContext = normalizeCouncilContext(context);
+  const artifactLines =
+    normalizedContext.sourceArtifacts.length > 0
+      ? normalizedContext.sourceArtifacts.map(artifact => `- ${artifact}`)
+      : ["- None provided. Work only from the prompt and runtime knowledge."];
+
+  return [
+    `You are advising Claude on Lisa runtime parity for the \`${normalizedContext.repository}\` repository.`,
+    `Runtime under consultation: ${runtime}.`,
+    "",
+    "Operate in read-only advisory mode.",
+    "Do not edit files, install dependencies, commit, push, open PRs, or suggest destructive commands.",
+    "Treat this as analysis only; Claude remains the final decision-maker.",
+    "",
+    "## Feature Topic",
+    trimmedTopic,
+    "",
+    "## Repository Context",
+    `- Repository: ${normalizedContext.repository}`,
+    `- Target backend environment: ${normalizedContext.targetEnvironment}`,
+    ...artifactLines,
+    "",
+    "## Required Response Sections",
+    ...FIRST_ROUND_REQUIRED_SECTIONS.map((section, index) => {
+      return `${index + 1}. ${section}`;
+    }),
+    "",
+    "Use concise bullets under each section. Call out any uncertainty explicitly.",
+  ].join("\n");
+}
+
+/**
+ * Convert arbitrary CLI output into a stable text form for council synthesis.
+ *
+ * @param {string} value Raw CLI output.
+ * @returns {string} Normalized text capture.
+ */
+export function normalizeCouncilOutput(value) {
+  return `${value ?? ""}`
+    .replaceAll("\r\n", "\n")
+    .replace(ANSI_ESCAPE_PATTERN, "")
+    .split("\n")
+    .map(line => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+/**
+ * Parse JSON-like response text when possible; otherwise keep it as plain text.
+ *
+ * @param {string} value Normalized CLI output.
+ * @returns {unknown | null} Parsed JSON value when available, else null.
+ */
+export function parseCouncilOutput(value) {
+  const trimmed = value.trim();
+  if (!trimmed || !["{", "["].includes(trimmed[0])) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the runtime invocation payload for the first-round consultation loop.
+ *
+ * @param {{
+ *   topic: string;
+ *   runtime: keyof typeof RUNTIME_ADAPTERS;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   env?: NodeJS.ProcessEnv;
+ * }} input Invocation inputs.
+ * @returns {{
+ *   runtime: string;
+ *   command: string;
+ *   args: string[];
+ *   timeoutMs: number;
+ *   prompt: string;
+ *   safeInvocation: { mode: string; args: string[]; readOnlyReason: string; verification: string };
+ * }} Invocation payload.
+ */
+export function buildFirstRoundInvocation({
+  topic,
+  runtime,
+  context = {},
+  env,
+}) {
+  return {
+    ...describeRuntimePlan(runtime, env),
+    prompt: buildFirstRoundPrompt({ topic, runtime, context }),
+  };
+}
+
+/**
+ * Normalize one executor result into a stable council capture.
+ *
+ * @param {{
+ *   invocation: ReturnType<typeof buildFirstRoundInvocation>;
+ *   probe: ReturnType<typeof probeRuntimeAdapter>;
+ *   result?: {
+ *     exitStatus?: number | null;
+ *     stdout?: string;
+ *     stderr?: string;
+ *     timedOut?: boolean;
+ *     authMissing?: boolean | null;
+ *     error?: { code?: string | null; message?: string } | null;
+ *   };
+ * }} input Runtime capture inputs.
+ * @returns {{
+ *   runtime: string;
+ *   status: "responded" | "empty" | "failed" | "timed_out" | "unavailable";
+ *   command: string;
+ *   args: string[];
+ *   timeoutMs: number;
+ *   authMissing: boolean | null;
+ *   outputText: string;
+ *   parsedOutput: unknown | null;
+ *   stderrText: string;
+ *   exitStatus: number | null;
+ *   timedOut: boolean;
+ *   unavailableReason: string | null;
+ *   readOnlyReason: string;
+ *   docsEvidence: string;
+ *   error: { code: string | null; message: string } | null;
+ * }} Normalized council capture.
+ */
+export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
+  const unavailableReason = !probe.available
+    ? probe.helpProbe.commandMissing || probe.versionProbe.commandMissing
+      ? "command-missing"
+      : probe.authMissing
+        ? "auth-missing"
+        : "probe-failed"
+    : null;
+
+  if (unavailableReason) {
+    return {
+      runtime: invocation.runtime,
+      status: "unavailable",
+      command: invocation.command,
+      args: invocation.safeInvocation.args,
+      timeoutMs: invocation.timeoutMs,
+      authMissing: probe.authMissing,
+      outputText: "",
+      parsedOutput: null,
+      stderrText: "",
+      exitStatus: null,
+      timedOut: false,
+      unavailableReason,
+      readOnlyReason: invocation.safeInvocation.readOnlyReason,
+      docsEvidence: invocation.docsEvidence,
+      error: probe.helpProbe.error ?? probe.versionProbe.error,
+    };
+  }
+
+  const outputText = normalizeCouncilOutput(result.stdout ?? "");
+  const stderrText = normalizeCouncilOutput(result.stderr ?? "");
+  const combinedText = [outputText, stderrText].filter(Boolean).join("\n\n");
+  const timedOut = result.timedOut === true;
+  const exitStatus =
+    typeof result.exitStatus === "number" ? result.exitStatus : null;
+
+  const status = timedOut
+    ? "timed_out"
+    : (exitStatus ?? 0) !== 0
+      ? "failed"
+      : !combinedText
+        ? "empty"
+        : "responded";
+
+  return {
+    runtime: invocation.runtime,
+    status,
+    command: invocation.command,
+    args: invocation.safeInvocation.args,
+    timeoutMs: invocation.timeoutMs,
+    authMissing: result.authMissing ?? probe.authMissing ?? false,
+    outputText: combinedText,
+    parsedOutput: parseCouncilOutput(outputText),
+    stderrText,
+    exitStatus,
+    timedOut,
+    unavailableReason: null,
+    readOnlyReason: invocation.safeInvocation.readOnlyReason,
+    docsEvidence: invocation.docsEvidence,
+    error: result.error
+      ? {
+          code: result.error.code ?? null,
+          message: result.error.message,
+        }
+      : null,
+  };
+}
+
+/**
+ * Run the first-round consultation loop with an injected executor.
+ *
+ * @param {{
+ *   topic: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   runtimes?: (keyof typeof RUNTIME_ADAPTERS)[];
+ *   env?: NodeJS.ProcessEnv;
+ *   probeRuntime?: typeof probeRuntimeAdapter;
+ *   executor?: (invocation: ReturnType<typeof buildFirstRoundInvocation>) => Promise<{
+ *     exitStatus?: number | null;
+ *     stdout?: string;
+ *     stderr?: string;
+ *     timedOut?: boolean;
+ *     authMissing?: boolean | null;
+ *     error?: { code?: string | null; message?: string } | null;
+ *   } | {
+ *     exitStatus?: number | null;
+ *     stdout?: string;
+ *     stderr?: string;
+ *     timedOut?: boolean;
+ *     authMissing?: boolean | null;
+ *     error?: { code?: string | null; message?: string } | null;
+ *   }>;
+ * }} input Consultation inputs.
+ * @returns {Promise<ReturnType<typeof buildFirstRoundSynthesisInput>>} Claude-facing synthesis inputs.
+ */
+export async function collectFirstRoundResponses({
+  topic,
+  context = {},
+  runtimes = Object.keys(RUNTIME_ADAPTERS),
+  env,
+  probeRuntime = probeRuntimeAdapter,
+  executor,
+}) {
+  const captures = [];
+
+  for (const runtime of runtimes) {
+    const invocation = buildFirstRoundInvocation({
+      topic,
+      runtime,
+      context,
+      env,
+    });
+    const probe = probeRuntime(runtime, env);
+    const result =
+      probe.available && typeof executor === "function"
+        ? await executor(invocation)
+        : undefined;
+
+    captures.push(normalizeFirstRoundCapture({ invocation, probe, result }));
+  }
+
+  return buildFirstRoundSynthesisInput({ topic, context, captures });
+}
+
+/**
+ * Convert normalized runtime captures into Claude-facing synthesis inputs.
+ *
+ * @param {{
+ *   topic: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   captures: ReturnType<typeof normalizeFirstRoundCapture>[];
+ * }} input Synthesis inputs.
+ * @returns {{
+ *   topic: string;
+ *   context: ReturnType<typeof normalizeCouncilContext>;
+ *   requiredSections: string[];
+ *   availableRuntimes: string[];
+ *   unavailableRuntimes: Array<{ runtime: string; reason: string | null; authMissing: boolean | null }>;
+ *   responseEvidence: Array<{
+ *     runtime: string;
+ *     status: string;
+ *     outputText: string;
+ *     parsedOutput: unknown | null;
+ *     readOnlyReason: string;
+ *     docsEvidence: string;
+ *   }>;
+ *   claudeSynthesisTemplate: {
+ *     agreements: string[];
+ *     disagreements: string[];
+ *     runtimeSpecificRisks: string[];
+ *     testsToAdd: string[];
+ *     docsToUpdate: string[];
+ *     openQuestions: string[];
+ *   };
+ * }} Claude-facing synthesis payload.
+ */
+export function buildFirstRoundSynthesisInput({
+  topic,
+  context = {},
+  captures,
+}) {
+  const normalizedContext = normalizeCouncilContext(context);
+  const availableRuntimes = captures
+    .filter(capture => capture.status !== "unavailable")
+    .map(capture => capture.runtime);
+  const unavailableRuntimes = captures
+    .filter(capture => capture.status === "unavailable")
+    .map(capture => {
+      return {
+        runtime: capture.runtime,
+        reason: capture.unavailableReason,
+        authMissing: capture.authMissing,
+      };
+    });
+
+  return {
+    topic: topic.trim(),
+    context: normalizedContext,
+    requiredSections: [...FIRST_ROUND_REQUIRED_SECTIONS],
+    availableRuntimes,
+    unavailableRuntimes,
+    responseEvidence: captures.map(capture => {
+      return {
+        runtime: capture.runtime,
+        status: capture.status,
+        outputText: capture.outputText,
+        parsedOutput: capture.parsedOutput,
+        readOnlyReason: capture.readOnlyReason,
+        docsEvidence: capture.docsEvidence,
+      };
+    }),
+    claudeSynthesisTemplate: {
+      agreements: [],
+      disagreements: [],
+      runtimeSpecificRisks: [],
+      testsToAdd: [],
+      docsToUpdate: [],
+      openQuestions: captures
+        .filter(capture => capture.status !== "responded")
+        .map(capture => {
+          return `${capture.runtime}: explain ${capture.status.replaceAll("_", " ")}`;
+        }),
+    },
+  };
+}
+
+/**
+ * CLI entrypoint for printing first-round council synthesis inputs.
+ */
+async function main() {
+  const topic = process.argv.slice(2).join(" ").trim();
+  if (!topic) {
+    throw new Error("Usage: node first-round.mjs <topic>");
+  }
+
+  const synthesisInput = await collectFirstRoundResponses({ topic });
+  process.stdout.write(`${JSON.stringify(synthesisInput, null, 2)}\n`);
+}
+
+const isEntrypoint = import.meta.url === `file://${process.argv[1]}`;
+
+if (isEntrypoint) {
+  await main();
+}

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const moduleUrl = pathToFileURL(
+  path.resolve(".agents/skills/harness-parity-council/first-round.mjs")
+).href;
+
+const council = await import(moduleUrl);
+const COUNCIL_TOPIC = "Compare Codex and Cursor parity surfaces";
+
+describe("harness parity council first-round flow", () => {
+  it("builds a structured prompt with Lisa-specific guardrails and sections", () => {
+    const prompt = council.buildFirstRoundPrompt({
+      topic: "Review Codex parity for install-time hooks",
+      runtime: "codex",
+      context: {
+        repository: "lisa",
+        sourceArtifacts: ["PRD #721", "Issue #770"],
+      },
+    });
+
+    expect(prompt).toContain("Operate in read-only advisory mode.");
+    expect(prompt).toContain(
+      "Do not edit files, install dependencies, commit, push, open PRs, or suggest destructive commands."
+    );
+    expect(prompt).toContain("Runtime under consultation: codex.");
+    expect(prompt).toContain("Review Codex parity for install-time hooks");
+    expect(prompt).toContain("- Repository: lisa");
+    expect(prompt).toContain("- PRD #721");
+    expect(prompt).toContain("1. Supported native surfaces for this feature");
+    expect(prompt).toContain(
+      "8. Questions Claude should resolve before implementation"
+    );
+  });
+
+  it("normalizes captured output and parses JSON payloads when present", () => {
+    const normalized = council.normalizeCouncilOutput(
+      '\u001b[32m{"answer":"ok"}\u001b[0m\r\n\r\n'
+    );
+
+    expect(normalized).toBe('{"answer":"ok"}');
+    expect(council.parseCouncilOutput(normalized)).toEqual({
+      answer: "ok",
+    });
+  });
+
+  it("collects stable synthesis inputs across available and unavailable runtimes", async () => {
+    const synthesis = await council.collectFirstRoundResponses({
+      topic: COUNCIL_TOPIC,
+      context: {
+        repository: "lisa",
+        sourceArtifacts: ["Issue #770"],
+      },
+      runtimes: ["codex", "cursor"],
+      probeRuntime(runtime: string) {
+        if (runtime === "cursor") {
+          return {
+            ...council.buildFirstRoundInvocation({
+              topic: COUNCIL_TOPIC,
+              runtime,
+              context: { repository: "lisa" },
+            }),
+            available: false,
+            authMissing: null,
+            helpProbe: {
+              commandMissing: true,
+              error: { code: "ENOENT", message: "cursor-agent not found" },
+            },
+            versionProbe: {
+              commandMissing: true,
+              error: { code: "ENOENT", message: "cursor-agent not found" },
+            },
+          };
+        }
+
+        return {
+          ...council.buildFirstRoundInvocation({
+            topic: COUNCIL_TOPIC,
+            runtime,
+            context: { repository: "lisa" },
+          }),
+          available: true,
+          authMissing: false,
+          helpProbe: { commandMissing: false, error: null },
+          versionProbe: { commandMissing: false, error: null },
+        };
+      },
+      async executor(invocation: { runtime: string }) {
+        if (invocation.runtime !== "codex") {
+          throw new Error("unexpected runtime");
+        }
+
+        return {
+          exitStatus: 0,
+          stdout: JSON.stringify({
+            supported: ["read-only sandbox", "json output"],
+            risks: ["naming drift"],
+          }),
+          stderr: "",
+          timedOut: false,
+          authMissing: false,
+          error: null,
+        };
+      },
+    });
+
+    expect(synthesis.availableRuntimes).toEqual(["codex"]);
+    expect(synthesis.unavailableRuntimes).toEqual([
+      {
+        runtime: "cursor",
+        reason: "command-missing",
+        authMissing: null,
+      },
+    ]);
+    expect(synthesis.responseEvidence).toEqual([
+      expect.objectContaining({
+        runtime: "codex",
+        status: "responded",
+        parsedOutput: {
+          supported: ["read-only sandbox", "json output"],
+          risks: ["naming drift"],
+        },
+      }),
+      expect.objectContaining({
+        runtime: "cursor",
+        status: "unavailable",
+        outputText: "",
+      }),
+    ]);
+    expect(synthesis.claudeSynthesisTemplate.openQuestions).toContain(
+      "cursor: explain unavailable"
+    );
+  });
+});

--- a/tests/unit/strategies/harness-parity-council-skill.test.ts
+++ b/tests/unit/strategies/harness-parity-council-skill.test.ts
@@ -28,6 +28,7 @@ describe("harness-parity-council internal skill contract", () => {
     expect(skill).toContain("LISA_CODEX_CLI");
     expect(skill).toContain("LISA_COPILOT_CLI");
     expect(skill).toContain("LISA_ANTIGRAVITY_CLI");
+    expect(skill).toContain("first-round.mjs");
   });
 
   it("locks the default mode to read-only advisory behavior", () => {


### PR DESCRIPTION
## Summary
- add a Lisa-local first-round council helper for prompt construction, runtime capture normalization, and Claude synthesis inputs
- document the new helper in the internal harness-parity-council skill
- add focused unit coverage for prompt shape, normalized captures, and unavailable runtime handling

## Testing
- bun test tests/unit/strategies/harness-parity-council-runtime-adapters.test.ts tests/unit/strategies/harness-parity-council-skill.test.ts tests/unit/strategies/harness-parity-council-first-round.test.ts
- commit hook: tsc --noEmit, lint-staged, bun audit, eslint . --config eslint.slow.config.ts --quiet, knip, vitest run --coverage, vitest run tests/integration

Closes #770