### PR TITLE
feat: add intake-explain scaffold

### DIFF
--- a/plugins/lisa/commands/intake-explain.md
+++ b/plugins/lisa/commands/intake-explain.md
@@ -1,0 +1,14 @@
+---
+description: "Inspect one PRD or build item, explain how Lisa classifies it right now, and report the exact intake or repair gate affecting it. Read-only by default."
+argument-hint: "<item-ref>"
+---
+
+Use the /lisa:intake-explain skill to inspect a single repo-scoped PRD or build item, explain its current lifecycle role, and report whether Lisa would intake it, repair it, hold it, skip it, or leave it product-owned. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:intake-explain https://github.com/acme/repo/issues/123`
+- `/lisa:intake-explain PRD-456`
+- `/lisa:intake-explain https://linear.app/acme/issue/ENG-123/example`
+
+This surface is read-only in v1. Use it when you need a deterministic explanation for why one item is moving, waiting, blocked, skipped, or ignored before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.

--- a/plugins/lisa/skills/intake-explain/SKILL.md
+++ b/plugins/lisa/skills/intake-explain/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: intake-explain
+description: "Read-only operator surface for diagnosing one repo-scoped PRD or build item against Lisa's current intake and repair contracts. Resolves the item's queue family, lifecycle role, ownership boundary, and gate outcomes using the same source/tracker detection, lifecycle naming, leaf-only, dependency, staleness, and backoff semantics the write-side intake and repair flows already enforce."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Intake Explain: $ARGUMENTS
+
+`/lisa:intake-explain` is the operator-facing explanation surface for one specific item in the **current repo or project**. It answers the per-item diagnosis question Lisa's batch flows intentionally do not answer directly: what lifecycle lane the item belongs to, which Lisa rule or gate applies right now, whether the item is eligible for intake or repair, and what the next relevant action should be.
+
+This command is **read-only** in v1. It does not claim, relabel, repair, transition, comment on, decompose, or otherwise mutate the item. It complements `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, `/lisa:automation-status`, and tracker-native inspection; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects one item and reports what the current Lisa contract says about it. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect exactly one repo-scoped item reference:
+
+- a GitHub issue URL or `owner/repo#123` ref
+- a Linear issue or project URL
+- a JIRA issue key
+- a Notion PRD/item URL
+- a Confluence PRD page URL
+
+The skill must determine whether the item belongs to the PRD lifecycle or the build lifecycle, then explain the item's status using the **same contract** Lisa already uses for `/lisa:intake` and `/lisa:repair-intake`. Do **not** invent a second source of truth for queue detection, lifecycle role naming, repo scoping, or repair eligibility.
+
+## Contract reuse
+
+Resolve item family, queue source/tracker, and lifecycle role names from `.lisa.config.json` plus the same defaults the active intake and repair flows already consume.
+
+Reuse the existing execution-side semantics instead of recreating them by hand:
+
+- queue/source detection and lifecycle naming from intake + repair-intake
+- product-owned versus Lisa-owned lifecycle roles
+- leaf-only and repo-scope build eligibility
+- active dependency holds
+- repair staleness thresholds and activity signals
+- repair backoff / loop-prevention suppression
+
+Work from the same vendor families Lisa already supports for intake and repair: GitHub, Linear, JIRA, Notion, and Confluence.
+
+## What to report
+
+Render a stable terminal-first diagnosis for one item:
+
+1. Item identity and resolved lifecycle family (`PRD` or `BUILD`).
+2. The current lifecycle role and whether that role is product-owned or Lisa-owned.
+3. The exact rule, gate, or ownership boundary currently driving behavior.
+4. A verdict such as `ELIGIBLE_FOR_INTAKE`, `ELIGIBLE_FOR_REPAIR`, `WAITING_ON_STALENESS`, `HELD_BY_BLOCKERS`, `NON_LEAF_CONTAINER`, `PRODUCT_OWNED_STATE`, or `MISCONFIGURED`.
+5. The smallest useful next action, such as `/lisa:intake`, `/lisa:repair-intake`, decomposition, blocker resolution, or manual product clarification.
+
+Keep observable item facts separate from the recommended next step so operators can tell what Lisa knows versus what Lisa suggests.
+
+## Gate and ownership expectations
+
+The explanation must stay aligned with existing Lisa rules:
+
+- If a build item is a parent/container or a childless Epic/Story/Spike, explain the leaf-only gate and say direct build pickup is not allowed.
+- If a build item has active blockers, list the blocker refs and explain that intake would hold or skip it until they clear.
+- If a PRD is in a product-owned role such as `draft`, `shipped`, or `verified`, explain why intake or repair will not mutate it.
+- If a claimed, in-review, or blocked item is not yet repairable, explain the relevant staleness or backoff condition at a human-readable level.
+- If the repo or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
+
+## Output shape
+
+Use a stable grouped shape so one diagnosis is easy to scan:
+
+```text
+Item: <identity>
+Lifecycle: <PRD|BUILD>
+Role: <current role> (<product-owned|Lisa-owned>)
+Verdict: <VERDICT>
+Why: <rule or gate explanation>
+Next action: <smallest useful follow-up>
+```
+
+When helpful, include one short `Signals:` or `Relevant refs:` line for the exact blockers, staleness timestamps, parent/child classification, or repair markers that justify the verdict.
+
+## Rules
+
+- Stay **read-only**. Never claim, relabel, transition, comment on, create, decompose, or repair work from this skill.
+- Keep the explanation repo-scoped to the current project rather than aggregating unrelated repos or trackers.
+- Reuse intake and repair-intake contract semantics so diagnosis and execution do not drift.
+- Prefer existing vendor read surfaces and validators over creating a second lifecycle engine.
+- If the current runtime or vendor surface cannot expose a needed signal, say that explicitly instead of guessing.

