### PR TITLE
feat(automation-status): add grouped fleet report renderer

### DIFF
--- a/plugins/lisa/scripts/automation-status-report.mjs
+++ b/plugins/lisa/scripts/automation-status-report.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Shared automation-status report helpers for the base Lisa operator surface.
+ *
+ * Keep this dependency-free so the grouped fleet rendering contract can ship in
+ * plugin distributions and downstream repos before the runtime adapters land.
+ */
+
+export const AUTOMATION_HEALTH_STATUSES = [
+  "HEALTHY",
+  "MISSING",
+  "UNSUPPORTED",
+  "DRIFTED",
+  "STALE",
+  "FAILING",
+];
+
+export const AUTOMATION_FLEET_VERDICTS = [
+  "HEALTHY",
+  "PARTIAL_SUPPORT",
+  "ATTENTION_NEEDED",
+];
+
+/**
+ * @typedef {"HEALTHY" | "MISSING" | "UNSUPPORTED" | "DRIFTED" | "STALE" | "FAILING"} AutomationHealthStatus
+ * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly status: AutomationHealthStatus
+ *   readonly summary: string
+ *   readonly expectedCadence?: string
+ *   readonly expectedCommand?: string
+ *   readonly observed?: string
+ *   readonly remediation?: string
+ * }} AutomationStatusItem
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly title: string
+ *   readonly items: readonly AutomationStatusItem[]
+ * }} AutomationStatusGroup
+ *
+ * @typedef {{
+ *   readonly runtime?: string
+ *   readonly generatedAt?: string
+ *   readonly groups: readonly AutomationStatusGroup[]
+ * }} AutomationStatusReportInput
+ */
+
+/**
+ * @param {readonly AutomationStatusGroup[]} groups
+ * @returns {AutomationFleetVerdict}
+ */
+export function computeAutomationFleetVerdict(groups) {
+  const items = groups.flatMap(group => group.items);
+  if (
+    items.some(item =>
+      ["MISSING", "DRIFTED", "STALE", "FAILING"].includes(item.status)
+    )
+  ) {
+    return "ATTENTION_NEEDED";
+  }
+  if (items.some(item => item.status === "UNSUPPORTED")) {
+    return "PARTIAL_SUPPORT";
+  }
+  return "HEALTHY";
+}
+
+/**
+ * @param {readonly AutomationStatusGroup[]} groups
+ * @returns {Record<AutomationHealthStatus, number>}
+ */
+export function countAutomationHealthStatuses(groups) {
+  return groups
+    .flatMap(group => group.items)
+    .reduce(
+      (counts, item) => ({
+        ...counts,
+        [item.status]: counts[item.status] + 1,
+      }),
+      {
+        HEALTHY: 0,
+        MISSING: 0,
+        UNSUPPORTED: 0,
+        DRIFTED: 0,
+        STALE: 0,
+        FAILING: 0,
+      }
+    );
+}
+
+/**
+ * @param {AutomationStatusReportInput} input
+ * @returns {{ readonly verdict: AutomationFleetVerdict, readonly counts: Record<AutomationHealthStatus, number>, readonly text: string }}
+ */
+export function renderAutomationStatusReport(input) {
+  const groups = input.groups.map(normalizeGroup);
+  const verdict = computeAutomationFleetVerdict(groups);
+  const counts = countAutomationHealthStatuses(groups);
+  const lines = [
+    `Overall verdict: ${verdict}`,
+    `Counts: ${AUTOMATION_HEALTH_STATUSES.map(status => `${counts[status]} ${status}`).join(", ")}`,
+  ];
+
+  if (input.runtime) {
+    lines.push(`Runtime inspected: ${input.runtime}`);
+  }
+
+  if (input.generatedAt) {
+    lines.push(`Generated at: ${input.generatedAt}`);
+  }
+
+  for (const group of groups) {
+    lines.push("", `${group.id}. ${group.title}`);
+    if (group.items.length === 0) {
+      lines.push(
+        "- UNSUPPORTED empty-group: no automations expected in this group"
+      );
+      continue;
+    }
+
+    for (const item of group.items) {
+      lines.push(`- ${item.status} ${item.id}: ${item.summary}`);
+      if (item.expectedCadence || item.expectedCommand) {
+        const cadence = item.expectedCadence ?? "cadence unavailable";
+        const command = item.expectedCommand ?? "command unavailable";
+        lines.push(`  Expected: ${cadence} -> ${command}`);
+      }
+      if (item.observed) {
+        lines.push(`  Observed: ${item.observed}`);
+      }
+      if (item.remediation) {
+        lines.push(`  Remediation: ${item.remediation}`);
+      }
+    }
+  }
+
+  return {
+    verdict,
+    counts,
+    text: `${lines.join("\n")}\n`,
+  };
+}
+
+/**
+ * @param {AutomationStatusGroup} group
+ * @returns {AutomationStatusGroup}
+ */
+function normalizeGroup(group) {
+  return {
+    ...group,
+    items: group.items.map(normalizeItem),
+  };
+}
+
+/**
+ * @param {AutomationStatusItem} item
+ * @returns {AutomationStatusItem}
+ */
+function normalizeItem(item) {
+  const normalizedStatus = AUTOMATION_HEALTH_STATUSES.includes(item.status)
+    ? item.status
+    : "FAILING";
+
+  return {
+    ...item,
+    status: normalizedStatus,
+  };
+}

