### PR TITLE
feat(rules): add wiki-as-knowledge-source rule to base plugin

### DIFF
--- a/plugins/lisa/rules/wiki-knowledge-source.md
+++ b/plugins/lisa/rules/wiki-knowledge-source.md
@@ -1,0 +1,14 @@
+# Wiki as Knowledge Source
+
+If this project has an LLM Wiki (a `wiki/` directory with an `index.md`), treat it as the canonical source of durable project knowledge. The wiki is curated and current; ad-hoc scraping of code, tickets, chat history, or stale READMEs is not.
+
+Before researching project background, conventions, ownership, architecture, glossary terms, or "how/why does X work here":
+
+1. Consult the wiki first. Start from `wiki/index.md` and follow links, or use the wiki query skill (`/lisa-wiki-query`, or the runtime's wiki query skill) to find the relevant page.
+2. Use what the wiki says as the authoritative answer when it covers the question. Do not re-derive it from raw sources when the wiki already documents it.
+3. Fall back to primary sources (code, tickets, commit history, external docs) only when the wiki is silent, ambiguous, or contradicted by what you observe in the code.
+4. If you find the wiki is wrong, stale, or missing knowledge that belongs there, surface the gap — and where the project's workflow supports it, capture the correction back into the wiki via its ingestion path (`/lisa-wiki-ingest` or equivalent) rather than leaving the knowledge only in this session.
+
+The wiki documents knowledge; it does not override executable behavior. When the wiki and the running code disagree about what the system actually does, trust the code and treat the wiki as out of date. See the `documentation-source-paths` rule for how source-material directories relate to the wiki.
+
+If the project has no `wiki/`, this rule does not apply.

--- a/plugins/src/base/rules/wiki-knowledge-source.md
+++ b/plugins/src/base/rules/wiki-knowledge-source.md
@@ -1,0 +1,14 @@
+# Wiki as Knowledge Source
+
+If this project has an LLM Wiki (a `wiki/` directory with an `index.md`), treat it as the canonical source of durable project knowledge. The wiki is curated and current; ad-hoc scraping of code, tickets, chat history, or stale READMEs is not.
+
+Before researching project background, conventions, ownership, architecture, glossary terms, or "how/why does X work here":
+
+1. Consult the wiki first. Start from `wiki/index.md` and follow links, or use the wiki query skill (`/lisa-wiki-query`, or the runtime's wiki query skill) to find the relevant page.
+2. Use what the wiki says as the authoritative answer when it covers the question. Do not re-derive it from raw sources when the wiki already documents it.
+3. Fall back to primary sources (code, tickets, commit history, external docs) only when the wiki is silent, ambiguous, or contradicted by what you observe in the code.
+4. If you find the wiki is wrong, stale, or missing knowledge that belongs there, surface the gap — and where the project's workflow supports it, capture the correction back into the wiki via its ingestion path (`/lisa-wiki-ingest` or equivalent) rather than leaving the knowledge only in this session.
+
+The wiki documents knowledge; it does not override executable behavior. When the wiki and the running code disagree about what the system actually does, trust the code and treat the wiki as out of date. See the `documentation-source-paths` rule for how source-material directories relate to the wiki.
+
+If the project has no `wiki/`, this rule does not apply.


### PR DESCRIPTION
## What

Adds a new distributable rule `wiki-knowledge-source.md` to the base plugin (`plugins/src/base/rules/`, with its regenerated artifact at `plugins/lisa/rules/`).

The rule instructs agents: if the project has an LLM Wiki (`wiki/` + `index.md`), consult it **first** as the canonical knowledge source — via `wiki/index.md` or the wiki query skill — before scraping code, tickets, or chat. It falls back to primary sources only when the wiki is silent or contradicted, directs agents to capture corrections back via the ingestion path, and subordinates the wiki to running code when they disagree. It no-ops on projects without a `wiki/`.

## Why base plugin (not lisa-wiki)

Rules reach context only via `inject-rules.sh`, which reads `${CLAUDE_PLUGIN_ROOT}/rules` and is registered solely in the **base** plugin's SessionStart/SubagentStart hooks. The `lisa-wiki` plugin has no rules dir or inject hook, so a rule placed there would be inert. This matches the precedent of the wiki-aware `documentation-source-paths` rule, which also lives in base and is gated on a wiki existing.

## Distribution

Ships to Claude downstreams through the base `lisa` plugin (GitHub marketplace, tracks `main`) and to Codex via `lisa apply`.

## Verification

- `bun run build:plugins` regenerated all artifacts cleanly.
- Artifact is byte-identical to source, so the 🧩 Plugins Sync guard (`check:plugins`) will pass.
- Pre-commit hooks (gitleaks, tsc, prettier, commitlint) passed.

🤖 Generated with Claude Code