--- a/plugins/lisa/skills/intake-explain/agents/openai.yaml
+++ b/plugins/lisa/skills/intake-explain/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Intake Explain"
+short_description: "Read-only operator surface for diagnosing one repo-scoped PRD or build item against Lisa's current intake and repair contracts"
+default_prompt:
+  - "Use $intake-explain: Read-only operator surface for diagnosing one repo-scoped PRD or build item against Lisa's current intake and repair contracts."

--- a/plugins/src/base/commands/intake-explain.md
+++ b/plugins/src/base/commands/intake-explain.md
@@ -1,0 +1,14 @@
+---
+description: "Inspect one PRD or build item, explain how Lisa classifies it right now, and report the exact intake or repair gate affecting it. Read-only by default."
+argument-hint: "<item-ref>"
+---
+
+Use the /lisa:intake-explain skill to inspect a single repo-scoped PRD or build item, explain its current lifecycle role, and report whether Lisa would intake it, repair it, hold it, skip it, or leave it product-owned. $ARGUMENTS
+
+Common operator usage:
+
+- `/lisa:intake-explain https://github.com/acme/repo/issues/123`
+- `/lisa:intake-explain PRD-456`
+- `/lisa:intake-explain https://linear.app/acme/issue/ENG-123/example`
+
+This surface is read-only in v1. Use it when you need a deterministic explanation for why one item is moving, waiting, blocked, skipped, or ignored before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.

