### PR TITLE
Record project ideation automation memory contract

### DIFF
--- a/plugins/lisa/scripts/project-ideation-idempotency-harness.mjs
+++ b/plugins/lisa/scripts/project-ideation-idempotency-harness.mjs
@@ -5,10 +5,17 @@
  * The harness runs a caller-supplied deterministic project-ideation command
  * twice, checks that exactly one open GitHub PRD contains the expected marker,
  * then optionally removes the automation memory file and verifies a third run
- * recreates memory without creating a duplicate PRD.
+ * recreates memory without creating a duplicate PRD. The recreated memory entry
+ * must include the advisory run fields project-ideation promises to write.
  */
 
-import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -190,7 +197,7 @@ function queryOpenIssuesByMarker(repo, marker) {
  * @param {string} marker
  * @param {string} command
  * @param {string} memoryFile
- * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean }}
+ * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean, readonly memoryFieldsRecorded: boolean }}
  */
 function runMissingMemoryVariant(repo, marker, command, memoryFile) {
   const backup = `${memoryFile}.project-ideation-idempotency-backup`;
@@ -208,9 +215,27 @@ function runMissingMemoryVariant(repo, marker, command, memoryFile) {
       marker,
       "after missing-memory run"
     );
+    const memoryRecreated = existsSync(memoryFile);
+    const memoryFieldsRecorded =
+      memoryRecreated &&
+      memoryContainsRunEntry(memoryFile, {
+        marker,
+        prdUrl: String(result.issue.url),
+      });
+
+    if (!memoryRecreated) {
+      fail(`Expected missing-memory run to recreate ${memoryFile}`);
+    }
+    if (!memoryFieldsRecorded) {
+      fail(
+        `Expected recreated memory to record marker, PRD URL, outcome, lifecycle_role, and source_agreement`
+      );
+    }
+
     return {
       ...result,
-      memoryRecreated: existsSync(memoryFile),
+      memoryRecreated,
+      memoryFieldsRecorded,
     };
   } finally {
     if (existsSync(backup)) {
@@ -219,6 +244,24 @@ function runMissingMemoryVariant(repo, marker, command, memoryFile) {
       renameSync(backup, memoryFile);
     }
   }
+}
+
+/**
+ * @param {string} memoryFile
+ * @param {{ readonly marker: string, readonly prdUrl: string }} expected
+ * @returns {boolean}
+ */
+function memoryContainsRunEntry(memoryFile, expected) {
+  const memory = readFileSync(memoryFile, "utf8");
+  const requiredFragments = [
+    expected.marker,
+    expected.prdUrl,
+    "outcome:",
+    "lifecycle_role:",
+    "source_agreement:",
+  ];
+
+  return requiredFragments.every(fragment => memory.includes(fragment));
 }
 
 /**

--- a/plugins/lisa/skills/project-ideation/SKILL.md
+++ b/plugins/lisa/skills/project-ideation/SKILL.md
@@ -161,6 +161,26 @@ For each idea in the creation set, invoke `/lisa:research` with:
 `lisa:prd-source-write`. `project-ideation` never writes to the source directly — it delegates, so
 the PRD source stays switchable per project. Capture each returned PRD ref / URL / role / outcome.
 
+### Optional Codex automation memory
+
+When the run has a Codex automation id or memory path, maintain a concise local advisory ledger after
+the PRD source write returns. Resolve the memory path in this order:
+
+1. explicit `memory_file=<path>` or `automation_memory=<path>` argument, when supplied;
+2. `$CODEX_AUTOMATION_MEMORY`, when set;
+3. `$CODEX_HOME/automations/<automation_id>/memory.md`, when `automation_id=<id>` or
+   `$CODEX_AUTOMATION_ID` is available.
+
+Create the parent directory and `memory.md` if missing. Write one concise run entry keyed by the
+dedupe marker and run timestamp. The entry must include the marker, PRD URL/ref, outcome
+(`created | reused | updated | blocked`), lifecycle role (`draft | ready | blocked` or the returned
+source role), and `source_agreement` (`github-source-wins`, `memory-created`, `memory-updated`, or
+`memory-missing-runtime`). If memory says one thing but the PRD source search finds a matching open
+PRD, GitHub/source truth wins: reuse the source PRD and update memory rather than creating a
+duplicate. Keep memory advisory only; never use it to override lifecycle labels, source marker
+matches, or the PRD source writer's returned role. Do not store secrets, tokens, full PRD bodies, or
+private source excerpts in memory.
+
 ### Dedupe marker (stable, never title-based)
 
 Each created PRD carries the marker `[lisa-project-ideation] idea=<stable-key>`. Compute

--- a/plugins/lisa/skills/project-ideation/examples/idempotency-verification-harness.md
+++ b/plugins/lisa/skills/project-ideation/examples/idempotency-verification-harness.md
@@ -43,7 +43,8 @@ The harness performs the acceptance check in three phases:
    require exactly one match.
 2. Run the same command again, then require the open marker count to remain one.
 3. Move the automation memory file aside, run the command again, require the marker count to remain
-   one, and require the memory file to be recreated. The original memory file is restored at the end.
+   one, and require the memory file to be recreated with marker, PRD URL, outcome, lifecycle role,
+   and source agreement fields. The original memory file is restored at the end.
 
 ## Expected evidence
 
@@ -53,4 +54,4 @@ Capture the harness JSON output as:
 - `[EVIDENCE: memory-recreated-after-rerun]` from the missing-memory variant.
 
 The run passes only when all reported counts are `1`, the issue URL is the same across phases, and
-`memoryRecreated` is `true` when `--memory-file` is supplied.
+`memoryRecreated` and `memoryFieldsRecorded` are `true` when `--memory-file` is supplied.

--- a/plugins/src/base/scripts/project-ideation-idempotency-harness.mjs
+++ b/plugins/src/base/scripts/project-ideation-idempotency-harness.mjs
@@ -5,10 +5,17 @@
  * The harness runs a caller-supplied deterministic project-ideation command
  * twice, checks that exactly one open GitHub PRD contains the expected marker,
  * then optionally removes the automation memory file and verifies a third run
- * recreates memory without creating a duplicate PRD.
+ * recreates memory without creating a duplicate PRD. The recreated memory entry
+ * must include the advisory run fields project-ideation promises to write.
  */
 
