### PR TITLE
Add Lisa wiki status command surface

### DIFF
--- a/plugins/lisa-wiki/commands/status.md
+++ b/plugins/lisa-wiki/commands/status.md
@@ -1,0 +1,6 @@
+---
+description: "Report Lisa wiki source freshness across enabled connectors. Read-only — summarizes last ingest evidence, skipped/blocker reasons, and targeted next actions without running ingestion."
+argument-hint: "[--json] [--wiki <path>] [--config <path>]"
+---
+
+Use the lisa-wiki-status skill to render the wiki source freshness report from `wiki/lisa-wiki.config.json`, `wiki/log.md`, `wiki/sources/**`, and `wiki/state/**`. This is read-only and must not ingest, edit, branch, commit, push, or open PRs. $ARGUMENTS

--- a/plugins/lisa-wiki/skills/lisa-wiki-status/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-status/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: lisa-wiki-status
+description: Report Lisa wiki source freshness across enabled ingestion connectors. Reads wiki config, log, source notes, and state cursors, then renders a concise read-only freshness table with skipped/blocker reasons and exact next actions. Use when maintainers ask whether the wiki sources are fresh, stale, skipped, blocked, or need targeted ingest.
+allowed-tools: ["Bash", "Read"]
+---
+
+# lisa-wiki-status
+
+Render the Lisa wiki source freshness report without changing the repository.
+
+## Scope
+
+This skill answers a narrower question than `lisa-wiki-doctor` or `lisa-wiki-lint`: whether each enabled, non-external-write ingestion connector has current source evidence and what the operator should do next.
+
+Read these repository files as the source of truth:
+
+- `wiki/lisa-wiki.config.json` for enabled connectors and wiki root.
+- `wiki/log.md` for latest ingest, skip, and blocker notes.
+- `wiki/sources/**` for reader-safe source notes.
+- `wiki/state/**` for connector state cursors and source-note references.
+
+## Workflow
+
+1. Resolve the wiki root from `wiki/lisa-wiki.config.json`, unless `--wiki` or `--config` is passed.
+2. Run the bundled deterministic renderer:
+
+   ```bash
+   node plugins/lisa-wiki/scripts/wiki-status.mjs $ARGUMENTS
+   ```
+
+   If running from the source plugin tree before distribution, use `plugins/src/wiki/scripts/wiki-status.mjs`.
+3. Report the rendered connector table. Preserve connector verdicts exactly:
+   `fresh`, `stale`, `never_ingested`, `skipped`, or `blocked`.
+4. Include the evidence paths, last observed date, skip/blocker reason when present, and exact next action for each non-fresh connector.
+5. Mention `lisa-wiki-lint` only as a separate integrity follow-up. Do not conflate freshness with broken links, stale claims, or structure linting.
+
+## Rules
+
+- **Read-only.** Do not ingest, edit wiki pages, edit config, advance state, branch, commit, push, open PRs, or run repair flows.
+- Do **not** ask for confirmation before rendering. This status command has no write side effects.
+- Do **not** use global Codex memory or non-project memory as fresh wiki evidence. Only project-scoped source notes, state, and log entries count.
+- If the wiki/config is missing, surface the renderer output or error directly and stop.
+- If a connector is skipped because project-scoped memory is unavailable, preserve that reason and treat accepting the expected skip as a valid next action.
+
+## Related
+
+`lisa-wiki-ingest` refreshes sources, `lisa-wiki-lint` checks wiki integrity, and `lisa-wiki-doctor` verifies setup/readiness.

--- a/plugins/lisa-wiki/skills/lisa-wiki-status/agents/openai.yaml
+++ b/plugins/lisa-wiki/skills/lisa-wiki-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Lisa Wiki Status"
+short_description: "Report Lisa wiki source freshness across enabled ingestion connectors"
+default_prompt:
+  - "Use $lisa-wiki-status: Report Lisa wiki source freshness across enabled ingestion connectors."

--- a/plugins/src/wiki/commands/status.md
+++ b/plugins/src/wiki/commands/status.md
@@ -1,0 +1,6 @@
+---
+description: "Report Lisa wiki source freshness across enabled connectors. Read-only — summarizes last ingest evidence, skipped/blocker reasons, and targeted next actions without running ingestion."
+argument-hint: "[--json] [--wiki <path>] [--config <path>]"
+---
+
+Use the lisa-wiki-status skill to render the wiki source freshness report from `wiki/lisa-wiki.config.json`, `wiki/log.md`, `wiki/sources/**`, and `wiki/state/**`. This is read-only and must not ingest, edit, branch, commit, push, or open PRs. $ARGUMENTS

