### PR TITLE
docs(queue-status): add operator guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Most users only ever call `/lisa:research`, `/lisa:plan`, and `/lisa:implement`.
 | Command | What it does |
 | --- | --- |
 | `/lisa:intake <queue-url>` | Scans a Ready queue (Notion PRD database, JIRA project, GitHub repo, Linear team, Confluence space) and dispatches each item through the right lifecycle command. Designed as the cron target for unattended runs. |
+| `/lisa:queue-status [queue=prd|queue=build]` | Read-only queue inspection for the current repo. Distinguishes idle vs misconfigured queues, highlights the most actionable item, and points operators to `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd`. |
+| `/lisa:repair-intake <queue-url>` | Read/write recovery scan for blocked, stale, or inconsistent queue state when normal intake is not the right next move. |
+| `/lisa:automation-status` | Read-only inspection of the repo's expected Lisa automation fleet so operators can distinguish empty queues from stale, drifted, or failing scheduler jobs. |
+| `/lisa:verify-prd <prd>` | Initiative-level acceptance pass for shipped PRDs. Verifies the shipped surface against the PRD and reopens to ticketed with fix work on failure. |
 
 PRD intake records generated work with native hierarchy where the source and tracker support it, and with a durable generated-work fallback everywhere else. The vendor matrix for GitHub, Linear, JIRA/Atlassian, Confluence, Notion, and cross-vendor queues lives in `plugins/src/base/rules/prd-lifecycle-rollup.md`.
 

--- a/plugins/lisa/commands/queue-status.md
+++ b/plugins/lisa/commands/queue-status.md
@@ -10,4 +10,25 @@ Common operator usage:
 - `/lisa:queue-status queue=prd`
 - `/lisa:queue-status queue=build`
 
-This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, or deeper tracker-native investigation.
+Use this when you need to answer:
+
+- Is the queue actually idle, or is Lisa misconfigured?
+- Which queue item is the most actionable next?
+- Should the next command be `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd`?
+
+This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, `/lisa:verify-prd`, or deeper tracker-native investigation.
+
+Quick interpretation guide:
+
+- `IDLE`: the queue resolved correctly and nothing actionable is waiting. No immediate Lisa action is required.
+- `HEALTHY`: the queue resolved correctly and normal work is present. Follow the highlighted next step, usually `/lisa:intake`.
+- `ATTENTION_NEEDED`: blocked, stalled, or aging work needs operator follow-up. Use the highlighted item and remediation hint to choose the next command, usually `/lisa:repair-intake`.
+- `MISCONFIGURED`: queue resolution or lifecycle adoption is broken. Fix config, labels/statuses, or scheduler drift before trusting queue state.
+
+Highlighted-item semantics:
+
+- A highlighted item is the single oldest or most actionable queue item for that section, not a full dump of all matching work.
+- `ready` highlights usually point to `/lisa:intake`.
+- `blocked`, stalled, or long-claimed highlights usually point to `/lisa:repair-intake`.
+- Shipped PRD highlights usually point to `/lisa:verify-prd`.
+- If queue behavior looks wrong for both PRD and build lanes, inspect `/lisa:automation-status` before assuming the queue itself is the problem.

--- a/plugins/lisa/skills/queue-status/SKILL.md
+++ b/plugins/lisa/skills/queue-status/SKILL.md
@@ -29,6 +29,24 @@ Support a repo-scoped queue selector when requested:
 - `queue=prd`: inspect only the PRD queue
 - `queue=build`: inspect only the build queue
 
+## Operator usage
+
+Typical entrypoints:
+
+```text
+/lisa:queue-status
+/lisa:queue-status queue=prd
+/lisa:queue-status queue=build
+```
+
+Use this command when an operator needs to answer one of these questions for the current repo:
+
+- "Is this queue truly idle, or is it misconfigured?"
+- "Which item is the most actionable next?"
+- "Should I run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd` next?"
+
+Keep the report terminal-first and immediately actionable: observable queue facts first, then the smallest useful next command.
+
 ## What to report
 
 Render the report in **grouped sections** so operators can scan it top-down without reading raw tracker dumps:
@@ -47,6 +65,19 @@ For each inspected queue, report:
 6. A concise remediation hint when attention is needed.
 
 The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Highlight semantics
+
+Each queue section may include one or more highlighted items. A highlight is not a raw dump of every issue in that role; it is the single oldest or otherwise most actionable item Lisa can justify surfacing without mutating work.
+
+Interpret highlights by role:
+
+- `ready`: work is waiting to be claimed. The usual next step is `/lisa:intake <queue>`.
+- `blocked`: work is stuck behind an explicit blocker or failed pre-flight. The usual next step is `/lisa:repair-intake <queue>` after validating the blocker context.
+- `claimed` or in-review/review states: work is in motion but may be aging. The usual next step is to inspect the active implementation or review path before escalating to `/lisa:repair-intake <queue>`.
+- `shipped`: PRD work looks ready for initiative-level acceptance. The usual next step is `/lisa:verify-prd <prd-ref>`.
+
+If both queues look unexpectedly quiet or stale, mention `/lisa:automation-status` as the scheduler-health follow-up before implying the queues themselves are empty or broken.
 
 ## Output shape
 
@@ -85,6 +116,13 @@ Status-specific remediation guidance:
 - `HEALTHY`: point operators to `/lisa:intake` or `/lisa:repair-intake` when they want Lisa to act on the reported state.
 - `ATTENTION_NEEDED`: identify the most actionable blocked or stalled items and suggest the next Lisa or tracker-native command to investigate.
 - `MISCONFIGURED`: show which queue contract is missing or unresolved and recommend fixing `.lisa.config.json`, adopting the lifecycle namespace, or rerunning the relevant setup flow.
