### PR TITLE
Add project ideation idempotency harness

### DIFF
--- a/plugins/lisa/scripts/project-ideation-idempotency-harness.mjs
+++ b/plugins/lisa/scripts/project-ideation-idempotency-harness.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Deterministic verification harness for project-ideation PRD dedupe.
+ *
+ * The harness runs a caller-supplied deterministic project-ideation command
+ * twice, checks that exactly one open GitHub PRD contains the expected marker,
+ * then optionally removes the automation memory file and verifies a third run
+ * recreates memory without creating a duplicate PRD.
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+const repo = requireValue(args.repo, "--repo");
+const marker = requireValue(args.marker, "--marker");
+const command = requireValue(args.command, "--command");
+const memoryFile = args.memoryFile ? resolve(args.memoryFile) : null;
+
+runCommand("first ideation run", command);
+const first = assertSingleOpenMarker(repo, marker, "after first run");
+
+runCommand("second ideation run", command);
+const second = assertSingleOpenMarker(repo, marker, "after second run");
+
+let missingMemory = null;
+if (memoryFile) {
+  missingMemory = runMissingMemoryVariant(repo, marker, command, memoryFile);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      repo,
+      marker,
+      first,
+      second,
+      missingMemory,
+      verdict: "PASS",
+    },
+    null,
+    2
+  )
+);
+
+/**
+ * @param {string[]} argv
+ * @returns {Record<string, string | boolean>}
+ */
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      fail(`Unexpected positional argument: ${token}`);
+    }
+
+    const eqIndex = token.indexOf("=");
+    if (eqIndex !== -1) {
+      parsed[token.slice(2, eqIndex)] = token.slice(eqIndex + 1);
+      continue;
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      fail(`Missing value for --${key}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+/**
+ * @param {Record<string, string | boolean>} input
+ * @param {string} key
+ * @returns {string}
+ */
+function requireValue(input, key) {
+  const normalized = key.replace(/^--/, "");
+  const value = input[normalized];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`${key} is required`);
+  }
+  return value.trim();
+}
+
+/**
+ * @param {string} label
+ * @param {string} command
+ */
+function runCommand(label, command) {
+  const result = spawnSync(command, {
+    shell: true,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    fail(`${label} failed with exit code ${String(result.status)}`);
+  }
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @param {string} phase
+ * @returns {{ readonly count: number, readonly issue: Record<string, any> }}
+ */
+function assertSingleOpenMarker(repo, marker, phase) {
+  const issues = queryOpenIssuesByMarker(repo, marker);
+  if (issues.length !== 1) {
+    fail(
+      `Expected exactly one open issue containing marker ${JSON.stringify(marker)} ${phase}, found ${issues.length}`
+    );
+  }
+
+  return {
+    count: issues.length,
+    issue: {
+      number: issues[0].number,
+      title: issues[0].title,
+      url: issues[0].url,
+      labels: normalizeLabels(issues[0].labels),
+    },
+  };
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @returns {readonly Record<string, any>[]}
+ */
+function queryOpenIssuesByMarker(repo, marker) {
+  const search = runJson("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--search",
+    `"${marker}" in:body`,
+    "--limit",
+    "100",
+    "--json",
+    "number,title,url,labels",
+  ]);
+
+  if (Array.isArray(search) && search.length > 0) {
+    return search;
+  }
+
+  const fallback = runJson("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    "1000",
+    "--json",
+    "number,title,url,labels,body",
+  ]);
+
+  if (!Array.isArray(fallback)) {
+    return [];
+  }
+
+  return fallback.filter(issue => String(issue.body ?? "").includes(marker));
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @param {string} command
+ * @param {string} memoryFile
+ * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean }}
+ */
+function runMissingMemoryVariant(repo, marker, command, memoryFile) {
+  const backup = `${memoryFile}.project-ideation-idempotency-backup`;
+  rmSync(backup, { force: true });
+
+  if (existsSync(memoryFile)) {
+    mkdirSync(dirname(backup), { recursive: true });
+    renameSync(memoryFile, backup);
+  }
+
+  try {
+    runCommand("missing-memory ideation run", command);
+    const result = assertSingleOpenMarker(
+      repo,
+      marker,
+      "after missing-memory run"
+    );
+    return {
+      ...result,
+      memoryRecreated: existsSync(memoryFile),
+    };
+  } finally {
+    if (existsSync(backup)) {
+      rmSync(memoryFile, { force: true });
+      mkdirSync(dirname(memoryFile), { recursive: true });
+      renameSync(backup, memoryFile);
+    }
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {readonly string[]} argv
+ * @returns {any}
+ */
+function runJson(command, argv) {
+  const result = spawnSync(command, argv, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    fail(`${command} ${argv.join(" ")} failed:\n${result.stderr}`);
+  }
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    fail(`Could not parse JSON from ${command}: ${error.message}`);
+  }
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node plugins/lisa/scripts/project-ideation-idempotency-harness.mjs \\
+    --repo CodySwannGT/lisa \\
+    --marker "[lisa-project-ideation] idea=<stable-key>" \\
+    --command "codex exec '/lisa:project-ideation ./fixtures/project-ideation-idempotency prd_ready=true max_prds=1'" \\
+    --memory-file "$CODEX_HOME/automations/<automation_id>/memory.md"
+
+The command must be deterministic: it should select the same idea and marker on
+each run. When --memory-file is provided, the harness temporarily moves it aside
+for the missing-memory variant and restores the original file afterward.`);
+}
+
+/**
+ * @param {string} message
+ * @returns {never}
+ */
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/plugins/lisa/skills/project-ideation/SKILL.md
+++ b/plugins/lisa/skills/project-ideation/SKILL.md
@@ -25,6 +25,10 @@ cannot verify yourself is noise — demote it honestly.
   creates **one** PRD (the single top-ranked idea), because `lisa:research` is a heavy full flow.
   `max_prds=3` creates the top three; `max_prds=all` creates one per build-ready idea. Discovery
   Spikes and Rejected ideas are never turned into PRDs regardless of `max_prds`.
