### PR TITLE
feat(wiki): standard digital-staff roster as setup default + knip toolchain fix

### DIFF
--- a/cdk/copy-overwrite/knip.json
+++ b/cdk/copy-overwrite/knip.json
@@ -42,7 +42,20 @@
     "constructs",
     "aws-cdk-github-oidc"
   ],
-  "ignoreBinaries": ["expo", "playwright", "audit", "docker", "eval"],
+  "ignoreBinaries": [
+    "expo",
+    "playwright",
+    "audit",
+    "docker",
+    "eval",
+    "ast-grep",
+    "eslint",
+    "husky",
+    "knip",
+    "prettier",
+    "tsc",
+    "vitest"
+  ],
   "ignoreExportsUsedInFile": true,
   "rules": {
     "devDependencies": "off"

--- a/plugins/lisa-wiki/skills/lisa-wiki-setup/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup/SKILL.md
@@ -21,7 +21,9 @@ never overwrites human-authored content.
    `displayName`, **`purpose`** (one paragraph — what this wiki is for), `mode`
    (`embedded|wrapper|standalone|subdir`), `categories`, source layout, connectors, sensitivity,
    `sourceRetention`, and the **README mode** (`rich` default | `stub` | `preserve` — always ask;
-   never select `stub` implicitly). Validate with `scripts/validate-config.mjs`.
+   never select `stub` implicitly). If `staff` is absent, seed the **standard roster** (below) as the
+   default — every wiki gets the standard operating team unless the user opts out or edits it. Union
+   each role's owned categories into `config.categories`. Validate with `scripts/validate-config.mjs`.
 2. **Structure.** Scaffold the canonical tree per `schema/wiki-structure.schema.json`:
    `wiki/{index.md, log.md, start-here.md, schema/, sources/, state/, staff/, <category dirs>}`.
    Create only what is missing.
@@ -29,11 +31,30 @@ never overwrites human-authored content.
    `scripts/render-contract.mjs`, stamping the `kernelVersion`. This snapshot keeps the wiki
    self-describing without the plugin installed.
 4. **Pointers.** Ensure `AGENTS.md` / `CLAUDE.md` point at the contract + plugin (thin pointers only).
-5. **Staff.** For each `config.staff[]` entry, generate the role's `wiki/staff/<role>.md` page and its
-   dual-runtime subagents by delegating to `lisa-wiki-add-role` (running the subagents is out of scope).
+5. **Staff.** For each `config.staff[]` entry (the standard roster by default), generate the role's
+   `wiki/staff/<role>.md` page and its dual-runtime subagents by delegating to `lisa-wiki-add-role`
+   (running the subagents is out of scope).
 6. **README.** Apply the chosen README mode (ingest the old README first; `rich` keeps install/usage +
    adds the onboarding line; `stub` is the minimal pointer; `preserve` leaves it).
 7. **Verify.** Run `lisa-wiki-doctor` and report the verdict + any blocking items.
+
+## Standard roster
+The default operating team seeded into `config.staff[]` for every new wiki (Chief of Staff plus six
+domain agents). Each role becomes a `wiki/staff/<id>.md` page and a dual-runtime subagent; the human
+owner talks to Chief, who routes to the others. Owned categories are unioned into `config.categories`.
+
+| id | role | owns (categories) | sensitivity |
+|---|---|---|---|
+| `chief` | Chief of Staff | `projects`, `decisions`, `playbooks`, `open-questions` | confidential |
+| `sally` | Sales | `sales` | internal |
+| `mark` | Marketing | `marketing` | internal |
+| `felix` | Finance | `finance` | confidential |
+| `casey` | Customer Success | `customers` | internal |
+| `parker` | People | `people` | confidential |
+| `lex` | Legal & Compliance | `legal` | confidential |
+
+Projects may add, remove, or rename roles afterward; the standard roster is the starting point, not a
+constraint.
 
 ## Rules
 - Idempotent; re-running produces no spurious changes.

