### PR TITLE
feat: inspect Codex automation metadata for automation-status

### DIFF
--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+/**
+ * Shared Codex runtime adapter for `/lisa:automation-status`.
+ *
+ * This adapter inspects the local Codex automation backing store read-only:
+ * the per-automation `automation.toml` contract plus the automation memory file
+ * used by recurring runs. It scopes the scan to the current repo's expected
+ * Lisa automation prefix, derives normalized command/cadence metadata, and
+ * overlays available recency/failure signals onto the shared fleet report
+ * contract.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+
+const CODEx_RUNTIME_LABEL = "Codex automations";
+const RUN_FAILURE_PATTERN =
+  /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
+const NEGATED_FAILURE_PATTERN =
+  /\b(no|without)\s+(?:recent\s+)?fail(?:ure|ed)\b/i;
+
+/**
+ * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
+ *
+ * @typedef {{
+ *   readonly automationId: string
+ *   readonly status?: string
+ *   readonly prompt?: string
+ *   readonly observedCadence?: string
+ *   readonly observedRRule?: string
+ *   readonly observedCommand?: string
+ *   readonly cwd?: string | null
+ *   readonly createdAt?: number | null
+ *   readonly updatedAt?: number | null
+ *   readonly lastRunAt?: string | null
+ *   readonly lastRunSummary?: string | null
+ *   readonly lastRunFailed?: boolean
+ * }} ObservedCodexAutomation
+ */
+
+/**
+ * Inspect the current repo's Codex automation fleet and map it to the shared
+ * automation-status report contract.
+ *
+ * @param {{
+ *   readonly expectedFleet: ExpectedFleet
+ *   readonly automationsDir?: string
+ *   readonly now?: string | Date
+ * }} input
+ * @returns {Promise<{
+ *   readonly runtime: string
+ *   readonly generatedAt: string
+ *   readonly groups: readonly {
+ *     readonly id: string
+ *     readonly title: string
+ *     readonly items: readonly {
+ *       readonly id: string
+ *       readonly status: "HEALTHY" | "MISSING" | "UNSUPPORTED" | "DRIFTED" | "STALE" | "FAILING"
+ *       readonly summary: string
+ *       readonly expectedCadence?: string
+ *       readonly expectedCommand?: string
+ *       readonly observed?: string
+ *       readonly remediation?: string
+ *     }[]
+ *   }[]
+ *   readonly observedAutomations: readonly ObservedCodexAutomation[]
+ * }>}
+ */
+export async function inspectCodexAutomationFleet(input) {
+  const expectedFleet = input.expectedFleet;
+  const now = normalizeDate(input.now);
+  const observedAutomations = await listCodexAutomations({
+    automationsDir: input.automationsDir,
+    automationPrefix: expectedFleet.automationPrefix,
+  });
+
+  const expectedGroups = new Map([
+    ["core", []],
+    ["exploratory", []],
+  ]);
+
+  for (const expected of expectedFleet.expected) {
+    const comparison = compareAutomationContract({
+      expected,
+      observedAutomations,
+    });
+    expectedGroups.get(expected.group)?.push(
+      createObservedStatusItem({
+        expected,
+        comparison,
+        now,
+      })
+    );
+  }
+
+  for (const unsupported of expectedFleet.unsupported) {
+    expectedGroups.get(unsupported.group)?.push({
+      id: unsupported.automationId,
+      status: "UNSUPPORTED",
+      summary: unsupported.reason,
+      expectedCadence: unsupported.expectedCadence,
+      observed: "No automation is expected for this repo/runtime combination.",
+    });
+  }
+
+  return {
+    runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
+    generatedAt: now.toISOString(),
+    groups: [
+      {
+        id: "1",
+        title: "Core automations",
+        items: expectedGroups.get("core") ?? [],
+      },
+      {
+        id: "2",
+        title: "Exploratory automations",
+        items: expectedGroups.get("exploratory") ?? [],
+      },
+    ],
+    observedAutomations,
+  };
+}
+
+/**
+ * Read every Codex automation whose id matches the current repo's Lisa prefix.
+ *
+ * @param {{
+ *   readonly automationsDir?: string
+ *   readonly automationPrefix: string
+ * }} input
+ * @returns {Promise<readonly ObservedCodexAutomation[]>}
+ */
+export async function listCodexAutomations(input) {
+  const automationsDir =
+    input.automationsDir ?? resolveDefaultCodexAutomationsDir();
+  const dirEntries = await fs.readdir(automationsDir, {
+    withFileTypes: true,
+  });
+
+  const automationDirs = dirEntries
+    .filter(
+      entry =>
+        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
+    )
+    .map(entry => path.join(automationsDir, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  const automations = await Promise.all(
+    automationDirs.map(dir => readCodexAutomation(dir))
+  );
+
+  return automations.filter(Boolean);
+}
+
+/**
+ * Normalize a Lisa Codex automation prompt back into the slash-command surface
+ * expected by the shared drift classifier.
+ *
+ * @param {string | undefined} prompt
+ * @returns {string | undefined}
+ */
+export function deriveCodexObservedCommand(prompt) {
+  if (!prompt) {
+    return undefined;
+  }
+
+  const lisaSkillMatch = prompt.match(
+    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+  );
+  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  }
+
+  const aliasSkillMatch = prompt.match(
+    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+  );
+  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
+    return `/${aliasSkillMatch[1]} ${aliasSkillMatch[2]}`.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse the latest run metadata from an automation memory file.
+ *
+ * @param {string | undefined} memoryContent
+ * @returns {{
+ *   readonly lastRunAt: string | null
+ *   readonly lastRunSummary: string | null
+ *   readonly lastRunFailed: boolean
+ * }}
+ */
+export function parseCodexAutomationMemory(memoryContent) {
+  if (!memoryContent) {
+    return {
+      lastRunAt: null,
+      lastRunSummary: null,
+      lastRunFailed: false,
+    };
+  }
+
+  const timestampMatch = memoryContent.match(
+    /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/
+  );
+  const lines = memoryContent.split(/\r?\n/);
+  const summaryLine =
+    lines
+      .find(line => line.startsWith("- "))
+      ?.replace(/^- /, "")
+      .trim() ?? null;
+
+  const latestBlock = lines.slice(0, 20).join("\n");
+  const lastRunFailed =
+    RUN_FAILURE_PATTERN.test(latestBlock) &&
+    !NEGATED_FAILURE_PATTERN.test(latestBlock);
+
+  return {
+    lastRunAt: timestampMatch?.[0] ?? null,
+    lastRunSummary: summaryLine,
+    lastRunFailed,
+  };
+}
+
+async function readCodexAutomation(automationDir) {
+  const tomlPath = path.join(automationDir, "automation.toml");
+  const memoryPath = path.join(automationDir, "memory.md");
+  const tomlContent = await fs.readFile(tomlPath, "utf8");
+  const automation = parseAutomationToml(tomlContent);
+  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memory = parseCodexAutomationMemory(memoryContent);
+  const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
+
+  return {
+    automationId:
+      stringOrUndefined(automation.id) ?? path.basename(automationDir),
+    status: stringOrUndefined(automation.status),
+    prompt: stringOrUndefined(automation.prompt),
+    observedCadence: humanizeAutomationCadence(
+      stringOrUndefined(automation.rrule)
+    ),
+    observedRRule: stringOrUndefined(automation.rrule),
+    observedCommand: deriveCodexObservedCommand(
+      stringOrUndefined(automation.prompt)
+    ),
+    cwd: typeof cwd === "string" ? cwd : null,
+    createdAt: numberOrNull(automation.created_at),
+    updatedAt: numberOrNull(automation.updated_at),
+    ...memory,
+  };
+}
+
+function createObservedStatusItem(input) {
+  const expected = input.expected;
+  const comparison = input.comparison;
+  const observed = comparison.observedAutomation;
+  const runSignal = classifyAutomationRunSignal({
+    expected,
+    observedAutomation: observed,
+    now: input.now,
+  });
+
+  const observedDetails = [comparison.observed];
+  if (observed?.status) {
+    observedDetails.push(`Scheduler status: ${observed.status}`);
+  }
+  if (observed?.lastRunAt) {
+    observedDetails.push(`Last run: ${observed.lastRunAt}`);
+  } else if (observed) {
+    observedDetails.push("Last run metadata unavailable.");
+  }
+  if (observed?.lastRunSummary) {
+    observedDetails.push(`Latest summary: ${observed.lastRunSummary}`);
+  }
+
+  const status =
+    runSignal?.status ??
+    /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
+
+  return {
+    id: expected.automationId,
+    status,
+    summary: composeAutomationSummary({
+      comparison,
+      runSignal,
+    }),
+    expectedCadence: expected.expectedCadence,
+    expectedCommand: expected.expectedCommand,
+    observed: observedDetails.join(" "),
+    remediation: runSignal?.remediation ?? comparison.remediation,
+  };
+}
+
+function composeAutomationSummary(input) {
+  const comparisonSummary = input.comparison.summary;
+  if (!input.runSignal) {
+    return comparisonSummary;
+  }
+  if (input.comparison.status === "HEALTHY") {
+    return input.runSignal.summary;
+  }
+  return `${input.runSignal.summary}; ${comparisonSummary}`;
+}
+
+function classifyAutomationRunSignal(input) {
+  const observed = input.observedAutomation;
+  if (!observed) {
+    return null;
+  }
+
+  if (observed.status && observed.status !== "ACTIVE") {
+    return {
+      status: "FAILING",
+      summary: `scheduler entry is ${observed.status.toLowerCase()}`,
+      remediation: "Resume or re-enable the automation in Codex.",
+    };
+  }
+
+  if (observed.lastRunFailed) {
+    return {
+      status: "FAILING",
+      summary: "latest recorded run failed",
+      remediation:
+        "Inspect the latest automation run output and fix the failing job before re-running setup.",
+    };
+  }
+
+  if (!observed.lastRunAt) {
+    return null;
+  }
+
+  const cadenceMs =
+    rruleToIntervalMs(observed.observedRRule) ??
+    cadenceLabelToIntervalMs(input.expected.expectedCadence);
+  if (!cadenceMs) {
+    return null;
+  }
+
+  const lastRunAt = Date.parse(observed.lastRunAt);
+  if (Number.isNaN(lastRunAt)) {
+    return null;
+  }
+
+  const staleAfterMs = cadenceMs * 3;
+  if (input.now.getTime() - lastRunAt > staleAfterMs) {
+    return {
+      status: "STALE",
+      summary: `last recorded run is stale for the expected cadence`,
+      remediation:
+        "Inspect why the automation has not run recently, then resume normal scheduling or recreate it with `/lisa:setup-automations`.",
+    };
+  }
+
+  return null;
+}
+
+function resolveDefaultCodexAutomationsDir() {
+  return path.join(
+    process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex"),
+    "automations"
+  );
+}
+
+function humanizeAutomationCadence(rrule) {
+  if (!rrule) {
+    return undefined;
+  }
+  if (rrule === "FREQ=HOURLY;INTERVAL=1") {
+    return "every 60 minutes";
+  }
+  if (rrule === "FREQ=MINUTELY;INTERVAL=10") {
+    return "every 10 minutes";
+  }
+  if (rrule === "FREQ=DAILY;INTERVAL=1") {
+    return "once a day";
+  }
+
+  const everyMinutes = rrule.match(/^FREQ=MINUTELY;INTERVAL=(\d+)$/);
+  if (everyMinutes?.[1]) {
+    return `every ${everyMinutes[1]} minutes`;
+  }
+
+  const everyHours = rrule.match(/^FREQ=HOURLY;INTERVAL=(\d+)$/);
+  if (everyHours?.[1]) {
+    return `every ${Number(everyHours[1]) * 60} minutes`;
+  }
+
+  const everyDays = rrule.match(/^FREQ=DAILY;INTERVAL=(\d+)$/);
+  if (everyDays?.[1]) {
+    return Number(everyDays[1]) === 1
+      ? "once a day"
+      : `every ${everyDays[1]} days`;
+  }
+
+  return rrule;
+}
+
+function rruleToIntervalMs(rrule) {
+  if (!rrule) {
+    return null;
+  }
+
+  const minutely = rrule.match(/^FREQ=MINUTELY;INTERVAL=(\d+)$/);
+  if (minutely?.[1]) {
+    return Number(minutely[1]) * 60_000;
+  }
+
+  const hourly = rrule.match(/^FREQ=HOURLY;INTERVAL=(\d+)$/);
+  if (hourly?.[1]) {
+    return Number(hourly[1]) * 60 * 60_000;
+  }
+
+  const daily = rrule.match(/^FREQ=DAILY;INTERVAL=(\d+)$/);
+  if (daily?.[1]) {
+    return Number(daily[1]) * 24 * 60 * 60_000;
+  }
+
+  return null;
+}
+
+function cadenceLabelToIntervalMs(label) {
+  if (!label) {
+    return null;
+  }
+
+  const everyMinutes = label.match(/^every (\d+) minutes$/);
+  if (everyMinutes?.[1]) {
+    return Number(everyMinutes[1]) * 60_000;
+  }
+
+  if (label === "once a day") {
+    return 24 * 60 * 60_000;
+  }
+
+  return null;
+}
+
+function normalizeDate(value) {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return new Date(value);
+  }
+  return new Date();
+}
+
+function stringOrUndefined(value) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberOrNull(value) {
+  return typeof value === "number" ? value : null;
+}
+
+function parseAutomationToml(tomlContent) {
+  return tomlContent
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith("#"))
+    .reduce((parsed, line) => {
+      const separatorIndex = line.indexOf("=");
+      if (separatorIndex === -1) {
+        return parsed;
+      }
+
+      const key = line.slice(0, separatorIndex).trim();
+      const rawValue = line.slice(separatorIndex + 1).trim();
+
+      return {
+        ...parsed,
+        [key]: parseTomlValue(rawValue),
+      };
+    }, {});
+}
+
+function parseTomlValue(rawValue) {
+  if (rawValue.startsWith('"') && rawValue.endsWith('"')) {
+    return rawValue.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+
+  if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+    const inner = rawValue.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+    return inner
+      .split(",")
+      .map(value => parseTomlValue(value.trim()))
+      .filter(value => value !== undefined);
+  }
+
+  if (/^-?\d+$/.test(rawValue)) {
+    return Number(rawValue);
+  }
+
+  if (rawValue === "true") {
+    return true;
+  }
+
+  if (rawValue === "false") {
+    return false;
+  }
+
+  return rawValue;
+}

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+/**
+ * Shared Codex runtime adapter for `/lisa:automation-status`.
+ *
+ * This adapter inspects the local Codex automation backing store read-only:
+ * the per-automation `automation.toml` contract plus the automation memory file
+ * used by recurring runs. It scopes the scan to the current repo's expected
+ * Lisa automation prefix, derives normalized command/cadence metadata, and
+ * overlays available recency/failure signals onto the shared fleet report
+ * contract.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+
+const CODEx_RUNTIME_LABEL = "Codex automations";
+const RUN_FAILURE_PATTERN =
+  /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
+const NEGATED_FAILURE_PATTERN =
+  /\b(no|without)\s+(?:recent\s+)?fail(?:ure|ed)\b/i;
+
+/**
+ * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
+ *
+ * @typedef {{
+ *   readonly automationId: string
+ *   readonly status?: string
+ *   readonly prompt?: string
+ *   readonly observedCadence?: string
+ *   readonly observedRRule?: string
+ *   readonly observedCommand?: string
+ *   readonly cwd?: string | null
+ *   readonly createdAt?: number | null
+ *   readonly updatedAt?: number | null
+ *   readonly lastRunAt?: string | null
+ *   readonly lastRunSummary?: string | null
+ *   readonly lastRunFailed?: boolean
+ * }} ObservedCodexAutomation
+ */
+
+/**
+ * Inspect the current repo's Codex automation fleet and map it to the shared
+ * automation-status report contract.
+ *
+ * @param {{
+ *   readonly expectedFleet: ExpectedFleet
+ *   readonly automationsDir?: string
+ *   readonly now?: string | Date
+ * }} input
+ * @returns {Promise<{
+ *   readonly runtime: string
+ *   readonly generatedAt: string
+ *   readonly groups: readonly {
+ *     readonly id: string
+ *     readonly title: string
+ *     readonly items: readonly {
+ *       readonly id: string
+ *       readonly status: "HEALTHY" | "MISSING" | "UNSUPPORTED" | "DRIFTED" | "STALE" | "FAILING"
+ *       readonly summary: string
+ *       readonly expectedCadence?: string
+ *       readonly expectedCommand?: string
+ *       readonly observed?: string
+ *       readonly remediation?: string
+ *     }[]
+ *   }[]
+ *   readonly observedAutomations: readonly ObservedCodexAutomation[]
+ * }>}
+ */
+export async function inspectCodexAutomationFleet(input) {
+  const expectedFleet = input.expectedFleet;
+  const now = normalizeDate(input.now);
+  const observedAutomations = await listCodexAutomations({
+    automationsDir: input.automationsDir,
+    automationPrefix: expectedFleet.automationPrefix,
+  });
+
+  const expectedGroups = new Map([
+    ["core", []],
+    ["exploratory", []],
+  ]);
+
+  for (const expected of expectedFleet.expected) {
+    const comparison = compareAutomationContract({
+      expected,
+      observedAutomations,
+    });
+    expectedGroups.get(expected.group)?.push(
+      createObservedStatusItem({
+        expected,
+        comparison,
+        now,
+      })
+    );
+  }
+
+  for (const unsupported of expectedFleet.unsupported) {
+    expectedGroups.get(unsupported.group)?.push({
+      id: unsupported.automationId,
+      status: "UNSUPPORTED",
+      summary: unsupported.reason,
+      expectedCadence: unsupported.expectedCadence,
+      observed: "No automation is expected for this repo/runtime combination.",
+    });
+  }
+
+  return {
+    runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
+    generatedAt: now.toISOString(),
+    groups: [
+      {
+        id: "1",
+        title: "Core automations",
+        items: expectedGroups.get("core") ?? [],
+      },
+      {
+        id: "2",
+        title: "Exploratory automations",
+        items: expectedGroups.get("exploratory") ?? [],
+      },
+    ],
+    observedAutomations,
+  };
+}
+
+/**
+ * Read every Codex automation whose id matches the current repo's Lisa prefix.
+ *
+ * @param {{
+ *   readonly automationsDir?: string
+ *   readonly automationPrefix: string
+ * }} input
+ * @returns {Promise<readonly ObservedCodexAutomation[]>}
+ */
+export async function listCodexAutomations(input) {
+  const automationsDir =
+    input.automationsDir ?? resolveDefaultCodexAutomationsDir();
+  const dirEntries = await fs.readdir(automationsDir, {
+    withFileTypes: true,
+  });
+
+  const automationDirs = dirEntries
+    .filter(
+      entry =>
+        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
+    )
+    .map(entry => path.join(automationsDir, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  const automations = await Promise.all(
+    automationDirs.map(dir => readCodexAutomation(dir))
+  );
+
+  return automations.filter(Boolean);
+}
+
+/**
+ * Normalize a Lisa Codex automation prompt back into the slash-command surface
+ * expected by the shared drift classifier.
+ *
+ * @param {string | undefined} prompt
+ * @returns {string | undefined}
+ */
+export function deriveCodexObservedCommand(prompt) {
+  if (!prompt) {
+    return undefined;
+  }
+
+  const lisaSkillMatch = prompt.match(
+    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+  );
+  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  }
+
+  const aliasSkillMatch = prompt.match(
+    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+  );
+  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
+    return `/${aliasSkillMatch[1]} ${aliasSkillMatch[2]}`.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse the latest run metadata from an automation memory file.
+ *
+ * @param {string | undefined} memoryContent
+ * @returns {{
+ *   readonly lastRunAt: string | null
+ *   readonly lastRunSummary: string | null
+ *   readonly lastRunFailed: boolean
+ * }}
+ */
+export function parseCodexAutomationMemory(memoryContent) {
+  if (!memoryContent) {
+    return {
+      lastRunAt: null,
+      lastRunSummary: null,
+      lastRunFailed: false,
+    };
+  }
+
+  const timestampMatch = memoryContent.match(
+    /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/
+  );
+  const lines = memoryContent.split(/\r?\n/);
+  const summaryLine =
+    lines
+      .find(line => line.startsWith("- "))
+      ?.replace(/^- /, "")
+      .trim() ?? null;
+
+  const latestBlock = lines.slice(0, 20).join("\n");
+  const lastRunFailed =
+    RUN_FAILURE_PATTERN.test(latestBlock) &&
+    !NEGATED_FAILURE_PATTERN.test(latestBlock);
+
+  return {
+    lastRunAt: timestampMatch?.[0] ?? null,
+    lastRunSummary: summaryLine,
+    lastRunFailed,
+  };
+}
+
+async function readCodexAutomation(automationDir) {
+  const tomlPath = path.join(automationDir, "automation.toml");
+  const memoryPath = path.join(automationDir, "memory.md");
+  const tomlContent = await fs.readFile(tomlPath, "utf8");
+  const automation = parseAutomationToml(tomlContent);
+  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memory = parseCodexAutomationMemory(memoryContent);
+  const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
+
+  return {
+    automationId:
+      stringOrUndefined(automation.id) ?? path.basename(automationDir),
+    status: stringOrUndefined(automation.status),
+    prompt: stringOrUndefined(automation.prompt),
+    observedCadence: humanizeAutomationCadence(
+      stringOrUndefined(automation.rrule)
+    ),
+    observedRRule: stringOrUndefined(automation.rrule),
+    observedCommand: deriveCodexObservedCommand(
+      stringOrUndefined(automation.prompt)
+    ),
+    cwd: typeof cwd === "string" ? cwd : null,
+    createdAt: numberOrNull(automation.created_at),
+    updatedAt: numberOrNull(automation.updated_at),
+    ...memory,
+  };
+}
+
+function createObservedStatusItem(input) {
+  const expected = input.expected;
+  const comparison = input.comparison;
+  const observed = comparison.observedAutomation;
+  const runSignal = classifyAutomationRunSignal({
+    expected,
+    observedAutomation: observed,
+    now: input.now,
+  });
+
+  const observedDetails = [comparison.observed];
+  if (observed?.status) {
+    observedDetails.push(`Scheduler status: ${observed.status}`);
+  }
+  if (observed?.lastRunAt) {
+    observedDetails.push(`Last run: ${observed.lastRunAt}`);
+  } else if (observed) {
+    observedDetails.push("Last run metadata unavailable.");
+  }
+  if (observed?.lastRunSummary) {
+    observedDetails.push(`Latest summary: ${observed.lastRunSummary}`);
+  }
+
+  const status =
+    runSignal?.status ??
+    /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
+
+  return {
+    id: expected.automationId,
+    status,
+    summary: composeAutomationSummary({
+      comparison,
+      runSignal,
+    }),
+    expectedCadence: expected.expectedCadence,
+    expectedCommand: expected.expectedCommand,
+    observed: observedDetails.join(" "),
+    remediation: runSignal?.remediation ?? comparison.remediation,
+  };
+}
+
+function composeAutomationSummary(input) {
+  const comparisonSummary = input.comparison.summary;
+  if (!input.runSignal) {
+    return comparisonSummary;
+  }
+  if (input.comparison.status === "HEALTHY") {
+    return input.runSignal.summary;
+  }
+  return `${input.runSignal.summary}; ${comparisonSummary}`;
+}
+
+function classifyAutomationRunSignal(input) {
+  const observed = input.observedAutomation;
+  if (!observed) {
+    return null;
+  }
+
+  if (observed.status && observed.status !== "ACTIVE") {
+    return {
+      status: "FAILING",
+      summary: `scheduler entry is ${observed.status.toLowerCase()}`,
+      remediation: "Resume or re-enable the automation in Codex.",
+    };
+  }
+
+  if (observed.lastRunFailed) {
+    return {
+      status: "FAILING",
+      summary: "latest recorded run failed",
+      remediation:
+        "Inspect the latest automation run output and fix the failing job before re-running setup.",
+    };
+  }
+
+  if (!observed.lastRunAt) {
+    return null;
+  }
+
+  const cadenceMs =
+    rruleToIntervalMs(observed.observedRRule) ??
+    cadenceLabelToIntervalMs(input.expected.expectedCadence);
+  if (!cadenceMs) {
+    return null;
+  }
+
+  const lastRunAt = Date.parse(observed.lastRunAt);
+  if (Number.isNaN(lastRunAt)) {
+    return null;
+  }
+
+  const staleAfterMs = cadenceMs * 3;
+  if (input.now.getTime() - lastRunAt > staleAfterMs) {
+    return {
+      status: "STALE",
+      summary: `last recorded run is stale for the expected cadence`,
+      remediation:
+        "Inspect why the automation has not run recently, then resume normal scheduling or recreate it with `/lisa:setup-automations`.",
+    };
+  }
+
+  return null;
+}
+
+function resolveDefaultCodexAutomationsDir() {
+  return path.join(
+    process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex"),
+    "automations"
+  );
+}
+
+function humanizeAutomationCadence(rrule) {
+  if (!rrule) {
+    return undefined;
+  }
+  if (rrule === "FREQ=HOURLY;INTERVAL=1") {
+    return "every 60 minutes";
+  }
+  if (rrule === "FREQ=MINUTELY;INTERVAL=10") {
+    return "every 10 minutes";
+  }
+  if (rrule === "FREQ=DAILY;INTERVAL=1") {
+    return "once a day";
+  }
+
+  const everyMinutes = rrule.match(/^FREQ=MINUTELY;INTERVAL=(\d+)$/);
+  if (everyMinutes?.[1]) {
+    return `every ${everyMinutes[1]} minutes`;
+  }
+
+  const everyHours = rrule.match(/^FREQ=HOURLY;INTERVAL=(\d+)$/);
+  if (everyHours?.[1]) {
+    return `every ${Number(everyHours[1]) * 60} minutes`;
+  }
+
+  const everyDays = rrule.match(/^FREQ=DAILY;INTERVAL=(\d+)$/);
+  if (everyDays?.[1]) {
+    return Number(everyDays[1]) === 1
+      ? "once a day"
+      : `every ${everyDays[1]} days`;
+  }
+
+  return rrule;
+}
+
+function rruleToIntervalMs(rrule) {
+  if (!rrule) {
+    return null;
+  }
+
+  const minutely = rrule.match(/^FREQ=MINUTELY;INTERVAL=(\d+)$/);
+  if (minutely?.[1]) {
+    return Number(minutely[1]) * 60_000;
+  }
+
+  const hourly = rrule.match(/^FREQ=HOURLY;INTERVAL=(\d+)$/);
+  if (hourly?.[1]) {
+    return Number(hourly[1]) * 60 * 60_000;
+  }
+
+  const daily = rrule.match(/^FREQ=DAILY;INTERVAL=(\d+)$/);
+  if (daily?.[1]) {
+    return Number(daily[1]) * 24 * 60 * 60_000;
+  }
+
+  return null;
+}
+
+function cadenceLabelToIntervalMs(label) {
+  if (!label) {
+    return null;
+  }
+
+  const everyMinutes = label.match(/^every (\d+) minutes$/);
+  if (everyMinutes?.[1]) {
+    return Number(everyMinutes[1]) * 60_000;
+  }
+
+  if (label === "once a day") {
+    return 24 * 60 * 60_000;
+  }
+
+  return null;
+}
+
+function normalizeDate(value) {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return new Date(value);
+  }
+  return new Date();
+}
+
+function stringOrUndefined(value) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberOrNull(value) {
+  return typeof value === "number" ? value : null;
+}
+
+function parseAutomationToml(tomlContent) {
+  return tomlContent
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith("#"))
+    .reduce((parsed, line) => {
+      const separatorIndex = line.indexOf("=");
+      if (separatorIndex === -1) {
+        return parsed;
+      }
+
+      const key = line.slice(0, separatorIndex).trim();
+      const rawValue = line.slice(separatorIndex + 1).trim();
+
+      return {
+        ...parsed,
+        [key]: parseTomlValue(rawValue),
+      };
+    }, {});
+}
+
+function parseTomlValue(rawValue) {
+  if (rawValue.startsWith('"') && rawValue.endsWith('"')) {
+    return rawValue.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+
+  if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+    const inner = rawValue.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+    return inner
+      .split(",")
+      .map(value => parseTomlValue(value.trim()))
+      .filter(value => value !== undefined);
+  }
+
+  if (/^-?\d+$/.test(rawValue)) {
+    return Number(rawValue);
+  }
+
+  if (rawValue === "true") {
+    return true;
+  }
+
+  if (rawValue === "false") {
+    return false;
+  }
+
+  return rawValue;
+}

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression coverage for the Codex automation-status runtime adapter.
+ *
+ * Issue #801 adds the repo-scoped Codex backing-store reader that normalizes
+ * automation prompts into shared command contracts and overlays recency/failure
+ * metadata from automation memory files without mutating jobs.
+ * @module tests/unit/strategies/automation-status-codex-adapter
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+import {
+  deriveCodexObservedCommand,
+  inspectCodexAutomationFleet,
+} from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+
+const BUILD_INTAKE_PROMPT =
+  "Run one cron-safe Lisa build-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=build`.";
+const BUILD_INTAKE_RRULE = "FREQ=MINUTELY;INTERVAL=10";
+const BUILD_INTAKE_AUTOMATION_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
+
+describe("automation-status Codex adapter (#801)", () => {
+  const tempDirs = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("reads repo-scoped automations and maps healthy, stale, failing, missing, and unsupported states", async () => {
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-automation-status-")
+    );
+    tempDirs.push(automationsDir);
+
+    await writeAutomationFixture(automationsDir, {
+      id: "lisa-auto-codyswanngt-lisa-intake-repair",
+      rrule: "FREQ=HOURLY;INTERVAL=1",
+      prompt:
+        "Run one cron-safe Lisa repair-intake cycle. Use the Lisa repair-intake skill with arguments `github intake_mode=both`.",
+      memory: `2026-05-26T11:10:00Z\n\n- Repaired one blocked build issue cleanly.\n`,
+    });
+    await writeAutomationFixture(automationsDir, {
+      id: "lisa-auto-codyswanngt-lisa-intake-prd",
+      rrule: "FREQ=HOURLY;INTERVAL=1",
+      prompt:
+        "Run one cron-safe Lisa PRD-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=prd`.",
+      memory: `2026-05-26T06:00:00Z\n\n- Found no ready PRDs.\n`,
+    });
+    await writeAutomationFixture(automationsDir, {
+      id: BUILD_INTAKE_AUTOMATION_ID,
+      rrule: BUILD_INTAKE_RRULE,
+      prompt: BUILD_INTAKE_PROMPT,
+      memory: `2026-05-26T11:55:00Z\n\n- Latest run failed because GitHub auth was unavailable.\n`,
+    });
+    await writeAutomationFixture(automationsDir, {
+      id: "lisa-auto-unrelated-other-repo-intake-tickets",
+      rrule: BUILD_INTAKE_RRULE,
+      prompt:
+        "Run one unrelated build-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=build`.",
+      memory: `2026-05-26T11:55:00Z\n\n- Unrelated repo run.\n`,
+    });
+
+    const expectedFleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: "github",
+        github: {
+          org: "CodySwannGT",
+          repo: "lisa",
+        },
+      },
+      detectedTypes: ["typescript"],
+      autoStartPrds: true,
+    });
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet,
+      automationsDir,
+      now: "2026-05-26T12:00:00Z",
+    });
+
+    expect(report.runtime).toContain("Codex automations");
+    expect(report.observedAutomations).toHaveLength(3);
+
+    const items = report.groups.flatMap(group => group.items);
+
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        id: "lisa-auto-codyswanngt-lisa-intake-repair",
+        status: "HEALTHY",
+      })
+    );
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        id: "lisa-auto-codyswanngt-lisa-intake-prd",
+        status: "STALE",
+        summary: "last recorded run is stale for the expected cadence",
+      })
+    );
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        id: BUILD_INTAKE_AUTOMATION_ID,
+        status: "FAILING",
+        summary: "latest recorded run failed",
+      })
+    );
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        id: "lisa-auto-codyswanngt-lisa-exploratory-prds",
+        status: "MISSING",
+      })
+    );
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        id: "lisa-auto-codyswanngt-lisa-exploratory-bugs",
+        status: "UNSUPPORTED",
+      })
+    );
+  });
+
+  it("derives normalized Lisa slash commands from Codex automation prompts", () => {
+    expect(deriveCodexObservedCommand(BUILD_INTAKE_PROMPT)).toBe(
+      "/lisa:intake github intake_mode=build"
+    );
+
+    expect(
+      deriveCodexObservedCommand(
+        "Run one evidence-grounded ideation pass. Use the Lisa project-ideation skill with arguments `prd_ready=true`."
+      )
+    ).toBe("/lisa:project-ideation prd_ready=true");
+
+    expect(
+      deriveCodexObservedCommand(
+        "Run one Playwright-backed exploratory QA pass. Use the `$lisa-exploratory-qa` skill with arguments `ready=true`."
+      )
+    ).toBe("/lisa-exploratory-qa ready=true");
+  });
+
+  it("inspects automation files read-only", async () => {
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-automation-readonly-")
+    );
+    tempDirs.push(automationsDir);
+
+    await writeAutomationFixture(automationsDir, {
+      id: BUILD_INTAKE_AUTOMATION_ID,
+      rrule: BUILD_INTAKE_RRULE,
+      prompt: BUILD_INTAKE_PROMPT,
+      memory: `2026-05-26T11:55:00Z\n\n- Idle run.\n`,
+    });
+
+    const before = await snapshotAutomationDir(automationsDir);
+
+    await inspectCodexAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: {
+          tracker: "github",
+          github: {
+            org: "CodySwannGT",
+            repo: "lisa",
+          },
+        },
+        detectedTypes: ["typescript"],
+      }),
+      automationsDir,
+      now: "2026-05-26T12:00:00Z",
+    });
+
+    const after = await snapshotAutomationDir(automationsDir);
+    expect(after).toEqual(before);
+  });
+});
+
+/**
+ * Create one temporary Codex automation fixture for adapter tests.
+ *
+ * @param {string} automationsDir Parent automations fixture directory.
+ * @param {{
+ *   readonly id: string
+ *   readonly rrule: string
+ *   readonly prompt: string
+ *   readonly memory: string
+ * }} input Fixture values to write.
+ * @returns {Promise<void>} Resolves after the fixture files are written.
+ */
+async function writeAutomationFixture(automationsDir, input) {
+  const automationDir = path.join(automationsDir, input.id);
+  await fs.mkdir(automationDir, { recursive: true });
+  await fs.writeFile(
+    path.join(automationDir, "automation.toml"),
+    [
+      "version = 1",
+      `id = "${input.id}"`,
+      'kind = "cron"',
+      `name = "${input.id}"`,
+      `prompt = "${escapeTomlString(input.prompt)}"`,
+      'status = "ACTIVE"',
+      `rrule = "${input.rrule}"`,
+      'model = "gpt-5.4"',
+      'reasoning_effort = "medium"',
+      'execution_environment = "local"',
+      'cwds = ["/tmp/repo"]',
+      "",
+    ].join("\n")
+  );
+  await fs.writeFile(path.join(automationDir, "memory.md"), input.memory);
+}
+
+/**
+ * Snapshot fixture automation contents to verify adapter reads remain read-only.
+ *
+ * @param {string} dir Fixture automation directory.
+ * @returns {Promise<Record<string, { automationToml: string, memory: string }>>}
+ *   Snapshot of fixture file contents keyed by automation directory name.
+ */
+async function snapshotAutomationDir(dir) {
+  const files = await fs.readdir(dir, { withFileTypes: true });
+  const sortedFiles = files.toSorted((left, right) =>
+    left.name.localeCompare(right.name)
+  );
+  const snapshot = {};
+  for (const entry of sortedFiles) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const automationDir = path.join(dir, entry.name);
+    const automationToml = await fs.readFile(
+      path.join(automationDir, "automation.toml"),
+      "utf8"
+    );
+    const memory = await fs.readFile(
+      path.join(automationDir, "memory.md"),
+      "utf8"
+    );
+    snapshot[entry.name] = { automationToml, memory };
+  }
+  return snapshot;
+}
+
+/**
+ * Escape a plain string for the limited TOML fixture format used in these tests.
+ *
+ * @param {string} value Raw string value.
+ * @returns {string} TOML-safe string literal contents.
+ */
+function escapeTomlString(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}


### PR DESCRIPTION
Closes #801

## Summary
- add a shared Codex automation-status adapter that reads repo-scoped automation.toml and memory.md metadata
- normalize Codex automation prompts back into Lisa command contracts and overlay stale/failing run signals
- add regression coverage for repo scoping, health-signal mapping, command derivation, and read-only inspection

## Verification
- bun test tests/unit/strategies/automation-status-codex-adapter.test.ts tests/unit/strategies/automation-status-contract-drift.test.ts tests/unit/strategies/automation-status-expected-fleet.test.ts tests/unit/strategies/automation-status-report-rendering.test.ts
- bun run typecheck
- git push (passed slow lint, knip, full unit tests with coverage, integration tests via hook)