### PR TITLE
docs(wiki): ingest incremental Lisa history

### DIFF
--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -31,3 +31,15 @@ A quality gate is an automated check that must pass before a change can progress
 ## Automation Checkout
 
 An automation checkout is the durable local Git work tree used by recurring Codex automations for a project. It should be synced to the default remote branch at the start of each run and verified as a non-bare Git work tree before the automation is saved or executed.
+
+## Query-First
+
+Query-first means project questions should be answered through the maintained Lisa wiki query path before relying on ad hoc session memory.
+
+## Ideation Ledger
+
+An ideation ledger is durable automation run metadata for project, PRD, or thread ideation work. It records enough context to make repeated runs idempotent and auditable.
+
+## E2E Coverage Gap
+
+An e2e coverage gap is behavior found during exploratory QA that should be represented by an end-to-end regression test rather than only a human-facing bug report.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,5 +1,7 @@
 # Lisa Wiki Index
 
+Last updated by incremental ingest on 2026-05-27 through Lisa release `2.113.0` and merged PR `#1017`.
+
 ## Orientation
 
 - [Start Here](start-here.md)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -97,3 +97,10 @@
 - Refreshed the `git` source note with 6 new commits through `c536c7a196ff811ce92403acd90493baad86ebd0`, advanced the merged-PR cursor to `#997`, and confirmed that `roles` still had no roster pages to ingest.
 - Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-27-memory.md`; global Codex memory remained out of scope.
 - Updated the monorepo snapshot, workflow playbook, vocabulary, and index for durable Codex automation checkouts, release-history changes through `2.106.8`, and the new Codex HTTP MCP plugin-shape memory note.
+
+## 2026-05-27 - Incremental connector ingest
+
+- Synced the durable checkout to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-27-173325`, and ran another full no-argument ingest against every enabled non-external-write connector.
+- Refreshed the `git` source note with 44 new commits through `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`, advanced the merged-PR cursor to `#1017`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` because the available Claude memory directory was not provably project-scoped for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
+- Updated the monorepo snapshot, workflow playbook, vocabulary, and index for Expo skills, query-first project answers, split exploratory QA coverage, repair-intake blocker diagnosis, ideation run ledgers, nested team orchestration, TypeScript error-suppression blocking, and crash-safe postinstall apply behavior.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -18,6 +18,18 @@ Lisa also supports local review, PR review handling, test coverage improvement, 
 
 Codex-hosted Lisa automations should run from durable project automation checkouts, not transient task worktrees. Setup flows create or refresh a stable checkout under the Codex worktree area, verify it is a normal non-bare Git work tree, and require each automation cycle to fetch and rebase or fast-forward against the default remote branch before queue or wiki work begins. If the checkout is dirty, conflicted, stale, or has broken Git metadata, the automation reports the blocker instead of mutating queue or wiki state.
 
+## Query-First Project Answers
+
+Agents should use the Lisa wiki query flow as the primary way to answer project questions from durable repository knowledge. This keeps operational answers grounded in maintained wiki pages and source notes instead of stale session context.
+
+## Exploratory QA
+
+Exploratory QA now separates human-experience findings from e2e coverage gaps. Use the human-experience pass for product-facing behavior, friction, and visible issues; use the e2e-coverage-gaps pass for regression coverage opportunities that should become tests or backlog work.
+
+## Repair Intake
+
+Repair intake treats work as stuck after a two-hour threshold and records PR or deploy blocker diagnosis before moving stale queue items. This makes the smallest next action explicit when a PR, deployment, or status label prevents normal intake progress.
+
 ## Quality Gate Habit
 
 Before shipping Lisa changes, expect local hooks and CI to run typecheck, formatting, linting, slow lint, dead-code detection, tests, coverage, security audit, and integration checks depending on the action.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,20 +20,26 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-27-133229` from `origin/main`
