### PR TITLE
fix(council): mark unexecuted first-round captures

### DIFF
--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -478,12 +478,13 @@ export function buildCouncilDryRunPlan({
  *     stderr?: string;
  *     timedOut?: boolean;
  *     authMissing?: boolean | null;
+ *     notExecuted?: boolean;
  *     error?: { code?: string | null; message?: string } | null;
  *   };
  * }} input Runtime capture inputs.
  * @returns {{
  *   runtime: string;
- *   status: "responded" | "empty" | "failed" | "timed_out" | "unavailable";
+ *   status: "responded" | "not_executed" | "empty" | "failed" | "timed_out" | "unavailable";
  *   command: string;
  *   args: string[];
  *   timeoutMs: number;
@@ -543,13 +544,16 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
   const exitStatus =
     typeof result.exitStatus === "number" ? result.exitStatus : null;
 
-  const status = timedOut
-    ? "timed_out"
-    : (exitStatus ?? 0) !== 0
-      ? "failed"
-      : !combinedText
-        ? "empty"
-        : "responded";
+  const status =
+    result.notExecuted === true
+      ? "not_executed"
+      : timedOut
+        ? "timed_out"
+        : (exitStatus ?? 0) !== 0
+          ? "failed"
+          : !combinedText
+            ? "empty"
+            : "responded";
 
   return {
     runtime: invocation.runtime,
@@ -595,6 +599,7 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
  *     stderr?: string;
  *     timedOut?: boolean;
  *     authMissing?: boolean | null;
+ *     notExecuted?: boolean;
  *     error?: { code?: string | null; message?: string } | null;
  *   } | {
  *     exitStatus?: number | null;
@@ -602,6 +607,7 @@ export function normalizeFirstRoundCapture({ invocation, probe, result = {} }) {
  *     stderr?: string;
  *     timedOut?: boolean;
  *     authMissing?: boolean | null;
+ *     notExecuted?: boolean;
  *     error?: { code?: string | null; message?: string } | null;
  *   }>;
  * }} input Consultation inputs.
@@ -628,10 +634,20 @@ export async function collectFirstRoundResponses({
     });
     assertInvocationMatchesCouncilPolicy(invocation, executionPolicy);
     const probe = probeRuntime(runtime, env);
-    const result =
-      probe.available && typeof executor === "function"
+    const result = !probe.available
+      ? undefined
+      : typeof executor === "function"
         ? await executor(invocation)
-        : undefined;
+        : {
+            exitStatus: 0,
+            stdout:
+              "No executor was provided for this non-dry first-round council run; runtime consultation was not executed.",
+            stderr: "",
+            timedOut: false,
+            authMissing: probe.authMissing ?? false,
+            notExecuted: true,
+            error: null,
+          };
 
     captures.push(normalizeFirstRoundCapture({ invocation, probe, result }));
   }

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -178,6 +178,39 @@ describe("harness parity council first-round flow", () => {
     );
   });
 
+  it("labels available runtimes as not executed when no executor is provided", async () => {
+    const synthesis = await council.collectFirstRoundResponses({
+      topic: COUNCIL_TOPIC,
+      runtimes: ["codex"],
+      probeRuntime(runtime: string) {
+        return {
+          ...council.buildFirstRoundInvocation({
+            topic: COUNCIL_TOPIC,
+            runtime,
+            context: { repository: "lisa" },
+          }),
+          available: true,
+          authMissing: false,
+          helpProbe: { commandMissing: false, error: null },
+          versionProbe: { commandMissing: false, error: null },
+        };
+      },
+    });
+
+    expect(synthesis.responseEvidence).toEqual([
+      expect.objectContaining({
+        runtime: "codex",
+        status: "not_executed",
+        outputText: expect.stringContaining(
+          "runtime consultation was not executed"
+        ),
+      }),
+    ]);
+    expect(synthesis.claudeSynthesisTemplate.openQuestions).toContain(
+      "codex: explain not executed"
+    );
+  });
+
   it("supports the documented runtime filter and dry-run planning output", () => {
     const parsed = council.parseCouncilCliArgs([
       COUNCIL_TOPIC,


### PR DESCRIPTION
## Summary
- Mark available council runtimes as `not_executed` when a non-dry first-round run has no executor wired
- Surface the no-executor state in response evidence and open questions instead of returning an empty capture
- Add regression coverage for the no-executor path

Fixes #865

## Validation
- `bun run test:unit -- tests/unit/strategies/harness-parity-council-first-round.test.ts`
- `bun run test:unit -- tests/unit/strategies/harness-parity-council-*.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with existing warnings)
- pre-push hook: `bun audit`, slow eslint, `knip`, `vitest run --coverage`, `vitest run tests/integration`