### PR TITLE
docs(wiki): ingest durable automation checkout guidance

### DIFF
--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -27,3 +27,7 @@ A strategy defines how Lisa applies a file to a downstream project: overwrite, c
 ## Quality Gate
 
 A quality gate is an automated check that must pass before a change can progress.
+
+## Automation Checkout
+
+An automation checkout is the durable local Git work tree used by recurring Codex automations for a project. It should be synced to the default remote branch at the start of each run and verified as a non-bare Git work tree before the automation is saved or executed.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -9,7 +9,7 @@
 ## Project
 
 - [Project Registry](projects/registry.md)
-- [lisa-monorepo](projects/lisa-monorepo.md)
+- [Lisa Monorepo Snapshot](projects/lisa-monorepo.md)
 
 ## Documentation
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -90,3 +90,10 @@
 - Refreshed the `git` source note with 3 new commits through `73072b8e5b839dede4bf50985232d1d6bddfe9f4`, advanced the merged-PR cursor to `#995`, and confirmed that `roles` still had no roster pages to ingest.
 - Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-27-memory.md`; global Codex memory remained out of scope.
 - Updated the monorepo snapshot synthesis for the prior wiki ingest merge, release-history changes through `2.106.6`, and newly captured project-scoped memory guidance.
+
+## 2026-05-27 - Incremental connector ingest
+
+- Synced safely to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-27-133229`, and ran another full no-argument ingest against every enabled non-external-write connector.
+- Refreshed the `git` source note with 6 new commits through `c536c7a196ff811ce92403acd90493baad86ebd0`, advanced the merged-PR cursor to `#997`, and confirmed that `roles` still had no roster pages to ingest.
+- Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-27-memory.md`; global Codex memory remained out of scope.
+- Updated the monorepo snapshot, workflow playbook, vocabulary, and index for durable Codex automation checkouts, release-history changes through `2.106.8`, and the new Codex HTTP MCP plugin-shape memory note.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -14,6 +14,10 @@ Lisa exposes lifecycle commands and quality workflows that route work through re
 
 Lisa also supports local review, PR review handling, test coverage improvement, test hardening, code-complexity reduction, max-lines reduction, linter-error cleanup, branch pruning, and security scans.
 
+## Recurring Automations
+
+Codex-hosted Lisa automations should run from durable project automation checkouts, not transient task worktrees. Setup flows create or refresh a stable checkout under the Codex worktree area, verify it is a normal non-bare Git work tree, and require each automation cycle to fetch and rebase or fast-forward against the default remote branch before queue or wiki work begins. If the checkout is dirty, conflicted, stale, or has broken Git metadata, the automation reports the blocker instead of mutating queue or wiki state.
+
 ## Quality Gate Habit
 
 Before shipping Lisa changes, expect local hooks and CI to run typecheck, formatting, linting, slow lint, dead-code detection, tests, coverage, security audit, and integration checks depending on the action.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,19 +20,20 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-27-053204` from `origin/main`
-- HEAD at 2026-05-27 incremental ingest: `73072b8e5b839dede4bf50985232d1d6bddfe9f4`
-- Current package version: `2.106.6`
-- Total commits on HEAD: 2391
-- Latest merged PR captured in the incremental git snapshot: `#995`
-- New commits since the previous incremental git cursor: `3`
-- Project-scoped memory files captured: `20`
+- Ingest branch: `wiki/ingest-2026-05-27-133229` from `origin/main`
+- HEAD at 2026-05-27 incremental ingest: `c536c7a196ff811ce92403acd90493baad86ebd0`
+- Current package version: `2.106.8`
+- Total commits on HEAD: 2397
+- Latest merged PR captured in the incremental git snapshot: `#997`
+- New commits since the previous incremental git cursor: `6`
+- Project-scoped memory files captured: `21`
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#995`.
-- Release automation advanced the monorepo to `2.106.6`.
-- Lisa project-scoped Claude memory is now captured as a sanitized internal source note, including operational guidance for Codex automation, Lisa merge method, CI verification, and project-specific workflow expectations.
+- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#996`.
+- Release automation advanced the monorepo to `2.106.8`.
+- Codex automation setup guidance now requires durable, synced project automation checkouts instead of transient or broken scratch worktrees.
+- Lisa project-scoped Claude memory added the Codex HTTP MCP plugin-shape note while continuing to capture operational guidance for Codex automation, Lisa merge method, CI verification, and project-specific workflow expectations.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
@@ -10,13 +10,16 @@ project: lisa-monorepo
 
 # git history — lisa-monorepo (2026-05-27)
 
