### PR TITLE
fix: reject missing council flag values

### DIFF
--- a/.agents/skills/harness-parity-council/first-round.mjs
+++ b/.agents/skills/harness-parity-council/first-round.mjs
@@ -306,24 +306,49 @@ export function buildFirstRoundInvocation({
  * }} Parsed council args.
  */
 export function parseCouncilCliArgs(argv) {
+  const readFlagValue = (flag, values, index, description) => {
+    const value = values[index + 1] ?? "";
+    if (!value.trim() || value.trim().startsWith("--")) {
+      throw new Error(`The ${flag} flag requires ${description}.`);
+    }
+    return value;
+  };
+
   const parsed = argv.reduce(
     (state, current, index, values) => {
       if (state.skipIndices.has(index)) {
         return state;
       }
 
-      const nextValue = values[index + 1] ?? "";
       if (current === "--runtime") {
+        const nextValue = readFlagValue(
+          "--runtime",
+          values,
+          index,
+          "a runtime name"
+        );
         state.skipIndices.add(index + 1);
         return { ...state, runtime: nextValue };
       }
 
       if (current === "--write-mode") {
+        const nextValue = readFlagValue(
+          "--write-mode",
+          values,
+          index,
+          "a mode value"
+        );
         state.skipIndices.add(index + 1);
         return { ...state, writeMode: nextValue };
       }
 
       if (current === "--summary") {
+        const nextValue = readFlagValue(
+          "--summary",
+          values,
+          index,
+          "sanitized summary text"
+        );
         state.skipIndices.add(index + 1);
         return { ...state, sanitizedSummary: nextValue };
       }
@@ -357,18 +382,6 @@ export function parseCouncilCliArgs(argv) {
     throw new Error(
       "Usage: node first-round.mjs <topic> [--runtime <name>] [--second-round] [--dry-run] [--write-mode <mode>] [--summary <text>]"
     );
-  }
-
-  if (parsed.runtime !== null && !parsed.runtime.trim()) {
-    throw new Error("The --runtime flag requires a runtime name.");
-  }
-
-  if (parsed.writeMode !== null && !parsed.writeMode.trim()) {
-    throw new Error("The --write-mode flag requires a mode value.");
-  }
-
-  if (parsed.sanitizedSummary !== null && !parsed.sanitizedSummary.trim()) {
-    throw new Error("The --summary flag requires sanitized summary text.");
   }
 
   return {

--- a/tests/unit/strategies/harness-parity-council-first-round.test.ts
+++ b/tests/unit/strategies/harness-parity-council-first-round.test.ts
@@ -210,6 +210,20 @@ describe("harness parity council first-round flow", () => {
     expect(dryRun.secondRound?.sanitizedSummary).toContain("TODO");
   });
 
+  it("rejects value-taking flags when the next token is another flag", () => {
+    expect(() =>
+      council.parseCouncilCliArgs([COUNCIL_TOPIC, "--runtime", "--dry-run"])
+    ).toThrow("--runtime flag requires a runtime name");
+
+    expect(() =>
+      council.parseCouncilCliArgs([COUNCIL_TOPIC, "--write-mode", "--dry-run"])
+    ).toThrow("--write-mode flag requires a mode value");
+
+    expect(() =>
+      council.parseCouncilCliArgs([COUNCIL_TOPIC, "--summary", "--dry-run"])
+    ).toThrow("--summary flag requires sanitized summary text");
+  });
+
   it("builds second-round critique prompts from Claude's sanitized summary", () => {
     const critique = council.buildSecondRoundSynthesisInput({
       topic: COUNCIL_TOPIC,


### PR DESCRIPTION
## Summary
- Reject value-taking council CLI flags when the next token is missing or another flag
- Preserve normal parsing for valid --runtime, --write-mode, and --summary values
- Add regression coverage for flag-as-value cases

Closes #866

## Validation
- bun run test:unit -- tests/unit/strategies/harness-parity-council-first-round.test.ts
- bun run test:unit -- tests/unit/strategies/harness-parity-council-*.test.ts
- bun run typecheck
- bun run lint
- pre-push hook: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration