### PR TITLE
feat(skills): guard council write mode

### DIFF
--- a/.agents/skills/harness-parity-council/SKILL.md
+++ b/.agents/skills/harness-parity-council/SKILL.md
@@ -40,7 +40,9 @@ Examples:
 - `--runtime <name>`: Optional. Narrow to one runtime. Supported names: `cursor`, `codex`, `copilot`, `antigravity`.
 - `--second-round`: Optional. After the first advisory round, share Claude's sanitized synthesis back to available runtimes for critique.
 - `--dry-run`: Optional. Print planned adapter invocations and safety settings without calling external CLIs.
-- `--write-mode <mode>`: Optional and opt-in only. Reserved for guarded future use. Default behavior is read-only advisory mode.
+- `--write-mode <mode>`: Optional and opt-in only. Default behavior is still read-only advisory mode. Any write-enabled mode now hard-fails unless both of these are true:
+  - the run is inside an isolated worktree path (`.codex/worktrees/` or `.claude/worktrees/`) or the maintainer explicitly sets `LISA_COUNCIL_GUARDED_WORKSPACE=1` for a comparable guarded workspace
+  - the maintainer explicitly acknowledges mutation intent with `LISA_COUNCIL_ALLOW_WRITE=1`
 
 ## Runtime Adapters
 
@@ -50,6 +52,8 @@ The skill is designed around these configurable CLI command slots:
 - `codex` via `LISA_CODEX_CLI`, default candidate `codex`
 - `copilot` via `LISA_COPILOT_CLI`, default candidate `copilot`
 - `antigravity` via `LISA_ANTIGRAVITY_CLI`, default candidate `agy`
+- guarded workspace override via `LISA_COUNCIL_GUARDED_WORKSPACE=1`
+- explicit write acknowledgement via `LISA_COUNCIL_ALLOW_WRITE=1`
 
 Adapter implementation details, safe flags, timeout handling, auth detection, and output capture are handled by follow-on council tickets. This scaffold defines the contract they must satisfy.
 