--- a/plugins/src/wiki/skills/lisa-wiki-setup/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-setup/SKILL.md
@@ -21,7 +21,9 @@ never overwrites human-authored content.
    `displayName`, **`purpose`** (one paragraph — what this wiki is for), `mode`
    (`embedded|wrapper|standalone|subdir`), `categories`, source layout, connectors, sensitivity,
    `sourceRetention`, and the **README mode** (`rich` default | `stub` | `preserve` — always ask;
-   never select `stub` implicitly). Validate with `scripts/validate-config.mjs`.
+   never select `stub` implicitly). If `staff` is absent, seed the **standard roster** (below) as the
+   default — every wiki gets the standard operating team unless the user opts out or edits it. Union
+   each role's owned categories into `config.categories`. Validate with `scripts/validate-config.mjs`.
 2. **Structure.** Scaffold the canonical tree per `schema/wiki-structure.schema.json`:
    `wiki/{index.md, log.md, start-here.md, schema/, sources/, state/, staff/, <category dirs>}`.
    Create only what is missing.
@@ -29,11 +31,30 @@ never overwrites human-authored content.
    `scripts/render-contract.mjs`, stamping the `kernelVersion`. This snapshot keeps the wiki
    self-describing without the plugin installed.
 4. **Pointers.** Ensure `AGENTS.md` / `CLAUDE.md` point at the contract + plugin (thin pointers only).
-5. **Staff.** For each `config.staff[]` entry, generate the role's `wiki/staff/<role>.md` page and its
-   dual-runtime subagents by delegating to `lisa-wiki-add-role` (running the subagents is out of scope).
+5. **Staff.** For each `config.staff[]` entry (the standard roster by default), generate the role's
+   `wiki/staff/<role>.md` page and its dual-runtime subagents by delegating to `lisa-wiki-add-role`
+   (running the subagents is out of scope).
 6. **README.** Apply the chosen README mode (ingest the old README first; `rich` keeps install/usage +
    adds the onboarding line; `stub` is the minimal pointer; `preserve` leaves it).
 7. **Verify.** Run `lisa-wiki-doctor` and report the verdict + any blocking items.
+
+## Standard roster
+The default operating team seeded into `config.staff[]` for every new wiki (Chief of Staff plus six
+domain agents). Each role becomes a `wiki/staff/<id>.md` page and a dual-runtime subagent; the human
+owner talks to Chief, who routes to the others. Owned categories are unioned into `config.categories`.
+
+| id | role | owns (categories) | sensitivity |
+|---|---|---|---|
+| `chief` | Chief of Staff | `projects`, `decisions`, `playbooks`, `open-questions` | confidential |
+| `sally` | Sales | `sales` | internal |
+| `mark` | Marketing | `marketing` | internal |
+| `felix` | Finance | `finance` | confidential |
+| `casey` | Customer Success | `customers` | internal |
+| `parker` | People | `people` | confidential |
+| `lex` | Legal & Compliance | `legal` | confidential |
+
+Projects may add, remove, or rename roles afterward; the standard roster is the starting point, not a
+constraint.
 
 ## Rules
 - Idempotent; re-running produces no spurious changes.

--- a/typescript/copy-overwrite/knip.json
+++ b/typescript/copy-overwrite/knip.json
@@ -37,7 +37,20 @@
     "graphql-ws",
     "lodash"
   ],
-  "ignoreBinaries": ["expo", "playwright", "audit", "docker", "eval"],
+  "ignoreBinaries": [
+    "expo",
+    "playwright",
+    "audit",
+    "docker",
+    "eval",
+    "ast-grep",
+    "eslint",
+    "husky",
+    "knip",
+    "prettier",
+    "tsc",
+    "vitest"
+  ],
   "ignoreExportsUsedInFile": true,
   "rules": {
     "devDependencies": "off"


### PR DESCRIPTION
## Standard roster is now the default
A fresh `/setup:wiki` seeds the standard operating team into `config.staff[]` by default — Chief of Staff plus Sally (Sales), Mark (Marketing), Felix (Finance), Casey (Customer Success), Parker (People), Lex (Legal & Compliance) — and unions each role's owned categories into `config.categories`. The `lisa-wiki-setup` skill now documents the roster as the consistent starting point for every wiki. Projects can still add/remove/rename roles.

## knip toolchain fix (typescript + cdk flavors)
The `typescript` and `cdk` `copy-overwrite/knip.json` templates only ignored `expo/playwright/audit/docker/eval`, so a minimal consumer that doesn't independently declare the lisa-provided dev toolchain (`ast-grep`, `eslint`, `husky`, `knip`, `prettier`, `tsc`, `vitest`) failed knip on "unlisted binaries". Added those, matching the `nestjs` flavor. Surfaced while standing up a fresh empty repo's wiki.

`check:plugins` confirms src ↔ built artifacts are in sync.

🤖 Generated with Claude Code