### PR TITLE
fix(plugin-sync): name marketplace source drift

### DIFF
--- a/plugins/lisa/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa/scripts/plugin-sync-explain.mjs
@@ -198,8 +198,7 @@ function classifyMarketplaceDrift(root) {
         classification: "MARKETPLACE_REGISTRATION_DRIFT",
         path: source.replace(/^\.\//, ""),
         counterpart: MARKETPLACE,
-        nextAction:
-          "Add the built plugin source to `.claude-plugin/marketplace.json`, then run `bun run check:plugins`.",
+        nextAction: `Add marketplace source "${source}" to \`${MARKETPLACE}\`, then run \`bun run check:plugins\`.`,
       });
     }
   }

--- a/plugins/src/base/scripts/plugin-sync-explain.mjs
+++ b/plugins/src/base/scripts/plugin-sync-explain.mjs
@@ -198,8 +198,7 @@ function classifyMarketplaceDrift(root) {
         classification: "MARKETPLACE_REGISTRATION_DRIFT",
         path: source.replace(/^\.\//, ""),
         counterpart: MARKETPLACE,
-        nextAction:
-          "Add the built plugin source to `.claude-plugin/marketplace.json`, then run `bun run check:plugins`.",
+        nextAction: `Add marketplace source "${source}" to \`${MARKETPLACE}\`, then run \`bun run check:plugins\`.`,
       });
     }
   }

--- a/tests/unit/strategies/plugin-sync-explain-fixtures.test.ts
+++ b/tests/unit/strategies/plugin-sync-explain-fixtures.test.ts
@@ -96,7 +96,10 @@ describe("plugin-sync-explain fixture classifications (#990)", () => {
         counterpart: MARKETPLACE,
       })
     );
-    expect(report.text).toContain("Add the built plugin source");
+    expect(report.text).toContain(
+      'Add marketplace source "./plugins/lisa-extra"'
+    );
+    expect(report.text).toContain(MARKETPLACE);
     expect(gitStatus(root)).toBe(before);
   });
 


### PR DESCRIPTION
## Summary
- include the exact missing marketplace source entry in plugin-sync-explain remediation
- keep generated plugins/lisa diagnostic output in sync with plugins/src/base
- assert the marketplace drift report names the expected source and manifest

## Evidence
- [EVIDENCE: marketplace-drift-output] Disposable fixture diagnostic reported `MARKETPLACE_REGISTRATION_DRIFT` for `plugins/lisa-extra`.
- [EVIDENCE: missing-source-remediation] Diagnostic output included `Add marketplace source "./plugins/lisa-extra" to `.claude-plugin/marketplace.json``.
- [EVIDENCE: read-only-status] Disposable fixture status before/after diagnostic was unchanged.
- [EVIDENCE: sync-gate-parity] `bun run check:plugins` passes on the committed tree; the disposable unregistered-plugin fixture exits non-zero under the sync gate.

## Verification
- `bun test tests/unit/strategies/plugin-sync-explain-fixtures.test.ts`
- `bun run typecheck`
- `bun run check:plugins`
- pre-push hook: security audit, slow lint, knip, unit coverage suite, integration suite

Closes #988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated plugin synchronization error messages to provide clearer, more specific instructions when resolving marketplace configuration mismatches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->