### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -41,3 +41,10 @@
 - Refreshed the `git` source note with 65 new commits through `7a56fd065774adb22bcb7ff7857e1d89170f5f75`, advanced the merged-PR cursor to `#789`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because the only Codex memory store available in this runtime was the global `/Users/cody/.codex/memories`, which the project-scoped memory connector correctly refuses to ingest.
 - Updated the monorepo snapshot synthesis for the latest council-planning, doctor-surface, GitHub build-intake, and release-history changes.
+
+## 2026-05-26 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-26-0130`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 31 new commits through `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`, advanced the merged-PR cursor to `#812`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the isolated worktree path had no matching project memory, and global Codex memory remains out of scope.
+- Updated the monorepo snapshot synthesis for the latest automation-status delivery, smoke coverage, operator documentation, and release-history changes.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,19 +20,18 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-25-3844` from `origin/main`
-- HEAD at 2026-05-25 incremental ingest: `7a56fd065774adb22bcb7ff7857e1d89170f5f75`
-- Current package version: `2.85.1`
-- Total commits on HEAD: 1953
-- Latest merged PR captured in the incremental git snapshot: `#789`
-- New commits since the previous incremental git cursor: `65`
+- Ingest branch: `wiki/ingest-2026-05-26-0130` from `origin/main`
+- HEAD at 2026-05-26 incremental ingest: `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`
+- Current package version: `2.91.2`
+- Total commits on HEAD: 1984
+- Latest merged PR captured in the incremental git snapshot: `#812`
+- New commits since the previous incremental git cursor: `31`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Council planning and runtime-guard coverage expanded across dry-run critique, second-round planning, workspace/runtime detection, and sanitized runtime capture handling.
-- The wiki plugin's doctor surface added command scaffolding, grouped report rendering, GitHub-readiness validation, and vendor/config readiness contracts.
-- GitHub build-intake work continued landing through the `codex/issue-*` queue, including usage-pricing delivery wiring and tighter internal Codex skill distribution guards.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.74.0` through `2.85.1` during this incremental window.
+- Automation-status now spans the full operator workflow: scaffolded command and skill surfaces, grouped output rendering, expected-fleet resolution, drift detection, Codex metadata inspection, and Claude schedule support.
+- Verification and operator guidance expanded with read-only smoke coverage plus remediation-focused documentation for automation-status users.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.85.2` through `2.91.2` during this incremental window.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
@@ -10,75 +10,41 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-26)
 
-- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.7znDMv`)
-- HEAD: `7a56fd065774adb22bcb7ff7857e1d89170f5f75`
-- Total commits on HEAD: 1953
-- New commits since last ingest (`362e4bf1248d47e406b19d56f2d3d8b27e7740c9`): 65
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #789 "fix: block internal Codex skill distribution"
+- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.AluvDw`)
+- HEAD: `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`
+- Total commits on HEAD: 1984
+- New commits since last ingest (`7a56fd065774adb22bcb7ff7857e1d89170f5f75`): 31
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #812 "[lisa] Document operator usage and remediation for automation status"
 
 ## New commits