-- Repo: `/Users/cody/.codex/worktrees/wiki-ingest-2026-05-27-053204`
-- HEAD: `73072b8e5b839dede4bf50985232d1d6bddfe9f4`
-- Total commits on HEAD: 2391
-- New commits since last ingest (`65043e915a23a992904badaf708fd5a849cd54e5`): 3
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #995 "docs(wiki): ingest incremental git history"
+- Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
+- HEAD: `c536c7a196ff811ce92403acd90493baad86ebd0`
+- Total commits on HEAD: 2397
+- New commits since last ingest (`73072b8e5b839dede4bf50985232d1d6bddfe9f4`): 6
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #997 "Fix durable synced Lisa automation checkouts"
 
 ## New commits
-- 73072b8e · 2026-05-27 · chore(release): 2.106.6 [skip ci]
-- ac893822 · 2026-05-26 · Merge pull request #995 from CodySwannGT/wiki/ingest-2026-05-26-213256
-- 0d7f4e48 · 2026-05-26 · docs(wiki): ingest incremental git history
+- c536c7a1 · 2026-05-27 · chore(release): 2.106.8 [skip ci]
+- f2c99cc8 · 2026-05-27 · Merge pull request #997 from CodySwannGT/codex/durable-lisa-automation-checkouts
+- ea4881c8 · 2026-05-27 · fix(automations): use durable synced Lisa checkouts
+- 1a77d456 · 2026-05-27 · chore(release): 2.106.7 [skip ci]
+- e395b77a · 2026-05-27 · Merge pull request #996 from CodySwannGT/wiki/ingest-2026-05-27-053204
+- 296785ee · 2026-05-27 · docs(wiki): ingest incremental Lisa knowledge

--- a/wiki/sources/memory/2026-05-27-memory.md
+++ b/wiki/sources/memory/2026-05-27-memory.md
@@ -11,7 +11,7 @@ sensitivity: internal
 # project-scoped memory (2026-05-27)
 
 - Source: `/Users/cody/.claude/projects/-Users-cody-workspace-lisa/memory` (project-scoped; global/Chronicle memory is never ingested)
-- Files: 20
+- Files: 21
 
 ### MEMORY.md
 
@@ -37,13 +37,14 @@ sensitivity: internal
 - `reference_codex_hooks_capabilities.md` — Codex 0.125.0 hook events/contract; plugin-bundled hooks.json DOESN'T run — must install into ~/.codex/hooks.json; no SubagentStart/SessionEnd
 - `reference_lisa_new_standalone_plugin_wiring.md` — 5 wiring points for a new standalone Lisa plugin; .agents/plugins/marketplace.json is the Codex install surface (NOT CI-enforced)
 - `reference_codex_commit_attribution.md` — Codex 0.125.0 commit attribution: top-level commit_attribution + features.codex_git_commit; emits "Co-authored-by: Codex"; Lisa hook broadened to accept Claude|Codex
+- `reference_codex_http_mcp_plugin_shape.md` — Codex 0.125.0 accepts the Claude {type:"http",url} .mcp.json shape via plugin pointer (no translation needed); bare TOML wants url= with no type
 
 ### feedback_bash_path_subshell.md
 
 ---
 name: feedback_bash_path_subshell
 description: "In this environment, Bash commands lose PATH inside subshells/functions — export PATH first or binaries fail with \"command not found\""
-metadata: 
+metadata:
   node_type: memory
   type: feedback
   originSessionId: a37ecee7-ca65-4361-ac4b-f748b6ca876f
@@ -106,7 +107,7 @@ When existing code (a guard, check, filter, conditional, etc.) is blocking the d
 ---
 name: feedback_lisa_pr_merge_method
 description: "In the Lisa repo, merge PRs with --merge (never --squash); prefer the git-submit-pr skill over raw gh"
