### PR TITLE
Fix council execution policy parity

### DIFF
--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -382,6 +382,26 @@ export function parseCouncilCliArgs(argv) {
 }
 
 /**
+ * Resolve first-round council execution policy from the same normalized input
+ * shape for dry-run planning, collection, and CLI execution.
+ * @param {{
+ *   writeMode?: string | null;
+ *   runtime?: string | null;
+ *   cwd?: string;
+ *   env?: NodeJS.ProcessEnv;
+ * }} [input] Execution policy inputs.
+ * @returns {ReturnType<typeof resolveCouncilExecutionPolicy>} Normalized execution policy.
+ */
+export function resolveCouncilFirstRoundExecutionPolicy({
+  writeMode = null,
+  runtime = null,
+  cwd = process.cwd(),
+  env,
+} = {}) {
+  return resolveCouncilExecutionPolicy({ writeMode, runtime, cwd }, env);
+}
+
+/**
  * Build the non-mutating dry-run planning payload for a council invocation.
  *
  * @param {{
@@ -395,6 +415,7 @@ export function parseCouncilCliArgs(argv) {
  *   secondRound?: boolean;
  *   sanitizedSummary?: string | null;
  *   writeMode?: string | null;
+ *   cwd?: string;
  *   env?: NodeJS.ProcessEnv;
  * }} input Planning inputs.
  * @returns {{
@@ -417,12 +438,15 @@ export function buildCouncilDryRunPlan({
   secondRound = false,
   sanitizedSummary = null,
   writeMode = null,
+  cwd,
   env,
 }) {
-  const executionPolicy = resolveCouncilExecutionPolicy(
-    { writeMode, runtime },
-    env
-  );
+  const executionPolicy = resolveCouncilFirstRoundExecutionPolicy({
+    writeMode,
+    runtime,
+    cwd,
+    env,
+  });
   const runtimes = resolveCouncilRuntimes(runtime);
   const firstRound = runtimes.map(selectedRuntime =>
     buildFirstRoundInvocation({
@@ -586,7 +610,9 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
  *     targetEnvironment?: string;
  *   };
  *   runtimes?: (keyof typeof RUNTIME_ADAPTERS)[];
+ *   runtime?: string | null;
  *   writeMode?: string | null;
+ *   cwd?: string;
  *   env?: NodeJS.ProcessEnv;
  *   probeRuntime?: typeof probeRuntimeAdapter;
  *   executor?: (invocation: ReturnType<typeof buildFirstRoundInvocation>) => Promise<{
@@ -611,12 +637,19 @@ export async function collectFirstRoundResponses({
   topic,
   context = {},
   runtimes = Object.keys(RUNTIME_ADAPTERS),
+  runtime = null,
   writeMode = null,
+  cwd,
   env,
   probeRuntime = probeRuntimeAdapter,
   executor,
 }) {
-  const executionPolicy = resolveCouncilExecutionPolicy({ writeMode }, env);
+  const executionPolicy = resolveCouncilFirstRoundExecutionPolicy({
+    writeMode,
+    runtime,
+    cwd,
+    env,
+  });
   const captures = [];
 
   for (const runtime of runtimes) {
@@ -730,10 +763,11 @@ export function buildFirstRoundSynthesisInput({
  */
 async function main() {
   const parsed = parseCouncilCliArgs(process.argv.slice(2));
-  const executionPolicy = resolveCouncilExecutionPolicy(
-    { writeMode: parsed.writeMode },
-    globalThis.process?.env ?? {}
-  );
+  const executionPolicy = resolveCouncilFirstRoundExecutionPolicy({
+    writeMode: parsed.writeMode,
+    runtime: parsed.runtime,
+    env: globalThis.process?.env ?? {},
+  });
 
   if (parsed.dryRun) {
     const plan = buildCouncilDryRunPlan(parsed);
@@ -745,6 +779,7 @@ async function main() {
   const firstRound = await collectFirstRoundResponses({
     topic: parsed.topic,
     runtimes,
+    runtime: parsed.runtime,
     writeMode: parsed.writeMode,
   });
   const payload = {

--- a/tests/unit/strategies/harness-parity-council-guardrails.test.ts
+++ b/tests/unit/strategies/harness-parity-council-guardrails.test.ts
@@ -13,6 +13,9 @@ const firstRoundModuleUrl = pathToFileURL(
 const shared = await import(sharedModuleUrl);
 const firstRound = await import(firstRoundModuleUrl);
 const WORKSPACE_WRITE_MODE = "workspace-write";
+const GUARDED_WORKSPACE_ENV = "LISA_COUNCIL_GUARDED_WORKSPACE";
+const WRITE_ACK_ENV = "LISA_COUNCIL_ALLOW_WRITE";
+const REGULAR_WORKSPACE_CWD = "/Users/dev/workspace/lisa";
 
 describe("harness parity council guardrails", () => {
   it("defaults to explicit read-only policy even inside a worktree", () => {
@@ -39,7 +42,7 @@ describe("harness parity council guardrails", () => {
       shared.resolveCouncilExecutionPolicy(
         {
           writeMode: WORKSPACE_WRITE_MODE,
-          cwd: "/Users/dev/workspace/lisa",
+          cwd: REGULAR_WORKSPACE_CWD,
         },
         {}
       )
@@ -65,11 +68,11 @@ describe("harness parity council guardrails", () => {
       shared.resolveCouncilExecutionPolicy(
         {
           writeMode: WORKSPACE_WRITE_MODE,
-          cwd: "/Users/dev/workspace/lisa",
+          cwd: REGULAR_WORKSPACE_CWD,
         },
         {
-          LISA_COUNCIL_GUARDED_WORKSPACE: "1",
-          LISA_COUNCIL_ALLOW_WRITE: "true",
+          [GUARDED_WORKSPACE_ENV]: "1",
+          [WRITE_ACK_ENV]: "true",
         }
       )
     ).toEqual({
@@ -98,6 +101,44 @@ describe("harness parity council guardrails", () => {
       guardedWorkspaceReason: "codex-worktree",
       requiresExplicitWriteAck: false,
       writeAck: false,
+    });
+  });
+
+  it("uses one execution policy input shape for dry-run and real collection", async () => {
+    const policyInput = {
+      topic: "Review council policy parity",
+      runtime: "codex",
+      writeMode: WORKSPACE_WRITE_MODE,
+      cwd: REGULAR_WORKSPACE_CWD,
+      env: {
+        [GUARDED_WORKSPACE_ENV]: "1",
+        [WRITE_ACK_ENV]: "true",
+      },
+    };
+    const dryRun = firstRound.buildCouncilDryRunPlan(policyInput);
+
+    expect(
+      firstRound.resolveCouncilFirstRoundExecutionPolicy(policyInput)
+    ).toEqual(dryRun.executionPolicy);
+
+    await expect(
+      firstRound.collectFirstRoundResponses({
+        topic: policyInput.topic,
+        runtimes: ["codex"],
+        runtime: policyInput.runtime,
+        writeMode: policyInput.writeMode,
+        cwd: policyInput.cwd,
+        env: policyInput.env,
+        probeRuntime: runtime => ({
+          runtime,
+          available: false,
+          authMissing: false,
+          helpProbe: {},
+          versionProbe: {},
+        }),
+      })
+    ).resolves.toMatchObject({
+      unavailableRuntimes: [{ runtime: "codex" }],
     });
   });
 


### PR DESCRIPTION
## Summary
- add a shared first-round execution policy resolver for dry-run, collection, and CLI paths
- pass the same write mode, runtime, cwd, and env policy inputs through real collection
- add regression coverage for dry-run vs real collection policy parity

## Validation
- bun run test:unit -- tests/unit/strategies/harness-parity-council-guardrails.test.ts
- bun run test:unit -- tests/unit/strategies/harness-parity-council-*.test.ts
- bun run typecheck
- bun run lint
- pre-push: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration

Closes #862