### PR TITLE
Fix durable synced Lisa automation checkouts

### DIFF
--- a/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -21,7 +21,12 @@ independent and use disjoint name prefixes, so running both is safe.
 - **Codex** → create a Codex **automation** via the native automations mechanism (prefer the
   `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
   only its backing store). Set the execution environment to **local** so it runs on this
-  workstation, scoped to this project's working directory.
+  workstation. Scope it to a durable project automation checkout, not a transient task worktree: use
+  `${CODEX_HOME:-~/.codex}/worktrees/<project>-automation-main` when available, create or refresh
+  that checkout from the project's `origin` remote if needed, and verify `git -C <cwd> rev-parse
+  --is-inside-work-tree --is-bare-repository` reports `true` then `false` before saving the
+  automation. Do not point recurring automations at hashed scratch worktrees or a checkout whose Git
+  metadata is broken.
 - **Claude** → use **`/schedule`** to create a local recurring routine.
 - **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
   state that scheduling is unavailable and stop.
@@ -38,6 +43,11 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
+Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
+rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
+checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
+rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
+rebase and report the blocker instead of ingesting from stale code.
 
 | Automation | Command it runs | Cadence |
 |---|---|---|
@@ -45,11 +55,12 @@ non-external-write source; commit/PR per the ingest skill's bookends; report the
 
 **Naming + scope (so teardown is precise).** Name the automation with the stable prefix
 `lisa-wiki-auto-<project>-` (i.e. `lisa-wiki-auto-<project>-ingest`), where `<project>` identifies
-this repo, and scope it to this project's working directory. This prefix is deliberately distinct
-from the base `lisa-auto-<project>-` set so `/lisa-wiki:tear-down-automations` removes exactly this
-automation and never touches the base automations or any other project's. Use a project identifier
-stable across runs and distinct from other repos (qualify it, e.g. with the owner — don't rely on a
-bare repo basename that could collide).
+this repo, and scope each Codex automation to the durable project automation checkout described
+above. This prefix is deliberately distinct from the base `lisa-auto-<project>-` set so
+`/lisa-wiki:tear-down-automations` removes exactly this automation and never touches the base
+automations or any other project's. Use a project identifier stable across runs and distinct from
+other repos (qualify it, e.g. with the owner — don't rely on a bare repo basename that could
+collide).
 
 **Idempotent.** Re-running this skill updates the existing `lisa-wiki-auto-<project>-ingest`
 automation in place (same name) rather than creating a duplicate.
@@ -60,6 +71,8 @@ automation in place (same name) rather than creating a duplicate.
   `wiki/lisa-wiki.config.json`. If there is no configured wiki, **stop and report** that the wiki
   must be set up first (run `/lisa-wiki:setup`); do not schedule ingest against a non-existent wiki.
 - If the runtime has no native scheduler, stop and report what's missing rather than guessing.
+- For Codex, if the durable checkout cannot be created, fetched, or verified as a non-bare Git work
+  tree, stop and report the checkout problem instead of creating an automation that will fail later.
 
 ## Report
 

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -13,6 +13,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
@@ -22,6 +24,7 @@ const RUN_FAILURE_PATTERN =
   /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
+const execFileAsync = promisify(execFile);
 
 /**
  * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
@@ -34,6 +37,10 @@ const NEGATED_FAILURE_PATTERN =
  *   readonly observedRRule?: string
  *   readonly observedCommand?: string
  *   readonly cwd?: string | null
+ *   readonly cwdHealth?: {
+ *     readonly status: "ok" | "missing" | "not_directory" | "not_git_work_tree" | "bare_git_repository" | "git_error"
+ *     readonly summary: string
+ *   }
  *   readonly createdAt?: number | null
  *   readonly updatedAt?: number | null
  *   readonly lastRunAt?: string | null
@@ -266,6 +273,8 @@ async function readCodexAutomation(automationDir) {
   const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
+  const normalizedCwd = typeof cwd === "string" ? cwd : null;
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
 
   return {
     automationId:
@@ -279,7 +288,8 @@ async function readCodexAutomation(automationDir) {
     observedCommand: deriveCodexObservedCommand(
       stringOrUndefined(automation.prompt)
     ),
-    cwd: typeof cwd === "string" ? cwd : null,
+    cwd: normalizedCwd,
+    cwdHealth,
     createdAt: numberOrNull(automation.created_at),
     updatedAt: numberOrNull(automation.updated_at),
     ...memory,
@@ -299,6 +309,9 @@ function createObservedStatusItem(input) {
   const observedDetails = [comparison.observed];
   if (observed?.status) {
     observedDetails.push(`Scheduler status: ${observed.status}`);
+  }
+  if (observed?.cwdHealth) {
+    observedDetails.push(`Cwd: ${observed.cwdHealth.summary}`);
   }
   if (observed?.lastRunAt) {
     observedDetails.push(`Last run: ${observed.lastRunAt}`);
@@ -352,6 +365,15 @@ function classifyAutomationRunSignal(input) {
     };
   }
 
+  if (observed.cwdHealth && observed.cwdHealth.status !== "ok") {
+    return {
+      status: "FAILING",
+      summary: `scheduler cwd is invalid: ${observed.cwdHealth.summary}`,
+      remediation:
+        "Recreate the automation with `/lisa:setup-automations` so it uses a durable non-bare project checkout, then verify the cwd before the next run.",
+    };
+  }
+
   if (observed.lastRunFailed) {
     return {
       status: "FAILING",
@@ -388,6 +410,69 @@ function classifyAutomationRunSignal(input) {
   }
 
   return null;
+}
+
+async function inspectAutomationCwd(cwd) {
+  if (!cwd) {
+    return {
+      status: "missing",
+      summary: "no cwd configured",
+    };
+  }
+
+  const stat = await fs.stat(cwd).catch(error => {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+
+  if (!stat) {
+    return {
+      status: "missing",
+      summary: `${cwd} does not exist`,
+    };
+  }
+
+  if (!stat.isDirectory()) {
+    return {
+      status: "not_directory",
+      summary: `${cwd} is not a directory`,
+    };
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
+      { timeout: 5000 }
+    );
+    const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
+
+    if (insideWorkTree !== "true") {
+      return {
+        status: "not_git_work_tree",
+        summary: `${cwd} is not inside a Git work tree`,
+      };
+    }
+
+    if (bareRepository === "true") {
+      return {
+        status: "bare_git_repository",
+        summary: `${cwd} is configured as a bare Git repository`,
+      };
+    }
+
+    return {
+      status: "ok",
+      summary: `${cwd} is a valid Git work tree`,
+    };
+  } catch (error) {
+    return {
+      status: "git_error",
+      summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,
+    };
+  }
 }
 
 function resolveDefaultCodexAutomationsDir() {

--- a/plugins/lisa/skills/setup-automations/SKILL.md
+++ b/plugins/lisa/skills/setup-automations/SKILL.md
@@ -16,7 +16,12 @@ create them; invoke the runtime's automation tool with the spec below.
 - **Codex** → create Codex **automations** via the native automations mechanism (prefer the
   `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
   only its backing store). Set the execution environment to **local** so they run on this