-metadata: 
+metadata:
   node_type: memory
   type: feedback
   originSessionId: 91079702-872d-4a69-8d3e-0206afb6fdc3
@@ -165,7 +166,7 @@ When fixing a GitHub Actions failure, verification means confirming the CI run p
 ---
 name: project_lisa_single_environment
 description: The Lisa repo (CodySwannGT/lisa) has a single deploy environment tied to main; no dev/staging
-metadata: 
+metadata:
   node_type: memory
   type: project
   originSessionId: 04d6ef7b-c05d-49d0-9a3f-d42791da9cbc
@@ -186,7 +187,7 @@ CodySwannGT/lisa has only ONE deploy environment, tied to the `main` branch — 
 ---
 name: project_lisa_tsconfig_base_path_resolution
 description: "Lisa base tsconfigs can't set a project's rootDir/outDir; the shipped tsconfig.local.json governs emit layout"
-metadata: 
+metadata:
   node_type: memory
   type: project
   originSessionId: 91079702-872d-4a69-8d3e-0206afb6fdc3
@@ -205,7 +206,7 @@ Lisa ships that `tsconfig.local.json` via the **typescript create-only** templat
 ---
 name: project_lisa_update_workspaces_config
 description: "lisa-update-projects reads its project list from .lisa.workspaces.json, not the .lisa.config.local.json the skill doc names"
-metadata: 
+metadata:
   node_type: memory
   type: project
   originSessionId: 4be8a61d-9fce-4d38-8632-f6c6e88d4f63
@@ -222,7 +223,7 @@ As of 2026-05-21 it lists projects under propswap, geminisportsai/projects, thum
 ---
 name: project-llmwiki-unification
 description: Plan to unify 5 hand-rolled LLM Wikis into one distributable Claude+Codex plugin via Lisa
-metadata: 
+metadata:
   node_type: memory
   type: project
   originSessionId: c0c4fb06-f435-4fc5-aaad-445be9967086
@@ -270,7 +271,7 @@ Lisa's vitest migration (v1.65.0) has a template overlap issue: the TypeScript s
 ---
 name: reference-codex-automations
 description: "How Codex \"automations\" (scheduled local agents) are defined on disk and managed"
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: af5c7830-c861-4f23-877d-3b15b41fb4c7
@@ -321,7 +322,7 @@ OOM-killed (exit 137). Do the filesystem investigation yourself; use codex for s
 ---
 name: reference-codex-cli-collaboration
 description: How to drive the codex CLI non-interactively for Claude↔Codex collaboration
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: c0c4fb06-f435-4fc5-aaad-445be9967086
@@ -343,7 +344,7 @@ Used 2026-05-22 to co-author the LLM Wiki unification PLAN.md (see `project_llmw
 ---
 name: reference-codex-commit-attribution
 description: "How Codex CLI 0.125.0 stamps commit attribution trailers, and how Lisa's commit-msg hook accepts them"
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: 4614617a-bc2d-4b67-8d45-e78648b64627
@@ -365,7 +366,7 @@ Lisa change (2026-05-24): its `commit-msg` hook (`.husky/commit-msg`, template `
 ---
 name: reference-codex-hooks-capabilities
 description: "What the Codex CLI 0.125.0 hook system supports vs. Lisa's Claude hooks (empirically verified)"
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: 91045a17-6bee-46bc-ab0e-63cd32a7d6a5
@@ -382,12 +383,30 @@ Codex CLI **0.125.0** hook system, verified by source-read + runtime tests with 
 
 Net for Lisa: porting hooks to Codex needs (1) an installer writing to a real Codex hook config layer, (2) inject-rules re-added with the `hookSpecificOutput` shape (SessionStart only), (3) edit hooks adapted to read file paths from apply_patch bodies. No-equivalent (cannot port): all SubagentStart hooks (inject-flow-context, enforce-team-first@subagent), SessionEnd (`entire ... session-end`), and enforce-team-first overall (Claude-team-specific).
 
+### reference_codex_http_mcp_plugin_shape.md
+
+---
+name: reference_codex_http_mcp_plugin_shape
+description: "Codex 0.125.0 accepts the Claude {type:\"http\",url} .mcp.json shape via plugin pointer (streamable_http); bare TOML wants url= with no type"
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 20686f3f-74bd-4fef-ba36-644a0989e18c
+---
+
+Codex 0.125.0 supports remote streamable-HTTP MCP servers. Two delivery paths, two shapes:
+
+- **Plugin-bundled `.mcp.json`** (referenced by `.codex-plugin` `mcpServers: ./.mcp.json`): Codex's JSON parser accepts the Claude wrapper shape **unchanged** — `{ "mcpServers": { "x": { "type": "http", "url": "..." } } }`. Verified: an installed Atlassian plugin uses exactly that and `codex mcp get` reports `transport: streamable_http`. So **no Claude→Codex translation is needed** for HTTP MCP servers; Lisa's `scripts/generate-codex-plugin-artifacts.mjs` already emits the `mcpServers: ./.mcp.json` pointer.
+- **Bare `~/.codex/config.toml`** (manual path): use `[mcp_servers.x]` with `url = "..."` and NO `type` key (transport inferred from `url` vs `command`). The `type="http"` key is Claude JSON only, not Codex TOML.
+
+Implication for `reference_lisa_new_standalone_plugin_wiring`: vendoring a Claude plugin's HTTP-MCP `.mcp.json` into `plugins/src/<stack>` and running `bun run build:plugins` gives Codex parity with no extra work. Established while auditing the lisa-expo plugin against Expo's official plugin (official MCP = https://mcp.expo.dev/mcp). Related: `reference_codex_plugin_skill_loading`, `reference_codex_hooks_capabilities`.
+
 ### reference_codex_plugin_skill_loading.md
 
 ---
 name: reference-codex-plugin-skill-loading
 description: How the Codex CLI loads skills shipped inside a Lisa plugin (no per-skill manifest needed)
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: b2c9f454-a9c9-462e-ae8a-8722797d34d1
@@ -410,7 +429,7 @@ Applies to the `project_llmwiki_unification` Claude+Codex dual-distribution mode
 ---
 name: reference-lisa-new-standalone-plugin-wiring
 description: The five wiring points to add a new standalone (non-stack) Lisa plugin so it works in both Claude Code and Codex
-metadata: 
+metadata:
   node_type: memory
   type: reference
   originSessionId: 2a2e9bbf-f6ae-46f3-a39a-ec5dcc91c12d

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-27T05:32:51.262Z",
+  "ingested_at": "2026-05-27T13:35:10.064Z",
   "cursor": {
-    "lastCommit": "73072b8e5b839dede4bf50985232d1d6bddfe9f4",
-    "lastPr": 995
+    "lastCommit": "c536c7a196ff811ce92403acd90493baad86ebd0",
+    "lastPr": 997
   },
   "source_notes": [
     "wiki/sources/git/2026-05-27-lisa-monorepo-git.md"

--- a/wiki/state/memory/latest.json
+++ b/wiki/state/memory/latest.json
@@ -1,9 +1,9 @@
 {
   "connector": "memory",
   "profile": "project",
-  "ingested_at": "2026-05-27T05:32:51.335Z",
+  "ingested_at": "2026-05-27T13:35:10.065Z",
   "cursor": {
-    "files": 20,
+    "files": 21,
     "lastIngest": "2026-05-27"
   },
   "source_notes": [

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-27T05:32:51.295Z",
+  "ingested_at": "2026-05-27T13:35:10.064Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary
- refreshed the Lisa wiki git source note through #997 / 2.106.8
- ingested project-scoped memory including the Codex HTTP MCP plugin-shape note
- synthesized durable Codex automation checkout guidance into the wiki snapshot, playbook, vocabulary, index, and log

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --config wiki/lisa-wiki.config.json (0 failures, existing 12 warnings)
- node plugins/lisa-wiki/scripts/diff-guard.mjs --base origin/main --allow 'wiki/**'
- commit hook: typecheck, gitleaks, lint-staged
- push hook: bun audit, slow lint, knip, unit coverage, integration tests