### PR TITLE
docs(wiki): ingest incremental Lisa history

### DIFF
--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -40,6 +40,14 @@ Query-first means project questions should be answered through the maintained Li
 
 An ideation ledger is durable automation run metadata for project, PRD, or thread ideation work. It records enough context to make repeated runs idempotent and auditable.
 
+## PRD Pressure
+
+PRD pressure is the queue condition where project ideation should not mark new PRDs ready automatically because existing ready or in-progress build work already needs attention. Lisa's queue-status helper exposes this pressure signal so ideation can document a PRD without overloading the build queue.
+
+## Digital Staff Roster
+
+A digital staff roster is the wiki-owned set of role pages and runtime subagents that represent domain experts for a project. Lisa wiki setup now seeds the standard roster by default when a project has not declared a custom `config.staff[]`.
+
 ## E2E Coverage Gap
 
 An e2e coverage gap is behavior found during exploratory QA that should be represented by an end-to-end regression test rather than only a human-facing bug report.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by incremental ingest on 2026-05-27 through Lisa release `2.113.0` and merged PR `#1017`.
+Last updated by incremental ingest on 2026-05-27 through Lisa release `2.115.3` and merged PR `#1033`.
 
 ## Orientation
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -104,3 +104,10 @@
 - Refreshed the `git` source note with 44 new commits through `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`, advanced the merged-PR cursor to `#1017`, and confirmed that `roles` still had no roster pages to ingest.
 - Skipped `memory` because the available Claude memory directory was not provably project-scoped for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
 - Updated the monorepo snapshot, workflow playbook, vocabulary, and index for Expo skills, query-first project answers, split exploratory QA coverage, repair-intake blocker diagnosis, ideation run ledgers, nested team orchestration, TypeScript error-suppression blocking, and crash-safe postinstall apply behavior.
+
+## 2026-05-27 - Incremental connector ingest
+
+- Synced the durable checkout to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-27-213503`, and ran another full no-argument ingest against every enabled non-external-write connector.
+- Refreshed the `git` source note with 19 new commits through `6dbfeb7ec507cfbb56bc905db47ea14f5bce9762`, advanced the merged-PR cursor to `#1033`, and confirmed that `roles` still had no roster pages to ingest.
+- Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-27-memory.md`; global Codex memory remained out of scope.
+- Updated the monorepo snapshot, workflow playbook, vocabulary, and index for standard wiki staff roster defaults, PRD pressure gating, hook-delivery guidance, and release-history changes through `2.115.3`.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -22,6 +22,14 @@ Codex-hosted Lisa automations should run from durable project automation checkou
 
 Agents should use the Lisa wiki query flow as the primary way to answer project questions from durable repository knowledge. This keeps operational answers grounded in maintained wiki pages and source notes instead of stale session context.
 
+## Project Ideation Pressure Gate
+
+Project ideation may document new PRD candidates while the build queue is busy, but it should not auto-mark them ready when queue-status reports PRD pressure. The pressure helper keeps ideation throughput from bypassing the one-item build-intake discipline.
+
+## Hook Delivery
+
+Claude receives Lisa plugin hooks through the GitHub marketplace copy of the plugin, which tracks committed generated plugin artifacts on `main`. Codex receives hooks when `lisa apply` installs them into a project's `.codex/hooks.json`; a package update alone is not the delivery mechanism for Codex hooks.
+
 ## Exploratory QA
 
 Exploratory QA now separates human-experience findings from e2e coverage gaps. Use the human-experience pass for product-facing behavior, friction, and visible issues; use the e2e-coverage-gaps pass for regression coverage opportunities that should become tests or backlog work.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,26 +20,22 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-27-173325` from `origin/main`