-  workstation, scoped to this project's working directory.
+  workstation. Scope them to a durable project automation checkout, not a transient task worktree:
+  use `${CODEX_HOME:-~/.codex}/worktrees/<project>-automation-main` when available, create or refresh
+  that checkout from the project's `origin` remote if needed, and verify `git -C <cwd> rev-parse
+  --is-inside-work-tree --is-bare-repository` reports `true` then `false` before saving the
+  automation. Do not point recurring automations at hashed scratch worktrees or a checkout whose Git
+  metadata is broken.
 - **Claude** → use **`/schedule`** to create local recurring routines, one per automation below.
 - **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
   state that scheduling is unavailable and stop.
@@ -37,6 +42,11 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
+Before running the Lisa command, each automation must sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
+the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
+the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
 
 | Automation | Command it runs | Cadence |
 |---|---|---|
@@ -56,10 +66,10 @@ are written).
 
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
-repo, and scope each to this project's working directory. This lets `/tear-down-automations` find and
-remove exactly this set and never touch other projects' automations or non-Lisa ones. Use a project
-identifier stable across runs and distinct from other repos (don't rely on a bare repo basename when
-it could collide; qualify it, e.g. with the owner).
+repo, and scope each Codex automation to the durable project automation checkout described above.
+This lets `/tear-down-automations` find and remove exactly this set and never touch other projects'
+automations or non-Lisa ones. Use a project identifier stable across runs and distinct from other
+repos (don't rely on a bare repo basename when it could collide; qualify it, e.g. with the owner).
 
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
@@ -71,6 +81,8 @@ place (same names) rather than creating duplicates.
   automation and note it — do not invent a command that doesn't exist.
 - If the runtime has no native scheduler, or the intake queues can't be resolved from config, stop
   and report what's missing rather than guessing.
+- For Codex, if the durable checkout cannot be created, fetched, or verified as a non-bare Git work
+  tree, stop and report the checkout problem instead of creating automations that will fail later.
 
 ## Report
 

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -13,6 +13,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
 
@@ -22,6 +24,7 @@ const RUN_FAILURE_PATTERN =
   /\b(failed|failure|errored|error|exception|crash(?:ed)?)\b/i;
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
+const execFileAsync = promisify(execFile);
 
 /**
  * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
@@ -34,6 +37,10 @@ const NEGATED_FAILURE_PATTERN =
  *   readonly observedRRule?: string
  *   readonly observedCommand?: string
  *   readonly cwd?: string | null
+ *   readonly cwdHealth?: {
+ *     readonly status: "ok" | "missing" | "not_directory" | "not_git_work_tree" | "bare_git_repository" | "git_error"
+ *     readonly summary: string
+ *   }
  *   readonly createdAt?: number | null
  *   readonly updatedAt?: number | null
  *   readonly lastRunAt?: string | null
@@ -266,6 +273,8 @@ async function readCodexAutomation(automationDir) {
   const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
+  const normalizedCwd = typeof cwd === "string" ? cwd : null;
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
 
   return {
     automationId:
@@ -279,7 +288,8 @@ async function readCodexAutomation(automationDir) {
     observedCommand: deriveCodexObservedCommand(
       stringOrUndefined(automation.prompt)
     ),
-    cwd: typeof cwd === "string" ? cwd : null,
+    cwd: normalizedCwd,
+    cwdHealth,
     createdAt: numberOrNull(automation.created_at),
     updatedAt: numberOrNull(automation.updated_at),
     ...memory,
@@ -299,6 +309,9 @@ function createObservedStatusItem(input) {
   const observedDetails = [comparison.observed];
   if (observed?.status) {
     observedDetails.push(`Scheduler status: ${observed.status}`);
+  }
+  if (observed?.cwdHealth) {
+    observedDetails.push(`Cwd: ${observed.cwdHealth.summary}`);
   }
   if (observed?.lastRunAt) {
     observedDetails.push(`Last run: ${observed.lastRunAt}`);
@@ -352,6 +365,15 @@ function classifyAutomationRunSignal(input) {
     };
   }
 
+  if (observed.cwdHealth && observed.cwdHealth.status !== "ok") {
+    return {
+      status: "FAILING",
+      summary: `scheduler cwd is invalid: ${observed.cwdHealth.summary}`,
+      remediation:
+        "Recreate the automation with `/lisa:setup-automations` so it uses a durable non-bare project checkout, then verify the cwd before the next run.",
+    };
+  }
+
   if (observed.lastRunFailed) {
     return {
       status: "FAILING",
@@ -388,6 +410,69 @@ function classifyAutomationRunSignal(input) {
   }
 
   return null;
+}
+
+async function inspectAutomationCwd(cwd) {
+  if (!cwd) {
+    return {
+      status: "missing",
+      summary: "no cwd configured",
+    };
+  }
+
+  const stat = await fs.stat(cwd).catch(error => {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+
+  if (!stat) {
+    return {
+      status: "missing",
+      summary: `${cwd} does not exist`,
+    };
+  }
+
+  if (!stat.isDirectory()) {
+    return {
+      status: "not_directory",
+      summary: `${cwd} is not a directory`,
+    };
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
+      { timeout: 5000 }
+    );
+    const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
+
+    if (insideWorkTree !== "true") {
+      return {
+        status: "not_git_work_tree",
+        summary: `${cwd} is not inside a Git work tree`,
+      };
+    }
+
+    if (bareRepository === "true") {
+      return {
+        status: "bare_git_repository",
+        summary: `${cwd} is configured as a bare Git repository`,
+      };
+    }
+
+    return {
+      status: "ok",
+      summary: `${cwd} is a valid Git work tree`,
+    };
+  } catch (error) {
+    return {
+      status: "git_error",
+      summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,
+    };
+  }
 }
 
 function resolveDefaultCodexAutomationsDir() {

--- a/plugins/src/base/skills/setup-automations/SKILL.md
+++ b/plugins/src/base/skills/setup-automations/SKILL.md
@@ -16,7 +16,12 @@ create them; invoke the runtime's automation tool with the spec below.
 - **Codex** → create Codex **automations** via the native automations mechanism (prefer the
   `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
   only its backing store). Set the execution environment to **local** so they run on this