--- a/plugins/src/wiki/skills/lisa-wiki-status/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-status/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: lisa-wiki-status
+description: Report Lisa wiki source freshness across enabled ingestion connectors. Reads wiki config, log, source notes, and state cursors, then renders a concise read-only freshness table with skipped/blocker reasons and exact next actions. Use when maintainers ask whether the wiki sources are fresh, stale, skipped, blocked, or need targeted ingest.
+allowed-tools: ["Bash", "Read"]
+---
+
+# lisa-wiki-status
+
+Render the Lisa wiki source freshness report without changing the repository.
+
+## Scope
+
+This skill answers a narrower question than `lisa-wiki-doctor` or `lisa-wiki-lint`: whether each enabled, non-external-write ingestion connector has current source evidence and what the operator should do next.
+
+Read these repository files as the source of truth:
+
+- `wiki/lisa-wiki.config.json` for enabled connectors and wiki root.
+- `wiki/log.md` for latest ingest, skip, and blocker notes.
+- `wiki/sources/**` for reader-safe source notes.
+- `wiki/state/**` for connector state cursors and source-note references.
+
+## Workflow
+
+1. Resolve the wiki root from `wiki/lisa-wiki.config.json`, unless `--wiki` or `--config` is passed.
+2. Run the bundled deterministic renderer:
+
+   ```bash
+   node plugins/lisa-wiki/scripts/wiki-status.mjs $ARGUMENTS
+   ```
+
+   If running from the source plugin tree before distribution, use `plugins/src/wiki/scripts/wiki-status.mjs`.
+3. Report the rendered connector table. Preserve connector verdicts exactly:
+   `fresh`, `stale`, `never_ingested`, `skipped`, or `blocked`.
+4. Include the evidence paths, last observed date, skip/blocker reason when present, and exact next action for each non-fresh connector.
+5. Mention `lisa-wiki-lint` only as a separate integrity follow-up. Do not conflate freshness with broken links, stale claims, or structure linting.
+
+## Rules
+
+- **Read-only.** Do not ingest, edit wiki pages, edit config, advance state, branch, commit, push, open PRs, or run repair flows.
+- Do **not** ask for confirmation before rendering. This status command has no write side effects.
+- Do **not** use global Codex memory or non-project memory as fresh wiki evidence. Only project-scoped source notes, state, and log entries count.
+- If the wiki/config is missing, surface the renderer output or error directly and stop.
+- If a connector is skipped because project-scoped memory is unavailable, preserve that reason and treat accepting the expected skip as a valid next action.
+
+## Related
+
+`lisa-wiki-ingest` refreshes sources, `lisa-wiki-lint` checks wiki integrity, and `lisa-wiki-doctor` verifies setup/readiness.

--- a/tests/unit/strategies/wiki-status-surface.test.ts
+++ b/tests/unit/strategies/wiki-status-surface.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for the Lisa wiki freshness status command and skill surfaces.
+ *
+ * Issue #929 exposes the deterministic wiki-status renderer through Claude
+ * command and Codex skill surfaces while keeping the operation read-only.
+ * @module tests/unit/strategies/wiki-status-surface
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = ["plugins/src/wiki", "plugins/lisa-wiki"] as const;
+const COMMAND_REL = "commands/status.md";
+const SKILL_REL = "skills/lisa-wiki-status/SKILL.md";
+const SCRIPT_REL = "scripts/wiki-status.mjs";
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("wiki status command and skill surfaces (#929)", () => {
+  describe.each(PLUGIN_ROOTS)("%s", root => {
+    it("ships the command, skill, and renderer script in this plugin root", () => {
+      expect(existsSync(path.resolve(root, COMMAND_REL))).toBe(true);
+      expect(existsSync(path.resolve(root, SKILL_REL))).toBe(true);
+      expect(existsSync(path.resolve(root, SCRIPT_REL))).toBe(true);
+    });
+
+    it("uses a pass-through command that delegates to lisa-wiki-status", () => {
+      const command = read(root, COMMAND_REL);
+
+      expect(command).toMatch(/^---/);
+      expect(command).toMatch(/description:/);
+      expect(command).toMatch(/Use the lisa-wiki-status skill/);
+      expect(command).toContain("$ARGUMENTS");
+    });
+
+    it("documents a read-only freshness surface backed by repository evidence", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toMatch(/^---/);
+      expect(skill).toMatch(/name:\s*lisa-wiki-status/);
+      expect(skill).toMatch(/allowed-tools:/);
+      expect(skill).toContain("Bash");
+      expect(skill).toContain("Read");
+      expect(skill).toMatch(/read-only/i);
+      expect(skill).toContain("wiki/lisa-wiki.config.json");
+      expect(skill).toContain("wiki/log.md");
+      expect(skill).toContain("wiki/sources/**");
+      expect(skill).toContain("wiki/state/**");
+    });
+
+    it("names freshness verdicts, targeted next actions, and lint separation", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toContain("fresh");
+      expect(skill).toContain("stale");
+      expect(skill).toContain("never_ingested");
+      expect(skill).toContain("skipped");
+      expect(skill).toContain("blocked");
+      expect(skill).toMatch(/exact next action/i);
+      expect(skill).toMatch(/lisa-wiki-lint/);
+      expect(skill).toMatch(/Do not conflate freshness/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/lisa-wiki:status` command surface for the existing wiki freshness renderer
- Add `$lisa-wiki-status` Codex skill with read-only freshness workflow guidance
- Add scaffold tests covering source and generated Lisa wiki plugin artifacts

## Validation
- bun test tests/unit/strategies/wiki-status-surface.test.ts tests/unit/strategies/wiki-status-report-rendering.test.ts
- node plugins/lisa-wiki/scripts/wiki-status.mjs --wiki wiki --config wiki/lisa-wiki.config.json
- bun run check:plugins
- pre-push: bun audit, eslint slow, knip, vitest run --coverage, vitest run tests/integration

Closes #929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "status" command to report wiki source freshness across enabled ingestion connectors, including last ingest evidence and skipped/blocker reasons.

* **Documentation**
  * Added comprehensive documentation for the new status command and skill.

* **Tests**
  * Added regression test suite to verify status command and skill functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->