### PR TITLE
feat(queue-status): classify queue health

### DIFF
--- a/plugins/lisa/scripts/queue-health-classification.mjs
+++ b/plugins/lisa/scripts/queue-health-classification.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Shared queue-health classification helpers for `/lisa:queue-status`.
+ *
+ * Queue readers normalize vendor-specific lifecycle data into the small set of
+ * signals below so queue-status can distinguish quiet, healthy, stuck, and
+ * misconfigured queues without inventing a second lifecycle vocabulary.
+ */
+
+export const QUEUE_HEALTH_VERDICTS = [
+  "IDLE",
+  "HEALTHY",
+  "ATTENTION_NEEDED",
+  "MISCONFIGURED",
+];
+
+/**
+ * @typedef {"IDLE" | "HEALTHY" | "ATTENTION_NEEDED" | "MISCONFIGURED"} QueueHealthVerdict
+ *
+ * @typedef {{
+ *   readonly queueResolved?: boolean
+ *   readonly namespaceAdopted?: boolean
+ *   readonly readyCount?: number
+ *   readonly activeCount?: number
+ *   readonly blockedCount?: number
+ *   readonly stalledCount?: number
+ *   readonly resolutionError?: string | null
+ * }} QueueHealthInput
+ */
+
+/**
+ * Classify a queue using the same high-level concepts intake and repair-intake
+ * already rely on:
+ * - queue must resolve from config;
+ * - lifecycle namespace must be adopted/present;
+ * - blocked or stalled work means operator attention is needed;
+ * - otherwise ready or active work is healthy;
+ * - otherwise the queue is truly idle.
+ *
+ * @param {QueueHealthInput} input
+ * @returns {{
+ *   readonly verdict: QueueHealthVerdict
+ *   readonly reasons: readonly string[]
+ *   readonly counts: Readonly<{
+ *     ready: number
+ *     active: number
+ *     blocked: number
+ *     stalled: number
+ *     attentionNeeded: number
+ *   }>
+ * }}
+ */
+export function classifyQueueHealth(input = {}) {
+  const counts = {
+    ready: normalizeCount(input.readyCount),
+    active: normalizeCount(input.activeCount),
+    blocked: normalizeCount(input.blockedCount),
+    stalled: normalizeCount(input.stalledCount),
+  };
+  const attentionNeeded = counts.blocked + counts.stalled;
+
+  if (input.queueResolved === false || hasContent(input.resolutionError)) {
+    return {
+      verdict: "MISCONFIGURED",
+      reasons: ["queue-unresolved"],
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (input.namespaceAdopted === false) {
+    return {
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (attentionNeeded > 0) {
+    return {
+      verdict: "ATTENTION_NEEDED",
+      reasons: [
+        counts.blocked > 0 ? "blocked-work-present" : null,
+        counts.stalled > 0 ? "stalled-work-present" : null,
+      ].filter(Boolean),
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (counts.ready > 0 || counts.active > 0) {
+    return {
+      verdict: "HEALTHY",
+      reasons: [
+        counts.ready > 0 ? "ready-work-present" : null,
+        counts.active > 0 ? "active-work-in-flight" : null,
+      ].filter(Boolean),
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  return {
+    verdict: "IDLE",
+    reasons: ["no-actionable-work"],
+    counts: {
+      ...counts,
+      attentionNeeded,
+    },
+  };
+}
+
+/**
+ * Combine individual queue verdicts into the overall queue-status verdict.
+ *
+ * @param {readonly { verdict: QueueHealthVerdict }[]} sections
+ * @returns {QueueHealthVerdict}
+ */
+export function computeOverallQueueVerdict(sections) {
+  const verdicts = sections.map(section => section.verdict);
+
+  if (verdicts.includes("MISCONFIGURED")) {
+    return "MISCONFIGURED";
+  }
+  if (verdicts.includes("ATTENTION_NEEDED")) {
+    return "ATTENTION_NEEDED";
+  }
+  if (verdicts.includes("HEALTHY")) {
+    return "HEALTHY";
+  }
+  return "IDLE";
+}
+
+/**
+ * @param {number | null | undefined} value
+ * @returns {number}
+ */
+function normalizeCount(value) {
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {boolean}
+ */
+function hasContent(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/plugins/src/base/scripts/queue-health-classification.mjs
+++ b/plugins/src/base/scripts/queue-health-classification.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Shared queue-health classification helpers for `/lisa:queue-status`.
+ *
+ * Queue readers normalize vendor-specific lifecycle data into the small set of
+ * signals below so queue-status can distinguish quiet, healthy, stuck, and
+ * misconfigured queues without inventing a second lifecycle vocabulary.
+ */
+
+export const QUEUE_HEALTH_VERDICTS = [
+  "IDLE",
+  "HEALTHY",
+  "ATTENTION_NEEDED",
+  "MISCONFIGURED",
+];
+
+/**
+ * @typedef {"IDLE" | "HEALTHY" | "ATTENTION_NEEDED" | "MISCONFIGURED"} QueueHealthVerdict
+ *
+ * @typedef {{
+ *   readonly queueResolved?: boolean
+ *   readonly namespaceAdopted?: boolean
+ *   readonly readyCount?: number
+ *   readonly activeCount?: number
+ *   readonly blockedCount?: number
+ *   readonly stalledCount?: number
+ *   readonly resolutionError?: string | null
+ * }} QueueHealthInput
+ */
+
+/**
+ * Classify a queue using the same high-level concepts intake and repair-intake
+ * already rely on:
+ * - queue must resolve from config;
+ * - lifecycle namespace must be adopted/present;
+ * - blocked or stalled work means operator attention is needed;
+ * - otherwise ready or active work is healthy;
+ * - otherwise the queue is truly idle.
+ *
+ * @param {QueueHealthInput} input
+ * @returns {{
+ *   readonly verdict: QueueHealthVerdict
+ *   readonly reasons: readonly string[]
+ *   readonly counts: Readonly<{
+ *     ready: number
+ *     active: number
+ *     blocked: number
+ *     stalled: number
+ *     attentionNeeded: number
+ *   }>
+ * }}
+ */
+export function classifyQueueHealth(input = {}) {
+  const counts = {
+    ready: normalizeCount(input.readyCount),
+    active: normalizeCount(input.activeCount),
+    blocked: normalizeCount(input.blockedCount),
+    stalled: normalizeCount(input.stalledCount),
+  };
+  const attentionNeeded = counts.blocked + counts.stalled;
+
+  if (input.queueResolved === false || hasContent(input.resolutionError)) {
+    return {
+      verdict: "MISCONFIGURED",
+      reasons: ["queue-unresolved"],
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (input.namespaceAdopted === false) {
+    return {
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (attentionNeeded > 0) {
+    return {
+      verdict: "ATTENTION_NEEDED",
+      reasons: [
+        counts.blocked > 0 ? "blocked-work-present" : null,
+        counts.stalled > 0 ? "stalled-work-present" : null,
+      ].filter(Boolean),
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  if (counts.ready > 0 || counts.active > 0) {
+    return {
+      verdict: "HEALTHY",
+      reasons: [
+        counts.ready > 0 ? "ready-work-present" : null,
+        counts.active > 0 ? "active-work-in-flight" : null,
+      ].filter(Boolean),
+      counts: {
+        ...counts,
+        attentionNeeded,
+      },
+    };
+  }
+
+  return {
+    verdict: "IDLE",
+    reasons: ["no-actionable-work"],
+    counts: {
+      ...counts,
+      attentionNeeded,
+    },
+  };
+}
+
+/**
+ * Combine individual queue verdicts into the overall queue-status verdict.
+ *
+ * @param {readonly { verdict: QueueHealthVerdict }[]} sections
+ * @returns {QueueHealthVerdict}
+ */
+export function computeOverallQueueVerdict(sections) {
+  const verdicts = sections.map(section => section.verdict);
+
+  if (verdicts.includes("MISCONFIGURED")) {
+    return "MISCONFIGURED";
+  }
+  if (verdicts.includes("ATTENTION_NEEDED")) {
+    return "ATTENTION_NEEDED";
+  }
+  if (verdicts.includes("HEALTHY")) {
+    return "HEALTHY";
+  }
+  return "IDLE";
+}
+
+/**
+ * @param {number | null | undefined} value
+ * @returns {number}
+ */
+function normalizeCount(value) {
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {boolean}
+ */
+function hasContent(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/tests/unit/strategies/queue-health-classification.test.ts
+++ b/tests/unit/strategies/queue-health-classification.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression coverage for queue-status health classification.
+ *
+ * Issue #823 adds the shared queue-health classifier that lets queue-status
+ * distinguish truly idle queues from healthy backlog, attention-needed stuck
+ * work, and misconfigured lifecycle setup without collapsing everything into
+ * "empty".
+ * @module tests/unit/strategies/queue-health-classification
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyQueueHealth,
+  computeOverallQueueVerdict,
+} from "../../../plugins/src/base/scripts/queue-health-classification.mjs";
+
+describe("queue health classification (#823)", () => {
+  it("treats unresolved queues as misconfigured instead of idle", () => {
+    expect(
+      classifyQueueHealth({
+        queueResolved: false,
+        resolutionError:
+          "Unable to resolve the PRD queue from config for source=confluence.",
+      })
+    ).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["queue-unresolved"],
+    });
+  });
+
+  it("treats missing lifecycle namespaces as misconfigured instead of empty", () => {
+    expect(
+      classifyQueueHealth({
+        queueResolved: true,
+        namespaceAdopted: false,
+        readyCount: 0,
+        activeCount: 0,
+        blockedCount: 0,
+        stalledCount: 0,
+      })
+    ).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+    });
+  });
+
+  it("flags blocked or stalled work as attention-needed using repair semantics", () => {
+    expect(
+      classifyQueueHealth({
+        queueResolved: true,
+        namespaceAdopted: true,
+        blockedCount: 1,
+        stalledCount: 2,
+      })
+    ).toMatchObject({
+      verdict: "ATTENTION_NEEDED",
+      reasons: ["blocked-work-present", "stalled-work-present"],
+      counts: {
+        attentionNeeded: 3,
+      },
+    });
+  });
+
+  it("treats ready or active non-stuck work as healthy", () => {
+    expect(
+      classifyQueueHealth({
+        queueResolved: true,
+        namespaceAdopted: true,
+        readyCount: 2,
+      })
+    ).toMatchObject({
+      verdict: "HEALTHY",
+      reasons: ["ready-work-present"],
+    });
+
+    expect(
+      classifyQueueHealth({
+        queueResolved: true,
+        namespaceAdopted: true,
+        activeCount: 1,
+      })
+    ).toMatchObject({
+      verdict: "HEALTHY",
+      reasons: ["active-work-in-flight"],
+    });
+  });
+
+  it("treats quiet adopted queues as idle", () => {
+    expect(
+      classifyQueueHealth({
+        queueResolved: true,
+        namespaceAdopted: true,
+      })
+    ).toMatchObject({
+      verdict: "IDLE",
+      reasons: ["no-actionable-work"],
+    });
+  });
+
+  it("uses the documented overall-verdict precedence", () => {
+    expect(
+      computeOverallQueueVerdict([{ verdict: "IDLE" }, { verdict: "HEALTHY" }])
+    ).toBe("HEALTHY");
+
+    expect(
+      computeOverallQueueVerdict([
+        { verdict: "HEALTHY" },
+        { verdict: "ATTENTION_NEEDED" },
+      ])
+    ).toBe("ATTENTION_NEEDED");
+
+    expect(
+      computeOverallQueueVerdict([
+        { verdict: "ATTENTION_NEEDED" },
+        { verdict: "MISCONFIGURED" },
+      ])
+    ).toBe("MISCONFIGURED");
+  });
+
+  it("keeps the distributed classifier artifact in lockstep with the source script", () => {
+    const sourcePath = path.resolve(
+      "plugins/src/base/scripts/queue-health-classification.mjs"
+    );
+    const generatedPath = path.resolve(
+      "plugins/lisa/scripts/queue-health-classification.mjs"
+    );
+
+    expect(existsSync(generatedPath)).toBe(true);
+    expect(readFileSync(generatedPath, "utf8")).toBe(
+      readFileSync(sourcePath, "utf8")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared queue-status health classifier for idle, healthy, attention-needed, and misconfigured verdicts
- add overall verdict precedence so future PRD/build readers can reuse one contract
- cover the new classifier and generated-plugin parity with focused regression tests

Closes #823