### PR TITLE
fix: canonicalize Codex Lisa automation aliases

### DIFF
--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -179,10 +179,17 @@ export function deriveCodexObservedCommand(prompt) {
     /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
   );
   if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `/${aliasSkillMatch[1]} ${aliasSkillMatch[2]}`.trim();
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
   }
 
   return undefined;
+}
+
+function canonicalizeCodexSkillAlias(alias) {
+  if (alias.startsWith("lisa-")) {
+    return `/lisa:${alias.slice("lisa-".length)}`;
+  }
+  return `/${alias}`;
 }
 
 /**

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -179,10 +179,17 @@ export function deriveCodexObservedCommand(prompt) {
     /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
   );
   if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `/${aliasSkillMatch[1]} ${aliasSkillMatch[2]}`.trim();
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
   }
 
   return undefined;
+}
+
+function canonicalizeCodexSkillAlias(alias) {
+  if (alias.startsWith("lisa-")) {
+    return `/lisa:${alias.slice("lisa-".length)}`;
+  }
+  return `/${alias}`;
 }
 
 /**

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+import { compareAutomationContract } from "../../../plugins/src/base/scripts/automation-status-contract-drift.mjs";
 import {
   deriveCodexObservedCommand,
   inspectCodexAutomationFleet,
@@ -21,6 +22,8 @@ import {
 
 const BUILD_INTAKE_PROMPT =
   "Run one cron-safe Lisa build-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=build`.";
+const BUILD_INTAKE_CADENCE = "every 10 minutes";
+const BUILD_INTAKE_COMMAND = "/lisa:intake github intake_mode=build";
 const BUILD_INTAKE_RRULE = "FREQ=MINUTELY;INTERVAL=10";
 const BUILD_INTAKE_AUTOMATION_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
 
@@ -127,7 +130,7 @@ describe("automation-status Codex adapter (#801)", () => {
 
   it("derives normalized Lisa slash commands from Codex automation prompts", () => {
     expect(deriveCodexObservedCommand(BUILD_INTAKE_PROMPT)).toBe(
-      "/lisa:intake github intake_mode=build"
+      BUILD_INTAKE_COMMAND
     );
 
     expect(
@@ -140,7 +143,31 @@ describe("automation-status Codex adapter (#801)", () => {
       deriveCodexObservedCommand(
         "Run one Playwright-backed exploratory QA pass. Use the `$lisa-exploratory-qa` skill with arguments `ready=true`."
       )
-    ).toBe("/lisa-exploratory-qa ready=true");
+    ).toBe("/lisa:exploratory-qa ready=true");
+  });
+
+  it("canonicalizes Codex $lisa-* aliases to Lisa slash-colon commands (#880)", () => {
+    const observedCommand = deriveCodexObservedCommand(
+      "Run one cron-safe Lisa build-intake cycle. Use the `$lisa-intake` skill with arguments `github intake_mode=build`."
+    );
+
+    expect(observedCommand).toBe(BUILD_INTAKE_COMMAND);
+    expect(
+      compareAutomationContract({
+        expected: {
+          automationId: BUILD_INTAKE_AUTOMATION_ID,
+          expectedCadence: BUILD_INTAKE_CADENCE,
+          expectedRRule: BUILD_INTAKE_RRULE,
+          expectedCommand: BUILD_INTAKE_COMMAND,
+        },
+        observedAutomation: {
+          automationId: BUILD_INTAKE_AUTOMATION_ID,
+          observedCadence: BUILD_INTAKE_CADENCE,
+          observedRRule: BUILD_INTAKE_RRULE,
+          observedCommand,
+        },
+      }).status
+    ).toBe("HEALTHY");
   });
 
   it("does not classify negated error or exception summaries as failures (#885)", () => {


### PR DESCRIPTION
## Summary
- canonicalize Codex `$lisa-*` skill aliases back to `/lisa:*` slash-colon commands in automation-status
- add regression coverage that `$lisa-intake github intake_mode=build` compares HEALTHY against the expected `/lisa:intake` fleet contract
- regenerate the shipped `plugins/lisa` adapter artifact

## Tests
- `bunx vitest run tests/unit/strategies/automation-status-codex-adapter.test.ts tests/unit/strategies/automation-status-contract-drift.test.ts`
- `bun run check:plugins`
- pre-push hook: `bun audit`, slow eslint, `knip`, unit tests with coverage, integration tests

Closes #880