-- HEAD at 2026-05-27 incremental ingest: `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`
-- Current package version: `2.113.0`
-- Total commits on HEAD: 2441
-- Latest merged PR captured in the incremental git snapshot: `#1017`
-- New commits since the previous incremental git cursor: `44`
-- Project-scoped memory files captured: `21` from the last successful memory ingest; this run skipped memory because the connector could not prove the available memory directory matched this worktree path.
+- Ingest branch: `wiki/ingest-2026-05-27-213503` from `origin/main`
+- HEAD at 2026-05-27 incremental ingest: `6dbfeb7ec507cfbb56bc905db47ea14f5bce9762`
+- Current package version: `2.115.3`
+- Total commits on HEAD: 2460
+- Latest merged PR captured in the incremental git snapshot: `#1033`
+- New commits since the previous incremental git cursor: `19`
+- Project-scoped memory files captured: `22` from the Lisa Claude project memory directory; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#999`.
-- Release automation advanced the monorepo to `2.113.0`.
-- Lisa added Expo-specific skills and an Expo MCP server to the shipped plugin surface.
-- Wiki query is now the primary rule-backed way for agents to answer project questions from durable wiki knowledge.
-- Exploratory QA split into a human-experience pass and an e2e-coverage-gaps pass so product-facing findings and automation backlog gaps stay distinct.
-- Repair intake now uses a two-hour stuck threshold and records PR/deploy blocker diagnosis for stale work.
-- Project ideation automation now records durable run ledgers, including PRD and thread ideation metadata plus an idempotency harness.
-- Nested team orchestration now adds specialists instead of collapsing nested flows to a single agent.
-- TypeScript template rules block error-suppression directives on edit across Claude and Codex surfaces.
-- Postinstall local installs re-enabled crash-safe template apply behavior.
+- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#1018`.
+- Release automation advanced the monorepo to `2.115.3`.
+- Wiki setup now treats the standard digital-staff roster as the default seed for new wiki setup flows.
+- Queue-status and project ideation added a PRD pressure helper so auto-ready PRDs are blocked when the build queue is already under pressure.
+- PRD pressure edge cases are covered by fixtures and the pressure gate is documented for ideation operators.
+- Project-scoped memory now records Lisa hook-delivery semantics: Claude plugin hooks track the GitHub marketplace on `main`, while Codex hooks arrive through `lisa apply`.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-27-lisa-monorepo-git.md
@@ -11,53 +11,28 @@ project: lisa-monorepo
 # git history — lisa-monorepo (2026-05-27)
 
 - Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
-- HEAD: `9e52f0d12bc01a85754f30b5ec70c97e6204bfab`
-- Total commits on HEAD: 2441
-- New commits since last ingest (`c536c7a196ff811ce92403acd90493baad86ebd0`): 44
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1017 "feat(postinstall): re-enable crash-safe template apply on local install"
+- HEAD: `6dbfeb7ec507cfbb56bc905db47ea14f5bce9762`
+- Total commits on HEAD: 2460
+- New commits since last ingest (`9e52f0d12bc01a85754f30b5ec70c97e6204bfab`): 19
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1033 "docs(ideation): document PRD pressure gate"
 
 ## New commits
