### PR TITLE
feat: resolve intake-explain one-item contract routing

### DIFF
--- a/plugins/lisa/skills/intake-explain/SKILL.md
+++ b/plugins/lisa/skills/intake-explain/SKILL.md
@@ -50,9 +50,18 @@ Keep the diagnosis terminal-first and human-readable: observable item facts firs
 
 Resolve item family, queue source/tracker, and lifecycle role names from `.lisa.config.json` plus the same defaults the active intake and repair flows already consume.
 
+Route one-item diagnosis through the same contract surfaces the write-side flows already trust:
+
+- determine whether the item belongs to the configured PRD **source** lane or build **tracker** lane using the same `source` / `tracker` settings that `/lisa:intake` and `/lisa:repair-intake` already resolve
+- read vendor lifecycle role names from the same config keys and fallback defaults documented in the `config-resolution` rule rather than inventing hardcoded status names
+- keep repo/project scoping aligned with the same current-repo detection and queue-target rules the active intake scanners use
+
+When the runtime can identify the item but cannot confidently resolve its source lane, tracker lane, lifecycle namespace, or current repo/project scope from that contract, report `MISCONFIGURED` instead of guessing.
+
 Reuse the existing execution-side semantics instead of recreating them by hand:
 
 - queue/source detection and lifecycle naming from intake + repair-intake
+- one-item routing helpers for resolving the item's queue family against the correct source/tracker contract
 - product-owned versus Lisa-owned lifecycle roles
 - leaf-only and repo-scope build eligibility
 - active dependency holds
@@ -103,7 +112,7 @@ The explanation must stay aligned with existing Lisa rules:
 - If a build item has active blockers, list the blocker refs and explain that intake would hold or skip it until they clear.
 - If a PRD is in a product-owned role such as `draft`, `shipped`, or `verified`, explain why intake or repair will not mutate it.
 - If a claimed, in-review, or blocked item is not yet repairable, explain the relevant staleness or backoff condition at a human-readable level.
-- If the repo or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
+- If the source lane, tracker lane, repo/project scope, or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
 
 ## Rule explanation expectations
 

--- a/plugins/src/base/skills/intake-explain/SKILL.md
+++ b/plugins/src/base/skills/intake-explain/SKILL.md
@@ -50,9 +50,18 @@ Keep the diagnosis terminal-first and human-readable: observable item facts firs
 
 Resolve item family, queue source/tracker, and lifecycle role names from `.lisa.config.json` plus the same defaults the active intake and repair flows already consume.
 
+Route one-item diagnosis through the same contract surfaces the write-side flows already trust:
+
+- determine whether the item belongs to the configured PRD **source** lane or build **tracker** lane using the same `source` / `tracker` settings that `/lisa:intake` and `/lisa:repair-intake` already resolve
+- read vendor lifecycle role names from the same config keys and fallback defaults documented in the `config-resolution` rule rather than inventing hardcoded status names
+- keep repo/project scoping aligned with the same current-repo detection and queue-target rules the active intake scanners use
+
+When the runtime can identify the item but cannot confidently resolve its source lane, tracker lane, lifecycle namespace, or current repo/project scope from that contract, report `MISCONFIGURED` instead of guessing.
+
 Reuse the existing execution-side semantics instead of recreating them by hand:
 
 - queue/source detection and lifecycle naming from intake + repair-intake
+- one-item routing helpers for resolving the item's queue family against the correct source/tracker contract
 - product-owned versus Lisa-owned lifecycle roles
 - leaf-only and repo-scope build eligibility
 - active dependency holds
@@ -103,7 +112,7 @@ The explanation must stay aligned with existing Lisa rules:
 - If a build item has active blockers, list the blocker refs and explain that intake would hold or skip it until they clear.
 - If a PRD is in a product-owned role such as `draft`, `shipped`, or `verified`, explain why intake or repair will not mutate it.
 - If a claimed, in-review, or blocked item is not yet repairable, explain the relevant staleness or backoff condition at a human-readable level.
-- If the repo or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
+- If the source lane, tracker lane, repo/project scope, or lifecycle namespace is unresolved, report `MISCONFIGURED` instead of pretending the item is idle or actionable.
 
 ## Rule explanation expectations
 

--- a/tests/unit/strategies/intake-explain-contract-resolution.test.ts
+++ b/tests/unit/strategies/intake-explain-contract-resolution.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression coverage for intake-explain one-item contract resolution.
+ *
+ * Issue #846 extends the read-only operator surface so a single diagnosis must
+ * resolve the same source lane, tracker lane, lifecycle namespace, and
+ * repo/project scope the write-side intake flows already use. This keeps the
+ * operator explanation contract aligned with the active intake scanners rather
+ * than inventing a second resolver.
+ * @module tests/unit/strategies/intake-explain-contract-resolution
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("intake-explain contract resolution (#846)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    it("ties one-item diagnosis to source/tracker config and fallback defaults", () => {
+      const skill = read(root, "skills/intake-explain/SKILL.md");
+
+      expect(skill).toContain(".lisa.config.json");
+      expect(skill).toContain("source");
+      expect(skill).toContain("tracker");
+      expect(skill).toMatch(/same `source` \/ `tracker` settings/i);
+      expect(skill).toMatch(/same config keys and fallback defaults/i);
+      expect(skill).toMatch(/config-resolution/);
+    });
+
+    it("documents one-item routing against the existing queue and repo-scope contract", () => {
+      const skill = read(root, "skills/intake-explain/SKILL.md");
+
+      expect(skill).toMatch(/one-item routing helpers/i);
+      expect(skill).toMatch(/queue family/i);
+      expect(skill).toMatch(/source\/tracker contract/i);
+      expect(skill).toMatch(/repo\/project scope|current-repo detection/i);
+      expect(skill).toMatch(/MISCONFIGURED/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- align intake-explain with the same source/tracker and lifecycle resolution contract used by intake and repair-intake
- document MISCONFIGURED handling when queue lane, lifecycle namespace, or repo/project scope cannot be resolved confidently
- add regression coverage for one-item contract resolution in both plugin roots

## Testing
- bun run build:plugins
- bun test tests/unit/strategies/intake-explain-scaffold.test.ts tests/unit/strategies/intake-explain-operator-docs.test.ts tests/unit/strategies/intake-explain-contract-resolution.test.ts
- git push -u origin feat/846-intake-explain-contract-resolution

Closes #846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified intake-explain operator routing through shared contract surfaces and helper semantics.
  * Enhanced misconfiguration guidance to require explicit error reporting when configuration resolution fails.

* **Tests**
  * Added regression test suite validating intake-explain contract resolution against documentation requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->