### PR TITLE
fix: sanitize council runtime captures

### DIFF
--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -31,6 +31,24 @@ const ANSI_ESCAPE_PATTERN =
   // Strip common SGR color/style escape sequences without touching regular text.
   /\u001B\[[0-9;]*m/gu;
 
+const SECRET_PATTERNS = Object.freeze([
+  /github_pat_\w{20,}/gu,
+  /\bgh[opusr]_\w{20,}\b/gu,
+  /\bsk-[\w-]{20,}\b/gu,
+  /\bBearer\s+[\w.-]{12,}\b/giu,
+  /\b((?:api|access|auth|refresh|secret)[-_ ]?key|token|password)\b\s*[:=]\s*([^\s,;]+)/giu,
+]);
+
+const RISKY_SUGGESTION_PATTERNS = Object.freeze([
+  /\b(?:npm|pnpm|yarn|bun)\s+(?:install|add|dlx|x)\b/i,
+  /\b(?:git|gh)\s+(?:commit|push|merge|checkout|switch|reset|clean|pr\s+create|issue\s+edit)\b/i,
+  /\b(?:apply_patch|write|edit|modify|delete|create)\b.*\b(?:file|files|repo|repository|host project|downstream|template|plugin)\b/i,
+  /\b(?:host project|downstream install|generated artifact|plugin bundle|template output)\b/i,
+]);
+
+const RISKY_SUGGESTION_PREFIX =
+  "[unsafe-runtime-suggestion: maintainer review required] ";
+
 /**
  * Build the structured first-round advisory prompt for one runtime.
  *
@@ -97,6 +115,88 @@ export function normalizeCouncilOutput(value) {
     .join("\n")
     .replace(/\n{3,}/gu, "\n\n")
     .trim();
+}
+
+/**
+ * Redact obvious secret-like substrings from runtime output before synthesis.
+ *
+ * @param {string} value Normalized CLI output.
+ * @returns {string} Output with token-like material replaced.
+ */
+export function redactSensitiveCouncilText(value) {
+  return SECRET_PATTERNS.reduce((redacted, pattern) => {
+    return redacted.replace(pattern, (...matches) => {
+      if (matches.length >= 3 && typeof matches[1] === "string") {
+        return `${matches[1]}=[REDACTED]`;
+      }
+      return "[REDACTED]";
+    });
+  }, value);
+}
+
+/**
+ * Prefix risky or out-of-scope mutation suggestions so maintainers do not treat
+ * them as safe instructions.
+ *
+ * @param {string} value Redacted runtime output.
+ * @returns {string} Output with risky lines annotated.
+ */
+export function annotateRiskyCouncilText(value) {
+  return value
+    .split("\n")
+    .map(line => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine) {
+        return line;
+      }
+
+      const isRisky = RISKY_SUGGESTION_PATTERNS.some(pattern =>
+        pattern.test(trimmedLine)
+      );
+      if (!isRisky || trimmedLine.startsWith(RISKY_SUGGESTION_PREFIX)) {
+        return line;
+      }
+
+      return `${RISKY_SUGGESTION_PREFIX}${line}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Sanitize normalized runtime output for maintainer-facing synthesis.
+ *
+ * @param {string} value Normalized CLI output.
+ * @returns {string} Redacted and annotated output text.
+ */
+export function sanitizeCouncilText(value) {
+  return annotateRiskyCouncilText(redactSensitiveCouncilText(value));
+}
+
+/**
+ * Recursively sanitize structured runtime output values.
+ *
+ * @param {unknown} value Parsed runtime payload.
+ * @returns {unknown} Payload with sensitive strings redacted and risky strings annotated.
+ */
+export function sanitizeCouncilData(value) {
+  if (typeof value === "string") {
+    return sanitizeCouncilText(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(entry => sanitizeCouncilData(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        sanitizeCouncilData(entry),
+      ])
+    );
+  }
+
+  return value;
 }
 
 /**
@@ -379,8 +479,16 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
     };
   }
 
-  const outputText = normalizeCouncilOutput(result.stdout ?? "");
-  const stderrText = normalizeCouncilOutput(result.stderr ?? "");
+  const normalizedStdout = normalizeCouncilOutput(result.stdout ?? "");
+  const normalizedStderr = normalizeCouncilOutput(result.stderr ?? "");
+  const parsedStdout = parseCouncilOutput(normalizedStdout);
+  const parsedOutput =
+    parsedStdout === null ? null : sanitizeCouncilData(parsedStdout);
+  const outputText =
+    parsedOutput === null
+      ? sanitizeCouncilText(normalizedStdout)
+      : JSON.stringify(parsedOutput);
+  const stderrText = sanitizeCouncilText(normalizedStderr);
   const combinedText = [outputText, stderrText].filter(Boolean).join("\n\n");
   const timedOut = result.timedOut === true;
   const exitStatus =
@@ -402,7 +510,7 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
     timeoutMs: invocation.timeoutMs,
     authMissing: result.authMissing ?? probe.authMissing ?? false,
     outputText: combinedText,
-    parsedOutput: parseCouncilOutput(outputText),
+    parsedOutput,
     stderrText,
     exitStatus,
     timedOut,

--- a/tests/fixtures/harness-parity-council/first-round-responded.json
+++ b/tests/fixtures/harness-parity-council/first-round-responded.json
@@ -14,8 +14,8 @@
   },
   "result": {
     "exitStatus": 0,
-    "stdout": "{\"supported\":[\"read-only sandbox\"],\"risks\":[\"naming drift\"]}\n",
-    "stderr": "",
+    "stdout": "\u001b[32m{\"supported\":[\"read-only sandbox\"],\"risks\":[\"naming drift\"],\"secret\":\"token=gho_abcdefghijklmnopqrstuvwxyz\",\"nextStep\":\"Run npm install lisa-internal in the host project\"}\u001b[0m\n",
+    "stderr": "Use git push origin codex/test after editing template output.\n",
     "timedOut": false,
     "authMissing": false,
     "error": null
@@ -24,7 +24,9 @@
     "status": "responded",
     "parsedOutput": {
       "supported": ["read-only sandbox"],
-      "risks": ["naming drift"]
+      "risks": ["naming drift"],
+      "secret": "token=[REDACTED]",
+      "nextStep": "[unsafe-runtime-suggestion: maintainer review required] Run npm install lisa-internal in the host project"
     }
   }
 }

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -9,11 +9,12 @@ const moduleUrl = pathToFileURL(
 
 const council = await import(moduleUrl);
 const COUNCIL_TOPIC = "Compare Codex and Cursor parity surfaces";
+const REVIEW_TOPIC = "Review Codex parity for install-time hooks";
 
 describe("harness parity council first-round flow", () => {
   it("builds a structured prompt with Lisa-specific guardrails and sections", () => {
     const prompt = council.buildFirstRoundPrompt({
-      topic: "Review Codex parity for install-time hooks",
+      topic: REVIEW_TOPIC,
       runtime: "codex",
       context: {
         repository: "lisa",
@@ -26,7 +27,7 @@ describe("harness parity council first-round flow", () => {
       "Do not edit files, install dependencies, commit, push, open PRs, or suggest destructive commands."
     );
     expect(prompt).toContain("Runtime under consultation: codex.");
-    expect(prompt).toContain("Review Codex parity for install-time hooks");
+    expect(prompt).toContain(REVIEW_TOPIC);
     expect(prompt).toContain("- Repository: lisa");
     expect(prompt).toContain("- PRD #721");
     expect(prompt).toContain("1. Supported native surfaces for this feature");
@@ -44,6 +45,49 @@ describe("harness parity council first-round flow", () => {
     expect(council.parseCouncilOutput(normalized)).toEqual({
       answer: "ok",
     });
+  });
+
+  it("redacts token-like material and annotates unsafe downstream suggestions", () => {
+    const capture = council.normalizeFirstRoundCapture({
+      invocation: council.buildFirstRoundInvocation({
+        topic: REVIEW_TOPIC,
+        runtime: "codex",
+      }),
+      probe: {
+        ...council.buildFirstRoundInvocation({
+          topic: REVIEW_TOPIC,
+          runtime: "codex",
+        }),
+        available: true,
+        authMissing: false,
+        helpProbe: { commandMissing: false, error: null },
+        versionProbe: { commandMissing: false, error: null },
+      },
+      result: {
+        exitStatus: 0,
+        stdout:
+          '\u001b[32m{"summary":"token=gho_abcdefghijklmnopqrstuvwxyz","nextStep":"Run npm install lisa-internal in the host project"}\u001b[0m\r\n',
+        stderr:
+          "Use git push origin codex/test after editing template output.\n",
+        timedOut: false,
+        authMissing: false,
+        error: null,
+      },
+    });
+
+    expect(capture.outputText).not.toContain("gho_abcdefghijklmnopqrstuvwxyz");
+    expect(capture.outputText).toContain("[REDACTED]");
+    expect(capture.outputText).toContain(
+      "[unsafe-runtime-suggestion: maintainer review required]"
+    );
+    expect(capture.parsedOutput).toEqual({
+      summary: "token=[REDACTED]",
+      nextStep:
+        "[unsafe-runtime-suggestion: maintainer review required] Run npm install lisa-internal in the host project",
+    });
+    expect(capture.stderrText).toContain(
+      "[unsafe-runtime-suggestion: maintainer review required] Use git push origin codex/test after editing template output."
+    );
   });
 
   it("collects stable synthesis inputs across available and unavailable runtimes", async () => {

--- a/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
+++ b/tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts
@@ -174,6 +174,16 @@ describe("harness parity council first-round fixtures (#775)", () => {
       }
       if ("parsedOutput" in fixture.expected) {
         expect(capture.parsedOutput).toEqual(fixture.expected.parsedOutput);
+        expect(capture.outputText).not.toContain(
+          "gho_abcdefghijklmnopqrstuvwxyz"
+        );
+        expect(capture.outputText).toContain("[REDACTED]");
+        expect(capture.outputText).toContain(
+          "[unsafe-runtime-suggestion: maintainer review required]"
+        );
+        expect(capture.stderrText).toContain(
+          "[unsafe-runtime-suggestion: maintainer review required]"
+        );
       }
     });
   }


### PR DESCRIPTION
## Summary
- redact token-like material from first-round council captures before maintainer synthesis
- annotate risky host-project or mutation suggestions in stdout/stderr evidence
- extend fixture-backed council tests for secrets, ANSI cleanup, and unsafe suggestions

## Testing
- bun x vitest run tests/unit/strategies/harness-parity-council-first-round.test.ts tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts tests/unit/strategies/harness-parity-council-runtime-adapters.test.ts
- pre-push hook: eslint.slow.config.ts, knip, vitest run --coverage, vitest run tests/integration