--- a/plugins/lisa/skills/automation-status/SKILL.md
+++ b/plugins/lisa/skills/automation-status/SKILL.md
@@ -49,6 +49,23 @@ For each expected automation, report:
 
 Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
 
+Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
+
+```text
+Overall verdict: <VERDICT>
+Counts: <n HEALTHY>, <n MISSING>, <n UNSUPPORTED>, <n DRIFTED>, <n STALE>, <n FAILING>
+Runtime inspected: <runtime surface>
+Generated at: <ISO timestamp>
+
+1. <group title>
+- <STATUS> <automation-id>: <summary>
+  Expected: <cadence> -> <command>
+  Observed: <what the runtime exposed>
+  Remediation: <next step when attention is needed>
+```
+
+Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+
 ## Rules
 
 - Stay **read-only**. Never create, update, delete, enable, disable, or rerun automations from this skill.

--- a/plugins/src/base/scripts/automation-status-report.mjs
+++ b/plugins/src/base/scripts/automation-status-report.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Shared automation-status report helpers for the base Lisa operator surface.
+ *
+ * Keep this dependency-free so the grouped fleet rendering contract can ship in
+ * plugin distributions and downstream repos before the runtime adapters land.
+ */
+
+export const AUTOMATION_HEALTH_STATUSES = [
+  "HEALTHY",
+  "MISSING",
+  "UNSUPPORTED",
+  "DRIFTED",
+  "STALE",
+  "FAILING",
+];
+
+export const AUTOMATION_FLEET_VERDICTS = [
+  "HEALTHY",
+  "PARTIAL_SUPPORT",
+  "ATTENTION_NEEDED",
+];
+
+/**
+ * @typedef {"HEALTHY" | "MISSING" | "UNSUPPORTED" | "DRIFTED" | "STALE" | "FAILING"} AutomationHealthStatus
+ * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly status: AutomationHealthStatus
+ *   readonly summary: string
+ *   readonly expectedCadence?: string
+ *   readonly expectedCommand?: string
+ *   readonly observed?: string
+ *   readonly remediation?: string
+ * }} AutomationStatusItem
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly title: string
+ *   readonly items: readonly AutomationStatusItem[]
+ * }} AutomationStatusGroup
+ *
+ * @typedef {{
+ *   readonly runtime?: string
+ *   readonly generatedAt?: string
+ *   readonly groups: readonly AutomationStatusGroup[]
+ * }} AutomationStatusReportInput
+ */
+
+/**
+ * @param {readonly AutomationStatusGroup[]} groups
+ * @returns {AutomationFleetVerdict}
+ */
+export function computeAutomationFleetVerdict(groups) {
+  const items = groups.flatMap(group => group.items);
+  if (
+    items.some(item =>
+      ["MISSING", "DRIFTED", "STALE", "FAILING"].includes(item.status)
+    )
+  ) {
+    return "ATTENTION_NEEDED";
+  }
+  if (items.some(item => item.status === "UNSUPPORTED")) {
+    return "PARTIAL_SUPPORT";
+  }
+  return "HEALTHY";
+}
+
+/**
+ * @param {readonly AutomationStatusGroup[]} groups
+ * @returns {Record<AutomationHealthStatus, number>}
+ */
+export function countAutomationHealthStatuses(groups) {
+  return groups
+    .flatMap(group => group.items)
+    .reduce(
+      (counts, item) => ({
+        ...counts,
+        [item.status]: counts[item.status] + 1,
+      }),
+      {
+        HEALTHY: 0,
+        MISSING: 0,
+        UNSUPPORTED: 0,
+        DRIFTED: 0,
+        STALE: 0,
+        FAILING: 0,
+      }
+    );
+}
+
+/**
+ * @param {AutomationStatusReportInput} input
+ * @returns {{ readonly verdict: AutomationFleetVerdict, readonly counts: Record<AutomationHealthStatus, number>, readonly text: string }}
+ */
+export function renderAutomationStatusReport(input) {
+  const groups = input.groups.map(normalizeGroup);
+  const verdict = computeAutomationFleetVerdict(groups);
+  const counts = countAutomationHealthStatuses(groups);
+  const lines = [
+    `Overall verdict: ${verdict}`,
+    `Counts: ${AUTOMATION_HEALTH_STATUSES.map(status => `${counts[status]} ${status}`).join(", ")}`,
+  ];
+
+  if (input.runtime) {
+    lines.push(`Runtime inspected: ${input.runtime}`);
+  }
+
+  if (input.generatedAt) {
+    lines.push(`Generated at: ${input.generatedAt}`);
+  }
+
+  for (const group of groups) {
+    lines.push("", `${group.id}. ${group.title}`);
+    if (group.items.length === 0) {
+      lines.push(
+        "- UNSUPPORTED empty-group: no automations expected in this group"
+      );
+      continue;
+    }
+
+    for (const item of group.items) {
+      lines.push(`- ${item.status} ${item.id}: ${item.summary}`);
+      if (item.expectedCadence || item.expectedCommand) {
+        const cadence = item.expectedCadence ?? "cadence unavailable";
+        const command = item.expectedCommand ?? "command unavailable";
+        lines.push(`  Expected: ${cadence} -> ${command}`);
+      }
+      if (item.observed) {
+        lines.push(`  Observed: ${item.observed}`);
+      }
+      if (item.remediation) {
+        lines.push(`  Remediation: ${item.remediation}`);
+      }
+    }
+  }
+
+  return {
+    verdict,
+    counts,
+    text: `${lines.join("\n")}\n`,
+  };
+}
+
+/**
+ * @param {AutomationStatusGroup} group
+ * @returns {AutomationStatusGroup}
+ */
+function normalizeGroup(group) {
+  return {
+    ...group,
+    items: group.items.map(normalizeItem),
+  };
+}
+
+/**
+ * @param {AutomationStatusItem} item
+ * @returns {AutomationStatusItem}
+ */
+function normalizeItem(item) {
+  const normalizedStatus = AUTOMATION_HEALTH_STATUSES.includes(item.status)
+    ? item.status
+    : "FAILING";
+
+  return {
+    ...item,
+    status: normalizedStatus,
+  };
+}