-- 9e52f0d1 · 2026-05-27 · chore(release): 2.113.0 [skip ci]
-- cb6b0a93 · 2026-05-27 · Merge pull request #1017 from CodySwannGT/fix/crash-safe-postinstall-apply
-- e4230b1a · 2026-05-27 · Merge branch 'main' into fix/crash-safe-postinstall-apply
-- 4b8f1136 · 2026-05-27 · feat(postinstall): re-enable crash-safe template apply on local install
-- f3d4d9e7 · 2026-05-27 · chore(release): 2.112.0 [skip ci]
-- a484db5d · 2026-05-27 · Merge pull request #998 from CodySwannGT/worktree-add-expo-skills
-- 2691cad7 · 2026-05-27 · feat(expo): adopt official Expo skills + Expo MCP server
-- e73132f8 · 2026-05-27 · chore(release): 2.111.0 [skip ci]
-- d3d5ee4c · 2026-05-27 · Merge pull request #1016 from CodySwannGT/worktree-misc-rules
-- 5710a2ff · 2026-05-27 · Merge branch 'main' into worktree-misc-rules
-- bb61982a · 2026-05-27 · test: update build-ready-control for exploratory-qa / e2e-coverage-gaps split
-- 7ef908df · 2026-05-27 · feat(repair-intake): 2h stuck threshold + PR/deploy blocker diagnosis
-- 8f7bfdbf · 2026-05-27 · chore(release): 2.110.1 [skip ci]
-- 05607ebc · 2026-05-27 · Merge pull request #1015 from CodySwannGT/codex/issue-1007-thread-exploratory-ledger
-- 9b245857 · 2026-05-27 · Merge branch 'main' into codex/issue-1007-thread-exploratory-ledger
-- 13f66f37 · 2026-05-27 · fix: thread ideation ledger payload
-- c5a68007 · 2026-05-27 · chore(release): 2.110.0 [skip ci]
-- 52bd3d0e · 2026-05-27 · Merge pull request #1014 from CodySwannGT/fix/lint-wiki-stdout-flush
-- 789c399b · 2026-05-27 · fix(wiki): flush lint-wiki --json output before exit
-- e48c5f98 · 2026-05-27 · Merge pull request #1013 from CodySwannGT/codex/issue-1008-github-prd-run-ledger
-- 5b8040ef · 2026-05-27 · feat: record github prd ideation ledger
-- 6527a3fa · 2026-05-27 · chore(release): 2.109.0 [skip ci]
-- ffd43fa5 · 2026-05-27 · feat(qa): split exploratory-qa into human-experience pass + e2e-coverage-gaps
-- b191a41e · 2026-05-27 · Merge pull request #1012 from CodySwannGT/codex/1009-exploratory-automation-memory
-- e8c7626e · 2026-05-27 · feat(project-ideation): record automation memory contract
-- 2c4f5976 · 2026-05-27 · chore(release): 2.108.0 [skip ci]
-- 247cd724 · 2026-05-27 · Merge pull request #1011 from CodySwannGT/codex/issue-1010-idempotency-harness
-- 81c6061b · 2026-05-27 · feat: add project ideation idempotency harness
-- 78265287 · 2026-05-27 · feat(wiki): make /query the primary way agents answer project questions
-- 464a9dcd · 2026-05-27 · chore(release): 2.107.2 [skip ci]
-- 8dc303b7 · 2026-05-27 · Merge pull request #1003 from CodySwannGT/chore/merge-origin-main
-- 6b20f89e · 2026-05-27 · Merge remote-tracking branch 'origin/main' into chore/merge-origin-main
-- 2fc4cb06 · 2026-05-27 · chore: minor
-- 78902c77 · 2026-05-27 · chore(release): 2.107.1 [skip ci]
-- 9e43ea46 · 2026-05-27 · Merge pull request #1002 from CodySwannGT/fix/cross-harness-nested-team-orchestration
-- 18740ec3 · 2026-05-27 · fix(orchestration): make nested team flows add specialists instead of collapsing to single-agent
-- afe4d7c9 · 2026-05-27 · chore(release): 2.107.0 [skip ci]
-- 8f7a1229 · 2026-05-27 · Merge pull request #1000 from CodySwannGT/worktree-hookify
-- 99c2542d · 2026-05-27 · Merge remote-tracking branch 'origin/main' into worktree-hookify
-- 382bf6b1 · 2026-05-27 · chore(release): 2.106.9 [skip ci]
-- 5354f982 · 2026-05-27 · fix(automation-status): isolate codex cwd git check from inherited GIT_DIR
-- 1d5ecaad · 2026-05-27 · Merge pull request #999 from CodySwannGT/wiki/ingest-2026-05-27-133229
-- b4c74bd5 · 2026-05-27 · docs(wiki): ingest durable automation checkout guidance
-- 10b6afd4 · 2026-05-27 · feat(typescript): block error-suppression directives on edit
+- 6dbfeb7e · 2026-05-27 · chore(release): 2.115.3 [skip ci]
+- d99c8384 · 2026-05-27 · Merge pull request #1033 from CodySwannGT/codex/issue-1028-prd-pressure-docs
+- ac5ce8e8 · 2026-05-27 · docs(ideation): document PRD pressure gate
+- b92a8cf2 · 2026-05-27 · chore(release): 2.115.2 [skip ci]
+- b9487ecb · 2026-05-27 · Merge pull request #1032 from CodySwannGT/codex/issue-1027-prd-pressure-fixtures
+- b431e885 · 2026-05-27 · test(prd): cover queue pressure edge cases
+- 8646f823 · 2026-05-27 · chore(release): 2.115.1 [skip ci]
+- 6b5c62d8 · 2026-05-27 · Merge pull request #1031 from CodySwannGT/codex/issue-1026-auto-ready-prd-pressure
+- 964ae081 · 2026-05-27 · fix(project-ideation): block auto-ready prds under queue pressure
+- 1db6ef14 · 2026-05-27 · chore(release): 2.115.0 [skip ci]
+- 487bb4e9 · 2026-05-27 · Merge pull request #1030 from CodySwannGT/codex/issue-1025-github-build-intake
+- b8b89878 · 2026-05-27 · feat(queue-status): add PRD pressure helper
+- 836aee18 · 2026-05-27 · chore(release): 2.114.0 [skip ci]
+- 964b3d8a · 2026-05-27 · Merge pull request #1020 from CodySwannGT/wiki/standard-roster-default
+- bd39f255 · 2026-05-27 · Merge remote-tracking branch 'origin/main' into wiki/standard-roster-default
+- fcb7a10e · 2026-05-27 · feat(wiki): make the standard digital-staff roster the setup default
+- 0ac3e446 · 2026-05-27 · chore(release): 2.113.1 [skip ci]
+- a3fccee3 · 2026-05-27 · Merge pull request #1018 from CodySwannGT/wiki/ingest-2026-05-27-173325
+- 46a44616 · 2026-05-27 · docs(wiki): ingest incremental Lisa history

