### PR TITLE
fix(ci): stop filing 'Claude auto-fix failed' issues when loop-guard intentionally skipped

### DIFF
--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       fixed: ${{ steps.check-fix.outputs.fixed }}
+      skipped_loop: ${{ steps.loop-guard.outputs.skip }}
     permissions:
       contents: write
       pull-requests: write
@@ -223,6 +224,7 @@ jobs:
     if: |
       always() &&
       needs.auto-fix.result != 'skipped' &&
+      needs.auto-fix.outputs.skipped_loop != 'true' &&
       needs.auto-fix.outputs.fixed != 'true'
     uses: CodySwannGT/lisa/.github/workflows/create-issue-on-failure.yml@main
     with:

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -337,17 +337,30 @@ describe("Lisa Integration Tests", () => {
         },
       });
 
-      const result = await createLisa().apply();
+      // Stub the `claude` CLI so plugin registration doesn't hit network/real
+      // marketplace and the test stays fast under full-suite contention.
+      const stubBin = path.join(tempDir, "stub-bin");
+      await fs.ensureDir(stubBin);
+      const stubClaude = path.join(stubBin, "claude");
+      await fs.writeFile(stubClaude, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${stubBin}:${originalPath ?? ""}`;
 
-      expect(result.success).toBe(true);
-      const settings = await fs.readJson(
-        path.join(destDir, ".claude", SETTINGS_JSON)
-      );
-      expect(settings.enabledPlugins["test-plugin@test-marketplace"]).toBe(
-        true
-      );
-      // Existing project keys preserved
-      expect(settings.env.SOME_VAR).toBe("1");
+      try {
+        const result = await createLisa().apply();
+
+        expect(result.success).toBe(true);
+        const settings = await fs.readJson(
+          path.join(destDir, ".claude", SETTINGS_JSON)
+        );
+        expect(settings.enabledPlugins["test-plugin@test-marketplace"]).toBe(
+          true
+        );
+        // Existing project keys preserved
+        expect(settings.env.SOME_VAR).toBe("1");
+      } finally {
+        process.env.PATH = originalPath;
+      }
     });
 
     it("applies all/ configs to project with no detected types", async () => {


### PR DESCRIPTION
## Summary

- Fixes [#960](https://github.com/CodySwannGT/lisa/issues/960) and the pattern of spurious "Claude auto-fix failed — manual intervention needed" issues filed whenever `claude[bot]`-authored commits trigger CI failures.
- Surfaces the loop-guard `skip` flag as a job output and excludes it from the `create-issue` gate so deliberate no-ops stay silent.
- Also fixes a flaky integration test (`registers plugins at project scope`) that timed out at 10s under full-suite contention by stubbing the real `claude` CLI via PATH.

## Root cause

The `auto-fix` job in `.github/workflows/reusable-claude-ci-auto-fix.yml` runs a loop-guard step that sets `skip=true` when the last commit was already authored by `claude[bot]` or `github-actions[bot]` (to prevent an auto-fix infinite loop). All downstream steps — including the one that sets `outputs.fixed` — are then conditionally skipped, but the job itself still finishes with `result=success` and `outputs.fixed=''`.

The `create-issue` gate only excluded `result == 'skipped'`, so a deliberate loop-guard bail was misclassified as "Claude couldn't fix it" and an issue was filed every time.

## Host project impact

Host projects pin the reusable workflow to `@main`, so they pick up this fix automatically the moment it merges — no template-bump needed.

## Test plan

- [x] All 2397 unit/integration tests pass locally
- [x] CI Quality Checks pass on this PR
- [ ] Confirm a future `claude[bot]` CI failure on a `codex/issue-*` branch does NOT file a new "manual intervention needed" issue

🤖 Generated with Claude Code

Co-Authored-By: Claude