-- 7a56fd06 · 2026-05-26 · chore(release): 2.85.1 [skip ci]
-- aab15876 · 2026-05-25 · Merge pull request #789 from CodySwannGT/codex/issue-774-github-build-intake
-- ccb0e3bb · 2026-05-25 · fix(codex): block internal skill distribution
-- 4b73e5d7 · 2026-05-26 · chore(release): 2.85.0 [skip ci]
-- 8da62d67 · 2026-05-25 · Merge pull request #787 from CodySwannGT/codex/issue-773-github-build-intake
-- 96f0142e · 2026-05-26 · fix(council): propagate runtime to workspace guard detection
-- 931c4c4f · 2026-05-25 · feat(skills): guard council write mode
-- b81827e9 · 2026-05-26 · chore(release): 2.84.1 [skip ci]
-- 1dd6a14e · 2026-05-25 · Merge pull request #786 from CodySwannGT/codex/issue-772-github-build-intake
-- 5bc05617 · 2026-05-26 · Merge branch 'main' into codex/issue-772-github-build-intake
-- 4f83acd5 · 2026-05-25 · fix(council): sanitize runtime captures
-- 56bcd10a · 2026-05-26 · chore(release): 2.84.0 [skip ci]
-- c8b8569d · 2026-05-25 · Merge pull request #785 from CodySwannGT/codex/issue-771-github-build-intake
-- 92c14ffa · 2026-05-26 · Merge branch 'main' into codex/issue-771-github-build-intake
-- f8a595cd · 2026-05-25 · Merge pull request #784 from CodySwannGT/codex/issue-775-github-build-intake
-- 3d142f9a · 2026-05-25 · feat(council): add runtime-filtered dry-run critique planning
-- e2c055e0 · 2026-05-26 · fix: address CodeRabbit review on PR #784
-- 2b024e7e · 2026-05-25 · test: add harness parity council fixture smoke coverage
-- 20e518c5 · 2026-05-25 · chore(release): 2.83.0 [skip ci]
-- 299c16eb · 2026-05-25 · Merge pull request #783 from CodySwannGT/codex/issue-770-github-build-intake
-- ca3693ef · 2026-05-25 · feat(skills): add first-round council consultation flow
-- fb720abf · 2026-05-25 · chore(release): 2.82.0 [skip ci]
-- bf5b6fce · 2026-05-25 · Merge pull request #782 from CodySwannGT/codex/issue-769-github-build-intake
-- 478cff7b · 2026-05-25 · feat(skills): add council runtime adapter planning
-- 0de792a5 · 2026-05-25 · chore(release): 2.81.0 [skip ci]
-- 606e35e3 · 2026-05-25 · Merge pull request #781 from CodySwannGT/codex/issue-768-council-skill
-- dfa595ae · 2026-05-25 · feat(skills): add harness parity council scaffold
-- c375f641 · 2026-05-25 · chore(release): 2.80.1 [skip ci]
-- 8b3a8717 · 2026-05-25 · Merge pull request #780 from CodySwannGT/codex/issue-756-github-build-intake
-- bb26d993 · 2026-05-25 · test(doctor): add fixture smoke and parity coverage
-- 4ec1b5e0 · 2026-05-25 · chore(release): 2.80.0 [skip ci]
-- ab9c98ac · 2026-05-25 · Merge pull request #779 from CodySwannGT/codex/issue-755-github-build-intake
-- f38b1976 · 2026-05-25 · feat(doctor): define wiki delegation contract
-- 753e8cc7 · 2026-05-25 · chore(release): 2.79.0 [skip ci]
-- cec3bc95 · 2026-05-25 · Merge pull request #778 from CodySwannGT/codex/issue-754-github-build-intake
-- 46a11ce4 · 2026-05-25 · feat: document doctor automation readiness
-- b21307a2 · 2026-05-25 · chore(release): 2.78.0 [skip ci]
-- d910724a · 2026-05-25 · Merge pull request #777 from CodySwannGT/codex/issue-753-github-build-intake
-- 6ba43628 · 2026-05-25 · feat(doctor): validate github project readiness
-- 616a27d1 · 2026-05-25 · chore(release): 2.77.2 [skip ci]
-- bd8a2048 · 2026-05-25 · Merge pull request #776 from CodySwannGT/codex/issue-752-github-build-intake
-- 03b93756 · 2026-05-25 · docs(doctor): define vendor preflight readiness contract
-- 69229c87 · 2026-05-25 · chore(release): 2.77.1 [skip ci]
-- be529e0c · 2026-05-25 · Merge pull request #762 from CodySwannGT/codex/issue-751-github-build-intake
-- cc3fd992 · 2026-05-25 · docs: lock doctor config readiness contract
-- 97a1a6a3 · 2026-05-25 · chore(release): 2.77.0 [skip ci]
-- 694fde21 · 2026-05-25 · Merge pull request #761 from CodySwannGT/codex/issue-750-github-build-intake
-- 1572c1e6 · 2026-05-25 · feat(doctor): add grouped report renderer
-- 4c058e0a · 2026-05-25 · chore(release): 2.76.0 [skip ci]
-- 1b8a221c · 2026-05-25 · Merge pull request #760 from CodySwannGT/codex/issue-749-github-build-intake
-- 27b2ceaf · 2026-05-25 · feat(doctor): add doctor command scaffold
-- c3916e3a · 2026-05-25 · chore(release): 2.75.1 [skip ci]
-- 826e05a5 · 2026-05-25 · Merge pull request #759 from CodySwannGT/codex/issue-735-github-build-intake
-- 164b247c · 2026-05-25 · test: harden usage accounting coverage
-- f57ba02c · 2026-05-25 · chore(release): 2.75.0 [skip ci]
-- ad713697 · 2026-05-25 · Merge pull request #757 from CodySwannGT/codex/issue-733-github-build-intake
-- 1f8568ab · 2026-05-25 · Merge branch 'main' into codex/issue-733-github-build-intake
-- 5983ed4f · 2026-05-25 · feat(config-resolution): add usage pricing contract
-- b56e32da · 2026-05-25 · chore(release): 2.74.1 [skip ci]
-- b6af54bd · 2026-05-25 · Merge pull request #743 from CodySwannGT/wiki/ingest-2026-05-25-2
-- 097b1543 · 2026-05-25 · Merge branch 'main' into wiki/ingest-2026-05-25-2
-- 0cb398da · 2026-05-25 · Merge pull request #742 from CodySwannGT/codex/issue-732-github-build-intake
-- 26781438 · 2026-05-25 · Merge branch 'main' into codex/issue-732-github-build-intake
-- 651f1fae · 2026-05-25 · docs(wiki): ingest incremental git history
-- 8958987c · 2026-05-25 · docs: wire usage accounting into delivery flows
+- ea144c8b · 2026-05-26 · chore(release): 2.91.2 [skip ci]
+- f83c8362 · 2026-05-25 · Merge pull request #812 from CodySwannGT/codex/issue-804-automation-status-docs
+- 8ddb5f01 · 2026-05-25 · docs: add automation-status operator guidance
+- 58b6b994 · 2026-05-26 · chore(release): 2.91.1 [skip ci]
+- e3c3cc33 · 2026-05-25 · Merge pull request #811 from CodySwannGT/codex/issue-803-automation-status-smoke
+- 29d99fbd · 2026-05-26 · Merge branch 'main' into codex/issue-803-automation-status-smoke
+- cc099af6 · 2026-05-25 · test(automation-status): add fixture smoke coverage
+- 0fffedf3 · 2026-05-26 · chore(release): 2.91.0 [skip ci]
+- 2b1ec625 · 2026-05-25 · Merge pull request #810 from CodySwannGT/codex/issue-802-claude-automation-status
+- cb272f8f · 2026-05-26 · Merge branch 'main' into codex/issue-802-claude-automation-status
+- dd127678 · 2026-05-25 · feat(automation-status): add Claude schedule adapter (#802)
+- 823ce331 · 2026-05-26 · chore(release): 2.90.0 [skip ci]
+- 4b25af24 · 2026-05-25 · Merge pull request #809 from CodySwannGT/codex/issue-801-codex-automation-status
+- d514c0ef · 2026-05-25 · feat(automation-status): inspect codex automation metadata
+- a68f93e5 · 2026-05-26 · chore(release): 2.89.0 [skip ci]
+- 2e0d90d7 · 2026-05-25 · Merge pull request #808 from CodySwannGT/codex/issue-800-automation-status-drift
+- 922de566 · 2026-05-25 · feat(automation-status): detect contract drift
+- fb7197bc · 2026-05-26 · chore(release): 2.88.0 [skip ci]
+- b1daa98f · 2026-05-25 · Merge pull request #807 from CodySwannGT/codex/issue-799-automation-status-expected-fleet
+- 31997323 · 2026-05-25 · feat(automation-status): resolve expected fleet contract
+- 934bfa03 · 2026-05-26 · chore(release): 2.87.0 [skip ci]
+- 5c543ee5 · 2026-05-25 · Merge pull request #806 from CodySwannGT/codex/issue-798-automation-status-output
+- 2a9cebf6 · 2026-05-26 · Merge branch 'main' into codex/issue-798-automation-status-output
+- 2958695e · 2026-05-26 · chore(release): 2.86.0 [skip ci]
+- e3bc4d74 · 2026-05-25 · feat(automation-status): add grouped fleet report renderer
+- a890a03b · 2026-05-25 · Merge pull request #805 from CodySwannGT/codex/issue-797-automation-status-scaffold
+- 08664f72 · 2026-05-26 · Merge branch 'main' into codex/issue-797-automation-status-scaffold
+- 1d004dcd · 2026-05-25 · feat(lisa): scaffold automation-status surfaces
+- dd9c248b · 2026-05-26 · chore(release): 2.85.2 [skip ci]
+- 6b49847f · 2026-05-25 · Merge pull request #791 from CodySwannGT/wiki/ingest-2026-05-25-3844
+- da1af529 · 2026-05-25 · docs(wiki): ingest incremental git history

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-26T01:29:36.312Z",
+  "ingested_at": "2026-05-26T05:31:30.185Z",
   "cursor": {
-    "lastCommit": "7a56fd065774adb22bcb7ff7857e1d89170f5f75",
-    "lastPr": 789
+    "lastCommit": "ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb",
+    "lastPr": 812
   },
   "source_notes": [
     "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-26T01:29:36.722Z",
+  "ingested_at": "2026-05-26T05:31:28.711Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary\n- ingest the latest enabled non-external-write Lisa wiki sources\n- refresh the monorepo snapshot and connector state\n- record the latest incremental wiki ingest in the log\n\n## Verification\n- git diff --check\n- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json\n- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project documentation logs and state tracking records to reflect the latest project ingestion cycle and version information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->