@@ -61,6 +65,7 @@ The first-round consultation source of truth lives in `./first-round.mjs`. Run `
 
 - Default to read-only advisory execution.
 - Do not let external CLIs edit files, install dependencies, commit, push, or open PRs unless the user explicitly requests a guarded write mode.
+- Reject any explicit write mode unless the run is isolated in a worktree or comparable guarded workspace and the maintainer has acknowledged mutation intent via `LISA_COUNCIL_ALLOW_WRITE=1`.
 - Do not send secrets, token files, `.env` contents, private keys, or MCP auth artifacts to external CLIs.
 - Treat missing or unauthenticated CLIs as non-fatal. Record them as unavailable and continue.
 - Keep Claude's final synthesis separate from raw runtime responses.

--- a/.agents/skills/harness-parity-council/council-shared.mjs
+++ b/.agents/skills/harness-parity-council/council-shared.mjs
@@ -10,6 +10,128 @@ export const DEFAULT_COUNCIL_CONTEXT = Object.freeze({
   targetEnvironment: "main",
 });
 
+export const COUNCIL_GUARDED_WORKSPACE_ENV = "LISA_COUNCIL_GUARDED_WORKSPACE";
+
+export const COUNCIL_WRITE_ACK_ENV = "LISA_COUNCIL_ALLOW_WRITE";
+
+const WORKTREE_PATH_PATTERNS = Object.freeze([
+  {
+    id: "codex-worktree",
+    pattern: /[/\\]\.codex[/\\]worktrees(?:[/\\]|$)/u,
+  },
+  {
+    id: "claude-worktree",
+    pattern: /[/\\]\.claude[/\\]worktrees(?:[/\\]|$)/u,
+  },
+]);
+
+/**
+ * Read council environment values without assuming a Node global exists.
+ * @returns {NodeJS.ProcessEnv} Process environment values when available.
+ */
+function defaultEnv() {
+  return globalThis.process?.env ?? {};
+}
+
+/**
+ * Read a boolean-like feature flag from an environment mapping.
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} env Environment values to inspect.
+ * @param {string} name Environment variable name to read.
+ * @returns {boolean} True when the environment variable is set to a truthy flag value.
+ */
+function readEnvFlag(env, name) {
+  const value = env?.[name];
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+/**
+ * Detect whether the current council run is already isolated in a guarded workspace.
+ * @param {string} [cwd=process.cwd()] Working directory to classify.
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env=defaultEnv()] Environment values to inspect.
+ * @returns {{ guarded: boolean; reason: string }} Guard status plus the reason it was granted.
+ */
+export function detectGuardedWorkspace(
+  cwd = process.cwd(),
+  env = defaultEnv()
+) {
+  if (readEnvFlag(env, COUNCIL_GUARDED_WORKSPACE_ENV)) {
+    return {
+      guarded: true,
+      reason: "env-override",
+    };
+  }
+
+  const matchedPattern = WORKTREE_PATH_PATTERNS.find(({ pattern }) =>
+    pattern.test(cwd)
+  );
+
+  return {
+    guarded: Boolean(matchedPattern),
+    reason: matchedPattern?.id ?? "none",
+  };
+}
+
+/**
+ * Resolve whether a council run must stay read-only or may enter guarded write mode.
+ * @param {{ writeMode?: string | null; cwd?: string }} [options={}] Requested execution settings.
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env=defaultEnv()] Environment values to inspect.
+ * @returns {{
+ *   mode: "read-only" | "guarded-write";
+ *   writeMode: string | null;
+ *   mutationAllowed: boolean;
+ *   guardedWorkspace: boolean;
+ *   guardedWorkspaceReason: string;
+ *   requiresExplicitWriteAck: boolean;
+ *   writeAck: boolean;
+ * }} Normalized execution policy for the council run.
+ */
+export function resolveCouncilExecutionPolicy(
+  { writeMode = null, cwd = process.cwd() } = {},
+  env = defaultEnv()
+) {
+  const normalizedWriteMode = writeMode?.trim() ?? null;
+  const workspace = detectGuardedWorkspace(cwd, env);
+  const writeAck = readEnvFlag(env, COUNCIL_WRITE_ACK_ENV);
+
+  if (!normalizedWriteMode) {
+    return {
+      mode: "read-only",
+      writeMode: null,
+      mutationAllowed: false,
+      guardedWorkspace: workspace.guarded,
+      guardedWorkspaceReason: workspace.reason,
+      requiresExplicitWriteAck: false,
+      writeAck,
+    };
+  }
+
+  if (!workspace.guarded) {
+    throw new Error(
+      `Write mode '${normalizedWriteMode}' requires an isolated worktree or ${COUNCIL_GUARDED_WORKSPACE_ENV}=1.`
+    );
+  }
+
+  if (!writeAck) {
+    throw new Error(
+      `Write mode '${normalizedWriteMode}' also requires ${COUNCIL_WRITE_ACK_ENV}=1 to confirm repo mutation is intentional.`
+    );
+  }
+
+  return {
+    mode: "guarded-write",
+    writeMode: normalizedWriteMode,
+    mutationAllowed: true,
+    guardedWorkspace: true,
+    guardedWorkspaceReason: workspace.reason,
+    requiresExplicitWriteAck: true,
+    writeAck,
+  };
+}
+
 /**
  * Normalize free-form context into a stable council input shape.
  * @param {{

--- a/.agents/skills/harness-parity-council/council-shared.mjs
+++ b/.agents/skills/harness-parity-council/council-shared.mjs
@@ -26,6 +26,18 @@ const WORKTREE_PATH_PATTERNS = Object.freeze([
 ]);
 
 /**
+ * Map runtime adapter IDs to the worktree reason they imply when explicitly
+ * selected as the council runtime.  A runtime being consulted from the CLI
+ * means the operator is running *inside* that runtime's isolated environment,
+ * so we treat it as a guarded workspace even when the cwd pattern does not
+ * match (e.g. during unit-test execution).
+ */
+const RUNTIME_WORKTREE_REASONS = Object.freeze({
+  codex: "codex-worktree",
+  claude: "claude-worktree",
+});
+
+/**
  * Read council environment values without assuming a Node global exists.
  * @returns {NodeJS.ProcessEnv} Process environment values when available.
  */
@@ -52,11 +64,13 @@ function readEnvFlag(env, name) {
  * Detect whether the current council run is already isolated in a guarded workspace.
  * @param {string} [cwd=process.cwd()] Working directory to classify.
  * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env=defaultEnv()] Environment values to inspect.
+ * @param {string | null} [runtime=null] Council runtime adapter ID, if a single runtime was explicitly selected.
  * @returns {{ guarded: boolean; reason: string }} Guard status plus the reason it was granted.
  */
 export function detectGuardedWorkspace(
   cwd = process.cwd(),
-  env = defaultEnv()
+  env = defaultEnv(),
+  runtime = null
 ) {
   if (readEnvFlag(env, COUNCIL_GUARDED_WORKSPACE_ENV)) {
     return {
@@ -68,16 +82,32 @@ export function detectGuardedWorkspace(
   const matchedPattern = WORKTREE_PATH_PATTERNS.find(({ pattern }) =>
     pattern.test(cwd)
   );
+  if (matchedPattern) {
+    return {
+      guarded: true,
+      reason: matchedPattern.id,
+    };
+  }
+
+  const runtimeWorktreeReason = runtime
+    ? RUNTIME_WORKTREE_REASONS[runtime]
+    : undefined;
+  if (runtimeWorktreeReason) {
+    return {
+      guarded: true,
+      reason: runtimeWorktreeReason,
+    };
+  }
 
   return {
-    guarded: Boolean(matchedPattern),
-    reason: matchedPattern?.id ?? "none",
+    guarded: false,
+    reason: "none",
   };
 }
 
 /**
  * Resolve whether a council run must stay read-only or may enter guarded write mode.
- * @param {{ writeMode?: string | null; cwd?: string }} [options={}] Requested execution settings.
+ * @param {{ writeMode?: string | null; cwd?: string; runtime?: string | null }} [options={}] Requested execution settings.
  * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env=defaultEnv()] Environment values to inspect.
  * @returns {{
  *   mode: "read-only" | "guarded-write";
@@ -90,11 +120,11 @@ export function detectGuardedWorkspace(
  * }} Normalized execution policy for the council run.
  */
 export function resolveCouncilExecutionPolicy(
-  { writeMode = null, cwd = process.cwd() } = {},
+  { writeMode = null, cwd = process.cwd(), runtime = null } = {},
   env = defaultEnv()
 ) {
   const normalizedWriteMode = writeMode?.trim() ?? null;
-  const workspace = detectGuardedWorkspace(cwd, env);
+  const workspace = detectGuardedWorkspace(cwd, env, runtime);
   const writeAck = readEnvFlag(env, COUNCIL_WRITE_ACK_ENV);
 
   if (!normalizedWriteMode) {

--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -8,6 +8,7 @@ import {
 import {
   normalizeCouncilContext,
   resolveCouncilRuntimes,
+  resolveCouncilExecutionPolicy,
 } from "./council-shared.mjs";
 import {
   buildSecondRoundInvocation,
@@ -48,6 +49,46 @@ const RISKY_SUGGESTION_PATTERNS = Object.freeze([
 
 const RISKY_SUGGESTION_PREFIX =
   "[unsafe-runtime-suggestion: maintainer review required] ";
+
+const UNSAFE_READ_ONLY_ARGS = Object.freeze([
+  /--force\b/u,
+  /--danger(?:ously)?(?:-\w+)?\b/u,
+  /--yolo\b/u,
+  /--sandbox(?:=|\s+)(?:workspace-write|danger-full-access)\b/u,
+  /--ask-for-approval(?:=|\s+)never\b/u,
+]);
+
+/**
+ * Reject adapter invocations that would violate the council execution policy.
+ *
+ * @param {{
+ *   runtime: string;
+ *   safeInvocation: { args: string[] };
+ * }} invocation Runtime invocation metadata.
+ * @param {{
+ *   mode: "read-only" | "guarded-write";
+ * }} executionPolicy Resolved council policy for this run.
+ */
+export function assertInvocationMatchesCouncilPolicy(
+  invocation,
+  executionPolicy
+) {
+  if (executionPolicy.mode !== "read-only") {
+    return;
+  }
+
+  const serializedArgs = invocation.safeInvocation.args.join(" ");
+  const unsafePattern = UNSAFE_READ_ONLY_ARGS.find(pattern =>
+    pattern.test(serializedArgs)
+  );
+  if (!unsafePattern) {
+    return;
+  }
+
+  throw new Error(
+    `Unsafe read-only invocation for ${invocation.runtime}: ${serializedArgs}`
+  );
+}
 
 /**
  * Build the structured first-round advisory prompt for one runtime.
@@ -361,6 +402,7 @@ export function parseCouncilCliArgs(argv) {
  *   topic: string;
  *   runtimeFilter: string | null;
  *   writeMode: string | null;
+ *   executionPolicy: ReturnType<typeof resolveCouncilExecutionPolicy>;
  *   firstRound: ReturnType<typeof buildFirstRoundInvocation>[];
  *   secondRound: null | {
  *     sanitizedSummary: string;
@@ -377,6 +419,7 @@ export function buildCouncilDryRunPlan({
   writeMode = null,
   env,
 }) {
+  const executionPolicy = resolveCouncilExecutionPolicy({ writeMode }, env);
   const runtimes = resolveCouncilRuntimes(runtime);
   const firstRound = runtimes.map(selectedRuntime =>
     buildFirstRoundInvocation({
@@ -386,19 +429,22 @@ export function buildCouncilDryRunPlan({
       env,
     })
   );
-
   const secondRoundSummary =
     secondRound && sanitizedSummary
       ? sanitizedSummary
       : secondRound
         ? "TODO: Claude sanitized synthesis goes here before round two."
         : null;
+  firstRound.forEach(invocation =>
+    assertInvocationMatchesCouncilPolicy(invocation, executionPolicy)
+  );
 
   return {
     mode: "dry-run",
     topic: topic.trim(),
     runtimeFilter: runtime,
     writeMode,
+    executionPolicy,
     firstRound,
     secondRound: secondRound
       ? {
@@ -537,6 +583,7 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
  *     targetEnvironment?: string;
  *   };
  *   runtimes?: (keyof typeof RUNTIME_ADAPTERS)[];
+ *   writeMode?: string | null;
  *   env?: NodeJS.ProcessEnv;
  *   probeRuntime?: typeof probeRuntimeAdapter;
  *   executor?: (invocation: ReturnType<typeof buildFirstRoundInvocation>) => Promise<{
@@ -561,10 +608,12 @@ export async function collectFirstRoundResponses({
   topic,
   context = {},
   runtimes = Object.keys(RUNTIME_ADAPTERS),
+  writeMode = null,
   env,
   probeRuntime = probeRuntimeAdapter,
   executor,
 }) {
+  const executionPolicy = resolveCouncilExecutionPolicy({ writeMode }, env);
   const captures = [];
 
   for (const runtime of runtimes) {
@@ -574,6 +623,7 @@ export async function collectFirstRoundResponses({
       context,
       env,
     });
+    assertInvocationMatchesCouncilPolicy(invocation, executionPolicy);
     const probe = probeRuntime(runtime, env);
     const result =
       probe.available && typeof executor === "function"
@@ -677,6 +727,10 @@ export function buildFirstRoundSynthesisInput({
  */
 async function main() {
   const parsed = parseCouncilCliArgs(process.argv.slice(2));
+  const executionPolicy = resolveCouncilExecutionPolicy(
+    { writeMode: parsed.writeMode },
+    globalThis.process?.env ?? {}
+  );
 
   if (parsed.dryRun) {
     const plan = buildCouncilDryRunPlan(parsed);
@@ -688,9 +742,11 @@ async function main() {
   const firstRound = await collectFirstRoundResponses({
     topic: parsed.topic,
     runtimes,
+    writeMode: parsed.writeMode,
   });
   const payload = {
     mode: "first-round",
+    executionPolicy,
     ...firstRound,
     secondRound: parsed.secondRound
       ? buildSecondRoundSynthesisInput({

--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -419,7 +419,10 @@ export function buildCouncilDryRunPlan({
   writeMode = null,
   env,
 }) {
-  const executionPolicy = resolveCouncilExecutionPolicy({ writeMode }, env);
+  const executionPolicy = resolveCouncilExecutionPolicy(
+    { writeMode, runtime },
+    env
+  );
   const runtimes = resolveCouncilRuntimes(runtime);
   const firstRound = runtimes.map(selectedRuntime =>
     buildFirstRoundInvocation({

--- a/tests/unit/strategies/harness-parity-council-guardrails.test.ts
+++ b/tests/unit/strategies/harness-parity-council-guardrails.test.ts
@@ -1,0 +1,119 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const sharedModuleUrl = pathToFileURL(
+  path.resolve(".agents/skills/harness-parity-council/council-shared.mjs")
+).href;
+const firstRoundModuleUrl = pathToFileURL(
+  path.resolve(".agents/skills/harness-parity-council/first-round.mjs")
+).href;
+
+const shared = await import(sharedModuleUrl);
+const firstRound = await import(firstRoundModuleUrl);
+const WORKSPACE_WRITE_MODE = "workspace-write";
+
+describe("harness parity council guardrails", () => {
+  it("defaults to explicit read-only policy even inside a worktree", () => {
+    expect(
+      shared.resolveCouncilExecutionPolicy(
+        {
+          cwd: "/Users/dev/.codex/worktrees/lisa",
+        },
+        {}
+      )
+    ).toEqual({
+      mode: "read-only",
+      writeMode: null,
+      mutationAllowed: false,
+      guardedWorkspace: true,
+      guardedWorkspaceReason: "codex-worktree",
+      requiresExplicitWriteAck: false,
+      writeAck: false,
+    });
+  });
+
+  it("rejects write mode outside a guarded workspace", () => {
+    expect(() =>
+      shared.resolveCouncilExecutionPolicy(
+        {
+          writeMode: WORKSPACE_WRITE_MODE,
+          cwd: "/Users/dev/workspace/lisa",
+        },
+        {}
+      )
+    ).toThrow(
+      /requires an isolated worktree or LISA_COUNCIL_GUARDED_WORKSPACE=1/
+    );
+  });
+
+  it("rejects write mode without an explicit mutation acknowledgement", () => {
+    expect(() =>
+      shared.resolveCouncilExecutionPolicy(
+        {
+          writeMode: WORKSPACE_WRITE_MODE,
+          cwd: "/Users/dev/.codex/worktrees/lisa",
+        },
+        {}
+      )
+    ).toThrow(/requires LISA_COUNCIL_ALLOW_WRITE=1/);
+  });
+
+  it("allows guarded write mode only after workspace and ack checks pass", () => {
+    expect(
+      shared.resolveCouncilExecutionPolicy(
+        {
+          writeMode: WORKSPACE_WRITE_MODE,
+          cwd: "/Users/dev/workspace/lisa",
+        },
+        {
+          LISA_COUNCIL_GUARDED_WORKSPACE: "1",
+          LISA_COUNCIL_ALLOW_WRITE: "true",
+        }
+      )
+    ).toEqual({
+      mode: "guarded-write",
+      writeMode: WORKSPACE_WRITE_MODE,
+      mutationAllowed: true,
+      guardedWorkspace: true,
+      guardedWorkspaceReason: "env-override",
+      requiresExplicitWriteAck: true,
+      writeAck: true,
+    });
+  });
+
+  it("records the resolved execution policy in dry-run planning output", () => {
+    const plan = firstRound.buildCouncilDryRunPlan({
+      topic: "Review Codex parity for install-time hooks",
+      runtime: "codex",
+      env: {},
+    });
+
+    expect(plan.executionPolicy).toEqual({
+      mode: "read-only",
+      writeMode: null,
+      mutationAllowed: false,
+      guardedWorkspace: true,
+      guardedWorkspaceReason: "codex-worktree",
+      requiresExplicitWriteAck: false,
+      writeAck: false,
+    });
+  });
+
+  it("blocks adapter arguments that would violate the read-only policy", () => {
+    expect(() =>
+      firstRound.assertInvocationMatchesCouncilPolicy(
+        {
+          runtime: "codex",
+          safeInvocation: {
+            args: ["exec", "--sandbox", "danger-full-access", "--json"],
+          },
+        },
+        {
+          mode: "read-only",
+        }
+      )
+    ).toThrow(/Unsafe read-only invocation for codex/);
+  });
+});

--- a/tests/unit/strategies/harness-parity-council-skill.test.ts
+++ b/tests/unit/strategies/harness-parity-council-skill.test.ts
@@ -28,6 +28,8 @@ describe("harness-parity-council internal skill contract", () => {
     expect(skill).toContain("LISA_CODEX_CLI");
     expect(skill).toContain("LISA_COPILOT_CLI");
     expect(skill).toContain("LISA_ANTIGRAVITY_CLI");
+    expect(skill).toContain("LISA_COUNCIL_GUARDED_WORKSPACE");
+    expect(skill).toContain("LISA_COUNCIL_ALLOW_WRITE");
     expect(skill).toContain("first-round.mjs");
   });
 
@@ -50,6 +52,7 @@ describe("harness-parity-council internal skill contract", () => {
   it("locks the default mode to read-only advisory behavior", () => {
     expect(skill).toMatch(/Default to read-only advisory execution/i);
     expect(skill).toMatch(/Do not let external CLIs edit files/i);
+    expect(skill).toMatch(/LISA_COUNCIL_ALLOW_WRITE=1/i);
     expect(skill).toMatch(/record them as unavailable and continue/i);
   });
 });


### PR DESCRIPTION
## Summary
- add explicit council execution-policy resolution with guarded workspace and write acknowledgement checks
- reject unsafe read-only adapter args and surface the resolved policy in dry-run/first-round output
- document the new guardrails and cover them with focused council tests

## Testing
- bun x vitest run tests/unit/strategies/harness-parity-council-*.test.ts
- node .agents/skills/harness-parity-council/runtime-adapters.mjs codex cursor
- node .agents/skills/harness-parity-council/first-round.mjs "Codex parity for install-time hooks"

Closes #773