### PR TITLE
feat: add council dry-run and second-round planning

### DIFF
--- a/.agents/skills/harness-parity-council/council-shared.mjs
+++ b/.agents/skills/harness-parity-council/council-shared.mjs
@@ -1,0 +1,57 @@
+import { RUNTIME_ADAPTERS } from "./runtime-adapters.mjs";
+
+export const SUPPORTED_COUNCIL_RUNTIMES = Object.freeze(
+  Object.keys(RUNTIME_ADAPTERS)
+);
+
+export const DEFAULT_COUNCIL_CONTEXT = Object.freeze({
+  repository: "lisa",
+  sourceArtifacts: [],
+  targetEnvironment: "main",
+});
+
+/**
+ * Normalize free-form context into a stable council input shape.
+ * @param {{
+ *   repository?: string;
+ *   sourceArtifacts?: string[];
+ *   targetEnvironment?: string;
+ * }} [context] Optional council context overrides.
+ * @returns {{
+ *   repository: string;
+ *   sourceArtifacts: string[];
+ *   targetEnvironment: string;
+ * }} Normalized council context.
+ */
+export function normalizeCouncilContext(context = {}) {
+  return {
+    repository:
+      context.repository?.trim() || DEFAULT_COUNCIL_CONTEXT.repository,
+    sourceArtifacts: Array.isArray(context.sourceArtifacts)
+      ? context.sourceArtifacts.map(value => `${value}`.trim()).filter(Boolean)
+      : [...DEFAULT_COUNCIL_CONTEXT.sourceArtifacts],
+    targetEnvironment:
+      context.targetEnvironment?.trim() ||
+      DEFAULT_COUNCIL_CONTEXT.targetEnvironment,
+  };
+}
+
+/**
+ * Resolve the runtime ids a council run should consult.
+ * @param {string | null | undefined} runtimeFilter Optional single-runtime filter.
+ * @returns {(keyof typeof RUNTIME_ADAPTERS)[]} Ordered council runtimes to consult.
+ */
+export function resolveCouncilRuntimes(runtimeFilter) {
+  if (!runtimeFilter) {
+    return [...SUPPORTED_COUNCIL_RUNTIMES];
+  }
+
+  const normalizedRuntime = runtimeFilter.trim().toLowerCase();
+  if (!SUPPORTED_COUNCIL_RUNTIMES.includes(normalizedRuntime)) {
+    throw new Error(
+      `Unsupported council runtime: ${runtimeFilter}. Supported runtimes: ${SUPPORTED_COUNCIL_RUNTIMES.join(", ")}`
+    );
+  }
+
+  return [normalizedRuntime];
+}

--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -1,8 +1,20 @@
+/* eslint-disable max-lines -- Keep the public first-round council entrypoint in one Lisa-local module. */
+
 import {
-  RUNTIME_ADAPTERS,
   describeRuntimePlan,
   probeRuntimeAdapter,
+  RUNTIME_ADAPTERS,
 } from "./runtime-adapters.mjs";
