### PR TITLE
fix: parse latest Codex automation memory run

### DIFF
--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,7 @@ import path from "node:path";
 import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
+const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
 const RUN_FAILURE_PATTERN =
   /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
 const NEGATED_FAILURE_PATTERN =
@@ -211,25 +212,47 @@ export function parseCodexAutomationMemory(memoryContent) {
     };
   }
 
-  const timestampMatch = memoryContent.match(
-    /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/
-  );
   const lines = memoryContent.split(/\r?\n/);
+  const latestBlock = findLatestAutomationMemoryBlock(lines);
   const summaryLine =
-    lines
+    latestBlock.lines
       .find(line => line.startsWith("- "))
       ?.replace(/^- /, "")
       .trim() ?? null;
 
-  const latestBlock = lines.slice(0, 20).join("\n");
+  const latestBlockText = latestBlock.lines.join("\n");
   const lastRunFailed =
-    RUN_FAILURE_PATTERN.test(latestBlock) &&
-    !NEGATED_FAILURE_PATTERN.test(latestBlock);
+    RUN_FAILURE_PATTERN.test(latestBlockText) &&
+    !NEGATED_FAILURE_PATTERN.test(latestBlockText);
 
   return {
-    lastRunAt: timestampMatch?.[0] ?? null,
+    lastRunAt: latestBlock.timestamp,
     lastRunSummary: summaryLine,
     lastRunFailed,
+  };
+}
+
+function findLatestAutomationMemoryBlock(lines) {
+  const timestampLines = lines
+    .map((line, index) => ({
+      index,
+      timestamp: line.match(RUN_TIMESTAMP_PATTERN)?.[0] ?? null,
+    }))
+    .filter(entry => entry.timestamp);
+
+  if (timestampLines.length === 0) {
+    return {
+      timestamp: null,
+      lines,
+    };
+  }
+
+  const latest = timestampLines.at(-1);
+  const next = timestampLines.find(entry => entry.index > latest.index);
+
+  return {
+    timestamp: latest.timestamp,
+    lines: lines.slice(latest.index, next?.index),
   };
 }
 

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,7 @@ import path from "node:path";
 import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
+const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
 const RUN_FAILURE_PATTERN =
   /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
 const NEGATED_FAILURE_PATTERN =
@@ -211,25 +212,47 @@ export function parseCodexAutomationMemory(memoryContent) {
     };
   }
 
-  const timestampMatch = memoryContent.match(
-    /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/
-  );
   const lines = memoryContent.split(/\r?\n/);
+  const latestBlock = findLatestAutomationMemoryBlock(lines);
   const summaryLine =
-    lines
+    latestBlock.lines
       .find(line => line.startsWith("- "))
       ?.replace(/^- /, "")
       .trim() ?? null;
 
-  const latestBlock = lines.slice(0, 20).join("\n");
+  const latestBlockText = latestBlock.lines.join("\n");
   const lastRunFailed =
-    RUN_FAILURE_PATTERN.test(latestBlock) &&
-    !NEGATED_FAILURE_PATTERN.test(latestBlock);
+    RUN_FAILURE_PATTERN.test(latestBlockText) &&
+    !NEGATED_FAILURE_PATTERN.test(latestBlockText);
 
   return {
-    lastRunAt: timestampMatch?.[0] ?? null,
+    lastRunAt: latestBlock.timestamp,
     lastRunSummary: summaryLine,
     lastRunFailed,
+  };
+}
+
+function findLatestAutomationMemoryBlock(lines) {
+  const timestampLines = lines
+    .map((line, index) => ({
+      index,
+      timestamp: line.match(RUN_TIMESTAMP_PATTERN)?.[0] ?? null,
+    }))
+    .filter(entry => entry.timestamp);
+
+  if (timestampLines.length === 0) {
+    return {
+      timestamp: null,
+      lines,
+    };
+  }
+
+  const latest = timestampLines.at(-1);
+  const next = timestampLines.find(entry => entry.index > latest.index);
+
+  return {
+    timestamp: latest.timestamp,
+    lines: lines.slice(latest.index, next?.index),
   };
 }
 

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -26,6 +26,7 @@ const BUILD_INTAKE_CADENCE = "every 10 minutes";
 const BUILD_INTAKE_COMMAND = "/lisa:intake github intake_mode=build";
 const BUILD_INTAKE_RRULE = "FREQ=MINUTELY;INTERVAL=10";
 const BUILD_INTAKE_AUTOMATION_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
+const RECENT_RUN_AT = "2026-05-26T12:00:00Z";
 
 describe("automation-status Codex adapter (#801)", () => {
   const tempDirs = [];
@@ -86,7 +87,7 @@ describe("automation-status Codex adapter (#801)", () => {
     const report = await inspectCodexAutomationFleet({
       expectedFleet,
       automationsDir,
-      now: "2026-05-26T12:00:00Z",
+      now: RECENT_RUN_AT,
     });
 
     expect(report.runtime).toContain("Codex automations");
@@ -173,21 +174,37 @@ describe("automation-status Codex adapter (#801)", () => {
   it("does not classify negated error or exception summaries as failures (#885)", () => {
     expect(
       parseCodexAutomationMemory(
-        "2026-05-26T12:00:00Z\n\n- completed with no errors\n"
+        `${RECENT_RUN_AT}\n\n- completed with no errors\n`
       ).lastRunFailed
     ).toBe(false);
 
     expect(
       parseCodexAutomationMemory(
-        "2026-05-26T12:00:00Z\n\n- ran without exceptions\n"
+        `${RECENT_RUN_AT}\n\n- ran without exceptions\n`
       ).lastRunFailed
     ).toBe(false);
 
     expect(
       parseCodexAutomationMemory(
-        "2026-05-26T12:00:00Z\n\n- encountered an exception\n"
+        `${RECENT_RUN_AT}\n\n- encountered an exception\n`
       ).lastRunFailed
     ).toBe(true);
+  });
+
+  it("uses the newest append-only memory run for timestamps and failure state (#881)", () => {
+    const memory = [
+      "# Lisa Build Intake Automation Memory",
+      "",
+      "- 2025-01-01T00:00:00Z: Completed successfully with no errors.",
+      `- ${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
+      "",
+    ].join("\n");
+
+    expect(parseCodexAutomationMemory(memory)).toEqual({
+      lastRunAt: RECENT_RUN_AT,
+      lastRunSummary: `${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
+      lastRunFailed: true,
+    });
   });
 
   it("inspects automation files read-only", async () => {


### PR DESCRIPTION
## Summary
- Parse Codex automation memory by selecting the newest append-only run block instead of the first timestamp/bullet.
- Derive last-run summary and failure state from that same latest block.
- Add regression coverage for issue #881 and regenerate the Lisa plugin mirror.

Fixes #881

## Verification
- bun test tests/unit/strategies/automation-status-codex-adapter.test.ts
- bun run typecheck
- bun run lint
- bun run check:plugins
- pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests