### PR TITLE
feat(queue-status): define grouped output contract

### DIFF
--- a/plugins/lisa/skills/queue-status/SKILL.md
+++ b/plugins/lisa/skills/queue-status/SKILL.md
@@ -31,6 +31,12 @@ Support a repo-scoped queue selector when requested:
 
 ## What to report
 
+Render the report in **grouped sections** so operators can scan it top-down without reading raw tracker dumps:
+
+1. An optional overall queue-health summary when inspecting both queues.
+2. One PRD queue section when the PRD queue is in scope.
+3. One build queue section when the build queue is in scope.
+
 For each inspected queue, report:
 
 1. The queue source or tracker Lisa resolved.
@@ -41,6 +47,16 @@ For each inspected queue, report:
 6. A concise remediation hint when attention is needed.
 
 The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Output shape
+
+Use a stable terminal-friendly shape:
+
+1. `Overall verdict` line when both queues are shown.
+2. `PRD queue` heading with resolved source, verdict, lifecycle counts, actionable highlights, and remediation.
+3. `Build queue` heading with resolved tracker, verdict, lifecycle counts, actionable highlights, and remediation.
+
+Queue sections should stay visually grouped. Do not interleave PRD and build facts item-by-item.
 
 ## Runtime and vendor expectations
 
@@ -55,6 +71,13 @@ The report should stay terminal-first and immediately actionable: observable que
 - `HEALTHY`: the queue resolved successfully and the current backlog/state appears normal.
 - `ATTENTION_NEEDED`: the queue resolved, but blocked, stalled, or accumulating work needs operator follow-up.
 - `MISCONFIGURED`: Lisa could not resolve the queue, could not find the expected lifecycle namespace, or detected another setup/adoption problem.
+
+When both queues are in scope, derive the **overall verdict** from the queue sections:
+
+- `MISCONFIGURED` if any inspected queue is misconfigured.
+- Otherwise `ATTENTION_NEEDED` if any inspected queue needs operator follow-up.
+- Otherwise `HEALTHY` if any inspected queue has normal actionable work in motion.
+- Otherwise `IDLE`.
 
 Status-specific remediation guidance:
 

--- a/plugins/src/base/skills/queue-status/SKILL.md
+++ b/plugins/src/base/skills/queue-status/SKILL.md
@@ -31,6 +31,12 @@ Support a repo-scoped queue selector when requested:
 
 ## What to report
 
+Render the report in **grouped sections** so operators can scan it top-down without reading raw tracker dumps:
+
+1. An optional overall queue-health summary when inspecting both queues.
+2. One PRD queue section when the PRD queue is in scope.
+3. One build queue section when the build queue is in scope.
+
 For each inspected queue, report:
 
 1. The queue source or tracker Lisa resolved.
@@ -41,6 +47,16 @@ For each inspected queue, report:
 6. A concise remediation hint when attention is needed.
 
 The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Output shape
+
+Use a stable terminal-friendly shape:
+
+1. `Overall verdict` line when both queues are shown.
+2. `PRD queue` heading with resolved source, verdict, lifecycle counts, actionable highlights, and remediation.
+3. `Build queue` heading with resolved tracker, verdict, lifecycle counts, actionable highlights, and remediation.
+
+Queue sections should stay visually grouped. Do not interleave PRD and build facts item-by-item.
 
 ## Runtime and vendor expectations
 
@@ -55,6 +71,13 @@ The report should stay terminal-first and immediately actionable: observable que
 - `HEALTHY`: the queue resolved successfully and the current backlog/state appears normal.
 - `ATTENTION_NEEDED`: the queue resolved, but blocked, stalled, or accumulating work needs operator follow-up.
 - `MISCONFIGURED`: Lisa could not resolve the queue, could not find the expected lifecycle namespace, or detected another setup/adoption problem.
+
+When both queues are in scope, derive the **overall verdict** from the queue sections:
+
+- `MISCONFIGURED` if any inspected queue is misconfigured.
+- Otherwise `ATTENTION_NEEDED` if any inspected queue needs operator follow-up.
+- Otherwise `HEALTHY` if any inspected queue has normal actionable work in motion.
+- Otherwise `IDLE`.
 
 Status-specific remediation guidance:
 

--- a/tests/unit/strategies/queue-status-scaffold.test.ts
+++ b/tests/unit/strategies/queue-status-scaffold.test.ts
@@ -13,7 +13,9 @@
  *   (2) the skill is read-only and repo-scoped;
  *   (3) the skill reuses intake and repair-intake contract semantics rather than
  *       inventing a second source of truth;
- *   (4) the skill names the expected queue verdicts and vendor families.
+ *   (4) the skill names the expected queue verdicts and vendor families;
+ *   (5) the skill defines a grouped PRD/build output shape with an overall
+ *       verdict and concise remediation guidance.
  *
  * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
  * suite.
@@ -103,6 +105,27 @@ describe("queue-status scaffold (#820)", () => {
       expect(skill).toMatch(/claimed/i);
       expect(skill).toMatch(/shipped/i);
       expect(skill).toMatch(/remediation/i);
+    });
+
+    it("defines grouped queue sections and overall-verdict mapping", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/grouped sections/i);
+      expect(skill).toMatch(/overall queue-health summary|overall verdict/i);
+      expect(skill).toMatch(/PRD queue section|PRD queue heading/i);
+      expect(skill).toMatch(/Build queue section|Build queue heading/i);
+      expect(skill).toMatch(/Do not interleave PRD and build facts/i);
+      expect(skill).toMatch(
+        /derive the \*\*overall verdict\*\*|derive the overall verdict/i
+      );
+      expect(skill).toMatch(
+        /`MISCONFIGURED` if any inspected queue is misconfigured/i
+      );
+      expect(skill).toMatch(
+        /`ATTENTION_NEEDED` if any inspected queue needs operator follow-up/i
+      );
+      expect(skill).toMatch(/Otherwise `HEALTHY`|Otherwise HEALTHY/i);
+      expect(skill).toMatch(/Otherwise `IDLE`|Otherwise IDLE/i);
     });
   });
 });


### PR DESCRIPTION
## Summary
- define the grouped PRD/build queue-status report shape in the upstream skill contract
- document overall verdict rollup rules and remediation expectations
- extend queue-status scaffold coverage to lock the new contract in both plugin roots

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/queue-status-scaffold.test.ts
- hook verification during git push: eslint.slow.config.ts, knip, vitest --coverage, vitest tests/integration

Closes #821