+
+Command handoff expectations:
+
+- Prefer `/lisa:intake <queue>` when the actionable highlight is `ready` work.
+- Prefer `/lisa:repair-intake <queue>` when the actionable highlight is blocked, stalled, or suspiciously old claimed/review work.
+- Prefer `/lisa:verify-prd <prd-ref>` when the PRD side surfaces shipped work that appears ready for initiative-level verification.
+- Prefer `/lisa:automation-status` when queue output suggests scheduler drift, stale unattended execution, or a mismatch between expected and observed queue activity.
 
 ## Rules
 

--- a/plugins/src/base/commands/queue-status.md
+++ b/plugins/src/base/commands/queue-status.md
@@ -10,4 +10,25 @@ Common operator usage:
 - `/lisa:queue-status queue=prd`
 - `/lisa:queue-status queue=build`
 
-This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, or deeper tracker-native investigation.
+Use this when you need to answer:
+
+- Is the queue actually idle, or is Lisa misconfigured?
+- Which queue item is the most actionable next?
+- Should the next command be `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd`?
+
+This surface is read-only in v1. Use it to understand whether the repo's PRD and build queues are idle, healthy, attention-needed, or misconfigured before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, `/lisa:verify-prd`, or deeper tracker-native investigation.
+
+Quick interpretation guide:
+
+- `IDLE`: the queue resolved correctly and nothing actionable is waiting. No immediate Lisa action is required.
+- `HEALTHY`: the queue resolved correctly and normal work is present. Follow the highlighted next step, usually `/lisa:intake`.
+- `ATTENTION_NEEDED`: blocked, stalled, or aging work needs operator follow-up. Use the highlighted item and remediation hint to choose the next command, usually `/lisa:repair-intake`.
+- `MISCONFIGURED`: queue resolution or lifecycle adoption is broken. Fix config, labels/statuses, or scheduler drift before trusting queue state.
+
+Highlighted-item semantics:
+
+- A highlighted item is the single oldest or most actionable queue item for that section, not a full dump of all matching work.
+- `ready` highlights usually point to `/lisa:intake`.
+- `blocked`, stalled, or long-claimed highlights usually point to `/lisa:repair-intake`.
+- Shipped PRD highlights usually point to `/lisa:verify-prd`.
+- If queue behavior looks wrong for both PRD and build lanes, inspect `/lisa:automation-status` before assuming the queue itself is the problem.

--- a/plugins/src/base/skills/queue-status/SKILL.md
+++ b/plugins/src/base/skills/queue-status/SKILL.md
@@ -29,6 +29,24 @@ Support a repo-scoped queue selector when requested:
 - `queue=prd`: inspect only the PRD queue
 - `queue=build`: inspect only the build queue
 
+## Operator usage
+
+Typical entrypoints:
+
+```text
+/lisa:queue-status
+/lisa:queue-status queue=prd
+/lisa:queue-status queue=build
+```
+
+Use this command when an operator needs to answer one of these questions for the current repo:
+
+- "Is this queue truly idle, or is it misconfigured?"
+- "Which item is the most actionable next?"
+- "Should I run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd` next?"
+
+Keep the report terminal-first and immediately actionable: observable queue facts first, then the smallest useful next command.
+
 ## What to report
 
 Render the report in **grouped sections** so operators can scan it top-down without reading raw tracker dumps:
@@ -47,6 +65,19 @@ For each inspected queue, report:
 6. A concise remediation hint when attention is needed.
 
 The report should stay terminal-first and immediately actionable: observable queue facts first, then the smallest useful next step.
+
+## Highlight semantics
+
+Each queue section may include one or more highlighted items. A highlight is not a raw dump of every issue in that role; it is the single oldest or otherwise most actionable item Lisa can justify surfacing without mutating work.
+
+Interpret highlights by role:
+
+- `ready`: work is waiting to be claimed. The usual next step is `/lisa:intake <queue>`.
+- `blocked`: work is stuck behind an explicit blocker or failed pre-flight. The usual next step is `/lisa:repair-intake <queue>` after validating the blocker context.
+- `claimed` or in-review/review states: work is in motion but may be aging. The usual next step is to inspect the active implementation or review path before escalating to `/lisa:repair-intake <queue>`.
+- `shipped`: PRD work looks ready for initiative-level acceptance. The usual next step is `/lisa:verify-prd <prd-ref>`.
+
+If both queues look unexpectedly quiet or stale, mention `/lisa:automation-status` as the scheduler-health follow-up before implying the queues themselves are empty or broken.
 
 ## Output shape
 
@@ -85,6 +116,13 @@ Status-specific remediation guidance:
 - `HEALTHY`: point operators to `/lisa:intake` or `/lisa:repair-intake` when they want Lisa to act on the reported state.
 - `ATTENTION_NEEDED`: identify the most actionable blocked or stalled items and suggest the next Lisa or tracker-native command to investigate.
 - `MISCONFIGURED`: show which queue contract is missing or unresolved and recommend fixing `.lisa.config.json`, adopting the lifecycle namespace, or rerunning the relevant setup flow.
+
+Command handoff expectations:
+
+- Prefer `/lisa:intake <queue>` when the actionable highlight is `ready` work.
+- Prefer `/lisa:repair-intake <queue>` when the actionable highlight is blocked, stalled, or suspiciously old claimed/review work.
+- Prefer `/lisa:verify-prd <prd-ref>` when the PRD side surfaces shipped work that appears ready for initiative-level verification.
+- Prefer `/lisa:automation-status` when queue output suggests scheduler drift, stale unattended execution, or a mismatch between expected and observed queue activity.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- expand queue-status command docs with verdict meanings and highlighted-item semantics
- document how operators choose between intake, repair-intake, automation-status, and verify-prd
- add the queue-status and related operator commands to the README batch-work section

Closes #827