+- **`fixture=<path>`** (optional, verification-only) — a deterministic host-project fixture used
+  for idempotency verification. When present, read the fixture before ranking and honor its declared
+  single persona, single idea, existing-fit anchor, and expected dedupe marker. Do not use this
+  parameter for normal ideation runs.
 
 ## When to use
 
@@ -232,3 +236,6 @@ Use the markdown examples in `examples/` as shape references for the idea report
   requirements.
 - `unavailable-data-rejection.md` — naming missing private/paid/unavailable sources when demoting.
 - `evidence-card-format.md` — the required evidence fields every Practical Idea card must carry.
+- `idempotency-verification-harness.md` — deterministic fixture and script procedure proving that
+  repeated `prd_ready=true` ideation keeps the open GitHub marker count at one, including the
+  missing-memory rerun variant.

--- a/plugins/lisa/skills/project-ideation/examples/idempotency-verification-harness.md
+++ b/plugins/lisa/skills/project-ideation/examples/idempotency-verification-harness.md
@@ -1,0 +1,56 @@
+# Project Ideation Idempotency Verification Harness
+
+Use this documented harness when validating that `project-ideation prd_ready=true` reuses an
+existing GitHub PRD by stable marker instead of creating duplicates.
+
+## Deterministic fixture
+
+Create an isolated fixture project with only one evidence-backed persona and one build-ready idea.
+The fixture should make the selected marker predictable:
+
+- Repo identity: `CodySwannGT/lisa`
+- Persona key: `queue-automation-operators`
+- Idea name: `Exploratory PRD run ledger`
+- Existing-fit anchor: `plugins/src/base/skills/project-ideation/SKILL.md`
+- Expected marker: `[lisa-project-ideation] idea=codyswanngt-lisa-exploratory-prd-run-ledger-queue-automation-operators-plugins-lisa-skills-project-ideation-skill-md`
+
+The fixture may be a tiny directory with:
+
+- `README.md` naming queue automation operators and their goals.
+- `.lisa.config.json` pointing `source` and `tracker` to GitHub.
+- `PROJECT_IDEATION_FIXTURE.md` listing the single persona, the single idea, and the expected
+  marker above.
+
+Invoke project ideation against that fixture with `prd_ready=true max_prds=1`. The fixture is valid
+only if the idea report selects the single expected idea and the PRD summary reports the expected
+marker.
+
+## Scripted verification
+
+Run the shipped harness after choosing the deterministic command for your runtime:
+
+```bash
+node plugins/lisa/scripts/project-ideation-idempotency-harness.mjs \
+  --repo CodySwannGT/lisa \
+  --marker "[lisa-project-ideation] idea=codyswanngt-lisa-exploratory-prd-run-ledger-queue-automation-operators-plugins-lisa-skills-project-ideation-skill-md" \
+  --command "codex exec '/lisa:project-ideation ./fixtures/project-ideation-idempotency prd_ready=true max_prds=1'" \
+  --memory-file "$CODEX_HOME/automations/<automation_id>/memory.md"
+```
+
+The harness performs the acceptance check in three phases:
+
+1. Run the deterministic ideation command once, then query open GitHub issues for the marker and
+   require exactly one match.
+2. Run the same command again, then require the open marker count to remain one.
+3. Move the automation memory file aside, run the command again, require the marker count to remain
+   one, and require the memory file to be recreated. The original memory file is restored at the end.
+
+## Expected evidence
+
+Capture the harness JSON output as:
+
+- `[EVIDENCE: marker-count-one]` from the first and second marker-count checks.
+- `[EVIDENCE: memory-recreated-after-rerun]` from the missing-memory variant.
+
+The run passes only when all reported counts are `1`, the issue URL is the same across phases, and
+`memoryRecreated` is `true` when `--memory-file` is supplied.