--- a/plugins/src/base/skills/intake-explain/SKILL.md
+++ b/plugins/src/base/skills/intake-explain/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: intake-explain
+description: "Read-only operator surface for diagnosing one repo-scoped PRD or build item against Lisa's current intake and repair contracts. Resolves the item's queue family, lifecycle role, ownership boundary, and gate outcomes using the same source/tracker detection, lifecycle naming, leaf-only, dependency, staleness, and backoff semantics the write-side intake and repair flows already enforce."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Intake Explain: $ARGUMENTS
+
+`/lisa:intake-explain` is the operator-facing explanation surface for one specific item in the **current repo or project**. It answers the per-item diagnosis question Lisa's batch flows intentionally do not answer directly: what lifecycle lane the item belongs to, which Lisa rule or gate applies right now, whether the item is eligible for intake or repair, and what the next relevant action should be.
+
+This command is **read-only** in v1. It does not claim, relabel, repair, transition, comment on, decompose, or otherwise mutate the item. It complements `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, `/lisa:automation-status`, and tracker-native inspection; it does not replace them.
+
+## Confirmation policy
+
+Do **not** ask for confirmation once invoked. This skill inspects one item and reports what the current Lisa contract says about it. There are no write-side effects in the v1 surface.
+
+## Scope
+
+Inspect exactly one repo-scoped item reference:
+
+- a GitHub issue URL or `owner/repo#123` ref
+- a Linear issue or project URL
+- a JIRA issue key
+- a Notion PRD/item URL
+- a Confluence PRD page URL
+
+The skill must determine whether the item belongs to the PRD lifecycle or the build lifecycle, then explain the item's status using the **same contract** Lisa already uses for `/lisa:intake` and `/lisa:repair-intake`. Do **not** invent a second source of truth for queue detection, lifecycle role naming, repo scoping, or repair eligibility.
+
+## Contract reuse
+
+Resolve item family, queue source/tracker, and lifecycle role names from `.lisa.config.json` plus the same defaults the active intake and repair flows already consume.
+
+Reuse the existing execution-side semantics instead of recreating them by hand:
+
+- queue/source detection and lifecycle naming from intake + repair-intake
+- product-owned versus Lisa-owned lifecycle roles
+- leaf-only and repo-scope build eligibility
+- active dependency holds
+- repair staleness thresholds and activity signals
+- repair backoff / loop-prevention suppression
+
+Work from the same vendor families Lisa already supports for intake and repair: GitHub, Linear, JIRA, Notion, and Confluence.
+
+## What to report
+
+Render a stable terminal-first diagnosis for one item:
+
+1. Item identity and resolved lifecycle family (`PRD` or `BUILD`).
+2. The current lifecycle role and whether that role is product-owned or Lisa-owned.
+3. The exact rule, gate, or ownership boundary currently driving behavior.
+4. A verdict such as `ELIGIBLE_FOR_INTAKE`, `ELIGIBLE_FOR_REPAIR`, `WAITING_ON_STALENESS`, `HELD_BY_BLOCKERS`, `NON_LEAF_CONTAINER`, `PRODUCT_OWNED_STATE`, or `MISCONFIGURED`.
+5. The smallest useful next action, such as `/lisa:intake`, `/lisa:repair-intake`, decomposition, blocker resolution, or manual product clarification.
+
+Keep observable item facts separate from the recommended next step so operators can tell what Lisa knows versus what Lisa suggests.
+
+## Gate and ownership expectations
+
+The explanation must stay aligned with existing Lisa rules:
+
+- If a build item is a parent/container or a childless Epic/Story/Spike, explain the leaf-only gate and say direct build pickup is not allowed.
+- If a build item has active blockers, list the blocker refs and explain that intake would hold or skip it until they clear.
+- If a PRD is in a product-owned role such as `draft`, `shipped`, or `verified`, explain why intake or repair will not mutate it.
+- If a claimed, in-review, or blocked item is not yet repairable, explain the relevant staleness or backoff condition at a human-readable level.
+- If the repo or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
+
+## Output shape
+
+Use a stable grouped shape so one diagnosis is easy to scan:
+
+```text
+Item: <identity>
+Lifecycle: <PRD|BUILD>
+Role: <current role> (<product-owned|Lisa-owned>)
+Verdict: <VERDICT>
+Why: <rule or gate explanation>
+Next action: <smallest useful follow-up>
+```
+
+When helpful, include one short `Signals:` or `Relevant refs:` line for the exact blockers, staleness timestamps, parent/child classification, or repair markers that justify the verdict.
+
+## Rules
+
+- Stay **read-only**. Never claim, relabel, transition, comment on, create, decompose, or repair work from this skill.
+- Keep the explanation repo-scoped to the current project rather than aggregating unrelated repos or trackers.
+- Reuse intake and repair-intake contract semantics so diagnosis and execution do not drift.
+- Prefer existing vendor read surfaces and validators over creating a second lifecycle engine.
+- If the current runtime or vendor surface cannot expose a needed signal, say that explicitly instead of guessing.