+import {
+  normalizeCouncilContext,
+  resolveCouncilRuntimes,
+} from "./council-shared.mjs";
+import {
+  buildSecondRoundInvocation,
+  buildSecondRoundSynthesisInput,
+} from "./second-round.mjs";
+
+export { resolveCouncilRuntimes, buildSecondRoundSynthesisInput };
 
 export const FIRST_ROUND_REQUIRED_SECTIONS = Object.freeze([
   "Supported native surfaces for this feature",
@@ -15,42 +27,9 @@ export const FIRST_ROUND_REQUIRED_SECTIONS = Object.freeze([
   "Questions Claude should resolve before implementation",
 ]);
 
-export const DEFAULT_COUNCIL_CONTEXT = Object.freeze({
-  repository: "lisa",
-  sourceArtifacts: [],
-  targetEnvironment: "main",
-});
-
 const ANSI_ESCAPE_PATTERN =
   // Strip common SGR color/style escape sequences without touching regular text.
   /\u001B\[[0-9;]*m/gu;
-
-/**
- * Normalize free-form context into a stable council input shape.
- *
- * @param {{
- *   repository?: string;
- *   sourceArtifacts?: string[];
- *   targetEnvironment?: string;
- * }} [context] Optional council context overrides.
- * @returns {{
- *   repository: string;
- *   sourceArtifacts: string[];
- *   targetEnvironment: string;
- * }} Normalized council context.
- */
-export function normalizeCouncilContext(context = {}) {
-  return {
-    repository:
-      context.repository?.trim() || DEFAULT_COUNCIL_CONTEXT.repository,
-    sourceArtifacts: Array.isArray(context.sourceArtifacts)
-      ? context.sourceArtifacts.map(value => `${value}`.trim()).filter(Boolean)
-      : [...DEFAULT_COUNCIL_CONTEXT.sourceArtifacts],
-    targetEnvironment:
-      context.targetEnvironment?.trim() ||
-      DEFAULT_COUNCIL_CONTEXT.targetEnvironment,
-  };
-}
 
 /**
  * Build the structured first-round advisory prompt for one runtime.
@@ -170,6 +149,171 @@ export function buildFirstRoundInvocation({
   return {
     ...describeRuntimePlan(runtime, env),
     prompt: buildFirstRoundPrompt({ topic, runtime, context }),
+  };
+}
+
+/**
+ * Parse the documented council CLI flags into a normalized argument object.
+ * @param {string[]} argv CLI args excluding `node` and script path.
+ * @returns {{
+ *   topic: string;
+ *   runtime: string | null;
+ *   secondRound: boolean;
+ *   dryRun: boolean;
+ *   writeMode: string | null;
+ *   sanitizedSummary: string | null;
+ * }} Parsed council args.
+ */
+export function parseCouncilCliArgs(argv) {
+  const parsed = argv.reduce(
+    (state, current, index, values) => {
+      if (state.skipIndices.has(index)) {
+        return state;
+      }
+
+      const nextValue = values[index + 1] ?? "";
+      if (current === "--runtime") {
+        state.skipIndices.add(index + 1);
+        return { ...state, runtime: nextValue };
+      }
+
+      if (current === "--write-mode") {
+        state.skipIndices.add(index + 1);
+        return { ...state, writeMode: nextValue };
+      }
+
+      if (current === "--summary") {
+        state.skipIndices.add(index + 1);
+        return { ...state, sanitizedSummary: nextValue };
+      }
+
+      if (current === "--second-round") {
+        return { ...state, secondRound: true };
+      }
+
+      if (current === "--dry-run") {
+        return { ...state, dryRun: true };
+      }
+
+      return {
+        ...state,
+        topicParts: [...state.topicParts, current],
+      };
+    },
+    {
+      topicParts: [],
+      runtime: null,
+      writeMode: null,
+      sanitizedSummary: null,
+      secondRound: false,
+      dryRun: false,
+      skipIndices: new Set(),
+    }
+  );
+
+  const topic = parsed.topicParts.join(" ").trim();
+  if (!topic) {
+    throw new Error(
+      "Usage: node first-round.mjs <topic> [--runtime <name>] [--second-round] [--dry-run] [--write-mode <mode>] [--summary <text>]"
+    );
+  }
+
+  if (parsed.runtime !== null && !parsed.runtime.trim()) {
+    throw new Error("The --runtime flag requires a runtime name.");
+  }
+
+  if (parsed.writeMode !== null && !parsed.writeMode.trim()) {
+    throw new Error("The --write-mode flag requires a mode value.");
+  }
+
+  if (parsed.sanitizedSummary !== null && !parsed.sanitizedSummary.trim()) {
+    throw new Error("The --summary flag requires sanitized summary text.");
+  }
+
+  return {
+    topic,
+    runtime: parsed.runtime?.trim().toLowerCase() ?? null,
+    secondRound: parsed.secondRound,
+    dryRun: parsed.dryRun,
+    writeMode: parsed.writeMode?.trim() ?? null,
+    sanitizedSummary: parsed.sanitizedSummary?.trim() ?? null,
+  };
+}
+
+/**
+ * Build the non-mutating dry-run planning payload for a council invocation.
+ *
+ * @param {{
+ *   topic: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   runtime?: string | null;
+ *   secondRound?: boolean;
+ *   sanitizedSummary?: string | null;
+ *   writeMode?: string | null;
+ *   env?: NodeJS.ProcessEnv;
+ * }} input Planning inputs.
+ * @returns {{
+ *   mode: "dry-run";
+ *   topic: string;
+ *   runtimeFilter: string | null;
+ *   writeMode: string | null;
+ *   firstRound: ReturnType<typeof buildFirstRoundInvocation>[];
+ *   secondRound: null | {
+ *     sanitizedSummary: string;
+ *     invocations: ReturnType<typeof buildSecondRoundInvocation>[];
+ *   };
+ * }} Dry-run planning payload.
+ */
+export function buildCouncilDryRunPlan({
+  topic,
+  context = {},
+  runtime = null,
+  secondRound = false,
+  sanitizedSummary = null,
+  writeMode = null,
+  env,
+}) {
+  const runtimes = resolveCouncilRuntimes(runtime);
+  const firstRound = runtimes.map(selectedRuntime =>
+    buildFirstRoundInvocation({
+      topic,
+      runtime: selectedRuntime,
+      context,
+      env,
+    })
+  );
+
+  const secondRoundSummary =
+    secondRound && sanitizedSummary
+      ? sanitizedSummary
+      : secondRound
+        ? "TODO: Claude sanitized synthesis goes here before round two."
+        : null;
+
+  return {
+    mode: "dry-run",
+    topic: topic.trim(),
+    runtimeFilter: runtime,
+    writeMode,
+    firstRound,
+    secondRound: secondRound
+      ? {
+          sanitizedSummary: secondRoundSummary,
+          invocations: runtimes.map(selectedRuntime =>
+            buildSecondRoundInvocation({
+              topic,
+              runtime: selectedRuntime,
+              sanitizedSummary: secondRoundSummary,
+              context,
+              env,
+            })
+          ),
+        }
+      : null,
   };
 }
 
@@ -424,13 +568,34 @@ export function buildFirstRoundSynthesisInput({
  * CLI entrypoint for printing first-round council synthesis inputs.
  */
 async function main() {
-  const topic = process.argv.slice(2).join(" ").trim();
-  if (!topic) {
-    throw new Error("Usage: node first-round.mjs <topic>");
+  const parsed = parseCouncilCliArgs(process.argv.slice(2));
+
+  if (parsed.dryRun) {
+    const plan = buildCouncilDryRunPlan(parsed);
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
   }
 
-  const synthesisInput = await collectFirstRoundResponses({ topic });
-  process.stdout.write(`${JSON.stringify(synthesisInput, null, 2)}\n`);
+  const runtimes = resolveCouncilRuntimes(parsed.runtime);
+  const firstRound = await collectFirstRoundResponses({
+    topic: parsed.topic,
+    runtimes,
+  });
+  const payload = {
+    mode: "first-round",
+    ...firstRound,
+    secondRound: parsed.secondRound
+      ? buildSecondRoundSynthesisInput({
+          topic: parsed.topic,
+          sanitizedSummary:
+            parsed.sanitizedSummary ??
+            "TODO: Claude sanitized synthesis goes here before round two.",
+          runtimes: firstRound.availableRuntimes,
+        })
+      : null,
+  };
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
 const isEntrypoint = import.meta.url === `file://${process.argv[1]}`;
@@ -438,3 +603,4 @@ const isEntrypoint = import.meta.url === `file://${process.argv[1]}`;
 if (isEntrypoint) {
   await main();
 }
+/* eslint-enable max-lines -- End of the first-round entrypoint exception. */

--- a/.agents/skills/harness-parity-council/second-round.mjs
+++ b/.agents/skills/harness-parity-council/second-round.mjs
@@ -1,0 +1,172 @@
+import { describeRuntimePlan } from "./runtime-adapters.mjs";
+import { normalizeCouncilContext } from "./council-shared.mjs";
+
+export const SECOND_ROUND_REQUIRED_SECTIONS = Object.freeze([
+  "Incorrect assumptions in Claude's summary",
+  "Missing native feature surfaces or constraints",
+  "Runtime-specific test gaps",
+  "Packaging or artifact placement risks",
+  "Documentation updates Claude should add",
+  "Final caveats before implementation",
+]);
+
+/**
+ * Build the critique prompt for the optional second-round consultation loop.
+ * @param {{
+ *   topic: string;
+ *   runtime: string;
+ *   sanitizedSummary: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ * }} input Prompt inputs.
+ * @returns {string} Runtime-specific second-round critique prompt.
+ */
+export function buildSecondRoundPrompt({
+  topic,
+  runtime,
+  sanitizedSummary,
+  context = {},
+}) {
+  const trimmedTopic = topic?.trim();
+  if (!trimmedTopic) {
+    throw new Error("Second-round council prompt requires a non-empty topic.");
+  }
+
+  const trimmedSummary = sanitizedSummary?.trim();
+  if (!trimmedSummary) {
+    throw new Error(
+      "Second-round council prompt requires a non-empty sanitized summary."
+    );
+  }
+
+  const normalizedContext = normalizeCouncilContext(context);
+  const artifactLines =
+    normalizedContext.sourceArtifacts.length > 0
+      ? normalizedContext.sourceArtifacts.map(artifact => `- ${artifact}`)
+      : ["- None provided. Work only from the prompt and runtime knowledge."];
+
+  return [
+    `You are reviewing Claude's Lisa runtime-parity synthesis for the \`${normalizedContext.repository}\` repository.`,
+    `Runtime under consultation: ${runtime}.`,
+    "",
+    "Operate in read-only advisory mode.",
+    "Do not edit files, install dependencies, commit, push, open PRs, or suggest destructive commands.",
+    "Treat Claude's summary as sanitized evidence; identify mistakes, omissions, and runtime-specific caveats.",
+    "",
+    "## Feature Topic",
+    trimmedTopic,
+    "",
+    "## Repository Context",
+    `- Repository: ${normalizedContext.repository}`,
+    `- Target backend environment: ${normalizedContext.targetEnvironment}`,
+    ...artifactLines,
+    "",
+    "## Claude's Sanitized Summary",
+    trimmedSummary,
+    "",
+    "## Required Response Sections",
+    ...SECOND_ROUND_REQUIRED_SECTIONS.map((section, index) => {
+      return `${index + 1}. ${section}`;
+    }),
+    "",
+    "Use concise bullets under each section. Call out disagreements explicitly.",
+  ].join("\n");
+}
+
+/**
+ * Build the runtime invocation payload for the optional second-round critique loop.
+ * @param {{
+ *   topic: string;
+ *   runtime: string;
+ *   sanitizedSummary: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   env?: NodeJS.ProcessEnv;
+ * }} input Invocation inputs.
+ * @returns {{
+ *   runtime: string;
+ *   command: string;
+ *   args: string[];
+ *   timeoutMs: number;
+ *   prompt: string;
+ *   safeInvocation: { mode: string; args: string[]; readOnlyReason: string; verification: string };
+ * }} Invocation payload.
+ */
+export function buildSecondRoundInvocation({
+  topic,
+  runtime,
+  sanitizedSummary,
+  context = {},
+  env,
+}) {
+  return {
+    ...describeRuntimePlan(runtime, env),
+    prompt: buildSecondRoundPrompt({
+      topic,
+      runtime,
+      sanitizedSummary,
+      context,
+    }),
+  };
+}
+
+/**
+ * Build the Claude-facing second-round critique scaffold.
+ * @param {{
+ *   topic: string;
+ *   context?: {
+ *     repository?: string;
+ *     sourceArtifacts?: string[];
+ *     targetEnvironment?: string;
+ *   };
+ *   sanitizedSummary: string;
+ *   runtimes: string[];
+ *   env?: NodeJS.ProcessEnv;
+ * }} input Second-round planning inputs.
+ * @returns {{
+ *   sanitizedSummary: string;
+ *   requiredSections: string[];
+ *   availableRuntimes: string[];
+ *   critiquePrompts: Array<{
+ *     runtime: string;
+ *     command: string;
+ *     args: string[];
+ *     timeoutMs: number;
+ *     prompt: string;
+ *   }>;
+ * }} Second-round critique scaffold.
+ */
+export function buildSecondRoundSynthesisInput({
+  topic,
+  context = {},
+  sanitizedSummary,
+  runtimes,
+  env,
+}) {
+  if (!sanitizedSummary?.trim()) {
+    throw new Error(
+      "Second-round synthesis input requires a non-empty sanitized summary."
+    );
+  }
+
+  return {
+    sanitizedSummary: sanitizedSummary.trim(),
+    requiredSections: [...SECOND_ROUND_REQUIRED_SECTIONS],
+    availableRuntimes: [...runtimes],
+    critiquePrompts: runtimes.map(runtime =>
+      buildSecondRoundInvocation({
+        topic,
+        runtime,
+        sanitizedSummary,
+        context,
+        env,
+      })
+    ),
+  };
+}

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -133,4 +133,60 @@ describe("harness parity council first-round flow", () => {
       "cursor: explain unavailable"
     );
   });
+
+  it("supports the documented runtime filter and dry-run planning output", () => {
+    const parsed = council.parseCouncilCliArgs([
+      COUNCIL_TOPIC,
+      "--runtime",
+      "codex",
+      "--dry-run",
+      "--second-round",
+    ]);
+
+    expect(parsed).toEqual({
+      topic: COUNCIL_TOPIC,
+      runtime: "codex",
+      secondRound: true,
+      dryRun: true,
+      writeMode: null,
+      sanitizedSummary: null,
+    });
+
+    const dryRun = council.buildCouncilDryRunPlan(parsed);
+    expect(dryRun.mode).toBe("dry-run");
+    expect(dryRun.runtimeFilter).toBe("codex");
+    expect(dryRun.firstRound).toHaveLength(1);
+    expect(dryRun.firstRound[0]).toEqual(
+      expect.objectContaining({
+        runtime: "codex",
+        command: "codex",
+      })
+    );
+    expect(dryRun.secondRound?.invocations).toHaveLength(1);
+    expect(dryRun.secondRound?.sanitizedSummary).toContain("TODO");
+  });
+
+  it("builds second-round critique prompts from Claude's sanitized summary", () => {
+    const critique = council.buildSecondRoundSynthesisInput({
+      topic: COUNCIL_TOPIC,
+      sanitizedSummary:
+        "Codex and Cursor both support read-only advisory mode, but naming may drift.",
+      runtimes: ["codex"],
+    });
+
+    expect(critique.availableRuntimes).toEqual(["codex"]);
+    expect(critique.requiredSections).toContain(
+      "Incorrect assumptions in Claude's summary"
+    );
+    expect(critique.critiquePrompts[0].prompt).toContain(
+      "## Claude's Sanitized Summary"
+    );
+    expect(critique.critiquePrompts[0].prompt).toContain("naming may drift");
+  });
+
+  it("rejects unsupported runtime filters", () => {
+    expect(() => council.resolveCouncilRuntimes("claude")).toThrow(
+      /Unsupported council runtime/
+    );
+  });
 });


### PR DESCRIPTION
## Summary\n- add runtime filtering and dry-run planning for the Lisa-only harness parity council helper\n- generate second-round critique prompts from Claude's sanitized synthesis\n- cover the new council flow with focused unit tests\n\nCloses #771