### PR TITLE
fix(queue-status): apply default GitHub reader labels

### DIFF
--- a/plugins/lisa/scripts/queue-status-build-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-build-readers.mjs
@@ -9,6 +9,7 @@
  */
 
 import { classifyQueueHealth } from "./queue-health-classification.mjs";
+import { resolveBuildLifecycleRoles } from "./queue-contract-resolution.mjs";
 
 export const BUILD_LIFECYCLE_ORDER = [
   "ready",
@@ -60,7 +61,7 @@ const HIGHLIGHT_COPY = {
  * }} input
  */
 export function readGithubBuildQueueSnapshot(input = {}) {
-  const roles = input.roles ?? {};
+  const roles = input.roles ?? resolveBuildLifecycleRoles({}, "github").roles;
   const normalizedItems = (input.issues ?? [])
     .map(issue => normalizeGithubBuildIssue(issue, roles))
     .filter(Boolean);

--- a/plugins/lisa/scripts/queue-status-prd-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-prd-readers.mjs
@@ -9,6 +9,7 @@
  */
 
 import { classifyQueueHealth } from "./queue-health-classification.mjs";
+import { resolvePrdLifecycleRoles } from "./queue-contract-resolution.mjs";
 
 export const PRD_LIFECYCLE_ORDER = [
   "draft",
@@ -67,7 +68,7 @@ const HIGHLIGHT_COPY = {
  * }} input
  */
 export function readGithubPrdQueueSnapshot(input = {}) {
-  const roles = input.roles ?? {};
+  const roles = input.roles ?? resolvePrdLifecycleRoles({}, "github").roles;
   const normalizedItems = (input.issues ?? [])
     .map(issue => normalizeGithubPrdIssue(issue, roles))
     .filter(Boolean);

--- a/plugins/src/base/scripts/queue-status-build-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-build-readers.mjs
@@ -9,6 +9,7 @@
  */
 
 import { classifyQueueHealth } from "./queue-health-classification.mjs";
+import { resolveBuildLifecycleRoles } from "./queue-contract-resolution.mjs";
 
 export const BUILD_LIFECYCLE_ORDER = [
   "ready",
@@ -60,7 +61,7 @@ const HIGHLIGHT_COPY = {
  * }} input
  */
 export function readGithubBuildQueueSnapshot(input = {}) {
-  const roles = input.roles ?? {};
+  const roles = input.roles ?? resolveBuildLifecycleRoles({}, "github").roles;
   const normalizedItems = (input.issues ?? [])
     .map(issue => normalizeGithubBuildIssue(issue, roles))
     .filter(Boolean);

--- a/plugins/src/base/scripts/queue-status-prd-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-prd-readers.mjs
@@ -9,6 +9,7 @@
  */
 
 import { classifyQueueHealth } from "./queue-health-classification.mjs";
+import { resolvePrdLifecycleRoles } from "./queue-contract-resolution.mjs";
 
 export const PRD_LIFECYCLE_ORDER = [
   "draft",
@@ -67,7 +68,7 @@ const HIGHLIGHT_COPY = {
  * }} input
  */
 export function readGithubPrdQueueSnapshot(input = {}) {
-  const roles = input.roles ?? {};
+  const roles = input.roles ?? resolvePrdLifecycleRoles({}, "github").roles;
   const normalizedItems = (input.issues ?? [])
     .map(issue => normalizeGithubPrdIssue(issue, roles))
     .filter(Boolean);

--- a/tests/unit/strategies/queue-status-build-readers.test.ts
+++ b/tests/unit/strategies/queue-status-build-readers.test.ts
@@ -140,6 +140,21 @@ describe("queue-status build readers (#825)", () => {
     });
   });
 
+  it("applies default GitHub build labels when roles are omitted", () => {
+    const snapshot = readGithubBuildQueueSnapshot({
+      namespaceAdopted: true,
+      issues: [
+        {
+          number: 875,
+          title: "Ready build item using the default label",
+          labels: [{ name: GITHUB_READY_LABEL }],
+        },
+      ],
+    });
+
+    expect(snapshot.counts.ready).toBe(1);
+  });
+
   it("fails loudly when a non-GitHub tracker has no raw reader input", () => {
     const snapshot = createBuildQueueSnapshot({
       tracker: "linear",

--- a/tests/unit/strategies/queue-status-prd-readers.test.ts
+++ b/tests/unit/strategies/queue-status-prd-readers.test.ts
@@ -146,6 +146,21 @@ describe("queue-status PRD readers (#824)", () => {
     });
   });
 
+  it("applies default GitHub PRD labels when roles are omitted", () => {
+    const snapshot = readGithubPrdQueueSnapshot({
+      namespaceAdopted: true,
+      issues: [
+        {
+          number: 875,
+          title: "Ready PRD using the default label",
+          labels: [{ name: GITHUB_PRD_ROLES.ready }],
+        },
+      ],
+    });
+
+    expect(snapshot.counts.ready).toBe(1);
+  });
+
   it("fails loudly when a non-GitHub source has no raw reader input", () => {
     const snapshot = createPrdQueueSnapshot({
       source: "confluence",


### PR DESCRIPTION
## Summary
- Apply shared GitHub build/PRD lifecycle defaults before raw queue-status label matching when `roles` is omitted.
- Add regressions for omitted-role GitHub build and PRD snapshots.
- Rebuild generated `plugins/lisa` reader artifacts from `plugins/src/base`.

Fixes #875

## Verification
- `bun test tests/unit/strategies/queue-status-build-readers.test.ts tests/unit/strategies/queue-status-prd-readers.test.ts`
- `bun test tests/unit/strategies/queue-status-build-readers.test.ts tests/unit/strategies/queue-status-prd-readers.test.ts tests/unit/strategies/queue-contract-resolution.test.ts tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts`
- `bun run check:plugins`
- pre-commit hook: gitleaks, typecheck, lint-staged
- pre-push hook: `bun audit`, slow lint, knip, full unit coverage, integration tests
