### PR TITLE
docs(intake-explain): publish operator guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Most users only ever call `/lisa:research`, `/lisa:plan`, and `/lisa:implement`.
 | Command | What it does |
 | --- | --- |
 | `/lisa:intake <queue-url>` | Scans a Ready queue (Notion PRD database, JIRA project, GitHub repo, Linear team, Confluence space) and dispatches each item through the right lifecycle command. Designed as the cron target for unattended runs. |
+| `/lisa:intake-explain <item-ref>` | Read-only per-item diagnosis for PRD or build work. Reports the lifecycle role, verdict, decisive intake or repair gate, and smallest next action before an operator chooses `/lisa:intake`, `/lisa:repair-intake`, blocker cleanup, decomposition, or product follow-up. |
 | `/lisa:queue-status [queue=prd|queue=build]` | Read-only queue inspection for the current repo. Distinguishes idle vs misconfigured queues, highlights the most actionable item, and points operators to `/lisa:intake`, `/lisa:repair-intake`, `/lisa:automation-status`, or `/lisa:verify-prd`. |
 | `/lisa:repair-intake <queue-url>` | Read/write recovery scan for blocked, stale, or inconsistent queue state when normal intake is not the right next move. |
 | `/lisa:automation-status` | Read-only inspection of the repo's expected Lisa automation fleet so operators can distinguish empty queues from stale, drifted, or failing scheduler jobs. |

--- a/plugins/lisa/commands/intake-explain.md
+++ b/plugins/lisa/commands/intake-explain.md
@@ -11,4 +11,21 @@ Common operator usage:
 - `/lisa:intake-explain PRD-456`
 - `/lisa:intake-explain https://linear.app/acme/issue/ENG-123/example`
 
-This surface is read-only in v1. Use it when you need a deterministic explanation for why one item is moving, waiting, blocked, skipped, or ignored before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.
+The diagnosis uses stable verdicts:
+
+- `ELIGIBLE_FOR_INTAKE`: run `/lisa:intake <queue>` when normal pickup is the next move.
+- `ELIGIBLE_FOR_REPAIR`: run `/lisa:repair-intake <queue>` when Lisa-owned stuck work is actionable.
+- `WAITING_ON_STALENESS`: wait and re-check after the configured freshness window.
+- `HELD_BY_BLOCKERS`: clear the listed dependency or blocker before rerunning intake.
+- `NON_LEAF_CONTAINER`: decompose the item or move build-ready status to leaf work.
+- `PRODUCT_OWNED_STATE`: finish product clarification, promotion, or verification first.
+- `MISCONFIGURED`: fix lifecycle labels, repo scope, or queue configuration before relying on automation.
+
+Use it for these operator workflows:
+
+- Intake triage: confirm whether one item would be picked up by `/lisa:intake` right now.
+- Repair triage: decide whether a blocked or in-progress item is stale enough for `/lisa:repair-intake`.
+- Product follow-up: distinguish product-owned draft/shipped/verified states from Lisa-owned work.
+- Queue cleanup: identify leaf-only, repo-scope, dependency, or lifecycle-adoption fixes without mutating the item.
+
+This surface is read-only in v1. It never claims, relabels, comments on, repairs, or decomposes the item; it only reports the item facts, verdict, decisive gate, and smallest useful next action before an operator chooses `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.

--- a/plugins/src/base/commands/intake-explain.md
+++ b/plugins/src/base/commands/intake-explain.md
@@ -11,4 +11,21 @@ Common operator usage:
 - `/lisa:intake-explain PRD-456`
 - `/lisa:intake-explain https://linear.app/acme/issue/ENG-123/example`
 
-This surface is read-only in v1. Use it when you need a deterministic explanation for why one item is moving, waiting, blocked, skipped, or ignored before deciding whether to run `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.
+The diagnosis uses stable verdicts:
+
+- `ELIGIBLE_FOR_INTAKE`: run `/lisa:intake <queue>` when normal pickup is the next move.
+- `ELIGIBLE_FOR_REPAIR`: run `/lisa:repair-intake <queue>` when Lisa-owned stuck work is actionable.
+- `WAITING_ON_STALENESS`: wait and re-check after the configured freshness window.
+- `HELD_BY_BLOCKERS`: clear the listed dependency or blocker before rerunning intake.
+- `NON_LEAF_CONTAINER`: decompose the item or move build-ready status to leaf work.
+- `PRODUCT_OWNED_STATE`: finish product clarification, promotion, or verification first.
+- `MISCONFIGURED`: fix lifecycle labels, repo scope, or queue configuration before relying on automation.
+
+Use it for these operator workflows:
+
+- Intake triage: confirm whether one item would be picked up by `/lisa:intake` right now.
+- Repair triage: decide whether a blocked or in-progress item is stale enough for `/lisa:repair-intake`.
+- Product follow-up: distinguish product-owned draft/shipped/verified states from Lisa-owned work.
+- Queue cleanup: identify leaf-only, repo-scope, dependency, or lifecycle-adoption fixes without mutating the item.
+
+This surface is read-only in v1. It never claims, relabels, comments on, repairs, or decomposes the item; it only reports the item facts, verdict, decisive gate, and smallest useful next action before an operator chooses `/lisa:intake`, `/lisa:repair-intake`, `/lisa:queue-status`, or a tracker-native fix.

--- a/tests/unit/strategies/intake-explain-published-docs.test.ts
+++ b/tests/unit/strategies/intake-explain-published-docs.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression coverage for the published intake-explain operator docs.
+ *
+ * Issue #853 makes the concise command/README surfaces useful without requiring
+ * operators to read the full skill body first.
+ * @module tests/unit/strategies/intake-explain-published-docs
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const read = (filePath: string): string =>
+  readFileSync(path.resolve(filePath), "utf8");
+
+describe("intake-explain published docs (#853)", () => {
+  it("lists intake-explain in the README batch and scheduled work table", () => {
+    const readme = read("README.md");
+
+    expect(readme).toContain("/lisa:intake-explain <item-ref>");
+    expect(readme).toMatch(
+      /lifecycle role, verdict, decisive intake or repair gate/i
+    );
+    expect(readme).toContain("/lisa:intake");
+    expect(readme).toContain("/lisa:repair-intake");
+  });
+
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    it("documents command usage, verdict taxonomy, and workflows", () => {
+      const command = read(path.join(root, "commands", "intake-explain.md"));
+
+      expect(command).toContain("Common operator usage");
+      expect(command).toContain("The diagnosis uses stable verdicts");
+      expect(command).toContain("Use it for these operator workflows");
+
+      for (const verdict of [
+        "ELIGIBLE_FOR_INTAKE",
+        "ELIGIBLE_FOR_REPAIR",
+        "WAITING_ON_STALENESS",
+        "HELD_BY_BLOCKERS",
+        "NON_LEAF_CONTAINER",
+        "PRODUCT_OWNED_STATE",
+        "MISCONFIGURED",
+      ]) {
+        expect(command).toContain(verdict);
+      }
+
+      expect(command).toMatch(/Intake triage/i);
+      expect(command).toMatch(/Repair triage/i);
+      expect(command).toMatch(/Product follow-up/i);
+      expect(command).toMatch(/Queue cleanup/i);
+      expect(command).toMatch(/read-only/i);
+      expect(command).toMatch(
+        /never claims, relabels, comments on, repairs, or decomposes/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `/lisa:intake-explain <item-ref>` to the README batch/scheduled command table
- document verdict meanings and operator workflows in the intake-explain command surface
- add regression coverage for the published README and command docs

## Validation
- bun run build:plugins
- bun run check:plugins
- bun run test:unit -- tests/unit/strategies/intake-explain-published-docs.test.ts tests/unit/strategies/intake-explain-operator-docs.test.ts tests/unit/strategies/intake-explain-scaffold.test.ts
- pre-push hook: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration

Closes #853