### PR TITLE
feat(queue-status): add PRD pressure helper

### DIFF
--- a/plugins/lisa/scripts/queue-status-prd-readers.mjs
+++ b/plugins/lisa/scripts/queue-status-prd-readers.mjs
@@ -56,6 +56,41 @@ const HIGHLIGHT_COPY = {
 };
 
 /**
+ * Decide whether a PRD queue snapshot has open lifecycle pressure that should
+ * pause automatic PRD promotion or ideation work.
+ *
+ * @param {{
+ *   readonly counts?: Record<string, number>
+ *   readonly highlights?: readonly Record<string, any>[]
+ * }} snapshot
+ */
+export function evaluatePrdQueuePressure(snapshot = {}) {
+  const decisiveRole = ACTIONABLE_ROLE_ORDER.find(
+    role => normalizeCount(snapshot.counts?.[role]) > 0
+  );
+
+  if (!decisiveRole) {
+    return {
+      allowed: true,
+      decisiveRole: null,
+      blockerItem: null,
+      nextStep: null,
+    };
+  }
+
+  const blockerItem =
+    snapshot.highlights?.find(highlight => highlight.role === decisiveRole) ??
+    null;
+
+  return {
+    allowed: false,
+    decisiveRole,
+    blockerItem,
+    nextStep: blockerItem?.nextStep ?? HIGHLIGHT_COPY[decisiveRole].nextStep,
+  };
+}
+
+/**
  * Read a GitHub-backed PRD queue snapshot from issue payloads.
  *
  * @param {{
@@ -392,4 +427,12 @@ function normalizeTimestamp(value) {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeCount(value) {
+  return Number.isFinite(value) && value > 0 ? value : 0;
 }

--- a/plugins/src/base/scripts/queue-status-prd-readers.mjs
+++ b/plugins/src/base/scripts/queue-status-prd-readers.mjs
@@ -56,6 +56,41 @@ const HIGHLIGHT_COPY = {
 };
 
 /**
+ * Decide whether a PRD queue snapshot has open lifecycle pressure that should
+ * pause automatic PRD promotion or ideation work.
+ *
+ * @param {{
+ *   readonly counts?: Record<string, number>
+ *   readonly highlights?: readonly Record<string, any>[]
+ * }} snapshot
+ */
+export function evaluatePrdQueuePressure(snapshot = {}) {
+  const decisiveRole = ACTIONABLE_ROLE_ORDER.find(
+    role => normalizeCount(snapshot.counts?.[role]) > 0
+  );
+
+  if (!decisiveRole) {
+    return {
+      allowed: true,
+      decisiveRole: null,
+      blockerItem: null,
+      nextStep: null,
+    };
+  }
+
+  const blockerItem =
+    snapshot.highlights?.find(highlight => highlight.role === decisiveRole) ??
+    null;
+
+  return {
+    allowed: false,
+    decisiveRole,
+    blockerItem,
+    nextStep: blockerItem?.nextStep ?? HIGHLIGHT_COPY[decisiveRole].nextStep,
+  };
+}
+
+/**
  * Read a GitHub-backed PRD queue snapshot from issue payloads.
  *
  * @param {{
@@ -392,4 +427,12 @@ function normalizeTimestamp(value) {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeCount(value) {
+  return Number.isFinite(value) && value > 0 ? value : 0;
 }

--- a/tests/unit/strategies/queue-status-prd-readers.test.ts
+++ b/tests/unit/strategies/queue-status-prd-readers.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   createPrdQueueSnapshot,
+  evaluatePrdQueuePressure,
   readGithubPrdQueueSnapshot,
 } from "../../../plugins/src/base/scripts/queue-status-prd-readers.mjs";
 
@@ -33,6 +34,8 @@ const GITHUB_PRD_ROLES = {
   shipped: "prd-shipped",
   verified: "prd-verified",
 } as const;
+const GITHUB_PRD_QUEUE_ARGUMENT = "github intake_mode=prd";
+const GITHUB_PRD_ITEM_URL_BASE = "https://github.com/CodySwannGT/lisa/issues";
 
 /**
  *
@@ -51,7 +54,7 @@ describe("queue-status PRD readers (#824)", () => {
   it("parses GitHub PRD lifecycle labels into counts and actionable highlights", () => {
     const snapshot = readGithubPrdQueueSnapshot({
       namespaceAdopted: true,
-      queueArgument: "github intake_mode=prd",
+      queueArgument: GITHUB_PRD_QUEUE_ARGUMENT,
       roles: GITHUB_PRD_ROLES,
       issues: [
         {
@@ -245,6 +248,69 @@ describe("queue-status PRD readers (#824)", () => {
     }
   });
 
+  it("evaluates source-neutral PRD queue pressure from fixture payloads", () => {
+    const quiet = createPrdQueueSnapshot({
+      source: "github",
+      namespaceAdopted: true,
+      queueArgument: GITHUB_PRD_QUEUE_ARGUMENT,
+      items: [],
+    });
+    const ready = createPressureSnapshot("ready", 101);
+    const blocked = createPrdQueueSnapshot({
+      source: "github",
+      namespaceAdopted: true,
+      queueArgument: GITHUB_PRD_QUEUE_ARGUMENT,
+      items: [
+        toPressureFixtureItem("ready", 102),
+        toPressureFixtureItem("blocked", 103),
+      ],
+    });
+    const ticketed = createPressureSnapshot("ticketed", 104);
+    const shipped = createPressureSnapshot("shipped", 105);
+
+    expect(evaluatePrdQueuePressure(quiet)).toEqual({
+      allowed: true,
+      decisiveRole: null,
+      blockerItem: null,
+      nextStep: null,
+    });
+    expect(evaluatePrdQueuePressure(ready)).toMatchObject({
+      allowed: false,
+      decisiveRole: "ready",
+      blockerItem: {
+        url: `${GITHUB_PRD_ITEM_URL_BASE}/101`,
+        nextStep:
+          "Run /lisa:intake github intake_mode=prd to ticket the next PRD.",
+      },
+    });
+    expect(evaluatePrdQueuePressure(blocked)).toMatchObject({
+      allowed: false,
+      decisiveRole: "blocked",
+      blockerItem: {
+        url: `${GITHUB_PRD_ITEM_URL_BASE}/103`,
+        nextStep:
+          "Run /lisa:repair-intake github intake_mode=prd after clarifying the blocker.",
+      },
+    });
+    expect(evaluatePrdQueuePressure(ticketed)).toMatchObject({
+      allowed: false,
+      decisiveRole: "ticketed",
+      blockerItem: {
+        url: `${GITHUB_PRD_ITEM_URL_BASE}/104`,
+        nextStep:
+          "Monitor downstream build work or inspect the build queue with /lisa:queue-status queue=build.",
+      },
+    });
+    expect(evaluatePrdQueuePressure(shipped)).toMatchObject({
+      allowed: false,
+      decisiveRole: "shipped",
+      blockerItem: {
+        url: `${GITHUB_PRD_ITEM_URL_BASE}/105`,
+        nextStep: `Run /lisa:verify-prd ${GITHUB_PRD_ITEM_URL_BASE}/105 to close the shipped loop.`,
+      },
+    });
+  });
+
   it("keeps the distributed reader artifact in lockstep with the source script", () => {
     const sourcePath = path.resolve(
       "plugins/src/base/scripts/queue-status-prd-readers.mjs"
@@ -258,4 +324,21 @@ describe("queue-status PRD readers (#824)", () => {
       readFileSync(sourcePath, "utf8")
     );
   });
+});
+
+const createPressureSnapshot = (role: string, number: number) =>
+  createPrdQueueSnapshot({
+    source: "github",
+    namespaceAdopted: true,
+    queueArgument: GITHUB_PRD_QUEUE_ARGUMENT,
+    items: [toPressureFixtureItem(role, number)],
+  });
+
+const toPressureFixtureItem = (role: string, number: number) => ({
+  id: String(number),
+  ref: `#${number}`,
+  title: `${role} PRD pressure fixture`,
+  url: `${GITHUB_PRD_ITEM_URL_BASE}/${number}`,
+  createdAt: `2026-05-27T19:${number % 60}:00Z`,
+  role,
 });


### PR DESCRIPTION
## Summary
- add a source-neutral PRD queue pressure helper that reuses queue-status lifecycle counts and next-action highlights
- cover quiet, ready, blocked, ticketed, and shipped pressure fixture payloads
- sync the generated Lisa plugin script copy

## Verification
- bunx vitest run tests/unit/strategies/queue-status-prd-readers.test.ts
- bun run typecheck
- bun run lint
- bun run build:plugins
- cmp -s plugins/src/base/scripts/queue-status-prd-readers.mjs plugins/lisa/scripts/queue-status-prd-readers.mjs
- pre-push: bun audit, eslint slow rules, knip, vitest --coverage, integration tests

Closes #1025