### PR TITLE
test: add harness parity council fixture smoke coverage

### DIFF
--- a/.agents/skills/harness-parity-council/SKILL.md
+++ b/.agents/skills/harness-parity-council/SKILL.md
@@ -76,6 +76,20 @@ Each run should produce a concise synthesis with:
 - testing and documentation implications
 - open questions Claude should resolve before implementation
 
+## Maintainer Smoke Checks
+
+Use these checks when changing the council scaffolding, adapter metadata, or first-round capture logic. They are internal Lisa maintainer checks only; do not ship them into host-project artifacts.
+
+1. Probe metadata smoke:
+   `node .agents/skills/harness-parity-council/runtime-adapters.mjs codex cursor`
+   Expect JSON output with the resolved command slot, read-only-safe args, timeout budget, and help/version probe captures for each requested runtime.
+2. First-round synthesis smoke:
+   `node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"`
+   Expect JSON output with `availableRuntimes`, `unavailableRuntimes`, `responseEvidence`, and the Claude synthesis template. Missing or unauthenticated CLIs should be recorded as unavailable instead of crashing the entire run.
+3. Fixture contract smoke:
+   `bun vitest run tests/unit/strategies/harness-parity-council-*.test.ts`
+   Expect deterministic coverage for successful, missing, failing, and hanging runtime fixtures plus the Lisa-only placement/documentation guards.
+
 ## Notes For Maintainers
 
 - This skill intentionally lives only in `.agents/skills/`.

--- a/.agents/skills/harness-parity-council/SKILL.md
+++ b/.agents/skills/harness-parity-council/SKILL.md
@@ -87,7 +87,7 @@ Use these checks when changing the council scaffolding, adapter metadata, or fir
    `node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"`
    Expect JSON output with `availableRuntimes`, `unavailableRuntimes`, `responseEvidence`, and the Claude synthesis template. Missing or unauthenticated CLIs should be recorded as unavailable instead of crashing the entire run.
 3. Fixture contract smoke:
-   `bun vitest run tests/unit/strategies/harness-parity-council-*.test.ts`
+   `bun x vitest run tests/unit/strategies/harness-parity-council-*.test.ts`
    Expect deterministic coverage for successful, missing, failing, and hanging runtime fixtures plus the Lisa-only placement/documentation guards.
 
 ## Notes For Maintainers

--- a/.agents/skills/harness-parity-council/runtime-adapters.mjs
+++ b/.agents/skills/harness-parity-council/runtime-adapters.mjs
@@ -3,6 +3,21 @@ import { fileURLToPath } from "node:url";
 
 export const DEFAULT_TIMEOUT_MS = 45_000;
 