--- a/plugins/src/base/skills/automation-status/SKILL.md
+++ b/plugins/src/base/skills/automation-status/SKILL.md
@@ -49,6 +49,23 @@ For each expected automation, report:
 
 Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
 
+Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
+
+```text
+Overall verdict: <VERDICT>
+Counts: <n HEALTHY>, <n MISSING>, <n UNSUPPORTED>, <n DRIFTED>, <n STALE>, <n FAILING>
+Runtime inspected: <runtime surface>
+Generated at: <ISO timestamp>
+
+1. <group title>
+- <STATUS> <automation-id>: <summary>
+  Expected: <cadence> -> <command>
+  Observed: <what the runtime exposed>
+  Remediation: <next step when attention is needed>
+```
+
+Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+
 ## Rules
 
 - Stay **read-only**. Never create, update, delete, enable, disable, or rerun automations from this skill.

--- a/tests/unit/strategies/automation-status-report-rendering.test.ts
+++ b/tests/unit/strategies/automation-status-report-rendering.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression coverage for the shared automation-status report renderer.
+ *
+ * Issue #798 adds the grouped fleet output contract before the runtime adapter
+ * work lands. This suite proves the renderer computes the verdict ladder,
+ * keeps observed facts separate from remediation text, and renders expected
+ * cadence/command details for each automation row.
+ * @module tests/unit/strategies/automation-status-report-rendering
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  computeAutomationFleetVerdict,
+  countAutomationHealthStatuses,
+  renderAutomationStatusReport,
+} from "../../../plugins/src/base/scripts/automation-status-report.mjs";
+
+const EXPLORATORY_QA_UNSUPPORTED =
+  "The current repo does not expose the exploratory-qa skill surface.";
+const EXPLORATORY_AUTOMATIONS_GROUP = "Exploratory automations";
+
+describe("automation-status report rendering (#798)", () => {
+  it("renders grouped fleet sections with expected contract and remediation lines", () => {
+    const report = renderAutomationStatusReport({
+      runtime: "Codex automations",
+      generatedAt: "2026-05-26T02:15:00.000Z",
+      groups: [
+        {
+          id: "1",
+          title: "Core queue automations",
+          items: [
+            {
+              id: "intake-prd",
+              status: "HEALTHY",
+              summary: "expected automation exists and matches the contract",
+              expectedCadence: "every 60 minutes",
+              expectedCommand: "/lisa:intake github intake_mode=prd",
+              observed:
+                "Last run completed 12 minutes ago with the configured command.",
+            },
+            {
+              id: "intake-tickets",
+              status: "DRIFTED",
+              summary: "cadence and queue arguments no longer match setup",
+              expectedCadence: "every 10 minutes",
+              expectedCommand: "/lisa:intake github intake_mode=build",
+              observed:
+                "Live automation runs every 30 minutes with stale queue arguments.",
+              remediation:
+                "Re-run `/lisa:setup-automations` or update the scheduler entry to the expected command and cadence.",
+            },
+          ],
+        },
+        {
+          id: "2",
+          title: EXPLORATORY_AUTOMATIONS_GROUP,
+          items: [
+            {
+              id: "exploratory-bugs",
+              status: "UNSUPPORTED",
+              summary: "exploratory-qa is not installed for this stack",
+              expectedCadence: "every 6 hours",
+              expectedCommand: "/lisa:product-walkthrough /",
+              observed: EXPLORATORY_QA_UNSUPPORTED,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(report.verdict).toBe("ATTENTION_NEEDED");
+    expect(report.counts).toEqual({
+      HEALTHY: 1,
+      MISSING: 0,
+      UNSUPPORTED: 1,
+      DRIFTED: 1,
+      STALE: 0,
+      FAILING: 0,
+    });
+    expect(report.text).toContain("Overall verdict: ATTENTION_NEEDED");
+    expect(report.text).toContain(
+      "Counts: 1 HEALTHY, 0 MISSING, 1 UNSUPPORTED, 1 DRIFTED, 0 STALE, 0 FAILING"
+    );
+    expect(report.text).toContain("Runtime inspected: Codex automations");
+    expect(report.text).toContain("1. Core queue automations");
+    expect(report.text).toContain(
+      "- DRIFTED intake-tickets: cadence and queue arguments no longer match setup"
+    );
+    expect(report.text).toContain(
+      "Expected: every 10 minutes -> /lisa:intake github intake_mode=build"
+    );
+    expect(report.text).toContain(
+      "Observed: Live automation runs every 30 minutes with stale queue arguments."
+    );
+    expect(report.text).toContain(
+      "Remediation: Re-run `/lisa:setup-automations` or update the scheduler entry to the expected command and cadence."
+    );
+  });
+
+  it("returns HEALTHY when every expected automation is healthy", () => {
+    expect(
+      computeAutomationFleetVerdict([
+        {
+          id: "1",
+          title: "Core queue automations",
+          items: [
+            {
+              id: "intake-repair",
+              status: "HEALTHY",
+              summary: "present and current",
+            },
+          ],
+        },
+      ])
+    ).toBe("HEALTHY");
+  });
+
+  it("returns PARTIAL_SUPPORT when only unsupported entries keep the fleet from full coverage", () => {
+    expect(
+      computeAutomationFleetVerdict([
+        {
+          id: "2",
+          title: EXPLORATORY_AUTOMATIONS_GROUP,
+          items: [
+            {
+              id: "exploratory-bugs",
+              status: "UNSUPPORTED",
+              summary: "stack does not support exploratory-qa",
+            },
+          ],
+        },
+      ])
+    ).toBe("PARTIAL_SUPPORT");
+  });
+
+  it("counts health states across all groups", () => {
+    expect(
+      countAutomationHealthStatuses([
+        {
+          id: "1",
+          title: "Queue automations",
+          items: [
+            { id: "one", status: "HEALTHY", summary: "ok" },
+            { id: "two", status: "MISSING", summary: "missing" },
+          ],
+        },
+        {
+          id: "2",
+          title: "Exploratory automations",
+          items: [
+            { id: "three", status: "STALE", summary: "stale" },
+            { id: "four", status: "FAILING", summary: "failing" },
+          ],
+        },
+      ])
+    ).toEqual({
+      HEALTHY: 1,
+      MISSING: 1,
+      UNSUPPORTED: 0,
+      DRIFTED: 0,
+      STALE: 1,
+      FAILING: 1,
+    });
+  });
+
+  it("renders empty groups as intentional unsupported buckets", () => {
+    const report = renderAutomationStatusReport({
+      groups: [{ id: "4", title: EXPLORATORY_AUTOMATIONS_GROUP, items: [] }],
+    });
+
+    expect(report.verdict).toBe("HEALTHY");
+    expect(report.text).toContain(`4. ${EXPLORATORY_AUTOMATIONS_GROUP}`);
+    expect(report.text).toContain(
+      "- UNSUPPORTED empty-group: no automations expected in this group"
+    );
+  });
+});

--- a/tests/unit/strategies/automation-status-scaffold.test.ts
+++ b/tests/unit/strategies/automation-status-scaffold.test.ts
@@ -26,6 +26,7 @@ import { describe, expect, it } from "vitest";
 const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
 const COMMAND_REL = "commands/automation-status.md";
 const SKILL_REL = "skills/automation-status/SKILL.md";
+const SCRIPT_REL = "scripts/automation-status-report.mjs";
 
 const read = (root: string, rel: string): string =>
   readFileSync(path.resolve(root, rel), "utf8");
@@ -34,10 +35,12 @@ describe("automation-status scaffold (#797)", () => {
   describe.each(PLUGIN_ROOTS)("%s", root => {
     const commandPath = path.resolve(root, COMMAND_REL);
     const skillPath = path.resolve(root, SKILL_REL);
+    const scriptPath = path.resolve(root, SCRIPT_REL);
 
-    it("ships both the command and the skill in this plugin root", () => {
+    it("ships the command, skill, and shared report script in this plugin root", () => {
       expect(existsSync(commandPath)).toBe(true);
       expect(existsSync(skillPath)).toBe(true);
+      expect(existsSync(scriptPath)).toBe(true);
     });
 
     it("uses a pass-through command that delegates to /lisa:automation-status", () => {
@@ -93,6 +96,28 @@ describe("automation-status scaffold (#797)", () => {
       expect(skill).toMatch(/HEALTHY/);
       expect(skill).toMatch(/ATTENTION_NEEDED/);
       expect(skill).toMatch(/PARTIAL_SUPPORT/);
+    });
+
+    it("documents the shared grouped report rendering contract", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toContain("scripts/automation-status-report.mjs");
+      expect(skill).toMatch(/Overall verdict: <VERDICT>/);
+      expect(skill).toMatch(/Counts:/);
+      expect(skill).toMatch(/Runtime inspected:/);
+      expect(skill).toMatch(/Expected:/);
+      expect(skill).toMatch(/Observed:/);
+      expect(skill).toMatch(/Remediation:/);
+    });
+
+    it("ships report helper exports for later runtime adapters", () => {
+      const script = read(root, SCRIPT_REL);
+
+      expect(script).toContain("computeAutomationFleetVerdict");
+      expect(script).toContain("countAutomationHealthStatuses");
+      expect(script).toContain("renderAutomationStatusReport");
+      expect(script).toMatch(/Overall verdict:/);
+      expect(script).toMatch(/Remediation:/);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a shared automation-status report renderer with grouped fleet verdict logic
- document the grouped report contract in the automation-status skill and generated plugin copy
- add renderer and scaffold parity regression coverage

## Testing
- bun test tests/unit/strategies/automation-status-report-rendering.test.ts
- bun test tests/unit/strategies/automation-status-scaffold.test.ts
- pre-push hook: bun audit, eslint slow config, knip, vitest with coverage, vitest integration

## Notes
- this branch is stacked on the still-open #805 scaffold work, so the diff includes that prerequisite until #805 merges

Refs #798