-  workstation, scoped to this project's working directory.
+  workstation. Scope them to a durable project automation checkout, not a transient task worktree:
+  use `${CODEX_HOME:-~/.codex}/worktrees/<project>-automation-main` when available, create or refresh
+  that checkout from the project's `origin` remote if needed, and verify `git -C <cwd> rev-parse
+  --is-inside-work-tree --is-bare-repository` reports `true` then `false` before saving the
+  automation. Do not point recurring automations at hashed scratch worktrees or a checkout whose Git
+  metadata is broken.
 - **Claude** → use **`/schedule`** to create local recurring routines, one per automation below.
 - **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
   state that scheduling is unavailable and stop.
@@ -37,6 +42,11 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
+Before running the Lisa command, each automation must sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
+the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
+the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
 
 | Automation | Command it runs | Cadence |
 |---|---|---|
@@ -56,10 +66,10 @@ are written).
 
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
-repo, and scope each to this project's working directory. This lets `/tear-down-automations` find and
-remove exactly this set and never touch other projects' automations or non-Lisa ones. Use a project
-identifier stable across runs and distinct from other repos (don't rely on a bare repo basename when
-it could collide; qualify it, e.g. with the owner).
+repo, and scope each Codex automation to the durable project automation checkout described above.
+This lets `/tear-down-automations` find and remove exactly this set and never touch other projects'
+automations or non-Lisa ones. Use a project identifier stable across runs and distinct from other
+repos (don't rely on a bare repo basename when it could collide; qualify it, e.g. with the owner).
 
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
@@ -71,6 +81,8 @@ place (same names) rather than creating duplicates.
   automation and note it — do not invent a command that doesn't exist.
 - If the runtime has no native scheduler, or the intake queues can't be resolved from config, stop
   and report what's missing rather than guessing.
+- For Codex, if the durable checkout cannot be created, fetched, or verified as a non-bare Git work
+  tree, stop and report the checkout problem instead of creating automations that will fail later.
 
 ## Report
 

--- a/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -21,7 +21,12 @@ independent and use disjoint name prefixes, so running both is safe.
 - **Codex** → create a Codex **automation** via the native automations mechanism (prefer the
   `automation_update` tool over hand-writing `~/.codex/automations/<id>/automation.toml`; the TOML is
   only its backing store). Set the execution environment to **local** so it runs on this
-  workstation, scoped to this project's working directory.
+  workstation. Scope it to a durable project automation checkout, not a transient task worktree: use
+  `${CODEX_HOME:-~/.codex}/worktrees/<project>-automation-main` when available, create or refresh
+  that checkout from the project's `origin` remote if needed, and verify `git -C <cwd> rev-parse
+  --is-inside-work-tree --is-bare-repository` reports `true` then `false` before saving the
+  automation. Do not point recurring automations at hashed scratch worktrees or a checkout whose Git
+  metadata is broken.
 - **Claude** → use **`/schedule`** to create a local recurring routine.
 - **Other runtimes** → use the runtime's native recurring-task mechanism. If the runtime has none,
   state that scheduling is unavailable and stop.
@@ -38,6 +43,11 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
+Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
+rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
+checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
+rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
+rebase and report the blocker instead of ingesting from stale code.
 
 | Automation | Command it runs | Cadence |
 |---|---|---|
@@ -45,11 +55,12 @@ non-external-write source; commit/PR per the ingest skill's bookends; report the
 
 **Naming + scope (so teardown is precise).** Name the automation with the stable prefix
 `lisa-wiki-auto-<project>-` (i.e. `lisa-wiki-auto-<project>-ingest`), where `<project>` identifies
-this repo, and scope it to this project's working directory. This prefix is deliberately distinct
-from the base `lisa-auto-<project>-` set so `/lisa-wiki:tear-down-automations` removes exactly this
-automation and never touches the base automations or any other project's. Use a project identifier
-stable across runs and distinct from other repos (qualify it, e.g. with the owner — don't rely on a
-bare repo basename that could collide).
+this repo, and scope each Codex automation to the durable project automation checkout described
+above. This prefix is deliberately distinct from the base `lisa-auto-<project>-` set so
+`/lisa-wiki:tear-down-automations` removes exactly this automation and never touches the base
+automations or any other project's. Use a project identifier stable across runs and distinct from
+other repos (qualify it, e.g. with the owner — don't rely on a bare repo basename that could
+collide).
 
 **Idempotent.** Re-running this skill updates the existing `lisa-wiki-auto-<project>-ingest`
 automation in place (same name) rather than creating a duplicate.
@@ -60,6 +71,8 @@ automation in place (same name) rather than creating a duplicate.
   `wiki/lisa-wiki.config.json`. If there is no configured wiki, **stop and report** that the wiki
   must be set up first (run `/lisa-wiki:setup`); do not schedule ingest against a non-existent wiki.
 - If the runtime has no native scheduler, stop and report what's missing rather than guessing.
+- For Codex, if the durable checkout cannot be created, fetched, or verified as a non-bare Git work
+  tree, stop and report the checkout problem instead of creating an automation that will fail later.
 
 ## Report
 

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -9,24 +9,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
-import { compareAutomationContract } from "../../../plugins/src/base/scripts/automation-status-contract-drift.mjs";
-import {
-  deriveCodexObservedCommand,
-  inspectCodexAutomationFleet,
-  parseCodexAutomationMemory,
-} from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+import { inspectCodexAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
 
 const BUILD_INTAKE_PROMPT =
   "Run one cron-safe Lisa build-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=build`.";
