### PR TITLE
docs(github): add project coordination rollout coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Most users only ever call `/lisa:research`, `/lisa:plan`, and `/lisa:implement`.
 
 PRD intake records generated work with native hierarchy where the source and tracker support it, and with a durable generated-work fallback everywhere else. The vendor matrix for GitHub, Linear, JIRA/Atlassian, Confluence, Notion, and cross-vendor queues lives in `plugins/src/base/rules/prd-lifecycle-rollup.md`.
 
+### Optional GitHub Project Coordination
+
+GitHub Projects are an optional coordination layer for GitHub-backed Lisa flows, not the lifecycle source of truth. Real GitHub Issues and Pull Requests still carry the durable labels, comments, hierarchy, dependencies, and review state; Project membership just gives you a cross-repo view over that work.
+
+Use `/lisa:setup-github` to scaffold `github.projects.v2` in `.lisa.config.json`, then `/lisa:doctor` to verify namespace and access before operators rely on it. In v1, `github.projects.v2.owner.slug` must match `github.org`. `required: false` is the default best-effort mode: repository-local issue and PR writes still succeed if Project membership cannot be added. `required: true` upgrades the same failure into a blocking readiness error.
+
+This does not relax Lisa's single-repo leaf rule. PRDs, Epics, Stories, and Spikes may coordinate work across repositories, but every build-ready Task, Bug, Sub-task, or Improvement must still target exactly one repository, carry exactly one `repo:<name>` marker, and be claimed only by that repository's intake lane.
+
 ### Maintenance and Operations
 
 | Command | What it does |

--- a/plugins/lisa/commands/doctor.md
+++ b/plugins/lisa/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional GitHub Project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
 argument-hint: "[--fix=false]"
 ---
 

--- a/plugins/lisa/commands/setup/github.md
+++ b/plugins/lisa/commands/setup/github.md
@@ -1,5 +1,5 @@
 ---
-description: "Set up GitHub Issues as the tracker and/or PRD source for this project. Verifies the gh CLI, resolves org/repo, scaffolds the `status:*` (build) and/or `prd-*` (PRD) label namespaces, writes the `github` section of `.lisa.config.json`, and offers to set top-level `tracker: \"github\"` / `source: \"github\"`. No /lisa:setup:atlassian prerequisite."
+description: "Set up GitHub Issues as the tracker and/or PRD source for this project. Verifies the gh CLI, resolves org/repo, scaffolds the `status:*` (build) and/or `prd-*` (PRD) label namespaces, writes the `github` section of `.lisa.config.json`, and can document optional GitHub ProjectV2 coordination before offering top-level `tracker: \"github\"` / `source: \"github\"`. No /lisa:setup:atlassian prerequisite."
 allowed-tools: ["Skill"]
 argument-hint: "[--repo=<org/repo>]"
 ---

--- a/plugins/src/base/commands/doctor.md
+++ b/plugins/src/base/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
+description: "Audit whether the current repository is ready to use Lisa. Runs grouped read-only readiness checks for config, runtime surfaces, tracker/source access, automation prerequisites, and optional GitHub Project/wiki coordination, then reports PASS/WARN/FAIL/SKIP results plus an overall verdict."
 argument-hint: "[--fix=false]"
 ---
 

--- a/plugins/src/base/commands/setup/github.md
+++ b/plugins/src/base/commands/setup/github.md
@@ -1,5 +1,5 @@
 ---
-description: "Set up GitHub Issues as the tracker and/or PRD source for this project. Verifies the gh CLI, resolves org/repo, scaffolds the `status:*` (build) and/or `prd-*` (PRD) label namespaces, writes the `github` section of `.lisa.config.json`, and offers to set top-level `tracker: \"github\"` / `source: \"github\"`. No /lisa:setup:atlassian prerequisite."
+description: "Set up GitHub Issues as the tracker and/or PRD source for this project. Verifies the gh CLI, resolves org/repo, scaffolds the `status:*` (build) and/or `prd-*` (PRD) label namespaces, writes the `github` section of `.lisa.config.json`, and can document optional GitHub ProjectV2 coordination before offering top-level `tracker: \"github\"` / `source: \"github\"`. No /lisa:setup:atlassian prerequisite."
 allowed-tools: ["Skill"]
 argument-hint: "[--repo=<org/repo>]"
 ---