-import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -190,7 +197,7 @@ function queryOpenIssuesByMarker(repo, marker) {
  * @param {string} marker
  * @param {string} command
  * @param {string} memoryFile
- * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean }}
+ * @returns {{ readonly count: number, readonly issue: Record<string, any>, readonly memoryRecreated: boolean, readonly memoryFieldsRecorded: boolean }}
  */
 function runMissingMemoryVariant(repo, marker, command, memoryFile) {
   const backup = `${memoryFile}.project-ideation-idempotency-backup`;
@@ -208,9 +215,27 @@ function runMissingMemoryVariant(repo, marker, command, memoryFile) {
       marker,
       "after missing-memory run"
     );
+    const memoryRecreated = existsSync(memoryFile);
+    const memoryFieldsRecorded =
+      memoryRecreated &&
+      memoryContainsRunEntry(memoryFile, {
+        marker,
+        prdUrl: String(result.issue.url),
+      });
+
+    if (!memoryRecreated) {
+      fail(`Expected missing-memory run to recreate ${memoryFile}`);
+    }
+    if (!memoryFieldsRecorded) {
+      fail(
+        `Expected recreated memory to record marker, PRD URL, outcome, lifecycle_role, and source_agreement`
+      );
+    }
+
     return {
       ...result,
-      memoryRecreated: existsSync(memoryFile),
+      memoryRecreated,
+      memoryFieldsRecorded,
     };
   } finally {
     if (existsSync(backup)) {
@@ -219,6 +244,24 @@ function runMissingMemoryVariant(repo, marker, command, memoryFile) {
       renameSync(backup, memoryFile);
     }
   }
+}
+
+/**
+ * @param {string} memoryFile
+ * @param {{ readonly marker: string, readonly prdUrl: string }} expected
+ * @returns {boolean}
+ */
+function memoryContainsRunEntry(memoryFile, expected) {
+  const memory = readFileSync(memoryFile, "utf8");
+  const requiredFragments = [
+    expected.marker,
+    expected.prdUrl,
+    "outcome:",
+    "lifecycle_role:",
+    "source_agreement:",
+  ];
+
+  return requiredFragments.every(fragment => memory.includes(fragment));
 }
 
 /**

--- a/plugins/src/base/skills/project-ideation/SKILL.md
+++ b/plugins/src/base/skills/project-ideation/SKILL.md
@@ -161,6 +161,26 @@ For each idea in the creation set, invoke `/lisa:research` with:
 `lisa:prd-source-write`. `project-ideation` never writes to the source directly — it delegates, so
 the PRD source stays switchable per project. Capture each returned PRD ref / URL / role / outcome.
 
+### Optional Codex automation memory
+
+When the run has a Codex automation id or memory path, maintain a concise local advisory ledger after
+the PRD source write returns. Resolve the memory path in this order:
+
+1. explicit `memory_file=<path>` or `automation_memory=<path>` argument, when supplied;
+2. `$CODEX_AUTOMATION_MEMORY`, when set;
+3. `$CODEX_HOME/automations/<automation_id>/memory.md`, when `automation_id=<id>` or
+   `$CODEX_AUTOMATION_ID` is available.
+
+Create the parent directory and `memory.md` if missing. Write one concise run entry keyed by the
+dedupe marker and run timestamp. The entry must include the marker, PRD URL/ref, outcome
+(`created | reused | updated | blocked`), lifecycle role (`draft | ready | blocked` or the returned
+source role), and `source_agreement` (`github-source-wins`, `memory-created`, `memory-updated`, or
+`memory-missing-runtime`). If memory says one thing but the PRD source search finds a matching open
+PRD, GitHub/source truth wins: reuse the source PRD and update memory rather than creating a
+duplicate. Keep memory advisory only; never use it to override lifecycle labels, source marker
+matches, or the PRD source writer's returned role. Do not store secrets, tokens, full PRD bodies, or
+private source excerpts in memory.
+
 ### Dedupe marker (stable, never title-based)
 
 Each created PRD carries the marker `[lisa-project-ideation] idea=<stable-key>`. Compute

--- a/plugins/src/base/skills/project-ideation/examples/idempotency-verification-harness.md
+++ b/plugins/src/base/skills/project-ideation/examples/idempotency-verification-harness.md
@@ -43,7 +43,8 @@ The harness performs the acceptance check in three phases:
    require exactly one match.
 2. Run the same command again, then require the open marker count to remain one.
 3. Move the automation memory file aside, run the command again, require the marker count to remain
-   one, and require the memory file to be recreated. The original memory file is restored at the end.
+   one, and require the memory file to be recreated with marker, PRD URL, outcome, lifecycle role,
+   and source agreement fields. The original memory file is restored at the end.
 
 ## Expected evidence
 
@@ -53,4 +54,4 @@ Capture the harness JSON output as:
 - `[EVIDENCE: memory-recreated-after-rerun]` from the missing-memory variant.
 
 The run passes only when all reported counts are `1`, the issue URL is the same across phases, and
-`memoryRecreated` is `true` when `--memory-file` is supplied.
+`memoryRecreated` and `memoryFieldsRecorded` are `true` when `--memory-file` is supplied.

--- a/tests/unit/codex/project-ideation-idempotency-harness.test.ts
+++ b/tests/unit/codex/project-ideation-idempotency-harness.test.ts
@@ -35,6 +35,8 @@ describe("project-ideation idempotency harness (#1010)", () => {
     expect(content).toContain("--memory-file");
     expect(content).toContain('`"${marker}" in:body`');
     expect(content).toContain("memoryRecreated");
+    expect(content).toContain("memoryFieldsRecorded");
+    expect(content).toContain("source_agreement:");
   });
 
   it.each(SKILL_ROOTS)("%s documents fixture-driven verification", root => {
@@ -43,5 +45,7 @@ describe("project-ideation idempotency harness (#1010)", () => {
     expect(content).toContain("fixture=<path>");
     expect(content).toContain("idempotency-verification-harness.md");
     expect(content).toMatch(/marker count at one/i);
+    expect(content).toContain("Optional Codex automation memory");
+    expect(content).toContain("source_agreement");
   });
 });


### PR DESCRIPTION
## Summary
- Document optional Codex automation-memory handling for project-ideation runs
- Require the idempotency harness to fail when recreated memory lacks marker, PRD URL, outcome, lifecycle role, or source agreement fields
- Update the fixture verification example and regression coverage for the stricter memory contract

## Verification
- bun vitest run tests/unit/codex/project-ideation-idempotency-harness.test.ts
- bun run typecheck
- bun run lint (passes; reports pre-existing warnings under .agents/skills/harness-parity-council during oxlint)
- bun run test:unit
- bun run check:plugins
- git push pre-push suite: bun audit, slow lint, knip, vitest --coverage, integration tests

Closes #1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automation memory ledger to track PRD operations with timestamped outcomes and lifecycle details.
  * Memory file now records run entries with marker, PRD URL, outcome, lifecycle role, and source agreement.

* **Documentation**
  * Updated skill documentation with automation memory configuration and reconciliation rules.
  * Updated harness verification requirements for memory field validation.

* **Tests**
  * Extended unit tests to verify memory field recording behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->