-- HEAD at 2026-05-27 incremental ingest: `c536c7a196ff811ce92403acd90493baad86ebd0`
-- Current package version: `2.106.8`
-- Total commits on HEAD: 2397
-- Latest merged PR captured in the incremental git snapshot: `#997`
-- New commits since the previous incremental git cursor: `6`
-- Project-scoped memory files captured: `21`
+- Ingest branch: `wiki/ingest-2026-05-27-173325` from `origin/main`
+- HEAD at 2026-05-27 incremental ingest: `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`
+- Current package version: `2.113.0`
+- Total commits on HEAD: 2441
+- Latest merged PR captured in the incremental git snapshot: `#1017`
+- New commits since the previous incremental git cursor: `44`
+- Project-scoped memory files captured: `21` from the last successful memory ingest; this run skipped memory because the connector could not prove the available memory directory matched this worktree path.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#996`.
-- Release automation advanced the monorepo to `2.106.8`.
-- Codex automation setup guidance now requires durable, synced project automation checkouts instead of transient or broken scratch worktrees.
-- Lisa project-scoped Claude memory added the Codex HTTP MCP plugin-shape note while continuing to capture operational guidance for Codex automation, Lisa merge method, CI verification, and project-specific workflow expectations.
+- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#999`.
+- Release automation advanced the monorepo to `2.113.0`.
+- Lisa added Expo-specific skills and an Expo MCP server to the shipped plugin surface.
+- Wiki query is now the primary rule-backed way for agents to answer project questions from durable wiki knowledge.
+- Exploratory QA split into a human-experience pass and an e2e-coverage-gaps pass so product-facing findings and automation backlog gaps stay distinct.
+- Repair intake now uses a two-hour stuck threshold and records PR/deploy blocker diagnosis for stale work.
+- Project ideation automation now records durable run ledgers, including PRD and thread ideation metadata plus an idempotency harness.
+- Nested team orchestration now adds specialists instead of collapsing nested flows to a single agent.
+- TypeScript template rules block error-suppression directives on edit across Claude and Codex surfaces.
+- Postinstall local installs re-enabled crash-safe template apply behavior.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
@@ -11,15 +11,53 @@ project: lisa-monorepo
 # git history — lisa-monorepo (2026-05-27)
 
 - Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
-- HEAD: `c536c7a196ff811ce92403acd90493baad86ebd0`
-- Total commits on HEAD: 2397
-- New commits since last ingest (`73072b8e5b839dede4bf50985232d1d6bddfe9f4`): 6
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #997 "Fix durable synced Lisa automation checkouts"
+- HEAD: `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`
+- Total commits on HEAD: 2441
+- New commits since last ingest (`c536c7a196ff811ce92403acd90493baad86ebd0`): 44
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1017 "feat(postinstall): re-enable crash-safe template apply on local install"
 
 ## New commits
