### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -48,3 +48,10 @@
 - Refreshed the `git` source note with 31 new commits through `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`, advanced the merged-PR cursor to `#812`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the isolated worktree path had no matching project memory, and global Codex memory remains out of scope.
 - Updated the monorepo snapshot synthesis for the latest automation-status delivery, smoke coverage, operator documentation, and release-history changes.
+
+## 2026-05-26 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-26-053019`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 36 new commits through `c4879d40b123baf4f38d4c5530090b9003d4217a`, advanced the merged-PR cursor to `#837`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the isolated worktree path had no matching project memory, and global Codex memory remains out of scope.
+- Updated the monorepo snapshot synthesis for the latest queue-status delivery, repair-intake remediation, and release-history changes.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,18 +20,18 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-26-0130` from `origin/main`
-- HEAD at 2026-05-26 incremental ingest: `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`
-- Current package version: `2.91.2`
-- Total commits on HEAD: 1984
-- Latest merged PR captured in the incremental git snapshot: `#812`
-- New commits since the previous incremental git cursor: `31`
+- Ingest branch: `wiki/ingest-2026-05-26-053019` from `origin/main`
+- HEAD at 2026-05-26 incremental ingest: `c4879d40b123baf4f38d4c5530090b9003d4217a`
+- Current package version: `2.98.0`
+- Total commits on HEAD: 2020
+- Latest merged PR captured in the incremental git snapshot: `#837`
+- New commits since the previous incremental git cursor: `36`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Automation-status now spans the full operator workflow: scaffolded command and skill surfaces, grouped output rendering, expected-fleet resolution, drift detection, Codex metadata inspection, and Claude schedule support.
-- Verification and operator guidance expanded with read-only smoke coverage plus remediation-focused documentation for automation-status users.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.85.2` through `2.91.2` during this incremental window.
+- Queue-status coverage expanded across shared contract resolution, grouped output, queue readers for PRD and build modes, health classification, and smoke coverage.
+- Repair-intake now closes out stuck work in batch, extending the operational remediation path beyond status reporting alone.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.91.3` through `2.98.0` during this incremental window.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
@@ -10,41 +10,46 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-26)
 
-- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.AluvDw`)
-- HEAD: `ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`
-- Total commits on HEAD: 1984
-- New commits since last ingest (`7a56fd065774adb22bcb7ff7857e1d89170f5f75`): 31
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #812 "[lisa] Document operator usage and remediation for automation status"
+- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.AV0A5X`)
+- HEAD: `c4879d40b123baf4f38d4c5530090b9003d4217a`
+- Total commits on HEAD: 2020
+- New commits since last ingest (`ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`): 36
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #837 "[codex] Expand repair-intake batch close-out"
 
 ## New commits
