### PR TITLE
fix(wiki): flush lint-wiki --json output before exit

### DIFF
--- a/plugins/lisa-wiki/scripts/lint-wiki.mjs
+++ b/plugins/lisa-wiki/scripts/lint-wiki.mjs
@@ -317,4 +317,8 @@ if (asJson) {
   );
 }
 
-process.exit(blocking === 0 ? 0 : 1);
+// Set exitCode instead of calling process.exit() so a large `--json` payload
+// written to a pipe (e.g. captured via spawnSync by verify-migration) is fully
+// flushed before the process exits. process.exit() can truncate async stdout
+// writes at the OS pipe buffer (~64KB), corrupting the JSON for the reader.
+process.exitCode = blocking === 0 ? 0 : 1;

--- a/plugins/src/wiki/scripts/lint-wiki.mjs
+++ b/plugins/src/wiki/scripts/lint-wiki.mjs
@@ -317,4 +317,8 @@ if (asJson) {
   );
 }
 
-process.exit(blocking === 0 ? 0 : 1);
+// Set exitCode instead of calling process.exit() so a large `--json` payload
+// written to a pipe (e.g. captured via spawnSync by verify-migration) is fully
+// flushed before the process exits. process.exit() can truncate async stdout
+// writes at the OS pipe buffer (~64KB), corrupting the JSON for the reader.
+process.exitCode = blocking === 0 ? 0 : 1;


### PR DESCRIPTION
## Problem

`plugins/src/wiki/scripts/lint-wiki.mjs` printed its `--json` report with `console.log` and then immediately called `process.exit()`. When stdout is a **pipe** (not a file/TTY) — e.g. when `verify-migration.mjs` captures it via `spawnSync` — the async stdout write gets truncated at the OS pipe buffer (~64KB) before it drains, so the reader's `JSON.parse` throws.

On a wiki with many warnings (an ~186KB / 800-item report), this surfaced during `/lisa-wiki:migrate` as a spurious migration **FAIL**:

```
✗ [lint-run] lint-wiki did not produce JSON: { "wikiRoot": "wiki", "strict": false, "fails": 0, "warns": 800, "items": [ ...truncated at 65536 bytes... }
```

…even though lint itself exits `0 fail`. The truncated payload visibly contains `"fails": 0`, confirming the lint ran clean and only the capture was corrupted.

This is the flush-before-exit gotcha, not a `maxBuffer` issue (`spawnSync`'s default `maxBuffer` is 1MB, well above 186KB).

## Fix

Set `process.exitCode` instead of calling `process.exit()`, so the event loop drains stdout before the process terminates. The script is fully synchronous with no lingering handles, so it still exits promptly. The early error guard (`process.exit(1)` on missing wiki root) is left as-is since it must halt immediately and emits only a one-line stderr message.

Updated both the source (`plugins/src/wiki/scripts/`) and built (`plugins/lisa-wiki/scripts/`) copies to keep them in sync.

## Verification

Captured the patched script via `spawnSync` (encoding utf8, default buffer) against a wiki producing an ~186KB / 800-item report:

```
captured bytes: 185560  status: 0  error: none
JSON.parse OK -> fails: 0  warns: 800  items: 800
```

Previously the same capture truncated at 65536 bytes and failed to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)