--- a/tests/unit/strategies/github-project-operator-docs.test.ts
+++ b/tests/unit/strategies/github-project-operator-docs.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Operator-facing docs coverage for first-version GitHub Project coordination.
+ *
+ * Issue #706 adds the rollout-facing docs and static proof that setup, doctor,
+ * README guidance, and the single-repo leaf invariant stay aligned while the
+ * generated `plugins/lisa` command surfaces remain in lockstep with the
+ * `plugins/src/base` sources.
+ * @module tests/unit/strategies/github-project-operator-docs
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (filePath: string): string =>
+  readFileSync(path.resolve(filePath), "utf8");
+
+describe("GitHub Project coordination rollout docs (#706)", () => {
+  it("documents operator entrypoints and v1 semantics in the README", () => {
+    const readme = read("README.md");
+
+    expect(readme).toContain("### Optional GitHub Project Coordination");
+    expect(readme).toContain("/lisa:setup-github");
+    expect(readme).toContain("/lisa:doctor");
+    expect(readme).toMatch(/optional coordination layer/i);
+    expect(readme).toMatch(/not the lifecycle source of truth/i);
+    expect(readme).toMatch(/owner\.slug.*must match.*github\.org/i);
+    expect(readme).toMatch(/required:\s*false.*best-effort/i);
+    expect(readme).toMatch(/required:\s*true.*blocking readiness error/i);
+    expect(readme).toMatch(/single-repo leaf rule/i);
+    expect(readme).toMatch(/Task, Bug, Sub-task, or Improvement/i);
+    expect(readme).toMatch(/exactly one `repo:<name>` marker/i);
+  });
+
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    it("keeps setup and doctor command descriptions explicit about Project coordination", () => {
+      const setupCommand = read(
+        path.join(root, "commands", "setup", "github.md")
+      );
+      const doctorCommand = read(path.join(root, "commands", "doctor.md"));
+
+      expect(setupCommand).toMatch(/optional GitHub ProjectV2 coordination/i);
+      expect(setupCommand).toContain(".lisa.config.json");
+      expect(setupCommand).toMatch(/tracker:\s*\\?"github\\?"/i);
+      expect(doctorCommand).toMatch(
+        /optional GitHub Project\/wiki coordination/i
+      );
+      expect(doctorCommand).toMatch(/PASS\/WARN\/FAIL\/SKIP/i);
+    });
+
+    it("keeps setup, doctor, and intake docs aligned with the single-repo leaf invariant", () => {
+      const setupSkill = read(
+        path.join(root, "skills", "setup-github", "SKILL.md")
+      );
+      const doctorSkill = read(path.join(root, "skills", "doctor", "SKILL.md"));
+      const intakeSkill = read(
+        path.join(root, "skills", "github-build-intake", "SKILL.md")
+      );
+      const decompositionSkill = read(
+        path.join(root, "skills", "task-decomposition", "SKILL.md")
+      );
+
+      expect(setupSkill).toMatch(/Project membership is best-effort/i);
+      expect(setupSkill).toMatch(
+        /cross-namespace Project ownership is rejected/i
+      );
+      expect(doctorSkill).toMatch(/required:\s*false.*doctor `WARN`/i);
+      expect(doctorSkill).toMatch(/required:\s*true.*doctor `FAIL`/i);
+      expect(intakeSkill).toMatch(/repo:<name>/);
+      expect(intakeSkill).toMatch(/Multi-repo leaf.*never claim/i);
+      expect(decompositionSkill).toMatch(/PRD.*MAY span repos/i);
+      expect(decompositionSkill).toMatch(
+        /Task, Bug, Sub-task, Improvement.*MUST name exactly one repo/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add operator-facing README guidance for optional GitHub Project coordination
- clarify setup/doctor command surfaces around ProjectV2 readiness checks
- add static regression coverage tying project coordination docs to the single-repo leaf invariant

## Testing
- bun x vitest run tests/unit/strategies/github-project-operator-docs.test.ts tests/unit/strategies/setup-github-project-verification.test.ts tests/unit/strategies/doctor-project-readiness.test.ts tests/unit/strategies/github-project-v2-utility.test.ts tests/unit/strategies/github-writer-project-membership.test.ts tests/unit/strategies/multi-repo-container-decomposition.test.ts
- pre-push hook: eslint slow rules, knip, vitest run --coverage, vitest run tests/integration

Closes #706