### PR TITLE
feat: share queue contract resolution

### DIFF
--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -8,6 +8,13 @@
  * truth.
  */
 
+import {
+  resolveBuildQueueArgument,
+  resolveGithubRepoRef,
+  resolvePrdQueueArgument,
+  resolvePrdSource,
+} from "./queue-contract-resolution.mjs";
+
 export const AUTOMATION_EXPECTED_CADENCES = {
   "intake-repair": {
     human: "every 60 minutes",
@@ -32,11 +39,6 @@ export const AUTOMATION_EXPECTED_CADENCES = {
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
-
-const GITHUB_REMOTE_PATTERNS = [
-  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
-  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
-];
 
 /**
  * @typedef {{
@@ -232,83 +234,6 @@ function createUnsupportedEntry(identity, id, reason) {
 /**
  * @param {Record<string, any>} config
  * @param {string | undefined} source
- * @returns {string}
- */
-function resolvePrdQueueArgument(config, source) {
-  switch (source) {
-    case "github":
-      requireGithubRepo(config);
-      return "github intake_mode=prd";
-    case "linear":
-      requireLinearWorkspace(config);
-      return "linear";
-    case "notion": {
-      const databaseId = config.notion?.prdDatabaseId;
-      if (!databaseId) {
-        throw new Error(
-          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
-        );
-      }
-      return databaseId;
-    }
-    case "confluence": {
-      const parentPageId = config.confluence?.parentPageId;
-      const spaceKey = config.confluence?.spaceKey;
-      if (!parentPageId && !spaceKey) {
-        throw new Error(
-          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
-        );
-      }
-      return parentPageId ?? spaceKey;
-    }
-    case "jira": {
-      const project = config.jira?.project;
-      if (!project) {
-        throw new Error(
-          "Unable to resolve the PRD queue: jira.project is required when source=jira."
-        );
-      }
-      return project;
-    }
-    default:
-      throw new Error(
-        "Unable to resolve the PRD queue from config. Set source or use tracker=github self-host with github.org/github.repo."
-      );
-  }
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} tracker
- * @returns {string}
- */
-function resolveBuildQueueArgument(config, tracker) {
-  switch (tracker) {
-    case "github":
-      requireGithubRepo(config);
-      return "github intake_mode=build";
-    case "linear":
-      requireLinearWorkspace(config);
-      return "linear";
-    case "jira": {
-      const project = config.jira?.project;
-      if (!project) {
-        throw new Error(
-          "Unable to resolve the build queue: jira.project is required when tracker=jira."
-        );
-      }
-      return project;
-    }
-    default:
-      throw new Error(
-        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
-      );
-  }
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} source
  * @param {string | undefined} tracker
  * @returns {string}
  */
@@ -341,56 +266,6 @@ function resolveRepairQueueArgument(config, source, tracker) {
   throw new Error(
     `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
   );
-}
-
-/**
- * @param {Record<string, any>} config
- * @returns {string | undefined}
- */
-function resolvePrdSource(config) {
-  if (typeof config.source === "string" && config.source.length > 0) {
-    return config.source;
-  }
-
-  if (
-    config.tracker === "github" &&
-    config.github?.org &&
-    config.github?.repo
-  ) {
-    return "github";
-  }
-
-  return undefined;
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} gitRemoteUrl
- * @returns {{ readonly owner: string, readonly repo: string } | null}
- */
-function resolveGithubRepoRef(config, gitRemoteUrl) {
-  const owner = config.github?.org;
-  const repo = config.github?.repo;
-
-  if (owner && repo) {
-    return { owner, repo };
-  }
-
-  if (!gitRemoteUrl) {
-    return null;
-  }
-
-  for (const pattern of GITHUB_REMOTE_PATTERNS) {
-    const match = gitRemoteUrl.match(pattern);
-    if (match?.groups?.owner && match.groups.repo) {
-      return {
-        owner: match.groups.owner,
-        repo: match.groups.repo,
-      };
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/plugins/lisa/scripts/queue-contract-resolution.mjs
+++ b/plugins/lisa/scripts/queue-contract-resolution.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+/**
+ * Shared queue-contract resolution helpers for queue-facing Lisa operator
+ * surfaces. These helpers intentionally mirror the same config-resolution
+ * defaults that `intake`, `repair-intake`, and future queue-status runtime
+ * adapters need, so repo/source/tracker detection does not drift.
+ */
+
+const GITHUB_REMOTE_PATTERNS = [
+  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+];
+
+const DEFAULT_GITHUB_BUILD_DONE = {
+  dev: "status:on-dev",
+  staging: "status:on-stg",
+  production: "status:done",
+};
+
+const DEFAULT_JIRA_BUILD_DONE = {
+  dev: "On Dev",
+  staging: "On Stg",
+  production: "Done",
+};
+
+const DEFAULT_GITHUB_LINEAR_PRD_ROLES = {
+  draft: "prd-draft",
+  ready: "prd-ready",
+  in_review: "prd-in-review",
+  blocked: "prd-blocked",
+  ticketed: "prd-ticketed",
+  shipped: "prd-shipped",
+  verified: "prd-verified",
+  sentinel: "prd-intake-feedback",
+};
+
+const DEFAULT_NOTION_PRD_ROLES = {
+  draft: "Draft",
+  ready: "Ready",
+  in_review: "In Review",
+  blocked: "Blocked",
+  ticketed: "Ticketed",
+  shipped: "Shipped",
+  verified: "Verified",
+};
+
+const DEFAULT_CONFLUENCE_PARENT_ROLES = {
+  draft: null,
+  ready: null,
+  in_review: null,
+  blocked: null,
+  ticketed: null,
+  shipped: null,
+  verified: null,
+};
+
+/**
+ * Resolve the current repo short name per config-resolution's repo-scoping
+ * ladder: explicit `.repo`, then `github.repo`, then the origin remote basename.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {string | null}
+ */
+export function resolveCurrentRepo(input = {}) {
+  const config = input.config ?? {};
+
+  if (typeof config.repo === "string" && config.repo.trim().length > 0) {
+    return config.repo.trim();
+  }
+
+  const githubRef = resolveGithubRepoRef(config, input.gitRemoteUrl);
+  if (githubRef?.repo) {
+    return githubRef.repo;
+  }
+
+  return resolveRepoNameFromRemote(input.gitRemoteUrl);
+}
+
+/**
+ * Resolve the repo's configured build tracker.
+ *
+ * @param {Record<string, any>} config
+ * @returns {string}
+ */
+export function resolveBuildTracker(config = {}) {
+  if (typeof config.tracker === "string" && config.tracker.trim().length > 0) {
+    return config.tracker.trim();
+  }
+
+  throw new Error(
+    "Unable to resolve the build tracker from config. tracker must be github, linear, or jira."
+  );
+}
+
+/**
+ * Resolve the repo's configured PRD source. Self-hosted GitHub falls back to
+ * `github` when `tracker=github` and a GitHub repo identity is configured.
+ *
+ * @param {Record<string, any>} config
+ * @returns {string}
+ */
+export function resolvePrdSource(config = {}) {
+  if (typeof config.source === "string" && config.source.trim().length > 0) {
+    return config.source.trim();
+  }
+
+  if (
+    config.tracker === "github" &&
+    config.github?.org &&
+    config.github?.repo
+  ) {
+    return "github";
+  }
+
+  throw new Error(
+    "Unable to resolve the PRD source from config. Set source explicitly or use tracker=github self-host with github.org/github.repo."
+  );
+}
+
+/**
+ * Resolve the PRD queue argument shape Lisa batch skills expect.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [source]
+ * @returns {string}
+ */
+export function resolvePrdQueueArgument(
+  config = {},
+  source = resolvePrdSource(config)
+) {
+  switch (source) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=prd";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "notion": {
+      const databaseId = config.notion?.prdDatabaseId;
+      if (!databaseId) {
+        throw new Error(
+          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
+        );
+      }
+      return databaseId;
+    }
+    case "confluence": {
+      const parentPageId = config.confluence?.parentPageId;
+      const spaceKey = config.confluence?.spaceKey;
+      if (!parentPageId && !spaceKey) {
+        throw new Error(
+          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
+        );
+      }
+      return parentPageId ?? spaceKey;
+    }
+    default:
+      throw new Error(
+        `Unable to resolve the PRD queue from config. source=${String(source)} is not a supported Lisa PRD source.`
+      );
+  }
+}
+
+/**
+ * Resolve the build queue argument shape Lisa batch skills expect.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [tracker]
+ * @returns {string}
+ */
+export function resolveBuildQueueArgument(
+  config = {},
+  tracker = resolveBuildTracker(config)
+) {
+  switch (tracker) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=build";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the build queue: jira.project is required when tracker=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
+      );
+  }
+}
+
+/**
+ * Resolve the PRD lifecycle roles for the configured source vendor.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [source]
+ * @returns {Record<string, any>}
+ */
+export function resolvePrdLifecycleRoles(
+  config = {},
+  source = resolvePrdSource(config)
+) {
+  switch (source) {
+    case "github":
+      return {
+        vendor: "github",
+        kind: "labels",
+        roles: resolveObjectRoles(
+          config.github?.labels?.prd,
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.github?.labels?.prd?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "linear":
+      return {
+        vendor: "linear",
+        kind: "labels",
+        roles: resolveObjectRoles(
+          config.linear?.labels?.prd,
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.linear?.labels?.prd?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "notion":
+      return {
+        vendor: "notion",
+        kind: "status",
+        statusProperty: config.notion?.statusProperty || "Status",
+        roles: resolveObjectRoles(
+          config.notion?.values,
+          DEFAULT_NOTION_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.notion?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "confluence":
+      return {
+        vendor: "confluence",
+        kind: "parent-pages",
+        roles: resolveObjectRoles(
+          config.confluence?.parents,
+          DEFAULT_CONFLUENCE_PARENT_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.confluence?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    default:
+      throw new Error(
+        `Unable to resolve PRD lifecycle roles. source=${String(source)} is not a supported Lisa PRD source.`
+      );
+  }
+}
+
+/**
+ * Resolve the build lifecycle roles for the configured tracker vendor.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [tracker]
+ * @returns {Record<string, any>}
+ */
+export function resolveBuildLifecycleRoles(
+  config = {},
+  tracker = resolveBuildTracker(config)
+) {
+  switch (tracker) {
+    case "github":
+      return {
+        vendor: "github",
+        kind: "labels",
+        roles: {
+          ready: config.github?.labels?.build?.ready || "status:ready",
+          claimed:
+            config.github?.labels?.build?.claimed || "status:in-progress",
+          blocked: config.github?.labels?.build?.blocked || "status:blocked",
+          done:
+            config.github?.labels?.build?.done ||
+            structuredClone(DEFAULT_GITHUB_BUILD_DONE),
+        },
+      };
+    case "linear":
+      return {
+        vendor: "linear",
+        kind: "labels",
+        roles: {
+          ready: config.linear?.labels?.build?.ready || "status:ready",
+          claimed:
+            config.linear?.labels?.build?.claimed || "status:in-progress",
+          review: config.linear?.labels?.build?.review || "status:code-review",
+          blocked: config.linear?.labels?.build?.blocked || "status:blocked",
+          done:
+            config.linear?.labels?.build?.done ||
+            structuredClone(DEFAULT_GITHUB_BUILD_DONE),
+        },
+      };
+    case "jira":
+      return {
+        vendor: "jira",
+        kind: "workflow",
+        roles: {
+          ready: config.jira?.workflow?.ready || "Ready",
+          claimed: config.jira?.workflow?.claimed || "In Progress",
+          review: config.jira?.workflow?.review || "Code Review",
+          blocked: config.jira?.workflow?.blocked || "Blocked",
+          done:
+            config.jira?.workflow?.done ||
+            structuredClone(DEFAULT_JIRA_BUILD_DONE),
+        },
+      };
+    default:
+      throw new Error(
+        `Unable to resolve build lifecycle roles. tracker=${String(tracker)} is not a supported Lisa build tracker.`
+      );
+  }
+}
+
+/**
+ * Resolve the repo-scoped queue contract queue-status should report against.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {{
+ *   readonly currentRepo: string | null
+ *   readonly source: string
+ *   readonly tracker: string
+ *   readonly prdQueue: { readonly argument: string } & Record<string, any>
+ *   readonly buildQueue: { readonly argument: string } & Record<string, any>
+ * }}
+ */
+export function resolveQueueContract(input = {}) {
+  const config = input.config ?? {};
+  const source = resolvePrdSource(config);
+  const tracker = resolveBuildTracker(config);
+
+  return {
+    currentRepo: resolveCurrentRepo(input),
+    source,
+    tracker,
+    prdQueue: {
+      argument: resolvePrdQueueArgument(config, source),
+      ...resolvePrdLifecycleRoles(config, source),
+    },
+    buildQueue: {
+      argument: resolveBuildQueueArgument(config, tracker),
+      ...resolveBuildLifecycleRoles(config, tracker),
+    },
+  };
+}
+
+/**
+ * @param {Record<string, any> | undefined} values
+ * @param {Record<string, any>} defaults
+ * @returns {Record<string, any>}
+ */
+function resolveObjectRoles(values, defaults) {
+  return {
+    ...defaults,
+    ...(values ?? {}),
+  };
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {{ readonly owner: string, readonly repo: string } | null}
+ */
+export function resolveGithubRepoRef(config = {}, gitRemoteUrl) {
+  const owner = config.github?.org;
+  const repo = config.github?.repo;
+
+  if (owner && repo) {
+    return { owner, repo };
+  }
+
+  if (!gitRemoteUrl) {
+    return null;
+  }
+
+  for (const pattern of GITHUB_REMOTE_PATTERNS) {
+    const match = gitRemoteUrl.match(pattern);
+    if (match?.groups?.owner && match.groups.repo) {
+      return {
+        owner: match.groups.owner,
+        repo: match.groups.repo,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {string | null}
+ */
+function resolveRepoNameFromRemote(gitRemoteUrl) {
+  if (!gitRemoteUrl || typeof gitRemoteUrl !== "string") {
+    return null;
+  }
+
+  const trimmed = gitRemoteUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const basename = trimmed.split(/[/:]/).pop();
+  if (!basename) {
+    return null;
+  }
+
+  return basename.replace(/\.git$/i, "") || null;
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireGithubRepo(config) {
+  if (!config.github?.org || !config.github?.repo) {
+    throw new Error(
+      "Unable to resolve the GitHub queue: github.org and github.repo are required."
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireLinearWorkspace(config) {
+  if (!config.linear?.workspace) {
+    throw new Error(
+      "Unable to resolve the Linear queue: linear.workspace is required."
+    );
+  }
+}

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -8,6 +8,13 @@
  * truth.
  */
 
+import {
+  resolveBuildQueueArgument,
+  resolveGithubRepoRef,
+  resolvePrdQueueArgument,
+  resolvePrdSource,
+} from "./queue-contract-resolution.mjs";
+
 export const AUTOMATION_EXPECTED_CADENCES = {
   "intake-repair": {
     human: "every 60 minutes",
@@ -32,11 +39,6 @@ export const AUTOMATION_EXPECTED_CADENCES = {
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
-
-const GITHUB_REMOTE_PATTERNS = [
-  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
-  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
-];
 
 /**
  * @typedef {{
@@ -232,83 +234,6 @@ function createUnsupportedEntry(identity, id, reason) {
 /**
  * @param {Record<string, any>} config
  * @param {string | undefined} source
- * @returns {string}
- */
-function resolvePrdQueueArgument(config, source) {
-  switch (source) {
-    case "github":
-      requireGithubRepo(config);
-      return "github intake_mode=prd";
-    case "linear":
-      requireLinearWorkspace(config);
-      return "linear";
-    case "notion": {
-      const databaseId = config.notion?.prdDatabaseId;
-      if (!databaseId) {
-        throw new Error(
-          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
-        );
-      }
-      return databaseId;
-    }
-    case "confluence": {
-      const parentPageId = config.confluence?.parentPageId;
-      const spaceKey = config.confluence?.spaceKey;
-      if (!parentPageId && !spaceKey) {
-        throw new Error(
-          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
-        );
-      }
-      return parentPageId ?? spaceKey;
-    }
-    case "jira": {
-      const project = config.jira?.project;
-      if (!project) {
-        throw new Error(
-          "Unable to resolve the PRD queue: jira.project is required when source=jira."
-        );
-      }
-      return project;
-    }
-    default:
-      throw new Error(
-        "Unable to resolve the PRD queue from config. Set source or use tracker=github self-host with github.org/github.repo."
-      );
-  }
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} tracker
- * @returns {string}
- */
-function resolveBuildQueueArgument(config, tracker) {
-  switch (tracker) {
-    case "github":
-      requireGithubRepo(config);
-      return "github intake_mode=build";
-    case "linear":
-      requireLinearWorkspace(config);
-      return "linear";
-    case "jira": {
-      const project = config.jira?.project;
-      if (!project) {
-        throw new Error(
-          "Unable to resolve the build queue: jira.project is required when tracker=jira."
-        );
-      }
-      return project;
-    }
-    default:
-      throw new Error(
-        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
-      );
-  }
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} source
  * @param {string | undefined} tracker
  * @returns {string}
  */
@@ -341,56 +266,6 @@ function resolveRepairQueueArgument(config, source, tracker) {
   throw new Error(
     `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
   );
-}
-
-/**
- * @param {Record<string, any>} config
- * @returns {string | undefined}
- */
-function resolvePrdSource(config) {
-  if (typeof config.source === "string" && config.source.length > 0) {
-    return config.source;
-  }
-
-  if (
-    config.tracker === "github" &&
-    config.github?.org &&
-    config.github?.repo
-  ) {
-    return "github";
-  }
-
-  return undefined;
-}
-
-/**
- * @param {Record<string, any>} config
- * @param {string | undefined} gitRemoteUrl
- * @returns {{ readonly owner: string, readonly repo: string } | null}
- */
-function resolveGithubRepoRef(config, gitRemoteUrl) {
-  const owner = config.github?.org;
-  const repo = config.github?.repo;
-
-  if (owner && repo) {
-    return { owner, repo };
-  }
-
-  if (!gitRemoteUrl) {
-    return null;
-  }
-
-  for (const pattern of GITHUB_REMOTE_PATTERNS) {
-    const match = gitRemoteUrl.match(pattern);
-    if (match?.groups?.owner && match.groups.repo) {
-      return {
-        owner: match.groups.owner,
-        repo: match.groups.repo,
-      };
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/plugins/src/base/scripts/queue-contract-resolution.mjs
+++ b/plugins/src/base/scripts/queue-contract-resolution.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+/**
+ * Shared queue-contract resolution helpers for queue-facing Lisa operator
+ * surfaces. These helpers intentionally mirror the same config-resolution
+ * defaults that `intake`, `repair-intake`, and future queue-status runtime
+ * adapters need, so repo/source/tracker detection does not drift.
+ */
+
+const GITHUB_REMOTE_PATTERNS = [
+  /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+  /^git@github\.com:(?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/,
+];
+
+const DEFAULT_GITHUB_BUILD_DONE = {
+  dev: "status:on-dev",
+  staging: "status:on-stg",
+  production: "status:done",
+};
+
+const DEFAULT_JIRA_BUILD_DONE = {
+  dev: "On Dev",
+  staging: "On Stg",
+  production: "Done",
+};
+
+const DEFAULT_GITHUB_LINEAR_PRD_ROLES = {
+  draft: "prd-draft",
+  ready: "prd-ready",
+  in_review: "prd-in-review",
+  blocked: "prd-blocked",
+  ticketed: "prd-ticketed",
+  shipped: "prd-shipped",
+  verified: "prd-verified",
+  sentinel: "prd-intake-feedback",
+};
+
+const DEFAULT_NOTION_PRD_ROLES = {
+  draft: "Draft",
+  ready: "Ready",
+  in_review: "In Review",
+  blocked: "Blocked",
+  ticketed: "Ticketed",
+  shipped: "Shipped",
+  verified: "Verified",
+};
+
+const DEFAULT_CONFLUENCE_PARENT_ROLES = {
+  draft: null,
+  ready: null,
+  in_review: null,
+  blocked: null,
+  ticketed: null,
+  shipped: null,
+  verified: null,
+};
+
+/**
+ * Resolve the current repo short name per config-resolution's repo-scoping
+ * ladder: explicit `.repo`, then `github.repo`, then the origin remote basename.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {string | null}
+ */
+export function resolveCurrentRepo(input = {}) {
+  const config = input.config ?? {};
+
+  if (typeof config.repo === "string" && config.repo.trim().length > 0) {
+    return config.repo.trim();
+  }
+
+  const githubRef = resolveGithubRepoRef(config, input.gitRemoteUrl);
+  if (githubRef?.repo) {
+    return githubRef.repo;
+  }
+
+  return resolveRepoNameFromRemote(input.gitRemoteUrl);
+}
+
+/**
+ * Resolve the repo's configured build tracker.
+ *
+ * @param {Record<string, any>} config
+ * @returns {string}
+ */
+export function resolveBuildTracker(config = {}) {
+  if (typeof config.tracker === "string" && config.tracker.trim().length > 0) {
+    return config.tracker.trim();
+  }
+
+  throw new Error(
+    "Unable to resolve the build tracker from config. tracker must be github, linear, or jira."
+  );
+}
+
+/**
+ * Resolve the repo's configured PRD source. Self-hosted GitHub falls back to
+ * `github` when `tracker=github` and a GitHub repo identity is configured.
+ *
+ * @param {Record<string, any>} config
+ * @returns {string}
+ */
+export function resolvePrdSource(config = {}) {
+  if (typeof config.source === "string" && config.source.trim().length > 0) {
+    return config.source.trim();
+  }
+
+  if (
+    config.tracker === "github" &&
+    config.github?.org &&
+    config.github?.repo
+  ) {
+    return "github";
+  }
+
+  throw new Error(
+    "Unable to resolve the PRD source from config. Set source explicitly or use tracker=github self-host with github.org/github.repo."
+  );
+}
+
+/**
+ * Resolve the PRD queue argument shape Lisa batch skills expect.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [source]
+ * @returns {string}
+ */
+export function resolvePrdQueueArgument(
+  config = {},
+  source = resolvePrdSource(config)
+) {
+  switch (source) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=prd";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "notion": {
+      const databaseId = config.notion?.prdDatabaseId;
+      if (!databaseId) {
+        throw new Error(
+          "Unable to resolve the PRD queue: notion.prdDatabaseId is required when source=notion."
+        );
+      }
+      return databaseId;
+    }
+    case "confluence": {
+      const parentPageId = config.confluence?.parentPageId;
+      const spaceKey = config.confluence?.spaceKey;
+      if (!parentPageId && !spaceKey) {
+        throw new Error(
+          "Unable to resolve the PRD queue: confluence.parentPageId or confluence.spaceKey is required when source=confluence."
+        );
+      }
+      return parentPageId ?? spaceKey;
+    }
+    default:
+      throw new Error(
+        `Unable to resolve the PRD queue from config. source=${String(source)} is not a supported Lisa PRD source.`
+      );
+  }
+}
+
+/**
+ * Resolve the build queue argument shape Lisa batch skills expect.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [tracker]
+ * @returns {string}
+ */
+export function resolveBuildQueueArgument(
+  config = {},
+  tracker = resolveBuildTracker(config)
+) {
+  switch (tracker) {
+    case "github":
+      requireGithubRepo(config);
+      return "github intake_mode=build";
+    case "linear":
+      requireLinearWorkspace(config);
+      return "linear";
+    case "jira": {
+      const project = config.jira?.project;
+      if (!project) {
+        throw new Error(
+          "Unable to resolve the build queue: jira.project is required when tracker=jira."
+        );
+      }
+      return project;
+    }
+    default:
+      throw new Error(
+        "Unable to resolve the build queue from config. tracker must be github, linear, or jira."
+      );
+  }
+}
+
+/**
+ * Resolve the PRD lifecycle roles for the configured source vendor.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [source]
+ * @returns {Record<string, any>}
+ */
+export function resolvePrdLifecycleRoles(
+  config = {},
+  source = resolvePrdSource(config)
+) {
+  switch (source) {
+    case "github":
+      return {
+        vendor: "github",
+        kind: "labels",
+        roles: resolveObjectRoles(
+          config.github?.labels?.prd,
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.github?.labels?.prd?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "linear":
+      return {
+        vendor: "linear",
+        kind: "labels",
+        roles: resolveObjectRoles(
+          config.linear?.labels?.prd,
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.linear?.labels?.prd?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "notion":
+      return {
+        vendor: "notion",
+        kind: "status",
+        statusProperty: config.notion?.statusProperty || "Status",
+        roles: resolveObjectRoles(
+          config.notion?.values,
+          DEFAULT_NOTION_PRD_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.notion?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    case "confluence":
+      return {
+        vendor: "confluence",
+        kind: "parent-pages",
+        roles: resolveObjectRoles(
+          config.confluence?.parents,
+          DEFAULT_CONFLUENCE_PARENT_ROLES
+        ),
+        rollup: {
+          closeOnShipped: Boolean(
+            config.confluence?.rollup?.closeOnShipped ?? false
+          ),
+        },
+      };
+    default:
+      throw new Error(
+        `Unable to resolve PRD lifecycle roles. source=${String(source)} is not a supported Lisa PRD source.`
+      );
+  }
+}
+
+/**
+ * Resolve the build lifecycle roles for the configured tracker vendor.
+ *
+ * @param {Record<string, any>} config
+ * @param {string} [tracker]
+ * @returns {Record<string, any>}
+ */
+export function resolveBuildLifecycleRoles(
+  config = {},
+  tracker = resolveBuildTracker(config)
+) {
+  switch (tracker) {
+    case "github":
+      return {
+        vendor: "github",
+        kind: "labels",
+        roles: {
+          ready: config.github?.labels?.build?.ready || "status:ready",
+          claimed:
+            config.github?.labels?.build?.claimed || "status:in-progress",
+          blocked: config.github?.labels?.build?.blocked || "status:blocked",
+          done:
+            config.github?.labels?.build?.done ||
+            structuredClone(DEFAULT_GITHUB_BUILD_DONE),
+        },
+      };
+    case "linear":
+      return {
+        vendor: "linear",
+        kind: "labels",
+        roles: {
+          ready: config.linear?.labels?.build?.ready || "status:ready",
+          claimed:
+            config.linear?.labels?.build?.claimed || "status:in-progress",
+          review: config.linear?.labels?.build?.review || "status:code-review",
+          blocked: config.linear?.labels?.build?.blocked || "status:blocked",
+          done:
+            config.linear?.labels?.build?.done ||
+            structuredClone(DEFAULT_GITHUB_BUILD_DONE),
+        },
+      };
+    case "jira":
+      return {
+        vendor: "jira",
+        kind: "workflow",
+        roles: {
+          ready: config.jira?.workflow?.ready || "Ready",
+          claimed: config.jira?.workflow?.claimed || "In Progress",
+          review: config.jira?.workflow?.review || "Code Review",
+          blocked: config.jira?.workflow?.blocked || "Blocked",
+          done:
+            config.jira?.workflow?.done ||
+            structuredClone(DEFAULT_JIRA_BUILD_DONE),
+        },
+      };
+    default:
+      throw new Error(
+        `Unable to resolve build lifecycle roles. tracker=${String(tracker)} is not a supported Lisa build tracker.`
+      );
+  }
+}
+
+/**
+ * Resolve the repo-scoped queue contract queue-status should report against.
+ *
+ * @param {{
+ *   readonly config?: Record<string, any>
+ *   readonly gitRemoteUrl?: string
+ * }} input
+ * @returns {{
+ *   readonly currentRepo: string | null
+ *   readonly source: string
+ *   readonly tracker: string
+ *   readonly prdQueue: { readonly argument: string } & Record<string, any>
+ *   readonly buildQueue: { readonly argument: string } & Record<string, any>
+ * }}
+ */
+export function resolveQueueContract(input = {}) {
+  const config = input.config ?? {};
+  const source = resolvePrdSource(config);
+  const tracker = resolveBuildTracker(config);
+
+  return {
+    currentRepo: resolveCurrentRepo(input),
+    source,
+    tracker,
+    prdQueue: {
+      argument: resolvePrdQueueArgument(config, source),
+      ...resolvePrdLifecycleRoles(config, source),
+    },
+    buildQueue: {
+      argument: resolveBuildQueueArgument(config, tracker),
+      ...resolveBuildLifecycleRoles(config, tracker),
+    },
+  };
+}
+
+/**
+ * @param {Record<string, any> | undefined} values
+ * @param {Record<string, any>} defaults
+ * @returns {Record<string, any>}
+ */
+function resolveObjectRoles(values, defaults) {
+  return {
+    ...defaults,
+    ...(values ?? {}),
+  };
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {{ readonly owner: string, readonly repo: string } | null}
+ */
+export function resolveGithubRepoRef(config = {}, gitRemoteUrl) {
+  const owner = config.github?.org;
+  const repo = config.github?.repo;
+
+  if (owner && repo) {
+    return { owner, repo };
+  }
+
+  if (!gitRemoteUrl) {
+    return null;
+  }
+
+  for (const pattern of GITHUB_REMOTE_PATTERNS) {
+    const match = gitRemoteUrl.match(pattern);
+    if (match?.groups?.owner && match.groups.repo) {
+      return {
+        owner: match.groups.owner,
+        repo: match.groups.repo,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {string | undefined} gitRemoteUrl
+ * @returns {string | null}
+ */
+function resolveRepoNameFromRemote(gitRemoteUrl) {
+  if (!gitRemoteUrl || typeof gitRemoteUrl !== "string") {
+    return null;
+  }
+
+  const trimmed = gitRemoteUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const basename = trimmed.split(/[/:]/).pop();
+  if (!basename) {
+    return null;
+  }
+
+  return basename.replace(/\.git$/i, "") || null;
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireGithubRepo(config) {
+  if (!config.github?.org || !config.github?.repo) {
+    throw new Error(
+      "Unable to resolve the GitHub queue: github.org and github.repo are required."
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ */
+function requireLinearWorkspace(config) {
+  if (!config.linear?.workspace) {
+    throw new Error(
+      "Unable to resolve the Linear queue: linear.workspace is required."
+    );
+  }
+}

--- a/tests/unit/strategies/queue-contract-resolution.test.ts
+++ b/tests/unit/strategies/queue-contract-resolution.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression coverage for queue-status contract resolution.
+ *
+ * Issue #822 adds the shared queue-contract resolver that queue-status can use
+ * to stay aligned with the same repo/source/tracker defaults as intake and
+ * repair-intake, without inventing a second source of truth.
+ * @module tests/unit/strategies/queue-contract-resolution
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveBuildLifecycleRoles,
+  resolveCurrentRepo,
+  resolvePrdLifecycleRoles,
+  resolveQueueContract,
+} from "../../../plugins/src/base/scripts/queue-contract-resolution.mjs";
+
+describe("queue contract resolution (#822)", () => {
+  it("resolves self-hosted GitHub queue defaults from the shared contract", () => {
+    const contract = resolveQueueContract({
+      config: {
+        tracker: "github",
+        github: {
+          org: "CodySwannGT",
+          repo: "lisa",
+        },
+      },
+    });
+
+    expect(contract.currentRepo).toBe("lisa");
+    expect(contract.source).toBe("github");
+    expect(contract.tracker).toBe("github");
+    expect(contract.prdQueue).toMatchObject({
+      vendor: "github",
+      kind: "labels",
+      argument: "github intake_mode=prd",
+      roles: {
+        ready: "prd-ready",
+        in_review: "prd-in-review",
+        blocked: "prd-blocked",
+        ticketed: "prd-ticketed",
+        shipped: "prd-shipped",
+        verified: "prd-verified",
+      },
+      rollup: {
+        closeOnShipped: false,
+      },
+    });
+    expect(contract.buildQueue).toMatchObject({
+      vendor: "github",
+      kind: "labels",
+      argument: "github intake_mode=build",
+      roles: {
+        ready: "status:ready",
+        claimed: "status:in-progress",
+        blocked: "status:blocked",
+        done: {
+          dev: "status:on-dev",
+          staging: "status:on-stg",
+          production: "status:done",
+        },
+      },
+    });
+  });
+
+  it("resolves mixed notion/jira queues with explicit overrides and repo override precedence", () => {
+    const contract = resolveQueueContract({
+      config: {
+        repo: "frontend-v2",
+        tracker: "jira",
+        source: "notion",
+        jira: {
+          project: "FE",
+          workflow: {
+            ready: "Queued",
+            claimed: "Working",
+            review: "Review",
+            blocked: "Needs Help",
+            done: "Done",
+          },
+        },
+        notion: {
+          prdDatabaseId: "db-123",
+          statusProperty: "Lifecycle",
+          values: {
+            ready: "Ready to Plan",
+            in_review: "Planning",
+          },
+        },
+        github: {
+          org: "Acme",
+          repo: "platform-monorepo",
+        },
+      },
+      gitRemoteUrl: "git@github.com:Acme/platform-monorepo.git",
+    });
+
+    expect(contract.currentRepo).toBe("frontend-v2");
+    expect(contract.source).toBe("notion");
+    expect(contract.tracker).toBe("jira");
+    expect(contract.prdQueue).toMatchObject({
+      vendor: "notion",
+      kind: "status",
+      argument: "db-123",
+      statusProperty: "Lifecycle",
+      roles: {
+        draft: "Draft",
+        ready: "Ready to Plan",
+        in_review: "Planning",
+        blocked: "Blocked",
+        ticketed: "Ticketed",
+        shipped: "Shipped",
+        verified: "Verified",
+      },
+    });
+    expect(contract.buildQueue).toMatchObject({
+      vendor: "jira",
+      kind: "workflow",
+      argument: "FE",
+      roles: {
+        ready: "Queued",
+        claimed: "Working",
+        review: "Review",
+        blocked: "Needs Help",
+        done: "Done",
+      },
+    });
+  });
+
+  it("falls back to the git remote basename when config does not carry repo identity", () => {
+    expect(
+      resolveCurrentRepo({
+        config: { tracker: "jira", source: "confluence" },
+        gitRemoteUrl: "git@github.com:Acme/customer-portal.git",
+      })
+    ).toBe("customer-portal");
+  });
+
+  it("fails loudly for unsupported PRD sources instead of inventing queue semantics", () => {
+    expect(() =>
+      resolvePrdLifecycleRoles({
+        source: "jira",
+      })
+    ).toThrow(/not a supported Lisa PRD source/i);
+  });
+
+  it("keeps the distributed resolver artifact in lockstep with the source script", () => {
+    const sourcePath = path.resolve(
+      "plugins/src/base/scripts/queue-contract-resolution.mjs"
+    );
+    const generatedPath = path.resolve(
+      "plugins/lisa/scripts/queue-contract-resolution.mjs"
+    );
+
+    expect(existsSync(generatedPath)).toBe(true);
+    expect(readFileSync(generatedPath, "utf8")).toBe(
+      readFileSync(sourcePath, "utf8")
+    );
+  });
+
+  it("keeps vendor defaults explicit when only lifecycle-role readers are used directly", () => {
+    expect(
+      resolveBuildLifecycleRoles({
+        tracker: "linear",
+      })
+    ).toMatchObject({
+      vendor: "linear",
+      roles: {
+        ready: "status:ready",
+        claimed: "status:in-progress",
+        review: "status:code-review",
+        blocked: "status:blocked",
+        done: {
+          dev: "status:on-dev",
+          staging: "status:on-stg",
+          production: "status:done",
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared queue-contract resolver for current repo, PRD source, build tracker, queue arguments, and lifecycle-role defaults
- refactor automation-status expected-fleet resolution to reuse the shared queue helpers instead of duplicating GitHub/queue logic
- add regression coverage for self-hosted GitHub defaults, mixed-vendor overrides, unsupported PRD sources, and generated plugin parity

## Testing
- bun test tests/unit/strategies/automation-status-expected-fleet.test.ts tests/unit/strategies/queue-contract-resolution.test.ts tests/unit/strategies/queue-status-scaffold.test.ts
- hooks on git push: eslint slow rules, knip, vitest --coverage, vitest tests/integration

Closes #822