### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -34,3 +34,10 @@
 - Refreshed the `git` source note with 47 new commits through `362e4bf1248d47e406b19d56f2d3d8b27e7740c9` and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime.
 - Updated the monorepo snapshot synthesis for the latest GitHub project-coordination, usage-accounting, intake-filtering, and release-history changes.
+
+## 2026-05-25 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-25-3844`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 65 new commits through `7a56fd065774adb22bcb7ff7857e1d89170f5f75`, advanced the merged-PR cursor to `#789`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because the only Codex memory store available in this runtime was the global `/Users/cody/.codex/memories`, which the project-scoped memory connector correctly refuses to ingest.
+- Updated the monorepo snapshot synthesis for the latest council-planning, doctor-surface, GitHub build-intake, and release-history changes.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,19 +20,19 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-25-2` from `origin/main`
-- HEAD at 2026-05-25 incremental ingest: `362e4bf1248d47e406b19d56f2d3d8b27e7740c9`
-- Current package version: `2.74.0`
-- Total commits on HEAD: 1888
-- Latest merged PR captured in the incremental git snapshot: `#740`
-- New commits since the previous incremental git cursor: `47`
+- Ingest branch: `wiki/ingest-2026-05-25-3844` from `origin/main`
+- HEAD at 2026-05-25 incremental ingest: `7a56fd065774adb22bcb7ff7857e1d89170f5f75`
+- Current package version: `2.85.1`
+- Total commits on HEAD: 1953
+- Latest merged PR captured in the incremental git snapshot: `#789`
+- New commits since the previous incremental git cursor: `65`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Wiki operations now include native automation setup and teardown flows, and the first wiki ingest PR has merged back to `main` as part of the standing branch-sync and auto-merge workflow.
-- GitHub project coordination coverage expanded across project configuration, validation modes, project-v2 utility contracts, writer coordination, linked-PR membership, and multi-repo container preservation.
-- Usage accounting coverage landed across shared contract docs, idempotent utilities, writer preservation, and research-plan plus debrief usage ledgers.
-- Intake behavior added repo-local assignee queue filtering while release automation continued to publish rapid follow-on versions through `2.74.0`.
+- Council planning and runtime-guard coverage expanded across dry-run critique, second-round planning, workspace/runtime detection, and sanitized runtime capture handling.
+- The wiki plugin's doctor surface added command scaffolding, grouped report rendering, GitHub-readiness validation, and vendor/config readiness contracts.
+- GitHub build-intake work continued landing through the `codex/issue-*` queue, including usage-pricing delivery wiring and tighter internal Codex skill distribution guards.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.74.0` through `2.85.1` during this incremental window.
 
 ## Workspace Packages
 
@@ -47,4 +47,6 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/repository/2026-05-14-monorepo-baseline.md`
 - `wiki/sources/github/2026-05-14-git-and-pr-history.md`
 - `wiki/sources/git/2026-05-25-lisa-monorepo-git.md`
+- `wiki/sources/git/2026-05-26-lisa-monorepo-git.md`
 - `wiki/sources/roles/2026-05-25-roles.md`
+- `wiki/sources/roles/2026-05-26-roles.md`