-- ea144c8b · 2026-05-26 · chore(release): 2.91.2 [skip ci]
-- f83c8362 · 2026-05-25 · Merge pull request #812 from CodySwannGT/codex/issue-804-automation-status-docs
-- 8ddb5f01 · 2026-05-25 · docs: add automation-status operator guidance
-- 58b6b994 · 2026-05-26 · chore(release): 2.91.1 [skip ci]
-- e3c3cc33 · 2026-05-25 · Merge pull request #811 from CodySwannGT/codex/issue-803-automation-status-smoke
-- 29d99fbd · 2026-05-26 · Merge branch 'main' into codex/issue-803-automation-status-smoke
-- cc099af6 · 2026-05-25 · test(automation-status): add fixture smoke coverage
-- 0fffedf3 · 2026-05-26 · chore(release): 2.91.0 [skip ci]
-- 2b1ec625 · 2026-05-25 · Merge pull request #810 from CodySwannGT/codex/issue-802-claude-automation-status
-- cb272f8f · 2026-05-26 · Merge branch 'main' into codex/issue-802-claude-automation-status
-- dd127678 · 2026-05-25 · feat(automation-status): add Claude schedule adapter (#802)
-- 823ce331 · 2026-05-26 · chore(release): 2.90.0 [skip ci]
-- 4b25af24 · 2026-05-25 · Merge pull request #809 from CodySwannGT/codex/issue-801-codex-automation-status
-- d514c0ef · 2026-05-25 · feat(automation-status): inspect codex automation metadata
-- a68f93e5 · 2026-05-26 · chore(release): 2.89.0 [skip ci]
-- 2e0d90d7 · 2026-05-25 · Merge pull request #808 from CodySwannGT/codex/issue-800-automation-status-drift
-- 922de566 · 2026-05-25 · feat(automation-status): detect contract drift
-- fb7197bc · 2026-05-26 · chore(release): 2.88.0 [skip ci]
-- b1daa98f · 2026-05-25 · Merge pull request #807 from CodySwannGT/codex/issue-799-automation-status-expected-fleet
-- 31997323 · 2026-05-25 · feat(automation-status): resolve expected fleet contract
-- 934bfa03 · 2026-05-26 · chore(release): 2.87.0 [skip ci]
-- 5c543ee5 · 2026-05-25 · Merge pull request #806 from CodySwannGT/codex/issue-798-automation-status-output
-- 2a9cebf6 · 2026-05-26 · Merge branch 'main' into codex/issue-798-automation-status-output
-- 2958695e · 2026-05-26 · chore(release): 2.86.0 [skip ci]
-- e3bc4d74 · 2026-05-25 · feat(automation-status): add grouped fleet report renderer
-- a890a03b · 2026-05-25 · Merge pull request #805 from CodySwannGT/codex/issue-797-automation-status-scaffold
-- 08664f72 · 2026-05-26 · Merge branch 'main' into codex/issue-797-automation-status-scaffold
-- 1d004dcd · 2026-05-25 · feat(lisa): scaffold automation-status surfaces
-- dd9c248b · 2026-05-26 · chore(release): 2.85.2 [skip ci]
-- 6b49847f · 2026-05-25 · Merge pull request #791 from CodySwannGT/wiki/ingest-2026-05-25-3844
-- da1af529 · 2026-05-25 · docs(wiki): ingest incremental git history
+- c4879d40 · 2026-05-26 · chore(release): 2.98.0 [skip ci]
+- b36fb1d4 · 2026-05-26 · Merge pull request #837 from CodySwannGT/codex/repair-intake-batch-rollups
+- 62439d51 · 2026-05-26 · feat(repair-intake): batch close out stuck work
+- 3939b1be · 2026-05-26 · chore(release): 2.97.1 [skip ci]
+- 42f52fea · 2026-05-26 · Merge pull request #836 from CodySwannGT/codex/827-queue-status-docs
+- 8e143c94 · 2026-05-26 · docs(queue-status): add operator guidance
+- 286752eb · 2026-05-26 · chore(release): 2.97.0 [skip ci]
+- cdfbd312 · 2026-05-26 · Merge pull request #833 from CodySwannGT/codex/issue-824-prd-queue-readers
+- f71b0d79 · 2026-05-26 · Merge branch 'main' into codex/issue-824-prd-queue-readers
+- c1406ca3 · 2026-05-26 · Merge pull request #835 from CodySwannGT/codex/issue-826-queue-status-smoke
+- 4235a9e3 · 2026-05-26 · Merge branch 'main' into codex/issue-826-queue-status-smoke
+- 68f42c66 · 2026-05-26 · test: add queue-status smoke coverage
+- e39158b1 · 2026-05-26 · chore(release): 2.96.0 [skip ci]
+- 2af85276 · 2026-05-26 · fix(queue-status): pass raw roles to inferNamespaceAdopted to avoid false-positive
+- b3adcbba · 2026-05-26 · Merge branch 'main' into codex/issue-824-prd-queue-readers
+- 2dbbfd83 · 2026-05-26 · Merge pull request #834 from CodySwannGT/codex/issue-825-build-queue-readers
+- ab9ce336 · 2026-05-26 · feat(queue-status): add build queue readers
+- ec926acf · 2026-05-26 · feat(queue-status): add PRD queue readers
+- 07f6b93c · 2026-05-26 · chore(release): 2.95.0 [skip ci]
+- 627300b3 · 2026-05-26 · Merge pull request #832 from CodySwannGT/codex/build-intake-823-queue-status-health
+- be8d807e · 2026-05-26 · feat(queue-status): classify queue health
+- d4edba87 · 2026-05-26 · chore(release): 2.94.0 [skip ci]
+- b850a97a · 2026-05-26 · Merge pull request #831 from CodySwannGT/codex/822-queue-status-contract-resolution
+- af1a3382 · 2026-05-26 · feat: share queue contract resolution (#822)
+- 567dd015 · 2026-05-26 · chore(release): 2.93.0 [skip ci]
+- 92845597 · 2026-05-26 · Merge pull request #830 from CodySwannGT/codex/issue-821-queue-health-remediation
+- 7e7c016d · 2026-05-26 · feat(queue-status): define grouped output contract
+- 932c87d8 · 2026-05-26 · chore(release): 2.92.0 [skip ci]
+- 28c2b828 · 2026-05-26 · Merge pull request #829 from CodySwannGT/codex/issue-820-queue-status
+- 6f3e4679 · 2026-05-26 · feat(queue-status): scaffold command and skill surfaces
+- 040950f2 · 2026-05-26 · chore(release): 2.91.4 [skip ci]
+- 077a4ed2 · 2026-05-26 · Merge pull request #828 from CodySwannGT/codex/issue-706-project-docs-smoke-20260526
+- c0076ab0 · 2026-05-26 · docs(github): add project coordination rollout coverage
+- 02b8a612 · 2026-05-26 · chore(release): 2.91.3 [skip ci]
+- 26d7882a · 2026-05-26 · Merge pull request #814 from CodySwannGT/wiki/ingest-2026-05-26-0130
+- ea01a847 · 2026-05-26 · docs(wiki): ingest incremental git history

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-26T05:31:30.185Z",
+  "ingested_at": "2026-05-26T09:30:43.768Z",
   "cursor": {
-    "lastCommit": "ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb",
-    "lastPr": 812
+    "lastCommit": "c4879d40b123baf4f38d4c5530090b9003d4217a",
+    "lastPr": 837
   },
   "source_notes": [
     "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-26T05:31:28.711Z",
+  "ingested_at": "2026-05-26T09:30:43.141Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary\n- refresh the 2026-05-26 git source note through the latest merged PRs and release commits\n- update the monorepo wiki snapshot and incremental connector log entry\n- advance incremental git and roles wiki state after verification\n\n## Verification\n- git diff --check\n- node plugins/src/wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json\n- node plugins/src/wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json