### PR TITLE
test(wiki): cover freshness verdict fixtures

### DIFF
--- a/tests/unit/strategies/wiki-status-report-rendering.test.ts
+++ b/tests/unit/strategies/wiki-status-report-rendering.test.ts
@@ -26,6 +26,7 @@ import {
 const SOURCE_PLUGIN_ROOT = path.resolve("plugins/src/wiki");
 const GENERATED_PLUGIN_ROOT = path.resolve("plugins/lisa-wiki");
 const READ_ONLY_INGEST = "read-only-ingest";
+const FIXTURE_NOW = "2026-05-26T12:00:00.000Z";
 
 const tempRoots: string[] = [];
 
@@ -113,6 +114,27 @@ function makeWikiFixture(): {
   return { root, wikiRoot, configPath };
 }
 
+/**
+ * Add a read-only connector to the fixture config.
+ * @param configPath Fixture config file path.
+ * @param connector Connector key to enable.
+ * @param connectorConfig Connector configuration override.
+ */
+function addConnector(
+  configPath: string,
+  connector: string,
+  connectorConfig: Record<string, unknown> = {
+    enabled: true,
+    sideEffects: READ_ONLY_INGEST,
+  }
+): void {
+  const config = JSON.parse(readUtf8(configPath)) as {
+    connectors: Record<string, unknown>;
+  };
+  config.connectors[connector] = connectorConfig;
+  writeJson(configPath, config);
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -127,7 +149,7 @@ describe("wiki-status report rendering (#930)", () => {
     const report = createWikiFreshnessReport({
       configPath: fixture.configPath,
       wikiRoot: fixture.wikiRoot,
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now: new Date(FIXTURE_NOW),
     });
     const text = renderWikiFreshnessReport(report);
 
@@ -162,19 +184,12 @@ describe("wiki-status report rendering (#930)", () => {
 
   it("recommends targeted ingest when enabled connector state or source evidence is absent", () => {
     const fixture = makeWikiFixture();
-    const config = JSON.parse(readUtf8(fixture.configPath)) as {
-      connectors: Record<string, unknown>;
-    };
-    config.connectors.docs = {
-      enabled: true,
-      sideEffects: READ_ONLY_INGEST,
-    };
-    writeJson(fixture.configPath, config);
+    addConnector(fixture.configPath, "docs");
 
     const report = createWikiFreshnessReport({
       configPath: fixture.configPath,
       wikiRoot: fixture.wikiRoot,
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now: new Date(FIXTURE_NOW),
     });
 
     expect(report.items).toContainEqual(
@@ -183,6 +198,73 @@ describe("wiki-status report rendering (#930)", () => {
         verdict: "never_ingested",
         nextAction: "Run /lisa-wiki:ingest --source docs.",
       })
+    );
+  });
+
+  it("derives fresh, stale, never-ingested, skipped, and blocked verdicts from fixture evidence", () => {
+    const fixture = makeWikiFixture();
+    const oldConnector = "confluence";
+    const blockedConnector = "jira";
+
+    addConnector(fixture.configPath, oldConnector);
+    addConnector(fixture.configPath, "docs");
+    addConnector(fixture.configPath, blockedConnector);
+    writeText(
+      path.join(
+        fixture.wikiRoot,
+        `sources/${oldConnector}/2026-05-10-space.md`
+      ),
+      "# Confluence source\n"
+    );
+    writeJson(
+      path.join(fixture.wikiRoot, `state/${oldConnector}/latest.json`),
+      {
+        connector: oldConnector,
+        ingested_at: "2026-05-10T09:00:00.000Z",
+        source_notes: [`wiki/sources/${oldConnector}/2026-05-10-space.md`],
+      }
+    );
+    writeText(
+      path.join(fixture.wikiRoot, "log.md"),
+      `${readUtf8(path.join(fixture.wikiRoot, "log.md"))}\n## 2026-05-26 - Connector blockers\n\n- Blocked \`${blockedConnector}\` because Atlassian MCP credentials are missing.\n`
+    );
+
+    const report = createWikiFreshnessReport({
+      configPath: fixture.configPath,
+      wikiRoot: fixture.wikiRoot,
+      now: new Date(FIXTURE_NOW),
+    });
+
+    expect(report.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ connector: "git", verdict: "fresh" }),
+        expect.objectContaining({
+          connector: oldConnector,
+          verdict: "stale",
+          lastObserved: "2026-05-10",
+          nextAction: `Run /lisa-wiki:ingest --source ${oldConnector}.`,
+        }),
+        expect.objectContaining({
+          connector: "docs",
+          verdict: "never_ingested",
+          nextAction: "Run /lisa-wiki:ingest --source docs.",
+        }),
+        expect.objectContaining({
+          connector: "memory",
+          verdict: "skipped",
+          reason: expect.stringContaining(
+            "no provably project-scoped memory directory"
+          ),
+          nextAction:
+            "Provide project-scoped memory for this repo, or accept the expected skip.",
+        }),
+        expect.objectContaining({
+          connector: blockedConnector,
+          verdict: "blocked",
+          reason: expect.stringContaining("Atlassian MCP credentials"),
+          nextAction: `Resolve the blocker, then run /lisa-wiki:ingest --source ${blockedConnector}.`,
+        }),
+      ])
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add fixture helper coverage for read-only wiki-status connector setup
- Cover fresh, stale, never-ingested, skipped, and blocked source freshness verdicts
- Preserve the Lisa repository project-scoped memory skip expectation

Closes #928

## Validation
- bun test tests/unit/strategies/wiki-status-report-rendering.test.ts
- bun run typecheck
- bun run lint
- bun run check:plugins
- pre-push: bun audit, slow lint, knip, unit coverage, integration tests