--- a/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
@@ -1,0 +1,84 @@
+---
+type: source
+created: 2026-05-26
+updated: 2026-05-26
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-05-26)
+
+- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.7znDMv`)
+- HEAD: `7a56fd065774adb22bcb7ff7857e1d89170f5f75`
+- Total commits on HEAD: 1953
+- New commits since last ingest (`362e4bf1248d47e406b19d56f2d3d8b27e7740c9`): 65
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #789 "fix: block internal Codex skill distribution"
+
+## New commits
+- 7a56fd06 · 2026-05-26 · chore(release): 2.85.1 [skip ci]
+- aab15876 · 2026-05-25 · Merge pull request #789 from CodySwannGT/codex/issue-774-github-build-intake
+- ccb0e3bb · 2026-05-25 · fix(codex): block internal skill distribution
+- 4b73e5d7 · 2026-05-26 · chore(release): 2.85.0 [skip ci]
+- 8da62d67 · 2026-05-25 · Merge pull request #787 from CodySwannGT/codex/issue-773-github-build-intake
+- 96f0142e · 2026-05-26 · fix(council): propagate runtime to workspace guard detection
+- 931c4c4f · 2026-05-25 · feat(skills): guard council write mode
+- b81827e9 · 2026-05-26 · chore(release): 2.84.1 [skip ci]
+- 1dd6a14e · 2026-05-25 · Merge pull request #786 from CodySwannGT/codex/issue-772-github-build-intake
+- 5bc05617 · 2026-05-26 · Merge branch 'main' into codex/issue-772-github-build-intake
+- 4f83acd5 · 2026-05-25 · fix(council): sanitize runtime captures
+- 56bcd10a · 2026-05-26 · chore(release): 2.84.0 [skip ci]
+- c8b8569d · 2026-05-25 · Merge pull request #785 from CodySwannGT/codex/issue-771-github-build-intake
+- 92c14ffa · 2026-05-26 · Merge branch 'main' into codex/issue-771-github-build-intake
+- f8a595cd · 2026-05-25 · Merge pull request #784 from CodySwannGT/codex/issue-775-github-build-intake
+- 3d142f9a · 2026-05-25 · feat(council): add runtime-filtered dry-run critique planning
+- e2c055e0 · 2026-05-26 · fix: address CodeRabbit review on PR #784
+- 2b024e7e · 2026-05-25 · test: add harness parity council fixture smoke coverage
+- 20e518c5 · 2026-05-25 · chore(release): 2.83.0 [skip ci]
+- 299c16eb · 2026-05-25 · Merge pull request #783 from CodySwannGT/codex/issue-770-github-build-intake
+- ca3693ef · 2026-05-25 · feat(skills): add first-round council consultation flow
+- fb720abf · 2026-05-25 · chore(release): 2.82.0 [skip ci]
+- bf5b6fce · 2026-05-25 · Merge pull request #782 from CodySwannGT/codex/issue-769-github-build-intake
+- 478cff7b · 2026-05-25 · feat(skills): add council runtime adapter planning
+- 0de792a5 · 2026-05-25 · chore(release): 2.81.0 [skip ci]
+- 606e35e3 · 2026-05-25 · Merge pull request #781 from CodySwannGT/codex/issue-768-council-skill
+- dfa595ae · 2026-05-25 · feat(skills): add harness parity council scaffold
+- c375f641 · 2026-05-25 · chore(release): 2.80.1 [skip ci]
+- 8b3a8717 · 2026-05-25 · Merge pull request #780 from CodySwannGT/codex/issue-756-github-build-intake
+- bb26d993 · 2026-05-25 · test(doctor): add fixture smoke and parity coverage
+- 4ec1b5e0 · 2026-05-25 · chore(release): 2.80.0 [skip ci]
+- ab9c98ac · 2026-05-25 · Merge pull request #779 from CodySwannGT/codex/issue-755-github-build-intake
+- f38b1976 · 2026-05-25 · feat(doctor): define wiki delegation contract
+- 753e8cc7 · 2026-05-25 · chore(release): 2.79.0 [skip ci]
+- cec3bc95 · 2026-05-25 · Merge pull request #778 from CodySwannGT/codex/issue-754-github-build-intake
+- 46a11ce4 · 2026-05-25 · feat: document doctor automation readiness
+- b21307a2 · 2026-05-25 · chore(release): 2.78.0 [skip ci]
+- d910724a · 2026-05-25 · Merge pull request #777 from CodySwannGT/codex/issue-753-github-build-intake
+- 6ba43628 · 2026-05-25 · feat(doctor): validate github project readiness
+- 616a27d1 · 2026-05-25 · chore(release): 2.77.2 [skip ci]
+- bd8a2048 · 2026-05-25 · Merge pull request #776 from CodySwannGT/codex/issue-752-github-build-intake
+- 03b93756 · 2026-05-25 · docs(doctor): define vendor preflight readiness contract
+- 69229c87 · 2026-05-25 · chore(release): 2.77.1 [skip ci]
+- be529e0c · 2026-05-25 · Merge pull request #762 from CodySwannGT/codex/issue-751-github-build-intake
+- cc3fd992 · 2026-05-25 · docs: lock doctor config readiness contract
+- 97a1a6a3 · 2026-05-25 · chore(release): 2.77.0 [skip ci]
+- 694fde21 · 2026-05-25 · Merge pull request #761 from CodySwannGT/codex/issue-750-github-build-intake
+- 1572c1e6 · 2026-05-25 · feat(doctor): add grouped report renderer
+- 4c058e0a · 2026-05-25 · chore(release): 2.76.0 [skip ci]
+- 1b8a221c · 2026-05-25 · Merge pull request #760 from CodySwannGT/codex/issue-749-github-build-intake
+- 27b2ceaf · 2026-05-25 · feat(doctor): add doctor command scaffold
+- c3916e3a · 2026-05-25 · chore(release): 2.75.1 [skip ci]
+- 826e05a5 · 2026-05-25 · Merge pull request #759 from CodySwannGT/codex/issue-735-github-build-intake
+- 164b247c · 2026-05-25 · test: harden usage accounting coverage
+- f57ba02c · 2026-05-25 · chore(release): 2.75.0 [skip ci]
+- ad713697 · 2026-05-25 · Merge pull request #757 from CodySwannGT/codex/issue-733-github-build-intake
+- 1f8568ab · 2026-05-25 · Merge branch 'main' into codex/issue-733-github-build-intake
+- 5983ed4f · 2026-05-25 · feat(config-resolution): add usage pricing contract
+- b56e32da · 2026-05-25 · chore(release): 2.74.1 [skip ci]
+- b6af54bd · 2026-05-25 · Merge pull request #743 from CodySwannGT/wiki/ingest-2026-05-25-2
+- 097b1543 · 2026-05-25 · Merge branch 'main' into wiki/ingest-2026-05-25-2
+- 0cb398da · 2026-05-25 · Merge pull request #742 from CodySwannGT/codex/issue-732-github-build-intake
+- 26781438 · 2026-05-25 · Merge branch 'main' into codex/issue-732-github-build-intake
+- 651f1fae · 2026-05-25 · docs(wiki): ingest incremental git history
+- 8958987c · 2026-05-25 · docs: wire usage accounting into delivery flows

--- a/wiki/sources/roles/2026-05-26-roles.md
+++ b/wiki/sources/roles/2026-05-26-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-05-26
+updated: 2026-05-26
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-05-26)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-25T21:28:36.781Z",
+  "ingested_at": "2026-05-26T01:29:36.312Z",
   "cursor": {
-    "lastCommit": "362e4bf1248d47e406b19d56f2d3d8b27e7740c9",
-    "lastPr": 740
+    "lastCommit": "7a56fd065774adb22bcb7ff7857e1d89170f5f75",
+    "lastPr": 789
   },
   "source_notes": [
-    "wiki/sources/git/2026-05-25-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-25T21:28:36.069Z",
+  "ingested_at": "2026-05-26T01:29:36.722Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-05-25"
+    "lastIngest": "2026-05-26"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-05-25-roles.md"
+    "wiki/sources/roles/2026-05-26-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- ingest the latest enabled non-external-write wiki sources
- refresh git and roles source notes plus connector state
- update the monorepo wiki snapshot and ingest log

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json