--- a/plugins/src/base/scripts/project-ideation-idempotency-harness.mjs
+++ b/plugins/src/base/scripts/project-ideation-idempotency-harness.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Deterministic verification harness for project-ideation PRD dedupe.
+ *
+ * The harness runs a caller-supplied deterministic project-ideation command
+ * twice, checks that exactly one open GitHub PRD contains the expected marker,
+ * then optionally removes the automation memory file and verifies a third run
+ * recreates memory without creating a duplicate PRD.
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+const repo = requireValue(args.repo, "--repo");
+const marker = requireValue(args.marker, "--marker");
+const command = requireValue(args.command, "--command");
+const memoryFile = args.memoryFile ? resolve(args.memoryFile) : null;
+
+runCommand("first ideation run", command);
+const first = assertSingleOpenMarker(repo, marker, "after first run");
+
+runCommand("second ideation run", command);
+const second = assertSingleOpenMarker(repo, marker, "after second run");
+
+let missingMemory = null;
+if (memoryFile) {
+  missingMemory = runMissingMemoryVariant(repo, marker, command, memoryFile);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      repo,
+      marker,
+      first,
+      second,
+      missingMemory,
+      verdict: "PASS",
+    },
+    null,
+    2
+  )
+);
+
+/**
+ * @param {string[]} argv
+ * @returns {Record<string, string | boolean>}
+ */
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (!token.startsWith("--")) {
+      fail(`Unexpected positional argument: ${token}`);
+    }
+
+    const eqIndex = token.indexOf("=");
+    if (eqIndex !== -1) {
+      parsed[token.slice(2, eqIndex)] = token.slice(eqIndex + 1);
+      continue;
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      fail(`Missing value for --${key}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+/**
+ * @param {Record<string, string | boolean>} input
+ * @param {string} key
+ * @returns {string}
+ */
+function requireValue(input, key) {
+  const normalized = key.replace(/^--/, "");
+  const value = input[normalized];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`${key} is required`);
+  }
+  return value.trim();
+}
+
+/**
+ * @param {string} label
+ * @param {string} command
+ */
+function runCommand(label, command) {
+  const result = spawnSync(command, {
+    shell: true,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    fail(`${label} failed with exit code ${String(result.status)}`);
+  }
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @param {string} phase
+ * @returns {{ readonly count: number, readonly issue: Record<string, any> }}
+ */
+function assertSingleOpenMarker(repo, marker, phase) {
+  const issues = queryOpenIssuesByMarker(repo, marker);
+  if (issues.length !== 1) {
+    fail(
+      `Expected exactly one open issue containing marker ${JSON.stringify(marker)} ${phase}, found ${issues.length}`
+    );
+  }
+
+  return {
+    count: issues.length,
+    issue: {
+      number: issues[0].number,
+      title: issues[0].title,
+      url: issues[0].url,
+      labels: normalizeLabels(issues[0].labels),
+    },
+  };
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @returns {readonly Record<string, any>[]}
+ */
+function queryOpenIssuesByMarker(repo, marker) {
+  const search = runJson("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--search",
+    `"${marker}" in:body`,
+    "--limit",
+    "100",
+    "--json",
+    "number,title,url,labels",
+  ]);
+
+  if (Array.isArray(search) && search.length > 0) {
+    return search;
+  }
+
+  const fallback = runJson("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "open",
+    "--limit",
+    "1000",
+    "--json",
+    "number,title,url,labels,body",
+  ]);
+
+  if (!Array.isArray(fallback)) {
+    return [];
+  }
+
+  return fallback.filter(issue => String(issue.body ?? "").includes(marker));
+}
+
+/**
+ * @param {string} repo
+ * @param {string} marker
+ * @param {string} command
+ * @param {string} memoryFile
+ * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean }}
+ */
+function runMissingMemoryVariant(repo, marker, command, memoryFile) {
+  const backup = `${memoryFile}.project-ideation-idempotency-backup`;
+  rmSync(backup, { force: true });
+
+  if (existsSync(memoryFile)) {
+    mkdirSync(dirname(backup), { recursive: true });
+    renameSync(memoryFile, backup);
+  }
+
+  try {
+    runCommand("missing-memory ideation run", command);
+    const result = assertSingleOpenMarker(
+      repo,
+      marker,
+      "after missing-memory run"
+    );
+    return {
+      ...result,
+      memoryRecreated: existsSync(memoryFile),
+    };
+  } finally {
+    if (existsSync(backup)) {
+      rmSync(memoryFile, { force: true });
+      mkdirSync(dirname(memoryFile), { recursive: true });
+      renameSync(backup, memoryFile);
+    }
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {readonly string[]} argv
+ * @returns {any}
+ */
+function runJson(command, argv) {
+  const result = spawnSync(command, argv, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    fail(`${command} ${argv.join(" ")} failed:\n${result.stderr}`);
+  }
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    fail(`Could not parse JSON from ${command}: ${error.message}`);
+  }
+}
+
+/**
+ * @param {readonly any[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node plugins/lisa/scripts/project-ideation-idempotency-harness.mjs \\
+    --repo CodySwannGT/lisa \\
+    --marker "[lisa-project-ideation] idea=<stable-key>" \\
+    --command "codex exec '/lisa:project-ideation ./fixtures/project-ideation-idempotency prd_ready=true max_prds=1'" \\
+    --memory-file "$CODEX_HOME/automations/<automation_id>/memory.md"
+
+The command must be deterministic: it should select the same idea and marker on
+each run. When --memory-file is provided, the harness temporarily moves it aside
+for the missing-memory variant and restores the original file afterward.`);
+}
+
+/**
+ * @param {string} message
+ * @returns {never}
+ */
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/plugins/src/base/skills/project-ideation/SKILL.md
+++ b/plugins/src/base/skills/project-ideation/SKILL.md
@@ -25,6 +25,10 @@ cannot verify yourself is noise — demote it honestly.
   creates **one** PRD (the single top-ranked idea), because `lisa:research` is a heavy full flow.
   `max_prds=3` creates the top three; `max_prds=all` creates one per build-ready idea. Discovery
   Spikes and Rejected ideas are never turned into PRDs regardless of `max_prds`.