+/**
+ * SpawnSync-compatible runner used for runtime probes.
+ * @callback SpawnRunner
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{ encoding: string; timeout: number }} options
+ * @returns {{
+ *   status?: number | null;
+ *   stdout?: string;
+ *   stderr?: string;
+ *   signal?: NodeJS.Signals | null;
+ *   error?: NodeJS.ErrnoException | null;
+ * }}
+ */
+
 const AUTH_MISSING_PATTERNS = [
   /auth(?:entication)? (?:required|failed|missing)/i,
   /not authenticated/i,
@@ -104,7 +119,6 @@ export const RUNTIME_ADAPTERS = Object.freeze(runtimeSpecs);
 
 /**
  * Return a safe environment mapping without assuming a Node global exists.
- *
  * @returns {NodeJS.ProcessEnv} Process environment values when available.
  */
 function defaultEnv() {
@@ -113,7 +127,6 @@ function defaultEnv() {
 
 /**
  * Return the canonical council runtime spec for a supported runtime id.
- *
  * @param {keyof typeof runtimeSpecs} runtimeId Supported council runtime id.
  * @returns {(typeof runtimeSpecs)[keyof typeof runtimeSpecs]} Normalized runtime spec.
  */
@@ -127,7 +140,6 @@ export function getRuntimeSpec(runtimeId) {
 
 /**
  * Resolve the executable name for one runtime, honoring its environment override.
- *
  * @param {keyof typeof runtimeSpecs} runtimeId Supported council runtime id.
  * @param {NodeJS.ProcessEnv} [env] Optional environment override map.
  * @returns {string} Executable name to invoke for this runtime.
@@ -140,7 +152,6 @@ export function resolveRuntimeCommand(runtimeId, env = defaultEnv()) {
 
 /**
  * Heuristically classify output as an authentication-missing failure.
- *
  * @param {string} output Combined stdout/stderr capture to inspect.
  * @returns {boolean} True when the output looks like a missing-auth failure.
  */
@@ -153,7 +164,6 @@ export function detectAuthMissing(output) {
 
 /**
  * Build the normalized planning metadata for one runtime adapter.
- *
  * @param {keyof typeof runtimeSpecs} runtimeId Supported council runtime id.
  * @param {NodeJS.ProcessEnv} [env] Optional environment override map.
  * @returns {{
@@ -186,10 +196,10 @@ export function describeRuntimePlan(runtimeId, env = defaultEnv()) {
 
 /**
  * Execute one probe command and normalize the capture payload.
- *
  * @param {string} command Executable to run.
  * @param {string[]} args Arguments for the probe.
  * @param {number} timeoutMs Timeout budget in milliseconds.
+ * @param {SpawnRunner} [runner] Optional injected runner for fixture-backed probes.
  * @returns {{
  *   args: string[];
  *   exitStatus: number | null;
@@ -202,8 +212,8 @@ export function describeRuntimePlan(runtimeId, env = defaultEnv()) {
  *   error: { code: string | null; message: string } | null;
  * }} Structured probe capture.
  */
-function capture(command, args, timeoutMs) {
-  const result = spawnSync(command, args, {
+function capture(command, args, timeoutMs, runner = spawnSync) {
+  const result = runner(command, args, {
     encoding: "utf8",
     timeout: timeoutMs,
   });
@@ -235,9 +245,9 @@ function capture(command, args, timeoutMs) {
 
 /**
  * Probe help/version surfaces for one runtime and return structured capture metadata.
- *
  * @param {keyof typeof runtimeSpecs} runtimeId Supported council runtime id.
  * @param {NodeJS.ProcessEnv} [env] Optional environment override map.
+ * @param {SpawnRunner} [runner] Optional injected runner for fixture-backed probes.
  * @returns {ReturnType<typeof describeRuntimePlan> & {
  *   available: boolean;
  *   authMissing: boolean | null;
@@ -245,10 +255,24 @@ function capture(command, args, timeoutMs) {
  *   versionProbe: ReturnType<typeof capture>;
  * }} Runtime probe result.
  */
-export function probeRuntimeAdapter(runtimeId, env = defaultEnv()) {
+export function probeRuntimeAdapter(
+  runtimeId,
+  env = defaultEnv(),
+  runner = spawnSync
+) {
   const plan = describeRuntimePlan(runtimeId, env);
-  const helpProbe = capture(plan.command, plan.helpArgs, plan.timeoutMs);
-  const versionProbe = capture(plan.command, plan.versionArgs, plan.timeoutMs);
+  const helpProbe = capture(
+    plan.command,
+    plan.helpArgs,
+    plan.timeoutMs,
+    runner
+  );
+  const versionProbe = capture(
+    plan.command,
+    plan.versionArgs,
+    plan.timeoutMs,
+    runner
+  );
   const available = !helpProbe.commandMissing && !versionProbe.commandMissing;
 
   return {
@@ -267,13 +291,16 @@ export function probeRuntimeAdapter(runtimeId, env = defaultEnv()) {
 
 /**
  * Probe every supported council runtime adapter.
- *
  * @param {NodeJS.ProcessEnv} [env] Optional environment override map.
+ * @param {SpawnRunner} [runner] Optional injected runner for fixture-backed probes.
  * @returns {ReturnType<typeof probeRuntimeAdapter>[]} Probe results for every runtime.
  */
-export function probeAllRuntimeAdapters(env = defaultEnv()) {
+export function probeAllRuntimeAdapters(
+  env = defaultEnv(),
+  runner = spawnSync
+) {
   return Object.keys(runtimeSpecs).map(runtimeId =>
-    probeRuntimeAdapter(runtimeId, env)
+    probeRuntimeAdapter(runtimeId, env, runner)
   );
 }
 

--- a/tests/fixtures/harness-parity-council/first-round-failed.json
+++ b/tests/fixtures/harness-parity-council/first-round-failed.json
@@ -1,0 +1,29 @@
+{
+  "runtime": "copilot",
+  "probe": {
+    "available": true,
+    "authMissing": false,
+    "helpProbe": {
+      "commandMissing": false,
+      "error": null
+    },
+    "versionProbe": {
+      "commandMissing": false,
+      "error": null
+    }
+  },
+  "result": {
+    "exitStatus": 2,
+    "stdout": "",
+    "stderr": "fatal: runtime rejected prompt\n",
+    "timedOut": false,
+    "authMissing": false,
+    "error": {
+      "code": null,
+      "message": "runtime rejected prompt"
+    }
+  },
+  "expected": {
+    "status": "failed"
+  }
+}

--- a/tests/fixtures/harness-parity-council/first-round-responded.json
+++ b/tests/fixtures/harness-parity-council/first-round-responded.json
@@ -1,0 +1,30 @@
+{
+  "runtime": "codex",
+  "probe": {
+    "available": true,
+    "authMissing": false,
+    "helpProbe": {
+      "commandMissing": false,
+      "error": null
+    },
+    "versionProbe": {
+      "commandMissing": false,
+      "error": null
+    }
+  },
+  "result": {
+    "exitStatus": 0,
+    "stdout": "{\"supported\":[\"read-only sandbox\"],\"risks\":[\"naming drift\"]}\n",
+    "stderr": "",
+    "timedOut": false,
+    "authMissing": false,
+    "error": null
+  },
+  "expected": {
+    "status": "responded",
+    "parsedOutput": {
+      "supported": ["read-only sandbox"],
+      "risks": ["naming drift"]
+    }
+  }
+}

--- a/tests/fixtures/harness-parity-council/first-round-timed-out.json
+++ b/tests/fixtures/harness-parity-council/first-round-timed-out.json
@@ -1,0 +1,29 @@
+{
+  "runtime": "antigravity",
+  "probe": {
+    "available": true,
+    "authMissing": false,
+    "helpProbe": {
+      "commandMissing": false,
+      "error": null
+    },
+    "versionProbe": {
+      "commandMissing": false,
+      "error": null
+    }
+  },
+  "result": {
+    "exitStatus": null,
+    "stdout": "",
+    "stderr": "probe timed out\n",
+    "timedOut": true,
+    "authMissing": false,
+    "error": {
+      "code": "ETIMEDOUT",
+      "message": "runtime probe timed out"
+    }
+  },
+  "expected": {
+    "status": "timed_out"
+  }
+}

--- a/tests/fixtures/harness-parity-council/first-round-unavailable.json
+++ b/tests/fixtures/harness-parity-council/first-round-unavailable.json
@@ -1,0 +1,26 @@
+{
+  "runtime": "cursor",
+  "probe": {
+    "available": false,
+    "authMissing": null,
+    "helpProbe": {
+      "commandMissing": true,
+      "error": {
+        "code": "ENOENT",
+        "message": "cursor-agent not found"
+      }
+    },
+    "versionProbe": {
+      "commandMissing": true,
+      "error": {
+        "code": "ENOENT",
+        "message": "cursor-agent not found"
+      }
+    }
+  },
+  "result": null,
+  "expected": {
+    "status": "unavailable",
+    "unavailableReason": "command-missing"
+  }
+}

--- a/tests/fixtures/harness-parity-council/probe-auth-missing.json
+++ b/tests/fixtures/harness-parity-council/probe-auth-missing.json
@@ -1,0 +1,19 @@
+{
+  "runtime": "copilot",
+  "env": {},
+  "helpResult": {
+    "status": 1,
+    "stdout": "",
+    "stderr": "Authentication required. Please log in.\n"
+  },
+  "versionResult": {
+    "status": 0,
+    "stdout": "copilot-cli 0.9.0\n",
+    "stderr": ""
+  },
+  "expected": {
+    "available": true,
+    "authMissing": true,
+    "command": "copilot"
+  }
+}

--- a/tests/fixtures/harness-parity-council/probe-command-missing.json
+++ b/tests/fixtures/harness-parity-council/probe-command-missing.json
@@ -1,0 +1,27 @@
+{
+  "runtime": "cursor",
+  "env": {},
+  "helpResult": {
+    "status": null,
+    "stdout": "",
+    "stderr": "cursor-agent: command not found\n",
+    "error": {
+      "code": "ENOENT",
+      "message": "spawnSync cursor-agent ENOENT"
+    }
+  },
+  "versionResult": {
+    "status": null,
+    "stdout": "",
+    "stderr": "cursor-agent: command not found\n",
+    "error": {
+      "code": "ENOENT",
+      "message": "spawnSync cursor-agent ENOENT"
+    }
+  },
+  "expected": {
+    "available": false,
+    "authMissing": null,
+    "command": "cursor-agent"
+  }
+}

--- a/tests/fixtures/harness-parity-council/probe-success.json
+++ b/tests/fixtures/harness-parity-council/probe-success.json
@@ -1,0 +1,21 @@
+{
+  "runtime": "codex",
+  "env": {
+    "LISA_CODEX_CLI": "codex-fixture"
+  },
+  "helpResult": {
+    "status": 0,
+    "stdout": "usage: codex exec [options]\n",
+    "stderr": ""
+  },
+  "versionResult": {
+    "status": 0,
+    "stdout": "codex 1.2.3\n",
+    "stderr": ""
+  },
+  "expected": {
+    "available": true,
+    "authMissing": false,
+    "command": "codex-fixture"
+  }
+}

--- a/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
+++ b/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Fake CLI fixture coverage for the Lisa-only harness parity council helpers.
+ *
+ * Issue #775 extends the council scaffolding with deterministic probe and
+ * first-round capture fixtures so maintainers can validate success, missing,
+ * failing, and hanging runtime behaviors without depending on real external
+ * CLIs being installed or authenticated.
+ * @module tests/unit/strategies/harness-parity-council-fixture-smoke
+ */
+/* eslint-disable jsdoc/require-jsdoc, @eslint-community/eslint-comments/disable-enable-pair -- Fixture-only local types/helpers are covered by the module-level contract. */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const runtimeModuleUrl = pathToFileURL(
+  path.resolve(".agents/skills/harness-parity-council/runtime-adapters.mjs")
+).href;
+const firstRoundModuleUrl = pathToFileURL(
+  path.resolve(".agents/skills/harness-parity-council/first-round.mjs")
+).href;
+
+const adapters = await import(runtimeModuleUrl);
+const council = await import(firstRoundModuleUrl);
+
+const FIXTURE_ROOT = path.resolve("tests/fixtures/harness-parity-council");
+
+type ProbeFixture = {
+  readonly runtime: "cursor" | "codex" | "copilot" | "antigravity";
+  readonly env: Record<string, string>;
+  readonly helpResult: SpawnResultFixture;
+  readonly versionResult: SpawnResultFixture;
+  readonly expected: {
+    readonly available: boolean;
+    readonly authMissing: boolean | null;
+    readonly command: string;
+  };
+};
+
+type SpawnResultFixture = {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly error?: {
+    readonly code: string | null;
+    readonly message: string;
+  };
+};
+
+type FirstRoundFixture = {
+  readonly runtime: "cursor" | "codex" | "copilot" | "antigravity";
+  readonly probe: {
+    readonly available: boolean;
+    readonly authMissing: boolean | null;
+    readonly helpProbe: {
+      readonly commandMissing: boolean;
+      readonly error: {
+        readonly code: string | null;
+        readonly message: string;
+      } | null;
+    };
+    readonly versionProbe: {
+      readonly commandMissing: boolean;
+      readonly error: {
+        readonly code: string | null;
+        readonly message: string;
+      } | null;
+    };
+  };
+  readonly result: {
+    readonly exitStatus: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+    readonly timedOut: boolean;
+    readonly authMissing: boolean | null;
+    readonly error: {
+      readonly code: string | null;
+      readonly message: string;
+    } | null;
+  } | null;
+  readonly expected: {
+    readonly status: string;
+    readonly unavailableReason?: string;
+    readonly parsedOutput?: unknown;
+  };
+};
+
+const readJsonFixture = <T>(name: string): T =>
+  JSON.parse(
+    readFileSync(path.join(FIXTURE_ROOT, `${name}.json`), "utf8")
+  ) as T;
+
+function buildFixtureRunner(fixture: ProbeFixture) {
+  const queue = [fixture.helpResult, fixture.versionResult];
+
+  return (
+    _command: string,
+    _args: string[],
+    _options: { encoding: string; timeout: number }
+  ) => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("Unexpected extra runtime probe call.");
+    }
+
+    return {
+      status: next.status,
+      stdout: next.stdout,
+      stderr: next.stderr,
+      signal: null,
+      error: next.error
+        ? Object.assign(new Error(next.error.message), {
+            code: next.error.code,
+          })
+        : undefined,
+    };
+  };
+}
+
+describe("harness parity council probe fixtures (#775)", () => {
+  for (const fixtureName of [
+    "probe-success",
+    "probe-command-missing",
+    "probe-auth-missing",
+  ] as const) {
+    it(`normalizes ${fixtureName} deterministically`, () => {
+      const fixture = readJsonFixture<ProbeFixture>(fixtureName);
+      const result = adapters.probeRuntimeAdapter(
+        fixture.runtime,
+        fixture.env,
+        buildFixtureRunner(fixture)
+      );
+
+      expect(result.command).toBe(fixture.expected.command);
+      expect(result.available).toBe(fixture.expected.available);
+      expect(result.authMissing).toBe(fixture.expected.authMissing);
+    });
+  }
+});
+
+describe("harness parity council first-round fixtures (#775)", () => {
+  for (const fixtureName of [
+    "first-round-responded",
+    "first-round-unavailable",
+    "first-round-failed",
+    "first-round-timed-out",
+  ] as const) {
+    it(`captures ${fixtureName} without real CLI dependencies`, () => {
+      const fixture = readJsonFixture<FirstRoundFixture>(fixtureName);
+      const invocation = council.buildFirstRoundInvocation({
+        topic: "Review council fixture coverage",
+        runtime: fixture.runtime,
+        context: {
+          repository: "lisa",
+          sourceArtifacts: ["Issue #775"],
+        },
+      });
+
+      const capture = council.normalizeFirstRoundCapture({
+        invocation,
+        probe: {
+          ...invocation,
+          ...fixture.probe,
+        },
+        result: fixture.result ?? undefined,
+      });
+
+      expect(capture.status).toBe(fixture.expected.status);
+      if (typeof fixture.expected.unavailableReason === "string") {
+        expect(capture.unavailableReason).toBe(
+          fixture.expected.unavailableReason
+        );
+      }
+      if (fixture.expected.parsedOutput) {
+        expect(capture.parsedOutput).toEqual(fixture.expected.parsedOutput);
+      }
+    });
+  }
+});

--- a/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
+++ b/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
@@ -172,7 +172,7 @@ describe("harness parity council first-round fixtures (#775)", () => {
           fixture.expected.unavailableReason
         );
       }
-      if (fixture.expected.parsedOutput) {
+      if ("parsedOutput" in fixture.expected) {
         expect(capture.parsedOutput).toEqual(fixture.expected.parsedOutput);
       }
     });

--- a/tests/unit/strategies/harness-parity-council-skill.test.ts
+++ b/tests/unit/strategies/harness-parity-council-skill.test.ts
@@ -31,6 +31,22 @@ describe("harness-parity-council internal skill contract", () => {
     expect(skill).toContain("first-round.mjs");
   });
 
+  it("includes maintainer smoke checks for internal-only council validation", () => {
+    expect(skill).toContain("## Maintainer Smoke Checks");
+    expect(skill).toContain(
+      "node .agents/skills/harness-parity-council/runtime-adapters.mjs codex cursor"
+    );
+    expect(skill).toContain(
+      'node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"'
+    );
+    expect(skill).toContain(
+      "bun vitest run tests/unit/strategies/harness-parity-council-*.test.ts"
+    );
+    expect(skill).toMatch(
+      /successful, missing, failing, and hanging runtime fixtures/i
+    );
+  });
+
   it("locks the default mode to read-only advisory behavior", () => {
     expect(skill).toMatch(/Default to read-only advisory execution/i);
     expect(skill).toMatch(/Do not let external CLIs edit files/i);

--- a/tests/unit/strategies/harness-parity-council-skill.test.ts
+++ b/tests/unit/strategies/harness-parity-council-skill.test.ts
@@ -40,7 +40,7 @@ describe("harness-parity-council internal skill contract", () => {
       'node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"'
     );
     expect(skill).toContain(
-      "bun vitest run tests/unit/strategies/harness-parity-council-*.test.ts"
+      "bun x vitest run tests/unit/strategies/harness-parity-council-*.test.ts"
     );
     expect(skill).toMatch(
       /successful, missing, failing, and hanging runtime fixtures/i


### PR DESCRIPTION
## Summary
- add injected probe-runner support so council runtime probes can be exercised with deterministic fake CLI fixtures
- add fixture-backed coverage for responded, unavailable, failed, and timed-out council runtime flows
- document maintainer smoke commands in the Lisa-only council skill and lock them with tests

## Testing
- bun x vitest run tests/unit/strategies/harness-parity-council-*.test.ts
- node .agents/skills/harness-parity-council/runtime-adapters.mjs codex cursor
- node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"
- pre-push hook: bun audit, eslint slow config, knip, vitest --coverage, vitest integration

Closes #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a maintainer "Smoke Checks" section with concrete validation commands and expected outcomes.

* **Tests**
  * Added a fixture-driven smoke test suite covering success, failure, timeout, unavailable and auth-missing probe scenarios.
  * Added a documentation verification test ensuring the maintainer guidance and example commands are present.

* **Refactor**
  * Internal probe execution made more injectable for deterministic testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->