### PR TITLE
fix: repair automation-status fleet matching

### DIFF
--- a/plugins/lisa/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-claude-adapter.mjs
@@ -9,7 +9,7 @@
  * Claude does not expose last-run or failure metadata.
  */
 
-import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -80,11 +80,13 @@ export function inspectClaudeAutomationFleet(input) {
     ["exploratory", []],
   ]);
 
-  for (const expected of expectedFleet.expected) {
-    const comparison = compareAutomationContract({
-      expected,
-      observedAutomations,
-    });
+  const comparisons = compareAutomationFleet({
+    expectedAutomations: expectedFleet.expected,
+    observedAutomations,
+  });
+
+  for (const [index, expected] of expectedFleet.expected.entries()) {
+    const comparison = comparisons[index];
     expectedGroups.get(expected.group)?.push(
       createObservedStatusItem({
         expected,

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -14,7 +14,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -83,11 +83,13 @@ export async function inspectCodexAutomationFleet(input) {
     ["exploratory", []],
   ]);
 
-  for (const expected of expectedFleet.expected) {
-    const comparison = compareAutomationContract({
-      expected,
-      observedAutomations,
-    });
+  const comparisons = compareAutomationFleet({
+    expectedAutomations: expectedFleet.expected,
+    observedAutomations,
+  });
+
+  for (const [index, expected] of expectedFleet.expected.entries()) {
+    const comparison = comparisons[index];
     expectedGroups.get(expected.group)?.push(
       createObservedStatusItem({
         expected,

--- a/plugins/lisa/scripts/automation-status-contract-drift.mjs
+++ b/plugins/lisa/scripts/automation-status-contract-drift.mjs
@@ -40,6 +40,41 @@ const DRIFT_LABELS = {
  */
 
 /**
+ * Compare the expected automation fleet against observed scheduler entries,
+ * consuming each observed automation at most once.
+ *
+ * @param {{
+ *   readonly expectedAutomations: readonly ExpectedAutomationContract[]
+ *   readonly observedAutomations?: readonly ObservedAutomationContract[]
+ * }} input
+ * @returns {readonly AutomationContractComparison[]}
+ */
+export function compareAutomationFleet(input) {
+  const remainingObserved = [...(input.observedAutomations ?? [])];
+
+  return input.expectedAutomations.map(expected => {
+    const observed = findObservedAutomationMatch(
+      expected,
+      remainingObserved,
+      input.expectedAutomations
+    );
+    const comparison = compareAutomationContract({
+      expected,
+      observedAutomation: observed,
+    });
+
+    if (observed) {
+      const index = remainingObserved.indexOf(observed);
+      if (index >= 0) {
+        remainingObserved.splice(index, 1);
+      }
+    }
+
+    return comparison;
+  });
+}
+
+/**
  * Find the best observed scheduler entry for an expected automation contract.
  *
  * Match order is:
@@ -50,11 +85,13 @@ const DRIFT_LABELS = {
  *
  * @param {ExpectedAutomationContract} expected
  * @param {readonly ObservedAutomationContract[]} observedAutomations
+ * @param {readonly ExpectedAutomationContract[]} expectedAutomations
  * @returns {ObservedAutomationContract | null}
  */
 export function findObservedAutomationMatch(
   expected,
-  observedAutomations = []
+  observedAutomations = [],
+  expectedAutomations = [expected]
 ) {
   const exactId = observedAutomations.find(
     observed => observed.automationId === expected.automationId
@@ -97,6 +134,15 @@ export function findObservedAutomationMatch(
   });
   if (exactCommand) {
     return exactCommand;
+  }
+
+  if (
+    isSharedExpectedCommandToken(
+      expectedCommand.commandToken,
+      expectedAutomations
+    )
+  ) {
+    return null;
   }
 
   return (
@@ -159,6 +205,24 @@ export function compareAutomationContract(input) {
     driftKinds,
     observedAutomation: observed,
   };
+}
+
+/**
+ * @param {string} commandToken
+ * @param {readonly ExpectedAutomationContract[]} expectedAutomations
+ * @returns {boolean}
+ */
+function isSharedExpectedCommandToken(commandToken, expectedAutomations) {
+  if (!commandToken) {
+    return false;
+  }
+
+  return (
+    expectedAutomations.filter(expected => {
+      const normalized = normalizeAutomationCommand(expected.expectedCommand);
+      return normalized.commandToken === commandToken;
+    }).length > 1
+  );
 }
 
 /**

--- a/plugins/src/base/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-claude-adapter.mjs
@@ -9,7 +9,7 @@
  * Claude does not expose last-run or failure metadata.
  */
 
-import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -80,11 +80,13 @@ export function inspectClaudeAutomationFleet(input) {
     ["exploratory", []],
   ]);
 
-  for (const expected of expectedFleet.expected) {
-    const comparison = compareAutomationContract({
-      expected,
-      observedAutomations,
-    });
+  const comparisons = compareAutomationFleet({
+    expectedAutomations: expectedFleet.expected,
+    observedAutomations,
+  });
+
+  for (const [index, expected] of expectedFleet.expected.entries()) {
+    const comparison = comparisons[index];
     expectedGroups.get(expected.group)?.push(
       createObservedStatusItem({
         expected,

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -14,7 +14,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { compareAutomationContract } from "./automation-status-contract-drift.mjs";
+import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -83,11 +83,13 @@ export async function inspectCodexAutomationFleet(input) {
     ["exploratory", []],
   ]);
 
-  for (const expected of expectedFleet.expected) {
-    const comparison = compareAutomationContract({
-      expected,
-      observedAutomations,
-    });
+  const comparisons = compareAutomationFleet({
+    expectedAutomations: expectedFleet.expected,
+    observedAutomations,
+  });
+
+  for (const [index, expected] of expectedFleet.expected.entries()) {
+    const comparison = comparisons[index];
     expectedGroups.get(expected.group)?.push(
       createObservedStatusItem({
         expected,

--- a/plugins/src/base/scripts/automation-status-contract-drift.mjs
+++ b/plugins/src/base/scripts/automation-status-contract-drift.mjs
@@ -40,6 +40,41 @@ const DRIFT_LABELS = {
  */
 
 /**
+ * Compare the expected automation fleet against observed scheduler entries,
+ * consuming each observed automation at most once.
+ *
+ * @param {{
+ *   readonly expectedAutomations: readonly ExpectedAutomationContract[]
+ *   readonly observedAutomations?: readonly ObservedAutomationContract[]
+ * }} input
+ * @returns {readonly AutomationContractComparison[]}
+ */
+export function compareAutomationFleet(input) {
+  const remainingObserved = [...(input.observedAutomations ?? [])];
+
+  return input.expectedAutomations.map(expected => {
+    const observed = findObservedAutomationMatch(
+      expected,
+      remainingObserved,
+      input.expectedAutomations
+    );
+    const comparison = compareAutomationContract({
+      expected,
+      observedAutomation: observed,
+    });
+
+    if (observed) {
+      const index = remainingObserved.indexOf(observed);
+      if (index >= 0) {
+        remainingObserved.splice(index, 1);
+      }
+    }
+
+    return comparison;
+  });
+}
+
+/**
  * Find the best observed scheduler entry for an expected automation contract.
  *
  * Match order is:
@@ -50,11 +85,13 @@ const DRIFT_LABELS = {
  *
  * @param {ExpectedAutomationContract} expected
  * @param {readonly ObservedAutomationContract[]} observedAutomations
+ * @param {readonly ExpectedAutomationContract[]} expectedAutomations
  * @returns {ObservedAutomationContract | null}
  */
 export function findObservedAutomationMatch(
   expected,
-  observedAutomations = []
+  observedAutomations = [],
+  expectedAutomations = [expected]
 ) {
   const exactId = observedAutomations.find(
     observed => observed.automationId === expected.automationId
@@ -97,6 +134,15 @@ export function findObservedAutomationMatch(
   });
   if (exactCommand) {
     return exactCommand;
+  }
+
+  if (
+    isSharedExpectedCommandToken(
+      expectedCommand.commandToken,
+      expectedAutomations
+    )
+  ) {
+    return null;
   }
 
   return (
@@ -159,6 +205,24 @@ export function compareAutomationContract(input) {
     driftKinds,
     observedAutomation: observed,
   };
+}
+
+/**
+ * @param {string} commandToken
+ * @param {readonly ExpectedAutomationContract[]} expectedAutomations
+ * @returns {boolean}
+ */
+function isSharedExpectedCommandToken(commandToken, expectedAutomations) {
+  if (!commandToken) {
+    return false;
+  }
+
+  return (
+    expectedAutomations.filter(expected => {
+      const normalized = normalizeAutomationCommand(expected.expectedCommand);
+      return normalized.commandToken === commandToken;
+    }).length > 1
+  );
 }
 
 /**

--- a/tests/unit/strategies/automation-status-contract-drift.test.ts
+++ b/tests/unit/strategies/automation-status-contract-drift.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   compareAutomationContract,
+  compareAutomationFleet,
   findObservedAutomationMatch,
 } from "../../../plugins/src/base/scripts/automation-status-contract-drift.mjs";
 
@@ -18,6 +19,8 @@ describe("automation-status contract drift (#800)", () => {
   const EXPECTED_CADENCE = "every 10 minutes";
   const EXPECTED_RRULE = "FREQ=MINUTELY;INTERVAL=10";
   const EXPECTED_COMMAND = "/lisa:intake github intake_mode=build";
+  const HOURLY_CADENCE = "every 60 minutes";
+  const HOURLY_RRULE = "FREQ=HOURLY;INTERVAL=1";
 
   const expected = {
     automationId: EXPECTED_AUTOMATION_ID,
@@ -94,15 +97,15 @@ describe("automation-status contract drift (#800)", () => {
     const comparison = compareAutomationContract({
       expected: {
         automationId: "lisa-auto-acme-repair",
-        expectedCadence: "every 60 minutes",
-        expectedRRule: "FREQ=HOURLY;INTERVAL=1",
+        expectedCadence: HOURLY_CADENCE,
+        expectedRRule: HOURLY_RRULE,
         expectedCommand:
           "/lisa:repair-intake github intake_mode=both assignee=codyswanngt",
       },
       observedAutomation: {
         automationId: "lisa-auto-acme-repair",
-        observedCadence: "every 60 minutes",
-        observedRRule: "FREQ=HOURLY;INTERVAL=1",
+        observedCadence: HOURLY_CADENCE,
+        observedRRule: HOURLY_RRULE,
         observedCommand:
           "/lisa:repair-intake github assignee=codyswanngt intake_mode=both",
       },
@@ -139,6 +142,47 @@ describe("automation-status contract drift (#800)", () => {
         status: "MISSING",
         summary: "expected automation is missing",
         observedAutomation: null,
+      })
+    );
+  });
+
+  it("does not let one observed intake job satisfy multiple expected contracts", () => {
+    const prdExpected = {
+      automationId: "lisa-auto-codyswanngt-lisa-intake-prd",
+      expectedCadence: HOURLY_CADENCE,
+      expectedRRule: HOURLY_RRULE,
+      expectedCommand: "/lisa:intake github intake_mode=prd",
+    };
+    const buildExpected = {
+      automationId: EXPECTED_AUTOMATION_ID,
+      expectedCadence: EXPECTED_CADENCE,
+      expectedRRule: EXPECTED_RRULE,
+      expectedCommand: EXPECTED_COMMAND,
+    };
+
+    const comparisons = compareAutomationFleet({
+      expectedAutomations: [prdExpected, buildExpected],
+      observedAutomations: [
+        {
+          automationId: EXPECTED_AUTOMATION_ID,
+          observedCadence: EXPECTED_CADENCE,
+          observedRRule: EXPECTED_RRULE,
+          observedCommand: EXPECTED_COMMAND,
+        },
+      ],
+    });
+
+    expect(comparisons).toHaveLength(2);
+    expect(comparisons[0]).toEqual(
+      expect.objectContaining({
+        status: "MISSING",
+        observedAutomation: null,
+      })
+    );
+    expect(comparisons[1]).toEqual(
+      expect.objectContaining({
+        status: "HEALTHY",
+        driftKinds: [],
       })
     );
   });


### PR DESCRIPTION
## Summary
- add fleet-level automation contract comparison that consumes each observed automation once
- prevent token-only fallback for non-unique expected command tokens like shared `/lisa:intake` jobs
- wire Claude and Codex automation-status adapters through the fleet comparator and sync generated plugin artifacts

Closes #883

## Verification
- bun run test:unit -- tests/unit/strategies/automation-status-contract-drift.test.ts tests/unit/strategies/automation-status-fixture-smoke-and-parity.test.ts
- bun run typecheck
- bun run lint -- plugins/src/base/scripts/automation-status-contract-drift.mjs plugins/src/base/scripts/automation-status-codex-adapter.mjs plugins/src/base/scripts/automation-status-claude-adapter.mjs tests/unit/strategies/automation-status-contract-drift.test.ts
- bun run check:plugins
- pre-push hook: bun audit, slow eslint, knip, vitest run --coverage, vitest run tests/integration