### PR TITLE
[lisa] Document operator usage and remediation for automation status

### DIFF
--- a/plugins/lisa/commands/automation-status.md
+++ b/plugins/lisa/commands/automation-status.md
@@ -3,3 +3,10 @@ description: "Inspect the current project's Lisa automation fleet and report whe
 ---
 
 Use the /lisa:automation-status skill to inspect the current project's expected Lisa automations, compare them with the runtime's scheduler metadata, and report fleet health, drift, staleness, unsupported jobs, and remediation hints. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:automation-status`
+- `/lisa:automation-status --verbose`
+
+This surface is read-only in v1. Use it to understand whether Lisa's unattended jobs are healthy before deciding whether to rerun `/lisa:setup-automations`, inspect scheduler errors, or use `/lisa:intake` / `/lisa:repair-intake` to address queue fallout.

--- a/plugins/lisa/skills/automation-status/SKILL.md
+++ b/plugins/lisa/skills/automation-status/SKILL.md
@@ -49,6 +49,42 @@ For each expected automation, report:
 
 Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
 
+## Operator usage
+
+Typical entrypoint:
+
+```text
+/lisa:automation-status
+```
+
+Use this command when an operator needs to answer one of these questions for the current repo:
+
+- "Did Lisa set up every automation this project expects?"
+- "Is the scheduler still pointing at the right cadence and queue arguments?"
+- "Is the queue idle because there is no work, or because the automation is stale or failing?"
+
+The report should be terminal-first and immediately actionable: observable scheduler facts first, then the smallest useful remediation step.
+
+## Runtime differences
+
+- **Codex**: prefer native automation metadata and use backing-store files only to fill gaps such as timestamps or failure recency. When Codex exposes health/memory signals, include them as observed facts rather than assumptions.
+- **Claude**: use the `/schedule` listing as the primary runtime surface. Compare the live schedule name, cadence, and command shape against the Lisa contract, but degrade gracefully when `/schedule` does not expose equivalent recency or failure fields.
+- **Other runtimes**: report automation-status as unsupported for that runtime instead of guessing from unrelated files or naming patterns.
+
+## Verdicts and remediation
+
+- `HEALTHY`: every expected automation exists and the inspected runtime metadata shows no actionable drift, staleness, or failure.
+- `PARTIAL_SUPPORT`: the fleet is otherwise healthy, but at least one exploratory job is intentionally unsupported for this stack or runtime.
+- `ATTENTION_NEEDED`: at least one automation is missing, drifted, stale, or failing.
+
+Status-specific remediation guidance:
+
+- `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
+- `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
+- `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
+
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
 
 ```text

--- a/plugins/src/base/commands/automation-status.md
+++ b/plugins/src/base/commands/automation-status.md
@@ -3,3 +3,10 @@ description: "Inspect the current project's Lisa automation fleet and report whe
 ---
 
 Use the /lisa:automation-status skill to inspect the current project's expected Lisa automations, compare them with the runtime's scheduler metadata, and report fleet health, drift, staleness, unsupported jobs, and remediation hints. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:automation-status`
+- `/lisa:automation-status --verbose`
+
+This surface is read-only in v1. Use it to understand whether Lisa's unattended jobs are healthy before deciding whether to rerun `/lisa:setup-automations`, inspect scheduler errors, or use `/lisa:intake` / `/lisa:repair-intake` to address queue fallout.

--- a/plugins/src/base/skills/automation-status/SKILL.md
+++ b/plugins/src/base/skills/automation-status/SKILL.md
@@ -49,6 +49,42 @@ For each expected automation, report:
 
 Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
 
+## Operator usage
+
+Typical entrypoint:
+
+```text
+/lisa:automation-status
+```
+
+Use this command when an operator needs to answer one of these questions for the current repo:
+
+- "Did Lisa set up every automation this project expects?"
+- "Is the scheduler still pointing at the right cadence and queue arguments?"
+- "Is the queue idle because there is no work, or because the automation is stale or failing?"
+
+The report should be terminal-first and immediately actionable: observable scheduler facts first, then the smallest useful remediation step.
+
+## Runtime differences
+
+- **Codex**: prefer native automation metadata and use backing-store files only to fill gaps such as timestamps or failure recency. When Codex exposes health/memory signals, include them as observed facts rather than assumptions.
+- **Claude**: use the `/schedule` listing as the primary runtime surface. Compare the live schedule name, cadence, and command shape against the Lisa contract, but degrade gracefully when `/schedule` does not expose equivalent recency or failure fields.
+- **Other runtimes**: report automation-status as unsupported for that runtime instead of guessing from unrelated files or naming patterns.
+
+## Verdicts and remediation
+
+- `HEALTHY`: every expected automation exists and the inspected runtime metadata shows no actionable drift, staleness, or failure.
+- `PARTIAL_SUPPORT`: the fleet is otherwise healthy, but at least one exploratory job is intentionally unsupported for this stack or runtime.
+- `ATTENTION_NEEDED`: at least one automation is missing, drifted, stale, or failing.
+
+Status-specific remediation guidance:
+
+- `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
+- `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
+- `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
+
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
 
 ```text

--- a/tests/unit/strategies/automation-status-operator-docs.test.ts
+++ b/tests/unit/strategies/automation-status-operator-docs.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression coverage for automation-status operator guidance.
+ *
+ * Issue #804 adds the operator-facing usage and remediation documentation on
+ * top of the command/skill scaffold. This suite keeps both plugin roots in
+ * sync and proves the docs stay actionable for Codex and Claude operators.
+ * @module tests/unit/strategies/automation-status-operator-docs
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("automation-status operator docs (#804)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    it("documents operator entrypoints in the command surface", () => {
+      const command = read(root, "commands/automation-status.md");
+
+      expect(command).toContain("/lisa:automation-status");
+      expect(command).toContain("--verbose");
+      expect(command).toMatch(/read-only/i);
+      expect(command).toContain("/lisa:setup-automations");
+      expect(command).toContain("/lisa:intake");
+      expect(command).toContain("/lisa:repair-intake");
+    });
+
+    it("documents runtime differences and remediation guidance in the skill", () => {
+      const skill = read(root, "skills/automation-status/SKILL.md");
+
+      expect(skill).toContain("## Operator usage");
+      expect(skill).toContain("## Runtime differences");
+      expect(skill).toContain("## Verdicts and remediation");
+      expect(skill).toContain("Codex");
+      expect(skill).toContain("Claude");
+      expect(skill).toMatch(/unsupported for that runtime/i);
+      expect(skill).toContain("HEALTHY");
+      expect(skill).toContain("PARTIAL_SUPPORT");
+      expect(skill).toContain("ATTENTION_NEEDED");
+      expect(skill).toContain("MISSING");
+      expect(skill).toContain("DRIFTED");
+      expect(skill).toContain("STALE");
+      expect(skill).toContain("FAILING");
+      expect(skill).toContain("UNSUPPORTED");
+      expect(skill).toContain("/lisa:setup-automations");
+      expect(skill).toContain("/lisa:intake");
+      expect(skill).toContain("/lisa:repair-intake");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add operator-facing usage examples to the automation-status command surface
- document runtime differences, verdict meanings, and remediation guidance in the automation-status skill
- add regression coverage to keep both plugin roots aligned on the new docs

## Testing
- bun test tests/unit/strategies/automation-status-operator-docs.test.ts tests/unit/strategies/automation-status-scaffold.test.ts tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts
- git push -u origin codex/issue-804-automation-status-docs

Closes #804