### PR TITLE
feat(queue-status): scaffold command and skill surfaces

### DIFF
--- a/plugins/lisa/commands/queue-status.md
+++ b/plugins/lisa/commands/queue-status.md
@@ -1,0 +1,13 @@
+---
+description: "Inspect the current project's PRD and build queues, summarize lifecycle counts, and surface actionable queue-health signals without mutating work."
+---
+
+Use the /lisa:queue-status skill to inspect the current project's configured PRD source and build tracker, report queue-health verdicts, and highlight actionable backlog or stuck-state signals. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:queue-status`
+- `/lisa:queue-status queue=prd`
+- `/lisa:queue-status queue=build`
+
+This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, or deeper tracker-native investigation.

--- a/plugins/lisa/skills/queue-status/SKILL.md
+++ b/plugins/lisa/skills/queue-status/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: queue-status
+description: "Read-only operator surface for the current project's PRD and build backlog health. Resolves the configured PRD source and build tracker from the same Lisa contract used by intake and repair, summarizes lifecycle-role counts, distinguishes idle queues from setup problems, and highlights actionable blocked, in-review, claimed, or shipped work."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Queue Status: $ARGUMENTS
+
+`/lisa:queue-status` is the operator-facing inspection surface for Lisa's live backlog state. It answers, for the **current repo only**, what Lisa's configured PRD queue and build queue currently look like, whether the queues appear healthy or stuck, and which items are most actionable next.
+
+This command is **read-only** in v1. It does not create, claim, relabel, repair, transition, comment on, or otherwise mutate queue items. It complements `/lisa:intake`, `/lisa:repair-intake`, `/lisa:verify-prd`, `/lisa:automation-status`, and the underlying vendor trackers; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects queue state and reports what it finds. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect only the Lisa queues for the current project:
+
+- the configured PRD source queue
+- the configured build tracker queue
+
+Resolve queue source, tracker, lifecycle roles, and queue arguments from the **same contract** Lisa already uses for `/lisa:intake` and `/lisa:repair-intake`. Do **not** invent a second source of truth for queue detection, lifecycle naming, or stack support.
+
+Support a repo-scoped queue selector when requested:
+
+- default: inspect both queues
+- `queue=prd`: inspect only the PRD queue
+- `queue=build`: inspect only the build queue
+
+## What to report
+
+For each inspected queue, report:
+
+1. The queue source or tracker Lisa resolved.
+2. Lifecycle counts using the repo's configured role names.
+3. Whether the queue appears `IDLE`, `HEALTHY`, `ATTENTION_NEEDED`, or `MISCONFIGURED`.
+4. Whether the lifecycle namespace appears adopted versus absent.
+5. The oldest or most actionable blocked, in-review, claimed, shipped, or similar stuck items Lisa can surface without mutating work.
+6. A concise remediation hint when attention is needed.
+
+The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Runtime and vendor expectations
+
+- Reuse the same config-resolution defaults and queue-routing rules that `intake` and `repair-intake` use.
+- Work from the current repo's `.lisa.config.json` instead of hardcoding one vendor's lifecycle names.
+- Support the vendor families already served by Lisa intake: GitHub, Linear, JIRA, Notion, and Confluence.
+- If a queue cannot be resolved or its lifecycle namespace has not been adopted, report that explicitly as `MISCONFIGURED` rather than pretending the queue is empty.
+
+## Verdicts and remediation
+
+- `IDLE`: the queue resolved successfully and no actionable ready or stuck work is present.
+- `HEALTHY`: the queue resolved successfully and the current backlog/state appears normal.
+- `ATTENTION_NEEDED`: the queue resolved, but blocked, stalled, or accumulating work needs operator follow-up.
+- `MISCONFIGURED`: Lisa could not resolve the queue, could not find the expected lifecycle namespace, or detected another setup/adoption problem.
+
+Status-specific remediation guidance:
+
+- `IDLE`: explain that the queue is currently quiet and no immediate operator action is required.
+- `HEALTHY`: point operators to `/lisa:intake` or `/lisa:repair-intake` when they want Lisa to act on the reported state.
+- `ATTENTION_NEEDED`: identify the most actionable blocked or stalled items and suggest the next Lisa or tracker-native command to investigate.
+- `MISCONFIGURED`: show which queue contract is missing or unresolved and recommend fixing `.lisa.config.json`, adopting the lifecycle namespace, or rerunning the relevant setup flow.
+
+## Rules
+
+- Stay **read-only**. Never create, update, claim, relabel, repair, transition, or comment on queue items from this skill.
+- Keep the report repo-scoped to the current project instead of aggregating unrelated repos or teams.
+- Distinguish truly idle queues from lifecycle-namespace absence or unresolved config.
+- Reuse `intake` and `repair-intake` contract semantics so queue health reporting does not drift from execution behavior.
+- Keep observable queue facts separate from remediation guidance so operators can tell the current state from the recommended next step.

