### PR TITLE
feat(lisa): scaffold automation-status surfaces

### DIFF
--- a/plugins/lisa/commands/automation-status.md
+++ b/plugins/lisa/commands/automation-status.md
@@ -1,0 +1,5 @@
+---
+description: "Inspect the current project's Lisa automation fleet and report whether the expected recurring jobs exist, match Lisa's setup contract, and show healthy recent activity. Read-only by default."
+---
+
+Use the /lisa:automation-status skill to inspect the current project's expected Lisa automations, compare them with the runtime's scheduler metadata, and report fleet health, drift, staleness, unsupported jobs, and remediation hints. $ARGUMENTS

--- a/plugins/lisa/skills/automation-status/SKILL.md
+++ b/plugins/lisa/skills/automation-status/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: automation-status
+description: "Read-only operator surface for the current project's Lisa automation fleet. Resolves the expected recurring jobs from the same setup-automations contract Lisa uses to create them, inspects the active runtime scheduler (Codex automations or Claude /schedule), compares live command/cadence/queue arguments against the expected contract, and reports grouped fleet health such as healthy, missing, unsupported, drifted, stale, or failing with remediation guidance."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Automation Status: $ARGUMENTS
+
+`/lisa:automation-status` is the operator-facing inspection surface for Lisa's unattended job fleet. It answers, for the **current repo only**, whether the recurring Lisa automations that should exist actually exist, still match Lisa's setup contract, and appear healthy based on the runtime metadata available.
+
+This command is **read-only** in v1. It does not create, update, resume, rerun, pause, or delete automations. It complements `/lisa:setup-automations`, `/lisa:tear-down-automations`, `/lisa:intake`, `/lisa:repair-intake`, `doctor`, and `monitor`; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects scheduler state and reports what it finds. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect only the Lisa automation fleet for the current project:
+
+- `intake-repair`
+- `intake-prd`
+- `intake-tickets`
+- `exploratory-bugs` when the current stack supports `exploratory-qa`
+- `exploratory-prds`
+
+Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
+
+## Runtime inspection
+
+Branch on the active runtime and prefer the runtime's native automation listing surface:
+
+- **Codex**: inspect Codex automations metadata first. Use backing-store files only as a fallback or to enrich timestamps when the runtime surface cannot provide enough status detail directly.
+- **Claude**: inspect the `/schedule` listing surface and any exposed recency or failure metadata available there.
+- **Other runtimes**: if no native recurring-task inspection exists, report that automation-status is unsupported in this runtime rather than guessing.
+
+The report must stay repo-scoped: inspect only automations whose names belong to the current repo's Lisa fleet prefix, and do not absorb unrelated automations into the result.
+
+## What to report
+
+For each expected automation, report:
+
+1. Whether it exists.
+2. Whether it is expected or intentionally unsupported.
+3. The configured command and cadence Lisa expects.
+4. Any detected drift in name, cadence, command shape, or queue arguments.
+5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
+6. A concise remediation hint when attention is needed.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+
+## Rules
+
+- Stay **read-only**. Never create, update, delete, enable, disable, or rerun automations from this skill.
+- Reuse `setup-automations` contract logic for expected fleet resolution, cadence, queue arguments, naming, and stack-specific support checks.
+- Distinguish **unsupported** from **missing**. An exploratory job omitted because the current stack lacks `exploratory-qa` is not a failure.
+- If the runtime cannot expose a field such as last-run timestamp or failure state, say that explicitly instead of implying health.
+- Keep the output operational and repo-scoped so operators can tell whether Lisa's unattended surfaces are present, current, and healthy right now.

--- a/plugins/lisa/skills/automation-status/agents/openai.yaml
+++ b/plugins/lisa/skills/automation-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Automation Status"
+short_description: "Read-only operator surface for the current project's Lisa automation fleet"
+default_prompt:
+  - "Use $automation-status: Read-only operator surface for the current project's Lisa automation fleet."

--- a/plugins/src/base/commands/automation-status.md
+++ b/plugins/src/base/commands/automation-status.md
@@ -1,0 +1,5 @@
+---
+description: "Inspect the current project's Lisa automation fleet and report whether the expected recurring jobs exist, match Lisa's setup contract, and show healthy recent activity. Read-only by default."
+---
+
+Use the /lisa:automation-status skill to inspect the current project's expected Lisa automations, compare them with the runtime's scheduler metadata, and report fleet health, drift, staleness, unsupported jobs, and remediation hints. $ARGUMENTS