--- a/tests/unit/strategies/intake-explain-scaffold.test.ts
+++ b/tests/unit/strategies/intake-explain-scaffold.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the `/lisa:intake-explain` command + skill scaffold.
+ *
+ * Issue #843 introduces the initial distribution surfaces for the per-item
+ * intake/repair diagnosis flow: the base command file, the base skill scaffold,
+ * and the generated `plugins/lisa` artifact mirror. The lifecycle readers,
+ * verdict renderer, vendor adapters, and read-only smoke coverage land in the
+ * follow-up tickets under PRD #838.
+ *
+ * This suite proves the scaffold shipped in both plugin roots and documents the
+ * intended contract clearly enough for later implementation work:
+ *   (1) the command delegates to `/lisa:intake-explain`;
+ *   (2) the skill is read-only and scoped to one repo/project item;
+ *   (3) the skill reuses `intake` / `repair-intake` contract semantics rather
+ *       than inventing a second source of truth;
+ *   (4) the skill names the expected verdict families and supported vendors;
+ *   (5) the skill defines a stable per-item output shape and next-action model.
+ *
+ * Both plugin roots are asserted so a missed `bun run build:plugins` fails the
+ * suite.
+ * @module tests/unit/strategies/intake-explain-scaffold
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+const COMMAND_REL = "commands/intake-explain.md";
+const SKILL_REL = "skills/intake-explain/SKILL.md";
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("intake-explain scaffold (#843)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    const commandPath = path.resolve(root, COMMAND_REL);
+    const skillPath = path.resolve(root, SKILL_REL);
+
+    it("ships the command and skill in this plugin root", () => {
+      expect(existsSync(commandPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
+    });
+
+    it("uses a pass-through command that delegates to /lisa:intake-explain", () => {
+      const command = read(root, COMMAND_REL);
+
+      expect(command).toMatch(/^---/);
+      expect(command).toMatch(/description:/);
+      expect(command).toContain('argument-hint: "<item-ref>"');
+      expect(command).toMatch(/Use the \/lisa:intake-explain skill/);
+      expect(command).toContain("$ARGUMENTS");
+    });
+
+    it("documents a read-only, single-item operator surface", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/^---/);
+      expect(skill).toMatch(/name:\s*intake-explain/);
+      expect(skill).toMatch(/allowed-tools:/);
+      expect(skill).toContain("Skill");
+      expect(skill).toContain("Bash");
+      expect(skill).toContain("Read");
+      expect(skill).toMatch(/read-only/i);
+      expect(skill).toMatch(/one specific item|exactly one repo-scoped item/i);
+      expect(skill).toMatch(/current repo|current project/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* ask for confirmation|do not ask for confirmation/i
+      );
+    });
+
+    it("reuses intake and repair-intake contract semantics", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/intake/);
+      expect(skill).toMatch(/repair-intake/);
+      expect(skill).toMatch(/same contract/i);
+      expect(skill).toMatch(
+        /do \*\*not\*\* invent a second source of truth|do not invent a second source of truth/i
+      );
+      expect(skill).toMatch(/queue detection|queue source/i);
+      expect(skill).toMatch(/lifecycle role/i);
+      expect(skill).toMatch(/staleness/i);
+      expect(skill).toMatch(/backoff|loop-prevention/i);
+    });
+
+    it("names the expected verdict families and supported vendors", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/ELIGIBLE_FOR_INTAKE/);
+      expect(skill).toMatch(/ELIGIBLE_FOR_REPAIR/);
+      expect(skill).toMatch(/WAITING_ON_STALENESS/);
+      expect(skill).toMatch(/HELD_BY_BLOCKERS/);
+      expect(skill).toMatch(/NON_LEAF_CONTAINER/);
+      expect(skill).toMatch(/PRODUCT_OWNED_STATE/);
+      expect(skill).toMatch(/MISCONFIGURED/);
+      expect(skill).toMatch(/GitHub/);
+      expect(skill).toMatch(/Linear/);
+      expect(skill).toMatch(/JIRA/);
+      expect(skill).toMatch(/Notion/);
+      expect(skill).toMatch(/Confluence/);
+    });
+
+    it("documents the key gate families and next-action handoff", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/leaf-only/i);
+      expect(skill).toMatch(/repo-scope/i);
+      expect(skill).toMatch(/active blocker|dependency hold/i);
+      expect(skill).toMatch(/product-owned/i);
+      expect(skill).toMatch(/Lisa-owned/i);
+      expect(skill).toMatch(/\/lisa:intake/);
+      expect(skill).toMatch(/\/lisa:repair-intake/);
+      expect(skill).toMatch(/manual product clarification|decomposition/i);
+    });
+
+    it("defines a stable per-item output shape", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/Item: <identity>/);
+      expect(skill).toMatch(/Lifecycle: <PRD\|BUILD>/);
+      expect(skill).toMatch(/Role: <current role>/);
+      expect(skill).toMatch(/Verdict: <VERDICT>/);
+      expect(skill).toMatch(/Why: <rule or gate explanation>/);
+      expect(skill).toMatch(/Next action: <smallest useful follow-up>/);
+      expect(skill).toMatch(/Signals:|Relevant refs:/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the base `/lisa:intake-explain` command and read-only skill scaffold
- document the verdict, gate, and next-action contract for one-item diagnosis
- add scaffold regression coverage and regenerate the Lisa plugin artifacts

## Validation
- `bun run build:plugins`
- `bun test tests/unit/strategies/intake-explain-scaffold.test.ts`
- pre-push hooks: `eslint . --config eslint.slow.config.ts --quiet`, `knip`, `vitest run --coverage`, `vitest run tests/integration`

Closes #843