### PR TITLE
feat(queue-status): add PRD queue readers

### DIFF
--- a/plugins/lisa/scripts/queue-status-prd-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-prd-readers.mjs
@@ -96,14 +96,15 @@ export function readGithubPrdQueueSnapshot(input = {}) {
  * }} input
  */
 export function createPrdQueueSnapshot(input = {}) {
-  const roles = normalizeRoles(input.roles);
+  const rawRoles = input.roles ?? {};
+  const roles = normalizeRoles(rawRoles);
   const items = normalizeItems(input.items);
   const counts = buildLifecycleCounts(items);
   const highlights = buildActionableHighlights(items, input.queueArgument);
   const queueResolved =
     input.queueResolved ?? typeof input.resolutionError !== "string";
   const namespaceAdopted =
-    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, rawRoles);
 
   const health = classifyQueueHealth({
     queueResolved,

--- a/plugins/lisa/scripts/queue-status-prd-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-prd-readers.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * Shared PRD-side queue readers for `/lisa:queue-status`.
+ *
+ * These helpers normalize vendor-specific PRD lifecycle items into a common
+ * snapshot shape so queue-status can report lifecycle counts, actionable
+ * highlights, and queue-health verdict inputs without drifting from Lisa's PRD
+ * lifecycle contract.
+ */
+
+import { classifyQueueHealth } from "./queue-health-classification.mjs";
+
+export const PRD_LIFECYCLE_ORDER = [
+  "draft",
+  "ready",
+  "in_review",
+  "blocked",
+  "ticketed",
+  "shipped",
+  "verified",
+];
+
+const ACTIONABLE_ROLE_ORDER = [
+  "blocked",
+  "in_review",
+  "shipped",
+  "ready",
+  "ticketed",
+];
+
+const HIGHLIGHT_COPY = {
+  blocked: {
+    summary: "Oldest blocked PRD",
+    nextStep: "Run /lisa:repair-intake <queue> after clarifying the blocker.",
+  },
+  in_review: {
+    summary: "Oldest PRD still in review",
+    nextStep:
+      "Inspect the active intake run or resume it with /lisa:repair-intake <queue>.",
+  },
+  shipped: {
+    summary: "Oldest shipped PRD awaiting verification",
+    nextStep: "Run /lisa:verify-prd <item-url> to close the shipped loop.",
+  },
+  ready: {
+    summary: "Oldest ready PRD awaiting intake",
+    nextStep: "Run /lisa:intake <queue> to ticket the next PRD.",
+  },
+  ticketed: {
+    summary: "Oldest ticketed PRD still waiting on downstream delivery",
+    nextStep:
+      "Monitor downstream build work or inspect the build queue with /lisa:queue-status queue=build.",
+  },
+};
+
+/**
+ * Read a GitHub-backed PRD queue snapshot from issue payloads.
+ *
+ * @param {{
+ *   readonly issues?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, string>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function readGithubPrdQueueSnapshot(input = {}) {
+  const roles = input.roles ?? {};
+  const normalizedItems = (input.issues ?? [])
+    .map(issue => normalizeGithubPrdIssue(issue, roles))
+    .filter(Boolean);
+
+  return createPrdQueueSnapshot({
+    source: "github",
+    items: normalizedItems,
+    roles,
+    namespaceAdopted: input.namespaceAdopted,
+    queueResolved: input.queueResolved,
+    queueArgument: input.queueArgument,
+    resolutionError: input.resolutionError,
+  });
+}
+
+/**
+ * Build a vendor-agnostic PRD queue snapshot from normalized lifecycle items.
+ *
+ * @param {{
+ *   readonly source?: string
+ *   readonly items?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, string>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function createPrdQueueSnapshot(input = {}) {
+  const roles = normalizeRoles(input.roles);
+  const items = normalizeItems(input.items);
+  const counts = buildLifecycleCounts(items);
+  const highlights = buildActionableHighlights(items, input.queueArgument);
+  const queueResolved =
+    input.queueResolved ?? typeof input.resolutionError !== "string";
+  const namespaceAdopted =
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+
+  const health = classifyQueueHealth({
+    queueResolved,
+    namespaceAdopted,
+    readyCount: counts.ready,
+    activeCount: counts.in_review + counts.ticketed,
+    blockedCount: counts.blocked,
+    stalledCount: counts.shipped,
+    resolutionError: input.resolutionError ?? null,
+  });
+
+  return {
+    source: input.source ?? "unknown",
+    queueResolved,
+    namespaceAdopted,
+    roles,
+    counts,
+    highlights,
+    health,
+    resolutionError: input.resolutionError ?? null,
+  };
+}
+
+/**
+ * @param {Record<string, any>} issue
+ * @param {Record<string, string>} roles
+ * @returns {Record<string, any> | null}
+ */
+function normalizeGithubPrdIssue(issue, roles) {
+  if (!issue || typeof issue !== "object") {
+    return null;
+  }
+
+  const role = resolveGithubPrdRole(issue.labels, roles);
+
+  return normalizeItem({
+    id: String(issue.id ?? issue.number ?? issue.url ?? issue.title ?? ""),
+    ref:
+      issue.number !== undefined && issue.number !== null
+        ? `#${issue.number}`
+        : String(issue.url ?? issue.title ?? ""),
+    title: String(issue.title ?? "").trim(),
+    url: typeof issue.url === "string" ? issue.url : null,
+    createdAt: issue.createdAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    role,
+  });
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @param {Record<string, string>} roles
+ * @returns {string | null}
+ */
+function resolveGithubPrdRole(labels, roles) {
+  if (!Array.isArray(labels)) {
+    return null;
+  }
+
+  const labelNames = new Set(
+    labels
+      .map(label =>
+        typeof label === "string"
+          ? label
+          : typeof label?.name === "string"
+            ? label.name
+            : null
+      )
+      .filter(Boolean)
+  );
+
+  for (const role of PRD_LIFECYCLE_ORDER) {
+    const configuredName = roles[role];
+    if (configuredName && labelNames.has(configuredName)) {
+      return role;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, string> | undefined} roles
+ * @returns {Record<string, string>}
+ */
+function normalizeRoles(roles) {
+  const normalized = {};
+
+  for (const role of PRD_LIFECYCLE_ORDER) {
+    normalized[role] =
+      typeof roles?.[role] === "string" && roles[role].trim().length > 0
+        ? roles[role].trim()
+        : role;
+  }
+
+  return normalized;
+}
+
+/**
+ * @param {readonly Record<string, any>[] | undefined} items
+ * @returns {readonly Record<string, any>[]}
+ */
+function normalizeItems(items) {
+  return (items ?? []).map(normalizeItem).filter(Boolean);
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any> | null}
+ */
+function normalizeItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const role =
+    typeof item.role === "string" && PRD_LIFECYCLE_ORDER.includes(item.role)
+      ? item.role
+      : null;
+
+  const createdAt = normalizeTimestamp(item.createdAt);
+  const updatedAt = normalizeTimestamp(item.updatedAt);
+
+  return {
+    id: String(item.id ?? item.ref ?? item.title ?? ""),
+    ref: String(item.ref ?? item.id ?? item.title ?? ""),
+    title: String(item.title ?? "").trim(),
+    url: typeof item.url === "string" ? item.url : null,
+    role,
+    createdAt,
+    updatedAt,
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ */
+function buildLifecycleCounts(items) {
+  const counts = Object.fromEntries(PRD_LIFECYCLE_ORDER.map(role => [role, 0]));
+
+  for (const item of items) {
+    if (item.role && counts[item.role] !== undefined) {
+      counts[item.role] += 1;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string | undefined} queueArgument
+ */
+function buildActionableHighlights(items, queueArgument) {
+  const highlights = [];
+
+  for (const role of ACTIONABLE_ROLE_ORDER) {
+    const oldest = findOldestItemForRole(items, role);
+    if (!oldest) {
+      continue;
+    }
+
+    const copy = HIGHLIGHT_COPY[role];
+    highlights.push({
+      role,
+      ref: oldest.ref,
+      title: oldest.title,
+      url: oldest.url,
+      createdAt: oldest.createdAt,
+      summary: copy.summary,
+      nextStep: expandHighlightNextStep(
+        copy.nextStep,
+        queueArgument,
+        oldest.url
+      ),
+    });
+  }
+
+  return highlights;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string} role
+ */
+function findOldestItemForRole(items, role) {
+  return (
+    items
+      .filter(item => item.role === role)
+      .sort(compareQueueItemsByCreatedAt)[0] ?? null
+  );
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, string>} roles
+ * @returns {boolean}
+ */
+function inferNamespaceAdopted(items, roles) {
+  if (items.some(item => item.role)) {
+    return true;
+  }
+
+  return Object.values(roles).some(
+    value => typeof value === "string" && value.trim().length > 0
+  );
+}
+
+/**
+ * @param {string} template
+ * @param {string | undefined} queueArgument
+ * @param {string | null} itemUrl
+ * @returns {string}
+ */
+function expandHighlightNextStep(template, queueArgument, itemUrl) {
+  return template
+    .replace("<queue>", queueArgument ?? "queue")
+    .replace("<item-url>", itemUrl ?? "item URL");
+}
+
+/**
+ * @param {Record<string, any>} left
+ * @param {Record<string, any>} right
+ * @returns {number}
+ */
+function compareQueueItemsByCreatedAt(left, right) {
+  const leftMs = left.createdAt
+    ? Date.parse(left.createdAt)
+    : Number.POSITIVE_INFINITY;
+  const rightMs = right.createdAt
+    ? Date.parse(right.createdAt)
+    : Number.POSITIVE_INFINITY;
+
+  if (leftMs !== rightMs) {
+    return leftMs - rightMs;
+  }
+
+  return String(left.ref).localeCompare(String(right.ref));
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string | null}
+ */
+function normalizeTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/plugins/src/base/scripts/queue-status-prd-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-prd-readers.mjs
@@ -96,14 +96,15 @@ export function readGithubPrdQueueSnapshot(input = {}) {
  * }} input
  */
 export function createPrdQueueSnapshot(input = {}) {
-  const roles = normalizeRoles(input.roles);
+  const rawRoles = input.roles ?? {};
+  const roles = normalizeRoles(rawRoles);
   const items = normalizeItems(input.items);
   const counts = buildLifecycleCounts(items);
   const highlights = buildActionableHighlights(items, input.queueArgument);
   const queueResolved =
     input.queueResolved ?? typeof input.resolutionError !== "string";
   const namespaceAdopted =
-    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, rawRoles);
 
   const health = classifyQueueHealth({
     queueResolved,

--- a/plugins/src/base/scripts/queue-status-prd-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-prd-readers.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * Shared PRD-side queue readers for `/lisa:queue-status`.
+ *
+ * These helpers normalize vendor-specific PRD lifecycle items into a common
+ * snapshot shape so queue-status can report lifecycle counts, actionable
+ * highlights, and queue-health verdict inputs without drifting from Lisa's PRD
+ * lifecycle contract.
+ */
+
+import { classifyQueueHealth } from "./queue-health-classification.mjs";
+
+export const PRD_LIFECYCLE_ORDER = [
+  "draft",
+  "ready",
+  "in_review",
+  "blocked",
+  "ticketed",
+  "shipped",
+  "verified",
+];
+
+const ACTIONABLE_ROLE_ORDER = [
+  "blocked",
+  "in_review",
+  "shipped",
+  "ready",
+  "ticketed",
+];
+
+const HIGHLIGHT_COPY = {
+  blocked: {
+    summary: "Oldest blocked PRD",
+    nextStep: "Run /lisa:repair-intake <queue> after clarifying the blocker.",
+  },
+  in_review: {
+    summary: "Oldest PRD still in review",
+    nextStep:
+      "Inspect the active intake run or resume it with /lisa:repair-intake <queue>.",
+  },
+  shipped: {
+    summary: "Oldest shipped PRD awaiting verification",
+    nextStep: "Run /lisa:verify-prd <item-url> to close the shipped loop.",
+  },
+  ready: {
+    summary: "Oldest ready PRD awaiting intake",
+    nextStep: "Run /lisa:intake <queue> to ticket the next PRD.",
+  },
+  ticketed: {
+    summary: "Oldest ticketed PRD still waiting on downstream delivery",
+    nextStep:
+      "Monitor downstream build work or inspect the build queue with /lisa:queue-status queue=build.",
+  },
+};
+
+/**
+ * Read a GitHub-backed PRD queue snapshot from issue payloads.
+ *
+ * @param {{
+ *   readonly issues?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, string>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function readGithubPrdQueueSnapshot(input = {}) {
+  const roles = input.roles ?? {};
+  const normalizedItems = (input.issues ?? [])
+    .map(issue => normalizeGithubPrdIssue(issue, roles))
+    .filter(Boolean);
+
+  return createPrdQueueSnapshot({
+    source: "github",
+    items: normalizedItems,
+    roles,
+    namespaceAdopted: input.namespaceAdopted,
+    queueResolved: input.queueResolved,
+    queueArgument: input.queueArgument,
+    resolutionError: input.resolutionError,
+  });
+}
+
+/**
+ * Build a vendor-agnostic PRD queue snapshot from normalized lifecycle items.
+ *
+ * @param {{
+ *   readonly source?: string
+ *   readonly items?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, string>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function createPrdQueueSnapshot(input = {}) {
+  const roles = normalizeRoles(input.roles);
+  const items = normalizeItems(input.items);
+  const counts = buildLifecycleCounts(items);
+  const highlights = buildActionableHighlights(items, input.queueArgument);
+  const queueResolved =
+    input.queueResolved ?? typeof input.resolutionError !== "string";
+  const namespaceAdopted =
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+
+  const health = classifyQueueHealth({
+    queueResolved,
+    namespaceAdopted,
+    readyCount: counts.ready,
+    activeCount: counts.in_review + counts.ticketed,
+    blockedCount: counts.blocked,
+    stalledCount: counts.shipped,
+    resolutionError: input.resolutionError ?? null,
+  });
+
+  return {
+    source: input.source ?? "unknown",
+    queueResolved,
+    namespaceAdopted,
+    roles,
+    counts,
+    highlights,
+    health,
+    resolutionError: input.resolutionError ?? null,
+  };
+}
+
+/**
+ * @param {Record<string, any>} issue
+ * @param {Record<string, string>} roles
+ * @returns {Record<string, any> | null}
+ */
+function normalizeGithubPrdIssue(issue, roles) {
+  if (!issue || typeof issue !== "object") {
+    return null;
+  }
+
+  const role = resolveGithubPrdRole(issue.labels, roles);
+
+  return normalizeItem({
+    id: String(issue.id ?? issue.number ?? issue.url ?? issue.title ?? ""),
+    ref:
+      issue.number !== undefined && issue.number !== null
+        ? `#${issue.number}`
+        : String(issue.url ?? issue.title ?? ""),
+    title: String(issue.title ?? "").trim(),
+    url: typeof issue.url === "string" ? issue.url : null,
+    createdAt: issue.createdAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    role,
+  });
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @param {Record<string, string>} roles
+ * @returns {string | null}
+ */
+function resolveGithubPrdRole(labels, roles) {
+  if (!Array.isArray(labels)) {
+    return null;
+  }
+
+  const labelNames = new Set(
+    labels
+      .map(label =>
+        typeof label === "string"
+          ? label
+          : typeof label?.name === "string"
+            ? label.name
+            : null
+      )
+      .filter(Boolean)
+  );
+
+  for (const role of PRD_LIFECYCLE_ORDER) {
+    const configuredName = roles[role];
+    if (configuredName && labelNames.has(configuredName)) {
+      return role;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, string> | undefined} roles
+ * @returns {Record<string, string>}
+ */
+function normalizeRoles(roles) {
+  const normalized = {};
+
+  for (const role of PRD_LIFECYCLE_ORDER) {
+    normalized[role] =
+      typeof roles?.[role] === "string" && roles[role].trim().length > 0
+        ? roles[role].trim()
+        : role;
+  }
+
+  return normalized;
+}
+
+/**
+ * @param {readonly Record<string, any>[] | undefined} items
+ * @returns {readonly Record<string, any>[]}
+ */
+function normalizeItems(items) {
+  return (items ?? []).map(normalizeItem).filter(Boolean);
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any> | null}
+ */
+function normalizeItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const role =
+    typeof item.role === "string" && PRD_LIFECYCLE_ORDER.includes(item.role)
+      ? item.role
+      : null;
+
+  const createdAt = normalizeTimestamp(item.createdAt);
+  const updatedAt = normalizeTimestamp(item.updatedAt);
+
+  return {
+    id: String(item.id ?? item.ref ?? item.title ?? ""),
+    ref: String(item.ref ?? item.id ?? item.title ?? ""),
+    title: String(item.title ?? "").trim(),
+    url: typeof item.url === "string" ? item.url : null,
+    role,
+    createdAt,
+    updatedAt,
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ */
+function buildLifecycleCounts(items) {
+  const counts = Object.fromEntries(PRD_LIFECYCLE_ORDER.map(role => [role, 0]));
+
+  for (const item of items) {
+    if (item.role && counts[item.role] !== undefined) {
+      counts[item.role] += 1;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string | undefined} queueArgument
+ */
+function buildActionableHighlights(items, queueArgument) {
+  const highlights = [];
+
+  for (const role of ACTIONABLE_ROLE_ORDER) {
+    const oldest = findOldestItemForRole(items, role);
+    if (!oldest) {
+      continue;
+    }
+
+    const copy = HIGHLIGHT_COPY[role];
+    highlights.push({
+      role,
+      ref: oldest.ref,
+      title: oldest.title,
+      url: oldest.url,
+      createdAt: oldest.createdAt,
+      summary: copy.summary,
+      nextStep: expandHighlightNextStep(
+        copy.nextStep,
+        queueArgument,
+        oldest.url
+      ),
+    });
+  }
+
+  return highlights;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string} role
+ */
+function findOldestItemForRole(items, role) {
+  return (
+    items
+      .filter(item => item.role === role)
+      .sort(compareQueueItemsByCreatedAt)[0] ?? null
+  );
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, string>} roles
+ * @returns {boolean}
+ */
+function inferNamespaceAdopted(items, roles) {
+  if (items.some(item => item.role)) {
+    return true;
+  }
+
+  return Object.values(roles).some(
+    value => typeof value === "string" && value.trim().length > 0
+  );
+}
+
+/**
+ * @param {string} template
+ * @param {string | undefined} queueArgument
+ * @param {string | null} itemUrl
+ * @returns {string}
+ */
+function expandHighlightNextStep(template, queueArgument, itemUrl) {
+  return template
+    .replace("<queue>", queueArgument ?? "queue")
+    .replace("<item-url>", itemUrl ?? "item URL");
+}
+
+/**
+ * @param {Record<string, any>} left
+ * @param {Record<string, any>} right
+ * @returns {number}
+ */
+function compareQueueItemsByCreatedAt(left, right) {
+  const leftMs = left.createdAt
+    ? Date.parse(left.createdAt)
+    : Number.POSITIVE_INFINITY;
+  const rightMs = right.createdAt
+    ? Date.parse(right.createdAt)
+    : Number.POSITIVE_INFINITY;
+
+  if (leftMs !== rightMs) {
+    return leftMs - rightMs;
+  }
+
+  return String(left.ref).localeCompare(String(right.ref));
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string | null}
+ */
+function normalizeTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/tests/fixtures/queue-status-prd-readers/confluence.json
+++ b/tests/fixtures/queue-status-prd-readers/confluence.json
@@ -1,0 +1,53 @@
+{
+  "source": "confluence",
+  "items": [
+    {
+      "id": "2001",
+      "ref": "PRD-Ready",
+      "title": "Ready PRD waiting for intake",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2001",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "2002",
+      "ref": "PRD-Review",
+      "title": "PRD still in review",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2002",
+      "role": "in_review",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "2003",
+      "ref": "PRD-Blocked",
+      "title": "Blocked PRD needs clarification",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2003",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "2004",
+      "ref": "PRD-Ticketed",
+      "title": "Ticketed PRD waiting on build work",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2004",
+      "role": "ticketed",
+      "createdAt": "2026-05-22T10:00:00Z"
+    },
+    {
+      "id": "2005",
+      "ref": "PRD-Shipped",
+      "title": "Shipped PRD awaiting verify-prd",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2005",
+      "role": "shipped",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "2006",
+      "ref": "PRD-Verified",
+      "title": "Verified PRD",
+      "url": "https://acme.atlassian.net/wiki/spaces/PRD/pages/2006",
+      "role": "verified",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/queue-status-prd-readers/github.json
+++ b/tests/fixtures/queue-status-prd-readers/github.json
@@ -1,0 +1,53 @@
+{
+  "source": "github",
+  "items": [
+    {
+      "id": "824",
+      "ref": "#824",
+      "title": "Ready PRD waiting for intake",
+      "url": "https://github.com/CodySwannGT/lisa/issues/824",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "825",
+      "ref": "#825",
+      "title": "PRD still in review",
+      "url": "https://github.com/CodySwannGT/lisa/issues/825",
+      "role": "in_review",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "826",
+      "ref": "#826",
+      "title": "Blocked PRD needs clarification",
+      "url": "https://github.com/CodySwannGT/lisa/issues/826",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "827",
+      "ref": "#827",
+      "title": "Ticketed PRD waiting on build work",
+      "url": "https://github.com/CodySwannGT/lisa/issues/827",
+      "role": "ticketed",
+      "createdAt": "2026-05-22T10:00:00Z"
+    },
+    {
+      "id": "828",
+      "ref": "#828",
+      "title": "Shipped PRD awaiting verify-prd",
+      "url": "https://github.com/CodySwannGT/lisa/issues/828",
+      "role": "shipped",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "829",
+      "ref": "#829",
+      "title": "Verified PRD",
+      "url": "https://github.com/CodySwannGT/lisa/issues/829",
+      "role": "verified",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/queue-status-prd-readers/linear.json
+++ b/tests/fixtures/queue-status-prd-readers/linear.json
@@ -1,0 +1,53 @@
+{
+  "source": "linear",
+  "items": [
+    {
+      "id": "LISA-824",
+      "ref": "LISA-824",
+      "title": "Ready PRD waiting for intake",
+      "url": "https://linear.app/acme/issue/LISA-824",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "LISA-825",
+      "ref": "LISA-825",
+      "title": "PRD still in review",
+      "url": "https://linear.app/acme/issue/LISA-825",
+      "role": "in_review",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "LISA-826",
+      "ref": "LISA-826",
+      "title": "Blocked PRD needs clarification",
+      "url": "https://linear.app/acme/issue/LISA-826",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "LISA-827",
+      "ref": "LISA-827",
+      "title": "Ticketed PRD waiting on build work",
+      "url": "https://linear.app/acme/issue/LISA-827",
+      "role": "ticketed",
+      "createdAt": "2026-05-22T10:00:00Z"
+    },
+    {
+      "id": "LISA-828",
+      "ref": "LISA-828",
+      "title": "Shipped PRD awaiting verify-prd",
+      "url": "https://linear.app/acme/issue/LISA-828",
+      "role": "shipped",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "LISA-829",
+      "ref": "LISA-829",
+      "title": "Verified PRD",
+      "url": "https://linear.app/acme/issue/LISA-829",
+      "role": "verified",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/queue-status-prd-readers/notion.json
+++ b/tests/fixtures/queue-status-prd-readers/notion.json
@@ -1,0 +1,53 @@
+{
+  "source": "notion",
+  "items": [
+    {
+      "id": "page-ready",
+      "ref": "Ready page",
+      "title": "Ready PRD waiting for intake",
+      "url": "https://www.notion.so/acme/ready-page",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "page-review",
+      "ref": "Review page",
+      "title": "PRD still in review",
+      "url": "https://www.notion.so/acme/review-page",
+      "role": "in_review",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "page-blocked",
+      "ref": "Blocked page",
+      "title": "Blocked PRD needs clarification",
+      "url": "https://www.notion.so/acme/blocked-page",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "page-ticketed",
+      "ref": "Ticketed page",
+      "title": "Ticketed PRD waiting on build work",
+      "url": "https://www.notion.so/acme/ticketed-page",
+      "role": "ticketed",
+      "createdAt": "2026-05-22T10:00:00Z"
+    },
+    {
+      "id": "page-shipped",
+      "ref": "Shipped page",
+      "title": "Shipped PRD awaiting verify-prd",
+      "url": "https://www.notion.so/acme/shipped-page",
+      "role": "shipped",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "page-verified",
+      "ref": "Verified page",
+      "title": "Verified PRD",
+      "url": "https://www.notion.so/acme/verified-page",
+      "role": "verified",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/unit/strategies/queue-status-prd-readers.test.ts
+++ b/tests/unit/strategies/queue-status-prd-readers.test.ts
@@ -20,6 +20,21 @@ import {
 const FIXTURE_ROOT = path.resolve("tests/fixtures/queue-status-prd-readers");
 
 /**
+ * Canonical label names used by the GitHub PRD lifecycle namespace in tests.
+ * Centralised here so each string literal appears exactly once, satisfying the
+ * sonarjs/no-duplicate-string rule while keeping tests readable.
+ */
+const GITHUB_PRD_ROLES = {
+  draft: "prd-draft",
+  ready: "prd-ready",
+  in_review: "prd-in-review",
+  blocked: "prd-blocked",
+  ticketed: "prd-ticketed",
+  shipped: "prd-shipped",
+  verified: "prd-verified",
+} as const;
+
+/**
  *
  */
 type QueueFixture = {
@@ -37,57 +52,49 @@ describe("queue-status PRD readers (#824)", () => {
     const snapshot = readGithubPrdQueueSnapshot({
       namespaceAdopted: true,
       queueArgument: "github intake_mode=prd",
-      roles: {
-        draft: "prd-draft",
-        ready: "prd-ready",
-        in_review: "prd-in-review",
-        blocked: "prd-blocked",
-        ticketed: "prd-ticketed",
-        shipped: "prd-shipped",
-        verified: "prd-verified",
-      },
+      roles: GITHUB_PRD_ROLES,
       issues: [
         {
           number: 824,
           title: "Ready PRD waiting for intake",
           url: "https://github.com/CodySwannGT/lisa/issues/824",
           createdAt: "2026-05-25T10:00:00Z",
-          labels: [{ name: "prd-ready" }],
+          labels: [{ name: GITHUB_PRD_ROLES.ready }],
         },
         {
           number: 825,
           title: "PRD still in review",
           url: "https://github.com/CodySwannGT/lisa/issues/825",
           createdAt: "2026-05-24T10:00:00Z",
-          labels: [{ name: "prd-in-review" }],
+          labels: [{ name: GITHUB_PRD_ROLES.in_review }],
         },
         {
           number: 826,
           title: "Blocked PRD needs clarification",
           url: "https://github.com/CodySwannGT/lisa/issues/826",
           createdAt: "2026-05-23T10:00:00Z",
-          labels: [{ name: "prd-blocked" }],
+          labels: [{ name: GITHUB_PRD_ROLES.blocked }],
         },
         {
           number: 827,
           title: "Ticketed PRD waiting on build work",
           url: "https://github.com/CodySwannGT/lisa/issues/827",
           createdAt: "2026-05-22T10:00:00Z",
-          labels: [{ name: "prd-ticketed" }],
+          labels: [{ name: GITHUB_PRD_ROLES.ticketed }],
         },
         {
           number: 828,
           title: "Shipped PRD awaiting verify-prd",
           url: "https://github.com/CodySwannGT/lisa/issues/828",
           createdAt: "2026-05-21T10:00:00Z",
-          labels: [{ name: "prd-shipped" }],
+          labels: [{ name: GITHUB_PRD_ROLES.shipped }],
         },
         {
           number: 829,
           title: "Verified PRD",
           url: "https://github.com/CodySwannGT/lisa/issues/829",
           createdAt: "2026-05-20T10:00:00Z",
-          labels: [{ name: "prd-verified" }],
+          labels: [{ name: GITHUB_PRD_ROLES.verified }],
         },
       ],
     });
@@ -137,6 +144,36 @@ describe("queue-status PRD readers (#824)", () => {
       verdict: "MISCONFIGURED",
       reasons: ["lifecycle-namespace-absent"],
     });
+  });
+
+  it("infers namespaceAdopted=false when no roles are configured and no items have roles", () => {
+    // When neither namespaceAdopted nor roles is supplied, the inference must
+    // detect that the lifecycle namespace is absent and return false — not true,
+    // which would be the (buggy) result of comparing already-normalized roles
+    // against a "non-empty string" check.
+    const snapshot = createPrdQueueSnapshot({
+      source: "github",
+      items: [],
+    });
+
+    expect(snapshot.namespaceAdopted).toBe(false);
+    expect(snapshot.health).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+    });
+  });
+
+  it("infers namespaceAdopted=true when roles are explicitly configured", () => {
+    const snapshot = createPrdQueueSnapshot({
+      source: "github",
+      roles: {
+        ready: GITHUB_PRD_ROLES.ready,
+        in_review: GITHUB_PRD_ROLES.in_review,
+      },
+      items: [],
+    });
+
+    expect(snapshot.namespaceAdopted).toBe(true);
   });
 
   it("keeps fixture-backed vendor parity for counts, highlights, and verdicts", () => {

--- a/tests/unit/strategies/queue-status-prd-readers.test.ts
+++ b/tests/unit/strategies/queue-status-prd-readers.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression coverage for PRD-side queue readers used by `/lisa:queue-status`.
+ *
+ * Issue #824 adds the first runtime queue readers for the queue-status surface:
+ * GitHub PRD queue parsing plus vendor-parity snapshots that preserve the same
+ * lifecycle counts and actionable highlights across GitHub, Linear, Notion, and
+ * Confluence inputs.
+ * @module tests/unit/strategies/queue-status-prd-readers
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createPrdQueueSnapshot,
+  readGithubPrdQueueSnapshot,
+} from "../../../plugins/src/base/scripts/queue-status-prd-readers.mjs";
+
+const FIXTURE_ROOT = path.resolve("tests/fixtures/queue-status-prd-readers");
+
+/**
+ *
+ */
+type QueueFixture = {
+  readonly source: string;
+  readonly items: readonly Record<string, unknown>[];
+};
+
+const readFixture = (name: string): QueueFixture =>
+  JSON.parse(
+    readFileSync(path.join(FIXTURE_ROOT, `${name}.json`), "utf8")
+  ) as QueueFixture;
+
+describe("queue-status PRD readers (#824)", () => {
+  it("parses GitHub PRD lifecycle labels into counts and actionable highlights", () => {
+    const snapshot = readGithubPrdQueueSnapshot({
+      namespaceAdopted: true,
+      queueArgument: "github intake_mode=prd",
+      roles: {
+        draft: "prd-draft",
+        ready: "prd-ready",
+        in_review: "prd-in-review",
+        blocked: "prd-blocked",
+        ticketed: "prd-ticketed",
+        shipped: "prd-shipped",
+        verified: "prd-verified",
+      },
+      issues: [
+        {
+          number: 824,
+          title: "Ready PRD waiting for intake",
+          url: "https://github.com/CodySwannGT/lisa/issues/824",
+          createdAt: "2026-05-25T10:00:00Z",
+          labels: [{ name: "prd-ready" }],
+        },
+        {
+          number: 825,
+          title: "PRD still in review",
+          url: "https://github.com/CodySwannGT/lisa/issues/825",
+          createdAt: "2026-05-24T10:00:00Z",
+          labels: [{ name: "prd-in-review" }],
+        },
+        {
+          number: 826,
+          title: "Blocked PRD needs clarification",
+          url: "https://github.com/CodySwannGT/lisa/issues/826",
+          createdAt: "2026-05-23T10:00:00Z",
+          labels: [{ name: "prd-blocked" }],
+        },
+        {
+          number: 827,
+          title: "Ticketed PRD waiting on build work",
+          url: "https://github.com/CodySwannGT/lisa/issues/827",
+          createdAt: "2026-05-22T10:00:00Z",
+          labels: [{ name: "prd-ticketed" }],
+        },
+        {
+          number: 828,
+          title: "Shipped PRD awaiting verify-prd",
+          url: "https://github.com/CodySwannGT/lisa/issues/828",
+          createdAt: "2026-05-21T10:00:00Z",
+          labels: [{ name: "prd-shipped" }],
+        },
+        {
+          number: 829,
+          title: "Verified PRD",
+          url: "https://github.com/CodySwannGT/lisa/issues/829",
+          createdAt: "2026-05-20T10:00:00Z",
+          labels: [{ name: "prd-verified" }],
+        },
+      ],
+    });
+
+    expect(snapshot.source).toBe("github");
+    expect(snapshot.counts).toEqual({
+      draft: 0,
+      ready: 1,
+      in_review: 1,
+      blocked: 1,
+      ticketed: 1,
+      shipped: 1,
+      verified: 1,
+    });
+    expect(snapshot.highlights.map(highlight => highlight.role)).toEqual([
+      "blocked",
+      "in_review",
+      "shipped",
+      "ready",
+      "ticketed",
+    ]);
+    expect(snapshot.highlights[0]).toMatchObject({
+      ref: "#826",
+      summary: "Oldest blocked PRD",
+    });
+    expect(snapshot.highlights[0].nextStep).toBe(
+      "Run /lisa:repair-intake github intake_mode=prd after clarifying the blocker."
+    );
+    expect(snapshot.highlights[2].nextStep).toBe(
+      "Run /lisa:verify-prd https://github.com/CodySwannGT/lisa/issues/828 to close the shipped loop."
+    );
+    expect(snapshot.health).toMatchObject({
+      verdict: "ATTENTION_NEEDED",
+      reasons: ["blocked-work-present", "stalled-work-present"],
+    });
+  });
+
+  it("treats missing namespace adoption as misconfigured instead of idle", () => {
+    const snapshot = createPrdQueueSnapshot({
+      source: "github",
+      namespaceAdopted: false,
+      queueArgument: "github intake_mode=prd",
+      items: [],
+    });
+
+    expect(snapshot.health).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+    });
+  });
+
+  it("keeps fixture-backed vendor parity for counts, highlights, and verdicts", () => {
+    const fixtureNames = ["github", "linear", "notion", "confluence"];
+    const snapshots = fixtureNames.map(name => {
+      const fixture = readFixture(name);
+      return createPrdQueueSnapshot({
+        source: fixture.source,
+        queueArgument: `${fixture.source} intake_mode=prd`,
+        namespaceAdopted: true,
+        items: fixture.items,
+      });
+    });
+
+    for (const snapshot of snapshots) {
+      expect(snapshot.counts).toEqual({
+        draft: 0,
+        ready: 1,
+        in_review: 1,
+        blocked: 1,
+        ticketed: 1,
+        shipped: 1,
+        verified: 1,
+      });
+      expect(snapshot.highlights.map(highlight => highlight.role)).toEqual([
+        "blocked",
+        "in_review",
+        "shipped",
+        "ready",
+        "ticketed",
+      ]);
+      expect(snapshot.highlights[0].title).toBe(
+        "Blocked PRD needs clarification"
+      );
+      expect(snapshot.health.verdict).toBe("ATTENTION_NEEDED");
+    }
+  });
+
+  it("keeps the distributed reader artifact in lockstep with the source script", () => {
+    const sourcePath = path.resolve(
+      "plugins/src/base/scripts/queue-status-prd-readers.mjs"
+    );
+    const generatedPath = path.resolve(
+      "plugins/lisa/scripts/queue-status-prd-readers.mjs"
+    );
+
+    expect(existsSync(generatedPath)).toBe(true);
+    expect(readFileSync(generatedPath, "utf8")).toBe(
+      readFileSync(sourcePath, "utf8")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared PRD queue-reader helper for queue-status with lifecycle counts, actionable highlights, and queue-health inputs
- cover GitHub label parsing plus fixture-backed vendor parity for GitHub, Linear, Notion, and Confluence
- regenerate the distributed plugin script artifact

## Testing
- bun test tests/unit/strategies/queue-contract-resolution.test.ts tests/unit/strategies/queue-health-classification.test.ts tests/unit/strategies/queue-status-prd-readers.test.ts tests/unit/strategies/queue-status-scaffold.test.ts

Closes #824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified PRD queue status across GitHub, Linear, Notion, and Confluence with consistent item normalization, lifecycle ordering, actionable role highlights, and automatic health/resolution assessment.
  * Snapshots now surface per-lifecycle counts, oldest-item highlights with next-step guidance, and inferred namespace/resolution status.

* **Tests**
  * Expanded test suite and fixtures to validate parity, counts, highlights, and health verdicts across all sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->