+- **`fixture=<path>`** (optional, verification-only) — a deterministic host-project fixture used
+  for idempotency verification. When present, read the fixture before ranking and honor its declared
+  single persona, single idea, existing-fit anchor, and expected dedupe marker. Do not use this
+  parameter for normal ideation runs.
 
 ## When to use
 
@@ -232,3 +236,6 @@ Use the markdown examples in `examples/` as shape references for the idea report
   requirements.
 - `unavailable-data-rejection.md` — naming missing private/paid/unavailable sources when demoting.
 - `evidence-card-format.md` — the required evidence fields every Practical Idea card must carry.
+- `idempotency-verification-harness.md` — deterministic fixture and script procedure proving that
+  repeated `prd_ready=true` ideation keeps the open GitHub marker count at one, including the
+  missing-memory rerun variant.

--- a/plugins/src/base/skills/project-ideation/examples/idempotency-verification-harness.md
+++ b/plugins/src/base/skills/project-ideation/examples/idempotency-verification-harness.md
@@ -1,0 +1,56 @@
+# Project Ideation Idempotency Verification Harness
+
+Use this documented harness when validating that `project-ideation prd_ready=true` reuses an
+existing GitHub PRD by stable marker instead of creating duplicates.
+
+## Deterministic fixture
+
+Create an isolated fixture project with only one evidence-backed persona and one build-ready idea.
+The fixture should make the selected marker predictable:
+
+- Repo identity: `CodySwannGT/lisa`
+- Persona key: `queue-automation-operators`
+- Idea name: `Exploratory PRD run ledger`
+- Existing-fit anchor: `plugins/src/base/skills/project-ideation/SKILL.md`
+- Expected marker: `[lisa-project-ideation] idea=codyswanngt-lisa-exploratory-prd-run-ledger-queue-automation-operators-plugins-lisa-skills-project-ideation-skill-md`
+
+The fixture may be a tiny directory with:
+
+- `README.md` naming queue automation operators and their goals.
+- `.lisa.config.json` pointing `source` and `tracker` to GitHub.
+- `PROJECT_IDEATION_FIXTURE.md` listing the single persona, the single idea, and the expected
+  marker above.
+
+Invoke project ideation against that fixture with `prd_ready=true max_prds=1`. The fixture is valid
+only if the idea report selects the single expected idea and the PRD summary reports the expected
+marker.
+
+## Scripted verification
+
+Run the shipped harness after choosing the deterministic command for your runtime:
+
+```bash
+node plugins/lisa/scripts/project-ideation-idempotency-harness.mjs \
+  --repo CodySwannGT/lisa \
+  --marker "[lisa-project-ideation] idea=codyswanngt-lisa-exploratory-prd-run-ledger-queue-automation-operators-plugins-lisa-skills-project-ideation-skill-md" \
+  --command "codex exec '/lisa:project-ideation ./fixtures/project-ideation-idempotency prd_ready=true max_prds=1'" \
+  --memory-file "$CODEX_HOME/automations/<automation_id>/memory.md"
+```
+
+The harness performs the acceptance check in three phases:
+
+1. Run the deterministic ideation command once, then query open GitHub issues for the marker and
+   require exactly one match.
+2. Run the same command again, then require the open marker count to remain one.
+3. Move the automation memory file aside, run the command again, require the marker count to remain
+   one, and require the memory file to be recreated. The original memory file is restored at the end.
+
+## Expected evidence
+
+Capture the harness JSON output as:
+
+- `[EVIDENCE: marker-count-one]` from the first and second marker-count checks.
+- `[EVIDENCE: memory-recreated-after-rerun]` from the missing-memory variant.
+
+The run passes only when all reported counts are `1`, the issue URL is the same across phases, and
+`memoryRecreated` is `true` when `--memory-file` is supplied.

