### PR TITLE
feat(queue-status): add build queue readers

### DIFF
--- a/plugins/lisa/scripts/queue-status-build-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-build-readers.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * Shared build-side queue readers for `/lisa:queue-status`.
+ *
+ * These helpers normalize vendor-specific build lifecycle items into a common
+ * snapshot shape so queue-status can report lifecycle counts, actionable
+ * highlights, and repair-intake signals without drifting from Lisa's build
+ * lifecycle contract.
+ */
+
+import { classifyQueueHealth } from "./queue-health-classification.mjs";
+
+export const BUILD_LIFECYCLE_ORDER = [
+  "ready",
+  "claimed",
+  "review",
+  "blocked",
+  "done",
+];
+
+const ACTIONABLE_ROLE_ORDER = ["blocked", "ready", "claimed", "review"];
+
+const HIGHLIGHT_COPY = {
+  blocked: {
+    summary: "Oldest blocked build item",
+    nextStep: "Run /lisa:repair-intake <queue> after clearing the blocker.",
+  },
+  stalled: {
+    summary: "Oldest stalled build item likely actionable for repair-intake",
+    nextStep:
+      "Run /lisa:repair-intake <queue> to re-evaluate the stalled build item.",
+  },
+  ready: {
+    summary: "Oldest ready build item awaiting intake",
+    nextStep: "Run /lisa:intake <queue> to claim the next build issue.",
+  },
+  claimed: {
+    summary: "Oldest claimed build item still in flight",
+    nextStep:
+      "Inspect the active implementation path before escalating to /lisa:repair-intake <queue>.",
+  },
+  review: {
+    summary: "Oldest build item waiting in review",
+    nextStep:
+      "Check the linked PR or review handoff before re-running /lisa:intake <queue>.",
+  },
+};
+
+/**
+ * Read a GitHub-backed build queue snapshot from issue payloads.
+ *
+ * @param {{
+ *   readonly issues?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, any>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function readGithubBuildQueueSnapshot(input = {}) {
+  const roles = input.roles ?? {};
+  const normalizedItems = (input.issues ?? [])
+    .map(issue => normalizeGithubBuildIssue(issue, roles))
+    .filter(Boolean);
+
+  return createBuildQueueSnapshot({
+    tracker: "github",
+    items: normalizedItems,
+    roles,
+    namespaceAdopted: input.namespaceAdopted,
+    queueResolved: input.queueResolved,
+    queueArgument: input.queueArgument,
+    resolutionError: input.resolutionError,
+  });
+}
+
+/**
+ * Build a vendor-agnostic build queue snapshot from normalized lifecycle items.
+ *
+ * @param {{
+ *   readonly tracker?: string
+ *   readonly items?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, any>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function createBuildQueueSnapshot(input = {}) {
+  const roles = normalizeRoles(input.roles);
+  const items = normalizeItems(input.items);
+  const counts = buildLifecycleCounts(items);
+  const repairSignals = buildRepairSignals(items, input.queueArgument);
+  const highlights = buildActionableHighlights(
+    items,
+    repairSignals,
+    input.queueArgument
+  );
+  const queueResolved =
+    input.queueResolved ?? typeof input.resolutionError !== "string";
+  const namespaceAdopted =
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+
+  const health = classifyQueueHealth({
+    queueResolved,
+    namespaceAdopted,
+    readyCount: counts.ready,
+    activeCount: counts.claimed + counts.review,
+    blockedCount: counts.blocked,
+    stalledCount: repairSignals.stalled.length,
+    resolutionError: input.resolutionError ?? null,
+  });
+
+  return {
+    tracker: input.tracker ?? "unknown",
+    queueResolved,
+    namespaceAdopted,
+    roles,
+    counts,
+    highlights,
+    repairSignals,
+    health,
+    resolutionError: input.resolutionError ?? null,
+  };
+}
+
+/**
+ * @param {Record<string, any>} issue
+ * @param {Record<string, any>} roles
+ * @returns {Record<string, any> | null}
+ */
+function normalizeGithubBuildIssue(issue, roles) {
+  if (!issue || typeof issue !== "object") {
+    return null;
+  }
+
+  const role = resolveGithubBuildRole(issue.labels, roles);
+
+  return normalizeItem({
+    id: String(issue.id ?? issue.number ?? issue.url ?? issue.title ?? ""),
+    ref:
+      issue.number !== undefined && issue.number !== null
+        ? `#${issue.number}`
+        : String(issue.url ?? issue.title ?? ""),
+    title: String(issue.title ?? "").trim(),
+    url: typeof issue.url === "string" ? issue.url : null,
+    createdAt: issue.createdAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    role,
+    stalled: Boolean(issue.stalled),
+  });
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @param {Record<string, any>} roles
+ * @returns {string | null}
+ */
+function resolveGithubBuildRole(labels, roles) {
+  if (!Array.isArray(labels)) {
+    return null;
+  }
+
+  const labelNames = new Set(
+    labels
+      .map(label =>
+        typeof label === "string"
+          ? label
+          : typeof label?.name === "string"
+            ? label.name
+            : null
+      )
+      .filter(Boolean)
+  );
+
+  for (const role of BUILD_LIFECYCLE_ORDER) {
+    if (role === "done") {
+      if (resolveDoneRoleNames(roles).some(name => labelNames.has(name))) {
+        return "done";
+      }
+      continue;
+    }
+
+    const configuredName = roles[role];
+    if (configuredName && labelNames.has(configuredName)) {
+      return role;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, any> | undefined} roles
+ * @returns {Record<string, any>}
+ */
+function normalizeRoles(roles) {
+  return {
+    ready:
+      typeof roles?.ready === "string" && roles.ready.trim().length > 0
+        ? roles.ready.trim()
+        : "ready",
+    claimed:
+      typeof roles?.claimed === "string" && roles.claimed.trim().length > 0
+        ? roles.claimed.trim()
+        : "claimed",
+    review:
+      typeof roles?.review === "string" && roles.review.trim().length > 0
+        ? roles.review.trim()
+        : "review",
+    blocked:
+      typeof roles?.blocked === "string" && roles.blocked.trim().length > 0
+        ? roles.blocked.trim()
+        : "blocked",
+    done: normalizeDoneRoles(roles?.done),
+  };
+}
+
+/**
+ * @param {Record<string, any> | undefined} done
+ * @returns {Record<string, string>}
+ */
+function normalizeDoneRoles(done) {
+  if (typeof done === "string" && done.trim().length > 0) {
+    return { default: done.trim() };
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(done ?? {})) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      normalized[key] = value.trim();
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : { default: "done" };
+}
+
+/**
+ * @param {Record<string, any>} roles
+ * @returns {readonly string[]}
+ */
+function resolveDoneRoleNames(roles) {
+  return Object.values(normalizeDoneRoles(roles?.done));
+}
+
+/**
+ * @param {readonly Record<string, any>[] | undefined} items
+ * @returns {readonly Record<string, any>[]}
+ */
+function normalizeItems(items) {
+  return (items ?? []).map(normalizeItem).filter(Boolean);
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any> | null}
+ */
+function normalizeItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const role =
+    typeof item.role === "string" && BUILD_LIFECYCLE_ORDER.includes(item.role)
+      ? item.role
+      : null;
+
+  return {
+    id: String(item.id ?? item.ref ?? item.title ?? ""),
+    ref: String(item.ref ?? item.id ?? item.title ?? ""),
+    title: String(item.title ?? "").trim(),
+    url: typeof item.url === "string" ? item.url : null,
+    role,
+    createdAt: normalizeTimestamp(item.createdAt),
+    updatedAt: normalizeTimestamp(item.updatedAt),
+    stalled: Boolean(item.stalled),
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ */
+function buildLifecycleCounts(items) {
+  const counts = Object.fromEntries(
+    BUILD_LIFECYCLE_ORDER.map(role => [role, 0])
+  );
+
+  for (const item of items) {
+    if (item.role && counts[item.role] !== undefined) {
+      counts[item.role] += 1;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string | undefined} queueArgument
+ */
+function buildRepairSignals(items, queueArgument) {
+  const blocked = items
+    .filter(item => item.role === "blocked")
+    .sort(compareQueueItemsByCreatedAt)
+    .map(toRepairSignalItem);
+  const stalled = items
+    .filter(item => item.stalled)
+    .sort(compareQueueItemsByCreatedAt)
+    .map(toRepairSignalItem);
+
+  return {
+    actionable: blocked.length > 0 || stalled.length > 0,
+    blocked,
+    stalled,
+    suggestedCommand:
+      blocked.length > 0 || stalled.length > 0
+        ? expandHighlightNextStep(
+            "Run /lisa:repair-intake <queue> to inspect the most actionable stuck build work.",
+            queueArgument
+          )
+        : null,
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, any>} repairSignals
+ * @param {string | undefined} queueArgument
+ */
+function buildActionableHighlights(items, repairSignals, queueArgument) {
+  const highlights = [];
+
+  const oldestStalled = repairSignals.stalled[0];
+  if (oldestStalled) {
+    highlights.push({
+      role: "stalled",
+      ref: oldestStalled.ref,
+      title: oldestStalled.title,
+      url: oldestStalled.url,
+      createdAt: oldestStalled.createdAt,
+      summary: HIGHLIGHT_COPY.stalled.summary,
+      nextStep: expandHighlightNextStep(
+        HIGHLIGHT_COPY.stalled.nextStep,
+        queueArgument
+      ),
+    });
+  }
+
+  for (const role of ACTIONABLE_ROLE_ORDER) {
+    const oldest = findOldestItemForRole(items, role);
+    if (!oldest) {
+      continue;
+    }
+
+    const copy = HIGHLIGHT_COPY[role];
+    highlights.push({
+      role,
+      ref: oldest.ref,
+      title: oldest.title,
+      url: oldest.url,
+      createdAt: oldest.createdAt,
+      summary: copy.summary,
+      nextStep: expandHighlightNextStep(copy.nextStep, queueArgument),
+    });
+  }
+
+  return highlights;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string} role
+ */
+function findOldestItemForRole(items, role) {
+  return (
+    items
+      .filter(item => item.role === role)
+      .sort(compareQueueItemsByCreatedAt)[0] ?? null
+  );
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, any>} roles
+ * @returns {boolean}
+ */
+function inferNamespaceAdopted(items, roles) {
+  if (items.some(item => item.role)) {
+    return true;
+  }
+
+  return (
+    ["ready", "claimed", "review", "blocked"].some(
+      role => typeof roles[role] === "string" && roles[role].trim().length > 0
+    ) || resolveDoneRoleNames(roles).length > 0
+  );
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any>}
+ */
+function toRepairSignalItem(item) {
+  return {
+    ref: item.ref,
+    title: item.title,
+    url: item.url,
+    createdAt: item.createdAt,
+  };
+}
+
+/**
+ * @param {string} template
+ * @param {string | undefined} queueArgument
+ * @returns {string}
+ */
+function expandHighlightNextStep(template, queueArgument) {
+  return template.replace("<queue>", queueArgument ?? "queue");
+}
+
+/**
+ * @param {Record<string, any>} left
+ * @param {Record<string, any>} right
+ * @returns {number}
+ */
+function compareQueueItemsByCreatedAt(left, right) {
+  const leftMs = left.createdAt
+    ? Date.parse(left.createdAt)
+    : Number.POSITIVE_INFINITY;
+  const rightMs = right.createdAt
+    ? Date.parse(right.createdAt)
+    : Number.POSITIVE_INFINITY;
+
+  if (leftMs !== rightMs) {
+    return leftMs - rightMs;
+  }
+
+  return String(left.ref).localeCompare(String(right.ref));
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string | null}
+ */
+function normalizeTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/plugins/src/base/scripts/queue-status-build-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-build-readers.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * Shared build-side queue readers for `/lisa:queue-status`.
+ *
+ * These helpers normalize vendor-specific build lifecycle items into a common
+ * snapshot shape so queue-status can report lifecycle counts, actionable
+ * highlights, and repair-intake signals without drifting from Lisa's build
+ * lifecycle contract.
+ */
+
+import { classifyQueueHealth } from "./queue-health-classification.mjs";
+
+export const BUILD_LIFECYCLE_ORDER = [
+  "ready",
+  "claimed",
+  "review",
+  "blocked",
+  "done",
+];
+
+const ACTIONABLE_ROLE_ORDER = ["blocked", "ready", "claimed", "review"];
+
+const HIGHLIGHT_COPY = {
+  blocked: {
+    summary: "Oldest blocked build item",
+    nextStep: "Run /lisa:repair-intake <queue> after clearing the blocker.",
+  },
+  stalled: {
+    summary: "Oldest stalled build item likely actionable for repair-intake",
+    nextStep:
+      "Run /lisa:repair-intake <queue> to re-evaluate the stalled build item.",
+  },
+  ready: {
+    summary: "Oldest ready build item awaiting intake",
+    nextStep: "Run /lisa:intake <queue> to claim the next build issue.",
+  },
+  claimed: {
+    summary: "Oldest claimed build item still in flight",
+    nextStep:
+      "Inspect the active implementation path before escalating to /lisa:repair-intake <queue>.",
+  },
+  review: {
+    summary: "Oldest build item waiting in review",
+    nextStep:
+      "Check the linked PR or review handoff before re-running /lisa:intake <queue>.",
+  },
+};
+
+/**
+ * Read a GitHub-backed build queue snapshot from issue payloads.
+ *
+ * @param {{
+ *   readonly issues?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, any>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function readGithubBuildQueueSnapshot(input = {}) {
+  const roles = input.roles ?? {};
+  const normalizedItems = (input.issues ?? [])
+    .map(issue => normalizeGithubBuildIssue(issue, roles))
+    .filter(Boolean);
+
+  return createBuildQueueSnapshot({
+    tracker: "github",
+    items: normalizedItems,
+    roles,
+    namespaceAdopted: input.namespaceAdopted,
+    queueResolved: input.queueResolved,
+    queueArgument: input.queueArgument,
+    resolutionError: input.resolutionError,
+  });
+}
+
+/**
+ * Build a vendor-agnostic build queue snapshot from normalized lifecycle items.
+ *
+ * @param {{
+ *   readonly tracker?: string
+ *   readonly items?: readonly Record<string, any>[]
+ *   readonly roles?: Record<string, any>
+ *   readonly namespaceAdopted?: boolean
+ *   readonly queueResolved?: boolean
+ *   readonly queueArgument?: string
+ *   readonly resolutionError?: string | null
+ * }} input
+ */
+export function createBuildQueueSnapshot(input = {}) {
+  const roles = normalizeRoles(input.roles);
+  const items = normalizeItems(input.items);
+  const counts = buildLifecycleCounts(items);
+  const repairSignals = buildRepairSignals(items, input.queueArgument);
+  const highlights = buildActionableHighlights(
+    items,
+    repairSignals,
+    input.queueArgument
+  );
+  const queueResolved =
+    input.queueResolved ?? typeof input.resolutionError !== "string";
+  const namespaceAdopted =
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+
+  const health = classifyQueueHealth({
+    queueResolved,
+    namespaceAdopted,
+    readyCount: counts.ready,
+    activeCount: counts.claimed + counts.review,
+    blockedCount: counts.blocked,
+    stalledCount: repairSignals.stalled.length,
+    resolutionError: input.resolutionError ?? null,
+  });
+
+  return {
+    tracker: input.tracker ?? "unknown",
+    queueResolved,
+    namespaceAdopted,
+    roles,
+    counts,
+    highlights,
+    repairSignals,
+    health,
+    resolutionError: input.resolutionError ?? null,
+  };
+}
+
+/**
+ * @param {Record<string, any>} issue
+ * @param {Record<string, any>} roles
+ * @returns {Record<string, any> | null}
+ */
+function normalizeGithubBuildIssue(issue, roles) {
+  if (!issue || typeof issue !== "object") {
+    return null;
+  }
+
+  const role = resolveGithubBuildRole(issue.labels, roles);
+
+  return normalizeItem({
+    id: String(issue.id ?? issue.number ?? issue.url ?? issue.title ?? ""),
+    ref:
+      issue.number !== undefined && issue.number !== null
+        ? `#${issue.number}`
+        : String(issue.url ?? issue.title ?? ""),
+    title: String(issue.title ?? "").trim(),
+    url: typeof issue.url === "string" ? issue.url : null,
+    createdAt: issue.createdAt ?? null,
+    updatedAt: issue.updatedAt ?? null,
+    role,
+    stalled: Boolean(issue.stalled),
+  });
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @param {Record<string, any>} roles
+ * @returns {string | null}
+ */
+function resolveGithubBuildRole(labels, roles) {
+  if (!Array.isArray(labels)) {
+    return null;
+  }
+
+  const labelNames = new Set(
+    labels
+      .map(label =>
+        typeof label === "string"
+          ? label
+          : typeof label?.name === "string"
+            ? label.name
+            : null
+      )
+      .filter(Boolean)
+  );
+
+  for (const role of BUILD_LIFECYCLE_ORDER) {
+    if (role === "done") {
+      if (resolveDoneRoleNames(roles).some(name => labelNames.has(name))) {
+        return "done";
+      }
+      continue;
+    }
+
+    const configuredName = roles[role];
+    if (configuredName && labelNames.has(configuredName)) {
+      return role;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Record<string, any> | undefined} roles
+ * @returns {Record<string, any>}
+ */
+function normalizeRoles(roles) {
+  return {
+    ready:
+      typeof roles?.ready === "string" && roles.ready.trim().length > 0
+        ? roles.ready.trim()
+        : "ready",
+    claimed:
+      typeof roles?.claimed === "string" && roles.claimed.trim().length > 0
+        ? roles.claimed.trim()
+        : "claimed",
+    review:
+      typeof roles?.review === "string" && roles.review.trim().length > 0
+        ? roles.review.trim()
+        : "review",
+    blocked:
+      typeof roles?.blocked === "string" && roles.blocked.trim().length > 0
+        ? roles.blocked.trim()
+        : "blocked",
+    done: normalizeDoneRoles(roles?.done),
+  };
+}
+
+/**
+ * @param {Record<string, any> | undefined} done
+ * @returns {Record<string, string>}
+ */
+function normalizeDoneRoles(done) {
+  if (typeof done === "string" && done.trim().length > 0) {
+    return { default: done.trim() };
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(done ?? {})) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      normalized[key] = value.trim();
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : { default: "done" };
+}
+
+/**
+ * @param {Record<string, any>} roles
+ * @returns {readonly string[]}
+ */
+function resolveDoneRoleNames(roles) {
+  return Object.values(normalizeDoneRoles(roles?.done));
+}
+
+/**
+ * @param {readonly Record<string, any>[] | undefined} items
+ * @returns {readonly Record<string, any>[]}
+ */
+function normalizeItems(items) {
+  return (items ?? []).map(normalizeItem).filter(Boolean);
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any> | null}
+ */
+function normalizeItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const role =
+    typeof item.role === "string" && BUILD_LIFECYCLE_ORDER.includes(item.role)
+      ? item.role
+      : null;
+
+  return {
+    id: String(item.id ?? item.ref ?? item.title ?? ""),
+    ref: String(item.ref ?? item.id ?? item.title ?? ""),
+    title: String(item.title ?? "").trim(),
+    url: typeof item.url === "string" ? item.url : null,
+    role,
+    createdAt: normalizeTimestamp(item.createdAt),
+    updatedAt: normalizeTimestamp(item.updatedAt),
+    stalled: Boolean(item.stalled),
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ */
+function buildLifecycleCounts(items) {
+  const counts = Object.fromEntries(
+    BUILD_LIFECYCLE_ORDER.map(role => [role, 0])
+  );
+
+  for (const item of items) {
+    if (item.role && counts[item.role] !== undefined) {
+      counts[item.role] += 1;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string | undefined} queueArgument
+ */
+function buildRepairSignals(items, queueArgument) {
+  const blocked = items
+    .filter(item => item.role === "blocked")
+    .sort(compareQueueItemsByCreatedAt)
+    .map(toRepairSignalItem);
+  const stalled = items
+    .filter(item => item.stalled)
+    .sort(compareQueueItemsByCreatedAt)
+    .map(toRepairSignalItem);
+
+  return {
+    actionable: blocked.length > 0 || stalled.length > 0,
+    blocked,
+    stalled,
+    suggestedCommand:
+      blocked.length > 0 || stalled.length > 0
+        ? expandHighlightNextStep(
+            "Run /lisa:repair-intake <queue> to inspect the most actionable stuck build work.",
+            queueArgument
+          )
+        : null,
+  };
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, any>} repairSignals
+ * @param {string | undefined} queueArgument
+ */
+function buildActionableHighlights(items, repairSignals, queueArgument) {
+  const highlights = [];
+
+  const oldestStalled = repairSignals.stalled[0];
+  if (oldestStalled) {
+    highlights.push({
+      role: "stalled",
+      ref: oldestStalled.ref,
+      title: oldestStalled.title,
+      url: oldestStalled.url,
+      createdAt: oldestStalled.createdAt,
+      summary: HIGHLIGHT_COPY.stalled.summary,
+      nextStep: expandHighlightNextStep(
+        HIGHLIGHT_COPY.stalled.nextStep,
+        queueArgument
+      ),
+    });
+  }
+
+  for (const role of ACTIONABLE_ROLE_ORDER) {
+    const oldest = findOldestItemForRole(items, role);
+    if (!oldest) {
+      continue;
+    }
+
+    const copy = HIGHLIGHT_COPY[role];
+    highlights.push({
+      role,
+      ref: oldest.ref,
+      title: oldest.title,
+      url: oldest.url,
+      createdAt: oldest.createdAt,
+      summary: copy.summary,
+      nextStep: expandHighlightNextStep(copy.nextStep, queueArgument),
+    });
+  }
+
+  return highlights;
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {string} role
+ */
+function findOldestItemForRole(items, role) {
+  return (
+    items
+      .filter(item => item.role === role)
+      .sort(compareQueueItemsByCreatedAt)[0] ?? null
+  );
+}
+
+/**
+ * @param {readonly Record<string, any>[]} items
+ * @param {Record<string, any>} roles
+ * @returns {boolean}
+ */
+function inferNamespaceAdopted(items, roles) {
+  if (items.some(item => item.role)) {
+    return true;
+  }
+
+  return (
+    ["ready", "claimed", "review", "blocked"].some(
+      role => typeof roles[role] === "string" && roles[role].trim().length > 0
+    ) || resolveDoneRoleNames(roles).length > 0
+  );
+}
+
+/**
+ * @param {Record<string, any>} item
+ * @returns {Record<string, any>}
+ */
+function toRepairSignalItem(item) {
+  return {
+    ref: item.ref,
+    title: item.title,
+    url: item.url,
+    createdAt: item.createdAt,
+  };
+}
+
+/**
+ * @param {string} template
+ * @param {string | undefined} queueArgument
+ * @returns {string}
+ */
+function expandHighlightNextStep(template, queueArgument) {
+  return template.replace("<queue>", queueArgument ?? "queue");
+}
+
+/**
+ * @param {Record<string, any>} left
+ * @param {Record<string, any>} right
+ * @returns {number}
+ */
+function compareQueueItemsByCreatedAt(left, right) {
+  const leftMs = left.createdAt
+    ? Date.parse(left.createdAt)
+    : Number.POSITIVE_INFINITY;
+  const rightMs = right.createdAt
+    ? Date.parse(right.createdAt)
+    : Number.POSITIVE_INFINITY;
+
+  if (leftMs !== rightMs) {
+    return leftMs - rightMs;
+  }
+
+  return String(left.ref).localeCompare(String(right.ref));
+}
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string | null}
+ */
+function normalizeTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/tests/fixtures/queue-status-build-readers/github.json
+++ b/tests/fixtures/queue-status-build-readers/github.json
@@ -1,0 +1,54 @@
+{
+  "tracker": "github",
+  "items": [
+    {
+      "id": "825",
+      "ref": "#825",
+      "title": "Ready build item waiting for intake",
+      "url": "https://github.com/CodySwannGT/lisa/issues/825",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "826",
+      "ref": "#826",
+      "title": "Claimed build item still in flight",
+      "url": "https://github.com/CodySwannGT/lisa/issues/826",
+      "role": "claimed",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "827",
+      "ref": "#827",
+      "title": "Blocked build item needs clarification",
+      "url": "https://github.com/CodySwannGT/lisa/issues/827",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "828",
+      "ref": "#828",
+      "title": "Stalled claimed build item",
+      "url": "https://github.com/CodySwannGT/lisa/issues/828",
+      "role": "claimed",
+      "createdAt": "2026-05-22T10:00:00Z",
+      "stalled": true
+    },
+    {
+      "id": "829",
+      "ref": "#829",
+      "title": "Reviewing build item",
+      "url": "https://github.com/CodySwannGT/lisa/issues/829",
+      "role": "review",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "830",
+      "ref": "#830",
+      "title": "Done build item on production",
+      "url": "https://github.com/CodySwannGT/lisa/issues/830",
+      "role": "done",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/queue-status-build-readers/jira.json
+++ b/tests/fixtures/queue-status-build-readers/jira.json
@@ -1,0 +1,54 @@
+{
+  "tracker": "jira",
+  "items": [
+    {
+      "id": "LAS-825",
+      "ref": "LAS-825",
+      "title": "Ready build item waiting for intake",
+      "url": "https://acme.atlassian.net/browse/LAS-825",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "LAS-826",
+      "ref": "LAS-826",
+      "title": "Claimed build item still in flight",
+      "url": "https://acme.atlassian.net/browse/LAS-826",
+      "role": "claimed",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "LAS-827",
+      "ref": "LAS-827",
+      "title": "Blocked build item needs clarification",
+      "url": "https://acme.atlassian.net/browse/LAS-827",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "LAS-828",
+      "ref": "LAS-828",
+      "title": "Stalled claimed build item",
+      "url": "https://acme.atlassian.net/browse/LAS-828",
+      "role": "claimed",
+      "createdAt": "2026-05-22T10:00:00Z",
+      "stalled": true
+    },
+    {
+      "id": "LAS-829",
+      "ref": "LAS-829",
+      "title": "Reviewing build item",
+      "url": "https://acme.atlassian.net/browse/LAS-829",
+      "role": "review",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "LAS-830",
+      "ref": "LAS-830",
+      "title": "Done build item on production",
+      "url": "https://acme.atlassian.net/browse/LAS-830",
+      "role": "done",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/queue-status-build-readers/linear.json
+++ b/tests/fixtures/queue-status-build-readers/linear.json
@@ -1,0 +1,54 @@
+{
+  "tracker": "linear",
+  "items": [
+    {
+      "id": "L-825",
+      "ref": "L-825",
+      "title": "Ready build item waiting for intake",
+      "url": "https://linear.app/acme/issue/L-825",
+      "role": "ready",
+      "createdAt": "2026-05-25T10:00:00Z"
+    },
+    {
+      "id": "L-826",
+      "ref": "L-826",
+      "title": "Claimed build item still in flight",
+      "url": "https://linear.app/acme/issue/L-826",
+      "role": "claimed",
+      "createdAt": "2026-05-24T10:00:00Z"
+    },
+    {
+      "id": "L-827",
+      "ref": "L-827",
+      "title": "Blocked build item needs clarification",
+      "url": "https://linear.app/acme/issue/L-827",
+      "role": "blocked",
+      "createdAt": "2026-05-23T10:00:00Z"
+    },
+    {
+      "id": "L-828",
+      "ref": "L-828",
+      "title": "Stalled claimed build item",
+      "url": "https://linear.app/acme/issue/L-828",
+      "role": "claimed",
+      "createdAt": "2026-05-22T10:00:00Z",
+      "stalled": true
+    },
+    {
+      "id": "L-829",
+      "ref": "L-829",
+      "title": "Reviewing build item",
+      "url": "https://linear.app/acme/issue/L-829",
+      "role": "review",
+      "createdAt": "2026-05-21T10:00:00Z"
+    },
+    {
+      "id": "L-830",
+      "ref": "L-830",
+      "title": "Done build item on production",
+      "url": "https://linear.app/acme/issue/L-830",
+      "role": "done",
+      "createdAt": "2026-05-20T10:00:00Z"
+    }
+  ]
+}

--- a/tests/unit/strategies/queue-status-build-readers.test.ts
+++ b/tests/unit/strategies/queue-status-build-readers.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression coverage for build-side queue readers used by `/lisa:queue-status`.
+ *
+ * Issue #825 adds the first build queue readers for the queue-status surface:
+ * GitHub build queue parsing plus vendor-parity snapshots that preserve the
+ * same lifecycle counts, actionable highlights, and repair-intake signals
+ * across GitHub, Linear, and JIRA inputs.
+ * @module tests/unit/strategies/queue-status-build-readers
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createBuildQueueSnapshot,
+  readGithubBuildQueueSnapshot,
+} from "../../../plugins/src/base/scripts/queue-status-build-readers.mjs";
+
+const FIXTURE_ROOT = path.resolve("tests/fixtures/queue-status-build-readers");
+const GITHUB_READY_LABEL = "status:ready";
+const GITHUB_CLAIMED_LABEL = "status:in-progress";
+const GITHUB_BLOCKED_LABEL = "status:blocked";
+const GITHUB_DONE_LABEL = "status:done";
+const GITHUB_DONE_ROLES = {
+  dev: "status:on-dev",
+  staging: "status:on-stg",
+  production: GITHUB_DONE_LABEL,
+} as const;
+
+/**
+ *
+ */
+type QueueFixture = {
+  readonly tracker: string;
+  readonly items: readonly Record<string, unknown>[];
+};
+
+const readFixture = (name: string): QueueFixture =>
+  JSON.parse(
+    readFileSync(path.join(FIXTURE_ROOT, `${name}.json`), "utf8")
+  ) as QueueFixture;
+
+describe("queue-status build readers (#825)", () => {
+  it("parses GitHub build lifecycle labels into counts, highlights, and repair signals", () => {
+    const snapshot = readGithubBuildQueueSnapshot({
+      namespaceAdopted: true,
+      queueArgument: "github intake_mode=build",
+      roles: {
+        ready: GITHUB_READY_LABEL,
+        claimed: GITHUB_CLAIMED_LABEL,
+        blocked: GITHUB_BLOCKED_LABEL,
+        done: GITHUB_DONE_ROLES,
+      },
+      issues: [
+        {
+          number: 825,
+          title: "Ready build item waiting for intake",
+          url: "https://github.com/CodySwannGT/lisa/issues/825",
+          createdAt: "2026-05-25T10:00:00Z",
+          labels: [{ name: GITHUB_READY_LABEL }],
+        },
+        {
+          number: 826,
+          title: "Claimed build item still in flight",
+          url: "https://github.com/CodySwannGT/lisa/issues/826",
+          createdAt: "2026-05-24T10:00:00Z",
+          labels: [{ name: GITHUB_CLAIMED_LABEL }],
+        },
+        {
+          number: 827,
+          title: "Blocked build item needs clarification",
+          url: "https://github.com/CodySwannGT/lisa/issues/827",
+          createdAt: "2026-05-23T10:00:00Z",
+          labels: [{ name: GITHUB_BLOCKED_LABEL }],
+        },
+        {
+          number: 828,
+          title: "Stalled claimed build item",
+          url: "https://github.com/CodySwannGT/lisa/issues/828",
+          createdAt: "2026-05-22T10:00:00Z",
+          labels: [{ name: GITHUB_CLAIMED_LABEL }],
+          stalled: true,
+        },
+        {
+          number: 829,
+          title: "Done build item on production",
+          url: "https://github.com/CodySwannGT/lisa/issues/829",
+          createdAt: "2026-05-21T10:00:00Z",
+          labels: [{ name: GITHUB_DONE_LABEL }],
+        },
+      ],
+    });
+
+    expect(snapshot.tracker).toBe("github");
+    expect(snapshot.counts).toEqual({
+      ready: 1,
+      claimed: 2,
+      review: 0,
+      blocked: 1,
+      done: 1,
+    });
+    expect(snapshot.highlights.map(highlight => highlight.role)).toEqual([
+      "stalled",
+      "blocked",
+      "ready",
+      "claimed",
+    ]);
+    expect(snapshot.highlights[0]).toMatchObject({
+      ref: "#828",
+      summary: "Oldest stalled build item likely actionable for repair-intake",
+    });
+    expect(snapshot.highlights[1].nextStep).toBe(
+      "Run /lisa:repair-intake github intake_mode=build after clearing the blocker."
+    );
+    expect(snapshot.repairSignals).toMatchObject({
+      actionable: true,
+      blocked: [{ ref: "#827" }],
+      stalled: [{ ref: "#828" }],
+      suggestedCommand:
+        "Run /lisa:repair-intake github intake_mode=build to inspect the most actionable stuck build work.",
+    });
+    expect(snapshot.health).toMatchObject({
+      verdict: "ATTENTION_NEEDED",
+      reasons: ["blocked-work-present", "stalled-work-present"],
+    });
+  });
+
+  it("treats missing namespace adoption as misconfigured instead of idle", () => {
+    const snapshot = createBuildQueueSnapshot({
+      tracker: "github",
+      namespaceAdopted: false,
+      queueArgument: "github intake_mode=build",
+      items: [],
+    });
+
+    expect(snapshot.health).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+    });
+  });
+
+  it("keeps fixture-backed vendor parity for counts, highlights, and repair signals", () => {
+    const fixtureNames = ["github", "linear", "jira"];
+    const snapshots = fixtureNames.map(name => {
+      const fixture = readFixture(name);
+      return createBuildQueueSnapshot({
+        tracker: fixture.tracker,
+        queueArgument:
+          fixture.tracker === "jira"
+            ? "LAS"
+            : `${fixture.tracker} intake_mode=build`,
+        namespaceAdopted: true,
+        items: fixture.items,
+      });
+    });
+
+    for (const snapshot of snapshots) {
+      expect(snapshot.counts).toEqual({
+        ready: 1,
+        claimed: 2,
+        review: 1,
+        blocked: 1,
+        done: 1,
+      });
+      expect(snapshot.highlights.map(highlight => highlight.role)).toEqual([
+        "stalled",
+        "blocked",
+        "ready",
+        "claimed",
+        "review",
+      ]);
+      expect(snapshot.repairSignals.actionable).toBe(true);
+      expect(snapshot.repairSignals.blocked[0].title).toBe(
+        "Blocked build item needs clarification"
+      );
+      expect(snapshot.repairSignals.stalled[0].title).toBe(
+        "Stalled claimed build item"
+      );
+      expect(snapshot.health.verdict).toBe("ATTENTION_NEEDED");
+    }
+  });
+
+  it("keeps the distributed reader artifact in lockstep with the source script", () => {
+    const sourcePath = path.resolve(
+      "plugins/src/base/scripts/queue-status-build-readers.mjs"
+    );
+    const generatedPath = path.resolve(
+      "plugins/lisa/scripts/queue-status-build-readers.mjs"
+    );
+
+    expect(existsSync(generatedPath)).toBe(true);
+    expect(readFileSync(generatedPath, "utf8")).toBe(
+      readFileSync(sourcePath, "utf8")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add shared build-side queue reader helpers for queue-status in both source and generated plugin trees
- normalize build lifecycle counts, actionable highlights, and repair-intake signals across GitHub, Linear, and JIRA
- cover the new readers with fixture-backed parity tests and GitHub label parsing coverage

## Testing
- bun test tests/unit/strategies/queue-contract-resolution.test.ts tests/unit/strategies/queue-health-classification.test.ts tests/unit/strategies/queue-status-scaffold.test.ts tests/unit/strategies/queue-status-build-readers.test.ts
- bun run build:plugins
- bun test tests/unit/strategies/queue-status-build-readers.test.ts
- git push -u origin codex/issue-825-build-queue-readers

Resolves #825