--- a/plugins/lisa/skills/queue-status/agents/openai.yaml
+++ b/plugins/lisa/skills/queue-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Queue Status"
+short_description: "Read-only operator surface for the current project's PRD and build backlog health"
+default_prompt:
+  - "Use $queue-status: Read-only operator surface for the current project's PRD and build backlog health."

--- a/plugins/src/base/commands/queue-status.md
+++ b/plugins/src/base/commands/queue-status.md
@@ -1,0 +1,13 @@
+---
+description: "Inspect the current project's PRD and build queues, summarize lifecycle counts, and surface actionable queue-health signals without mutating work."
+---
+
+Use the /lisa:queue-status skill to inspect the current project's configured PRD source and build tracker, report queue-health verdicts, and highlight actionable backlog or stuck-state signals. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:queue-status`
+- `/lisa:queue-status queue=prd`
+- `/lisa:queue-status queue=build`
+
+This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, or deeper tracker-native investigation.

--- a/plugins/src/base/skills/queue-status/SKILL.md
+++ b/plugins/src/base/skills/queue-status/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: queue-status
+description: "Read-only operator surface for the current project's PRD and build backlog health. Resolves the configured PRD source and build tracker from the same Lisa contract used by intake and repair, summarizes lifecycle-role counts, distinguishes idle queues from setup problems, and highlights actionable blocked, in-review, claimed, or shipped work."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Queue Status: $ARGUMENTS
+
+`/lisa:queue-status` is the operator-facing inspection surface for Lisa's live backlog state. It answers, for the **current repo only**, what Lisa's configured PRD queue and build queue currently look like, whether the queues appear healthy or stuck, and which items are most actionable next.
+
+This command is **read-only** in v1. It does not create, claim, relabel, repair, transition, comment on, or otherwise mutate queue items. It complements `/lisa:intake`, `/lisa:repair-intake`, `/lisa:verify-prd`, `/lisa:automation-status`, and the underlying vendor trackers; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects queue state and reports what it finds. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect only the Lisa queues for the current project:
+
+- the configured PRD source queue
+- the configured build tracker queue
+
+Resolve queue source, tracker, lifecycle roles, and queue arguments from the **same contract** Lisa already uses for `/lisa:intake` and `/lisa:repair-intake`. Do **not** invent a second source of truth for queue detection, lifecycle naming, or stack support.
+
+Support a repo-scoped queue selector when requested:
+
+- default: inspect both queues
+- `queue=prd`: inspect only the PRD queue
+- `queue=build`: inspect only the build queue
+
+## What to report
+
+For each inspected queue, report:
+
+1. The queue source or tracker Lisa resolved.
+2. Lifecycle counts using the repo's configured role names.
+3. Whether the queue appears `IDLE`, `HEALTHY`, `ATTENTION_NEEDED`, or `MISCONFIGURED`.
+4. Whether the lifecycle namespace appears adopted versus absent.
+5. The oldest or most actionable blocked, in-review, claimed, shipped, or similar stuck items Lisa can surface without mutating work.
+6. A concise remediation hint when attention is needed.
+
+The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Runtime and vendor expectations
+
+- Reuse the same config-resolution defaults and queue-routing rules that `intake` and `repair-intake` use.
+- Work from the current repo's `.lisa.config.json` instead of hardcoding one vendor's lifecycle names.
+- Support the vendor families already served by Lisa intake: GitHub, Linear, JIRA, Notion, and Confluence.
+- If a queue cannot be resolved or its lifecycle namespace has not been adopted, report that explicitly as `MISCONFIGURED` rather than pretending the queue is empty.
+
+## Verdicts and remediation
+
+- `IDLE`: the queue resolved successfully and no actionable ready or stuck work is present.
+- `HEALTHY`: the queue resolved successfully and the current backlog/state appears normal.
+- `ATTENTION_NEEDED`: the queue resolved, but blocked, stalled, or accumulating work needs operator follow-up.
+- `MISCONFIGURED`: Lisa could not resolve the queue, could not find the expected lifecycle namespace, or detected another setup/adoption problem.
+
+Status-specific remediation guidance:
+
+- `IDLE`: explain that the queue is currently quiet and no immediate operator action is required.
+- `HEALTHY`: point operators to `/lisa:intake` or `/lisa:repair-intake` when they want Lisa to act on the reported state.
+- `ATTENTION_NEEDED`: identify the most actionable blocked or stalled items and suggest the next Lisa or tracker-native command to investigate.
+- `MISCONFIGURED`: show which queue contract is missing or unresolved and recommend fixing `.lisa.config.json`, adopting the lifecycle namespace, or rerunning the relevant setup flow.
+
+## Rules
+
+- Stay **read-only**. Never create, update, claim, relabel, repair, transition, or comment on queue items from this skill.
+- Keep the report repo-scoped to the current project instead of aggregating unrelated repos or teams.
+- Distinguish truly idle queues from lifecycle-namespace absence or unresolved config.
+- Reuse `intake` and `repair-intake` contract semantics so queue health reporting does not drift from execution behavior.
+- Keep observable queue facts separate from remediation guidance so operators can tell the current state from the recommended next step.

