### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -55,3 +55,10 @@
 - Refreshed the `git` source note with 36 new commits through `c4879d40b123baf4f38d4c5530090b9003d4217a`, advanced the merged-PR cursor to `#837`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the isolated worktree path had no matching project memory, and global Codex memory remains out of scope.
 - Updated the monorepo snapshot synthesis for the latest queue-status delivery, repair-intake remediation, and release-history changes.
+
+## 2026-05-26 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-26-093056`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 60 new commits through `fd8db85fb79d5ea18628fdf071bbe761885d793f`, advanced the merged-PR cursor to `#905`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because only global Codex memory was available, and the connector refuses non-project-scoped memory.
+- Updated the monorepo snapshot synthesis for the latest intake-explain guidance, council and automation-status hardening, usage accounting fixes, and release-history changes.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,18 +20,19 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-26-053019` from `origin/main`
-- HEAD at 2026-05-26 incremental ingest: `c4879d40b123baf4f38d4c5530090b9003d4217a`
-- Current package version: `2.98.0`
-- Total commits on HEAD: 2020
-- Latest merged PR captured in the incremental git snapshot: `#837`
-- New commits since the previous incremental git cursor: `36`
+- Ingest branch: `wiki/ingest-2026-05-26-093056` from `origin/main`
+- HEAD at 2026-05-26 incremental ingest: `fd8db85fb79d5ea18628fdf071bbe761885d793f`
+- Current package version: `2.100.1`
+- Total commits on HEAD: 2080
+- Latest merged PR captured in the incremental git snapshot: `#905`
+- New commits since the previous incremental git cursor: `60`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Queue-status coverage expanded across shared contract resolution, grouped output, queue readers for PRD and build modes, health classification, and smoke coverage.
-- Repair-intake now closes out stuck work in batch, extending the operational remediation path beyond status reporting alone.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.91.3` through `2.98.0` during this incremental window.
+- Intake-explain guidance expanded across scaffold, output contract, ownership readiness, contract resolution, build gates, and operator documentation.
+- Council and automation-status handling hardened around policy inputs, executor failures, missing flag values, and negated failure classification.
+- Usage accounting now preserves decimal cost totals, rejects invalid numeric tokens, keeps token serialization reversible, and recomputes merged usage rollups.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.98.1` through `2.100.1` during this incremental window.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
@@ -10,46 +10,70 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-26)
 
-- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.AV0A5X`)
-- HEAD: `c4879d40b123baf4f38d4c5530090b9003d4217a`
-- Total commits on HEAD: 2020
-- New commits since last ingest (`ea144c8b5ffbc29d5f42f35ec6daa2d3bdcbaaeb`): 36
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #837 "[codex] Expand repair-intake batch close-out"
+- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.ouRhK8`)
+- HEAD: `fd8db85fb79d5ea18628fdf071bbe761885d793f`
+- Total commits on HEAD: 2080
+- New commits since last ingest (`c4879d40b123baf4f38d4c5530090b9003d4217a`): 60
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #905 "fix: recompute merged usage rollups"
 
 ## New commits
