### PR TITLE
docs(wiki): ingest incremental git history

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -76,3 +76,10 @@
 - Refreshed the `git` source note with 9 new commits through `6e98950d496260faad821f90e5f4f6e2b059c3fb`, advanced the merged-PR cursor to `#992`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; `CODEX_HOME` was unset and global Codex memory remains out of scope.
 - Updated the monorepo snapshot synthesis for the latest plugin-sync marketplace drift fixes, fixture coverage, prior wiki ingest merge, and release-history changes.
+
+## 2026-05-27 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-26-213256`, and ran another full no-argument ingest against every enabled non-external-write connector that was available.
+- Refreshed the `git` source note with 7 new commits through `65043e915a23a992904badaf708fd5a849cd54e5`, advanced the merged-PR cursor to `#994`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the only known Codex memory store is global and remains out of scope.
+- Updated the monorepo snapshot synthesis for the prior wiki ingest merge, plugin-sync scratch drift comparison, and release-history changes through `2.106.5`.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,18 +20,18 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-26-213208` from `origin/main`
-- HEAD at 2026-05-26 incremental ingest: `6e98950d496260faad821f90e5f4f6e2b059c3fb`
-- Current package version: `2.106.3`
-- Total commits on HEAD: 2381
-- Latest merged PR captured in the incremental git snapshot: `#992`
-- New commits since the previous incremental git cursor: `9`
+- Ingest branch: `wiki/ingest-2026-05-26-213256` from `origin/main`
+- HEAD at 2026-05-27 incremental ingest: `65043e915a23a992904badaf708fd5a849cd54e5`
+- Current package version: `2.106.5`
+- Total commits on HEAD: 2388
+- Latest merged PR captured in the incremental git snapshot: `#994`
+- New commits since the previous incremental git cursor: `7`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Plugin synchronization gained marketplace source-drift fixture coverage and a fix for naming marketplace source drift.
+- Plugin synchronization now compares generated drift in a scratch workspace, covering marketplace source-drift classification without mutating tracked generated files.
 - The previous wiki ingest PR merged, advancing the wiki cursor into this release window.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.106.1` through `2.106.3` during this incremental window.
+- Release automation continued its rapid cadence, advancing the monorepo from `2.106.3` through `2.106.5` during this incremental window.
 
 ## Workspace Packages
 
@@ -47,5 +47,7 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/github/2026-05-14-git-and-pr-history.md`
 - `wiki/sources/git/2026-05-25-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-26-lisa-monorepo-git.md`
+- `wiki/sources/git/2026-05-27-lisa-monorepo-git.md`
 - `wiki/sources/roles/2026-05-25-roles.md`
 - `wiki/sources/roles/2026-05-26-roles.md`
+- `wiki/sources/roles/2026-05-27-roles.md`

--- a/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
@@ -1,0 +1,26 @@
+---
+type: source
+created: 2026-05-27
+updated: 2026-05-27
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-05-27)
+
+- Repo: `/Users/cody/.codex/worktrees/wiki-ingest-2026-05-26-213256`
+- HEAD: `65043e915a23a992904badaf708fd5a849cd54e5`
+- Total commits on HEAD: 2388
+- New commits since last ingest (`6e98950d496260faad821f90e5f4f6e2b059c3fb`): 7
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #994 "docs(wiki): ingest incremental git history"
+
+## New commits
+- 65043e91 · 2026-05-26 · chore(release): 2.106.5 [skip ci]
+- a7e5eff1 · 2026-05-26 · Merge pull request #994 from CodySwannGT/wiki/ingest-2026-05-26-213208
+- 8a666fe9 · 2026-05-26 · Merge branch 'main' into wiki/ingest-2026-05-26-213208
+- 8565a6fc · 2026-05-26 · chore(release): 2.106.4 [skip ci]
+- 774bd8bf · 2026-05-26 · docs(wiki): ingest incremental git history
+- e51d6318 · 2026-05-26 · Merge pull request #993 from CodySwannGT/codex/issue-986-plugin-sync-classifier
+- 251fe7b2 · 2026-05-26 · fix(plugin-sync): compare generated drift in scratch

--- a/wiki/sources/roles/2026-05-27-roles.md
+++ b/wiki/sources/roles/2026-05-27-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-05-27
+updated: 2026-05-27
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-05-27)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-26T21:33:01.733Z",
+  "ingested_at": "2026-05-27T01:33:58.521Z",
   "cursor": {
-    "lastCommit": "6e98950d496260faad821f90e5f4f6e2b059c3fb",
-    "lastPr": 992
+    "lastCommit": "65043e915a23a992904badaf708fd5a849cd54e5",
+    "lastPr": 994
   },
   "source_notes": [
-    "wiki/sources/git/2026-05-26-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-05-27-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-26T21:33:01.232Z",
+  "ingested_at": "2026-05-27T01:33:57.878Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-05-26"
+    "lastIngest": "2026-05-27"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-05-26-roles.md"
+    "wiki/sources/roles/2026-05-27-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- ingest git history through 65043e915a23a992904badaf708fd5a849cd54e5
- refresh roles source note and advance git/roles cursors
- update Lisa monorepo wiki snapshot and ingestion log

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json (0 fail, 12 existing warnings)
- changed-file secret scan
- pre-commit hook: gitleaks, typecheck, lint-staged, commitlint
- pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests

## Connector notes
- git: ingested 7 new commits; latest merged PR cursor #994
- roles: no roster changes
- memory: skipped; no project-scoped memory store available, global Codex memory remains out of scope

Auto-merge is intended for this read-only ingest run.