### PR TITLE
feat(typescript): block error-suppression directives on edit (Claude + Codex)

### DIFF
--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lisa-typescript",
   "version": "2.106.8",
-  "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
+  "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"
   },
@@ -9,6 +9,17 @@
     "lisa"
   ],
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-suppress-directives.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/plugins/lisa-typescript/hooks/block-suppress-directives.sh
+++ b/plugins/lisa-typescript/hooks/block-suppress-directives.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# PreToolUse hook (Write|Edit): block adding error-suppression directives to
+# JS/TS source. Suppressing the type checker, linter, or formatter hides real
+# defects instead of fixing them, so it is a documented last resort (see the
+# base "ASK FIRST" governance rule). The agent should stop and get the user's
+# approval rather than slip a suppression past silently.
+#
+# Inspects only the NEW text the tool introduces, scoped to JS/TS files, and
+# matches the directive only in comment syntax (// or /*) so prose, strings,
+# and identifiers that merely mention these tokens are not flagged.
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+
+JSON_INPUT=$(cat)
+
+# Project rule (.claude/rules/PROJECT_RULES.md): never parse JSON in shell with
+# grep/sed/cut/awk — always use jq. Fail open without jq so we never hard-block
+# the agent on missing tooling.
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+# Only guard JS/TS source. Directives in other file types (docs, configs that
+# document the rules, this script) are not suppressions.
+case "${FILE_PATH##*.}" in
+  ts | tsx | js | jsx | mjs | cjs) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve the new text per tool shape:
+#   Write     -> tool_input.content
+#   MultiEdit -> tool_input.edits[].new_string
+#   Edit      -> tool_input.new_string
+NEW_TEXT=$(printf '%s' "$JSON_INPUT" | jq -r '
+  .tool_input as $i
+  | if   ($i.content     // null) != null then $i.content
+    elif ($i.edits       // null) != null then ([$i.edits[].new_string] | join("\n"))
+    elif ($i.new_string  // null) != null then $i.new_string
+    else "" end')
+
+# Comment-syntax-only match: a // or /* opener, optional whitespace, then the
+# suppression directive. @ts-expect-error is intentionally NOT matched — it is
+# the safer alternative this hook steers toward.
+DIRECTIVE_RE='(//|/\*)[[:space:]]*(@ts-(ignore|nocheck)|eslint-disable|biome-ignore|prettier-ignore)'
+
+if printf '%s' "$NEW_TEXT" | grep -Eq "$DIRECTIVE_RE"; then
+  cat >&2 <<MSG
+❌ Blocked: error-suppression directive in $FILE_PATH
+
+You are adding a @ts-ignore / @ts-nocheck / eslint-disable / biome-ignore /
+prettier-ignore comment. These silence the type checker, linter, or formatter
+instead of fixing the underlying problem. They are a last resort, not a default.
+
+Fix it properly first:
+  - Resolve the actual type/lint error rather than suppressing it.
+  - Add the missing annotation, narrow the type, or restructure the code so the
+    rule passes legitimately.
+  - For a faulty dependency type, prefer a typed wrapper or module augmentation.
+
+If — and only if — there is genuinely no other way (e.g. a known upstream bug):
+  - STOP and get the user's approval before suppressing (base "ASK FIRST" rule).
+  - Prefer @ts-expect-error over @ts-ignore (it fails once the error is gone).
+  - Scope the disable to one line and one rule, never a whole file.
+  - Include a "-- <reason>" description (eslint-comments/require-description).
+MSG
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa/rules/base-rules.md
+++ b/plugins/lisa/rules/base-rules.md
@@ -111,7 +111,7 @@ NEVER:
 - Update CHANGELOG.
 
 ASK FIRST:
-- Before adding a lint suppression comment (e.g. eslint-disable, noqa, #[allow(...)], @SuppressWarnings). These should be a last resort.
+- Before adding a lint or formatter suppression comment (e.g. eslint-disable, biome-ignore, prettier-ignore, noqa, #[allow(...)], @SuppressWarnings). These should be a last resort.
 - Before adding a type-checking suppression comment (e.g. ts-ignore, ts-expect-error, ts-nocheck, type: ignore).
 - Lint suppression in test files is acceptable without asking only when comprehensive test coverage requires it (e.g. file length limits) or when intentional duplication improves test isolation. Include matching re-enable comments where applicable.
 

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -27,6 +27,77 @@ const NEGATED_FAILURE_PATTERN =
 const execFileAsync = promisify(execFile);
 
 /**
+ * Git location env vars that, when inherited, override the `-C <dir>` flag and
+ * cwd. When this adapter runs inside a Git hook (e.g. pre-push) these are
+ * exported by Git, so a `git -C <cwd> rev-parse` would answer about the hook's
+ * repository instead of the inspected automation cwd — misreporting every
+ * healthy automation as FAILING. They must be scrubbed so `-C`/cwd governs.
+ */
+const GIT_LOCATION_ENV_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_NAMESPACE",
+  "GIT_PREFIX",
+];
+
+/**
+ * Process-spawn failures that are transient under heavy fork load (the OS could
+ * not start the child, not git reporting a result). Retrying these avoids
+ * misclassifying a healthy cwd as a `git_error` when the machine is saturated.
+ */
+const TRANSIENT_SPAWN_ERROR_CODES = new Set([
+  "EAGAIN",
+  "ENOMEM",
+  "EMFILE",
+  "ENFILE",
+  "ETXTBSY",
+]);
+
+/**
+ * Build a git-safe environment: the ambient process env minus the location
+ * overrides so a `-C <dir>` invocation targets the intended directory.
+ *
+ * @returns {NodeJS.ProcessEnv}
+ */
+function gitEnvWithoutLocationOverrides() {
+  const env = { ...process.env };
+  for (const key of GIT_LOCATION_ENV_VARS) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * Run `git` against an explicit directory, immune to inherited Git location env
+ * vars, with a bounded retry on transient process-spawn failures. A git process
+ * that actually ran — success or non-zero exit — is surfaced unchanged on the
+ * first attempt; only failures to launch the child at all are retried.
+ *
+ * @param {readonly string[]} args git arguments
+ * @param {import("node:child_process").ExecFileOptions} [options]
+ * @param {number} [attempts] maximum attempts (default 4)
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ */
+async function execGitWithRetry(args, options, attempts = 4) {
+  const mergedOptions = { ...options, env: gitEnvWithoutLocationOverrides() };
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await execFileAsync("git", args, mergedOptions);
+    } catch (error) {
+      const transient = TRANSIENT_SPAWN_ERROR_CODES.has(error?.code);
+      if (!transient || attempt >= attempts) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+    }
+  }
+}
+
+/**
  * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
  *
  * @typedef {{
@@ -442,8 +513,7 @@ async function inspectAutomationCwd(cwd) {
   }
 
   try {
-    const { stdout } = await execFileAsync(
-      "git",
+    const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
       { timeout: 5000 }
     );

--- a/plugins/src/base/rules/base-rules.md
+++ b/plugins/src/base/rules/base-rules.md
@@ -111,7 +111,7 @@ NEVER:
 - Update CHANGELOG.
 
 ASK FIRST:
-- Before adding a lint suppression comment (e.g. eslint-disable, noqa, #[allow(...)], @SuppressWarnings). These should be a last resort.
+- Before adding a lint or formatter suppression comment (e.g. eslint-disable, biome-ignore, prettier-ignore, noqa, #[allow(...)], @SuppressWarnings). These should be a last resort.
 - Before adding a type-checking suppression comment (e.g. ts-ignore, ts-expect-error, ts-nocheck, type: ignore).
 - Lint suppression in test files is acceptable without asking only when comprehensive test coverage requires it (e.g. file length limits) or when intentional duplication improves test isolation. Include matching re-enable comments where applicable.
 

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -27,6 +27,77 @@ const NEGATED_FAILURE_PATTERN =
 const execFileAsync = promisify(execFile);
 
 /**
+ * Git location env vars that, when inherited, override the `-C <dir>` flag and
+ * cwd. When this adapter runs inside a Git hook (e.g. pre-push) these are
+ * exported by Git, so a `git -C <cwd> rev-parse` would answer about the hook's
+ * repository instead of the inspected automation cwd — misreporting every
+ * healthy automation as FAILING. They must be scrubbed so `-C`/cwd governs.
+ */
+const GIT_LOCATION_ENV_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_NAMESPACE",
+  "GIT_PREFIX",
+];
+
+/**
+ * Process-spawn failures that are transient under heavy fork load (the OS could
+ * not start the child, not git reporting a result). Retrying these avoids
+ * misclassifying a healthy cwd as a `git_error` when the machine is saturated.
+ */
+const TRANSIENT_SPAWN_ERROR_CODES = new Set([
+  "EAGAIN",
+  "ENOMEM",
+  "EMFILE",
+  "ENFILE",
+  "ETXTBSY",
+]);
+
+/**
+ * Build a git-safe environment: the ambient process env minus the location
+ * overrides so a `-C <dir>` invocation targets the intended directory.
+ *
+ * @returns {NodeJS.ProcessEnv}
+ */
+function gitEnvWithoutLocationOverrides() {
+  const env = { ...process.env };
+  for (const key of GIT_LOCATION_ENV_VARS) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * Run `git` against an explicit directory, immune to inherited Git location env
+ * vars, with a bounded retry on transient process-spawn failures. A git process
+ * that actually ran — success or non-zero exit — is surfaced unchanged on the
+ * first attempt; only failures to launch the child at all are retried.
+ *
+ * @param {readonly string[]} args git arguments
+ * @param {import("node:child_process").ExecFileOptions} [options]
+ * @param {number} [attempts] maximum attempts (default 4)
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ */
+async function execGitWithRetry(args, options, attempts = 4) {
+  const mergedOptions = { ...options, env: gitEnvWithoutLocationOverrides() };
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await execFileAsync("git", args, mergedOptions);
+    } catch (error) {
+      const transient = TRANSIENT_SPAWN_ERROR_CODES.has(error?.code);
+      if (!transient || attempt >= attempts) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+    }
+  }
+}
+
+/**
  * @typedef {import("./automation-status-expected-fleet.mjs").resolveExpectedAutomationFleet extends (...args: any[]) => infer T ? T : never} ExpectedFleet
  *
  * @typedef {{
@@ -442,8 +513,7 @@ async function inspectAutomationCwd(cwd) {
   }
 
   try {
-    const { stdout } = await execFileAsync(
-      "git",
+    const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
       { timeout: 5000 }
     );

--- a/plugins/src/typescript/.claude-plugin/plugin.json
+++ b/plugins/src/typescript/.claude-plugin/plugin.json
@@ -1,10 +1,18 @@
 {
   "name": "lisa-typescript",
   "version": "1.0.0",
-  "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, and ast-grep scanning on edit",
+  "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": { "name": "Cody Swann" },
   "dependencies": ["lisa"],
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-suppress-directives.sh" }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/plugins/src/typescript/hooks/block-suppress-directives.sh
+++ b/plugins/src/typescript/hooks/block-suppress-directives.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# PreToolUse hook (Write|Edit): block adding error-suppression directives to
+# JS/TS source. Suppressing the type checker, linter, or formatter hides real
+# defects instead of fixing them, so it is a documented last resort (see the
+# base "ASK FIRST" governance rule). The agent should stop and get the user's
+# approval rather than slip a suppression past silently.
+#
+# Inspects only the NEW text the tool introduces, scoped to JS/TS files, and
+# matches the directive only in comment syntax (// or /*) so prose, strings,
+# and identifiers that merely mention these tokens are not flagged.
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+
+JSON_INPUT=$(cat)
+
+# Project rule (.claude/rules/PROJECT_RULES.md): never parse JSON in shell with
+# grep/sed/cut/awk — always use jq. Fail open without jq so we never hard-block
+# the agent on missing tooling.
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+# Only guard JS/TS source. Directives in other file types (docs, configs that
+# document the rules, this script) are not suppressions.
+case "${FILE_PATH##*.}" in
+  ts | tsx | js | jsx | mjs | cjs) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve the new text per tool shape:
+#   Write     -> tool_input.content
+#   MultiEdit -> tool_input.edits[].new_string
+#   Edit      -> tool_input.new_string
+NEW_TEXT=$(printf '%s' "$JSON_INPUT" | jq -r '
+  .tool_input as $i
+  | if   ($i.content     // null) != null then $i.content
+    elif ($i.edits       // null) != null then ([$i.edits[].new_string] | join("\n"))
+    elif ($i.new_string  // null) != null then $i.new_string
+    else "" end')
+
+# Comment-syntax-only match: a // or /* opener, optional whitespace, then the
+# suppression directive. @ts-expect-error is intentionally NOT matched — it is
+# the safer alternative this hook steers toward.
+DIRECTIVE_RE='(//|/\*)[[:space:]]*(@ts-(ignore|nocheck)|eslint-disable|biome-ignore|prettier-ignore)'
+
+if printf '%s' "$NEW_TEXT" | grep -Eq "$DIRECTIVE_RE"; then
+  cat >&2 <<MSG
+❌ Blocked: error-suppression directive in $FILE_PATH
+
+You are adding a @ts-ignore / @ts-nocheck / eslint-disable / biome-ignore /
+prettier-ignore comment. These silence the type checker, linter, or formatter
+instead of fixing the underlying problem. They are a last resort, not a default.
+
+Fix it properly first:
+  - Resolve the actual type/lint error rather than suppressing it.
+  - Add the missing annotation, narrow the type, or restructure the code so the
+    rule passes legitimately.
+  - For a faulty dependency type, prefer a typed wrapper or module augmentation.
+
+If — and only if — there is genuinely no other way (e.g. a known upstream bug):
+  - STOP and get the user's approval before suppressing (base "ASK FIRST" rule).
+  - Prefer @ts-expect-error over @ts-ignore (it fails once the error is gone).
+  - Scope the disable to one line and one rule, never a whole file.
+  - Include a "-- <reason>" description (eslint-comments/require-description).
+MSG
+  exit 2
+fi
+
+exit 0

--- a/src/codex/hooks-installer.ts
+++ b/src/codex/hooks-installer.ts
@@ -182,6 +182,14 @@ const HOOK_CATALOG: readonly HookCatalogEntry[] = [
     forProjectTypes: ["nestjs"],
     needsEditPathLib: true,
   },
+  {
+    id: "block-suppress-directives",
+    event: "PreToolUse",
+    matcher: WRITE_MATCHER,
+    scriptFilename: "block-suppress-directives.sh",
+    forProjectTypes: ["typescript"],
+    statusMessage: "Checking for error-suppression directives",
+  },
 ];
 
 /** Result of the hooks install pass */

--- a/src/codex/scripts/block-suppress-directives.sh
+++ b/src/codex/scripts/block-suppress-directives.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Lisa-managed Codex hook script (PreToolUse Edit|Write|apply_patch).
+# Blocks adding error-suppression directives (@ts-ignore, @ts-nocheck,
+# eslint-disable, biome-ignore, prettier-ignore) to JS/TS source. Suppressing
+# the type checker, linter, or formatter hides real defects — fix the
+# underlying error. Suppression is a last resort: when genuinely unavoidable
+# the agent should stop and get the user's approval rather than slip it past.
+#
+# Codex blocks the tool call when the script exits 2 with a deny message on
+# stderr. apply_patch carries the whole diff as a STRING under
+# tool_input.command (verified against codex-cli 0.125.0), so we walk the patch
+# and inspect added (`+`) lines under JS/TS file headers. Edit/Write inspect the
+# new text directly. Only comment-syntax matches count, so prose/strings that
+# merely mention these tokens are not flagged.
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+# Project rule: never parse JSON with grep/sed/cut/awk — use jq. Fail open.
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Comment-syntax-only match: // or /* opener, optional whitespace, directive.
+# @ts-expect-error is intentionally NOT matched — it is the safer alternative.
+DIRECTIVE_RE='(//|/\*)[[:space:]]*(@ts-(ignore|nocheck)|eslint-disable|biome-ignore|prettier-ignore)'
+
+# True only for JS/TS file extensions.
+is_js_ts() {
+  case "${1##*.}" in
+    ts | tsx | js | jsx | mjs | cjs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+deny() {
+  cat >&2 <<MSG
+⚠ block-suppress-directives: refusing to add an error-suppression directive to ${1}.
+
+@ts-ignore / @ts-nocheck / eslint-disable / biome-ignore / prettier-ignore
+silence the type checker, linter, or formatter instead of fixing the problem.
+Fix the underlying type/lint error instead — add the missing annotation, narrow
+the type, or restructure the code so the rule passes.
+
+Suppression is a last resort. If there is genuinely no other way, STOP and get
+the user's approval first, prefer @ts-expect-error over @ts-ignore, scope the
+disable to one line and one rule, and add a "-- <reason>" description.
+MSG
+  exit 2
+}
+
+TOOL_NAME="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_name // .tool // empty')"
+
+if [ "$TOOL_NAME" = "apply_patch" ]; then
+  PATCH_TEXT="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty')"
+  [ -n "$PATCH_TEXT" ] || exit 0
+  current_file=""
+  while IFS= read -r line; do
+    case "$line" in
+      "*** Add File: "* | "*** Update File: "*)
+        current_file="${line#*File: }"
+        ;;
+      "*** Delete File: "* | "*** Begin Patch"* | "*** End Patch"*)
+        current_file=""
+        ;;
+      "+"*)
+        [ -n "$current_file" ] || continue
+        is_js_ts "$current_file" || continue
+        # Strip the single leading '+' that marks an added line.
+        added="${line#+}"
+        if printf '%s' "$added" | grep -Eq "$DIRECTIVE_RE"; then
+          deny "$current_file"
+        fi
+        ;;
+    esac
+  done <<EOF
+$PATCH_TEXT
+EOF
+  exit 0
+fi
+
+# Edit / Write
+FILE_PATH="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')"
+[ -n "$FILE_PATH" ] || exit 0
+is_js_ts "$FILE_PATH" || exit 0
+
+NEW_TEXT="$(printf '%s' "$JSON_INPUT" | jq -r '
+  .tool_input as $i
+  | if   ($i.content    // null) != null then $i.content
+    elif ($i.edits      // null) != null then ([$i.edits[].new_string] | join("\n"))
+    elif ($i.new_string // null) != null then $i.new_string
+    else "" end')"
+
+if printf '%s' "$NEW_TEXT" | grep -Eq "$DIRECTIVE_RE"; then
+  deny "$FILE_PATH"
+fi
+
+exit 0

--- a/tests/unit/codex/block-suppress-directives.test.ts
+++ b/tests/unit/codex/block-suppress-directives.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for block-suppress-directives.sh — the PreToolUse hook that refuses
+ * edits introducing error-suppression directives (@ts-ignore, @ts-nocheck,
+ * eslint-disable, biome-ignore, prettier-ignore) into JS/TS source.
+ *
+ * The hook inspects only the NEW text a tool introduces (Edit/Write/MultiEdit
+ * new content, or the added `+` lines of an apply_patch diff), scoped to JS/TS
+ * files, and matches the directive only in comment syntax so prose, strings,
+ * and identifiers that merely mention the tokens are not flagged. @ts-expect-
+ * error is intentionally allowed as the safer alternative.
+ *
+ * Directive tokens are assembled from parts at runtime so this source file does
+ * not itself contain a literal comment-directive (which would otherwise be
+ * caught by the very hook under test when this file is later edited).
+ * @module tests/unit/codex/block-suppress-directives
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = path.resolve(
+  "src/codex/scripts/block-suppress-directives.sh"
+);
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+// Comment marker kept out of the literal source (see module note).
+const SLASH = "//";
+const TS_IGNORE = `${SLASH} @ts-ignore`;
+const TS_NOCHECK = `${SLASH} @ts-nocheck`;
+const TS_EXPECT_ERROR = `${SLASH} @ts-expect-error`;
+const ESLINT_DISABLE = `${SLASH} eslint-disable-next-line no-console`;
+const PRETTIER_IGNORE = `${SLASH} prettier-ignore`;
+
+const editEnvelope = (filePath: string, newString: string): string =>
+  JSON.stringify({
+    tool_name: "Edit",
+    tool_input: { file_path: filePath, new_string: newString },
+  });
+
+const writeEnvelope = (filePath: string, content: string): string =>
+  JSON.stringify({
+    tool_name: "Write",
+    tool_input: { file_path: filePath, content },
+  });
+
+const multiEditEnvelope = (
+  filePath: string,
+  newStrings: readonly string[]
+): string =>
+  JSON.stringify({
+    tool_name: "MultiEdit",
+    tool_input: {
+      file_path: filePath,
+      edits: newStrings.map(s => ({ new_string: s })),
+    },
+  });
+
+const applyPatchEnvelope = (patch: string): string =>
+  JSON.stringify({
+    tool_name: "apply_patch",
+    tool_input: { command: patch },
+  });
+
+const run = (envelope: string): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [SCRIPT_PATH], {
+    input: envelope,
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+describe("block-suppress-directives.sh", () => {
+  describe("Edit / Write / MultiEdit", () => {
+    it("blocks an Edit adding @ts-ignore to a .ts file", () => {
+      const { status, stderr } = run(
+        editEnvelope("src/a.ts", `const x = 1; ${TS_IGNORE}`)
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("block-suppress-directives");
+    });
+
+    it("blocks a Write adding eslint-disable to a .tsx file", () => {
+      const { status } = run(
+        writeEnvelope("src/a.tsx", `export const x = 1; ${ESLINT_DISABLE}`)
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks a Write adding @ts-nocheck to a .js file", () => {
+      const { status } = run(writeEnvelope("src/a.js", `${TS_NOCHECK}\nx()`));
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks prettier-ignore in a JSX expression comment", () => {
+      const { status } = run(
+        editEnvelope("src/a.tsx", `{/* ${PRETTIER_IGNORE.slice(3)} */}`)
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks when any one MultiEdit chunk introduces a directive", () => {
+      const { status } = run(
+        multiEditEnvelope("src/a.ts", [
+          "const ok = 1;",
+          `const y = 2; ${TS_IGNORE}`,
+        ])
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("allows @ts-expect-error (the safer alternative)", () => {
+      const { status } = run(
+        editEnvelope("src/a.ts", `${TS_EXPECT_ERROR}\nbadCall();`)
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows a directive token in a non-JS/TS file", () => {
+      const { status } = run(
+        writeEnvelope("README.md", `Document the ${ESLINT_DISABLE} directive.`)
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows directive-looking text that is not a comment (string/identifier)", () => {
+      const { status } = run(
+        editEnvelope(
+          "src/a.ts",
+          'const url = "https://x"; const eslint_disable = true;'
+        )
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows a clean edit", () => {
+      const { status } = run(
+        editEnvelope(
+          "src/a.ts",
+          "export const sum = (a: number, b: number) => a + b;"
+        )
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("apply_patch", () => {
+    it("blocks an added line introducing a directive in a .ts file", () => {
+      const patch = `*** Begin Patch\n*** Update File: src/a.ts\n@@\n context\n+const x = 1; ${TS_IGNORE}\n*** End Patch\n`;
+      const { status } = run(applyPatchEnvelope(patch));
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("ignores a directive that appears only on an unchanged context line", () => {
+      const patch = `*** Begin Patch\n*** Update File: src/a.ts\n@@\n const existing = 1; ${TS_IGNORE}\n-const old = 1;\n+const next = 2;\n*** End Patch\n`;
+      const { status } = run(applyPatchEnvelope(patch));
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("ignores an added directive line in a non-JS/TS file", () => {
+      const patch = `*** Begin Patch\n*** Add File: notes.md\n+mentions ${ESLINT_DISABLE}\n*** End Patch\n`;
+      const { status } = run(applyPatchEnvelope(patch));
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("blocks when one of several files in a patch adds a directive", () => {
+      const patch =
+        "*** Begin Patch\n" +
+        "*** Add File: src/clean.ts\n+export const ok = 1;\n" +
+        `*** Update File: src/bad.ts\n@@\n+const y = 2; ${TS_IGNORE}\n` +
+        "*** End Patch\n";
+      const { status } = run(applyPatchEnvelope(patch));
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+  });
+
+  it("fails open (allows) when stdin is not a recognized envelope", () => {
+    const { status } = run(JSON.stringify({ tool_name: "Bash" }));
+    expect(status).toBe(EXIT_ALLOWED);
+  });
+});

--- a/tests/unit/codex/hooks-installer.test.ts
+++ b/tests/unit/codex/hooks-installer.test.ts
@@ -37,6 +37,8 @@ const FORMAT_ON_EDIT_ID = "format-on-edit";
 const RUBOCOP_ON_EDIT_ID = "rubocop-on-edit";
 /** Hook id for the NestJS-stack migration-block hook */
 const BLOCK_MIGRATION_EDITS_ID = "block-migration-edits";
+/** Hook id for the TypeScript-stack suppression-directive block hook */
+const BLOCK_SUPPRESS_DIRECTIVES_ID = "block-suppress-directives";
 /** Universal Bash policy hook id */
 const BLOCK_NO_VERIFY_ID = "block-no-verify";
 /** Universal dependency bootstrap hook id */
@@ -267,6 +269,7 @@ describe("codex/hooks-installer", () => {
       expect(ids).not.toContain(FORMAT_ON_EDIT_ID);
       expect(ids).not.toContain(RUBOCOP_ON_EDIT_ID);
       expect(ids).not.toContain(BLOCK_MIGRATION_EDITS_ID);
+      expect(ids).not.toContain(BLOCK_SUPPRESS_DIRECTIVES_ID);
       expect(result.hookEntries).toBe(5);
     });
 
@@ -276,13 +279,14 @@ describe("codex/hooks-installer", () => {
       expect(ids).toContain(FORMAT_ON_EDIT_ID);
       expect(ids).toContain("lint-on-edit");
       expect(ids).toContain("sg-scan-on-edit");
+      expect(ids).toContain(BLOCK_SUPPRESS_DIRECTIVES_ID);
       // Plus universal
       expect(ids).toContain(INJECT_RULES_ID);
       expect(ids).toContain(NOTIFY_NTFY_ID);
       // NOT rails or nestjs
       expect(ids).not.toContain(RUBOCOP_ON_EDIT_ID);
       expect(ids).not.toContain(BLOCK_MIGRATION_EDITS_ID);
-      expect(result.hookEntries).toBe(8);
+      expect(result.hookEntries).toBe(9);
     });
 
     it("ships Rails hooks when rails is detected", async () => {
@@ -306,7 +310,9 @@ describe("codex/hooks-installer", () => {
       const ids = await readLisaHookIds(destDir);
       expect(ids).toContain(BLOCK_MIGRATION_EDITS_ID);
       expect(ids).toContain(FORMAT_ON_EDIT_ID);
-      expect(result.hookEntries).toBe(9);
+      // typescript also brings the suppression-directive block
+      expect(ids).toContain(BLOCK_SUPPRESS_DIRECTIVES_ID);
+      expect(result.hookEntries).toBe(10);
     });
 
     it("copies only the script files for applicable hooks", async () => {

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -207,8 +207,73 @@ async function createGitWorkTreeFixture(automationsDir) {
   const reposDir = path.join(automationsDir, "_repos");
   await fs.mkdir(reposDir, { recursive: true });
   const repoDir = await fs.mkdtemp(path.join(reposDir, "repo-"));
-  await execFileAsync("git", ["init"], { cwd: repoDir });
+  // Retry transient process-spawn failures (e.g. EAGAIN under the heavy fork
+  // load of the full pre-push suite) so the fixture repo is reliably created;
+  // otherwise the adapter's cwd-health check sees a non-repo and flips the
+  // automation to FAILING, flaking the HEALTHY assertions.
+  await initGitRepoWithRetry(repoDir);
   return repoDir;
+}
+
+const TRANSIENT_SPAWN_ERROR_CODES = new Set([
+  "EAGAIN",
+  "ENOMEM",
+  "EMFILE",
+  "ENFILE",
+  "ETXTBSY",
+]);
+
+/**
+ * Git location env vars that override `cwd`/`-C`. They are exported when the
+ * suite runs inside a Git hook (e.g. pre-push), so scrub them to ensure
+ * `git init` targets the fixture directory and the adapter inspects it.
+ */
+const GIT_LOCATION_ENV_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_NAMESPACE",
+  "GIT_PREFIX",
+];
+
+/**
+ * Build the ambient env minus Git location overrides.
+ *
+ * @returns {NodeJS.ProcessEnv} A copy of process.env with Git location vars removed.
+ */
+function gitEnvWithoutLocationOverrides() {
+  const env = { ...process.env };
+  for (const key of GIT_LOCATION_ENV_VARS) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * Initialize a Git repo, retrying transient process-spawn failures so the
+ * fixture survives the heavy fork load of the full pre-push suite.
+ *
+ * @param {string} repoDir Directory to run `git init` in.
+ * @param {number} [attempts] Maximum attempts before surfacing the failure.
+ * @returns {Promise<void>}
+ */
+async function initGitRepoWithRetry(repoDir, attempts = 4) {
+  const env = gitEnvWithoutLocationOverrides();
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await execFileAsync("git", ["init"], { cwd: repoDir, env });
+      return;
+    } catch (error) {
+      const transient = TRANSIENT_SPAWN_ERROR_CODES.has(error?.code);
+      if (!transient || attempt >= attempts) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Adds a `PreToolUse` hook to the **TypeScript stack** (both runtimes) that blocks edits introducing error-suppression directives into JS/TS source — `@ts-ignore`, `@ts-nocheck`, `eslint-disable`, `biome-ignore`, `prettier-ignore`.

- Inspects only the **newly added** text, scoped to JS/TS files.
- Matches **comment syntax only**, so prose, strings, and identifiers that merely mention the tokens pass.
- `@ts-expect-error` is deliberately allowed — the safer alternative the hook steers toward.
- Exit 2 blocks with guidance to fix the real error or get user approval as a documented last resort.

## How it ships

- **Claude:** `plugins/src/typescript/hooks/block-suppress-directives.sh`, registered under `PreToolUse` in the `lisa-typescript` plugin manifest.
- **Codex:** `src/codex/scripts/block-suppress-directives.sh` (also parses `apply_patch` diffs, flagging only added lines), registered in the `hooks-installer` catalog for the `typescript` project type and installed into `.codex/hooks.json` on `lisa apply`.
- Extends the base "ASK FIRST" governance rule to name `biome-ignore`/`prettier-ignore` so rule and hook stay in sync.
- Plugin artifacts rebuilt.

## Incidental fix

While pushing, the pre-push suite surfaced a pre-existing flaky test (`automation-status-codex-adapter.test.ts`). Root cause: the Codex automation-status adapter runs `git -C <cwd> rev-parse`, but inside a Git hook `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` are exported and **override `-C`**, so every healthy automation was misreported as FAILING (a real production bug for `/lisa:automation-status` run from any hook/scripted context). Fixed by scrubbing Git location env vars when spawning git (plus a transient-spawn retry). Reproduced deterministically by exporting `GIT_DIR` before the test, and verified fixed.

## Verification

- New behavior test (`tests/unit/codex/block-suppress-directives.test.ts`, 14 cases) + updated catalog-count assertions.
- Full pre-push suite (lint:slow, knip, test:cov, integration) green — including the formerly-flaky test under the git-hook environment.

🤖 Generated with Claude Code