### PR TITLE
fix: reject invalid usage numeric tokens

### DIFF
--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -68,7 +68,11 @@ function parseNullableNumber(value: string): number | null {
   }
 
   const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid Lisa usage numeric token: ${value}`);
+  }
+
+  return parsed;
 }
 
 /**

--- a/tests/unit/utils/usage-accounting.test.ts
+++ b/tests/unit/utils/usage-accounting.test.ts
@@ -268,6 +268,19 @@ describe("usage-accounting utilities", () => {
     expect(parsed.rollup?.totalCost).toBeNull();
   });
 
+  it("rejects corrupted numeric tokens instead of rewriting them as null", () => {
+    const existingSection = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [makeEntry({ entryId: "entry-corrupt", runId: "run-corrupt" })],
+    }).replace("cost=0.12", "cost=bad");
+
+    expect(() =>
+      upsertLisaUsageSection(existingSection, {
+        entries: [makeEntry({ entryId: "entry-next", runId: "run-next" })],
+      })
+    ).toThrow("Invalid Lisa usage numeric token: bad");
+    expect(existingSection).toContain("cost=bad");
+  });
+
   it("preserves pricing metadata and prior child rollups during direct-entry refreshes", () => {
     const existingEntry = makeEntry({
       entryId: PRICED_ENTRY_ID,


### PR DESCRIPTION
## Summary
- reject malformed Lisa usage numeric tokens instead of parsing them as null
- add regression coverage so corrupted usage sections are not silently rewritten during upsert

## Validation
- bun run test:unit -- tests/unit/utils/usage-accounting.test.ts
- bun run typecheck
- bun run lint
- bun run format:check
- push hook: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration

Closes #870