### PR TITLE
Fix invalid PRD role override resolution

### DIFF
--- a/plugins/lisa/scripts/queue-contract-resolution.mjs
+++ b/plugins/lisa/scripts/queue-contract-resolution.mjs
@@ -216,7 +216,8 @@ export function resolvePrdLifecycleRoles(
         kind: "labels",
         roles: resolveObjectRoles(
           config.github?.labels?.prd,
-          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -230,7 +231,8 @@ export function resolvePrdLifecycleRoles(
         kind: "labels",
         roles: resolveObjectRoles(
           config.linear?.labels?.prd,
-          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -245,7 +247,8 @@ export function resolvePrdLifecycleRoles(
         statusProperty: config.notion?.statusProperty || "Status",
         roles: resolveObjectRoles(
           config.notion?.values,
-          DEFAULT_NOTION_PRD_ROLES
+          DEFAULT_NOTION_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -259,7 +262,8 @@ export function resolvePrdLifecycleRoles(
         kind: "parent-pages",
         roles: resolveObjectRoles(
           config.confluence?.parents,
-          DEFAULT_CONFLUENCE_PARENT_ROLES
+          DEFAULT_CONFLUENCE_PARENT_ROLES,
+          { allowNull: true }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -374,13 +378,24 @@ export function resolveQueueContract(input = {}) {
 /**
  * @param {Record<string, any> | undefined} values
  * @param {Record<string, any>} defaults
+ * @param {{ readonly allowNull?: boolean }} [options]
  * @returns {Record<string, any>}
  */
-function resolveObjectRoles(values, defaults) {
-  return {
-    ...defaults,
-    ...(values ?? {}),
-  };
+function resolveObjectRoles(values, defaults, options = {}) {
+  const resolved = { ...defaults };
+
+  for (const [key, value] of Object.entries(values ?? {})) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      resolved[key] = value;
+      continue;
+    }
+
+    if (options.allowNull === true && value === null) {
+      resolved[key] = value;
+    }
+  }
+
+  return resolved;
 }
 
 /**

--- a/plugins/src/base/scripts/queue-contract-resolution.mjs
+++ b/plugins/src/base/scripts/queue-contract-resolution.mjs
@@ -216,7 +216,8 @@ export function resolvePrdLifecycleRoles(
         kind: "labels",
         roles: resolveObjectRoles(
           config.github?.labels?.prd,
-          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -230,7 +231,8 @@ export function resolvePrdLifecycleRoles(
         kind: "labels",
         roles: resolveObjectRoles(
           config.linear?.labels?.prd,
-          DEFAULT_GITHUB_LINEAR_PRD_ROLES
+          DEFAULT_GITHUB_LINEAR_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -245,7 +247,8 @@ export function resolvePrdLifecycleRoles(
         statusProperty: config.notion?.statusProperty || "Status",
         roles: resolveObjectRoles(
           config.notion?.values,
-          DEFAULT_NOTION_PRD_ROLES
+          DEFAULT_NOTION_PRD_ROLES,
+          { allowNull: false }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -259,7 +262,8 @@ export function resolvePrdLifecycleRoles(
         kind: "parent-pages",
         roles: resolveObjectRoles(
           config.confluence?.parents,
-          DEFAULT_CONFLUENCE_PARENT_ROLES
+          DEFAULT_CONFLUENCE_PARENT_ROLES,
+          { allowNull: true }
         ),
         rollup: {
           closeOnShipped: Boolean(
@@ -374,13 +378,24 @@ export function resolveQueueContract(input = {}) {
 /**
  * @param {Record<string, any> | undefined} values
  * @param {Record<string, any>} defaults
+ * @param {{ readonly allowNull?: boolean }} [options]
  * @returns {Record<string, any>}
  */
-function resolveObjectRoles(values, defaults) {
-  return {
-    ...defaults,
-    ...(values ?? {}),
-  };
+function resolveObjectRoles(values, defaults, options = {}) {
+  const resolved = { ...defaults };
+
+  for (const [key, value] of Object.entries(values ?? {})) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      resolved[key] = value;
+      continue;
+    }
+
+    if (options.allowNull === true && value === null) {
+      resolved[key] = value;
+    }
+  }
+
+  return resolved;
 }
 
 /**

--- a/tests/unit/strategies/queue-contract-resolution.test.ts
+++ b/tests/unit/strategies/queue-contract-resolution.test.ts
@@ -181,4 +181,61 @@ describe("queue contract resolution (#822)", () => {
       },
     });
   });
+
+  it("ignores invalid GitHub PRD role overrides instead of disabling defaults", () => {
+    expect(
+      resolvePrdLifecycleRoles({
+        source: "github",
+        github: {
+          labels: {
+            prd: {
+              ready: "",
+              blocked: null,
+              ticketed: 123,
+              shipped: "custom-shipped",
+            },
+          },
+        },
+      }).roles
+    ).toMatchObject({
+      ready: "prd-ready",
+      blocked: "prd-blocked",
+      ticketed: "prd-ticketed",
+      shipped: "custom-shipped",
+    });
+  });
+
+  it("ignores invalid Notion status overrides while preserving Confluence null parent defaults", () => {
+    expect(
+      resolvePrdLifecycleRoles({
+        source: "notion",
+        notion: {
+          values: {
+            ready: null,
+            blocked: "",
+            ticketed: "Custom Ticketed",
+          },
+        },
+      }).roles
+    ).toMatchObject({
+      ready: "Ready",
+      blocked: "Blocked",
+      ticketed: "Custom Ticketed",
+    });
+
+    expect(
+      resolvePrdLifecycleRoles({
+        source: "confluence",
+        confluence: {
+          parents: {
+            ready: null,
+            blocked: "12345",
+          },
+        },
+      }).roles
+    ).toMatchObject({
+      ready: null,
+      blocked: "12345",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ignore null, empty, and non-string PRD role overrides for GitHub, Linear, and Notion so defaults stay readable
- preserve Confluence null parent-page roles while accepting valid string overrides
- add regression coverage and regenerate the Lisa plugin artifact

## Verification
- bun run test tests/unit/strategies/queue-contract-resolution.test.ts
- bun run typecheck
- bun run lint
- bun run check:plugins
- pre-push hook: bun audit, slow lint, knip, full unit coverage, integration tests

Closes #877