### PR TITLE
Thread ideation ledger metadata

### DIFF
--- a/plugins/lisa/skills/github-write-prd/SKILL.md
+++ b/plugins/lisa/skills/github-write-prd/SKILL.md
@@ -10,7 +10,8 @@ Create (or update) a PRD issue in the configured source repo. Invoked by `lisa:p
 when `source = github`; do not call directly from a vendor-neutral caller.
 
 `$ARGUMENTS` carries the `lisa:prd-source-write` spec: `title`, `body` (full PRD markdown),
-`initial_role` (`draft` | `ready`, default `draft`), `dedupe_key`, `marker`, optional `source_ref`.
+`initial_role` (`draft` | `ready`, default `draft`), `dedupe_key`, `marker`, optional `source_ref`,
+and optional `ideation_ledger_payload` from `lisa:project-ideation` via `lisa:research`.
 
 ## Phase 1 — Resolve repo and PRD lifecycle labels
 
@@ -64,10 +65,13 @@ section, preserve it verbatim unless the caller intentionally supplied an update
 use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **Exploratory ideation run ledger (both paths).** When the write was initiated by
-`lisa:project-ideation` or carries a project-ideation marker, persist a managed `## Exploratory
-Ideation Run Ledger` section in the PRD body. Prefer the managed section over a comment so the PRD
-itself remains the operator's source of truth; use a managed comment only if the body cannot be
-updated. Keep one managed section by replacing the content between stable markers:
+`lisa:project-ideation`, carries a project-ideation marker, or includes
+`ideation_ledger_payload`, persist a managed `## Exploratory Ideation Run Ledger` section in the PRD
+body. Prefer the managed section over a comment so the PRD itself remains the operator's source of
+truth; use a managed comment only if the body cannot be updated. Populate the fields from
+`ideation_ledger_payload` when present, falling back to `marker`, `initial_role`, repo config, and
+runtime metadata only for missing fields. Keep one managed section by replacing the content between
+stable markers:
 
 ```markdown
 ## Exploratory Ideation Run Ledger

--- a/plugins/lisa/skills/prd-source-write/SKILL.md
+++ b/plugins/lisa/skills/prd-source-write/SKILL.md
@@ -27,6 +27,17 @@ dedupe_key: "<stable-key>"           # e.g. project-ideation's idea key
 marker: "[lisa-project-ideation] idea=<stable-key>"   # embedded in the PRD body for dedupe
 origin: { tool: project-ideation | research | manual }
 source_ref: "<optional existing PRD ref to force an update>"
+ideation_ledger_payload:              # optional; forwarded unchanged to the vendor writer
+  selected_marker: "<same value as marker>"
+  automation_id: "<Codex/Claude automation id or unavailable>"
+  automation_memory_path: "<path or unavailable>"
+  repo: "<org>/<repo or detected repo identity>"
+  prd_ready: true|false
+  persona_names: ["<derived persona name>"]
+  persona_evidence_refs: ["<file/doc/table/release ref>"]
+  selected_idea: "<selected idea title/key>"
+  rejected_overlap_candidates: ["<issue refs/titles considered and rejected>"]
+  expected_empirical_verification_artifact: "<artifact ref or unavailable>"
 ```
 
 `initial_role` semantics are uniform across vendors (the role STRINGS resolve per vendor from
@@ -72,6 +83,10 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
    the applied role (`draft`/`ready`), the dedupe marker, and whether it was created or reused.
    Downstream callers (research, project-ideation) parse this — do not paraphrase.
 
+When `ideation_ledger_payload` is present, this shim still does not render or interpret it. Forward
+the object verbatim to the selected vendor writer so source-specific rendering remains behind the
+configured writer and the dispatch layer never bypasses source selection.
+
 ## Rules
 
 - Never bypass dispatch — a vendor-neutral caller calling a `*-write-prd` skill directly defeats the
@@ -80,5 +95,7 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
   and fallback behavior belongs in the vendor writers and follows the `usage-accounting` contract.
 - Never accept a source outside `{notion, confluence, github, linear}`. `jira` and `file` fail loudly.
 - Never mutate the spec between layers. The vendor writers define their own create/dedupe contract.
+- Never drop, rename, or vendor-render `ideation_ledger_payload`; it is a pass-through payload for
+  the configured writer.
 - Never invent a PRD lifecycle role string — resolve every role from `config-resolution` per vendor.
 - Idempotency is the vendor writer's job (marker search before create); this shim only routes.

--- a/plugins/lisa/skills/project-ideation/SKILL.md
+++ b/plugins/lisa/skills/project-ideation/SKILL.md
@@ -155,7 +155,13 @@ For each idea in the creation set, invoke `/lisa:research` with:
   grounding and the empirical verification plan),
 - `prd_ready` (this run's flag — `lisa:research` maps it to draft vs prd-ready),
 - a stable **dedupe marker** (see below) so a re-run references the existing PRD instead of creating
-  a duplicate.
+  a duplicate,
+- a structured `ideation_ledger_payload` handoff containing the selected marker, automation id and
+  memory path when available, persona names, persona evidence references, rejected overlap
+  candidates, repo identity, `prd_ready`, selected idea title/key, and the expected empirical
+  verification artifact. This payload is the only ideation-run metadata channel between
+  `project-ideation`, `research`, `prd-source-write`, and the vendor writer; keep GitHub-specific
+  rendering out of this skill.
 
 `lisa:research` synthesizes the PRD and creates it in the configured source via
 `lisa:prd-source-write`. `project-ideation` never writes to the source directly — it delegates, so

--- a/plugins/lisa/skills/research/SKILL.md
+++ b/plugins/lisa/skills/research/SKILL.md
@@ -16,6 +16,12 @@ Produce a PRD for the problem in `$ARGUMENTS`, then create it in the configured 
 - `dedupe_key` / `marker` (optional) — a stable dedupe marker (e.g. supplied by
   `lisa:project-ideation`) embedded in the created PRD so re-runs reference the existing PRD rather
   than creating a duplicate.
+- `ideation_ledger_payload` (optional, required when invoked by `lisa:project-ideation`) — a
+  structured metadata object to forward unchanged to `lisa:prd-source-write`. It carries the
+  selected marker, automation id/path when available, persona names, persona evidence references,
+  rejected overlap candidates, repo identity, `prd_ready`, selected idea title/key, and expected
+  empirical verification artifact. `research` may use these fields to inform the PRD body, but must
+  not discard, rename, or vendor-render them.
 
 ## Orchestration: agent team
 
@@ -55,5 +61,8 @@ source — there is no loose document artifact.** Before handing the synthesized
 `lisa:usage-accounting` so the PRD body carries the canonical `## Lisa Usage` ledger from creation
 time onward. If the runtime does not expose trustworthy usage, the direct entry must still be
 written with `source: unavailable` and nullable token/cost fields rather than silently omitting the
-Research row. A `source` must be configured; if it is not, stop and report it rather than emitting
-a document. The Plan flow consumes the created PRD next.
+Research row. If the call includes `ideation_ledger_payload`, pass that object through in the
+`lisa:prd-source-write` spec unchanged alongside `marker`, `dedupe_key`, and `initial_role`; this is
+the vendor-neutral handoff that lets the configured writer render an auditable run ledger without
+`research` bypassing source selection. A `source` must be configured; if it is not, stop and report
+it rather than emitting a document. The Plan flow consumes the created PRD next.

--- a/plugins/src/base/skills/github-write-prd/SKILL.md
+++ b/plugins/src/base/skills/github-write-prd/SKILL.md
@@ -10,7 +10,8 @@ Create (or update) a PRD issue in the configured source repo. Invoked by `lisa:p
 when `source = github`; do not call directly from a vendor-neutral caller.
 
 `$ARGUMENTS` carries the `lisa:prd-source-write` spec: `title`, `body` (full PRD markdown),
-`initial_role` (`draft` | `ready`, default `draft`), `dedupe_key`, `marker`, optional `source_ref`.
+`initial_role` (`draft` | `ready`, default `draft`), `dedupe_key`, `marker`, optional `source_ref`,
+and optional `ideation_ledger_payload` from `lisa:project-ideation` via `lisa:research`.
 
 ## Phase 1 — Resolve repo and PRD lifecycle labels
 
@@ -64,10 +65,13 @@ section, preserve it verbatim unless the caller intentionally supplied an update
 use the shared `usage-accounting` serializer/merge path rather than hand-editing ledger rows.
 
 **Exploratory ideation run ledger (both paths).** When the write was initiated by
-`lisa:project-ideation` or carries a project-ideation marker, persist a managed `## Exploratory
-Ideation Run Ledger` section in the PRD body. Prefer the managed section over a comment so the PRD
-itself remains the operator's source of truth; use a managed comment only if the body cannot be
-updated. Keep one managed section by replacing the content between stable markers:
+`lisa:project-ideation`, carries a project-ideation marker, or includes
+`ideation_ledger_payload`, persist a managed `## Exploratory Ideation Run Ledger` section in the PRD
+body. Prefer the managed section over a comment so the PRD itself remains the operator's source of
+truth; use a managed comment only if the body cannot be updated. Populate the fields from
+`ideation_ledger_payload` when present, falling back to `marker`, `initial_role`, repo config, and
+runtime metadata only for missing fields. Keep one managed section by replacing the content between
+stable markers:
 
 ```markdown
 ## Exploratory Ideation Run Ledger

--- a/plugins/src/base/skills/prd-source-write/SKILL.md
+++ b/plugins/src/base/skills/prd-source-write/SKILL.md
@@ -27,6 +27,17 @@ dedupe_key: "<stable-key>"           # e.g. project-ideation's idea key
 marker: "[lisa-project-ideation] idea=<stable-key>"   # embedded in the PRD body for dedupe
 origin: { tool: project-ideation | research | manual }
 source_ref: "<optional existing PRD ref to force an update>"
+ideation_ledger_payload:              # optional; forwarded unchanged to the vendor writer
+  selected_marker: "<same value as marker>"
+  automation_id: "<Codex/Claude automation id or unavailable>"
+  automation_memory_path: "<path or unavailable>"
+  repo: "<org>/<repo or detected repo identity>"
+  prd_ready: true|false
+  persona_names: ["<derived persona name>"]
+  persona_evidence_refs: ["<file/doc/table/release ref>"]
+  selected_idea: "<selected idea title/key>"
+  rejected_overlap_candidates: ["<issue refs/titles considered and rejected>"]
+  expected_empirical_verification_artifact: "<artifact ref or unavailable>"
 ```
 
 `initial_role` semantics are uniform across vendors (the role STRINGS resolve per vendor from
@@ -72,6 +83,10 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
    the applied role (`draft`/`ready`), the dedupe marker, and whether it was created or reused.
    Downstream callers (research, project-ideation) parse this — do not paraphrase.
 
+When `ideation_ledger_payload` is present, this shim still does not render or interpret it. Forward
+the object verbatim to the selected vendor writer so source-specific rendering remains behind the
+configured writer and the dispatch layer never bypasses source selection.
+
 ## Rules
 
 - Never bypass dispatch — a vendor-neutral caller calling a `*-write-prd` skill directly defeats the
@@ -80,5 +95,7 @@ prior PRD-source-write behavior to preserve, so omitted means `draft`.
   and fallback behavior belongs in the vendor writers and follows the `usage-accounting` contract.
 - Never accept a source outside `{notion, confluence, github, linear}`. `jira` and `file` fail loudly.
 - Never mutate the spec between layers. The vendor writers define their own create/dedupe contract.
+- Never drop, rename, or vendor-render `ideation_ledger_payload`; it is a pass-through payload for
+  the configured writer.
 - Never invent a PRD lifecycle role string — resolve every role from `config-resolution` per vendor.
 - Idempotency is the vendor writer's job (marker search before create); this shim only routes.

--- a/plugins/src/base/skills/project-ideation/SKILL.md
+++ b/plugins/src/base/skills/project-ideation/SKILL.md
@@ -155,7 +155,13 @@ For each idea in the creation set, invoke `/lisa:research` with:
   grounding and the empirical verification plan),
 - `prd_ready` (this run's flag — `lisa:research` maps it to draft vs prd-ready),
 - a stable **dedupe marker** (see below) so a re-run references the existing PRD instead of creating
-  a duplicate.
+  a duplicate,
+- a structured `ideation_ledger_payload` handoff containing the selected marker, automation id and
+  memory path when available, persona names, persona evidence references, rejected overlap
+  candidates, repo identity, `prd_ready`, selected idea title/key, and the expected empirical
+  verification artifact. This payload is the only ideation-run metadata channel between
+  `project-ideation`, `research`, `prd-source-write`, and the vendor writer; keep GitHub-specific
+  rendering out of this skill.
 
 `lisa:research` synthesizes the PRD and creates it in the configured source via
 `lisa:prd-source-write`. `project-ideation` never writes to the source directly — it delegates, so

--- a/plugins/src/base/skills/research/SKILL.md
+++ b/plugins/src/base/skills/research/SKILL.md
@@ -16,6 +16,12 @@ Produce a PRD for the problem in `$ARGUMENTS`, then create it in the configured 
 - `dedupe_key` / `marker` (optional) — a stable dedupe marker (e.g. supplied by
   `lisa:project-ideation`) embedded in the created PRD so re-runs reference the existing PRD rather
   than creating a duplicate.
+- `ideation_ledger_payload` (optional, required when invoked by `lisa:project-ideation`) — a
+  structured metadata object to forward unchanged to `lisa:prd-source-write`. It carries the
+  selected marker, automation id/path when available, persona names, persona evidence references,
+  rejected overlap candidates, repo identity, `prd_ready`, selected idea title/key, and expected
+  empirical verification artifact. `research` may use these fields to inform the PRD body, but must
+  not discard, rename, or vendor-render them.
 
 ## Orchestration: agent team
 
@@ -55,5 +61,8 @@ source — there is no loose document artifact.** Before handing the synthesized
 `lisa:usage-accounting` so the PRD body carries the canonical `## Lisa Usage` ledger from creation
 time onward. If the runtime does not expose trustworthy usage, the direct entry must still be
 written with `source: unavailable` and nullable token/cost fields rather than silently omitting the
-Research row. A `source` must be configured; if it is not, stop and report it rather than emitting
-a document. The Plan flow consumes the created PRD next.
+Research row. If the call includes `ideation_ledger_payload`, pass that object through in the
+`lisa:prd-source-write` spec unchanged alongside `marker`, `dedupe_key`, and `initial_role`; this is
+the vendor-neutral handoff that lets the configured writer render an auditable run ledger without
+`research` bypassing source selection. A `source` must be configured; if it is not, stop and report
+it rather than emitting a document. The Plan flow consumes the created PRD next.

--- a/tests/unit/strategies/prd-source-write.test.ts
+++ b/tests/unit/strategies/prd-source-write.test.ts
@@ -69,6 +69,14 @@ describe("prd-source-write shim", () => {
       expect(content).toMatch(/marker/i);
       expect(content).toMatch(/dedupe/i);
     });
+
+    it("forwards the ideation ledger payload without vendor-specific rendering", () => {
+      expect(content).toContain("ideation_ledger_payload");
+      expect(content).toMatch(
+        /Forward\s+the object verbatim|pass-through payload/i
+      );
+      expect(content).toMatch(/Never drop, rename, or vendor-render/i);
+    });
   });
 });
 