--- a/tests/unit/strategies/queue-status-scaffold.test.ts
+++ b/tests/unit/strategies/queue-status-scaffold.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for the `/lisa:queue-status` command + skill scaffold.
+ *
+ * Issue #820 introduces the initial operator-facing distribution surfaces for
+ * queue inspection: the base command file, the base skill scaffold, and the
+ * generated `plugins/lisa` artifact mirror. Runtime adapters, lifecycle-role
+ * readers, output rendering, smoke coverage, and operator docs land in follow-up
+ * tickets.
+ *
+ * This suite proves the scaffold shipped in both plugin roots and documents the
+ * intended contract clearly enough for the later implementation work:
+ *   (1) the command delegates to `/lisa:queue-status`;
+ *   (2) the skill is read-only and repo-scoped;
+ *   (3) the skill reuses intake and repair-intake contract semantics rather than
+ *       inventing a second source of truth;
+ *   (4) the skill names the expected queue verdicts and vendor families.
+ *
+ * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
+ * suite.
+ * @module tests/unit/strategies/queue-status-scaffold
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+const COMMAND_REL = "commands/queue-status.md";
+const SKILL_REL = "skills/queue-status/SKILL.md";
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("queue-status scaffold (#820)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const commandPath = path.resolve(root, COMMAND_REL);
+    const skillPath = path.resolve(root, SKILL_REL);
+
+    it("ships the command and skill in this plugin root", () => {
+      expect(existsSync(commandPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    it("uses a pass-through command that delegates to /lisa:queue-status", () => {
+      const command = read(root, COMMAND_REL);
+
+      expect(command).toMatch(/^---/);
+      expect(command).toMatch(/description:/);
+      expect(command).toMatch(/Use the \/lisa:queue-status skill/);
+      expect(command).toContain("$ARGUMENTS");
+    });
+
+    it("documents a read-only, repo-scoped queue inspection surface", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/^---/);
+      expect(skill).toMatch(/name:\s*queue-status/);
+      expect(skill).toMatch(/allowed-tools:/);
+      expect(skill).toContain("Skill");
+      expect(skill).toContain("Bash");
+      expect(skill).toContain("Read");
+      expect(skill).toMatch(/read-only/i);
+      expect(skill).toMatch(/current repo|current project/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* ask for confirmation|do not ask for confirmation/i
+      );
+    });
+
+    it("reuses intake and repair-intake contract semantics", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/intake/);
+      expect(skill).toMatch(/repair-intake/);
+      expect(skill).toMatch(/same contract/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* invent a second source of truth|do not invent a second source of truth/i
+      );
+      expect(skill).toMatch(/queue source/i);
+      expect(skill).toMatch(/build tracker/i);
+    });
+
+    it("names the expected queue verdicts and supported vendor families", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/IDLE/);
+      expect(skill).toMatch(/HEALTHY/);
+      expect(skill).toMatch(/ATTENTION_NEEDED/);
+      expect(skill).toMatch(/MISCONFIGURED/);
+      expect(skill).toMatch(/GitHub/);
+      expect(skill).toMatch(/Linear/);
+      expect(skill).toMatch(/JIRA/);
+      expect(skill).toMatch(/Notion/);
+      expect(skill).toMatch(/Confluence/);
+    });
+
+    it("documents the queue selector and actionable-highlight expectations", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/queue=prd/);
+      expect(skill).toMatch(/queue=build/);
+      expect(skill).toMatch(/blocked/i);
+      expect(skill).toMatch(/in-review|in review/i);
+      expect(skill).toMatch(/claimed/i);
+      expect(skill).toMatch(/shipped/i);
+      expect(skill).toMatch(/remediation/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the source queue-status command and skill scaffold for the Lisa operator surface
- regenerate the distributed plugins/lisa queue-status artifacts, including the Codex interface file
- add focused regression coverage that proves both plugin roots ship the read-only scaffold contract

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/queue-status-scaffold.test.ts
- pre-push hook: eslint slow, knip, vitest --coverage, vitest integration

Closes #820