--- a/plugins/src/base/skills/automation-status/SKILL.md
+++ b/plugins/src/base/skills/automation-status/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: automation-status
+description: "Read-only operator surface for the current project's Lisa automation fleet. Resolves the expected recurring jobs from the same setup-automations contract Lisa uses to create them, inspects the active runtime scheduler (Codex automations or Claude /schedule), compares live command/cadence/queue arguments against the expected contract, and reports grouped fleet health such as healthy, missing, unsupported, drifted, stale, or failing with remediation guidance."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Automation Status: $ARGUMENTS
+
+`/lisa:automation-status` is the operator-facing inspection surface for Lisa's unattended job fleet. It answers, for the **current repo only**, whether the recurring Lisa automations that should exist actually exist, still match Lisa's setup contract, and appear healthy based on the runtime metadata available.
+
+This command is **read-only** in v1. It does not create, update, resume, rerun, pause, or delete automations. It complements `/lisa:setup-automations`, `/lisa:tear-down-automations`, `/lisa:intake`, `/lisa:repair-intake`, `doctor`, and `monitor`; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects scheduler state and reports what it finds. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect only the Lisa automation fleet for the current project:
+
+- `intake-repair`
+- `intake-prd`
+- `intake-tickets`
+- `exploratory-bugs` when the current stack supports `exploratory-qa`
+- `exploratory-prds`
+
+Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
+
+## Runtime inspection
+
+Branch on the active runtime and prefer the runtime's native automation listing surface:
+
+- **Codex**: inspect Codex automations metadata first. Use backing-store files only as a fallback or to enrich timestamps when the runtime surface cannot provide enough status detail directly.
+- **Claude**: inspect the `/schedule` listing surface and any exposed recency or failure metadata available there.
+- **Other runtimes**: if no native recurring-task inspection exists, report that automation-status is unsupported in this runtime rather than guessing.
+
+The report must stay repo-scoped: inspect only automations whose names belong to the current repo's Lisa fleet prefix, and do not absorb unrelated automations into the result.
+
+## What to report
+
+For each expected automation, report:
+
+1. Whether it exists.
+2. Whether it is expected or intentionally unsupported.
+3. The configured command and cadence Lisa expects.
+4. Any detected drift in name, cadence, command shape, or queue arguments.
+5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
+6. A concise remediation hint when attention is needed.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+
+## Rules
+
+- Stay **read-only**. Never create, update, delete, enable, disable, or rerun automations from this skill.
+- Reuse `setup-automations` contract logic for expected fleet resolution, cadence, queue arguments, naming, and stack-specific support checks.
+- Distinguish **unsupported** from **missing**. An exploratory job omitted because the current stack lacks `exploratory-qa` is not a failure.
+- If the runtime cannot expose a field such as last-run timestamp or failure state, say that explicitly instead of implying health.
+- Keep the output operational and repo-scoped so operators can tell whether Lisa's unattended surfaces are present, current, and healthy right now.

--- a/tests/unit/strategies/automation-status-scaffold.test.ts
+++ b/tests/unit/strategies/automation-status-scaffold.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for the `/lisa:automation-status` command + skill scaffold.
+ *
+ * Issue #797 introduces only the distribution surfaces for the new operator
+ * command: the base command file, the base skill scaffold, and the generated
+ * `plugins/lisa` artifact mirror. The runtime adapters, contract resolution,
+ * drift detection, and read-only smoke coverage land in follow-up tickets.
+ *
+ * This suite proves the scaffold shipped in both plugin roots and documents the
+ * intended contract clearly enough for the later implementation work:
+ *   (1) the command delegates to `/lisa:automation-status`;
+ *   (2) the skill is read-only and repo-scoped;
+ *   (3) the skill reuses `setup-automations` / `tear-down-automations`
+ *       contract semantics rather than inventing a second source of truth;
+ *   (4) the skill names the expected fleet outcomes and runtime branches.
+ *
+ * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
+ * suite.
+ * @module tests/unit/strategies/automation-status-scaffold
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+const COMMAND_REL = "commands/automation-status.md";
+const SKILL_REL = "skills/automation-status/SKILL.md";
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("automation-status scaffold (#797)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const commandPath = path.resolve(root, COMMAND_REL);
+    const skillPath = path.resolve(root, SKILL_REL);
+
+    it("ships both the command and the skill in this plugin root", () => {
+      expect(existsSync(commandPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    it("uses a pass-through command that delegates to /lisa:automation-status", () => {
+      const command = read(root, COMMAND_REL);
+
+      expect(command).toMatch(/^---/);
+      expect(command).toMatch(/description:/);
+      expect(command).toMatch(/Use the \/lisa:automation-status skill/);
+      expect(command).toContain("$ARGUMENTS");
+    });
+
+    it("documents a read-only, repo-scoped operator surface", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/^---/);
+      expect(skill).toMatch(/name:\s*automation-status/);
+      expect(skill).toMatch(/allowed-tools:/);
+      expect(skill).toContain("Skill");
+      expect(skill).toContain("Bash");
+      expect(skill).toContain("Read");
+      expect(skill).toMatch(/read-only/i);
+      expect(skill).toMatch(/current repo|current project/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* ask for confirmation|do not ask for confirmation/i
+      );
+    });
+
+    it("reuses setup-automations contract semantics instead of inventing new ones", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/setup-automations/);
+      expect(skill).toMatch(/tear-down-automations/);
+      expect(skill).toMatch(/same contract/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* invent a second source of truth|do not invent a second source of truth/i
+      );
+      expect(skill).toMatch(/queue arguments/i);
+      expect(skill).toMatch(/stack-support/i);
+    });
+
+    it("names the expected runtime branches and fleet outcomes", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toContain("Codex");
+      expect(skill).toContain("Claude");
+      expect(skill).toMatch(/unsupported in this runtime/i);
+      expect(skill).toMatch(/healthy/i);
+      expect(skill).toMatch(/missing/i);
+      expect(skill).toMatch(/unsupported/i);
+      expect(skill).toMatch(/drift/i);
+      expect(skill).toMatch(/stale/i);
+      expect(skill).toMatch(/failing/i);
+      expect(skill).toMatch(/HEALTHY/);
+      expect(skill).toMatch(/ATTENTION_NEEDED/);
+      expect(skill).toMatch(/PARTIAL_SUPPORT/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the source command and skill scaffold for `/lisa:automation-status`
- mirror the new surface into the generated `plugins/lisa` distribution
- add a regression test that locks the scaffold contract across both plugin roots

## Testing
- bun test tests/unit/strategies/automation-status-scaffold.test.ts
- pre-push hook suite (slow lint, knip, unit tests with coverage, integration tests)

Fixes #797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/lisa:automation-status` command to inspect project automation fleet status, detect health issues, and identify drift and staleness.

* **Documentation**
  * Added comprehensive documentation for the new automation status command and skill with detailed specifications.

* **Tests**
  * Added unit tests validating the automation status command and skill implementation across plugin roots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->