### PR TITLE
feat(cli): add package version update check

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "minimatch": "^3.1.2",
         "picocolors": "^1.0.0",
         "prettier": "^3.3.3",
+        "semver": "^7.8.1",
         "smol-toml": "^1.6.1",
         "standard-version": "^9.5.0",
         "ts-jest": "^29.4.9",
@@ -61,6 +62,7 @@
       "devDependencies": {
         "@codyswann/lisa": "^2.98.0",
         "@types/js-yaml": "^4.0.9",
+        "@types/semver": "^7.7.1",
         "eslint-plugin-oxlint": "^1.62.0",
         "js-yaml": "^4.1.1",
         "oxlint": "^1.62.0",
@@ -659,6 +661,8 @@
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
@@ -1768,7 +1772,7 @@
 
     "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2030,9 +2034,15 @@
 
     "@babel/core/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@babel/generator/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-member-expression-to-functions/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
@@ -2128,6 +2138,8 @@
 
     "conventional-changelog-core/git-raw-commits": ["git-raw-commits@2.0.11", "", { "dependencies": { "dargs": "^7.0.0", "lodash": "^4.17.15", "meow": "^8.0.0", "split2": "^3.0.0", "through2": "^4.0.0" }, "bin": { "git-raw-commits": "cli.js" } }, "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A=="],
 
+    "conventional-changelog-writer/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "conventional-commits-parser/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "conventional-recommended-bump/conventional-commits-parser": ["conventional-commits-parser@3.2.4", "", { "dependencies": { "JSONStream": "^1.0.4", "is-text-path": "^1.0.1", "lodash": "^4.17.15", "meow": "^8.0.0", "split2": "^3.0.0", "through2": "^4.0.0" }, "bin": { "conventional-commits-parser": "cli.js" } }, "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q=="],
@@ -2154,9 +2166,13 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "eslint-plugin-jsdoc/espree": ["espree@11.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-+gMeWRrIh/NsG+3NaLeWHuyeyk70p2tbvZIWBYcqQ4/7Xvars6GYTZNhF1sIeLcc6Wb11He5ffz3hsHyXFrw5A=="],
 
     "eslint-plugin-jsdoc/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "eslint-plugin-react-hooks/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
@@ -2187,6 +2203,8 @@
     "git-raw-commits/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "git-remote-origin-url/pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
+
+    "git-semver-tags/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "gitconfiglocal/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -2243,6 +2261,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "minimist-options/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
+
+    "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "normalize-package-data/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "minimatch": "^3.1.2",
     "picocolors": "^1.0.0",
     "prettier": "^3.3.3",
+    "semver": "^7.8.1",
     "smol-toml": "^1.6.1",
     "standard-version": "^9.5.0",
     "ts-jest": "^29.4.9",
@@ -202,6 +203,7 @@
   "devDependencies": {
     "@codyswann/lisa": "^2.98.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/semver": "^7.7.1",
     "eslint-plugin-oxlint": "^1.62.0",
     "js-yaml": "^4.1.1",
     "oxlint": "^1.62.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { MigrationRegistry } from "../migrations/index.js";
 import { StrategyRegistry } from "../strategies/index.js";
 import { BackupService, DryRunBackupService } from "../transaction/index.js";
 import { toAbsolutePath } from "../utils/path-utils.js";
+import { getPackageVersion } from "./version.js";
 import { createPrompter } from "./prompts.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -59,8 +60,9 @@ export function createProgram(): Command {
     .description(
       "Claude Code / Codex CLI governance framework - apply guardrails and guidance to projects"
     )
-    .version("1.0.0")
+    .version(getPackageVersion())
     .argument("[destination]", "Path to the project directory")
+    .option("--no-update-check", "Skip the npm latest-version check")
     .option("-n, --dry-run", "Show what would be done without making changes")
     .option(
       "-y, --yes",
@@ -94,6 +96,7 @@ interface CLIOptions {
   yes?: boolean;
   validate?: boolean;
   skipGitCheck?: boolean;
+  updateCheck?: boolean;
   harness?: Harness;
 }
 
@@ -118,6 +121,7 @@ function printUsageAndExit(): never {
   console.log(
     "  --skip-git-check  Skip dirty git working directory check (for postinstall use)"
   );
+  console.log("  --no-update-check Skip the npm latest-version check");
   console.log(
     `  --harness <h>     Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (persisted in .lisa.config.json)`
   );

--- a/src/cli/print-update-warning.ts
+++ b/src/cli/print-update-warning.ts
@@ -1,0 +1,19 @@
+import type { UpdateCheckResult } from "./update-check.js";
+
+/**
+ * Print the user-facing npm update warning for outdated Lisa installs.
+ * @param result - Completed update-check result
+ */
+export function printUpdateWarning(result: UpdateCheckResult): void {
+  if (!result.isOutdated || result.latest === null) {
+    return;
+  }
+
+  console.error(
+    [
+      `Lisa ${result.latest} is available; you are running ${result.current}.`,
+      "Update with: npm install -g @codyswann/lisa@latest",
+      "Continuing with the installed version.",
+    ].join("\n")
+  );
+}

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -1,0 +1,240 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gt, valid } from "semver";
+import { getPackageVersion } from "./version.js";
+
+const DEFAULT_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 2500;
+const NPM_LATEST_URL = "https://registry.npmjs.org/@codyswann/lisa/latest";
+
+/** Runtime options for Lisa's non-fatal update check. */
+export interface UpdateCheckOptions {
+  /** Process arguments used to detect --no-update-check. */
+  argv?: readonly string[];
+  /** Override cache path for tests and controlled runs. */
+  cachePath?: string;
+  /** Override current package version. */
+  currentVersion?: string;
+  /** Environment map used to detect LISA_SKIP_UPDATE_CHECK. */
+  env?: NodeJS.ProcessEnv;
+  /** Fetch implementation override. */
+  fetchImpl?: typeof fetch;
+  /** Clock override. */
+  now?: () => Date;
+  /** Registry timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Cache TTL in milliseconds. */
+  ttlMs?: number;
+}
+
+/** Result from a non-fatal npm latest-version check. */
+export interface UpdateCheckResult {
+  /** Installed Lisa version. */
+  current: string;
+  /** Latest npm version, or null when unavailable/skipped. */
+  latest: string | null;
+  /** True when latest is a valid semver greater than current. */
+  isOutdated: boolean;
+  /** Machine-readable non-fatal outcome reason. */
+  reason?: string;
+}
+
+/** Serialized cache file shape. */
+interface UpdateCheckCache {
+  /** Cached npm latest version. */
+  latest?: unknown;
+  /** ISO timestamp for the cache write. */
+  fetchedAt?: unknown;
+  /** Optional non-fatal failure reason. */
+  reason?: unknown;
+}
+
+/**
+ * Resolve the default Lisa update-check cache path.
+ * @returns Absolute cache file path
+ */
+function getDefaultCachePath(): string {
+  return path.join(os.homedir(), ".lisa", "update-check.json");
+}
+
+/**
+ * Read process.env through one explicit, reviewable exception to the app-template
+ * env rule. The CLI needs externally supplied process env for this root opt-out.
+ * @returns Current process environment
+ */
+function getProcessEnv(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line no-restricted-syntax -- CLI root option must read externally supplied process env once
+  return process.env;
+}
+
+/**
+ * Determine whether the update check is disabled for this invocation.
+ * @param argv - Process arguments
+ * @param env - Process environment
+ * @returns True when a flag or env opt-out is present
+ */
+function isUpdateCheckDisabled(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv
+): boolean {
+  return (
+    argv.includes("--no-update-check") || env.LISA_SKIP_UPDATE_CHECK === "1"
+  );
+}
+
+/**
+ * Return a fresh cached latest version when the cache is usable.
+ * @param raw - Raw cache JSON
+ * @param now - Current wall-clock time
+ * @param ttlMs - Freshness TTL in milliseconds
+ * @returns Cached latest version, or null when missing/stale/malformed
+ */
+function readCachedLatest(
+  raw: string,
+  now: Date,
+  ttlMs: number
+): string | null {
+  const parsed = JSON.parse(raw) as UpdateCheckCache;
+  if (
+    typeof parsed.latest !== "string" ||
+    typeof parsed.fetchedAt !== "string"
+  ) {
+    return null;
+  }
+
+  const fetchedAt = Date.parse(parsed.fetchedAt);
+  if (!Number.isFinite(fetchedAt)) {
+    return null;
+  }
+
+  if (now.getTime() - fetchedAt > ttlMs) {
+    return null;
+  }
+
+  return parsed.latest;
+}
+
+/**
+ * Convert current/latest values into the public result shape.
+ * @param current - Installed version
+ * @param latest - Latest version or null
+ * @param reason - Optional non-fatal reason
+ * @returns Normalized update-check result
+ */
+function toResult(
+  current: string,
+  latest: string | null,
+  reason?: string
+): UpdateCheckResult {
+  const isOutdated =
+    typeof latest === "string" &&
+    valid(current) !== null &&
+    valid(latest) !== null &&
+    gt(latest, current);
+
+  return {
+    current,
+    latest,
+    isOutdated,
+    ...(reason ? { reason } : {}),
+  };
+}
+
+/**
+ * Persist the latest-version cache used by later CLI invocations.
+ * @param cachePath - Absolute cache path
+ * @param latest - Latest version or null on failure
+ * @param fetchedAt - Fetch completion timestamp
+ * @param reason - Optional non-fatal reason
+ * @returns Promise that resolves after the cache is written
+ */
+async function writeCache(
+  cachePath: string,
+  latest: string | null,
+  fetchedAt: Date,
+  reason?: string
+): Promise<void> {
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  await writeFile(
+    cachePath,
+    `${JSON.stringify(
+      {
+        latest,
+        fetchedAt: fetchedAt.toISOString(),
+        ...(reason ? { reason } : {}),
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * Check npm for the latest Lisa version without ever failing the caller.
+ * @param opts - Runtime overrides for tests or controlled CLI execution
+ * @returns Update-check result with current/latest/outdated metadata
+ */
+export async function runUpdateCheck(
+  opts: UpdateCheckOptions = {}
+): Promise<UpdateCheckResult> {
+  const current = opts.currentVersion ?? getPackageVersion();
+  const argv = opts.argv ?? process.argv;
+  const env = opts.env ?? getProcessEnv();
+
+  if (isUpdateCheckDisabled(argv, env)) {
+    return toResult(current, null, "skipped");
+  }
+
+  const cachePath = opts.cachePath ?? getDefaultCachePath();
+  const now = opts.now ?? (() => new Date());
+  const ttlMs = opts.ttlMs ?? DEFAULT_CACHE_TTL_MS;
+
+  try {
+    const cached = readCachedLatest(
+      await readFile(cachePath, "utf8"),
+      now(),
+      ttlMs
+    );
+    if (cached) {
+      return toResult(current, cached, "cached");
+    }
+  } catch {
+    // Missing or malformed cache should not prevent a fresh check.
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  );
+
+  try {
+    const response = await (opts.fetchImpl ?? fetch)(NPM_LATEST_URL, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      await writeCache(cachePath, null, now(), `http-${response.status}`);
+      return toResult(current, null, `http-${response.status}`);
+    }
+
+    const body = (await response.json()) as { version?: unknown };
+    if (typeof body.version !== "string" || valid(body.version) === null) {
+      await writeCache(cachePath, null, now(), "invalid-response");
+      return toResult(current, null, "invalid-response");
+    }
+
+    await writeCache(cachePath, body.version, now());
+    return toResult(current, body.version);
+  } catch (error) {
+    const reason =
+      error instanceof Error && error.name === "AbortError"
+        ? "timeout"
+        : "network-error";
+    await writeCache(cachePath, null, now(), reason).catch(() => undefined);
+    return toResult(current, null, reason);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -103,6 +103,10 @@ function readCachedLatest(
     return null;
   }
 
+  if (valid(parsed.latest) === null) {
+    return null;
+  }
+
   const fetchedAt = Date.parse(parsed.fetchedAt);
   if (!Number.isFinite(fetchedAt)) {
     return null;
@@ -215,17 +219,21 @@ export async function runUpdateCheck(
       signal: controller.signal,
     });
     if (!response.ok) {
-      await writeCache(cachePath, null, now(), `http-${response.status}`);
+      await writeCache(cachePath, null, now(), `http-${response.status}`).catch(
+        () => undefined
+      );
       return toResult(current, null, `http-${response.status}`);
     }
 
     const body = (await response.json()) as { version?: unknown };
     if (typeof body.version !== "string" || valid(body.version) === null) {
-      await writeCache(cachePath, null, now(), "invalid-response");
+      await writeCache(cachePath, null, now(), "invalid-response").catch(
+        () => undefined
+      );
       return toResult(current, null, "invalid-response");
     }
 
-    await writeCache(cachePath, body.version, now());
+    await writeCache(cachePath, body.version, now()).catch(() => undefined);
     return toResult(current, body.version);
   } catch (error) {
     const reason =

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const versionCache: { value?: string } = {};
+
+/**
+ * Find the nearest package.json by walking from a compiled/source module path.
+ * @param startDir - Directory to start searching from
+ * @returns Absolute package.json path, or null when no package file exists above
+ */
+function findPackageJson(startDir: string): string | null {
+  const candidate = path.join(startDir, "package.json");
+  if (existsSync(candidate)) {
+    return candidate;
+  }
+
+  const parent = path.dirname(startDir);
+  return parent === startDir ? null : findPackageJson(parent);
+}
+
+/**
+ * Read Lisa's package version from package.json and cache it for this process.
+ * @returns Package version string
+ */
+export function getPackageVersion(): string {
+  if (versionCache.value) {
+    return versionCache.value;
+  }
+
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = findPackageJson(moduleDir);
+  if (!packageJsonPath) {
+    throw new Error("Unable to locate package.json for Lisa CLI version");
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof packageJson.version !== "string" || packageJson.version === "") {
+    throw new Error("package.json is missing a string version field");
+  }
+
+  versionCache.value = packageJson.version;
+  return versionCache.value;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 
 import { createProgram } from "./cli/index.js";
+import { printUpdateWarning } from "./cli/print-update-warning.js";
+import { runUpdateCheck } from "./cli/update-check.js";
 
-const program = createProgram();
-program.parseAsync().catch(error => {
+/**
+ * Run the Lisa CLI entrypoint.
+ * @returns Promise that resolves after Commander completes
+ */
+async function main(): Promise<void> {
+  const updateCheck = await runUpdateCheck();
+  const program = createProgram();
+
+  printUpdateWarning(updateCheck);
+  await program.parseAsync();
+}
+
+main().catch(error => {
   console.error(
     "Error:",
     error instanceof Error ? error.message : String(error)

--- a/tests/unit/cli/update-check.test.ts
+++ b/tests/unit/cli/update-check.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { printUpdateWarning } from "../../../src/cli/print-update-warning.js";
+import { runUpdateCheck } from "../../../src/cli/update-check.js";
+import { getPackageVersion } from "../../../src/cli/version.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Create the temporary directory shared by one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-update-check-"));
+  return tempDir;
+}
+
+/**
+ * Resolve the update-check cache path inside the current test temp directory.
+ * @returns Temporary cache path
+ */
+async function getCachePath(): Promise<string> {
+  return path.join(await getTempDir(), "update-check.json");
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("getPackageVersion", () => {
+  it("reads the package.json version", () => {
+    expect(getPackageVersion()).toBe("2.118.0");
+  });
+});
+
+describe("runUpdateCheck", () => {
+  it("skips the registry when the env opt-out is set", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      runUpdateCheck({
+        cachePath: await getCachePath(),
+        currentVersion: "2.63.2",
+        env: { LISA_SKIP_UPDATE_CHECK: "1" },
+        fetchImpl,
+      })
+    ).resolves.toMatchObject({
+      latest: null,
+      isOutdated: false,
+      reason: "skipped",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("skips the registry when the CLI flag opt-out is set", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await runUpdateCheck({
+      argv: ["node", "dist/index.js", "--no-update-check"],
+      cachePath: await getCachePath(),
+      currentVersion: "2.63.2",
+      env: {},
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("detects a newer npm version and writes the cache", async () => {
+    const cachePath = await getCachePath();
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "2.64.0" }),
+    } as Response);
+
+    await expect(
+      runUpdateCheck({
+        cachePath,
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+        now: () => new Date("2026-05-28T12:00:00.000Z"),
+      })
+    ).resolves.toMatchObject({
+      current: "2.63.2",
+      latest: "2.64.0",
+      isOutdated: true,
+    });
+
+    await expect(readFile(cachePath, "utf8")).resolves.toContain(
+      '"latest": "2.64.0"'
+    );
+  });
+
+  it("reuses a fresh cache instead of querying npm again", async () => {
+    const cachePath = await getCachePath();
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        latest: "2.64.0",
+        fetchedAt: "2026-05-28T11:00:00.000Z",
+      }),
+      "utf8"
+    );
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      runUpdateCheck({
+        cachePath,
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+        now: () => new Date("2026-05-28T12:00:00.000Z"),
+      })
+    ).resolves.toMatchObject({
+      latest: "2.64.0",
+      isOutdated: true,
+      reason: "cached",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns a non-fatal reason when the registry is unreachable", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error("offline"));
+
+    await expect(
+      runUpdateCheck({
+        cachePath: await getCachePath(),
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+      })
+    ).resolves.toMatchObject({
+      latest: null,
+      isOutdated: false,
+      reason: "network-error",
+    });
+  });
+});
+
+describe("printUpdateWarning", () => {
+  it("prints the PRD warning copy only for outdated installs", () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    printUpdateWarning({
+      current: "2.63.2",
+      latest: "2.64.0",
+      isOutdated: true,
+    });
+
+    expect(error).toHaveBeenCalledWith(
+      [
+        "Lisa 2.64.0 is available; you are running 2.63.2.",
+        "Update with: npm install -g @codyswann/lisa@latest",
+        "Continuing with the installed version.",
+      ].join("\n")
+    );
+  });
+});

--- a/tests/unit/cli/update-check.test.ts
+++ b/tests/unit/cli/update-check.test.ts
@@ -6,6 +6,9 @@ import { printUpdateWarning } from "../../../src/cli/print-update-warning.js";
 import { runUpdateCheck } from "../../../src/cli/update-check.js";
 import { getPackageVersion } from "../../../src/cli/version.js";
 
+const NOW_ISO = "2026-05-28T12:00:00.000Z";
+const CACHE_FETCHED_AT = "2026-05-28T11:00:00.000Z";
+
 let tempDir: string | undefined;
 
 /**
@@ -85,7 +88,7 @@ describe("runUpdateCheck", () => {
         currentVersion: "2.63.2",
         env: {},
         fetchImpl,
-        now: () => new Date("2026-05-28T12:00:00.000Z"),
+        now: () => new Date(NOW_ISO),
       })
     ).resolves.toMatchObject({
       current: "2.63.2",
@@ -104,7 +107,7 @@ describe("runUpdateCheck", () => {
       cachePath,
       JSON.stringify({
         latest: "2.64.0",
-        fetchedAt: "2026-05-28T11:00:00.000Z",
+        fetchedAt: CACHE_FETCHED_AT,
       }),
       "utf8"
     );
@@ -116,7 +119,7 @@ describe("runUpdateCheck", () => {
         currentVersion: "2.63.2",
         env: {},
         fetchImpl,
-        now: () => new Date("2026-05-28T12:00:00.000Z"),
+        now: () => new Date(NOW_ISO),
       })
     ).resolves.toMatchObject({
       latest: "2.64.0",
@@ -124,6 +127,78 @@ describe("runUpdateCheck", () => {
       reason: "cached",
     });
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("ignores a cached entry with a non-semver latest and fetches live", async () => {
+    const cachePath = await getCachePath();
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        latest: "not-a-semver",
+        fetchedAt: CACHE_FETCHED_AT,
+      }),
+      "utf8"
+    );
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "2.64.0" }),
+    } as Response);
+
+    await expect(
+      runUpdateCheck({
+        cachePath,
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+        now: () => new Date(NOW_ISO),
+      })
+    ).resolves.toMatchObject({
+      latest: "2.64.0",
+      isOutdated: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("returns the valid version even when writeCache fails on success", async () => {
+    const cachePath = "/dev/null/nonexistent-dir/update-check.json";
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "2.64.0" }),
+    } as Response);
+
+    await expect(
+      runUpdateCheck({
+        cachePath,
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+        now: () => new Date(NOW_ISO),
+      })
+    ).resolves.toMatchObject({
+      latest: "2.64.0",
+      isOutdated: true,
+    });
+  });
+
+  it("returns a non-fatal http reason even when writeCache fails on http error", async () => {
+    const cachePath = "/dev/null/nonexistent-dir/update-check.json";
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    await expect(
+      runUpdateCheck({
+        cachePath,
+        currentVersion: "2.63.2",
+        env: {},
+        fetchImpl,
+        now: () => new Date(NOW_ISO),
+      })
+    ).resolves.toMatchObject({
+      latest: null,
+      reason: "http-503",
+    });
   });
 
   it("returns a non-fatal reason when the registry is unreachable", async () => {


### PR DESCRIPTION
## Summary

- Replace the hardcoded CLI version with package.json-backed version resolution.
- Add a non-fatal npm latest-version check with 6h cache, `LISA_SKIP_UPDATE_CHECK=1`, and `--no-update-check` opt-outs.
- Add focused unit coverage for version lookup, cache reuse, opt-outs, network failure, and warning copy.

Closes #973.

## Evidence

- [cli-build-output] `bun run build` passed.
- [cli-version-output] `node dist/index.js --version` printed `2.118.0`, matching `package.json`.
- [update-check-offline-help] With fetch forced to throw, `node dist/index.js --help` exited `0`, stderr was empty, and stdout began `Usage: lisa [options] [destination]`.
- [update-check-skip-env] With `LISA_SKIP_UPDATE_CHECK=1` and fetch forced to throw if called, help exited `0`, stderr was empty, and no cache file was written.
- [update-check-cache-file] With fetch mocked to return `2.118.0`, `~/.lisa/update-check.json` contained `latest` and `fetchedAt`.
- [update-check-cache-warning] With cached latest `99.0.0`, help printed the PRD warning copy before help output.

Additional checks:

- `bun test tests/unit/cli/update-check.test.ts` passed: 7 tests.
- `bun run typecheck` passed.
- `bun run lint` passed for ESLint; oxlint reported 5 pre-existing `.agents/skills/harness-parity-council` warnings, no errors.
- Pre-push hook passed: security audit, slow lint, knip, full unit coverage (`146` files, `2505` tests), and integration tests (`2` files, `47` tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic update checking that notifies users when a newer version is available
  * Option to disable checks via a new CLI flag or LISA_SKIP_UPDATE_CHECK env var
  * CLI now reports its actual packaged version in help/output

* **Tests**
  * Added comprehensive unit tests covering update-check behavior and warning output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->