### PR TITLE
[lisa] Add automation-status fixture and read-only smoke coverage

### DIFF
--- a/tests/fixtures/automation-status/attention-needed-codex.json
+++ b/tests/fixtures/automation-status/attention-needed-codex.json
@@ -1,0 +1,60 @@
+{
+  "runtime": "Codex automations (backing-store metadata)",
+  "generatedAt": "2026-05-26T12:00:00.000Z",
+  "groups": [
+    {
+      "id": "1",
+      "title": "Core automations",
+      "items": [
+        {
+          "id": "lisa-auto-codyswanngt-lisa-intake-repair",
+          "status": "HEALTHY",
+          "summary": "latest recorded run is within cadence",
+          "expectedCadence": "every 60 minutes",
+          "expectedCommand": "/lisa:repair-intake github intake_mode=both",
+          "observed": "lisa-auto-codyswanngt-lisa-intake-repair runs every 60 minutes -> /lisa:repair-intake github intake_mode=both Scheduler status: ACTIVE Last run: 2026-05-26T11:10:00Z Latest summary: Repaired one blocked build issue cleanly."
+        },
+        {
+          "id": "lisa-auto-codyswanngt-lisa-intake-prd",
+          "status": "STALE",
+          "summary": "last recorded run is stale for the expected cadence",
+          "expectedCadence": "every 60 minutes",
+          "expectedCommand": "/lisa:intake github intake_mode=prd",
+          "observed": "lisa-auto-codyswanngt-lisa-intake-prd runs every 60 minutes -> /lisa:intake github intake_mode=prd Scheduler status: ACTIVE Last run: 2026-05-26T06:00:00Z Latest summary: Found no ready PRDs.",
+          "remediation": "Inspect why the automation has not run recently, then resume normal scheduling or recreate it with `/lisa:setup-automations`."
+        },
+        {
+          "id": "lisa-auto-codyswanngt-lisa-intake-tickets",
+          "status": "FAILING",
+          "summary": "latest recorded run failed",
+          "expectedCadence": "every 10 minutes",
+          "expectedCommand": "/lisa:intake github intake_mode=build",
+          "observed": "lisa-auto-codyswanngt-lisa-intake-tickets runs every 10 minutes -> /lisa:intake github intake_mode=build Scheduler status: ACTIVE Last run: 2026-05-26T11:55:00Z Latest summary: Latest run failed because GitHub auth was unavailable.",
+          "remediation": "Inspect the latest automation run output and fix the failing job before re-running setup."
+        },
+        {
+          "id": "lisa-auto-codyswanngt-lisa-exploratory-prds",
+          "status": "MISSING",
+          "summary": "expected automation is missing",
+          "expectedCadence": "once a day",
+          "expectedCommand": "/lisa:project-ideation prd_ready=true",
+          "observed": "No live automation matched the expected Lisa contract.",
+          "remediation": "Re-run `/lisa:setup-automations` or recreate the missing scheduler entry."
+        }
+      ]
+    },
+    {
+      "id": "2",
+      "title": "Exploratory automations",
+      "items": [
+        {
+          "id": "lisa-auto-codyswanngt-lisa-exploratory-bugs",
+          "status": "UNSUPPORTED",
+          "summary": "This repository does not ship an exploratory-qa command surface.",
+          "expectedCadence": "once a day",
+          "observed": "No automation is expected for this repo/runtime combination."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/automation-status/partial-support-codex.json
+++ b/tests/fixtures/automation-status/partial-support-codex.json
@@ -1,0 +1,24 @@
+{
+  "runtime": "Codex automations (backing-store metadata)",
+  "generatedAt": "2026-05-26T12:00:00.000Z",
+  "groups": [
+    {
+      "id": "1",
+      "title": "Core automations",
+      "items": []
+    },
+    {
+      "id": "2",
+      "title": "Exploratory automations",
+      "items": [
+        {
+          "id": "lisa-auto-codyswanngt-mobile-exploratory-bugs",
+          "status": "UNSUPPORTED",
+          "summary": "This repository does not ship an exploratory-qa command surface.",
+          "expectedCadence": "once a day",
+          "observed": "No automation is expected for this repo/runtime combination."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts
+++ b/tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Fixture-backed smoke coverage plus exact automation-status artifact parity.
+ *
+ * Issue #803 extends the earlier scaffold and adapter coverage with committed
+ * fleet fixtures that exercise degraded operator output, plus strict proof that
+ * the generated `plugins/lisa` assets stay byte-for-byte aligned with the
+ * `plugins/src/base` source assets for the read-only automation-status surface.
+ * @module tests/unit/strategies/automation-status-fixture-smoke-and-parity
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { renderAutomationStatusReport } from "../../../plugins/src/base/scripts/automation-status-report.mjs";
+
+/**
+ *
+ */
+type AutomationStatus =
+  | "HEALTHY"
+  | "MISSING"
+  | "UNSUPPORTED"
+  | "DRIFTED"
+  | "STALE"
+  | "FAILING";
+
+/**
+ *
+ */
+type AutomationItem = {
+  readonly id: string;
+  readonly status: AutomationStatus;
+  readonly summary: string;
+  readonly expectedCadence?: string;
+  readonly expectedCommand?: string;
+  readonly observed?: string;
+  readonly remediation?: string;
+};
+
+/**
+ *
+ */
+type AutomationGroup = {
+  readonly id: string;
+  readonly title: string;
+  readonly items: readonly AutomationItem[];
+};
+
+/**
+ *
+ */
+type AutomationFixture = {
+  readonly runtime?: string;
+  readonly generatedAt?: string;
+  readonly groups: readonly AutomationGroup[];
+};
+
+const BASE_PLUGIN_ROOT = path.resolve("plugins/src/base");
+const GENERATED_PLUGIN_ROOT = path.resolve("plugins/lisa");
+const AUTOMATION_STATUS_FIXTURES = path.resolve(
+  "tests/fixtures/automation-status"
+);
+
+const readUtf8 = (filePath: string): string => readFileSync(filePath, "utf8");
+
+const readFixture = (name: string): AutomationFixture =>
+  JSON.parse(
+    readUtf8(path.join(AUTOMATION_STATUS_FIXTURES, `${name}.json`))
+  ) as AutomationFixture;
+
+describe("automation-status fixture smoke coverage (#803)", () => {
+  it("renders a degraded Codex fleet fixture as ATTENTION_NEEDED with exact remediation", () => {
+    const report = renderAutomationStatusReport(
+      readFixture("attention-needed-codex")
+    );
+
+    expect(report.verdict).toBe("ATTENTION_NEEDED");
+    expect(report.counts).toEqual({
+      HEALTHY: 1,
+      MISSING: 1,
+      UNSUPPORTED: 1,
+      DRIFTED: 0,
+      STALE: 1,
+      FAILING: 1,
+    });
+    expect(report.text).toContain("Overall verdict: ATTENTION_NEEDED");
+    expect(report.text).toContain(
+      "Counts: 1 HEALTHY, 1 MISSING, 1 UNSUPPORTED, 0 DRIFTED, 1 STALE, 1 FAILING"
+    );
+    expect(report.text).toContain(
+      "Runtime inspected: Codex automations (backing-store metadata)"
+    );
+    expect(report.text).toContain(
+      "- STALE lisa-auto-codyswanngt-lisa-intake-prd: last recorded run is stale for the expected cadence"
+    );
+    expect(report.text).toContain(
+      "Expected: every 10 minutes -> /lisa:intake github intake_mode=build"
+    );
+    expect(report.text).toContain(
+      "Observed: lisa-auto-codyswanngt-lisa-intake-tickets runs every 10 minutes -> /lisa:intake github intake_mode=build Scheduler status: ACTIVE Last run: 2026-05-26T11:55:00Z Latest summary: Latest run failed because GitHub auth was unavailable."
+    );
+    expect(report.text).toContain(
+      "Remediation: Inspect the latest automation run output and fix the failing job before re-running setup."
+    );
+    expect(report.text).toContain(
+      "- MISSING lisa-auto-codyswanngt-lisa-exploratory-prds: expected automation is missing"
+    );
+  });
+
+  it("renders unsupported-only coverage as PARTIAL_SUPPORT rather than failure", () => {
+    const report = renderAutomationStatusReport(
+      readFixture("partial-support-codex")
+    );
+
+    expect(report.verdict).toBe("PARTIAL_SUPPORT");
+    expect(report.counts).toEqual({
+      HEALTHY: 0,
+      MISSING: 0,
+      UNSUPPORTED: 1,
+      DRIFTED: 0,
+      STALE: 0,
+      FAILING: 0,
+    });
+    expect(report.text).toContain("Overall verdict: PARTIAL_SUPPORT");
+    expect(report.text).toContain(
+      "- UNSUPPORTED lisa-auto-codyswanngt-mobile-exploratory-bugs: This repository does not ship an exploratory-qa command surface."
+    );
+  });
+});
+
+describe("automation-status source/generated parity (#803)", () => {
+  it("keeps the distributed automation-status command in lockstep with the source asset", () => {
+    expect(
+      readUtf8(
+        path.join(GENERATED_PLUGIN_ROOT, "commands", "automation-status.md")
+      )
+    ).toBe(
+      readUtf8(path.join(BASE_PLUGIN_ROOT, "commands", "automation-status.md"))
+    );
+  });
+
+  it("keeps the distributed automation-status skill in lockstep with the source asset", () => {
+    const sourceSkill = readUtf8(
+      path.join(BASE_PLUGIN_ROOT, "skills", "automation-status", "SKILL.md")
+    );
+
+    expect(
+      readUtf8(
+        path.join(
+          GENERATED_PLUGIN_ROOT,
+          "skills",
+          "automation-status",
+          "SKILL.md"
+        )
+      )
+    ).toBe(sourceSkill);
+    expect(sourceSkill).toMatch(/read-only/i);
+    expect(sourceSkill).toMatch(
+      /It does not create, update, resume, rerun, pause, or delete automations\./
+    );
+  });
+
+  it("keeps the distributed automation-status scripts in lockstep with the source assets", () => {
+    const scriptNames = [
+      "automation-status-report.mjs",
+      "automation-status-expected-fleet.mjs",
+      "automation-status-contract-drift.mjs",
+      "automation-status-codex-adapter.mjs",
+    ];
+
+    for (const scriptName of scriptNames) {
+      expect(
+        readUtf8(path.join(GENERATED_PLUGIN_ROOT, "scripts", scriptName))
+      ).toBe(readUtf8(path.join(BASE_PLUGIN_ROOT, "scripts", scriptName)));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add committed automation-status fixtures for degraded and partial-support fleet states
- add fixture-backed smoke assertions for rendered operator output and remediation text
- add source/generated parity checks for the read-only automation-status command, skill, and helper scripts

## Testing
- bun test tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts tests/unit/strategies/automation-status-report-rendering.test.ts tests/unit/strategies/automation-status-codex-adapter.test.ts tests/unit/strategies/automation-status-contract-drift.test.ts tests/unit/strategies/automation-status-expected-fleet.test.ts tests/unit/strategies/automation-status-scaffold.test.ts
- bun run typecheck
- git push -u origin codex/issue-803-automation-status-smoke