-- c536c7a1 · 2026-05-27 · chore(release): 2.106.8 [skip ci]
-- f2c99cc8 · 2026-05-27 · Merge pull request #997 from CodySwannGT/codex/durable-lisa-automation-checkouts
-- ea4881c8 · 2026-05-27 · fix(automations): use durable synced Lisa checkouts
-- 1a77d456 · 2026-05-27 · chore(release): 2.106.7 [skip ci]
-- e395b77a · 2026-05-27 · Merge pull request #996 from CodySwannGT/wiki/ingest-2026-05-27-053204
-- 296785ee · 2026-05-27 · docs(wiki): ingest incremental Lisa knowledge
+- 9e52f0d1 · 2026-05-27 · chore(release): 2.113.0 [skip ci]
+- cb6b0a93 · 2026-05-27 · Merge pull request #1017 from CodySwannGT/fix/crash-safe-postinstall-apply
+- e4230b1a · 2026-05-27 · Merge branch 'main' into fix/crash-safe-postinstall-apply
+- 4b8f1136 · 2026-05-27 · feat(postinstall): re-enable crash-safe template apply on local install
+- f3d4d9e7 · 2026-05-27 · chore(release): 2.112.0 [skip ci]
+- a484db5d · 2026-05-27 · Merge pull request #998 from CodySwannGT/worktree-add-expo-skills
+- 2691cad7 · 2026-05-27 · feat(expo): adopt official Expo skills + Expo MCP server
+- e73132f8 · 2026-05-27 · chore(release): 2.111.0 [skip ci]
+- d3d5ee4c · 2026-05-27 · Merge pull request #1016 from CodySwannGT/worktree-misc-rules
+- 5710a2ff · 2026-05-27 · Merge branch 'main' into worktree-misc-rules
+- bb61982a · 2026-05-27 · test: update build-ready-control for exploratory-qa / e2e-coverage-gaps split
+- 7ef908df · 2026-05-27 · feat(repair-intake): 2h stuck threshold + PR/deploy blocker diagnosis
+- 8f7bfdbf · 2026-05-27 · chore(release): 2.110.1 [skip ci]
+- 05607ebc · 2026-05-27 · Merge pull request #1015 from CodySwannGT/codex/issue-1007-thread-exploratory-ledger
+- 9b245857 · 2026-05-27 · Merge branch 'main' into codex/issue-1007-thread-exploratory-ledger
+- 13f66f37 · 2026-05-27 · fix: thread ideation ledger payload
+- c5a68007 · 2026-05-27 · chore(release): 2.110.0 [skip ci]
+- 52bd3d0e · 2026-05-27 · Merge pull request #1014 from CodySwannGT/fix/lint-wiki-stdout-flush
+- 789c399b · 2026-05-27 · fix(wiki): flush lint-wiki --json output before exit
+- e48c5f98 · 2026-05-27 · Merge pull request #1013 from CodySwannGT/codex/issue-1008-github-prd-run-ledger
+- 5b8040ef · 2026-05-27 · feat: record github prd ideation ledger
+- 6527a3fa · 2026-05-27 · chore(release): 2.109.0 [skip ci]
+- ffd43fa5 · 2026-05-27 · feat(qa): split exploratory-qa into human-experience pass + e2e-coverage-gaps
+- b191a41e · 2026-05-27 · Merge pull request #1012 from CodySwannGT/codex/1009-exploratory-automation-memory
+- e8c7626e · 2026-05-27 · feat(project-ideation): record automation memory contract
+- 2c4f5976 · 2026-05-27 · chore(release): 2.108.0 [skip ci]
+- 247cd724 · 2026-05-27 · Merge pull request #1011 from CodySwannGT/codex/issue-1010-idempotency-harness
+- 81c6061b · 2026-05-27 · feat: add project ideation idempotency harness
+- 78265287 · 2026-05-27 · feat(wiki): make /query the primary way agents answer project questions
+- 464a9dcd · 2026-05-27 · chore(release): 2.107.2 [skip ci]
+- 8dc303b7 · 2026-05-27 · Merge pull request #1003 from CodySwannGT/chore/merge-origin-main
+- 6b20f89e · 2026-05-27 · Merge remote-tracking branch 'origin/main' into chore/merge-origin-main
+- 2fc4cb06 · 2026-05-27 · chore: minor
+- 78902c77 · 2026-05-27 · chore(release): 2.107.1 [skip ci]
+- 9e43ea46 · 2026-05-27 · Merge pull request #1002 from CodySwannGT/fix/cross-harness-nested-team-orchestration
+- 18740ec3 · 2026-05-27 · fix(orchestration): make nested team flows add specialists instead of collapsing to single-agent
+- afe4d7c9 · 2026-05-27 · chore(release): 2.107.0 [skip ci]
+- 8f7a1229 · 2026-05-27 · Merge pull request #1000 from CodySwannGT/worktree-hookify
+- 99c2542d · 2026-05-27 · Merge remote-tracking branch 'origin/main' into worktree-hookify
+- 382bf6b1 · 2026-05-27 · chore(release): 2.106.9 [skip ci]
+- 5354f982 · 2026-05-27 · fix(automation-status): isolate codex cwd git check from inherited GIT_DIR
+- 1d5ecaad · 2026-05-27 · Merge pull request #999 from CodySwannGT/wiki/ingest-2026-05-27-133229
+- b4c74bd5 · 2026-05-27 · docs(wiki): ingest durable automation checkout guidance
+- 10b6afd4 · 2026-05-27 · feat(typescript): block error-suppression directives on edit

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-27T13:35:10.064Z",
+  "ingested_at": "2026-05-27T17:33:44.168Z",
   "cursor": {
-    "lastCommit": "c536c7a196ff811ce92403acd90493baad86ebd0",
-    "lastPr": 997
+    "lastCommit": "9e52f0d12bc01a85754f30b5ec70c97e6204bfab",
+    "lastPr": 1017
   },
   "source_notes": [
     "wiki/sources/git/2026-05-27-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-27T13:35:10.064Z",
+  "ingested_at": "2026-05-27T17:33:43.076Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary
- ingest latest Lisa git history through PR #1017 and release 2.113.0
- refresh wiki synthesis for Expo skills, query-first answers, exploratory QA split, repair-intake blocker diagnosis, ideation ledgers, nested team orchestration, TypeScript suppression blocking, and crash-safe postinstall apply
- advance git and roles cursors; skip memory because no project-scoped memory directory matched this worktree path

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json --json (0 fails, 12 existing warnings)
- node plugins/lisa-wiki/scripts/diff-guard.mjs --base origin/main --allow 'wiki/**'
- pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests