### PR TITLE
fix: normalize Claude schedule cadence

### DIFF
--- a/plugins/lisa/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-claude-adapter.mjs
@@ -175,6 +175,14 @@ export function deriveClaudeObservedCommand(command) {
   return undefined;
 }
 
+/**
+ * Extract the cadence argument from a Claude `/schedule` command string.
+ * Supports quoted (double-quote, single-quote, backtick) and unquoted cadence
+ * values, returning the first matched capture group via {@link firstString}.
+ *
+ * @param {string | undefined} command - The command string to parse
+ * @returns {string | undefined} The extracted cadence, or undefined if not found
+ */
 function extractClaudeScheduleCadence(command) {
   if (!command) {
     return undefined;

--- a/plugins/lisa/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-claude-adapter.mjs
@@ -175,6 +175,23 @@ export function deriveClaudeObservedCommand(command) {
   return undefined;
 }
 
+function extractClaudeScheduleCadence(command) {
+  if (!command) {
+    return undefined;
+  }
+
+  const scheduleLine = command
+    .trim()
+    .match(/^\/schedule\s+(?:"([^"]+)"|'([^']+)'|`([^`]+)`|(\S+))/m);
+
+  return firstString(
+    scheduleLine?.[1],
+    scheduleLine?.[2],
+    scheduleLine?.[3],
+    scheduleLine?.[4]
+  );
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
@@ -405,7 +422,7 @@ function normalizeClaudeScheduleTextEntry(block) {
 
   const cadenceSource =
     extractField(block, /^(?:Cadence|Schedule):\s*(.+)$/im) ??
-    block.match(/^\/schedule\s+(?:"[^"]+"|'[^']+'|`[^`]+`|\S+)/m)?.[0];
+    extractClaudeScheduleCadence(block);
   const commandSource =
     extractField(block, /^(?:Command|Prompt):\s*(.+)$/im) ??
     extractField(

--- a/plugins/src/base/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-claude-adapter.mjs
@@ -175,6 +175,14 @@ export function deriveClaudeObservedCommand(command) {
   return undefined;
 }
 
+/**
+ * Extract the cadence argument from a Claude `/schedule` command string.
+ * Supports quoted (double-quote, single-quote, backtick) and unquoted cadence
+ * values, returning the first matched capture group via {@link firstString}.
+ *
+ * @param {string | undefined} command - The command string to parse
+ * @returns {string | undefined} The extracted cadence, or undefined if not found
+ */
 function extractClaudeScheduleCadence(command) {
   if (!command) {
     return undefined;

--- a/plugins/src/base/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-claude-adapter.mjs
@@ -175,6 +175,23 @@ export function deriveClaudeObservedCommand(command) {
   return undefined;
 }
 
+function extractClaudeScheduleCadence(command) {
+  if (!command) {
+    return undefined;
+  }
+
+  const scheduleLine = command
+    .trim()
+    .match(/^\/schedule\s+(?:"([^"]+)"|'([^']+)'|`([^`]+)`|(\S+))/m);
+
+  return firstString(
+    scheduleLine?.[1],
+    scheduleLine?.[2],
+    scheduleLine?.[3],
+    scheduleLine?.[4]
+  );
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
@@ -405,7 +422,7 @@ function normalizeClaudeScheduleTextEntry(block) {
 
   const cadenceSource =
     extractField(block, /^(?:Cadence|Schedule):\s*(.+)$/im) ??
-    block.match(/^\/schedule\s+(?:"[^"]+"|'[^']+'|`[^`]+`|\S+)/m)?.[0];
+    extractClaudeScheduleCadence(block);
   const commandSource =
     extractField(block, /^(?:Command|Prompt):\s*(.+)$/im) ??
     extractField(

--- a/tests/unit/strategies/automation-status-claude-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-claude-adapter.test.ts
@@ -155,6 +155,42 @@ Last result: No recent failures reported.
     );
   });
 
+  it("normalizes quoted /schedule cadences when text listings omit cadence fields", () => {
+    const expectedFleet = resolveExpectedAutomationFleet({
+      config: REPO_CONFIG,
+      detectedTypes: DETECTED_TYPES,
+      autoStartPrds: true,
+    });
+
+    const report = inspectClaudeAutomationFleet({
+      expectedFleet,
+      scheduleListing: `
+ID: lisa-auto-codyswanngt-lisa-exploratory-prds
+/schedule "once a day" /lisa:project-ideation prd_ready=false
+Status: ACTIVE
+
+ID: ${BUILD_AUTOMATION_ID}
+/schedule "hourly" /lisa:intake github intake_mode=build
+Status: ACTIVE
+      `.trim(),
+      now: FIXTURE_NOW,
+    });
+
+    expect(report.observedAutomations).toContainEqual(
+      expect.objectContaining({
+        automationId: "lisa-auto-codyswanngt-lisa-exploratory-prds",
+        observedCadence: "once a day",
+        observedRRule: "FREQ=DAILY;INTERVAL=1",
+      })
+    );
+    expect(report.observedAutomations).toContainEqual(
+      expect.objectContaining({
+        automationId: BUILD_AUTOMATION_ID,
+        observedRRule: "FREQ=HOURLY;INTERVAL=1",
+      })
+    );
+  });
+
   it("derives normalized Lisa slash commands from Claude schedule entries", () => {
     expect(deriveClaudeObservedCommand(BUILD_SCHEDULE_COMMAND)).toBe(
       "/lisa:intake github intake_mode=build"

--- a/tests/unit/strategies/automation-status-claude-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-claude-adapter.test.ts
@@ -186,6 +186,7 @@ Status: ACTIVE
     expect(report.observedAutomations).toContainEqual(
       expect.objectContaining({
         automationId: BUILD_AUTOMATION_ID,
+        observedCadence: "every 60 minutes",
         observedRRule: "FREQ=HOURLY;INTERVAL=1",
       })
     );


### PR DESCRIPTION
## Summary
- Extract quoted `/schedule` cadence arguments when Claude text listings omit explicit Cadence/Schedule fields
- Preserve normalized Lisa command parsing for the same listing blocks
- Add regression coverage for daily and hourly quoted `/schedule` entries

## Verification
- `bun test tests/unit/strategies/automation-status-claude-adapter.test.ts`
- `bun run build:plugins`
- `bun run typecheck`
- `bun run lint` (passes with existing warnings in `.agents/skills/harness-parity-council`)
- `bun run check:plugins`
- pre-push: `bun audit`, slow lint, `knip`, full `vitest run --coverage`, `vitest run tests/integration`

Closes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced parsing of Claude `/schedule` commands to extract cadence information directly from command strings, enabling better schedule normalization

* **Tests**
  * Added test coverage verifying schedule cadence extraction and normalization when explicit cadence fields are omitted from listings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->