### PR TITLE
docs(wiki): ingest incremental Lisa knowledge

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -56,6 +56,7 @@
 ## Sources
 
 - [Git Sources](sources/git/)
+- [Memory Sources](sources/memory/)
 - [Roles Sources](sources/roles/)
 - [Repository Sources](sources/repository/)
 - [GitHub Sources](sources/github/)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -83,3 +83,10 @@
 - Refreshed the `git` source note with 7 new commits through `65043e915a23a992904badaf708fd5a849cd54e5`, advanced the merged-PR cursor to `#994`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` again because no provably project-scoped memory directory was available for this repository in the current runtime; the only known Codex memory store is global and remains out of scope.
 - Updated the monorepo snapshot synthesis for the prior wiki ingest merge, plugin-sync scratch drift comparison, and release-history changes through `2.106.5`.
+
+## 2026-05-27 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-27-053204`, and ran another full no-argument ingest against every enabled non-external-write connector.
+- Refreshed the `git` source note with 3 new commits through `73072b8e5b839dede4bf50985232d1d6bddfe9f4`, advanced the merged-PR cursor to `#995`, and confirmed that `roles` still had no roster pages to ingest.
+- Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-27-memory.md`; global Codex memory remained out of scope.
+- Updated the monorepo snapshot synthesis for the prior wiki ingest merge, release-history changes through `2.106.6`, and newly captured project-scoped memory guidance.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,18 +20,19 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-26-213256` from `origin/main`
-- HEAD at 2026-05-27 incremental ingest: `65043e915a23a992904badaf708fd5a849cd54e5`
-- Current package version: `2.106.5`
-- Total commits on HEAD: 2388
-- Latest merged PR captured in the incremental git snapshot: `#994`
-- New commits since the previous incremental git cursor: `7`
+- Ingest branch: `wiki/ingest-2026-05-27-053204` from `origin/main`
+- HEAD at 2026-05-27 incremental ingest: `73072b8e5b839dede4bf50985232d1d6bddfe9f4`
+- Current package version: `2.106.6`
+- Total commits on HEAD: 2391
+- Latest merged PR captured in the incremental git snapshot: `#995`
+- New commits since the previous incremental git cursor: `3`
+- Project-scoped memory files captured: `20`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Plugin synchronization now compares generated drift in a scratch workspace, covering marketplace source-drift classification without mutating tracked generated files.
-- The previous wiki ingest PR merged, advancing the wiki cursor into this release window.
-- Release automation continued its rapid cadence, advancing the monorepo from `2.106.3` through `2.106.5` during this incremental window.
+- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#995`.
+- Release automation advanced the monorepo to `2.106.6`.
+- Lisa project-scoped Claude memory is now captured as a sanitized internal source note, including operational guidance for Codex automation, Lisa merge method, CI verification, and project-specific workflow expectations.
 
 ## Workspace Packages
 