-const BUILD_INTAKE_CADENCE = "every 10 minutes";
-const BUILD_INTAKE_COMMAND = "/lisa:intake github intake_mode=build";
 const BUILD_INTAKE_RRULE = "FREQ=MINUTELY;INTERVAL=10";
 const BUILD_INTAKE_AUTOMATION_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
 const RECENT_RUN_AT = "2026-05-26T12:00:00Z";
+const execFileAsync = promisify(execFile);
 
 describe("automation-status Codex adapter (#801)", () => {
   const tempDirs = [];
@@ -129,84 +125,6 @@ describe("automation-status Codex adapter (#801)", () => {
     );
   });
 
-  it("derives normalized Lisa slash commands from Codex automation prompts", () => {
-    expect(deriveCodexObservedCommand(BUILD_INTAKE_PROMPT)).toBe(
-      BUILD_INTAKE_COMMAND
-    );
-
-    expect(
-      deriveCodexObservedCommand(
-        "Run one evidence-grounded ideation pass. Use the Lisa project-ideation skill with arguments `prd_ready=true`."
-      )
-    ).toBe("/lisa:project-ideation prd_ready=true");
-
-    expect(
-      deriveCodexObservedCommand(
-        "Run one Playwright-backed exploratory QA pass. Use the `$lisa-exploratory-qa` skill with arguments `ready=true`."
-      )
-    ).toBe("/lisa:exploratory-qa ready=true");
-  });
-
-  it("canonicalizes Codex $lisa-* aliases to Lisa slash-colon commands (#880)", () => {
-    const observedCommand = deriveCodexObservedCommand(
-      "Run one cron-safe Lisa build-intake cycle. Use the `$lisa-intake` skill with arguments `github intake_mode=build`."
-    );
-
-    expect(observedCommand).toBe(BUILD_INTAKE_COMMAND);
-    expect(
-      compareAutomationContract({
-        expected: {
-          automationId: BUILD_INTAKE_AUTOMATION_ID,
-          expectedCadence: BUILD_INTAKE_CADENCE,
-          expectedRRule: BUILD_INTAKE_RRULE,
-          expectedCommand: BUILD_INTAKE_COMMAND,
-        },
-        observedAutomation: {
-          automationId: BUILD_INTAKE_AUTOMATION_ID,
-          observedCadence: BUILD_INTAKE_CADENCE,
-          observedRRule: BUILD_INTAKE_RRULE,
-          observedCommand,
-        },
-      }).status
-    ).toBe("HEALTHY");
-  });
-
-  it("does not classify negated error or exception summaries as failures (#885)", () => {
-    expect(
-      parseCodexAutomationMemory(
-        `${RECENT_RUN_AT}\n\n- completed with no errors\n`
-      ).lastRunFailed
-    ).toBe(false);
-
-    expect(
-      parseCodexAutomationMemory(
-        `${RECENT_RUN_AT}\n\n- ran without exceptions\n`
-      ).lastRunFailed
-    ).toBe(false);
-
-    expect(
-      parseCodexAutomationMemory(
-        `${RECENT_RUN_AT}\n\n- encountered an exception\n`
-      ).lastRunFailed
-    ).toBe(true);
-  });
-
-  it("uses the newest append-only memory run for timestamps and failure state (#881)", () => {
-    const memory = [
-      "# Lisa Build Intake Automation Memory",
-      "",
-      "- 2025-01-01T00:00:00Z: Completed successfully with no errors.",
-      `- ${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
-      "",
-    ].join("\n");
-
-    expect(parseCodexAutomationMemory(memory)).toEqual({
-      lastRunAt: RECENT_RUN_AT,
-      lastRunSummary: `${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
-      lastRunFailed: true,
-    });
-  });
-
   it("inspects automation files read-only", async () => {
     const automationsDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "lisa-codex-automation-readonly-")
@@ -251,11 +169,13 @@ describe("automation-status Codex adapter (#801)", () => {
  *   readonly rrule: string
  *   readonly prompt: string
  *   readonly memory: string
+ *   readonly cwd?: string
  * }} input Fixture values to write.
  * @returns {Promise<void>} Resolves after the fixture files are written.
  */
 async function writeAutomationFixture(automationsDir, input) {
   const automationDir = path.join(automationsDir, input.id);
+  const cwd = input.cwd ?? (await createGitWorkTreeFixture(automationsDir));
   await fs.mkdir(automationDir, { recursive: true });
   await fs.writeFile(
     path.join(automationDir, "automation.toml"),
@@ -270,11 +190,25 @@ async function writeAutomationFixture(automationsDir, input) {
       'model = "gpt-5.4"',
       'reasoning_effort = "medium"',
       'execution_environment = "local"',
-      'cwds = ["/tmp/repo"]',
+      `cwds = ["${escapeTomlString(cwd)}"]`,
       "",
     ].join("\n")
   );
   await fs.writeFile(path.join(automationDir, "memory.md"), input.memory);
+}
+
+/**
+ * Create a tiny valid Git work tree for cwd health checks.
+ *
+ * @param {string} automationsDir Parent fixture directory.
+ * @returns {Promise<string>} Path to the created work tree.
+ */
+async function createGitWorkTreeFixture(automationsDir) {
+  const reposDir = path.join(automationsDir, "_repos");
+  await fs.mkdir(reposDir, { recursive: true });
+  const repoDir = await fs.mkdtemp(path.join(reposDir, "repo-"));
+  await execFileAsync("git", ["init"], { cwd: repoDir });
+  return repoDir;
 }
 
 /**
@@ -295,10 +229,15 @@ async function snapshotAutomationDir(dir) {
       continue;
     }
     const automationDir = path.join(dir, entry.name);
-    const automationToml = await fs.readFile(
-      path.join(automationDir, "automation.toml"),
-      "utf8"
-    );
+    const automationTomlPath = path.join(automationDir, "automation.toml");
+    const hasAutomationToml = await fs
+      .access(automationTomlPath)
+      .then(() => true)
+      .catch(() => false);
+    if (!hasAutomationToml) {
+      continue;
+    }
+    const automationToml = await fs.readFile(automationTomlPath, "utf8");
     const memory = await fs.readFile(
       path.join(automationDir, "memory.md"),
       "utf8"

--- a/tests/unit/strategies/automation-status-codex-command-memory.test.ts
+++ b/tests/unit/strategies/automation-status-codex-command-memory.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression coverage for Codex automation command and memory normalization.
+ *
+ * @module tests/unit/strategies/automation-status-codex-command-memory
+ */
+import { describe, expect, it } from "vitest";
+
+import { compareAutomationContract } from "../../../plugins/src/base/scripts/automation-status-contract-drift.mjs";
+import {
+  deriveCodexObservedCommand,
+  parseCodexAutomationMemory,
+} from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+
+const BUILD_COMMAND = "/lisa:intake github intake_mode=build";
+const BUILD_PROMPT =
+  "Run one cron-safe Lisa build-intake cycle. Use the Lisa intake skill with arguments `github intake_mode=build`.";
+const BUILD_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
+const BUILD_RRULE = "FREQ=MINUTELY;INTERVAL=10";
+const RECENT_RUN_AT = "2026-05-26T12:00:00Z";
+
+describe("automation-status Codex command and memory normalization", () => {
+  it("derives normalized Lisa slash commands from Codex automation prompts", () => {
+    expect(deriveCodexObservedCommand(BUILD_PROMPT)).toBe(BUILD_COMMAND);
+    expect(
+      deriveCodexObservedCommand(
+        "Run ideation. Use the Lisa project-ideation skill with arguments `prd_ready=true`."
+      )
+    ).toBe("/lisa:project-ideation prd_ready=true");
+    expect(
+      deriveCodexObservedCommand(
+        "Run QA. Use the `$lisa-exploratory-qa` skill with arguments `ready=true`."
+      )
+    ).toBe("/lisa:exploratory-qa ready=true");
+  });
+
+  it("canonicalizes Codex $lisa-* aliases to Lisa slash-colon commands (#880)", () => {
+    const observedCommand = deriveCodexObservedCommand(
+      "Run one cycle. Use the `$lisa-intake` skill with arguments `github intake_mode=build`."
+    );
+
+    expect(observedCommand).toBe(BUILD_COMMAND);
+    expect(
+      compareAutomationContract({
+        expected: {
+          automationId: BUILD_ID,
+          expectedCadence: "every 10 minutes",
+          expectedRRule: BUILD_RRULE,
+          expectedCommand: BUILD_COMMAND,
+        },
+        observedAutomation: {
+          automationId: BUILD_ID,
+          observedCadence: "every 10 minutes",
+          observedRRule: BUILD_RRULE,
+          observedCommand,
+        },
+      }).status
+    ).toBe("HEALTHY");
+  });
+
+  it("does not classify negated error or exception summaries as failures (#885)", () => {
+    expect(
+      parseCodexAutomationMemory(
+        `${RECENT_RUN_AT}\n\n- completed with no errors\n`
+      ).lastRunFailed
+    ).toBe(false);
+    expect(
+      parseCodexAutomationMemory(
+        `${RECENT_RUN_AT}\n\n- ran without exceptions\n`
+      ).lastRunFailed
+    ).toBe(false);
+    expect(
+      parseCodexAutomationMemory(
+        `${RECENT_RUN_AT}\n\n- encountered an exception\n`
+      ).lastRunFailed
+    ).toBe(true);
+  });
+
+  it("uses the newest append-only memory run for timestamps and failure state (#881)", () => {
+    const memory = [
+      "# Lisa Build Intake Automation Memory",
+      "- 2025-01-01T00:00:00Z: Completed successfully with no errors.",
+      `- ${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
+      "",
+    ].join("\n");
+
+    expect(parseCodexAutomationMemory(memory)).toEqual({
+      lastRunAt: RECENT_RUN_AT,
+      lastRunSummary: `${RECENT_RUN_AT}: Latest run failed because GitHub auth crashed.`,
+      lastRunFailed: true,
+    });
+  });
+});

--- a/tests/unit/strategies/automation-status-codex-cwd.test.ts
+++ b/tests/unit/strategies/automation-status-codex-cwd.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression coverage for Codex automation cwd health reporting.
+ *
+ * @module tests/unit/strategies/automation-status-codex-cwd
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { inspectCodexAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+
+const AUTOMATION_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
+const RECENT_RUN_AT = "2026-05-26T12:00:00Z";
+
+describe("automation-status Codex cwd health", () => {
+  const tempDirs = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("flags missing scheduler cwd paths as failing", async () => {
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-automation-cwd-")
+    );
+    tempDirs.push(automationsDir);
+
+    const missingCwd = path.join(automationsDir, "missing-repo");
+    await writeAutomationFixture(automationsDir, missingCwd);
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: {
+          tracker: "github",
+          github: { org: "CodySwannGT", repo: "lisa" },
+        },
+        detectedTypes: ["typescript"],
+      }),
+      automationsDir,
+      now: RECENT_RUN_AT,
+    });
+
+    const buildItem = report.groups
+      .flatMap(group => group.items)
+      .find(item => item.id === AUTOMATION_ID);
+
+    expect(buildItem).toEqual(
+      expect.objectContaining({
+        status: "FAILING",
+        summary: expect.stringContaining("scheduler cwd is invalid"),
+        remediation: expect.stringContaining(
+          "durable non-bare project checkout"
+        ),
+      })
+    );
+    expect(buildItem?.observed).toContain(`${missingCwd} does not exist`);
+  });
+});
+
+/**
+ * Write a minimal Codex automation fixture with the supplied cwd.
+ *
+ * @param {string} automationsDir Parent automations fixture directory.
+ * @param {string} cwd Configured automation cwd value.
+ * @returns {Promise<void>} Resolves after the fixture is written.
+ */
+async function writeAutomationFixture(automationsDir, cwd) {
+  const automationDir = path.join(automationsDir, AUTOMATION_ID);
+  await fs.mkdir(automationDir, { recursive: true });
+  await fs.writeFile(
+    path.join(automationDir, "automation.toml"),
+    [
+      "version = 1",
+      `id = "${AUTOMATION_ID}"`,
+      'kind = "cron"',
+      'prompt = "Use the Lisa intake skill with arguments `github intake_mode=build`."',
+      'status = "ACTIVE"',
+      'rrule = "FREQ=MINUTELY;INTERVAL=10"',
+      `cwds = ["${cwd}"]`,
+      "",
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(automationDir, "memory.md"),
+    `${RECENT_RUN_AT}\n\n- Idle run.\n`
+  );
+}

--- a/tests/unit/strategies/automations-skills.test.ts
+++ b/tests/unit/strategies/automations-skills.test.ts
@@ -72,6 +72,13 @@ describe("setup-automations is a runtime-branched declarative spec", () => {
       expect(content).toMatch(/idempotent/i);
     });
 
+    it("requires a durable verified Codex checkout and pre-run rebase", () => {
+      expect(content).toContain("<project>-automation-main");
+      expect(content).toMatch(/non-bare Git work tree|--is-bare-repository/);
+      expect(content).toMatch(/fetch the default remote\s+branch/i);
+      expect(content).toMatch(/rebase.*origin\/main/i);
+    });
+
     it("only creates exploratory-bugs when the stack ships exploratory-qa", () => {
       // Names the three exploratory-qa stacks (markdown may wrap each in backticks).
       expect(content).toMatch(/expo[^]{0,12}rails[^]{0,16}harper-fabric/);


### PR DESCRIPTION
## Summary
- update Lisa setup automation specs to use durable verified Codex automation checkouts instead of transient scratch worktrees
- require recurring automations to fetch and rebase against the default remote branch before running queue or wiki work
- teach automation-status to flag missing, non-directory, non-worktree, bare, or otherwise broken cwd targets as failing

## Verification
- bun run build:plugins
- bun test tests/unit/strategies/automation-status-*.test.ts tests/unit/strategies/automations-skills.test.ts
- git diff --check
- commit hooks: typecheck, lint-staged, commitlint, AI co-authorship
- push hooks: bun audit, slow lint, knip, unit coverage, integration tests