### PR TITLE
fix: make usage tokens reversible

### DIFF
--- a/plugins/lisa/rules/usage-accounting.md
+++ b/plugins/lisa/rules/usage-accounting.md
@@ -73,7 +73,7 @@ Every visible direct entry row ends with exactly one machine-readable token:
 <!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions.
+Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -86,7 +86,7 @@ Every managed section also ends with exactly one rollup token:
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
 
-The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans.
+The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
 ## Visible rendering contract
 

--- a/plugins/src/base/rules/usage-accounting.md
+++ b/plugins/src/base/rules/usage-accounting.md
@@ -73,7 +73,7 @@ Every visible direct entry row ends with exactly one machine-readable token:
 <!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions.
+Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -86,7 +86,7 @@ Every managed section also ends with exactly one rollup token:
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
 
-The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans.
+The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
 ## Visible rendering contract
 

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -82,7 +82,32 @@ function parseNullableString(value: string): string | null {
     return null;
   }
 
-  return value;
+  return decodeTokenValue(value);
+}
+
+/**
+ * Decode a percent-encoded token field.
+ *
+ * @param value Serialized token field.
+ * @returns The decoded token value, or the original value for legacy tokens.
+ */
+function decodeTokenValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Serialize a token field so whitespace, delimiters, and HTML comment endings
+ * cannot corrupt the machine-readable comment on the next parse.
+ *
+ * @param value String token value to render.
+ * @returns The percent-encoded token value.
+ */
+function encodeTokenValue(value: string): string {
+  return encodeURIComponent(value);
 }
 
 /**
@@ -92,7 +117,11 @@ function parseNullableString(value: string): string | null {
  * @returns The canonical string form used inside usage tokens.
  */
 function renderNullable(value: number | string | null): string {
-  return value === null ? "null" : String(value);
+  if (value === null) {
+    return "null";
+  }
+
+  return typeof value === "number" ? String(value) : encodeTokenValue(value);
 }
 
 /**
@@ -106,7 +135,18 @@ function parseCsv(value: string): readonly string[] {
     return [];
   }
 
-  return value.split(",");
+  return value.split(",").map(decodeTokenValue);
+}
+
+/**
+ * Serialize a list as a comma-delimited token field with each item encoded
+ * independently, so commas inside item values are preserved.
+ *
+ * @param values String values to serialize.
+ * @returns Encoded comma-delimited list.
+ */
+function renderCsv(values: readonly string[]): string {
+  return values.map(encodeTokenValue).join(",");
 }
 
 /**
@@ -280,7 +320,7 @@ export function createLisaUsageRollup(
  * @returns The canonical `lisa:usage-entry` token line.
  */
 export function renderLisaUsageEntryToken(entry: LisaUsageEntry): string {
-  return `<!-- lisa:usage-entry entry_id=${entry.entryId} flow=${entry.flow} run_id=${entry.runId} provider=${entry.provider} model=${entry.model} source=${entry.source} input_tokens=${renderNullable(entry.inputTokens)} cached_input_tokens=${renderNullable(entry.cachedInputTokens)} output_tokens=${renderNullable(entry.outputTokens)} reasoning_tokens=${renderNullable(entry.reasoningTokens)} total_tokens=${renderNullable(entry.totalTokens)} cost=${renderNullable(entry.cost)} currency=${renderNullable(entry.currency)} pricing_status=${entry.pricingStatus} pricing_source=${renderNullable(entry.pricingSource)} artifact_ref=${entry.artifactRef} parent_artifact_ref=${entry.parentArtifactRef ?? ""} -->`;
+  return `<!-- lisa:usage-entry entry_id=${encodeTokenValue(entry.entryId)} flow=${encodeTokenValue(entry.flow)} run_id=${encodeTokenValue(entry.runId)} provider=${encodeTokenValue(entry.provider)} model=${encodeTokenValue(entry.model)} source=${encodeTokenValue(entry.source)} input_tokens=${renderNullable(entry.inputTokens)} cached_input_tokens=${renderNullable(entry.cachedInputTokens)} output_tokens=${renderNullable(entry.outputTokens)} reasoning_tokens=${renderNullable(entry.reasoningTokens)} total_tokens=${renderNullable(entry.totalTokens)} cost=${renderNullable(entry.cost)} currency=${renderNullable(entry.currency)} pricing_status=${encodeTokenValue(entry.pricingStatus)} pricing_source=${renderNullable(entry.pricingSource)} artifact_ref=${encodeTokenValue(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeTokenValue(entry.parentArtifactRef)} -->`;
 }
 
 /**
@@ -290,7 +330,7 @@ export function renderLisaUsageEntryToken(entry: LisaUsageEntry): string {
  * @returns The canonical `lisa:usage-rollup` token line.
  */
 export function renderLisaUsageRollupToken(rollup: LisaUsageRollup): string {
-  return `<!-- lisa:usage-rollup direct_entry_ids=${rollup.directEntryIds.join(",")} child_entry_ids=${rollup.childEntryIds.join(",")} child_refs=${rollup.childRefs.join(",")} direct_tokens=${renderNullable(rollup.directTokens)} child_tokens=${renderNullable(rollup.childTokens)} total_tokens=${renderNullable(rollup.totalTokens)} direct_cost=${renderNullable(rollup.directCost)} child_cost=${renderNullable(rollup.childCost)} total_cost=${renderNullable(rollup.totalCost)} currency=${renderNullable(rollup.currency)} -->`;
+  return `<!-- lisa:usage-rollup direct_entry_ids=${renderCsv(rollup.directEntryIds)} child_entry_ids=${renderCsv(rollup.childEntryIds)} child_refs=${renderCsv(rollup.childRefs)} direct_tokens=${renderNullable(rollup.directTokens)} child_tokens=${renderNullable(rollup.childTokens)} total_tokens=${renderNullable(rollup.totalTokens)} direct_cost=${renderNullable(rollup.directCost)} child_cost=${renderNullable(rollup.childCost)} total_cost=${renderNullable(rollup.totalCost)} currency=${renderNullable(rollup.currency)} -->`;
 }
 
 /**
@@ -341,12 +381,12 @@ export function parseLisaUsageSection(
   const range = findUsageSectionRange(document);
   const section = range ? document.slice(range.start, range.end) : "";
   const entries = Array.from(section.matchAll(ENTRY_PATTERN), match => ({
-    entryId: match[1] ?? "",
-    flow: match[2] ?? "",
-    runId: match[3] ?? "",
-    provider: match[4] ?? "",
-    model: match[5] ?? "",
-    source: match[6] ?? "",
+    entryId: decodeTokenValue(match[1] ?? ""),
+    flow: decodeTokenValue(match[2] ?? ""),
+    runId: decodeTokenValue(match[3] ?? ""),
+    provider: decodeTokenValue(match[4] ?? ""),
+    model: decodeTokenValue(match[5] ?? ""),
+    source: decodeTokenValue(match[6] ?? ""),
     inputTokens: parseNullableNumber(match[7] ?? ""),
     cachedInputTokens: parseNullableNumber(match[8] ?? ""),
     outputTokens: parseNullableNumber(match[9] ?? ""),
@@ -354,9 +394,9 @@ export function parseLisaUsageSection(
     totalTokens: parseNullableNumber(match[11] ?? ""),
     cost: parseNullableNumber(match[12] ?? ""),
     currency: parseNullableString(match[13] ?? ""),
-    pricingStatus: match[14] ?? "",
+    pricingStatus: decodeTokenValue(match[14] ?? ""),
     pricingSource: parseNullableString(match[15] ?? ""),
-    artifactRef: match[16] ?? "",
+    artifactRef: decodeTokenValue(match[16] ?? ""),
     parentArtifactRef: parseNullableString(match[17] ?? ""),
   }));
 

--- a/tests/unit/strategies/usage-accounting-contract.test.ts
+++ b/tests/unit/strategies/usage-accounting-contract.test.ts
@@ -81,10 +81,17 @@ const readRule = (root: string): string =>
   readFileSync(path.resolve(root, RULE_NAME), "utf8");
 
 const renderValue = (value: number | string | null): string =>
-  value === null ? "null" : String(value);
+  value === null
+    ? "null"
+    : typeof value === "number"
+      ? String(value)
+      : encodeURIComponent(value);
+
+const renderCsv = (values: readonly string[]): string =>
+  values.map(value => encodeURIComponent(value)).join(",");
 
 const renderEntryToken = (entry: UsageEntry): string =>
-  `<!-- lisa:usage-entry entry_id=${entry.entryId} flow=${entry.flow} run_id=${entry.runId} provider=${entry.provider} model=${entry.model} source=${entry.source} input_tokens=${renderValue(entry.inputTokens)} cached_input_tokens=${renderValue(entry.cachedInputTokens)} output_tokens=${renderValue(entry.outputTokens)} reasoning_tokens=${renderValue(entry.reasoningTokens)} total_tokens=${renderValue(entry.totalTokens)} cost=${renderValue(entry.cost)} currency=${renderValue(entry.currency)} pricing_status=${entry.pricingStatus} pricing_source=${renderValue(entry.pricingSource)} artifact_ref=${entry.artifactRef} parent_artifact_ref=${entry.parentArtifactRef ?? ""} -->`;
+  `<!-- lisa:usage-entry entry_id=${encodeURIComponent(entry.entryId)} flow=${encodeURIComponent(entry.flow)} run_id=${encodeURIComponent(entry.runId)} provider=${encodeURIComponent(entry.provider)} model=${encodeURIComponent(entry.model)} source=${encodeURIComponent(entry.source)} input_tokens=${renderValue(entry.inputTokens)} cached_input_tokens=${renderValue(entry.cachedInputTokens)} output_tokens=${renderValue(entry.outputTokens)} reasoning_tokens=${renderValue(entry.reasoningTokens)} total_tokens=${renderValue(entry.totalTokens)} cost=${renderValue(entry.cost)} currency=${renderValue(entry.currency)} pricing_status=${encodeURIComponent(entry.pricingStatus)} pricing_source=${renderValue(entry.pricingSource)} artifact_ref=${encodeURIComponent(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeURIComponent(entry.parentArtifactRef)} -->`;
 
 const renderRollupToken = (
   directEntryIds: readonly string[],
@@ -93,7 +100,7 @@ const renderRollupToken = (
   totalTokens: number | null,
   totalCost: string | null
 ): string =>
-  `<!-- lisa:usage-rollup direct_entry_ids=${directEntryIds.join(",")} child_entry_ids=${childEntryIds.join(",")} child_refs=${childRefs.join(",")} direct_tokens=${DIRECT_TOKENS} child_tokens=${CHILD_TOKENS} total_tokens=${renderValue(totalTokens)} direct_cost=${DIRECT_COST} child_cost=${CHILD_COST} total_cost=${renderValue(totalCost)} currency=USD -->`;
+  `<!-- lisa:usage-rollup direct_entry_ids=${renderCsv(directEntryIds)} child_entry_ids=${renderCsv(childEntryIds)} child_refs=${renderCsv(childRefs)} direct_tokens=${DIRECT_TOKENS} child_tokens=${CHILD_TOKENS} total_tokens=${renderValue(totalTokens)} direct_cost=${DIRECT_COST} child_cost=${CHILD_COST} total_cost=${renderValue(totalCost)} currency=USD -->`;
 
 const renderSection = (entries: readonly UsageEntry[]): string => {
   const sorted = [...entries].sort((a, b) =>
@@ -144,9 +151,9 @@ const parseEntries = (section: string): readonly ParsedEntry[] => {
   let match = tokenPattern.exec(section);
   while (match !== null) {
     entries.push({
-      entryId: match[1] ?? "",
-      flow: match[2] ?? "",
-      source: match[3] ?? "",
+      entryId: decodeURIComponent(match[1] ?? ""),
+      flow: decodeURIComponent(match[2] ?? ""),
+      source: decodeURIComponent(match[3] ?? ""),
       totalTokens: match[4] ?? "",
     });
     match = tokenPattern.exec(section);
@@ -201,6 +208,8 @@ describe("usage-accounting contract docs", () => {
       expect(content).toContain("<!-- lisa:usage-rollup");
       expect(content).toMatch(/Field order is fixed/i);
       expect(content).toMatch(/machine-readable summary/i);
+      expect(content).toMatch(/percent-encoded/i);
+      expect(content).toMatch(/commas inside an item are encoded/i);
     });
 
     it("documents rollup dedupe by stable entry_id", () => {

--- a/tests/unit/utils/usage-accounting-token-serialization.test.ts
+++ b/tests/unit/utils/usage-accounting-token-serialization.test.ts
@@ -1,0 +1,102 @@
+import {
+  createLisaUsageRollup,
+  parseLisaUsageSection,
+  type LisaUsageEntry,
+  type LisaUsageRollup,
+  upsertLisaUsageSection,
+} from "../../../src/utils/usage-accounting.js";
+
+const ARTIFACT_DOCUMENT = "# Artifact\n";
+const COMMA_CHILD_REF = "github:issue:900,comment";
+
+/**
+ * Create a deterministic direct usage entry for token serialization tests.
+ *
+ * @param overrides Test-specific field overrides.
+ * @returns A complete usage entry payload.
+ */
+function makeEntry(overrides: Partial<LisaUsageEntry> = {}): LisaUsageEntry {
+  return {
+    artifactRef: "github:issue:869",
+    cachedInputTokens: null,
+    cost: 0.12,
+    currency: "USD",
+    entryId: "entry-869",
+    flow: "implement",
+    inputTokens: 100,
+    model: "gpt-5",
+    outputTokens: 20,
+    parentArtifactRef: null,
+    pricingSource: "catalog",
+    pricingStatus: "estimated",
+    provider: "openai",
+    reasoningTokens: null,
+    runId: "run-869",
+    source: "prompt",
+    totalTokens: 120,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a deterministic rollup payload for token serialization tests.
+ *
+ * @param overrides Test-specific rollup overrides.
+ * @returns A complete rollup payload.
+ */
+function makeRollup(overrides: Partial<LisaUsageRollup> = {}): LisaUsageRollup {
+  return {
+    childCost: 0,
+    childEntryIds: [],
+    childRefs: [],
+    childTokens: 0,
+    currency: "USD",
+    directCost: 0,
+    directEntryIds: [],
+    directTokens: 0,
+    totalCost: 0,
+    totalTokens: 0,
+    ...overrides,
+  };
+}
+
+describe("usage-accounting token serialization", () => {
+  it("round-trips entry token fields containing whitespace and delimiters", () => {
+    const entry = makeEntry({
+      artifactRef: "github:issue:869, usage comment",
+      entryId: "entry 869",
+      flow: "build fix",
+      model: "claude-3-5-sonnet (2025-04)",
+      parentArtifactRef: "github:issue:868 --> child",
+      pricingSource: "config:catalog, fallback",
+      pricingStatus: "estimated with override",
+      runId: "run 869, attempt --> 1",
+    });
+
+    const updated = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [entry],
+      rollup: createLisaUsageRollup([entry]),
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(parsed.entries[0]).toEqual(entry);
+    expect(updated).toContain("model=claude-3-5-sonnet%20(2025-04)");
+    expect(updated).not.toContain("attempt --> 1");
+  });
+
+  it("round-trips rollup list fields containing commas", () => {
+    const rollup = makeRollup({
+      childEntryIds: ["child,a", "child b"],
+      childRefs: [COMMA_CHILD_REF, "github:issue:901"],
+      directEntryIds: ["direct,a"],
+    });
+    const updated = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [],
+      rollup,
+    });
+    const parsed = parseLisaUsageSection(updated);
+
+    expect(parsed.rollup).toEqual(rollup);
+    expect(updated).toContain("child_refs=github%3Aissue%3A900%2Ccomment");
+  });
+});


### PR DESCRIPTION
## Summary
- Percent-encode Lisa usage token string fields and decode them on parse
- Encode rollup list items independently so commas inside refs survive round-trips
- Document the token encoding contract and add regression coverage for whitespace, commas, and comment terminators

Closes #869

## Validation
- bun test tests/unit/utils/usage-accounting.test.ts tests/unit/utils/usage-accounting-token-serialization.test.ts tests/unit/strategies/usage-accounting-contract.test.ts
- bun run test:unit
- bun run typecheck
- bun run lint
- bun run format:check
- bun run build:plugins
- bun run check:plugins
- pre-push: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration