### PR TITLE
fix: block internal Codex skill distribution

### DIFF
--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -20,6 +20,16 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const INTERNAL_CODEX_SKILL_POLICY_PATH = path.join(
+  REPO_ROOT,
+  "scripts",
+  "internal-codex-skill-policy.json"
+);
+
 /**
  * Parse the leading YAML frontmatter block of a SKILL.md file.
  *
@@ -288,6 +298,69 @@ export function deriveSkillInterface(frontmatter, skillName) {
 }
 
 /**
+ * Read the denylisted-skill policy that keeps Lisa maintainer-only skills out
+ * of distributed Codex plugin artifacts.
+ *
+ * Missing or malformed policy files fail open to an empty set so the artifact
+ * builder stays usable in isolated tests that seed only a minimal plugin tree.
+ *
+ * @param {string} [policyPath] Optional override for tests.
+ * @returns {ReadonlySet<string>} Skill directory names that must not ship.
+ */
+export function loadInternalCodexSkillPolicy(
+  policyPath = INTERNAL_CODEX_SKILL_POLICY_PATH
+) {
+  if (!fs.existsSync(policyPath)) {
+    return new Set();
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(policyPath, "utf8"));
+    if (!Array.isArray(parsed.denylistedSkills)) {
+      return new Set();
+    }
+    return new Set(
+      parsed.denylistedSkills.filter(name => typeof name === "string")
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Remove denylisted internal skills from a built plugin directory before any
+ * Codex-facing artifacts are derived from it.
+ *
+ * This keeps maintainer-only skills out of committed built-plugin skill
+ * directories,
+ * generated per-skill `agents/openai.yaml` files, and downstream host-project
+ * installations that consume those built plugin directories.
+ *
+ * @param {string} pluginDir Absolute path to a built plugin directory.
+ * @param {ReadonlySet<string>} [denylistedSkills] Optional override for tests.
+ * @returns {readonly string[]} Sorted list of removed skill names.
+ */
+export function pruneInternalCodexSkills(
+  pluginDir,
+  denylistedSkills = loadInternalCodexSkillPolicy()
+) {
+  const skillsDir = path.join(pluginDir, "skills");
+  if (!fs.existsSync(skillsDir) || denylistedSkills.size === 0) {
+    return [];
+  }
+
+  const removed = [];
+  for (const skillName of [...denylistedSkills].sort()) {
+    const skillDir = path.join(skillsDir, skillName);
+    if (!fs.existsSync(skillDir)) {
+      continue;
+    }
+    fs.rmSync(skillDir, { recursive: true, force: true });
+    removed.push(skillName);
+  }
+  return removed;
+}
+
+/**
  * Walk every `skills/<name>/SKILL.md` in a built plugin and emit a per-skill
  * `skills/<name>/agents/openai.yaml` (issue #547).
  *
@@ -362,6 +435,7 @@ function main() {
   );
   const pluginName = claudeManifest.name;
 
+  pruneInternalCodexSkills(pluginDir);
   writeCodexManifest(pluginDir, claudeManifest, pluginName, versionArg);
   writeSkillAgents(pluginDir);
 }

--- a/scripts/internal-codex-skill-policy.json
+++ b/scripts/internal-codex-skill-policy.json
@@ -1,0 +1,3 @@
+{
+  "denylistedSkills": ["harness-parity-council"]
+}

--- a/src/codex/skills-installer.ts
+++ b/src/codex/skills-installer.ts
@@ -41,6 +41,10 @@ export const LISA_COMMAND_SKILL_PREFIX = "lisa-";
 
 /** Filename of the skill manifest at the root of every skill folder */
 const SKILL_MD_FILENAME = "SKILL.md";
+const INTERNAL_CODEX_SKILL_POLICY_RELATIVE_PATH = path.join(
+  "scripts",
+  "internal-codex-skill-policy.json"
+);
 
 /** Result of one skill copy */
 export interface InstalledSkill {
@@ -79,9 +83,10 @@ export async function installSkills(
 ): Promise<SkillsInstallResult> {
   const skillsDir = path.join(destDir, ".codex", LISA_SKILLS_SUBDIR);
   await fse.ensureDir(skillsDir);
+  const denylistedSkills = await loadInternalCodexSkillPolicy(lisaDir);
 
   // Step 1: bundled skills
-  const bundled = await discoverBundledSkills(lisaDir);
+  const bundled = await discoverBundledSkills(lisaDir, denylistedSkills);
   const bundledInstalls = await Promise.all(
     bundled.map(source => copyBundledSkill(source, skillsDir))
   );
@@ -117,6 +122,41 @@ export async function installSkills(
     managedFiles: Object.freeze([...bundledFiles, ...commandFiles]),
     deleted: Object.freeze(deleted),
   };
+}
+
+/**
+ * Load the Codex distribution policy that marks Lisa-maintainer-only skills as
+ * non-distributable.
+ *
+ * Missing or malformed policy files fail open to an empty set so tests and
+ * minimal package layouts remain usable.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package
+ * @returns Skill directory names that must not be installed into host projects
+ */
+async function loadInternalCodexSkillPolicy(
+  lisaDir: string
+): Promise<ReadonlySet<string>> {
+  const policyPath = path.join(
+    lisaDir,
+    INTERNAL_CODEX_SKILL_POLICY_RELATIVE_PATH
+  );
+  if (!(await fse.pathExists(policyPath))) {
+    return new Set();
+  }
+  try {
+    const raw = await readFile(policyPath, "utf8");
+    const parsed = JSON.parse(raw) as { denylistedSkills?: unknown };
+    if (!Array.isArray(parsed.denylistedSkills)) {
+      return new Set();
+    }
+    return new Set(
+      parsed.denylistedSkills.filter(
+        (name): name is string => typeof name === "string"
+      )
+    );
+  } catch {
+    return new Set();
+  }
 }
 
 /**
@@ -188,10 +228,12 @@ interface BundledSkillSource {
  * order, so any stack-specific or third-party plugin overrides the base
  * regardless of how the name sorts.
  * @param lisaDir - Absolute path to the Lisa repo / installed package
+ * @param denylistedSkills - Skill names that must not ship to host projects
  * @returns De-duplicated bundled-skill sources, sorted by skill name
  */
 async function discoverBundledSkills(
-  lisaDir: string
+  lisaDir: string,
+  denylistedSkills: ReadonlySet<string>
 ): Promise<readonly BundledSkillSource[]> {
   const pluginsDir = path.join(lisaDir, "plugins");
   if (!(await fse.pathExists(pluginsDir))) {
@@ -215,7 +257,9 @@ async function discoverBundledSkills(
     new Map(flat.map(source => [source.skillName, source])).values()
   );
   return Object.freeze(
-    [...deduped].sort((a, b) => a.skillName.localeCompare(b.skillName))
+    [...deduped]
+      .filter(source => !denylistedSkills.has(source.skillName))
+      .sort((a, b) => a.skillName.localeCompare(b.skillName))
   );
 }
 

--- a/tests/unit/codex/skill-agents-walk.test.ts
+++ b/tests/unit/codex/skill-agents-walk.test.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   deriveSkillInterface,
+  pruneInternalCodexSkills,
   writeSkillAgents,
 } from "../../../scripts/generate-codex-plugin-artifacts.mjs";
 import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
@@ -26,6 +27,10 @@ import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
 const OPENAI_YAML = "openai.yaml";
 /** A representative skill name used by the derivation tests. */
 const EXPLORATORY_QA = "exploratory-qa";
+/** Internal maintainer-only skill that must never ship in Codex artifacts. */
+const HARNESS_PARITY_COUNCIL = "harness-parity-council";
+/** Public skill used to prove non-denylisted artifacts still emit normally. */
+const PUBLIC_SKILL = "public-skill";
 
 describe("codex/skill-agents-walk", () => {
   let tempDir: string;
@@ -147,6 +152,23 @@ describe("codex/skill-agents-walk", () => {
     writeSkillAgents(tempDir);
 
     expect(await fs.pathExists(openaiYamlPath("not-a-skill"))).toBe(false);
+  });
+
+  it("prunes denylisted internal skills before Codex artifacts are emitted", async () => {
+    await writeSkill(
+      HARNESS_PARITY_COUNCIL,
+      frontmatter(HARNESS_PARITY_COUNCIL, "Maintainer-only workflow")
+    );
+    await writeSkill(PUBLIC_SKILL, frontmatter(PUBLIC_SKILL, "Ships"));
+
+    const removed = pruneInternalCodexSkills(tempDir);
+    writeSkillAgents(tempDir);
+
+    expect(removed).toEqual([HARNESS_PARITY_COUNCIL]);
+    expect(
+      await fs.pathExists(path.join(tempDir, "skills", HARNESS_PARITY_COUNCIL))
+    ).toBe(false);
+    expect(await fs.pathExists(openaiYamlPath(PUBLIC_SKILL))).toBe(true);
   });
 
   describe("deriveSkillInterface", () => {

--- a/tests/unit/codex/skills-installer-internal-skill-policy.test.ts
+++ b/tests/unit/codex/skills-installer-internal-skill-policy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression coverage for issue #774: Lisa must not install maintainer-only
+ * internal skills into downstream host-project `.codex/skills/lisa/`.
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_SKILLS_SUBDIR,
+  installSkills,
+} from "../../../src/codex/skills-installer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const SKILL_MD = "SKILL.md";
+const PUBLIC_SKILL = "bug-triage";
+const INTERNAL_SKILL = "harness-parity-council";
+const INTERNAL_CODEX_SKILL_POLICY = JSON.stringify(
+  {
+    denylistedSkills: [INTERNAL_SKILL],
+  },
+  null,
+  2
+);
+
+describe("codex/skills-installer internal skill policy (#774)", () => {
+  let tempDir: string;
+  let lisaDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Seed a bundled skill into a fake Lisa plugin tree.
+   * @param skillName - Skill directory name to create
+   */
+  async function seedSkill(skillName: string): Promise<void> {
+    const skillDir = path.join(lisaDir, "plugins", "lisa", "skills", skillName);
+    await fs.ensureDir(skillDir);
+    await fs.writeFile(
+      path.join(skillDir, SKILL_MD),
+      `---\nname: ${skillName}\ndescription: Seeded skill\n---\n`,
+      "utf8"
+    );
+  }
+
+  /**
+   * Seed the denylisted-skill policy file under the fake Lisa root.
+   */
+  async function seedInternalSkillPolicy(): Promise<void> {
+    const filePath = path.join(
+      lisaDir,
+      "scripts",
+      "internal-codex-skill-policy.json"
+    );
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, INTERNAL_CODEX_SKILL_POLICY, "utf8");
+  }
+
+  it("skips denylisted internal skills during host-project installation", async () => {
+    await seedInternalSkillPolicy();
+    await seedSkill(INTERNAL_SKILL);
+    await seedSkill(PUBLIC_SKILL);
+
+    const result = await installSkills(lisaDir, destDir, []);
+
+    expect(result.installed.map(skill => skill.name)).toEqual([PUBLIC_SKILL]);
+    expect(
+      await fs.pathExists(
+        path.join(destDir, ".codex", LISA_SKILLS_SUBDIR, INTERNAL_SKILL)
+      )
+    ).toBe(false);
+    expect(result.managedFiles).not.toContain(
+      path.join(LISA_SKILLS_SUBDIR, INTERNAL_SKILL, SKILL_MD)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a denylisted Codex skill policy for maintainer-only internal skills
- prune denylisted skills from built plugin artifacts before openai.yaml generation
- skip denylisted skills during downstream .codex skill installation and cover it with regression tests

## Testing
- bun test tests/unit/codex/skill-agents-walk.test.ts tests/unit/codex/skills-installer.test.ts tests/unit/codex/skills-installer-internal-skill-policy.test.ts
- git push -u origin codex/issue-774-github-build-intake

Closes #774