@@ -261,6 +269,22 @@ describe("project-ideation is persona-driven and chains into research", () => {
       expect(content).toContain("prd_ready");
     });
 
+    it("threads structured ideation ledger metadata into research", () => {
+      expect(content).toContain("ideation_ledger_payload");
+      for (const field of [
+        "selected marker",
+        "automation id",
+        "memory path",
+        "persona names",
+        "persona evidence references",
+        "rejected overlap",
+        "repo identity",
+        "expected empirical",
+      ]) {
+        expect(content).toMatch(new RegExp(field, "i"));
+      }
+    });
+
     it("defaults to creating one PRD via max_prds", () => {
       expect(content).toContain("max_prds");
       expect(content).toMatch(
@@ -281,6 +305,18 @@ describe("project-ideation is persona-driven and chains into research", () => {
       expect(content).toMatch(
         /never write.*PRD.*directly|do not write PRDs to the source directly/i
       );
+    });
+  });
+});
+
+describe("research forwards ideation ledger metadata to prd-source-write", () => {
+  describe.each(ROOTS)("%s", root => {
+    const content = readSkill(root, "research");
+
+    it("accepts and preserves ideation_ledger_payload", () => {
+      expect(content).toContain("ideation_ledger_payload");
+      expect(content).toMatch(/pass.*through.*unchanged|forward unchanged/i);
+      expect(content).toContain("lisa:prd-source-write");
     });
   });
 });


### PR DESCRIPTION
## Summary
- threads a structured `ideation_ledger_payload` from project-ideation through research and prd-source-write
- documents GitHub PRD writer consumption of that payload for the exploratory run ledger
- adds regression coverage across source and generated Lisa skill artifacts

## Verification
- `bunx vitest run tests/unit/strategies/prd-source-write.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check:plugins`
- pre-push: audit, slow lint, knip, coverage tests, integration tests

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support for an optional ideation ledger payload to carry exploratory ideation metadata through the PRD writing pipeline.
  * Updated specifications to ensure the payload is preserved without modification or interpretation.

* **Tests**
  * Added test coverage verifying the ideation ledger payload flows correctly through the ideation, research, and PRD writing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->