### PR TITLE
Fix build queue namespace adoption detection

### DIFF
--- a/plugins/lisa/scripts/queue-status-build-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-build-readers.mjs
@@ -93,7 +93,8 @@ export function readGithubBuildQueueSnapshot(input = {}) {
 export function createBuildQueueSnapshot(input = {}) {
   const tracker = normalizeTracker(input.tracker);
   const unsupportedReaderError = resolveUnsupportedReaderError(input, tracker);
-  const roles = normalizeRoles(input.roles);
+  const rawRoles = input.roles ?? {};
+  const roles = normalizeRoles(rawRoles);
   const items = normalizeItems(input.items);
   const counts = buildLifecycleCounts(items);
   const repairSignals = buildRepairSignals(items, input.queueArgument);
@@ -108,7 +109,7 @@ export function createBuildQueueSnapshot(input = {}) {
       ? false
       : typeof input.resolutionError !== "string");
   const namespaceAdopted =
-    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, rawRoles);
   const resolutionError =
     unsupportedReaderError ?? input.resolutionError ?? null;
 
@@ -430,7 +431,25 @@ function inferNamespaceAdopted(items, roles) {
   return (
     ["ready", "claimed", "review", "blocked"].some(
       role => typeof roles[role] === "string" && roles[role].trim().length > 0
-    ) || resolveDoneRoleNames(roles).length > 0
+    ) || hasConfiguredDoneRole(roles?.done)
+  );
+}
+
+/**
+ * @param {unknown} done
+ * @returns {boolean}
+ */
+function hasConfiguredDoneRole(done) {
+  if (typeof done === "string") {
+    return done.trim().length > 0;
+  }
+
+  if (!done || typeof done !== "object") {
+    return false;
+  }
+
+  return Object.values(done).some(
+    value => typeof value === "string" && value.trim().length > 0
   );
 }
 

--- a/plugins/src/base/scripts/queue-status-build-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-build-readers.mjs
@@ -93,7 +93,8 @@ export function readGithubBuildQueueSnapshot(input = {}) {
 export function createBuildQueueSnapshot(input = {}) {
   const tracker = normalizeTracker(input.tracker);
   const unsupportedReaderError = resolveUnsupportedReaderError(input, tracker);
-  const roles = normalizeRoles(input.roles);
+  const rawRoles = input.roles ?? {};
+  const roles = normalizeRoles(rawRoles);
   const items = normalizeItems(input.items);
   const counts = buildLifecycleCounts(items);
   const repairSignals = buildRepairSignals(items, input.queueArgument);
@@ -108,7 +109,7 @@ export function createBuildQueueSnapshot(input = {}) {
       ? false
       : typeof input.resolutionError !== "string");
   const namespaceAdopted =
-    input.namespaceAdopted ?? inferNamespaceAdopted(items, roles);
+    input.namespaceAdopted ?? inferNamespaceAdopted(items, rawRoles);
   const resolutionError =
     unsupportedReaderError ?? input.resolutionError ?? null;
 
@@ -430,7 +431,25 @@ function inferNamespaceAdopted(items, roles) {
   return (
     ["ready", "claimed", "review", "blocked"].some(
       role => typeof roles[role] === "string" && roles[role].trim().length > 0
-    ) || resolveDoneRoleNames(roles).length > 0
+    ) || hasConfiguredDoneRole(roles?.done)
+  );
+}
+
+/**
+ * @param {unknown} done
+ * @returns {boolean}
+ */
+function hasConfiguredDoneRole(done) {
+  if (typeof done === "string") {
+    return done.trim().length > 0;
+  }
+
+  if (!done || typeof done !== "object") {
+    return false;
+  }
+
+  return Object.values(done).some(
+    value => typeof value === "string" && value.trim().length > 0
   );
 }
 

--- a/tests/unit/strategies/queue-status-build-readers.test.ts
+++ b/tests/unit/strategies/queue-status-build-readers.test.ts
@@ -22,6 +22,7 @@ const GITHUB_READY_LABEL = "status:ready";
 const GITHUB_CLAIMED_LABEL = "status:in-progress";
 const GITHUB_BLOCKED_LABEL = "status:blocked";
 const GITHUB_DONE_LABEL = "status:done";
+const GITHUB_BUILD_QUEUE_ARGUMENT = "github intake_mode=build";
 const GITHUB_DONE_ROLES = {
   dev: "status:on-dev",
   staging: "status:on-stg",
@@ -45,7 +46,7 @@ describe("queue-status build readers (#825)", () => {
   it("parses GitHub build lifecycle labels into counts, highlights, and repair signals", () => {
     const snapshot = readGithubBuildQueueSnapshot({
       namespaceAdopted: true,
-      queueArgument: "github intake_mode=build",
+      queueArgument: GITHUB_BUILD_QUEUE_ARGUMENT,
       roles: {
         ready: GITHUB_READY_LABEL,
         claimed: GITHUB_CLAIMED_LABEL,
@@ -130,10 +131,24 @@ describe("queue-status build readers (#825)", () => {
     const snapshot = createBuildQueueSnapshot({
       tracker: "github",
       namespaceAdopted: false,
-      queueArgument: "github intake_mode=build",
+      queueArgument: GITHUB_BUILD_QUEUE_ARGUMENT,
       items: [],
     });
 
+    expect(snapshot.health).toMatchObject({
+      verdict: "MISCONFIGURED",
+      reasons: ["lifecycle-namespace-absent"],
+    });
+  });
+
+  it("does not infer namespace adoption from normalized fallback roles", () => {
+    const snapshot = createBuildQueueSnapshot({
+      tracker: "github",
+      queueArgument: GITHUB_BUILD_QUEUE_ARGUMENT,
+      items: [],
+    });
+
+    expect(snapshot.namespaceAdopted).toBe(false);
     expect(snapshot.health).toMatchObject({
       verdict: "MISCONFIGURED",
       reasons: ["lifecycle-namespace-absent"],


### PR DESCRIPTION
## Summary
- use raw build lifecycle roles when inferring namespace adoption
- avoid treating normalized fallback labels, including done, as adoption evidence
- add regression coverage for empty build snapshots returning MISCONFIGURED

Closes #876

## Verification
- bun run vitest run tests/unit/strategies/queue-status-build-readers.test.ts
- bun run typecheck
- bun run lint
- bun run check:plugins
- git push pre-push hook: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration