### PR TITLE
chore(eslint): add wiki/** to defaultIgnores

### DIFF
--- a/src/configs/eslint/base.ts
+++ b/src/configs/eslint/base.ts
@@ -76,6 +76,7 @@ export const defaultIgnores = [
   "scripts/**",
   "lib/**/*.js",
   "cdk.out/**",
+  "wiki/**",
 ];
 
 /**


### PR DESCRIPTION
Adds `wiki/**` to the base ESLint `defaultIgnores` so the lisa-wiki kernel scaffolding stops tripping `sonarjs/no-duplicate-string` in downstream projects.

## Why
The wiki kernel writes `wiki/lisa-wiki.config.json`, which legitimately repeats enum literals (e.g. `"read-only-ingest"` on each connector). The Lisa-managed ESLint pipeline picks up that JSON and the sonarjs rule fires — failing the Quality Checks / Lint CI gate.

Discovered while installing the wiki across 8 workspace repos this morning: each JS/TS project (api-creator, qualis-infrastructure, thumbwar-frontend, thumbwar-infrastructure) had to land an identical `wiki/**` entry in its own `eslint.ignore.config.json` to make the wiki PR mergeable. Pushing the ignore upstream removes that per-repo patch.

## Change
- `src/configs/eslint/base.ts` — append `"wiki/**"` to `defaultIgnores` (after `cdk.out/**`).

## Impact
- Projects that consume `@codyswann/lisa/eslint/*` factories will pick this up on next dependency bump / `lisa apply`.
- Wiki content isn't a TypeScript/JavaScript source tree — ignoring it doesn't weaken lint coverage of project code.

🤖 Generated with Claude Code