### PR TITLE
fix(doctor): normalize direct aggregator statuses

### DIFF
--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -39,7 +39,7 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  * @returns {DoctorVerdict}
  */
 export function computeDoctorVerdict(groups) {
-  const checks = groups.flatMap(group => group.checks);
+  const checks = groups.flatMap(group => group.checks.map(normalizeCheck));
   if (checks.some(check => check.status === "FAIL")) {
     return "NOT_READY";
   }
@@ -55,7 +55,7 @@ export function computeDoctorVerdict(groups) {
  */
 export function countDoctorStatuses(groups) {
   return groups
-    .flatMap(group => group.checks)
+    .flatMap(group => group.checks.map(normalizeCheck))
     .reduce(
       (counts, check) => ({
         ...counts,

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -39,7 +39,7 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  * @returns {DoctorVerdict}
  */
 export function computeDoctorVerdict(groups) {
-  const checks = groups.flatMap(group => group.checks);
+  const checks = groups.flatMap(group => group.checks.map(normalizeCheck));
   if (checks.some(check => check.status === "FAIL")) {
     return "NOT_READY";
   }
@@ -55,7 +55,7 @@ export function computeDoctorVerdict(groups) {
  */
 export function countDoctorStatuses(groups) {
   return groups
-    .flatMap(group => group.checks)
+    .flatMap(group => group.checks.map(normalizeCheck))
     .reduce(
       (counts, check) => ({
         ...counts,

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -159,6 +159,30 @@ describe("doctor report rendering (#750)", () => {
     ).toEqual({ PASS: 1, WARN: 1, FAIL: 1, SKIP: 1 });
   });
 
+  it("normalizes invalid statuses before direct aggregation", () => {
+    const groups = [
+      {
+        id: "1",
+        title: "Invalid status handling",
+        checks: [
+          {
+            id: "bad-status",
+            status: "BANANA",
+            summary: "invalid status from an external caller",
+          },
+        ],
+      },
+    ];
+
+    expect(computeDoctorVerdict(groups)).toBe("NOT_READY");
+    expect(countDoctorStatuses(groups)).toEqual({
+      PASS: 0,
+      WARN: 0,
+      FAIL: 1,
+      SKIP: 0,
+    });
+  });
+
   it("renders empty groups as grouped skips instead of omitting them", () => {
     const report = renderDoctorReport({
       groups: [{ id: "7", title: "Optional wiki delegation", checks: [] }],


### PR DESCRIPTION
## Summary
- Normalize doctor check statuses inside exported aggregation helpers
- Keep generated plugin doctor helper in sync with the base source
- Add regression coverage for invalid external statuses

## Validation
- bun run test:unit -- tests/unit/strategies/doctor-report-rendering.test.ts tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
- bun run typecheck
- bun run format:check
- bun run lint
- bun run check:plugins
- pre-push hook: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration

Closes #873