--- a/wiki/sources/memory/2026-05-27-memory.md
+++ b/wiki/sources/memory/2026-05-27-memory.md
@@ -11,7 +11,7 @@ sensitivity: internal
 # project-scoped memory (2026-05-27)
 
 - Source: `/Users/cody/.claude/projects/-Users-cody-workspace-lisa/memory` (project-scoped; global/Chronicle memory is never ingested)
-- Files: 21
+- Files: 22
 
 ### MEMORY.md
 
@@ -38,6 +38,7 @@ sensitivity: internal
 - `reference_lisa_new_standalone_plugin_wiring.md` — 5 wiring points for a new standalone Lisa plugin; .agents/plugins/marketplace.json is the Codex install surface (NOT CI-enforced)
 - `reference_codex_commit_attribution.md` — Codex 0.125.0 commit attribution: top-level commit_attribution + features.codex_git_commit; emits "Co-authored-by: Codex"; Lisa hook broadened to accept Claude|Codex
 - `reference_codex_http_mcp_plugin_shape.md` — Codex 0.125.0 accepts the Claude {type:"http",url} .mcp.json shape via plugin pointer (no translation needed); bare TOML wants url= with no type
+- `reference_lisa_hook_delivery.md` — Lisa hooks reach projects: Claude via GitHub marketplace (tracks main, not npm version), Codex via `lisa apply`; the source repo self-skips so updating the dep here is a no-op
 
 ### feedback_bash_path_subshell.md
 
