### PR TITLE
docs(ideation): document PRD pressure gate

### DIFF
--- a/plugins/lisa/skills/project-ideation/SKILL.md
+++ b/plugins/lisa/skills/project-ideation/SKILL.md
@@ -20,7 +20,8 @@ cannot verify yourself is noise — demote it honestly.
 - **`prd_ready=true|false`** (default **false**) — the PRD-lifecycle state for the PRDs this run
   creates. `false` → created in the source's **draft** state for human review. `true` → created
   **prd-ready** so the PRD side of `lisa:intake` auto-claims them. Passed straight through to
-  `lisa:research` (which maps it to `lisa:prd-source-write`'s `initial_role`).
+  `lisa:research` (which maps it to `lisa:prd-source-write`'s `initial_role`) only after the PRD queue
+  pressure gate allows auto-ready writes.
 - **`max_prds=<n>|all`** (default **1**) — how many build-ready ideas become PRDs this run. Default
   creates **one** PRD (the single top-ranked idea), because `lisa:research` is a heavy full flow.
   `max_prds=3` creates the top three; `max_prds=all` creates one per build-ready idea. Discovery
@@ -159,9 +160,15 @@ the same PRD reader contract used by `/lisa:queue-status` and evaluate it with
 the same way `lisa:intake` resolves the PRD side, and pass the matching queue argument in the
 blocked outcome (for example, `github intake_mode=prd`).
 
+Queue pressure is any unresolved PRD lifecycle work that would make another auto-ready PRD compete
+with existing intake work. Treat at least these roles as pressure when the helper reports them:
+`prd-ready`, `prd-in-review`, `prd-blocked`, unresolved `prd-ticketed`, and source-reader failures or
+misconfiguration snapshots. `prd-shipped` / `prd-verified` terminal history is not pressure unless the
+reader helper explicitly reports it as unresolved.
+
 If the helper returns `allowed: false`, stop before any `lisa:research`, `lisa:prd-source-write`, or
-vendor PRD writer invocation. Emit **PRDs Created** as a blocked outcome, not as an empty success.
-The blocked outcome must include:
+vendor PRD writer invocation. Emit **PRDs Created** as a blocked outcome, not as an empty success or a
+silent idle run. The blocked outcome must include:
 
 - `source` and `tracker` from `.lisa.config.json`;
 - the decisive PRD lifecycle `role`;
@@ -169,6 +176,21 @@ The blocked outcome must include:
 - the smallest next action, preferring the helper's `nextStep` and otherwise using
   `/lisa:intake <PRD queue>`;
 - a clear statement that no research or PRD source write was invoked.
+
+Use this output shape so recurring automations can surface a useful next step without digging through
+debug logs:
+
+```text
+## PRDs Created
+
+Blocked: PRD queue pressure prevents auto-ready creation.
+- source: <source>
+- tracker: <tracker>
+- role: <decisive role>
+- item: <ref or "unavailable"> <url when available>
+- next action: <helper nextStep or /lisa:intake <PRD queue>>
+- write invoked: no
+```
 
 If the helper returns `allowed: true`, continue to Step 6 normally and keep the existing draft/ready
 creation behavior unchanged.

--- a/plugins/lisa/skills/setup-automations/SKILL.md
+++ b/plugins/lisa/skills/setup-automations/SKILL.md
@@ -30,7 +30,10 @@ create them; invoke the runtime's automation tool with the spec below.
 
 - `auto-start-prds` (default **false**) — passed as `prd_ready` to the **exploratory-prds**
   automation. `true` → ideated PRDs are created `prd-ready` (auto-picked-up by PRD intake); `false` →
-  created as drafts for human review.
+  created as drafts for human review. When `true`, `/lisa:project-ideation` still checks the configured
+  PRD queue before writing: existing `prd-ready`, `prd-in-review`, `prd-blocked`, unresolved
+  `prd-ticketed`, or unresolved source-reader pressure can intentionally turn the automation cycle into
+  a blocked/idle outcome instead of creating another ready PRD.
 - `auto-start-tickets` (default **false**) — passed as `ready` to the **exploratory-bugs**
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
@@ -58,6 +61,12 @@ the rebase, leave queue state unchanged, and report the blocker instead of runni
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
 `FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+
+**Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
+lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
+`exploratory-prds` automation uses the same PRD source queue and pressure roles reported by
+`/lisa:queue-status`; if pressure exists, the cycle should report the blocking role/ref and the
+smallest next action, usually `/lisa:intake <PRD queue>`, without invoking research or writing a PRD.
 
 **Queue resolution.** Resolve the intake/repair queue from `.lisa.config.json` — `source` for the
 PRD queue, `tracker` for the build queue (for the common GitHub case these are `github

--- a/plugins/src/base/skills/project-ideation/SKILL.md
+++ b/plugins/src/base/skills/project-ideation/SKILL.md
@@ -20,7 +20,8 @@ cannot verify yourself is noise — demote it honestly.
 - **`prd_ready=true|false`** (default **false**) — the PRD-lifecycle state for the PRDs this run
   creates. `false` → created in the source's **draft** state for human review. `true` → created
   **prd-ready** so the PRD side of `lisa:intake` auto-claims them. Passed straight through to
-  `lisa:research` (which maps it to `lisa:prd-source-write`'s `initial_role`).
+  `lisa:research` (which maps it to `lisa:prd-source-write`'s `initial_role`) only after the PRD queue
+  pressure gate allows auto-ready writes.
 - **`max_prds=<n>|all`** (default **1**) — how many build-ready ideas become PRDs this run. Default
   creates **one** PRD (the single top-ranked idea), because `lisa:research` is a heavy full flow.
   `max_prds=3` creates the top three; `max_prds=all` creates one per build-ready idea. Discovery
@@ -159,9 +160,15 @@ the same PRD reader contract used by `/lisa:queue-status` and evaluate it with
 the same way `lisa:intake` resolves the PRD side, and pass the matching queue argument in the
 blocked outcome (for example, `github intake_mode=prd`).
 
+Queue pressure is any unresolved PRD lifecycle work that would make another auto-ready PRD compete
+with existing intake work. Treat at least these roles as pressure when the helper reports them:
+`prd-ready`, `prd-in-review`, `prd-blocked`, unresolved `prd-ticketed`, and source-reader failures or
+misconfiguration snapshots. `prd-shipped` / `prd-verified` terminal history is not pressure unless the
+reader helper explicitly reports it as unresolved.
+
 If the helper returns `allowed: false`, stop before any `lisa:research`, `lisa:prd-source-write`, or
-vendor PRD writer invocation. Emit **PRDs Created** as a blocked outcome, not as an empty success.
-The blocked outcome must include:
+vendor PRD writer invocation. Emit **PRDs Created** as a blocked outcome, not as an empty success or a
+silent idle run. The blocked outcome must include:
 
 - `source` and `tracker` from `.lisa.config.json`;
 - the decisive PRD lifecycle `role`;
@@ -169,6 +176,21 @@ The blocked outcome must include:
 - the smallest next action, preferring the helper's `nextStep` and otherwise using
   `/lisa:intake <PRD queue>`;
 - a clear statement that no research or PRD source write was invoked.
+
+Use this output shape so recurring automations can surface a useful next step without digging through
+debug logs:
+
+```text
+## PRDs Created
+
+Blocked: PRD queue pressure prevents auto-ready creation.
+- source: <source>
+- tracker: <tracker>
+- role: <decisive role>
+- item: <ref or "unavailable"> <url when available>
+- next action: <helper nextStep or /lisa:intake <PRD queue>>
+- write invoked: no
+```
 
 If the helper returns `allowed: true`, continue to Step 6 normally and keep the existing draft/ready
 creation behavior unchanged.

--- a/plugins/src/base/skills/setup-automations/SKILL.md
+++ b/plugins/src/base/skills/setup-automations/SKILL.md
@@ -30,7 +30,10 @@ create them; invoke the runtime's automation tool with the spec below.
 
 - `auto-start-prds` (default **false**) — passed as `prd_ready` to the **exploratory-prds**
   automation. `true` → ideated PRDs are created `prd-ready` (auto-picked-up by PRD intake); `false` →
-  created as drafts for human review.
+  created as drafts for human review. When `true`, `/lisa:project-ideation` still checks the configured
+  PRD queue before writing: existing `prd-ready`, `prd-in-review`, `prd-blocked`, unresolved
+  `prd-ticketed`, or unresolved source-reader pressure can intentionally turn the automation cycle into
+  a blocked/idle outcome instead of creating another ready PRD.
 - `auto-start-tickets` (default **false**) — passed as `ready` to the **exploratory-bugs**
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
@@ -58,6 +61,12 @@ the rebase, leave queue state unchanged, and report the blocker instead of runni
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
 `FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+
+**Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
+lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
+`exploratory-prds` automation uses the same PRD source queue and pressure roles reported by
+`/lisa:queue-status`; if pressure exists, the cycle should report the blocking role/ref and the
+smallest next action, usually `/lisa:intake <PRD queue>`, without invoking research or writing a PRD.
 
 **Queue resolution.** Resolve the intake/repair queue from `.lisa.config.json` — `source` for the
 PRD queue, `tracker` for the build queue (for the common GitHub case these are `github


### PR DESCRIPTION
## Summary
- Document that `auto-start-prds=true` is pressure-gated by the configured PRD queue.
- Add `project-ideation` blocked-output guidance for PRD queue pressure, roles, and smallest next action.
- Regenerate the shipped `plugins/lisa` skill docs from `plugins/src/base`.

## Verification
- `bun run build:plugins`
- `cmp` source/generated skill docs
- `bun run typecheck`
- `bun run lint` (existing warnings only)
- `bun run check:plugins`
- push hook: production audit, slow lint, knip, unit coverage, integration tests

Addresses #1028