-- c4879d40 · 2026-05-26 · chore(release): 2.98.0 [skip ci]
-- b36fb1d4 · 2026-05-26 · Merge pull request #837 from CodySwannGT/codex/repair-intake-batch-rollups
-- 62439d51 · 2026-05-26 · feat(repair-intake): batch close out stuck work
-- 3939b1be · 2026-05-26 · chore(release): 2.97.1 [skip ci]
-- 42f52fea · 2026-05-26 · Merge pull request #836 from CodySwannGT/codex/827-queue-status-docs
-- 8e143c94 · 2026-05-26 · docs(queue-status): add operator guidance
-- 286752eb · 2026-05-26 · chore(release): 2.97.0 [skip ci]
-- cdfbd312 · 2026-05-26 · Merge pull request #833 from CodySwannGT/codex/issue-824-prd-queue-readers
-- f71b0d79 · 2026-05-26 · Merge branch 'main' into codex/issue-824-prd-queue-readers
-- c1406ca3 · 2026-05-26 · Merge pull request #835 from CodySwannGT/codex/issue-826-queue-status-smoke
-- 4235a9e3 · 2026-05-26 · Merge branch 'main' into codex/issue-826-queue-status-smoke
-- 68f42c66 · 2026-05-26 · test: add queue-status smoke coverage
-- e39158b1 · 2026-05-26 · chore(release): 2.96.0 [skip ci]
-- 2af85276 · 2026-05-26 · fix(queue-status): pass raw roles to inferNamespaceAdopted to avoid false-positive
-- b3adcbba · 2026-05-26 · Merge branch 'main' into codex/issue-824-prd-queue-readers
-- 2dbbfd83 · 2026-05-26 · Merge pull request #834 from CodySwannGT/codex/issue-825-build-queue-readers
-- ab9ce336 · 2026-05-26 · feat(queue-status): add build queue readers
-- ec926acf · 2026-05-26 · feat(queue-status): add PRD queue readers
-- 07f6b93c · 2026-05-26 · chore(release): 2.95.0 [skip ci]
-- 627300b3 · 2026-05-26 · Merge pull request #832 from CodySwannGT/codex/build-intake-823-queue-status-health
-- be8d807e · 2026-05-26 · feat(queue-status): classify queue health
-- d4edba87 · 2026-05-26 · chore(release): 2.94.0 [skip ci]
-- b850a97a · 2026-05-26 · Merge pull request #831 from CodySwannGT/codex/822-queue-status-contract-resolution
-- af1a3382 · 2026-05-26 · feat: share queue contract resolution (#822)
-- 567dd015 · 2026-05-26 · chore(release): 2.93.0 [skip ci]
-- 92845597 · 2026-05-26 · Merge pull request #830 from CodySwannGT/codex/issue-821-queue-health-remediation
-- 7e7c016d · 2026-05-26 · feat(queue-status): define grouped output contract
-- 932c87d8 · 2026-05-26 · chore(release): 2.92.0 [skip ci]
-- 28c2b828 · 2026-05-26 · Merge pull request #829 from CodySwannGT/codex/issue-820-queue-status
-- 6f3e4679 · 2026-05-26 · feat(queue-status): scaffold command and skill surfaces
-- 040950f2 · 2026-05-26 · chore(release): 2.91.4 [skip ci]
-- 077a4ed2 · 2026-05-26 · Merge pull request #828 from CodySwannGT/codex/issue-706-project-docs-smoke-20260526
-- c0076ab0 · 2026-05-26 · docs(github): add project coordination rollout coverage
-- 02b8a612 · 2026-05-26 · chore(release): 2.91.3 [skip ci]
-- 26d7882a · 2026-05-26 · Merge pull request #814 from CodySwannGT/wiki/ingest-2026-05-26-0130
-- ea01a847 · 2026-05-26 · docs(wiki): ingest incremental git history
+- fd8db85f · 2026-05-26 · Merge pull request #889 from CodySwannGT/codex/issue-862-council-policy-parity
+- 5f129524 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- bccba495 · 2026-05-26 · Merge pull request #905 from CodySwannGT/codex/issue-871-explicit-rollup-merge
+- ca93a51f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- d98fd2dd · 2026-05-26 · Merge branch 'main' into codex/issue-871-explicit-rollup-merge
+- 4b2a17cd · 2026-05-26 · Merge pull request #887 from CodySwannGT/codex/issue-853-intake-explain-docs
+- 2bdf9e31 · 2026-05-26 · fix: recompute merged usage rollups
+- 1ee6fc21 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- b06bb852 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 60f6ff16 · 2026-05-26 · Merge pull request #900 from CodySwannGT/codex/issue-870-invalid-usage-numbers
+- 429171d4 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- 6bf9392f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 93f5be0f · 2026-05-26 · fix: reject invalid usage numeric tokens
+- 3d31632b · 2026-05-26 · Merge pull request #899 from CodySwannGT/codex/869-usage-token-serialization
+- 65e9d176 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- acc65909 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 54019eaf · 2026-05-26 · fix: make usage tokens reversible
+- 6e9953e7 · 2026-05-26 · Merge pull request #893 from CodySwannGT/codex/issue-885-automation-status-negated-errors
+- b86884b2 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- b82f765f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 227f4444 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
+- 7738cadd · 2026-05-26 · Merge pull request #894 from CodySwannGT/codex/issue-866-council-flag-values
+- d250e2a0 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- eaeae439 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 34e5bae2 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
+- 946b298d · 2026-05-26 · Merge branch 'main' into codex/issue-866-council-flag-values
+- bc22ca47 · 2026-05-26 · Merge pull request #891 from CodySwannGT/codex/issue-864-council-executor-error
+- cdbe4c91 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
+- d7b247d9 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
+- 20fd1146 · 2026-05-26 · Merge branch 'main' into codex/issue-864-council-executor-error
+- 6163de40 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
+- 80581897 · 2026-05-26 · Merge branch 'main' into codex/issue-866-council-flag-values
+- 4141ae93 · 2026-05-26 · Merge pull request #897 from CodySwannGT/codex/issue-868-usage-cost-precision
+- a4d6b842 · 2026-05-26 · fix: preserve decimal usage cost totals
+- 9eb34a27 · 2026-05-26 · fix: reject missing council flag values
+- f91e07cc · 2026-05-26 · fix: handle negated automation-status failures
+- c1bc3073 · 2026-05-26 · fix(council): classify executor errors as failed
+- d6a99fd2 · 2026-05-26 · fix: align council execution policy inputs
+- 1a1ea509 · 2026-05-26 · docs(intake-explain): publish operator guidance
+- c1854873 · 2026-05-26 · Merge pull request #859 from CodySwannGT/codex/issue-849-intake-explain-build-gates
+- 2ab8975b · 2026-05-26 · docs: explain intake build gates
+- e7f79234 · 2026-05-26 · chore(release): 2.100.1 [skip ci]
+- c937bbb8 · 2026-05-26 · Merge pull request #857 from CodySwannGT/codex/issue-847-intake-explain-ownership
+- 7cc7df83 · 2026-05-26 · docs: explain intake ownership readiness
+- 00d02646 · 2026-05-26 · chore(release): 2.100.0 [skip ci]
+- 114adbf2 · 2026-05-26 · Merge pull request #856 from CodySwannGT/feat/846-intake-explain-contract-resolution
+- e8c8825c · 2026-05-26 · feat(intake-explain): resolve one-item contract routing
+- 914ef345 · 2026-05-26 · chore(release): 2.99.1 [skip ci]
+- 86e06949 · 2026-05-26 · Merge pull request #855 from CodySwannGT/codex/issue-844-intake-explain-output
+- 0909b4ca · 2026-05-26 · docs: harden intake-explain operator contract
+- 5ba130fd · 2026-05-26 · chore(release): 2.99.0 [skip ci]
+- 0bc62140 · 2026-05-26 · Merge pull request #840 from CodySwannGT/codex/update-lisa-self
+- e0703ee3 · 2026-05-26 · Merge branch 'main' into codex/update-lisa-self
+- 2d3a58f7 · 2026-05-26 · Merge pull request #854 from CodySwannGT/codex/issue-843-intake-explain
+- 54098a3e · 2026-05-26 · feat: add intake-explain scaffold
+- 57334168 · 2026-05-26 · chore(release): 2.98.1 [skip ci]
+- cec15bb2 · 2026-05-26 · Merge branch 'main' into codex/update-lisa-self
+- 79eb3739 · 2026-05-26 · Merge pull request #839 from CodySwannGT/wiki/ingest-2026-05-26-053019
+- 2ce43e01 · 2026-05-26 · chore: self-update Lisa dependency
+- 810cc559 · 2026-05-26 · docs(wiki): ingest incremental git history

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-26T09:30:43.768Z",
+  "ingested_at": "2026-05-26T13:31:17.916Z",
   "cursor": {
-    "lastCommit": "c4879d40b123baf4f38d4c5530090b9003d4217a",
-    "lastPr": 837
+    "lastCommit": "fd8db85fb79d5ea18628fdf071bbe761885d793f",
+    "lastPr": 905
   },
   "source_notes": [
     "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-26T09:30:43.141Z",
+  "ingested_at": "2026-05-26T13:31:17.307Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary\n- ingest latest Lisa git history and merged PR metadata into the LLM Wiki\n- refresh roles connector source note and state\n- update wiki log and monorepo synthesis snapshot\n\n## Verification\n- git diff --check\n- node plugins/src/wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json\n- node plugins/src/wiki/scripts/lint-wiki.mjs --wiki wiki\n- commit hook: gitleaks, typecheck, lint-staged\n- pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests\n\nMemory connector skipped because only global Codex memory was available, and the project-scoped memory connector refuses global/unrelated memory.