@@ -54,7 +55,7 @@ When running Bash in the Lisa workspace (especially during `/lisa-update-project
 
 **Why:** environment/sandbox quirk — top-level command lookup works, nested lookup doesn't get the homebrew/mise PATH.
 
-**How to apply:** Begin every Bash command with `export PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"`. Prefer flat command sequences over shell functions. Use `git -C <dir>` instead of `cd` (the tool also resets cwd after operating on external worktrees). jq is at `/opt/homebrew/bin/jq`, git at `/opt/homebrew/bin/git`. Tell spawned subagents the same — they hit it too. Network ops (git fetch/push, gh) and writes to `~/workspace/*` work fine without disabling the sandbox once PATH is set. Related: `project_lisa_update_workspaces_config`.
+**How to apply:** Begin every Bash command with `export PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"`. Prefer flat command sequences over shell functions. Use `git -C <dir>` instead of `cd` (the tool also resets cwd after operating on external worktrees). jq is at `/opt/homebrew/bin/jq`, git at `/opt/homebrew/bin/git`. Tell spawned subagents the same — they hit it too. Network ops (git fetch/push, gh) and writes to `~/workspace/*` work fine without disabling the sandbox once PATH is set. Related: [[project_lisa_update_workspaces_config]].
 
 ### feedback_coderabbit_pr_reviews.md
 
@@ -117,7 +118,7 @@ In the Lisa repo, merge PRs with `gh pr merge --auto --merge` — **never `--squ
 
 **Why:** The repo's `git-submit-pr` skill (`plugins/src/base/skills/git-submit-pr/SKILL.md`) documents `--merge` for both promotion and feature PRs, established by PR #496. Squashing (a) flattens `chore(release): X.Y.Z [skip ci]` commits and strips the `[skip ci]` markers, breaking the release workflow's promotion-detection regex (double version bumps), and (b) makes a merged branch look unmerged to `git merge-base --is-ancestor`, breaking branch-merge auditing. The user noticed I was defaulting to `--squash` with no basis and asked why.
 
-**How to apply:** When merging a PR in Lisa, run `/lisa:git-submit-pr` or `gh pr merge <n> --auto --merge`. Don't default to `--squash`. Note the documented flow is feature → `dev` → `staging` → `main`; if asked to target `main` directly, follow the instruction but still use `--merge`. See `feedback_verify_ci_in_ci` for the related "watch CI in CI" habit.
+**How to apply:** When merging a PR in Lisa, run `/lisa:git-submit-pr` or `gh pr merge <n> --auto --merge`. Don't default to `--squash`. Note the documented flow is feature → `dev` → `staging` → `main`; if asked to target `main` directly, follow the instruction but still use `--merge`. See [[feedback_verify_ci_in_ci]] for the related "watch CI in CI" habit.
 
 ### feedback_never_no_verify.md
 
@@ -180,7 +181,7 @@ CodySwannGT/lisa has only ONE deploy environment, tied to the `main` branch — 
 - `target_environment` on generated tickets = `main`/production, never "dev".
 - The `github-build-intake` "done" label is env-aware: it reverse-looks-up the PR base branch in `deploy.branches`. With only `production: main`, merges to main resolve to `production` → `status:done` directly. Effective build lifecycle: `status:ready → status:in-progress → status:code-review → status:done`.
 - The `status:on-dev` and `status:on-stg` labels exist but are never reached (no dev/staging branch). They are dead/unused — candidates for deletion for tidiness, but functionally harmless.
-- PRDs touching build-intake behavior (e.g. `project_llmwiki_unification` siblings #522 rollup, #524 bounded parallel) should encode single-environment rollup/lifecycle, not multi-env.
+- PRDs touching build-intake behavior (e.g. [[project_llmwiki_unification]] siblings #522 rollup, #524 bounded parallel) should encode single-environment rollup/lifecycle, not multi-env.
 
 ### project_lisa_tsconfig_base_path_resolution.md
 
@@ -199,7 +200,7 @@ Lisa ships that `tsconfig.local.json` via the **typescript create-only** templat
 
 **Why:** A 2026-05 task asked to fix Harper/Fabric build scripts that pointed at `dist/src/*` for rootDir-src projects (advisory-rankings). The originally-reported force-clobber was already fixed in PR #508 / v2.23.1 (scripts moved force→defaults). The residual gap was that `harper-fabric/package-lisa/package.lisa.json` `defaults` still hardcoded `dist/src/*` — wrong for the rootDir-src emit. Fix was purely the defaults (`dist/build/*`, `dist/scripts/*`, smoke via `bun tests/*.ts`). Editing the base tsconfig's rootDir was attempted and reverted as inert.
 
-**How to apply:** When a Lisa package.lisa.json script references a tsc output path, match it to the rootDir-src emit (`dist/<subdir>/file.js`), not `dist/src/...`. Don't try to fix emit layout by changing a base tsconfig's rootDir — change the create-only `tsconfig.local.json` or the script default instead. See `project_vitest_template_overlap` for related TS-family template inheritance gotchas.
+**How to apply:** When a Lisa package.lisa.json script references a tsc output path, match it to the rootDir-src emit (`dist/<subdir>/file.js`), not `dist/src/...`. Don't try to fix emit layout by changing a base tsconfig's rootDir — change the create-only `tsconfig.local.json` or the script default instead. See [[project_vitest_template_overlap]] for related TS-family template inheritance gotchas.
 
 ### project_lisa_update_workspaces_config.md
 
@@ -248,7 +249,7 @@ IMPLEMENTATION STATUS (2026-05-22): **M0 complete + committed** on branch claude
 **SHIPPED**: PR #510 merged to main (squash, auto-merge) and released as **@codyswann/lisa@2.25.0 on npm** (latest). Merge blockers fixed en route: (1) eslint sonarjs/no-duplicate-string falsely flagged wiki/lisa-wiki.config.json → added `wiki/**` to eslint.config.local.ts ignores (wiki is content, not app code); (2) plugin-sync failed because main advanced to 2.24.0 mid-PR (build injects package version into manifests) → merged main + rebuilt plugins. The published tarball includes plugins/lisa-wiki/.claude-plugin + .codex-plugin and both marketplaces (.claude-plugin/marketplace.json + .agents/plugins/marketplace.json). Release-and-Deploy workflow succeeded. lisa's own wiki is migrated to Phase 1 (config committed). REMAINING: deeper lisa phases (normalize frontmatter/links by touch; swap old hand-rolled lisa-wiki-* skills for plugin once enabled) + migrate the other 4 live repos (gemini/propswap/gunner, publishing v1.1) — each a per-repo PR.
 
 **Why:** the wiki idea (Karpathy LLM Wiki) was reimplemented 5x with drift; a single plugin removes duplication and lets Lisa distribute it.
-**How to apply:** start from PLAN.md sections 17 (milestones M0-M7) and 18 (acceptance criteria). See `reference_codex_cli_collaboration` for how the plan was co-authored.
+**How to apply:** start from PLAN.md sections 17 (milestones M0-M7) and 18 (acceptance criteria). See [[reference_codex_cli_collaboration]] for how the plan was co-authored.
 
 ### project_vitest_template_overlap.md
 
@@ -312,7 +313,7 @@ updated_at = 1779636560575
 are declarative specs that tell the runtime to create/remove these via the native mechanism (Codex
 automations / Claude `/schedule`) — the skill never writes TOML itself. Names use a
 `lisa-auto-<project>-` prefix so teardown is project-scoped. Claude equivalent of Codex automations
-is `/schedule`. Drove codex via `reference_codex_cli_collaboration`.
+is `/schedule`. Drove codex via [[reference_codex_cli_collaboration]].
 
 Gotcha: a heavy `codex exec` with `model_reasoning_effort=high` + an agentic investigation loop got
 OOM-killed (exit 137). Do the filesystem investigation yourself; use codex for small focused prompts.
@@ -337,7 +338,7 @@ The `codex` CLI (codex-cli, model gpt-5.5) is installed and authed on this machi
 - It has danger-full-access in this env (can read the whole filesystem and verify claims itself).
 - Pattern that worked well: write a shared brief to `/tmp/...md`, have codex read it + write its response to another `/tmp/...md`, then `tail` stdout. Iterate via `resume --last`.
 
-Used 2026-05-22 to co-author the LLM Wiki unification PLAN.md (see `project_llmwiki_unification`).
+Used 2026-05-22 to co-author the LLM Wiki unification PLAN.md (see [[project_llmwiki_unification]]).
 
 ### reference_codex_commit_attribution.md
 
@@ -350,7 +351,7 @@ metadata:
   originSessionId: 4614617a-bc2d-4b67-8d45-e78648b64627
 ---
 
-Codex CLI **0.125.0** has a native commit-attribution mechanism (the mirror of Claude Code's `attribution.commit` setting). Verified by source-read + `codex debug prompt-input` (see `reference-codex-cli-collaboration`, `reference-codex-hooks-capabilities`).
+Codex CLI **0.125.0** has a native commit-attribution mechanism (the mirror of Claude Code's `attribution.commit` setting). Verified by source-read + `codex debug prompt-input` (see [[reference-codex-cli-collaboration]], [[reference-codex-hooks-capabilities]]).
 
 - Gated behind feature flag `features.codex_git_commit = true` (default OFF, "under development"). When off, Codex adds NO trailer by default.
 - Controlled by top-level config key `commit_attribution` (in `~/.codex/config.toml` or project `.codex/config.toml`). **Must be placed before the first `[table]` header** — it's a top-level key, so putting it after `[features]` would wrongly nest it as `features.commit_attribution`.
@@ -372,7 +373,7 @@ metadata:
   originSessionId: 91045a17-6bee-46bc-ab0e-63cd32a7d6a5
 ---
 
-Codex CLI **0.125.0** hook system, verified by source-read + runtime tests with codex (see `reference-codex-cli-collaboration`). Findings:
+Codex CLI **0.125.0** hook system, verified by source-read + runtime tests with codex (see [[reference-codex-cli-collaboration]]). Findings:
 
 - **Plugin-bundled hooks DO NOT RUN.** A distributed Codex plugin's `.codex-plugin/plugin.json` `hooks` pointer and `hooks/hooks.json` are NOT executed (manifest parser only honors skills/mcpServers/apps/interface). Lisa's `scripts/generate-codex-plugin-artifacts.mjs` emits these — they are **dead weight on Codex**. Hooks only load from `~/.codex/hooks.json`, project `.codex/hooks.json`, or `[hooks]` in `config.toml`. Enable via `[features].codex_hooks = true`.
 - **Supported events:** `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`. **No `SubagentStart`, no `SessionEnd`** (despite Codex having multi-agent/`spawn_agent`).
@@ -399,7 +400,7 @@ Codex 0.125.0 supports remote streamable-HTTP MCP servers. Two delivery paths, t
 - **Plugin-bundled `.mcp.json`** (referenced by `.codex-plugin` `mcpServers: ./.mcp.json`): Codex's JSON parser accepts the Claude wrapper shape **unchanged** — `{ "mcpServers": { "x": { "type": "http", "url": "..." } } }`. Verified: an installed Atlassian plugin uses exactly that and `codex mcp get` reports `transport: streamable_http`. So **no Claude→Codex translation is needed** for HTTP MCP servers; Lisa's `scripts/generate-codex-plugin-artifacts.mjs` already emits the `mcpServers: ./.mcp.json` pointer.
 - **Bare `~/.codex/config.toml`** (manual path): use `[mcp_servers.x]` with `url = "..."` and NO `type` key (transport inferred from `url` vs `command`). The `type="http"` key is Claude JSON only, not Codex TOML.
 
-Implication for `reference_lisa_new_standalone_plugin_wiring`: vendoring a Claude plugin's HTTP-MCP `.mcp.json` into `plugins/src/<stack>` and running `bun run build:plugins` gives Codex parity with no extra work. Established while auditing the lisa-expo plugin against Expo's official plugin (official MCP = https://mcp.expo.dev/mcp). Related: `reference_codex_plugin_skill_loading`, `reference_codex_hooks_capabilities`.
+Implication for [[reference_lisa_new_standalone_plugin_wiring]]: vendoring a Claude plugin's HTTP-MCP `.mcp.json` into `plugins/src/<stack>` and running `bun run build:plugins` gives Codex parity with no extra work. Established while auditing the lisa-expo plugin against Expo's official plugin (official MCP = https://mcp.expo.dev/mcp). Related: [[reference_codex_plugin_skill_loading]], [[reference_codex_hooks_capabilities]].
 
 ### reference_codex_plugin_skill_loading.md
 
@@ -422,7 +423,26 @@ How Codex consumes a Lisa-built plugin's skills:
 - Invocation/namespacing: plugin skills are addressed namespaced, e.g. `$lisa-expo:exploratory-qa`. A personal/global skill in `~/.codex/skills/<name>/` appears bare (`$exploratory-qa`) and coexists, but bare invocation hits the personal copy — remove the personal copy once the plugin ships to avoid masking the plugin version.
 - Optional future polish: generator could derive `skills/<name>/agents/openai.yaml` (interface.display_name / short_description / default_prompt) from SKILL.md frontmatter. Additive only.
 
-Applies to the `project_llmwiki_unification` Claude+Codex dual-distribution model. Drove codex via `reference_codex_cli_collaboration`.
+Applies to the [[project_llmwiki_unification]] Claude+Codex dual-distribution model. Drove codex via [[reference_codex_cli_collaboration]].
+
+### reference_lisa_hook_delivery.md
+
+---
+name: reference_lisa_hook_delivery
+description: "How Lisa plugin hooks reach projects — Claude via GitHub marketplace (not npm version), Codex via lisa apply; source repo self-skips"
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 13c9b8da-4d2c-45dd-b57e-17a193fb1a4c
+---
+
+How a Lisa plugin hook (e.g. a new `lisa-typescript` PreToolUse hook) actually reaches a project:
+
+- **Claude:** the plugin (`lisa-typescript@lisa`) is served from the **GitHub marketplace** `CodySwannGT/lisa` (declared in a project's `.claude/settings.json` `extraKnownMarketplaces`), NOT from the npm package. `scripts/install-claude-plugins.sh` (Lisa's `postinstall`) refreshes it via `claude plugin marketplace update lisa` + `claude plugin install lisa-typescript@lisa`. So the hook content tracks the **repo's `main` branch** (committed `plugins/lisa-*` artifacts), decoupled from the npm version number. A bare `claude plugin marketplace update` + reload picks it up even without an npm publish.
+- **Codex:** hooks are installed into the project's `.codex/hooks.json` by `src/codex/hooks-installer.ts` during a **full template apply** (`npx @codyswann/lisa .` / `lisa:update`), NOT during `postinstall`. So Codex gets a new hook on the apply step of an update, not on a bare `npm/bun update`.
+- **The Lisa monorepo itself:** `install-claude-plugins.sh` self-skips (`if [ "$PACKAGE_NAME" = "@codyswann/lisa" ]; then exit 0; fi`), so updating the `@codyswann/lisa` dep in this repo installs nothing. This repo's Claude session gets new hooks only by refreshing the marketplace plugin (works as soon as merged to `main`); it has no `.codex/hooks.json` (apply isn't run on self).
+
+Implication: "bump npm version → update package → hook installs" is only loosely true downstream — Claude delivery is marketplace/`main`-driven (the npm bump just triggers the postinstall that refreshes it), and Codex delivery needs the apply step. See [[reference_lisa_new_standalone_plugin_wiring]] and the PROJECT_RULES note that `plugins/lisa*` are generated build output from `plugins/src/`.
 
 ### reference_lisa_new_standalone_plugin_wiring.md
 
@@ -456,7 +476,7 @@ commit src + generated artifacts together:
      lisa-openclaw build, 2026-05-24.)
 
 Codex discovers a plugin's skills via the generated `.codex-plugin/plugin.json` `"skills":"./skills/"`
-pointer (see `reference_codex_plugin_skill_loading`); the `.agents` marketplace is install/discovery,
+pointer (see [[reference_codex_plugin_skill_loading]]); the `.agents` marketplace is install/discovery,
 the `.codex-plugin` pointer is post-install skill loading — both are needed.
 
 Note (2026-05-24): `lisa-wiki` is registered in `.claude-plugin` but was MISSING from `.agents` at

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-27T17:33:44.168Z",
+  "ingested_at": "2026-05-27T21:35:16.999Z",
   "cursor": {
-    "lastCommit": "9e52f0d12bc01a85754f30b5ec70c97e6204bfab",
-    "lastPr": 1017
+    "lastCommit": "6dbfeb7ec507cfbb56bc905db47ea14f5bce9762",
+    "lastPr": 1033
   },
   "source_notes": [
     "wiki/sources/git/2026-05-27-lisa-monorepo-git.md"

--- a/wiki/state/memory/latest.json
+++ b/wiki/state/memory/latest.json
@@ -1,9 +1,9 @@
 {
   "connector": "memory",
   "profile": "project",
-  "ingested_at": "2026-05-27T13:35:10.065Z",
+  "ingested_at": "2026-05-27T21:35:17.044Z",
   "cursor": {
-    "files": 21,
+    "files": 22,
     "lastIngest": "2026-05-27"
   },
   "source_notes": [

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-27T17:33:43.076Z",
+  "ingested_at": "2026-05-27T21:35:17.071Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary
- ingested git history through Lisa 2.115.3 / merged PR #1033
- refreshed project-scoped Lisa memory and connector state
- synthesized PRD pressure, digital-staff roster defaults, and hook-delivery guidance into the wiki

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --config wiki/lisa-wiki.config.json (0 fail, 12 pre-existing warnings)
- gitleaks commit hook
- tsc --noEmit
- bun audit
- eslint slow config
- knip
- vitest run --coverage
- vitest run tests/integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new vocabulary definitions: PRD Pressure (queue management for build readiness) and Digital Staff Roster (default role configuration)
  * Documented hook delivery mechanism for plugin integration
  * Added Project Ideation Pressure Gate playbook guidance
  * Updated wiki with latest release information and project metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->