--- a/tests/unit/codex/project-ideation-examples.test.ts
+++ b/tests/unit/codex/project-ideation-examples.test.ts
@@ -14,11 +14,14 @@ const EXAMPLE_ROOTS = [
   "plugins/lisa/skills/project-ideation/examples",
 ] as const;
 
+const IDEMPOTENCY_HARNESS_EXAMPLE = "idempotency-verification-harness.md";
+
 const EXAMPLE_FILES = [
   "host-project-only.md",
   "public-external-inspiration.md",
   "unavailable-data-rejection.md",
   "evidence-card-format.md",
+  IDEMPOTENCY_HARNESS_EXAMPLE,
 ] as const;
 
 /**
@@ -38,6 +41,12 @@ describe("codex/project-ideation-examples (#669)", () => {
       for (const file of EXAMPLE_FILES) {
         const content = readExample(root, file);
 
+        if (file === IDEMPOTENCY_HARNESS_EXAMPLE) {
+          expect(content).toContain("## Deterministic fixture");
+          expect(content).toContain("## Scripted verification");
+          continue;
+        }
+
         expect(content).toContain("## What Already Exists");
         expect(content).toContain("## Practical Ideas");
         expect(content).toContain("## Discovery Spikes");
@@ -51,6 +60,12 @@ describe("codex/project-ideation-examples (#669)", () => {
     root => {
       for (const file of EXAMPLE_FILES) {
         const content = readExample(root, file);
+
+        if (file === IDEMPOTENCY_HARNESS_EXAMPLE) {
+          expect(content).toContain("[EVIDENCE: marker-count-one]");
+          expect(content).toContain("[EVIDENCE: memory-recreated-after-rerun]");
+          continue;
+        }
 
         expect(content).toMatch(/- Empirical verification: .+/);
         expect(content).toMatch(/- Evidence: .+/);
@@ -68,4 +83,13 @@ describe("codex/project-ideation-examples (#669)", () => {
       expect(content).toContain("licensed data feed");
     }
   );
+
+  it.each(EXAMPLE_ROOTS)("%s documents the idempotency harness", root => {
+    const content = readExample(root, IDEMPOTENCY_HARNESS_EXAMPLE);
+
+    expect(content).toContain("project-ideation-idempotency-harness.mjs");
+    expect(content).toContain("prd_ready=true");
+    expect(content).toContain("max_prds=1");
+    expect(content).toContain("memoryRecreated");
+  });
 });

--- a/tests/unit/codex/project-ideation-idempotency-harness.test.ts
+++ b/tests/unit/codex/project-ideation-idempotency-harness.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression coverage for issue #1010: project-ideation ships a deterministic
+ * verification harness proving stable-marker PRD dedupe across repeated runs
+ * and missing automation memory.
+ *
+ * @module tests/unit/codex/project-ideation-idempotency-harness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_ROOTS = [
+  "plugins/src/base/scripts",
+  "plugins/lisa/scripts",
+] as const;
+const SKILL_ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+/**
+ * Read a committed source or generated artifact.
+ * @param root Directory containing the target file.
+ * @param file File path relative to the root.
+ * @returns File contents.
+ */
+function readFile(root: string, file: string): string {
+  return readFileSync(path.resolve(root, file), "utf8");
+}
+
+describe("project-ideation idempotency harness (#1010)", () => {
+  it.each(SCRIPT_ROOTS)("%s ships the marker-count harness script", root => {
+    const content = readFile(root, "project-ideation-idempotency-harness.mjs");
+
+    expect(content).toContain("--marker");
+    expect(content).toContain("--command");
+    expect(content).toContain("--memory-file");
+    expect(content).toContain('`"${marker}" in:body`');
+    expect(content).toContain("memoryRecreated");
+  });
+
+  it.each(SKILL_ROOTS)("%s documents fixture-driven verification", root => {
+    const content = readFile(root, "project-ideation/SKILL.md");
+
+    expect(content).toContain("fixture=<path>");
+    expect(content).toContain("idempotency-verification-harness.md");
+    expect(content).toMatch(/marker count at one/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shipped project-ideation idempotency harness script for marker-count and missing-memory verification
- document the deterministic fixture flow and expected evidence markers
- pin source and generated plugin artifacts with focused regression tests

## Verification
- bun vitest run tests/unit/codex/project-ideation-examples.test.ts tests/unit/codex/project-ideation-idempotency-harness.test.ts tests/unit/strategies/prd-source-write.test.ts
- pre-push hook: bun audit, slow eslint, knip, vitest --coverage, integration tests

Closes #1010