### PR TITLE
fix: preserve decimal usage cost totals

### DIFF
--- a/src/utils/decimal-sum.ts
+++ b/src/utils/decimal-sum.ts
@@ -1,0 +1,83 @@
+/**
+ * Render a finite number in plain decimal notation for BigInt scaling.
+ *
+ * @param value Finite number to normalize.
+ * @returns A plain decimal string without exponent notation.
+ */
+function renderPlainDecimal(value: number): string {
+  const rendered = String(value);
+  if (!rendered.includes("e") && !rendered.includes("E")) {
+    return rendered;
+  }
+
+  const [mantissa = "0", exponentPart = "0"] = rendered
+    .toLowerCase()
+    .split("e");
+  const exponent = Number(exponentPart);
+  const negative = mantissa.startsWith("-");
+  const unsigned = negative ? mantissa.slice(1) : mantissa;
+  const [whole = "0", fractional = ""] = unsigned.split(".");
+  const digits = `${whole}${fractional}`;
+  const decimalIndex = whole.length + exponent;
+  const plain =
+    decimalIndex <= 0
+      ? `0.${"0".repeat(Math.abs(decimalIndex))}${digits}`
+      : decimalIndex >= digits.length
+        ? `${digits}${"0".repeat(decimalIndex - digits.length)}`
+        : `${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`;
+
+  return negative ? `-${plain}` : plain;
+}
+
+/**
+ * Remove insignificant trailing zeros from a fractional decimal string.
+ *
+ * @param value Fractional decimal digits.
+ * @returns Fractional digits with redundant right-side zeros removed.
+ */
+function trimTrailingZeros(value: string): string {
+  const end = [...value].reduce(
+    (lastNonZero, digit, index) => (digit === "0" ? lastNonZero : index + 1),
+    0
+  );
+  return value.slice(0, end);
+}
+
+/**
+ * Sum nullable decimal amounts using scaled integer math.
+ *
+ * @param values Decimal values to aggregate.
+ * @returns The decimal sum of present values, or null when all are missing.
+ */
+export function sumNullableDecimals(
+  values: readonly (number | null)[]
+): number | null {
+  const present = values.filter((value): value is number => value !== null);
+  if (present.length === 0) {
+    return null;
+  }
+
+  const decimals = present.map(value => renderPlainDecimal(value));
+  const scale = Math.max(
+    ...decimals.map(decimal => decimal.split(".")[1]?.length ?? 0)
+  );
+  const factor = 10n ** BigInt(scale);
+  const total = decimals.reduce((sum, decimal) => {
+    const negative = decimal.startsWith("-");
+    const unsigned = negative ? decimal.slice(1) : decimal;
+    const [whole = "0", fractional = ""] = unsigned.split(".");
+    const units = BigInt(`${whole}${fractional.padEnd(scale, "0")}` || "0");
+    return negative ? sum - units : sum + units;
+  }, 0n);
+  const negative = total < 0n;
+  const absolute = negative ? -total : total;
+  const whole = absolute / factor;
+  const fractional =
+    scale === 0 ? "" : String(absolute % factor).padStart(scale, "0");
+  const rendered =
+    scale === 0
+      ? String(whole)
+      : `${whole}.${trimTrailingZeros(fractional) || "0"}`;
+
+  return Number(negative ? `-${rendered}` : rendered);
+}

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -1,3 +1,5 @@
+import { sumNullableDecimals } from "./decimal-sum.js";
+
 export const LISA_USAGE_HEADING = "## Lisa Usage";
 
 /**
@@ -239,7 +241,7 @@ export function createLisaUsageRollup(
 ): LisaUsageRollup {
   const directEntryIds = entries.map(entry => entry.entryId);
   const directTokens = sumNullable(entries.map(entry => entry.totalTokens));
-  const directCost = sumNullable(entries.map(entry => entry.cost));
+  const directCost = sumNullableDecimals(entries.map(entry => entry.cost));
   const childEntryIds = previousRollup?.childEntryIds ?? [];
   const childRefs = previousRollup?.childRefs ?? [];
   const childTokens = previousRollup ? previousRollup.childTokens : null;
@@ -251,7 +253,7 @@ export function createLisaUsageRollup(
   const totalCost =
     directCost === null && childCost === null
       ? null
-      : (directCost ?? 0) + (childCost ?? 0);
+      : sumNullableDecimals([directCost, childCost]);
   const currency =
     entries.find(entry => entry.currency !== null)?.currency ??
     previousRollup?.currency ??

--- a/tests/unit/utils/usage-accounting.test.ts
+++ b/tests/unit/utils/usage-accounting.test.ts
@@ -182,6 +182,50 @@ describe("usage-accounting utilities", () => {
     expect(parsed.rollup?.totalCost).toBeCloseTo(0.2);
   });
 
+  it("aggregates decimal cost totals without binary floating-point artifacts", () => {
+    const firstEntry = makeEntry({
+      entryId: "entry-cost-a",
+      runId: "run-cost-a",
+      cost: 0.1,
+    });
+    const secondEntry = makeEntry({
+      entryId: "entry-cost-b",
+      runId: "run-cost-b",
+      cost: 0.2,
+    });
+
+    const rollup = createLisaUsageRollup([firstEntry, secondEntry]);
+    const updated = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [firstEntry, secondEntry],
+      rollup,
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(rollup.directCost).toBe(0.3);
+    expect(rollup.totalCost).toBe(0.3);
+    expect(updated).toContain("direct_cost=0.3");
+    expect(updated).toContain("total_cost=0.3");
+    expect(updated).not.toContain("0.30000000000000004");
+    expect(parsed.rollup?.directCost).toBe(0.3);
+    expect(parsed.rollup?.totalCost).toBe(0.3);
+  });
+
+  it("aggregates refreshed direct and child costs with decimal precision", () => {
+    const entry = makeEntry({
+      entryId: "entry-parent",
+      runId: "run-parent",
+      cost: 0.1,
+    });
+    const rollup = createLisaUsageRollup(
+      [entry],
+      makeRollup({ childCost: 0.2 })
+    );
+
+    expect(rollup.directCost).toBe(0.1);
+    expect(rollup.childCost).toBe(0.2);
+    expect(rollup.totalCost).toBe(0.3);
+  });
+
   it("round-trips explicit unavailable usage entries with nullable fields", () => {
     const unavailableEntry = makeEntry({
       entryId: "entry-unavailable",


### PR DESCRIPTION
## Summary
- add scaled decimal summation for Lisa usage cost rollups
- use decimal aggregation for direct and child cost totals
- cover 0.1 + 0.2 rollup and round-trip behavior

Closes #868

## Validation
- bun run test:unit -- tests/unit/utils/usage-accounting.test.ts
- bun run typecheck
- bun run lint
- bun run format:check
- pre-push: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration