### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -62,3 +62,10 @@
 - Refreshed the `git` source note with 60 new commits through `fd8db85fb79d5ea18628fdf071bbe761885d793f`, advanced the merged-PR cursor to `#905`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because only global Codex memory was available, and the connector refuses non-project-scoped memory.
 - Updated the monorepo snapshot synthesis for the latest intake-explain guidance, council and automation-status hardening, usage accounting fixes, and release-history changes.
+
+## 2026-05-26 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-26-173027`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 292 new commits through `1d85bcb3acff15cdf89216c81ceb7efe975b1565`, advanced the merged-PR cursor to `#971`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because only global Codex memory was available, and the connector refuses non-project-scoped memory.
+- Updated the monorepo snapshot synthesis for the latest wiki status/freshness work, queue and intake automation hardening, CI/GitHub automation fixes, council behavior, usage accounting, and release-history changes.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,19 +20,20 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-26-093056` from `origin/main`
-- HEAD at 2026-05-26 incremental ingest: `fd8db85fb79d5ea18628fdf071bbe761885d793f`
-- Current package version: `2.100.1`
-- Total commits on HEAD: 2080
-- Latest merged PR captured in the incremental git snapshot: `#905`
-- New commits since the previous incremental git cursor: `60`
+- Ingest branch: `wiki/ingest-2026-05-26-173027` from `origin/main`
+- HEAD at 2026-05-26 incremental ingest: `1d85bcb3acff15cdf89216c81ceb7efe975b1565`
+- Current package version: `2.106.0`
+- Total commits on HEAD: 2372
+- Latest merged PR captured in the incremental git snapshot: `#971`
+- New commits since the previous incremental git cursor: `292`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Intake-explain guidance expanded across scaffold, output contract, ownership readiness, contract resolution, build gates, and operator documentation.
-- Council and automation-status handling hardened around policy inputs, executor failures, missing flag values, and negated failure classification.
-- Usage accounting now preserves decimal cost totals, rejects invalid numeric tokens, keeps token serialization reversible, and recomputes merged usage rollups.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.98.1` through `2.100.1` during this incremental window.
+- Wiki operations gained status/freshness surfaces, source freshness parsing, read-only status verification, and distribution parity coverage.
+- Queue and intake automation hardened around unsupported vendor readers, default GitHub reader labels, invalid PRD role overrides, verified PRD closure, and missing build lifecycle namespaces.
+- CI and GitHub automation improved author-association gating, loop-guard issue handling, automation-status fleet matching, and Claude schedule cadence normalization.
+- Council and usage-accounting fixes continued, including guarded workspace handling, executor exceptions, non-dry-run council execution, currency rollups, and decimal/cost token handling.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.100.1` through `2.106.0` during this incremental window.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-26-lisa-monorepo-git.md
@@ -10,70 +10,210 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-26)
 
-- Repo: `.` (ingested from an isolated worktree rooted at `/tmp/lisa-wiki-ingest.ouRhK8`)
-- HEAD: `fd8db85fb79d5ea18628fdf071bbe761885d793f`
-- Total commits on HEAD: 2080
-- New commits since last ingest (`c4879d40b123baf4f38d4c5530090b9003d4217a`): 60
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #905 "fix: recompute merged usage rollups"
+- Repo: `.` (ingested from an isolated worktree rooted at `/Users/cody/.codex/worktrees/wiki-ingest-2026-05-26-173027`)
+- HEAD: `1d85bcb3acff15cdf89216c81ceb7efe975b1565`
+- Total commits on HEAD: 2372
+- New commits since last ingest (`fd8db85fb79d5ea18628fdf071bbe761885d793f`): 292
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #971 "Fix build queue namespace adoption detection"
 
 ## New commits
-- fd8db85f · 2026-05-26 · Merge pull request #889 from CodySwannGT/codex/issue-862-council-policy-parity
-- 5f129524 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- bccba495 · 2026-05-26 · Merge pull request #905 from CodySwannGT/codex/issue-871-explicit-rollup-merge
-- ca93a51f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- d98fd2dd · 2026-05-26 · Merge branch 'main' into codex/issue-871-explicit-rollup-merge
-- 4b2a17cd · 2026-05-26 · Merge pull request #887 from CodySwannGT/codex/issue-853-intake-explain-docs
-- 2bdf9e31 · 2026-05-26 · fix: recompute merged usage rollups
-- 1ee6fc21 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- b06bb852 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 60f6ff16 · 2026-05-26 · Merge pull request #900 from CodySwannGT/codex/issue-870-invalid-usage-numbers
-- 429171d4 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- 6bf9392f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 93f5be0f · 2026-05-26 · fix: reject invalid usage numeric tokens
-- 3d31632b · 2026-05-26 · Merge pull request #899 from CodySwannGT/codex/869-usage-token-serialization
-- 65e9d176 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- acc65909 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 54019eaf · 2026-05-26 · fix: make usage tokens reversible
-- 6e9953e7 · 2026-05-26 · Merge pull request #893 from CodySwannGT/codex/issue-885-automation-status-negated-errors
-- b86884b2 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- b82f765f · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 227f4444 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
-- 7738cadd · 2026-05-26 · Merge pull request #894 from CodySwannGT/codex/issue-866-council-flag-values
-- d250e2a0 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- eaeae439 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 34e5bae2 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
-- 946b298d · 2026-05-26 · Merge branch 'main' into codex/issue-866-council-flag-values
-- bc22ca47 · 2026-05-26 · Merge pull request #891 from CodySwannGT/codex/issue-864-council-executor-error
-- cdbe4c91 · 2026-05-26 · Merge branch 'main' into codex/issue-853-intake-explain-docs
-- d7b247d9 · 2026-05-26 · Merge branch 'main' into codex/issue-862-council-policy-parity
-- 20fd1146 · 2026-05-26 · Merge branch 'main' into codex/issue-864-council-executor-error
-- 6163de40 · 2026-05-26 · Merge branch 'main' into codex/issue-885-automation-status-negated-errors
-- 80581897 · 2026-05-26 · Merge branch 'main' into codex/issue-866-council-flag-values
-- 4141ae93 · 2026-05-26 · Merge pull request #897 from CodySwannGT/codex/issue-868-usage-cost-precision
-- a4d6b842 · 2026-05-26 · fix: preserve decimal usage cost totals
-- 9eb34a27 · 2026-05-26 · fix: reject missing council flag values
-- f91e07cc · 2026-05-26 · fix: handle negated automation-status failures
-- c1bc3073 · 2026-05-26 · fix(council): classify executor errors as failed
-- d6a99fd2 · 2026-05-26 · fix: align council execution policy inputs
-- 1a1ea509 · 2026-05-26 · docs(intake-explain): publish operator guidance
-- c1854873 · 2026-05-26 · Merge pull request #859 from CodySwannGT/codex/issue-849-intake-explain-build-gates
-- 2ab8975b · 2026-05-26 · docs: explain intake build gates
-- e7f79234 · 2026-05-26 · chore(release): 2.100.1 [skip ci]
-- c937bbb8 · 2026-05-26 · Merge pull request #857 from CodySwannGT/codex/issue-847-intake-explain-ownership
-- 7cc7df83 · 2026-05-26 · docs: explain intake ownership readiness
-- 00d02646 · 2026-05-26 · chore(release): 2.100.0 [skip ci]
-- 114adbf2 · 2026-05-26 · Merge pull request #856 from CodySwannGT/feat/846-intake-explain-contract-resolution
-- e8c8825c · 2026-05-26 · feat(intake-explain): resolve one-item contract routing
-- 914ef345 · 2026-05-26 · chore(release): 2.99.1 [skip ci]
-- 86e06949 · 2026-05-26 · Merge pull request #855 from CodySwannGT/codex/issue-844-intake-explain-output
-- 0909b4ca · 2026-05-26 · docs: harden intake-explain operator contract
-- 5ba130fd · 2026-05-26 · chore(release): 2.99.0 [skip ci]
-- 0bc62140 · 2026-05-26 · Merge pull request #840 from CodySwannGT/codex/update-lisa-self
-- e0703ee3 · 2026-05-26 · Merge branch 'main' into codex/update-lisa-self
-- 2d3a58f7 · 2026-05-26 · Merge pull request #854 from CodySwannGT/codex/issue-843-intake-explain
-- 54098a3e · 2026-05-26 · feat: add intake-explain scaffold
-- 57334168 · 2026-05-26 · chore(release): 2.98.1 [skip ci]
-- cec15bb2 · 2026-05-26 · Merge branch 'main' into codex/update-lisa-self
-- 79eb3739 · 2026-05-26 · Merge pull request #839 from CodySwannGT/wiki/ingest-2026-05-26-053019
-- 2ce43e01 · 2026-05-26 · chore: self-update Lisa dependency
-- 810cc559 · 2026-05-26 · docs(wiki): ingest incremental git history
+- 1d85bcb3 · 2026-05-26 · chore(release): 2.106.0 [skip ci]
+- e7204466 · 2026-05-26 · Merge pull request #888 from CodySwannGT/codex/issue-861-council-guarded-workspace
+- 76f26c3f · 2026-05-26 · Merge pull request #890 from CodySwannGT/codex/issue-863-council-executor-exception
+- 5c80eb69 · 2026-05-26 · Merge pull request #895 from CodySwannGT/codex/issue-867-usage-currency-rollup
+- b4f3c70e · 2026-05-26 · Merge pull request #947 from CodySwannGT/codex/issue-927-wiki-source-parser
+- 41b3578c · 2026-05-26 · Merge remote-tracking branch 'origin/main' into pr-895
+- 1d9463ca · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 458aac6b · 2026-05-26 · test(wiki): split status report tests under max-lines limit
+- 23d5f747 · 2026-05-26 · chore(release): 2.105.1 [skip ci]
+- 13103e61 · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- 75172e3e · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 199ee932 · 2026-05-26 · Merge pull request #971 from CodySwannGT/codex/issue-876-build-snapshot-misconfig
+- d33abedc · 2026-05-26 · Merge remote-tracking branch 'origin/main' into codex/issue-861-council-guarded-workspace
+- f43b3ea1 · 2026-05-26 · fix: detect missing build lifecycle namespace
+- 13042bb7 · 2026-05-26 · chore(release): 2.105.0 [skip ci]
+- d3185446 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- f188c504 · 2026-05-26 · Merge pull request #758 from CodySwannGT/codex/issue-734-github-build-intake
+- 2fab8a98 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- ef81c208 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 571b78e3 · 2026-05-26 · Merge pull request #970 from CodySwannGT/codex/issue-682-author-association
+- 95504005 · 2026-05-26 · Merge branch 'main' into codex/issue-682-author-association
+- fffcfa0b · 2026-05-26 · fix: gate claude workflow by author association
+- 2aa40773 · 2026-05-26 · chore(release): 2.104.7 [skip ci]
+- 6b60a85b · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 2b776bdc · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- b3e80738 · 2026-05-26 · Merge pull request #969 from CodySwannGT/codex/issue-961-prd-verified-closure
+- a1ac4399 · 2026-05-26 · chore: merge main into PRD verification branch
+- 131500e8 · 2026-05-26 · fix: close PRDs only after verification
+- 4326c02f · 2026-05-26 · chore(release): 2.104.6 [skip ci]
+- bb340464 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 0987fa78 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 9219dfc9 · 2026-05-26 · Merge pull request #968 from CodySwannGT/codex/issue-877-role-overrides
+- 9d91ae5e · 2026-05-26 · fix(queue-status): ignore invalid prd role overrides
+- 790186f3 · 2026-05-26 · chore(release): 2.104.5 [skip ci]
+- 3e3087b6 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- c51abe00 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 386f8f0d · 2026-05-26 · Merge pull request #967 from CodySwannGT/claude/thirsty-heisenberg-6dc2c1
+- c122283e · 2026-05-26 · Merge branch 'main' into claude/thirsty-heisenberg-6dc2c1
+- efa4aa8b · 2026-05-26 · test(integration): stub claude CLI in plugin-registration test
+- 98332e85 · 2026-05-26 · fix(ci): don't file a 'Claude auto-fix failed' issue when loop-guard intentionally skipped
+- 1681d9e5 · 2026-05-26 · chore(release): 2.104.4 [skip ci]
+- 8e823363 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- a8bbfb0f · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 654a451e · 2026-05-26 · Merge pull request #892 from CodySwannGT/codex/issue-865-non-dry-council-exec
+- 8272a7db · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 62aceeb1 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- e17ad52e · 2026-05-26 · Merge branch 'main' into codex/issue-865-non-dry-council-exec
+- 9111b28d · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 8e1bc202 · 2026-05-26 · Merge pull request #956 from CodySwannGT/codex/issue-883-automation-status-contract
+- fc6c92ab · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 074515fa · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 168f1cef · 2026-05-26 · Merge branch 'main' into codex/issue-865-non-dry-council-exec
+- 8cbba8ce · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- ae2e3863 · 2026-05-26 · Merge branch 'main' into codex/issue-883-automation-status-contract
+- 398c8600 · 2026-05-26 · Merge pull request #949 from CodySwannGT/codex/issue-875-github-default-labels
+- 48b09adc · 2026-05-26 · Merge branch 'main' into codex/issue-883-automation-status-contract
+- eb3a0298 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- e7a5270c · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- d9cdea87 · 2026-05-26 · Merge branch 'main' into codex/issue-865-non-dry-council-exec
+- fc8fadb8 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 3ccce63a · 2026-05-26 · Merge branch 'main' into codex/issue-875-github-default-labels
+- 0ec667e2 · 2026-05-26 · Merge pull request #896 from CodySwannGT/codex/issue-884-schedule-cadence
+- 88d8854b · 2026-05-26 · fix: repair automation-status fleet matching
+- 8be5c411 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 246dd328 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 3c69f23f · 2026-05-26 · Merge branch 'main' into codex/issue-865-non-dry-council-exec
+- 55ecfd44 · 2026-05-26 · Merge branch 'main' into codex/issue-884-schedule-cadence
+- 8eb00c31 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 4f782ccc · 2026-05-26 · Merge branch 'main' into codex/issue-875-github-default-labels
+- 48a8faf2 · 2026-05-26 · Merge pull request #953 from CodySwannGT/codex/issue-931-wiki-parity
+- ba93a9f7 · 2026-05-26 · Merge branch 'main' into codex/issue-734-github-build-intake
+- 78435f5c · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- caf4bd0e · 2026-05-26 · Merge branch 'main' into codex/issue-865-non-dry-council-exec
+- 729cf46d · 2026-05-26 · Merge branch 'main' into codex/issue-884-schedule-cadence
+- 32a4fd27 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- bef8154f · 2026-05-26 · Merge branch 'main' into codex/issue-875-github-default-labels
+- 21d5fc93 · 2026-05-26 · Merge branch 'main' into codex/issue-931-wiki-parity
+- d1d3a217 · 2026-05-26 · Merge pull request #952 from CodySwannGT/codex/issue-881-codex-memory-latest
+- 93d53497 · 2026-05-26 · test(wiki): prove status distribution parity
+- e1c82658 · 2026-05-26 · fix: parse latest Codex automation memory run
+- df251078 · 2026-05-26 · Merge remote-tracking branch 'origin/main' into HEAD
+- 1d1266da · 2026-05-26 · Merge remote-tracking branch 'origin/main' into HEAD
+- fce5297d · 2026-05-26 · Merge remote-tracking branch 'origin/main' into HEAD
+- a6fcca55 · 2026-05-26 · chore(release): 2.104.3 [skip ci]
+- 5c483168 · 2026-05-26 · Merge branch 'main' into codex/issue-875-github-default-labels
+- 23b230e6 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- d9d0c6f9 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- d4a3ad56 · 2026-05-26 · Merge pull request #886 from CodySwannGT/codex/issue-852-intake-explain-smoke
+- 8c92544a · 2026-05-26 · fix(queue-status): apply default github reader labels
+- 86bfba3b · 2026-05-26 · Merge pull request #715 from CodySwannGT/codex/issue-704-github-build-intake
+- a1e70d5c · 2026-05-26 · test: add lockstep assertion for intake-explain SKILL.md source/generated parity
+- 832fecf0 · 2026-05-26 · Merge branch 'main' into codex/issue-927-wiki-source-parser
+- 89a6e36c · 2026-05-26 · chore(release): 2.104.2 [skip ci]
+- c2c277e5 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- c6ccdb8b · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 8f11cd13 · 2026-05-26 · feat(wiki): expose source freshness parser
+- adbbe89c · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 513dd779 · 2026-05-26 · Merge pull request #946 from CodySwannGT/codex/repair-932-readonly-status
+- cb0e2634 · 2026-05-26 · Merge remote-tracking branch 'origin/main' into codex/repair-932-readonly-status
+- 9f80e7f2 · 2026-05-26 · test: verify wiki status is read-only
+- 1e782978 · 2026-05-26 · chore(release): 2.104.1 [skip ci]
+- ca81f568 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 5084c061 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- dd857159 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 9b8fa9e6 · 2026-05-26 · Merge pull request #943 from CodySwannGT/codex/issue-928-freshness-fixtures
+- e88f9bc1 · 2026-05-26 · test(wiki): cover freshness verdict fixtures
+- 7b0ae527 · 2026-05-26 · chore(release): 2.104.0 [skip ci]
+- 06c9706f · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 9dfe28f0 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 7abf30d2 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 1dc745c1 · 2026-05-26 · Merge pull request #941 from CodySwannGT/codex/issue-929-wiki-status
+- 9194c8e4 · 2026-05-26 · feat(wiki): add status command surface
+- aeb5760d · 2026-05-26 · chore(release): 2.103.1 [skip ci]
+- 6089c57c · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 49b681d4 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 0dcfa9c8 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 3ea81217 · 2026-05-26 · Merge pull request #939 from CodySwannGT/codex/fix-automation-alias-880
+- 4f1236bc · 2026-05-26 · fix: canonicalize codex lisa automation aliases
+- 885ece0b · 2026-05-26 · chore(release): 2.103.0 [skip ci]
+- a7be074d · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- e72e2c13 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- cf730c8a · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- c740b067 · 2026-05-26 · Merge pull request #937 from CodySwannGT/codex/issue-930-wiki-status-render
+- 210020be · 2026-05-26 · feat(wiki): render source freshness status
+- ba5ddd52 · 2026-05-26 · chore(release): 2.102.0 [skip ci]
+- 279eb3fa · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 6a46c5a7 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- b1282817 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 009cd6e8 · 2026-05-26 · Merge pull request #858 from CodySwannGT/claude/objective-jepsen-91a96e
+- f111ea2c · 2026-05-26 · Merge branch 'claude/objective-jepsen-91a96e' of https://github.com/CodySwannGT/lisa into claude/objective-jepsen-91a96e
+- d8ffb1b1 · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- 623912d6 · 2026-05-26 · chore(release): 2.101.1 [skip ci]
+- e5977924 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- d8a3da3a · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 553be002 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- e701b70f · 2026-05-26 · Merge pull request #934 from CodySwannGT/codex/issue-874-queue-status-vendor-readers
+- a7c24a60 · 2026-05-26 · Merge branch 'main' into codex/issue-874-queue-status-vendor-readers
+- 9d735978 · 2026-05-26 · fix: fail unsupported queue-status vendor readers
+- d76a7672 · 2026-05-26 · chore(release): 2.101.0 [skip ci]
+- d8d7fbb3 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- ca400578 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- e0a52fcb · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- f6707b16 · 2026-05-26 · Merge pull request #911 from CodySwannGT/codex/issue-872-doctor-empty-groups
+- 84922bdf · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 5706fa2a · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 8266e8f9 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 543d5531 · 2026-05-26 · Merge branch 'main' into codex/issue-872-doctor-empty-groups
+- feba1dea · 2026-05-26 · Merge pull request #860 from CodySwannGT/codex/issue-850-intake-explain-prd-gates
+- 0ca787b2 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 9826e728 · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- bdd027ab · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 21c621db · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- fb729377 · 2026-05-26 · Merge branch 'main' into codex/issue-872-doctor-empty-groups
+- cc3f550c · 2026-05-26 · Merge pull request #919 from CodySwannGT/codex/issue-873-doctor-aggregator-statuses
+- a119c443 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 7533f528 · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- d28184d6 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 35a71b60 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 826a5c55 · 2026-05-26 · Merge branch 'main' into codex/issue-872-doctor-empty-groups
+- f3f2ed70 · 2026-05-26 · fix(doctor): normalize direct aggregator statuses
+- acf3e1eb · 2026-05-26 · Merge pull request #916 from CodySwannGT/wiki/ingest-2026-05-26-093056
+- 7b10bb84 · 2026-05-26 · Merge branch 'main' into wiki/ingest-2026-05-26-093056
+- f366150a · 2026-05-26 · chore(release): 2.100.2 [skip ci]
+- 4c7312d3 · 2026-05-26 · docs(wiki): ingest incremental git history
+- c4f82ad7 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 45e1db6f · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- 12bf2df4 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 3b70ae03 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 56ef45a6 · 2026-05-26 · Merge branch 'main' into codex/issue-872-doctor-empty-groups
+- 3d7a4ec8 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- ed12ca5b · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- 286e64f7 · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- 74545b2e · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 3ffe7cd6 · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- 6549404e · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 1554af5b · 2026-05-26 · fix: count empty doctor groups as skips
+- 61aabbe8 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 3768897a · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- a6d1dd22 · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- fb3bd148 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- cf366aaf · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- a8df9334 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 5b0bfefc · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- cb29d721 · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- 302628aa · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- cc46c22e · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- be134056 · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- 21f37682 · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- 81b0fcd9 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 70c1cec9 · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- 65ecbedc · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- 4f4a2f7c · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- f217a9b5 · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- 0851c79d · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception
+- c75b86c3 · 2026-05-26 · Merge branch 'main' into codex/issue-704-github-build-intake
+- 26bba8e5 · 2026-05-26 · Merge branch 'main' into claude/objective-jepsen-91a96e
+- 39670092 · 2026-05-26 · Merge branch 'main' into codex/issue-850-intake-explain-prd-gates
+- a377de48 · 2026-05-26 · Merge branch 'main' into codex/issue-852-intake-explain-smoke
+- 32b77457 · 2026-05-26 · Merge branch 'main' into codex/issue-861-council-guarded-workspace
+- 4fb289ca · 2026-05-26 · Merge branch 'main' into codex/issue-863-council-executor-exception

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-26T13:31:17.916Z",
+  "ingested_at": "2026-05-26T17:31:08.383Z",
   "cursor": {
-    "lastCommit": "fd8db85fb79d5ea18628fdf071bbe761885d793f",
-    "lastPr": 905
+    "lastCommit": "1d85bcb3acff15cdf89216c81ceb7efe975b1565",
+    "lastPr": 971
   },
   "source_notes": [
     "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-26T13:31:17.307Z",
+  "ingested_at": "2026-05-26T17:31:08.407Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary\n- ran the full lisa-wiki ingest cycle for enabled non-external-write sources\n- refreshed the git source note and advanced the git/roles cursors\n- updated the monorepo wiki snapshot and ingestion log\n\n## Ingested\n- git: 292 new commits through 1d85bcb3acff15cdf89216c81ceb7efe975b1565, latest merged PR #971\n- roles: 0 roles / 0 staff pages\n\n## Skipped\n- memory: no provably project-scoped memory directory was available; global Codex memory is intentionally refused\n\n## Verification\n- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json\n- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json (0 fail, existing warnings)\n- git diff --check\n- pre-commit hook: gitleaks, tsc, lint-staged, commitlint\n- pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests