### PR TITLE
feat(automation-status): resolve expected fleet contract

### DIFF
--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+/**
+ * Shared automation-status expected-fleet helpers.
+ *
+ * This module resolves the same naming, queue arguments, cadence, and
+ * exploratory support decisions documented by `/lisa:setup-automations`, so
+ * automation-status and later runtime adapters do not invent a second source of
+ * truth.
+ */
+
+export const AUTOMATION_EXPECTED_CADENCES = {
+  "intake-repair": {
+    human: "every 60 minutes",
+    rrule: "FREQ=HOURLY;INTERVAL=1",
+  },
+  "intake-prd": {
+    human: "every 60 minutes",
+    rrule: "FREQ=HOURLY;INTERVAL=1",
+  },
+  "intake-tickets": {
+    human: "every 10 minutes",
+    rrule: "FREQ=MINUTELY;INTERVAL=10",
+  },
+  "exploratory-bugs": {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "exploratory-prds": {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+};
+
+export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+const GITHUB_REMOTE_PATTERNS = [
+  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+];
+
+/**
+ * @typedef {{
+ *   readonly id: string
+ *   readonly automationId: string
+ *   readonly expectedCadence: string
+ *   readonly expectedRRule: string
+ *   readonly expectedCommand: string
+ *   readonly group: "core" | "exploratory"
+ * }} ExpectedAutomationEntry
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly automationId: string
+ *   readonly group: "core" | "exploratory"
+ *   readonly reason: string
+ *   readonly expectedCadence: string
+ *   readonly expectedRRule: string
+ * }} UnsupportedAutomationEntry
+ */
+
+/**
+ * Resolve the stable project identifier and automation prefix used by
+ * `/lisa:setup-automations`.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {{ readonly owner: string, readonly repo: string, readonly project: string, readonly automationPrefix: string }}
+ */
+export function resolveAutomationProjectIdentity(input = {}) {
+  const githubRef = resolveGithubRepoRef(
+    input.config ?? {},
+    input.gitRemoteUrl
+  );
+
+  if (!githubRef) {
+    throw new Error(
+      "Unable to resolve repo identity for automation naming. Configure github.org/github.repo or provide a GitHub origin remote."
+    );
+  }
+
+  const project = slugifyProjectToken(`${githubRef.owner}-${githubRef.repo}`);
+
+  return {
+    ...githubRef,
+    project,
+    automationPrefix: `lisa-auto-${project}-`,
+  };
+}
+
+/**
+ * Resolve the expected Lisa automation fleet for the current repo.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ *   readonly detectedTypes?: readonly string[]
+ *   readonly autoStartPrds?: boolean | string
+ *   readonly autoStartTickets?: boolean | string
+ * }} input
+ * @returns {{
+ *   readonly owner: string
+ *   readonly repo: string
+ *   readonly project: string
+ *   readonly automationPrefix: string
+ *   readonly expected: readonly ExpectedAutomationEntry[]
+ *   readonly unsupported: readonly UnsupportedAutomationEntry[]
+ * }}
+ */
+export function resolveExpectedAutomationFleet(input = {}) {
+  const config = input.config ?? {};
+  const identity = resolveAutomationProjectIdentity(input);
+  const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
+  const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const detectedTypes = input.detectedTypes ?? [];
+
+  const tracker = config.tracker;
+  const source = resolvePrdSource(config);
+  const prdQueue = resolvePrdQueueArgument(config, source);
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  const repairQueue = resolveRepairQueueArgument(config, source, tracker);
+
+  const expected = [
+    createExpectedEntry(
+      identity,
+      "intake-repair",
+      `/lisa:repair-intake ${repairQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "intake-prd",
+      `/lisa:intake ${prdQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "intake-tickets",
+      `/lisa:intake ${buildQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "exploratory-prds",
+      `/lisa:project-ideation prd_ready=${String(autoStartPrds)}`,
+      "exploratory"
+    ),
+  ];
+
+  const exploratoryStack = resolveExploratoryQaStack(detectedTypes);
+  const unsupported = [];
+
+  if (exploratoryStack) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "exploratory-bugs",
+        `/lisa-${exploratoryStack}:exploratory-qa ready=${String(autoStartTickets)}`,
+        "exploratory"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "exploratory-bugs",
+        "This repository does not ship an exploratory-qa command surface."
+      )
+    );
+  }
+
+  return {
+    ...identity,
+    expected,
+    unsupported,
+  };
+}
+
+/**
+ * Return the supported exploratory-qa surface for the detected host stacks.
+ *
+ * @param {readonly string[]} detectedTypes
+ * @returns {string | null}
+ */
+export function resolveExploratoryQaStack(detectedTypes = []) {
+  for (const stack of EXPLORATORY_QA_STACK_PRIORITY) {
+    if (detectedTypes.includes(stack)) {
+      return stack;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {{ readonly automationPrefix: string }} identity
+ * @param {string} id
+ * @param {string} expectedCommand
+ * @param {"core" | "exploratory"} group
+ * @returns {ExpectedAutomationEntry}
+ */
+function createExpectedEntry(identity, id, expectedCommand, group) {
+  const cadence = AUTOMATION_EXPECTED_CADENCES[id];
+  return {
+    id,
+    automationId: `${identity.automationPrefix}${id}`,
+    expectedCadence: cadence.human,
+    expectedRRule: cadence.rrule,
+    expectedCommand,
+    group,
+  };
+}
+
+/**
+ * @param {{ readonly automationPrefix: string }} identity
+ * @param {string} id
+ * @param {string} reason
+ * @returns {UnsupportedAutomationEntry}
+ */
+function createUnsupportedEntry(identity, id, reason) {
+  const cadence = AUTOMATION_EXPECTED_CADENCES[id];
+  return {
+    id,
+    automationId: `${identity.automationPrefix}${id}`,
+    expectedCadence: cadence.human,
+    expectedRRule: cadence.rrule,
+    group: "exploratory",
+    reason,
+  };
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} source
+ * @returns {string}
+ */
+function resolvePrdQueueArgument(config, source) {
+  switch (source) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=prd";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "notion": {
+      const databaseId = config.notion?.prdDatabaseId;
+      if (!databaseId) {
+        throw new Error(
+          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
+        );
+      }
+      return databaseId;
+    }
+    case "confluence": {
+      const parentPageId = config.confluence?.parentPageId;
+      const spaceKey = config.confluence?.spaceKey;
+      if (!parentPageId && !spaceKey) {
+        throw new Error(
+          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
+        );
+      }
+      return parentPageId ?? spaceKey;
+    }
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the PRD queue: jira.project is required when source=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the PRD queue from config. Set source or use tracker=github self-host with github.org/github.repo."
+      );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} tracker
+ * @returns {string}
+ */
+function resolveBuildQueueArgument(config, tracker) {
+  switch (tracker) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=build";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the build queue: jira.project is required when tracker=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
+      );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} source
+ * @param {string | undefined} tracker
+ * @returns {string}
+ */
+function resolveRepairQueueArgument(config, source, tracker) {
+  if (tracker === "github" && source === "github") {
+    requireGithubRepo(config);
+    return "github intake_mode=both";
+  }
+
+  if (tracker === "linear" && source === "linear") {
+    requireLinearWorkspace(config);
+    return "linear";
+  }
+
+  if (tracker === "jira" && source === "jira") {
+    const project = config.jira?.project;
+    if (!project) {
+      throw new Error(
+        "Unable to resolve the repair queue: jira.project is required when tracker=jira and source=jira."
+      );
+    }
+    return project;
+  }
+
+  if (tracker === "github" && source === undefined) {
+    requireGithubRepo(config);
+    return "github intake_mode=both";
+  }
+
+  throw new Error(
+    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
+  );
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @returns {string | undefined}
+ */
+function resolvePrdSource(config) {
+  if (typeof config.source === "string" && config.source.length > 0) {
+    return config.source;
+  }
+
+  if (
+    config.tracker === "github" &&
+    config.github?.org &&
+    config.github?.repo
+  ) {
+    return "github";
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {{ readonly owner: string, readonly repo: string } | null}
+ */
+function resolveGithubRepoRef(config, gitRemoteUrl) {
+  const owner = config.github?.org;
+  const repo = config.github?.repo;
+
+  if (owner && repo) {
+    return { owner, repo };
+  }
+
+  if (!gitRemoteUrl) {
+    return null;
+  }
+
+  for (const pattern of GITHUB_REMOTE_PATTERNS) {
+    const match = gitRemoteUrl.match(pattern);
+    if (match?.groups?.owner && match.groups.repo) {
+      return {
+        owner: match.groups.owner,
+        repo: match.groups.repo,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireGithubRepo(config) {
+  if (!config.github?.org || !config.github?.repo) {
+    throw new Error(
+      "Unable to resolve the GitHub queue: github.org and github.repo are required."
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireLinearWorkspace(config) {
+  if (!config.linear?.workspace) {
+    throw new Error(
+      "Unable to resolve the Linear queue: linear.workspace is required."
+    );
+  }
+}
+
+/**
+ * @param {boolean | string | undefined} value
+ * @returns {boolean}
+ */
+function normalizeBooleanFlag(value) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value.toLowerCase() === "true";
+  }
+
+  return false;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function slugifyProjectToken(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+/**
+ * Shared automation-status expected-fleet helpers.
+ *
+ * This module resolves the same naming, queue arguments, cadence, and
+ * exploratory support decisions documented by `/lisa:setup-automations`, so
+ * automation-status and later runtime adapters do not invent a second source of
+ * truth.
+ */
+
+export const AUTOMATION_EXPECTED_CADENCES = {
+  "intake-repair": {
+    human: "every 60 minutes",
+    rrule: "FREQ=HOURLY;INTERVAL=1",
+  },
+  "intake-prd": {
+    human: "every 60 minutes",
+    rrule: "FREQ=HOURLY;INTERVAL=1",
+  },
+  "intake-tickets": {
+    human: "every 10 minutes",
+    rrule: "FREQ=MINUTELY;INTERVAL=10",
+  },
+  "exploratory-bugs": {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "exploratory-prds": {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+};
+
+export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+const GITHUB_REMOTE_PATTERNS = [
+  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+];
+
+/**
+ * @typedef {{
+ *   readonly id: string
+ *   readonly automationId: string
+ *   readonly expectedCadence: string
+ *   readonly expectedRRule: string
+ *   readonly expectedCommand: string
+ *   readonly group: "core" | "exploratory"
+ * }} ExpectedAutomationEntry
+ *
+ * @typedef {{
+ *   readonly id: string
+ *   readonly automationId: string
+ *   readonly group: "core" | "exploratory"
+ *   readonly reason: string
+ *   readonly expectedCadence: string
+ *   readonly expectedRRule: string
+ * }} UnsupportedAutomationEntry
+ */
+
+/**
+ * Resolve the stable project identifier and automation prefix used by
+ * `/lisa:setup-automations`.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {{ readonly owner: string, readonly repo: string, readonly project: string, readonly automationPrefix: string }}
+ */
+export function resolveAutomationProjectIdentity(input = {}) {
+  const githubRef = resolveGithubRepoRef(
+    input.config ?? {},
+    input.gitRemoteUrl
+  );
+
+  if (!githubRef) {
+    throw new Error(
+      "Unable to resolve repo identity for automation naming. Configure github.org/github.repo or provide a GitHub origin remote."
+    );
+  }
+
+  const project = slugifyProjectToken(`${githubRef.owner}-${githubRef.repo}`);
+
+  return {
+    ...githubRef,
+    project,
+    automationPrefix: `lisa-auto-${project}-`,
+  };
+}
+
+/**
+ * Resolve the expected Lisa automation fleet for the current repo.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ *   readonly detectedTypes?: readonly string[]
+ *   readonly autoStartPrds?: boolean | string
+ *   readonly autoStartTickets?: boolean | string
+ * }} input
+ * @returns {{
+ *   readonly owner: string
+ *   readonly repo: string
+ *   readonly project: string
+ *   readonly automationPrefix: string
+ *   readonly expected: readonly ExpectedAutomationEntry[]
+ *   readonly unsupported: readonly UnsupportedAutomationEntry[]
+ * }}
+ */
+export function resolveExpectedAutomationFleet(input = {}) {
+  const config = input.config ?? {};
+  const identity = resolveAutomationProjectIdentity(input);
+  const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
+  const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const detectedTypes = input.detectedTypes ?? [];
+
+  const tracker = config.tracker;
+  const source = resolvePrdSource(config);
+  const prdQueue = resolvePrdQueueArgument(config, source);
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  const repairQueue = resolveRepairQueueArgument(config, source, tracker);
+
+  const expected = [
+    createExpectedEntry(
+      identity,
+      "intake-repair",
+      `/lisa:repair-intake ${repairQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "intake-prd",
+      `/lisa:intake ${prdQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "intake-tickets",
+      `/lisa:intake ${buildQueue}`,
+      "core"
+    ),
+    createExpectedEntry(
+      identity,
+      "exploratory-prds",
+      `/lisa:project-ideation prd_ready=${String(autoStartPrds)}`,
+      "exploratory"
+    ),
+  ];
+
+  const exploratoryStack = resolveExploratoryQaStack(detectedTypes);
+  const unsupported = [];
+
+  if (exploratoryStack) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "exploratory-bugs",
+        `/lisa-${exploratoryStack}:exploratory-qa ready=${String(autoStartTickets)}`,
+        "exploratory"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "exploratory-bugs",
+        "This repository does not ship an exploratory-qa command surface."
+      )
+    );
+  }
+
+  return {
+    ...identity,
+    expected,
+    unsupported,
+  };
+}
+
+/**
+ * Return the supported exploratory-qa surface for the detected host stacks.
+ *
+ * @param {readonly string[]} detectedTypes
+ * @returns {string | null}
+ */
+export function resolveExploratoryQaStack(detectedTypes = []) {
+  for (const stack of EXPLORATORY_QA_STACK_PRIORITY) {
+    if (detectedTypes.includes(stack)) {
+      return stack;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {{ readonly automationPrefix: string }} identity
+ * @param {string} id
+ * @param {string} expectedCommand
+ * @param {"core" | "exploratory"} group
+ * @returns {ExpectedAutomationEntry}
+ */
+function createExpectedEntry(identity, id, expectedCommand, group) {
+  const cadence = AUTOMATION_EXPECTED_CADENCES[id];
+  return {
+    id,
+    automationId: `${identity.automationPrefix}${id}`,
+    expectedCadence: cadence.human,
+    expectedRRule: cadence.rrule,
+    expectedCommand,
+    group,
+  };
+}
+
+/**
+ * @param {{ readonly automationPrefix: string }} identity
+ * @param {string} id
+ * @param {string} reason
+ * @returns {UnsupportedAutomationEntry}
+ */
+function createUnsupportedEntry(identity, id, reason) {
+  const cadence = AUTOMATION_EXPECTED_CADENCES[id];
+  return {
+    id,
+    automationId: `${identity.automationPrefix}${id}`,
+    expectedCadence: cadence.human,
+    expectedRRule: cadence.rrule,
+    group: "exploratory",
+    reason,
+  };
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} source
+ * @returns {string}
+ */
+function resolvePrdQueueArgument(config, source) {
+  switch (source) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=prd";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "notion": {
+      const databaseId = config.notion?.prdDatabaseId;
+      if (!databaseId) {
+        throw new Error(
+          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
+        );
+      }
+      return databaseId;
+    }
+    case "confluence": {
+      const parentPageId = config.confluence?.parentPageId;
+      const spaceKey = config.confluence?.spaceKey;
+      if (!parentPageId && !spaceKey) {
+        throw new Error(
+          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
+        );
+      }
+      return parentPageId ?? spaceKey;
+    }
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the PRD queue: jira.project is required when source=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the PRD queue from config. Set source or use tracker=github self-host with github.org/github.repo."
+      );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} tracker
+ * @returns {string}
+ */
+function resolveBuildQueueArgument(config, tracker) {
+  switch (tracker) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=build";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the build queue: jira.project is required when tracker=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
+      );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} source
+ * @param {string | undefined} tracker
+ * @returns {string}
+ */
+function resolveRepairQueueArgument(config, source, tracker) {
+  if (tracker === "github" && source === "github") {
+    requireGithubRepo(config);
+    return "github intake_mode=both";
+  }
+
+  if (tracker === "linear" && source === "linear") {
+    requireLinearWorkspace(config);
+    return "linear";
+  }
+
+  if (tracker === "jira" && source === "jira") {
+    const project = config.jira?.project;
+    if (!project) {
+      throw new Error(
+        "Unable to resolve the repair queue: jira.project is required when tracker=jira and source=jira."
+      );
+    }
+    return project;
+  }
+
+  if (tracker === "github" && source === undefined) {
+    requireGithubRepo(config);
+    return "github intake_mode=both";
+  }
+
+  throw new Error(
+    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
+  );
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @returns {string | undefined}
+ */
+function resolvePrdSource(config) {
+  if (typeof config.source === "string" && config.source.length > 0) {
+    return config.source;
+  }
+
+  if (
+    config.tracker === "github" &&
+    config.github?.org &&
+    config.github?.repo
+  ) {
+    return "github";
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {{ readonly owner: string, readonly repo: string } | null}
+ */
+function resolveGithubRepoRef(config, gitRemoteUrl) {
+  const owner = config.github?.org;
+  const repo = config.github?.repo;
+
+  if (owner && repo) {
+    return { owner, repo };
+  }
+
+  if (!gitRemoteUrl) {
+    return null;
+  }
+
+  for (const pattern of GITHUB_REMOTE_PATTERNS) {
+    const match = gitRemoteUrl.match(pattern);
+    if (match?.groups?.owner && match.groups.repo) {
+      return {
+        owner: match.groups.owner,
+        repo: match.groups.repo,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireGithubRepo(config) {
+  if (!config.github?.org || !config.github?.repo) {
+    throw new Error(
+      "Unable to resolve the GitHub queue: github.org and github.repo are required."
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireLinearWorkspace(config) {
+  if (!config.linear?.workspace) {
+    throw new Error(
+      "Unable to resolve the Linear queue: linear.workspace is required."
+    );
+  }
+}
+
+/**
+ * @param {boolean | string | undefined} value
+ * @returns {boolean}
+ */
+function normalizeBooleanFlag(value) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value.toLowerCase() === "true";
+  }
+
+  return false;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function slugifyProjectToken(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/tests/unit/strategies/automation-status-expected-fleet.test.ts
+++ b/tests/unit/strategies/automation-status-expected-fleet.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression coverage for automation-status expected fleet resolution.
+ *
+ * Issue #799 adds the shared resolver that turns the setup-automations
+ * contract into concrete expected automation entries for the current repo:
+ * naming, queue arguments, auto-start flags, and unsupported exploratory jobs.
+ * @module tests/unit/strategies/automation-status-expected-fleet
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveAutomationProjectIdentity,
+  resolveExpectedAutomationFleet,
+} from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+
+describe("automation-status expected fleet (#799)", () => {
+  it("resolves the self-host GitHub Lisa fleet and flags unsupported exploratory-bugs", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: "github",
+        github: {
+          org: "CodySwannGT",
+          repo: "lisa",
+        },
+      },
+      detectedTypes: ["typescript", "npm-package"],
+    });
+
+    expect(fleet.project).toBe("codyswanngt-lisa");
+    expect(fleet.automationPrefix).toBe("lisa-auto-codyswanngt-lisa-");
+    expect(fleet.expected).toEqual([
+      expect.objectContaining({
+        id: "intake-repair",
+        automationId: "lisa-auto-codyswanngt-lisa-intake-repair",
+        expectedCadence: "every 60 minutes",
+        expectedRRule: "FREQ=HOURLY;INTERVAL=1",
+        expectedCommand: "/lisa:repair-intake github intake_mode=both",
+      }),
+      expect.objectContaining({
+        id: "intake-prd",
+        expectedCommand: "/lisa:intake github intake_mode=prd",
+      }),
+      expect.objectContaining({
+        id: "intake-tickets",
+        expectedCadence: "every 10 minutes",
+        expectedRRule: "FREQ=MINUTELY;INTERVAL=10",
+        expectedCommand: "/lisa:intake github intake_mode=build",
+      }),
+      expect.objectContaining({
+        id: "exploratory-prds",
+        expectedCommand: "/lisa:project-ideation prd_ready=false",
+      }),
+    ]);
+    expect(fleet.unsupported).toEqual([
+      expect.objectContaining({
+        id: "exploratory-bugs",
+        automationId: "lisa-auto-codyswanngt-lisa-exploratory-bugs",
+        reason:
+          "This repository does not ship an exploratory-qa command surface.",
+      }),
+    ]);
+  });
+
+  it("emits the stack-specific exploratory command and auto-start flags when supported", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: "github",
+        source: "github",
+        github: {
+          org: "Acme",
+          repo: "mobile-app",
+        },
+      },
+      detectedTypes: ["expo", "typescript"],
+      autoStartPrds: true,
+      autoStartTickets: "true",
+    });
+
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: "exploratory-bugs",
+        expectedCadence: "once a day",
+        expectedCommand: "/lisa-expo:exploratory-qa ready=true",
+      })
+    );
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: "exploratory-prds",
+        expectedCommand: "/lisa:project-ideation prd_ready=true",
+      })
+    );
+    expect(fleet.unsupported).toEqual([]);
+  });
+
+  it("fails loudly instead of inventing a mixed-vendor repair queue", () => {
+    expect(() =>
+      resolveExpectedAutomationFleet({
+        config: {
+          tracker: "jira",
+          source: "notion",
+          jira: { project: "ENG" },
+          notion: { prdDatabaseId: "db-123" },
+          github: { org: "Acme", repo: "platform" },
+        },
+      })
+    ).toThrow(/single repair-intake queue/i);
+  });
+
+  it("falls back to the GitHub remote when config does not carry the repo identity", () => {
+    expect(
+      resolveAutomationProjectIdentity({
+        config: { tracker: "github" },
+        gitRemoteUrl: "git@github.com:CodySwannGT/lisa.git",
+      })
+    ).toEqual({
+      owner: "CodySwannGT",
+      repo: "lisa",
+      project: "codyswanngt-lisa",
+      automationPrefix: "lisa-auto-codyswanngt-lisa-",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared automation-status expected-fleet resolver that reuses setup-automations naming, queue, cadence, and stack-support rules
- cover GitHub self-host queue resolution, auto-start flags, unsupported exploratory jobs, and repo naming with focused regression tests
- ship the resolver in both plugin roots via build:plugins

Closes #799