@@ -48,6 +49,7 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/git/2026-05-25-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-26-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-27-lisa-monorepo-git.md`
+- `wiki/sources/memory/2026-05-27-memory.md`
 - `wiki/sources/roles/2026-05-25-roles.md`
 - `wiki/sources/roles/2026-05-26-roles.md`
 - `wiki/sources/roles/2026-05-27-roles.md`

--- a/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
@@ -10,17 +10,13 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-27)
 
-- Repo: `/Users/cody/.codex/worktrees/wiki-ingest-2026-05-26-213256`
-- HEAD: `65043e915a23a992904badaf708fd5a849cd54e5`
-- Total commits on HEAD: 2388
-- New commits since last ingest (`6e98950d496260faad821f90e5f4f6e2b059c3fb`): 7
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #994 "docs(wiki): ingest incremental git history"
+- Repo: `/Users/cody/.codex/worktrees/wiki-ingest-2026-05-27-053204`
+- HEAD: `73072b8e5b839dede4bf50985232d1d6bddfe9f4`
+- Total commits on HEAD: 2391
+- New commits since last ingest (`65043e915a23a992904badaf708fd5a849cd54e5`): 3
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #995 "docs(wiki): ingest incremental git history"
 
 ## New commits
-- 65043e91 · 2026-05-26 · chore(release): 2.106.5 [skip ci]
-- a7e5eff1 · 2026-05-26 · Merge pull request #994 from CodySwannGT/wiki/ingest-2026-05-26-213208
-- 8a666fe9 · 2026-05-26 · Merge branch 'main' into wiki/ingest-2026-05-26-213208
-- 8565a6fc · 2026-05-26 · chore(release): 2.106.4 [skip ci]
-- 774bd8bf · 2026-05-26 · docs(wiki): ingest incremental git history
-- e51d6318 · 2026-05-26 · Merge pull request #993 from CodySwannGT/codex/issue-986-plugin-sync-classifier
-- 251fe7b2 · 2026-05-26 · fix(plugin-sync): compare generated drift in scratch
+- 73072b8e · 2026-05-27 · chore(release): 2.106.6 [skip ci]
+- ac893822 · 2026-05-26 · Merge pull request #995 from CodySwannGT/wiki/ingest-2026-05-26-213256
+- 0d7f4e48 · 2026-05-26 · docs(wiki): ingest incremental git history

--- a/wiki/sources/memory/2026-05-27-memory.md
+++ b/wiki/sources/memory/2026-05-27-memory.md
@@ -1,0 +1,445 @@
+---
+type: source
+created: 2026-05-27
+updated: 2026-05-27
+related: []
+sources: []
+source_system: memory
+sensitivity: internal
+---
+
+# project-scoped memory (2026-05-27)
+
+- Source: `/Users/cody/.claude/projects/-Users-cody-workspace-lisa/memory` (project-scoped; global/Chronicle memory is never ingested)
+- Files: 20
+
+### MEMORY.md
+
+# Memory Index
+
+- `reference_codex_automations.md` — Codex "automations" = ~/.codex/automations/<id>/automation.toml (rrule cadence, execution_environment=local); no CLI subcommand, use automation_update tool; Claude equivalent is /schedule
+
+- `project_lisa_single_environment.md` — Lisa repo has one deploy env (main=production); no dev/staging, status:on-dev/on-stg are dead labels
+- `feedback_uncommitted_changes.md` — After creating a PR, always list uncommitted changes and ask if they should be included
+- `feedback_verify_ci_in_ci.md` — Verify CI fixes by watching the GitHub Actions run succeed, not by running locally
+- `feedback_coderabbit_pr_reviews.md` — Fix valid CodeRabbit feedback and push; reply to invalid ones explaining why; resolve all conversations
+- `project_vitest_template_overlap.md` — TypeScript stack vitest templates bleed into child stacks (Expo, CDK) that should stay on Jest
+- `feedback_never_no_verify.md` — NEVER use --no-verify; fix the code instead, or ask the user if too large for scope
+- `feedback_investigate_before_removing.md` — Investigate why a guard/check exists before proposing to remove or relax it (Chesterton's fence)
+- `feedback_intake_default_proceed.md` — For /intake and similar batch lifecycle skills, always run the default (option A) without asking — Blocked is a valid terminal state, not a failure
+- `project_lisa_update_workspaces_config.md` — lisa-update-projects reads its project list from .lisa.workspaces.json (not the .lisa.config.local.json the doc names); propswap repos live under propswap/projects/
+- `feedback_bash_path_subshell.md` — Bash loses PATH in subshells/functions here; `export PATH=...` first or git/jq/bun fail with "command not found"
+- `reference_codex_cli_collaboration.md` — How to drive the codex CLI non-interactively (`codex exec` / `resume --last`) for Claude↔Codex collaboration
+- `project_llmwiki_unification.md` — Plan (PLAN.md) to unify 5 LLM Wikis into one distributable Claude+Codex plugin via Lisa
+- `project_lisa_tsconfig_base_path_resolution.md` — Lisa base tsconfigs can't set a project's rootDir/outDir; the shipped tsconfig.local.json governs emit (dist/<subdir>, not dist/src)
+- `feedback_lisa_pr_merge_method.md` — In Lisa, merge PRs with --merge (never --squash); prefer the /lisa:git-submit-pr skill over raw gh pr merge
+- `reference_codex_plugin_skill_loading.md` — Codex loads Lisa-plugin skills via the .codex-plugin skills pointer (SKILL.md only); no per-skill manifest needed, commands/ ignored
+- `reference_codex_hooks_capabilities.md` — Codex 0.125.0 hook events/contract; plugin-bundled hooks.json DOESN'T run — must install into ~/.codex/hooks.json; no SubagentStart/SessionEnd
+- `reference_lisa_new_standalone_plugin_wiring.md` — 5 wiring points for a new standalone Lisa plugin; .agents/plugins/marketplace.json is the Codex install surface (NOT CI-enforced)
+- `reference_codex_commit_attribution.md` — Codex 0.125.0 commit attribution: top-level commit_attribution + features.codex_git_commit; emits "Co-authored-by: Codex"; Lisa hook broadened to accept Claude|Codex
+
+### feedback_bash_path_subshell.md
+
+---
+name: feedback_bash_path_subshell
+description: "In this environment, Bash commands lose PATH inside subshells/functions — export PATH first or binaries fail with \"command not found\""
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a37ecee7-ca65-4361-ac4b-f748b6ca876f
+---
+
+When running Bash in the Lisa workspace (especially during `/lisa-update-projects` batch runs that operate on repos under `~/workspace/*`), commands invoked **inside command substitution `$(...)` or shell functions** intermittently fail with `command not found: git/jq/tr/npm/bun` even though `command -v` finds them at top level. The profile PATH is not reliably inherited into subshells.
+
+**Why:** environment/sandbox quirk — top-level command lookup works, nested lookup doesn't get the homebrew/mise PATH.
+
+**How to apply:** Begin every Bash command with `export PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"`. Prefer flat command sequences over shell functions. Use `git -C <dir>` instead of `cd` (the tool also resets cwd after operating on external worktrees). jq is at `/opt/homebrew/bin/jq`, git at `/opt/homebrew/bin/git`. Tell spawned subagents the same — they hit it too. Network ops (git fetch/push, gh) and writes to `~/workspace/*` work fine without disabling the sandbox once PATH is set. Related: `project_lisa_update_workspaces_config`.
+
+### feedback_coderabbit_pr_reviews.md
+
+---
+name: feedback_coderabbit_pr_reviews
+description: How to handle CodeRabbit PR feedback — fix valid issues, reply to invalid ones, acknowledge verified NITs, resolve all conversations
+type: feedback
+originSessionId: 69ac25da-df1b-4f98-aee2-7815a9d19908
+---
+When handling CodeRabbit feedback on PRs:
+
+1. For **valid feedback**: Make the code changes, push to the PR branch, then resolve the conversation.
+2. For **invalid feedback**: Reply on the conversation explaining why it's not valid, then resolve the conversation.
+3. For **NITs** (comments CodeRabbit tags as `nit:` or equivalent): Verify it is actually a nit — a trivial style/preference suggestion with no correctness, security, performance, or clarity impact. If verified, reply with a brief "nit acknowledged" and resolve the conversation without making the change. If it turns out to be substantive despite the nit label, treat it as valid or invalid per the rules above.
+
+**Why:** The user wants all CodeRabbit conversations resolved systematically — either by fixing, explaining why no fix is needed, or acknowledging trivial nits. Nits don't warrant code churn, but they still must be closed out explicitly so nothing is silently dismissed.
+
+**How to apply:** When asked to handle CodeRabbit feedback on a PR, fetch all review comments, evaluate each one, batch valid fixes into a commit, reply to invalid ones, verify-and-acknowledge NITs, and resolve all conversations.
+
+### feedback_intake_default_proceed.md
+
+---
+name: /intake — always proceed with default option A
+description: For lisa:intake (and similar batch lifecycle skills), always run the documented default without asking for confirmation, even on large/risky-looking PRDs
+type: feedback
+originSessionId: 14a1bca1-3672-47fe-a689-674eec3fcc1e
+---
+For `/intake`, `/lisa:intake`, and similar batch lifecycle skills, always proceed with the skill's documented default action (option A — claim, dry-run validate, branch to Blocked or Ticketed). Do not pause to ask whether to proceed, even when the PRD looks unusually large, has many open questions, or is likely to end up Blocked.
+
+**Why:** Blocked is a valid terminal state of the intake lifecycle (Ready → In Review → Blocked|Ticketed), not a failure mode. The whole point of the skill is to autonomously route PRDs to the right state with clarifying comments. Background execution + agent teams are explicitly designed to handle large workloads without context overflow, so size is not a reason to bail out. Asking for confirmation defeats the purpose of having a default.
+
+**How to apply:** When invoking any intake/batch lifecycle skill that offers options A/B/C with A as the default, just run A. Surface concerns *after* execution in the report, not as a gate before starting. The user can always interrupt if they want to abort mid-run. Skip option C (dry-run-only) unless explicitly requested — the PRD landing in Blocked with comments is functionally equivalent and is the intended outcome of the lifecycle.
+
+### feedback_investigate_before_removing.md
+
+---
+name: Investigate existing code before proposing removal
+description: When encountering existing guards, checks, or constraints that block desired behavior, investigate why they exist before proposing to remove or relax them
+type: feedback
+originSessionId: d2adcbf0-f7fa-4e50-8e8e-807033ec4a3f
+---
+When existing code (a guard, check, filter, conditional, etc.) is blocking the desired behavior, do NOT immediately propose removing or loosening it. First investigate *why* it was added: check `git log -S`, read the commit message, read the PR description, look for related loop/safety guards added at the same time.
+
+**Why:** User explicitly called this out after I proposed relaxing a `!endsWith(pr_user_login, '[bot]')` guard in a workflow without first checking its origin. The guard turned out to be a deliberate loop-prevention measure added alongside other loop guards in the same PR. Understanding the intent made the difference between a blunt fix (strip the check) and a surgical one (denylist only the specific bots that actually cause loops). Chesterton's fence: don't remove a fence until you know why it was built.
+
+**How to apply:** Whenever a user reports "X didn't fire" / "Y is being blocked" / "why isn't Z working" and the answer is an existing conditional, resolve the investigation before proposing the fix. In the same turn where I identify the blocker, also surface *when* and *why* it was added — don't wait for the user to ask. Only after that context is on the table should I suggest modifications.
+
+### feedback_lisa_pr_merge_method.md
+
+---
+name: feedback_lisa_pr_merge_method
+description: "In the Lisa repo, merge PRs with --merge (never --squash); prefer the git-submit-pr skill over raw gh"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 91079702-872d-4a69-8d3e-0206afb6fdc3
+---
+
+In the Lisa repo, merge PRs with `gh pr merge --auto --merge` — **never `--squash`**. Prefer invoking the `/lisa:git-submit-pr` skill (which encodes the rule) over calling `gh pr merge` directly.
+
+**Why:** The repo's `git-submit-pr` skill (`plugins/src/base/skills/git-submit-pr/SKILL.md`) documents `--merge` for both promotion and feature PRs, established by PR #496. Squashing (a) flattens `chore(release): X.Y.Z [skip ci]` commits and strips the `[skip ci]` markers, breaking the release workflow's promotion-detection regex (double version bumps), and (b) makes a merged branch look unmerged to `git merge-base --is-ancestor`, breaking branch-merge auditing. The user noticed I was defaulting to `--squash` with no basis and asked why.
+
+**How to apply:** When merging a PR in Lisa, run `/lisa:git-submit-pr` or `gh pr merge <n> --auto --merge`. Don't default to `--squash`. Note the documented flow is feature → `dev` → `staging` → `main`; if asked to target `main` directly, follow the instruction but still use `--merge`. See `feedback_verify_ci_in_ci` for the related "watch CI in CI" habit.
+
+### feedback_never_no_verify.md
+
+---
+name: Never use --no-verify
+description: Never use --no-verify to bypass git hooks, even for pre-existing failures on main
+type: feedback
+---
+
+NEVER use `--no-verify` to bypass pre-push or pre-commit hooks. Even when the failure is pre-existing on the target branch and unrelated to our changes, the correct approach is to fix the code to pass the hooks.
+
+**Why:** User considers hook bypasses unacceptable regardless of context. The skill instructions explicitly say "fix the code, don't lower thresholds or bypass hooks."
+
+**How to apply:** When a pre-push hook fails (e.g., coverage thresholds not met), fix the underlying issue — add tests, fix lint errors, etc. If the fix is too large for scope, ask the user how to proceed rather than using --no-verify.
+
+### feedback_uncommitted_changes.md
+
+---
+name: feedback_uncommitted_changes
+description: After creating a PR, always list any uncommitted changes and ask the human if they should be included
+type: feedback
+---
+
+After finishing a PR, if there are uncommitted changes, do not assume they should be excluded. List them and ask the human whether they should be included in the commit/PR.
+
+**Why:** Uncommitted changes may be intentional side effects of the work (e.g., build artifacts, version bumps from build scripts) that belong in the PR. Silently leaving them out can cause incomplete PRs.
+
+**How to apply:** After every `gh pr create`, run `git status` and if there are uncommitted changes, present them to the human and ask: "These changes are uncommitted — should they be included in this PR?"
+
+### feedback_verify_ci_in_ci.md
+
+---
+name: feedback_verify_ci_in_ci
+description: When fixing a GitHub Actions failure, verify the fix by watching the CI run succeed — not by running locally
+type: feedback
+---
+
+When fixing a GitHub Actions failure, verification means confirming the CI run passes in GitHub Actions after pushing the fix. Use `gh run watch` or poll `gh run list` to wait for completion, then confirm the previously-failing job now shows green.
+
+**Why:** Running the same command locally is only a sanity check, not proof. The CI environment can differ (different tool versions, different file sets, environment variables, etc.). The only way to prove a GitHub Action is fixed is to watch it succeed in GitHub Actions.
+
+**How to apply:** After pushing a CI fix, always `gh run watch` the triggered workflow run and report the result. Do not claim the fix is verified based on local execution alone.
+
+### project_lisa_single_environment.md
+
+---
+name: project_lisa_single_environment
+description: The Lisa repo (CodySwannGT/lisa) has a single deploy environment tied to main; no dev/staging
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 04d6ef7b-c05d-49d0-9a3f-d42791da9cbc
+---
+
+CodySwannGT/lisa has only ONE deploy environment, tied to the `main` branch — there is no dev and no staging. `.lisa.config.json` `deploy.branches` contains only `production: main`.
+
+**Why:** Build-lifecycle tickets, verification plans, and target_environment fields should assume a single (main/production) environment — never a dev→staging→prod promotion chain.
+
+**How to apply:**
+- `target_environment` on generated tickets = `main`/production, never "dev".
+- The `github-build-intake` "done" label is env-aware: it reverse-looks-up the PR base branch in `deploy.branches`. With only `production: main`, merges to main resolve to `production` → `status:done` directly. Effective build lifecycle: `status:ready → status:in-progress → status:code-review → status:done`.
+- The `status:on-dev` and `status:on-stg` labels exist but are never reached (no dev/staging branch). They are dead/unused — candidates for deletion for tidiness, but functionally harmless.
+- PRDs touching build-intake behavior (e.g. `project_llmwiki_unification` siblings #522 rollup, #524 bounded parallel) should encode single-environment rollup/lifecycle, not multi-env.
+
+### project_lisa_tsconfig_base_path_resolution.md
+
+---
+name: project_lisa_tsconfig_base_path_resolution
+description: "Lisa base tsconfigs can't set a project's rootDir/outDir; the shipped tsconfig.local.json governs emit layout"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 91079702-872d-4a69-8d3e-0206afb6fdc3
+---
+
+In Lisa's tsconfig templates (e.g. `tsconfig/harper-fabric.json`), the path-valued options `rootDir`, `outDir`, and `include`/`exclude` resolve **relative to the base config file's own directory** (`repo/tsconfig/`), NOT the consuming project. So a downstream project can never inherit a usable `rootDir` from `@codyswann/lisa/tsconfig/*` — TypeScript would point it at `repo/tsconfig/src`. The project's own `tsconfig.local.json` (resolved relative to the project root) is what actually governs the emitted layout, and it always overrides the base.
+
+Lisa ships that `tsconfig.local.json` via the **typescript create-only** template (`typescript/create-only/tsconfig.local.json`), which sets `rootDir: "src"`, `include: ["src/**/*"]`, excludes tests. Harper/Fabric projects inherit it (detected as both typescript + harper-fabric). With `rootDir: "src"`, tsc strips the leading `src/`, so `src/build/build.ts` → `dist/build/build.js` (NOT `dist/src/build/build.js`).
+
+**Why:** A 2026-05 task asked to fix Harper/Fabric build scripts that pointed at `dist/src/*` for rootDir-src projects (advisory-rankings). The originally-reported force-clobber was already fixed in PR #508 / v2.23.1 (scripts moved force→defaults). The residual gap was that `harper-fabric/package-lisa/package.lisa.json` `defaults` still hardcoded `dist/src/*` — wrong for the rootDir-src emit. Fix was purely the defaults (`dist/build/*`, `dist/scripts/*`, smoke via `bun tests/*.ts`). Editing the base tsconfig's rootDir was attempted and reverted as inert.
+
+**How to apply:** When a Lisa package.lisa.json script references a tsc output path, match it to the rootDir-src emit (`dist/<subdir>/file.js`), not `dist/src/...`. Don't try to fix emit layout by changing a base tsconfig's rootDir — change the create-only `tsconfig.local.json` or the script default instead. See `project_vitest_template_overlap` for related TS-family template inheritance gotchas.
+
+### project_lisa_update_workspaces_config.md
+
+---
+name: project_lisa_update_workspaces_config
+description: "lisa-update-projects reads its project list from .lisa.workspaces.json, not the .lisa.config.local.json the skill doc names"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 4be8a61d-9fce-4d38-8632-f6c6e88d4f63
+---
+
+The `/lisa-update-projects` skill doc says it reads the project list from `.lisa.config.local.json`, but the actual file in the Lisa monorepo root is **`.lisa.workspaces.json`** (gitignored, local-only). Format is a flat map of `"~/workspace/<path>": "<target-branch>"`.
+
+As of 2026-05-21 it lists projects under propswap, geminisportsai/projects, thumbwar, qualis, plus railsstarter and api-creator. The propswap repos live at `~/workspace/propswap/projects/{backend,frontend,infrastructure}` (separate `propswapllc/*` repos), NOT `~/workspace/propswap/{...}` — an older config pointed at the wrong (now-wiki) path; I corrected it.
+
+**How to apply:** When running the update batch, read `.lisa.workspaces.json` for the project→branch map. Expand `~` to `/Users/cody`. Determine each project's package manager from `package.json` `engines` (bun=`please-use-npm` ⇒ use npm). Several PropSwap/gemini repos disable repo-level auto-merge — those PRs need manual merge and that's not a failure.
+
+### project_llmwiki_unification.md
+
+---
+name: project-llmwiki-unification
+description: Plan to unify 5 hand-rolled LLM Wikis into one distributable Claude+Codex plugin via Lisa
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: c0c4fb06-f435-4fc5-aaad-445be9967086
+---
+
+Goal: replace the 5 separately-built "LLM Wiki" implementations (lisa, geminisportsai, gunnertech, propswap, publishing — all under ~/workspace) with ONE distributable kernel packaged as both a Claude plugin and a Codex plugin, shipped via Lisa's existing `plugins/src` → `plugins/*` build (which already generates `.codex-plugin` artifacts via scripts/generate-codex-plugin-artifacts.mjs).
+
+Plan agreed by Claude + Codex on 2026-05-22, saved as `PLAN.md` at the lisa repo root (written in worktree mystifying-colden-9b0d4e). Cody will install Lisa in all 5 repos (incl. publishing + gunner), so the plugin is named `lisa-wiki` (Codex had recommended a neutral name, but that's moot once all consumers run Lisa). Headline decisions: plugin `lisa-wiki`, skills `lisa-wiki-*`, config `wiki/lisa-wiki.config.json`; "wiki kernel" framing centered on integrity not a connector SDK; skills-first (Codex can't carry Claude `commands/` — Claude commands are thin facades); repo-local rendered contract snapshot; JSON config `wiki/llmwiki.config.json` + JSON Schemas; narrowed connector contract (connectors write only source notes + run metadata; kernel does synthesis/index/log/verify/state/PR, state advanced only after verification); deterministic validator scripts + optional CI; modes embedded|wrapper|standalone|subdir; v1 migrates lisa/gemini/propswap/gunner, publishing is v1.1 (with a v1 read-only compatibility gate). Slack scripts are byte-identical in gemini+propswap → centralize first.
+
+Later refinements (also codex-ratified): canonical command surface = `/ingest` `/query` `/lint` `/setup` `/migrate` (bare verbs, Claude facades over skills; Codex via `$`-skills) — keep Lisa's existing tracker `/intake` distinct, do NOT overload it. Extensibility = two generators: `/add-ingest` (scaffolds a thin project front-door skill that enriches then CHAINS into `/ingest`; kernel still owns synthesis/index/log/verify/state/PR) and `/add-role` (scaffolds a domain-expert "digital staff" subagent over the wiki). Digital staff: `config.staff[]` (role, expertise, owns{categories,connectors,skills}, sensitivity) → `/setup` seeds a roster, each role generates `wiki/staff/<role>.md` doc page + a dual-runtime subagent: Claude `.claude/agents/<role>.md` and Codex `.codex/agents/<role>.toml` (keys name/description/developer_instructions; optional model/model_reasoning_effort/sandbox_mode). Subagents are brain-pointed not baked; RUNNING/scheduling/routing them is explicitly out of scope (plugin only sets them up).
+
+Universal sources every project ingests: self+other-projects git/PR history, roles (the wiki's own staff), and MEMORY — but memory is **project-scoped ONLY, never global** (Cody's explicit rule: don't ingest anything unrelated to the project). Claude per-project memory dir always qualifies; Codex `~/.codex/memories/` is global by default so it is NOT ingested unless project-scoped via a per-project CODEX_HOME; Codex Chronicle is never ingested. Bare `/ingest` (no args) = full ingest of all enabled NON-external-write sources (external-write like Slack OAuth/CRM writeback skipped unless explicit intent). Migration invariant: rename to canonical /ingest //add-ingest //add-role is fine, loss of functionality/data is NOT (parity-check old vs new before deleting).
+
+Round-5 additions (codex-ratified): the wiki is the project's DOCUMENTATION HOME — setup/migration "absorbs" the host repo's own docs (docs/, specs/, README deep content) into wiki/documentation/, ingests them, and a deterministic rewrite-refs.mjs fixes all links (zero dangling); keep-in-place files (LICENSE, SECURITY.md, CONTRIBUTING.md, CHANGELOG.md, .github/**, NOTICE*, SUPPORT.md, GOVERNANCE.md) stay put; wrapper mode moves ONLY host docs never child-project docs. README: readme.mode = rich (DEFAULT, never auto-stub) | stub | preserve — ASKED interactively by /setup & /migrate (not silently defaulted); stub is an explicit per-repo human choice (lisa=rich/public; gemini/propswap/gunner=stub; publishing=rich/preserve). New /onboard-me skill+command: interviews the user about the project, captures to project-scoped memory only (read-mostly, no PR, never PII into wiki, never global memory; audience-note only with --write-audience-note + onboarding.allowAudienceNote), then guided tour + sample /query questions. /setup asks the wiki PURPOSE (config.purpose, rendered into contract+start-here). Canonical folder structure enforced via wiki-structure.schema.json manifest = single source of truth for validate-config/lint/render-contract. Docs-absorption + README-rewrite are migration repo-write ops, NOT connectors.
+
+Post-migration verification (PLAN §16, codex-ratified): new `/doctor` command (skill lisa-wiki-doctor + deterministic verify-migration.mjs) runs as `/migrate`'s final gate and is re-runnable; writes wiki/state/migration/doctor-report.json with per-item PASS/WARN/FAIL/SKIP and overall verdict READY | READY_WITH_WARNINGS | NOT_READY. Checklist groups A–G: structure&config, integrity&safety, no-loss/parity, runtime surfaces (both runtimes), functional smoke (ingest/query/lint/onboard-me/dry-run — no extra PR), mode-specific (embedded/wrapper/standalone-subdir/no-PR), git/CI/distribution (build checks Lisa/release-only, SKIP downstream). A repo is not "migrated" until verdict is READY (or human-approved READY_WITH_WARNINGS). Plan is now 19 sections.
+
+IMPLEMENTATION STATUS (2026-05-22): **M0 complete + committed** on branch claude/mystifying-colden-9b0d4e (commits 9d8aaff docs/PLAN, d352cc1 feat/M0). Source at `plugins/src/wiki/` builds to `plugins/lisa-wiki/` (both .claude-plugin + .codex-plugin); `bun run check:plugins` green. M0 = 10 skill specs, 9 command facades, 2 JSON schemas (lisa-wiki-config + wiki-structure manifest), templates (contract/index/log/start-here/state/page-types/role-agent), and dependency-free validate-config.mjs + render-contract.mjs (smoke-tested). Build wiring: `build_plugin` helper + `STANDALONE=(wiki)` in scripts/build-plugins.sh; metadataFor("lisa-wiki") in generate-codex-plugin-artifacts.mjs; marketplace.json entry; `plugins/**` added to eslint.config.local.ts ignores (payload + generated artifacts must not be auto-fixed, else check:plugins desyncs). NOTE: plugin scripts are dependency-free Node (no ajv) for downstream portability. **M1 complete + committed** (commit 9e1fe7d): dependency-free validators in plugins/src/wiki/scripts/ — _wiki-lib.mjs (shared), lint-wiki.mjs (structure/frontmatter/links/orphans/secrets/contamination; warn default, --strict blocks warns), diff-guard.mjs (connector touched-file boundary, NUL-safe porcelain incl untracked+renames, --base union), rewrite-refs.mjs (bidirectional ref rewrite on moves, title-aware, zero-dangling check), verify-migration.mjs (deterministic half of /doctor → state/migration/doctor-report.json, verdict READY/READY_WITH_WARNINGS/NOT_READY, subset; C/D/E/G done by doctor skill), ci/lisa-wiki-validate.yml. Fixture-tested + codex-reviewed (fixed 2 diff-guard blockers). check:plugins green. NEXT = M2 connectors (git, memory[project-scoped], roles, slack[centralize gemini/propswap stdlib py], web, docs, jira/confluence/notion via MCP doctor) — connectors write only source notes; synthesis is the kernel skill. Each component reviewed by codex before commit; user wants commits batched per-milestone (commit after each milestone).
+
+**PLUGIN BUILD COMPLETE** (2026-05-23, branch claude/mystifying-colden-9b0d4e): commits 9d8aaff (PLAN), d352cc1 (M0 kernel), 9e1fe7d (M1 validators), 9573f41 (M2 connectors). lisa-wiki builds both .claude-plugin + .codex-plugin; check:plugins green; end-to-end proof passes (fresh wiki → connectors → lint 0/0 → doctor READY). M2 = 9 connectors (scripts: ingest-git/memory/roles/mcp-doctor + centralized slack py with tenant-guard + emit-meta; skill-driven: jira/confluence/notion/web/docs) all per the §7 contract (connector writes only source note + proposed cursor to wiki/state/handoff/; kernel advances final state after verification). Each milestone codex-reviewed (codex caught + I fixed real blockers each round: M1 diff-guard untracked/porcelain; M2 slack ordering-bug, slack tenant-guard, memory prove-scope). REMAINING = M3-M7 = ROLLOUT: migrate the 5 LIVE repos (lisa embedded, gemini/propswap wrapper, gunner standalone, publishing subdir v1.1) onto the kernel via the migrate skill — production-repo deployment, do per-repo with PRs (not unattended). The distributable plugin itself (the core ask) is done.
+
+**SHIPPED**: PR #510 merged to main (squash, auto-merge) and released as **@codyswann/lisa@2.25.0 on npm** (latest). Merge blockers fixed en route: (1) eslint sonarjs/no-duplicate-string falsely flagged wiki/lisa-wiki.config.json → added `wiki/**` to eslint.config.local.ts ignores (wiki is content, not app code); (2) plugin-sync failed because main advanced to 2.24.0 mid-PR (build injects package version into manifests) → merged main + rebuilt plugins. The published tarball includes plugins/lisa-wiki/.claude-plugin + .codex-plugin and both marketplaces (.claude-plugin/marketplace.json + .agents/plugins/marketplace.json). Release-and-Deploy workflow succeeded. lisa's own wiki is migrated to Phase 1 (config committed). REMAINING: deeper lisa phases (normalize frontmatter/links by touch; swap old hand-rolled lisa-wiki-* skills for plugin once enabled) + migrate the other 4 live repos (gemini/propswap/gunner, publishing v1.1) — each a per-repo PR.
+
+**Why:** the wiki idea (Karpathy LLM Wiki) was reimplemented 5x with drift; a single plugin removes duplication and lets Lisa distribute it.
+**How to apply:** start from PLAN.md sections 17 (milestones M0-M7) and 18 (acceptance criteria). See `reference_codex_cli_collaboration` for how the plan was co-authored.
+
+### project_vitest_template_overlap.md
+
+---
+name: vitest-template-overlap
+description: Lisa's TypeScript stack vitest templates bleed into child stacks (Expo, CDK) that should stay on Jest
+type: project
+---
+
+Lisa's vitest migration (v1.65.0) has a template overlap issue: the TypeScript stack's `deletions.json` deletes `jest.config.ts` and the `copy-overwrite` deploys `vitest.config.ts`, but these apply to ALL TypeScript-derived stacks (Expo, CDK, NestJS) since they inherit from TypeScript.
+
+**Why:** Lisa processes stack directories in order: `all` → `typescript` → `expo`/`nestjs`/`cdk`. The TypeScript stack's deletions and vitest templates run before the child stack can override. Expo and CDK stacks have their own jest configs in `copy-overwrite/`, but the TypeScript stack's `deletions.json` already deleted the jest files, and vitest files were created.
+
+**How to apply:** When modifying Lisa's template deployment strategy, the deletion and copy-overwrite logic needs to be stack-aware: if a child stack (expo, cdk) has its own jest config in copy-overwrite, the parent stack's vitest migration should not delete those files. Possible fix: move jest deletion entries to stack-specific deletions.json only for stacks that actually migrate (typescript root, nestjs), not in the shared typescript stack.
+
+**Impact:** During downstream updates (2026-03-19), agents had to manually restore jest configs for Expo, CDK, and some TypeScript projects (ask-gemini). This is a workaround, not a fix.
+
+### reference_codex_automations.md
+
+---
+name: reference-codex-automations
+description: "How Codex \"automations\" (scheduled local agents) are defined on disk and managed"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: af5c7830-c861-4f23-877d-3b15b41fb4c7
+---
+
+Confirmed empirically 2026-05-25 (codex-cli 0.125.0) by inspecting `~/.codex/` + codex review.
+
+**What a Codex automation is.** A recurring local agent. Store: `~/.codex/automations/<id>/` with:
+- `automation.toml` — the definition.
+- `memory.md` — appended run log (one block per run).
+
+`automation.toml` schema (real example, the user's Lisa intake automation):
+```toml
+version = 1
+id = "lisa-ticket-build-intake"
+kind = "cron"
+name = "Lisa ticket/build intake"
+prompt = "Run one Lisa ticket/build intake cycle ... `/lisa:intake github intake_mode=build` ..."
+status = "ACTIVE"
+rrule = "FREQ=MINUTELY;INTERVAL=10"
+model = "gpt-5.5"
+reasoning_effort = "medium"
+execution_environment = "local"   # runs on the workstation
+cwds = ["/Users/cody/workspace/advisory-rankings"]
+created_at = 1779630624619        # epoch ms
+updated_at = 1779636560575
+```
+- Cadence is an iCal **rrule**: hourly `FREQ=HOURLY;INTERVAL=1`, every 10 min `FREQ=MINUTELY;INTERVAL=10`, every 6h `FREQ=HOURLY;INTERVAL=6`, daily `FREQ=DAILY;INTERVAL=1`.
+- The automation runs a natural-language **prompt** (which can invoke a slash command like `/lisa:intake ...`) in `cwds`.
+
+**Key facts:**
+- There is **NO `codex automation` CLI subcommand** (checked `codex --help`). Codex's own tool guidance says agents should use the **`automation_update`** tool (the app/automations mechanism) to create/update — NOT hand-write the TOML, even though TOML is the backing store.
+- No separate registry in `state_5.sqlite` (only thread/job/history); the TOML files are the source of truth, but the **Codex app/scheduler must be running** to fire them. No explicit reload step found.
+- Delete = native delete (or remove the `<id>/` directory; picked up on next scan).
+- `model`/timestamps are present on all live cron automations — include them; don't omit `model`.
+
+**Lisa usage:** the `setup-automations` / `tear-down-automations` skills (base plugin, 2026-05-25)
+are declarative specs that tell the runtime to create/remove these via the native mechanism (Codex
+automations / Claude `/schedule`) — the skill never writes TOML itself. Names use a
+`lisa-auto-<project>-` prefix so teardown is project-scoped. Claude equivalent of Codex automations
+is `/schedule`. Drove codex via `reference_codex_cli_collaboration`.
+
+Gotcha: a heavy `codex exec` with `model_reasoning_effort=high` + an agentic investigation loop got
+OOM-killed (exit 137). Do the filesystem investigation yourself; use codex for small focused prompts.
+
+### reference_codex_cli_collaboration.md
+
+---
+name: reference-codex-cli-collaboration
+description: How to drive the codex CLI non-interactively for Claude↔Codex collaboration
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: c0c4fb06-f435-4fc5-aaad-445be9967086
+---
+
+The `codex` CLI (codex-cli, model gpt-5.5) is installed and authed on this machine. Use it to get a second AI's review/collaboration non-interactively.
+
+- One-shot: `codex exec "<prompt>"` — prints final message to stdout (and a session id).
+- Continue the SAME session (keeps context): `codex exec resume --last "<prompt>"` (filters by cwd).
+- Silence MCP noise / speed up: add `-c mcp_servers={}` (it otherwise tries Linear MCP and errors).
+- Deeper reasoning: `-c model_reasoning_effort="high"`. Run outside a git repo: `--skip-git-repo-check`. Throwaway: `--ephemeral`.
+- It has danger-full-access in this env (can read the whole filesystem and verify claims itself).
+- Pattern that worked well: write a shared brief to `/tmp/...md`, have codex read it + write its response to another `/tmp/...md`, then `tail` stdout. Iterate via `resume --last`.
+
+Used 2026-05-22 to co-author the LLM Wiki unification PLAN.md (see `project_llmwiki_unification`).
+
+### reference_codex_commit_attribution.md
+
+---
+name: reference-codex-commit-attribution
+description: "How Codex CLI 0.125.0 stamps commit attribution trailers, and how Lisa's commit-msg hook accepts them"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 4614617a-bc2d-4b67-8d45-e78648b64627
+---
+
+Codex CLI **0.125.0** has a native commit-attribution mechanism (the mirror of Claude Code's `attribution.commit` setting). Verified by source-read + `codex debug prompt-input` (see `reference-codex-cli-collaboration`, `reference-codex-hooks-capabilities`).
+
+- Gated behind feature flag `features.codex_git_commit = true` (default OFF, "under development"). When off, Codex adds NO trailer by default.
+- Controlled by top-level config key `commit_attribution` (in `~/.codex/config.toml` or project `.codex/config.toml`). **Must be placed before the first `[table]` header** — it's a top-level key, so putting it after `[features]` would wrongly nest it as `features.commit_attribution`.
+- When enabled, Codex injects model guidance (not a deterministic git wrapper) to append exactly once: `Co-authored-by: Codex <noreply@openai.com>`. Custom value: `commit_attribution = "Lisa Codex <...>"` → `Co-authored-by: Lisa Codex <...>`. Empty string disables.
+- Casing differs from Claude: Codex emits `Co-authored-by`, Claude emits `Co-Authored-By`.
+- **No PR-body attribution** equivalent to Claude's `attribution.pr`.
+- If a `commit-msg` hook rejects a commit (exit 1), Codex sees stderr and retries with an amended message — so a blocking hook stays a hard gate even if the trailer is missing.
+
+Lisa change (2026-05-24): its `commit-msg` hook (`.husky/commit-msg`, template `typescript/copy-contents/.husky/commit-msg`, parity copy `.claude-pr/.husky/commit-msg`) used `grep -q "Co-Authored-By:.*Claude"` (Claude-only, case-sensitive). Broadened to `grep -Eiq "Co-authored-by:.*(Claude|Codex)"` so Codex commits pass while un-attributed/human commits still block. Lisa's own `.codex/config.toml` now sets `codex_git_commit = true` + `commit_attribution`. NOTE: Lisa ships the husky hook downstream but does NOT ship a `.codex/config.toml` downstream — downstream Codex relies on the hook-reject-retry path unless a Codex config is also distributed.
+
+### reference_codex_hooks_capabilities.md
+
+---
+name: reference-codex-hooks-capabilities
+description: "What the Codex CLI 0.125.0 hook system supports vs. Lisa's Claude hooks (empirically verified)"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 91045a17-6bee-46bc-ab0e-63cd32a7d6a5
+---
+
+Codex CLI **0.125.0** hook system, verified by source-read + runtime tests with codex (see `reference-codex-cli-collaboration`). Findings:
+
+- **Plugin-bundled hooks DO NOT RUN.** A distributed Codex plugin's `.codex-plugin/plugin.json` `hooks` pointer and `hooks/hooks.json` are NOT executed (manifest parser only honors skills/mcpServers/apps/interface). Lisa's `scripts/generate-codex-plugin-artifacts.mjs` emits these — they are **dead weight on Codex**. Hooks only load from `~/.codex/hooks.json`, project `.codex/hooks.json`, or `[hooks]` in `config.toml`. Enable via `[features].codex_hooks = true`.
+- **Supported events:** `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`. **No `SubagentStart`, no `SessionEnd`** (despite Codex having multi-agent/`spawn_agent`).
+- **SessionStart context injection WORKS** (runtime-verified): emit `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}`. Honored on SessionStart/UserPromptSubmit/PostToolUse. NOT on PreToolUse. Top-level `{"additionalContext":...}` (Claude shape) is not the verified Codex shape.
+- **PreToolUse blocking WORKS** (runtime-verified): exit 2 + stderr blocks the tool and surfaces the reason. Also supports JSON `{"decision":"block","reason":...}`.
+- **stdin contract** matches Claude's field names: `session_id`, `cwd`, `hook_event_name`, `tool_name`, `tool_input.command`, etc. Shell tool canonical `tool_name` is `"Bash"`. Edit tool is `apply_patch` (matcher aliases `Write`/`Edit`, so `Edit|Write|apply_patch` matches once) — but **apply_patch supplies patch text in `tool_input`, NOT `tool_input.file_path`**, so Claude edit hooks that parse `file_path` silently no-op.
+- Hooks run under `$SHELL -lc` in session cwd; default timeout 600s. **`CLAUDE_PLUGIN_ROOT`/`CODEX_PLUGIN_ROOT` are NOT set** for hook commands — use absolute/repo-relative paths. SessionStart `source` ∈ {startup, resume, clear}. UserPromptSubmit/Stop ignore matchers.
+
+Net for Lisa: porting hooks to Codex needs (1) an installer writing to a real Codex hook config layer, (2) inject-rules re-added with the `hookSpecificOutput` shape (SessionStart only), (3) edit hooks adapted to read file paths from apply_patch bodies. No-equivalent (cannot port): all SubagentStart hooks (inject-flow-context, enforce-team-first@subagent), SessionEnd (`entire ... session-end`), and enforce-team-first overall (Claude-team-specific).
+
+### reference_codex_plugin_skill_loading.md
+
+---
+name: reference-codex-plugin-skill-loading
+description: How the Codex CLI loads skills shipped inside a Lisa plugin (no per-skill manifest needed)
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: b2c9f454-a9c9-462e-ae8a-8722797d34d1
+---
+
+Confirmed with codex (gpt-5.5) on 2026-05-23 by having it inspect the real Lisa artifacts.
+
+How Codex consumes a Lisa-built plugin's skills:
+
+- Codex discovers plugin skills via the `"skills": "./skills/"` pointer in `.codex-plugin/plugin.json` (relative to plugin root). It scans `skills/<name>/SKILL.md`, reading YAML frontmatter `name`/`description` as the model-visible metadata; the body loads on trigger.
+- **`agents/openai.yaml` is OPTIONAL** — UI/starter-prompt metadata only, not required for discovery or invocation. So porting a Codex skill into a Lisa plugin needs ONLY `SKILL.md`; the build's `generate-codex-plugin-artifacts.mjs` already emits the `skills` pointer whenever a `skills/` dir exists. **No generator change is needed to make a new skill work in Codex.**
+- Codex does **not** consume Claude `commands/` dirs (it ignores `allowed-tools`/`argument-hint`). The generator should not point to `commands/`. The real Codex surface is the skill itself.
+- Invocation/namespacing: plugin skills are addressed namespaced, e.g. `$lisa-expo:exploratory-qa`. A personal/global skill in `~/.codex/skills/<name>/` appears bare (`$exploratory-qa`) and coexists, but bare invocation hits the personal copy — remove the personal copy once the plugin ships to avoid masking the plugin version.
+- Optional future polish: generator could derive `skills/<name>/agents/openai.yaml` (interface.display_name / short_description / default_prompt) from SKILL.md frontmatter. Additive only.
+
+Applies to the `project_llmwiki_unification` Claude+Codex dual-distribution model. Drove codex via `reference_codex_cli_collaboration`.
+
+### reference_lisa_new_standalone_plugin_wiring.md
+
+---
+name: reference-lisa-new-standalone-plugin-wiring
+description: The five wiring points to add a new standalone (non-stack) Lisa plugin so it works in both Claude Code and Codex
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 2a2e9bbf-f6ae-46f3-a39a-ec5dcc91c12d
+---
+
+To add a new standalone Lisa plugin (like `lisa-wiki`, `lisa-openclaw`) — built from
+`plugins/src/<name>` → `plugins/lisa-<name>` — wire ALL of these, then `bun run build:plugins` and
+commit src + generated artifacts together:
+
+1. `plugins/src/<name>/.claude-plugin/plugin.json` — manifest (version injected at build).
+2. `plugins/src/<name>/skills/...` + `commands/...` (skills hold logic; commands are thin
+   `$ARGUMENTS` pass-throughs — Codex ignores commands, so each SKILL.md must be self-complete).
+3. `scripts/build-plugins.sh` — add the name to `STANDALONE=(wiki ...)`.
+4. `scripts/generate-codex-plugin-artifacts.mjs` — add a `metadataFor("lisa-<name>")` entry (else the
+   Codex manifest gets generic fallback UI text).
+5. **BOTH** marketplaces:
+   - `.claude-plugin/marketplace.json` — Claude install surface. **Enforced** by
+     `scripts/check-plugins-sync.sh` (`bun run check:plugins`): every built `plugins/lisa*` dir must
+     have an entry and every entry's source must exist.
+   - `.agents/plugins/marketplace.json` — the **Codex install surface** (entry shape:
+     `source:{source:"local",path}`, `policy:{installation:"AVAILABLE",authentication:"ON_INSTALL"}`).
+     NOT enforced by CI, so it's easy to forget — but omitting it means the plugin is not installable
+     in Codex even though its skills are otherwise Codex-ready. (Confirmed by codex during the
+     lisa-openclaw build, 2026-05-24.)
+
+Codex discovers a plugin's skills via the generated `.codex-plugin/plugin.json` `"skills":"./skills/"`
+pointer (see `reference_codex_plugin_skill_loading`); the `.agents` marketplace is install/discovery,
+the `.codex-plugin` pointer is post-install skill loading — both are needed.
+
+Note (2026-05-24): `lisa-wiki` is registered in `.claude-plugin` but was MISSING from `.agents` at
+that commit — a pre-existing gap being fixed in the main checkout's working tree. `check:plugins`
+never catches it because it only validates `.claude-plugin`.

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-27T01:33:58.521Z",
+  "ingested_at": "2026-05-27T05:32:51.262Z",
   "cursor": {
-    "lastCommit": "65043e915a23a992904badaf708fd5a849cd54e5",
-    "lastPr": 994
+    "lastCommit": "73072b8e5b839dede4bf50985232d1d6bddfe9f4",
+    "lastPr": 995
   },
   "source_notes": [
     "wiki/sources/git/2026-05-27-lisa-monorepo-git.md"

--- a/wiki/state/memory/latest.json
+++ b/wiki/state/memory/latest.json
@@ -1,0 +1,12 @@
+{
+  "connector": "memory",
+  "profile": "project",
+  "ingested_at": "2026-05-27T05:32:51.335Z",
+  "cursor": {
+    "files": 20,
+    "lastIngest": "2026-05-27"
+  },
+  "source_notes": [
+    "wiki/sources/memory/2026-05-27-memory.md"
+  ]
+}

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-27T01:33:57.878Z",
+  "ingested_at": "2026-05-27T05:32:51.295Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary
- ingest latest Lisa git history through 73072b8e / merged PR #995
- capture project-scoped Claude memory as a sanitized internal source note
- refresh wiki synthesis, source index, log, and connector state

## Verification
- git diff --check
- node plugins/src/wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/src/wiki/scripts/lint-wiki.mjs --wiki wiki (0 failures, existing 12 warnings)
- changed-file secret scan
- node plugins/src/wiki/scripts/diff-guard.mjs --base origin/main --allow 'wiki/**'
- pre-commit hook: typecheck, gitleaks, lint-staged, commitlint, AI co-authorship
- pre-push hook: bun audit, slow lint, knip, coverage tests, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Memory Sources now accessible in wiki navigation for organized guidance reference
* Added comprehensive project-scoped memory documentation with operational guidance, troubleshooting tips, and automation/CI reference materials
* Updated project metadata and state tracking with latest commits and release progress

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->