### PR TITLE
fix: gate claude workflow by author association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,9 +22,12 @@ permissions:
 
 jobs:
   claude:
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association || '')
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude.yml@main
     with:
       event_name: ${{ github.event_name }}
+      author_association: ${{ github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association || '' }}
       comment_body: ${{ github.event.comment.body || '' }}
       review_body: ${{ github.event.review.body || '' }}
       issue_body: ${{ github.event.issue.body || '' }}

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -10,6 +10,11 @@ on:
         description: 'The event that triggered the workflow'
         required: true
         type: string
+      author_association:
+        description: 'Author association of the event actor'
+        required: false
+        type: string
+        default: ''
       comment_body:
         description: 'Body of the comment (for issue_comment and PR review comment events)'
         required: false
@@ -37,10 +42,13 @@ on:
 jobs:
   claude:
     if: |
-      (inputs.event_name == 'issue_comment' && contains(inputs.comment_body, '@claude')) ||
-      (inputs.event_name == 'pull_request_review_comment' && contains(inputs.comment_body, '@claude')) ||
-      (inputs.event_name == 'pull_request_review' && contains(inputs.review_body, '@claude')) ||
-      (inputs.event_name == 'issues' && (contains(inputs.issue_body, '@claude') || contains(inputs.issue_title, '@claude')))
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), inputs.author_association) &&
+      (
+        (inputs.event_name == 'issue_comment' && contains(inputs.comment_body, '@claude')) ||
+        (inputs.event_name == 'pull_request_review_comment' && contains(inputs.comment_body, '@claude')) ||
+        (inputs.event_name == 'pull_request_review' && contains(inputs.review_body, '@claude')) ||
+        (inputs.event_name == 'issues' && (contains(inputs.issue_body, '@claude') || contains(inputs.issue_title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/typescript/create-only/.github/workflows/claude.yml
+++ b/typescript/create-only/.github/workflows/claude.yml
@@ -22,9 +22,12 @@ permissions:
 
 jobs:
   claude:
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association || '')
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude.yml@main
     with:
       event_name: ${{ github.event_name }}
+      author_association: ${{ github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association || '' }}
       comment_body: ${{ github.event.comment.body || '' }}
       review_body: ${{ github.event.review.body || '' }}
       issue_body: ${{ github.event.issue.body || '' }}


### PR DESCRIPTION
## Summary
- add an explicit author_association input to the reusable Claude workflow
- require OWNER, MEMBER, or COLLABORATOR before the privileged Claude job can run
- pass the event author_association from the Lisa caller and TypeScript create-only template

Closes #682

## Validation
- bunx prettier --check .github/workflows/claude.yml .github/workflows/reusable-claude.yml typescript/create-only/.github/workflows/claude.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/claude.yml .github/workflows/reusable-claude.yml typescript/create-only/.github/workflows/claude.yml\n- bun run typecheck\n- bun run lint\n- bun run test:unit\n- pre-push: bun audit, slow lint, knip, unit coverage, integration tests\n\nNote: `bunx actionlint ...` was attempted but the package did not expose a runnable executable in this environment, so YAML parse + repo checks were used instead.