### PR TITLE
fix(council): classify executor errors as failed

### DIFF
--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -542,10 +542,11 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
   const timedOut = result.timedOut === true;
   const exitStatus =
     typeof result.exitStatus === "number" ? result.exitStatus : null;
+  const hasExecutionError = result.error != null;
 
   const status = timedOut
     ? "timed_out"
-    : (exitStatus ?? 0) !== 0
+    : hasExecutionError || (exitStatus ?? 0) !== 0
       ? "failed"
       : !combinedText
         ? "empty"

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -90,6 +90,46 @@ describe("harness parity council first-round flow", () => {
     );
   });
 
+  it("classifies executor error payloads without exit status as failed", () => {
+    const invocation = council.buildFirstRoundInvocation({
+      topic: REVIEW_TOPIC,
+      runtime: "codex",
+    });
+    const probe = {
+      ...invocation,
+      available: true,
+      authMissing: false,
+      helpProbe: { commandMissing: false, error: null },
+      versionProbe: { commandMissing: false, error: null },
+    };
+
+    const capture = council.normalizeFirstRoundCapture({
+      invocation,
+      probe,
+      result: {
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        authMissing: false,
+        error: { code: "ENOENT", message: "no such file" },
+      },
+    });
+
+    expect(capture.status).toBe("failed");
+    expect(capture.error).toEqual({
+      code: "ENOENT",
+      message: "no such file",
+    });
+
+    const synthesis = council.buildFirstRoundSynthesisInput({
+      topic: REVIEW_TOPIC,
+      captures: [capture],
+    });
+    expect(synthesis.claudeSynthesisTemplate.openQuestions).toContain(
+      "codex: explain failed"
+    );
+  });
+
   it("collects stable synthesis inputs across available and unavailable runtimes", async () => {
     const synthesis = await council.collectFirstRoundResponses({
       topic: COUNCIL_TOPIC,


### PR DESCRIPTION
## Summary
- Treat first-round executor error payloads as failed captures even when no numeric exit status is present
- Add regression coverage for preserving the error payload and surfacing the failure in synthesis open questions

## Validation
- bun run test:unit -- tests/unit/strategies/harness-parity-council-first-round.test.ts
- bun run test:unit -- tests/unit/strategies/harness-parity-council-*.test.ts
- bun run typecheck
- bun run lint
- pre-push: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration

Closes #864