### PR TITLE
feat(parity): wave 3b — emit plugin-bundled Codex hooks (Wave 1 Action 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,6 +61,24 @@
       "source": "./plugins/lisa-openclaw",
       "description": "Connect staff to Telegram or Slack via OpenClaw — facilitator/specialist routing and repo-coding topics (Claude + Codex)",
       "category": "productivity"
+    },
+    {
+      "name": "lisa-cursor",
+      "source": "./plugins/lisa-cursor",
+      "description": "Cursor (cursor-agent) variant — skills and agents consumed via Cursor's native .claude-plugin loader",
+      "category": "productivity"
+    },
+    {
+      "name": "lisa-agy",
+      "source": "./plugins/lisa-agy",
+      "description": "Antigravity (agy) variant — bare-manifest plugin with skills and agents; rules baked into AGENTS.md since agy plugin hooks don't fire",
+      "category": "productivity"
+    },
+    {
+      "name": "lisa-copilot",
+      "source": "./plugins/lisa-copilot",
+      "description": "GitHub Copilot variant — agents emitted as <name>.agent.md with camelCase hook events",
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
@@ -1,24 +1,26 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    }
-  ],
-  "SubagentStart": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
@@ -1,0 +1,24 @@
+{
+  "SessionStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    }
+  ],
+  "SubagentStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lisa-harper-fabric/.codex-plugin/hooks/inject-rules.sh
+++ b/plugins/lisa-harper-fabric/.codex-plugin/hooks/inject-rules.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Reads all .md files from the plugin's rules/ directory and injects them
+# into Claude context at session/subagent start.
+set -euo pipefail
+
+ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+RULES_DIR="$ROOT/rules"
+
+[ -d "$RULES_DIR" ] || exit 0
+
+for rule in "$RULES_DIR"/*.md; do
+  [ -f "$rule" ] || continue
+  printf '\n<lisa-harper-fabric-rule path="%s">\n' "$rule"
+  cat "$rule"
+  printf '\n</lisa-harper-fabric-rule>\n'
+done

--- a/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
@@ -15,6 +15,7 @@
     "lisa-typescript"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Lisa Harper/Fabric",
     "shortDescription": "Harper/Fabric workflow guidance",

--- a/plugins/lisa-nestjs/.codex-plugin/hooks.json
+++ b/plugins/lisa-nestjs/.codex-plugin/hooks.json
@@ -1,13 +1,15 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/block-migration-edits.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/block-migration-edits.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/lisa-nestjs/.codex-plugin/hooks.json
+++ b/plugins/lisa-nestjs/.codex-plugin/hooks.json
@@ -1,0 +1,13 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/block-migration-edits.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lisa-nestjs/.codex-plugin/hooks/block-migration-edits.sh
+++ b/plugins/lisa-nestjs/.codex-plugin/hooks/block-migration-edits.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+# PreToolUse hook: block Write/Edit on TypeORM migration files.
+# NestJS projects must use `bun run migration:generate` to create migrations
+# from entity diffs. Hand-written migrations drift from entity metadata and
+# break the schema/migration contract.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+
+JSON_INPUT=$(cat)
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "⚠ block-migration-edits: jq not available, allowing edit" >&2
+  exit 0
+fi
+
+FILE_PATH=$(echo "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+case "$FILE_PATH" in
+  */migrations/*.ts|*/migrations/*.js)
+    cat >&2 <<EOF
+❌ Blocked: Direct edits to TypeORM migration files are not allowed.
+
+File: $FILE_PATH
+
+Entity files (src/database/entities/*.ts) are the single source of
+truth for the database schema in this project. Migrations are a derived
+artifact — generate them from entity diffs:
+
+  1. Edit the entity to express the desired schema.
+  2. Run: bun run migration:generate --name=<DescriptiveName>
+  3. Review the generated migration; commit entity + migration together.
+
+If a schema change cannot be expressed via the entity model, the entity
+model is wrong — fix the entity, do not hand-write the migration.
+
+OUT-OF-BAND MIGRATIONS (seed data, backfills, data transformations,
+one-off cleanup): these genuinely cannot come from entity diffs. They
+are legitimate but they bypass the entity-as-source-of-truth contract.
+
+If you believe this edit is an out-of-band migration:
+  1. STOP and tell the user what change is needed and why it cannot
+     be expressed via the entity model.
+  2. Get explicit approval before proceeding.
+  3. Document the rationale in the migration's class comment.
+
+Do NOT silently hand-write a migration. See the nestjs-rules skill
+for the full rationale.
+EOF
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-nestjs/.codex-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.codex-plugin/plugin.json
@@ -15,6 +15,7 @@
     "lisa-typescript"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Lisa NestJS",
     "shortDescription": "NestJS workflow guidance",

--- a/plugins/lisa-rails/.codex-plugin/hooks.json
+++ b/plugins/lisa-rails/.codex-plugin/hooks.json
@@ -1,0 +1,39 @@
+{
+  "SessionStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    }
+  ],
+  "SubagentStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/rubocop-on-edit.sh"
+        },
+        {
+          "type": "command",
+          "command": "./hooks/sg-scan-on-edit.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lisa-rails/.codex-plugin/hooks.json
+++ b/plugins/lisa-rails/.codex-plugin/hooks.json
@@ -1,39 +1,41 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    }
-  ],
-  "SubagentStart": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/rubocop-on-edit.sh"
-        },
-        {
-          "type": "command",
-          "command": "./hooks/sg-scan-on-edit.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/rubocop-on-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "./hooks/sg-scan-on-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/lisa-rails/.codex-plugin/hooks/inject-rules.sh
+++ b/plugins/lisa-rails/.codex-plugin/hooks/inject-rules.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Reads all .md files from the plugin's rules/ directory and injects them
+# into the session context via additionalContext.
+# Used by SessionStart and SubagentStart hooks.
+set -euo pipefail
+
+RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules"
+
+# Bail silently if no rules directory
+[ -d "$RULES_DIR" ] || exit 0
+
+CONTEXT=""
+for file in "$RULES_DIR"/*.md; do
+  [ -f "$file" ] || continue
+  CONTEXT+="$(cat "$file")"$'\n\n'
+done
+
+# Bail if no rules found
+[ -n "$CONTEXT" ] || exit 0
+
+# Output as JSON — jq handles escaping
+jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'

--- a/plugins/lisa-rails/.codex-plugin/hooks/rubocop-on-edit.sh
+++ b/plugins/lisa-rails/.codex-plugin/hooks/rubocop-on-edit.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# RuboCop Lint-and-Format-on-Edit Hook (PostToolUse - Write|Edit)
+# =============================================================================
+# Runs RuboCop -a (safe autocorrect) on each edited Ruby file, then checks for
+# remaining unfixable errors. RuboCop serves as both formatter and linter
+# for Ruby, so this single hook replaces the Prettier + ESLint pipeline.
+#
+# Behavior:
+#   - Exit 0: RuboCop passes or auto-fix resolved all errors
+#   - Exit 1: unfixable errors remain — blocks Claude so it fixes them immediately
+#
+# @see .claude/rules/verification.md "Self-Correction Loop" section
+# =============================================================================
+
+# Extract file path from JSON input
+FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Check if file type is supported (Ruby only)
+case "${FILE_PATH##*.}" in
+    rb) ;;
+    *) exit 0 ;;
+esac
+
+# Validate project directory
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    exit 0
+fi
+
+# Check if file is in a recognized source directory, excluding generated/vendored paths
+RELATIVE_PATH="${FILE_PATH#$CLAUDE_PROJECT_DIR/}"
+case "$RELATIVE_PATH" in
+    db/migrate/*|db/schema.rb) exit 0 ;;
+    vendor/*|bin/*|tmp/*|node_modules/*) exit 0 ;;
+esac
+case "$RELATIVE_PATH" in
+    app/*|lib/*|spec/*|config/*|db/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Verify this is a Ruby project with Bundler
+if [ ! -f "Gemfile" ]; then
+    exit 0
+fi
+
+# Run RuboCop autocorrect — fail only on errors (not warnings/conventions)
+echo "Running RuboCop on: $FILE_PATH"
+
+# First pass: attempt safe auto-correct
+OUTPUT=$(bundle exec rubocop -a --fail-level E "$FILE_PATH" 2>&1)
+FIX_EXIT=$?
+
+if [ $FIX_EXIT -eq 0 ]; then
+    echo "RuboCop: No errors in $(basename "$FILE_PATH")"
+    exit 0
+fi
+
+# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
+OUTPUT=$(bundle exec rubocop --fail-level E "$FILE_PATH" 2>&1)
+LINT_EXIT=$?
+
+if [ $LINT_EXIT -eq 0 ]; then
+    echo "RuboCop: Auto-fixed all errors in $(basename "$FILE_PATH")"
+    exit 0
+fi
+
+# Unfixable errors remain — block with feedback
+echo "RuboCop found unfixable errors in: $FILE_PATH" >&2
+echo "$OUTPUT" >&2
+exit 1

--- a/plugins/lisa-rails/.codex-plugin/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-rails/.codex-plugin/hooks/sg-scan-on-edit.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# ast-grep Scan-on-Edit Hook (PostToolUse - Write|Edit)
+# =============================================================================
+# Runs ast-grep scan on each edited Ruby file to enforce structural code rules.
+# Complements RuboCop by catching patterns that require AST-level analysis.
+#
+# Behavior:
+#   - Exit 0: no issues found or ast-grep not configured
+#   - Exit 1: issues found — blocks Claude so it fixes them immediately
+#
+# @see .claude/rules/verification.md "Self-Correction Loop" section
+# =============================================================================
+
+# Extract file path from JSON input
+FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Check if file type is supported (Ruby only)
+case "${FILE_PATH##*.}" in
+    rb) ;;
+    *) exit 0 ;;
+esac
+
+# Validate project directory
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    exit 0
+fi
+
+# Check if file is in a recognized source directory
+RELATIVE_PATH="${FILE_PATH#$CLAUDE_PROJECT_DIR/}"
+case "$RELATIVE_PATH" in
+    app/*|lib/*|config/*|spec/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Verify ast-grep configuration exists
+if [ ! -f "sgconfig.yml" ]; then
+    exit 0
+fi
+
+# Verify rules are defined
+RULE_COUNT=$(find ast-grep/rules -name "*.yml" -o -name "*.yaml" 2>/dev/null | grep -v ".gitkeep" | wc -l | tr -d ' ')
+if [ "$RULE_COUNT" -eq 0 ]; then
+    exit 0
+fi
+
+# Locate ast-grep binary — prefer local sg, then npx fallback
+if command -v sg >/dev/null 2>&1; then
+    SG_CMD="sg"
+elif command -v npx >/dev/null 2>&1; then
+    SG_CMD="npx @ast-grep/cli"
+else
+    echo "ast-grep: sg binary not found, skipping scan"
+    exit 0
+fi
+
+# Run ast-grep scan
+echo "Running ast-grep scan on: $FILE_PATH"
+if OUTPUT=$($SG_CMD scan "$FILE_PATH" 2>&1); then
+    echo "ast-grep: No issues found in $(basename "$FILE_PATH")"
+    exit 0
+else
+    echo "ast-grep found issues in: $FILE_PATH" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi

--- a/plugins/lisa-rails/.codex-plugin/plugin.json
+++ b/plugins/lisa-rails/.codex-plugin/plugin.json
@@ -15,6 +15,7 @@
     "lisa"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Lisa Rails",
     "shortDescription": "Ruby on Rails workflows",

--- a/plugins/lisa-typescript/.codex-plugin/hooks.json
+++ b/plugins/lisa-typescript/.codex-plugin/hooks.json
@@ -1,32 +1,34 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/block-suppress-directives.sh"
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Write|Edit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/format-on-edit.sh"
-        },
-        {
-          "type": "command",
-          "command": "./hooks/sg-scan-on-edit.sh"
-        },
-        {
-          "type": "command",
-          "command": "./hooks/lint-on-edit.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/block-suppress-directives.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/format-on-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "./hooks/sg-scan-on-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "./hooks/lint-on-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/lisa-typescript/.codex-plugin/hooks.json
+++ b/plugins/lisa-typescript/.codex-plugin/hooks.json
@@ -1,0 +1,32 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/block-suppress-directives.sh"
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/format-on-edit.sh"
+        },
+        {
+          "type": "command",
+          "command": "./hooks/sg-scan-on-edit.sh"
+        },
+        {
+          "type": "command",
+          "command": "./hooks/lint-on-edit.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lisa-typescript/.codex-plugin/hooks/block-suppress-directives.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/block-suppress-directives.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# PreToolUse hook (Write|Edit): block adding error-suppression directives to
+# JS/TS source. Suppressing the type checker, linter, or formatter hides real
+# defects instead of fixing them, so it is a documented last resort (see the
+# base "ASK FIRST" governance rule). The agent should stop and get the user's
+# approval rather than slip a suppression past silently.
+#
+# Inspects only the NEW text the tool introduces, scoped to JS/TS files, and
+# matches the directive only in comment syntax (// or /*) so prose, strings,
+# and identifiers that merely mention these tokens are not flagged.
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+
+JSON_INPUT=$(cat)
+
+# Project rule (.claude/rules/PROJECT_RULES.md): never parse JSON in shell with
+# grep/sed/cut/awk — always use jq. Fail open without jq so we never hard-block
+# the agent on missing tooling.
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+# Only guard JS/TS source. Directives in other file types (docs, configs that
+# document the rules, this script) are not suppressions.
+case "${FILE_PATH##*.}" in
+  ts | tsx | js | jsx | mjs | cjs) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve the new text per tool shape:
+#   Write     -> tool_input.content
+#   MultiEdit -> tool_input.edits[].new_string
+#   Edit      -> tool_input.new_string
+NEW_TEXT=$(printf '%s' "$JSON_INPUT" | jq -r '
+  .tool_input as $i
+  | if   ($i.content     // null) != null then $i.content
+    elif ($i.edits       // null) != null then ([$i.edits[].new_string] | join("\n"))
+    elif ($i.new_string  // null) != null then $i.new_string
+    else "" end')
+
+# Comment-syntax-only match: a // or /* opener, optional whitespace, then the
+# suppression directive. @ts-expect-error is intentionally NOT matched — it is
+# the safer alternative this hook steers toward.
+DIRECTIVE_RE='(//|/\*)[[:space:]]*(@ts-(ignore|nocheck)|eslint-disable|biome-ignore|prettier-ignore)'
+
+if printf '%s' "$NEW_TEXT" | grep -Eq "$DIRECTIVE_RE"; then
+  cat >&2 <<MSG
+❌ Blocked: error-suppression directive in $FILE_PATH
+
+You are adding a @ts-ignore / @ts-nocheck / eslint-disable / biome-ignore /
+prettier-ignore comment. These silence the type checker, linter, or formatter
+instead of fixing the underlying problem. They are a last resort, not a default.
+
+Fix it properly first:
+  - Resolve the actual type/lint error rather than suppressing it.
+  - Add the missing annotation, narrow the type, or restructure the code so the
+    rule passes legitimately.
+  - For a faulty dependency type, prefer a typed wrapper or module augmentation.
+
+If — and only if — there is genuinely no other way (e.g. a known upstream bug):
+  - STOP and get the user's approval before suppressing (base "ASK FIRST" rule).
+  - Prefer @ts-expect-error over @ts-ignore (it fails once the error is gone).
+  - Scope the disable to one line and one rule, never a whole file.
+  - Include a "-- <reason>" description (eslint-comments/require-description).
+MSG
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa-typescript/.codex-plugin/hooks/format-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/format-on-edit.sh
@@ -9,9 +9,11 @@
 # Read the JSON input from stdin
 JSON_INPUT=$(cat)
 
-# Extract the file path from the tool_input
-# The Edit tool input contains a "file_path" field in the tool_input object
-FILE_PATH=$(echo "$JSON_INPUT" | grep -o '"tool_input":{[^}]*"file_path":"[^"]*"' | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+# Extract the file path from the tool_input. Use jq for robust JSON parsing
+# (never grep/sed/cut — a JSON shape change silently skips formatting). Fail
+# open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Check if we successfully extracted a file path
 if [ -z "$FILE_PATH" ]; then

--- a/plugins/lisa-typescript/.codex-plugin/hooks/format-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/format-on-edit.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+# Hook script to format files with Prettier after Claude edits them
+# This script receives JSON input via stdin with tool information
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+
+# Read the JSON input from stdin
+JSON_INPUT=$(cat)
+
+# Extract the file path from the tool_input
+# The Edit tool input contains a "file_path" field in the tool_input object
+FILE_PATH=$(echo "$JSON_INPUT" | grep -o '"tool_input":{[^}]*"file_path":"[^"]*"' | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+
+# Check if we successfully extracted a file path
+if [ -z "$FILE_PATH" ]; then
+    echo "⚠ Skipping Prettier: Could not extract file path from Edit tool input" >&2
+    exit 0  # Exit gracefully to not interrupt Claude's workflow
+fi
+
+# Check if the file exists
+if [ ! -f "$FILE_PATH" ]; then
+    echo "⚠ Skipping Prettier: File does not exist: $FILE_PATH" >&2
+    exit 0  # Exit gracefully
+fi
+
+# Get the file extension
+FILE_EXT="${FILE_PATH##*.}"
+
+# Check if this is a TypeScript or JavaScript file that should be formatted
+# Based on package.json format command: "prettier --write \"src/**/*.ts\" \"test/**/*.ts\""
+case "$FILE_EXT" in
+    ts|tsx|js|jsx|json)
+        # File type is supported for formatting
+        ;;
+    *)
+        echo "ℹ Skipping Prettier: File type .$FILE_EXT is not configured for auto-formatting"
+        exit 0
+        ;;
+esac
+
+# Change to the project directory to ensure package manager commands work
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Resolve Prettier binary — prefer local node_modules/.bin, then package-manager exec
+if [ -x "./node_modules/.bin/prettier" ]; then
+    PRETTIER_CMD="./node_modules/.bin/prettier"
+    PKG_MANAGER="npm"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    PRETTIER_CMD="bunx prettier"
+    PKG_MANAGER="bun"
+elif [ -f "pnpm-lock.yaml" ]; then
+    PRETTIER_CMD="pnpm exec prettier"
+    PKG_MANAGER="pnpm"
+elif [ -f "yarn.lock" ]; then
+    PRETTIER_CMD="yarn exec prettier"
+    PKG_MANAGER="yarn"
+else
+    PRETTIER_CMD="npx prettier"
+    PKG_MANAGER="npm"
+fi
+
+# Run Prettier on the specific file
+echo "🎨 Running Prettier on: $FILE_PATH"
+$PRETTIER_CMD --write "$FILE_PATH" 2>&1 | grep -v "run v" | grep -v "Done in"
+
+# Check the exit status
+if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo "✓ Successfully formatted: $(basename "$FILE_PATH")"
+else
+    echo "⚠ Prettier formatting failed for: $FILE_PATH" >&2
+    echo "  You may need to run '$PKG_MANAGER run format' manually to fix formatting issues." >&2
+fi
+
+# Always exit successfully to not interrupt Claude's workflow
+exit 0

--- a/plugins/lisa-typescript/.codex-plugin/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/lint-on-edit.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# Lint-on-Edit Hook (PostToolUse - Write|Edit)
+# =============================================================================
+# Runs oxlint --fix, then ESLint --fix --quiet --cache on each edited
+# TypeScript file. Part of the inline self-correction pipeline:
+#   prettier → ast-grep → oxlint --fix → eslint --fix
+#
+# oxlint runs first because it's a Rust-native linter (~1000x faster) that
+# covers the majority of rules, leaving only the slow / type-aware / plugin
+# rules for ESLint to handle.
+#
+# Behavior:
+#   - Exit 0: lint passes or auto-fix resolved all errors
+#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
+#
+# @see .claude/rules/verfication.md "Self-Correction Loop" section
+# =============================================================================
+
+# Extract file path from JSON input
+FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Check if file type is supported (TypeScript only)
+case "${FILE_PATH##*.}" in
+    ts|tsx) ;;
+    *) exit 0 ;;
+esac
+
+# Validate project directory
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    exit 0
+fi
+
+# Check if file is in a source directory
+RELATIVE_PATH="${FILE_PATH#$CLAUDE_PROJECT_DIR/}"
+case "$RELATIVE_PATH" in
+    src/*|apps/*|libs/*|test/*|tests/*|features/*|components/*|hooks/*|screens/*|app/*|constants/*|utils/*|providers/*|stores/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Resolve oxlint and ESLint binaries — prefer local node_modules/.bin
+if [ -x "./node_modules/.bin/oxlint" ]; then
+    OXLINT_CMD="./node_modules/.bin/oxlint"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    OXLINT_CMD="bunx oxlint"
+elif [ -f "pnpm-lock.yaml" ]; then
+    OXLINT_CMD="pnpm exec oxlint"
+elif [ -f "yarn.lock" ]; then
+    OXLINT_CMD="yarn exec oxlint"
+else
+    OXLINT_CMD="npx oxlint"
+fi
+
+if [ -x "./node_modules/.bin/eslint" ]; then
+    ESLINT_CMD="./node_modules/.bin/eslint"
+elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    ESLINT_CMD="bunx eslint"
+elif [ -f "pnpm-lock.yaml" ]; then
+    ESLINT_CMD="pnpm exec eslint"
+elif [ -f "yarn.lock" ]; then
+    ESLINT_CMD="yarn exec eslint"
+else
+    ESLINT_CMD="npx eslint"
+fi
+
+# 1) oxlint --fix (REQUIRED in the Phase 2 hybrid pipeline)
+# If oxlint is missing the project is out of sync with the current Lisa
+# governance — fail loudly rather than silently skipping. ESLint alone is
+# no longer a complete lint pass.
+if [ ! -x "./node_modules/.bin/oxlint" ] && ! command -v "${OXLINT_CMD%% *}" >/dev/null 2>&1; then
+    echo "oxlint is required but not installed in this project." >&2
+    echo "Add 'oxlint' as a devDependency (Lisa governance pins it via package.lisa.json) and run install." >&2
+    exit 2
+fi
+
+if [ ! -f ".oxlintrc.json" ] && [ ! -f ".oxlintrc.jsonc" ] && [ ! -f "oxlint.config.ts" ]; then
+    echo "oxlint is installed but no .oxlintrc.json found. Run 'lisa update' to install the stack template." >&2
+    exit 2
+fi
+
+echo "Running oxlint --fix on: $FILE_PATH"
+OX_OUTPUT=$($OXLINT_CMD --fix --quiet "$FILE_PATH" 2>&1)
+OX_EXIT=$?
+if [ $OX_EXIT -ne 0 ]; then
+    # Re-run without --fix to capture remaining errors
+    OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
+    OX_EXIT=$?
+    if [ $OX_EXIT -ne 0 ]; then
+        echo "oxlint found unfixable errors in: $FILE_PATH" >&2
+        echo "$OX_OUTPUT" >&2
+        exit 2
+    fi
+fi
+
+# 2) ESLint --fix --quiet --cache
+# --quiet: suppress warnings, only show errors
+# --cache: use ESLint cache for performance
+# --rule: disable no-unused-vars auto-fix to prevent removing imports that Claude
+#         plans to use in a subsequent edit (pre-commit hook still catches them)
+echo "Running ESLint --fix on: $FILE_PATH"
+
+# First pass: attempt auto-fix
+OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
+FIX_EXIT=$?
+
+if [ $FIX_EXIT -eq 0 ]; then
+    echo "ESLint: No errors in $(basename "$FILE_PATH")"
+    exit 0
+fi
+
+# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
+OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
+LINT_EXIT=$?
+
+if [ $LINT_EXIT -eq 0 ]; then
+    echo "ESLint: Auto-fixed all errors in $(basename "$FILE_PATH")"
+    exit 0
+fi
+
+# Unfixable errors remain — block with feedback
+echo "ESLint found unfixable errors in: $FILE_PATH" >&2
+echo "$OUTPUT" >&2
+exit 2

--- a/plugins/lisa-typescript/.codex-plugin/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/lint-on-edit.sh
@@ -19,8 +19,11 @@
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would silently skip the blocking lint gate).
+# Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/plugins/lisa-typescript/.codex-plugin/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/sg-scan-on-edit.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+# Hook script to run ast-grep scan after Claude edits files
+# This script receives JSON input via stdin with tool information
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Note: This hook is BLOCKING - it returns non-zero exit codes so Claude must fix issues
+
+# Extract file path from JSON input
+FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Check if file type is supported (TypeScript, JavaScript)
+case "${FILE_PATH##*.}" in
+    ts|tsx|js|jsx|mjs|cjs) ;;
+    *) exit 0 ;;
+esac
+
+# Validate project directory
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+    exit 0
+fi
+
+# Check if file is in a source directory
+RELATIVE_PATH="${FILE_PATH#$CLAUDE_PROJECT_DIR/}"
+case "$RELATIVE_PATH" in
+    src/*|apps/*|libs/*|test/*|tests/*|features/*|components/*|hooks/*|screens/*|app/*|constants/*|utils/*|providers/*|stores/*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Verify ast-grep configuration exists
+if [ ! -f "sgconfig.yml" ]; then
+    exit 0
+fi
+
+# Verify rules are defined
+RULE_COUNT=$(find ast-grep/rules -name "*.yml" -o -name "*.yaml" 2>/dev/null | grep -v ".gitkeep" | wc -l | tr -d ' ')
+if [ "$RULE_COUNT" -eq 0 ]; then
+    exit 0
+fi
+
+# Detect package manager
+if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+    PKG_MANAGER="bun"
+elif [ -f "pnpm-lock.yaml" ]; then
+    PKG_MANAGER="pnpm"
+elif [ -f "yarn.lock" ]; then
+    PKG_MANAGER="yarn"
+else
+    PKG_MANAGER="npm"
+fi
+
+# Run ast-grep scan
+echo "Running ast-grep scan on: $FILE_PATH"
+if OUTPUT=$($PKG_MANAGER run sg:scan "$FILE_PATH" 2>&1); then
+    echo "ast-grep: No issues found in $(basename "$FILE_PATH")"
+    exit 0
+else
+    echo "ast-grep found issues in: $FILE_PATH" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi

--- a/plugins/lisa-typescript/.codex-plugin/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript/.codex-plugin/hooks/sg-scan-on-edit.sh
@@ -7,8 +7,11 @@
 # Reference: https://docs.claude.com/en/docs/claude-code/hooks
 # Note: This hook is BLOCKING - it returns non-zero exit codes so Claude must fix issues
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would turn this blocking scan into a silent
+# no-op). Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/plugins/lisa-typescript/.codex-plugin/plugin.json
+++ b/plugins/lisa-typescript/.codex-plugin/plugin.json
@@ -14,6 +14,7 @@
   "dependencies": [
     "lisa"
   ],
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Lisa TypeScript",
     "shortDescription": "TypeScript lifecycle checks",

--- a/plugins/lisa-typescript/hooks/format-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/format-on-edit.sh
@@ -9,9 +9,11 @@
 # Read the JSON input from stdin
 JSON_INPUT=$(cat)
 
-# Extract the file path from the tool_input
-# The Edit tool input contains a "file_path" field in the tool_input object
-FILE_PATH=$(echo "$JSON_INPUT" | grep -o '"tool_input":{[^}]*"file_path":"[^"]*"' | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+# Extract the file path from the tool_input. Use jq for robust JSON parsing
+# (never grep/sed/cut — a JSON shape change silently skips formatting). Fail
+# open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Check if we successfully extracted a file path
 if [ -z "$FILE_PATH" ]; then

--- a/plugins/lisa-typescript/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/lint-on-edit.sh
@@ -19,8 +19,11 @@
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would silently skip the blocking lint gate).
+# Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/plugins/lisa-typescript/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/sg-scan-on-edit.sh
@@ -7,8 +7,11 @@
 # Reference: https://docs.claude.com/en/docs/claude-code/hooks
 # Note: This hook is BLOCKING - it returns non-zero exit codes so Claude must fix issues
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would turn this blocking scan into a silent
+# no-op). Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -1,73 +1,75 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/block-no-verify.sh"
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/notify-ntfy.sh"
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "matcher": "startup",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/install-pkgs.sh"
-        }
-      ]
-    },
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    },
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/setup-jira-cli.sh"
-        }
-      ]
-    }
-  ],
-  "SubagentStart": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-rules.sh"
-        }
-      ]
-    },
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "./hooks/inject-flow-context.sh"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/block-no-verify.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/notify-ntfy.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/install-pkgs.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/setup-jira-cli.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-rules.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/inject-flow-context.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -1,0 +1,73 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/block-no-verify.sh"
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/notify-ntfy.sh"
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "matcher": "startup",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/install-pkgs.sh"
+        }
+      ]
+    },
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    },
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/setup-jira-cli.sh"
+        }
+      ]
+    }
+  ],
+  "SubagentStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-rules.sh"
+        }
+      ]
+    },
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "./hooks/inject-flow-context.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lisa/.codex-plugin/hooks/block-no-verify.sh
+++ b/plugins/lisa/.codex-plugin/hooks/block-no-verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks any command containing --no-verify.
+# --no-verify on git commit/push (and equivalents) bypasses pre-commit/pre-push
+# hooks that exist for a reason. The fix is to address the underlying issue,
+# not silence the check. See feedback_never_no_verify in user memory.
+#
+# Word-boundary match avoids false positives on flags like --no-verify-ssl,
+# --no-verify-host, etc.
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Match --no-verify bounded by non-token characters (not alphanumeric, _, or -).
+# This catches all syntactic positions including subshells (e.g. `(git commit --no-verify)`)
+# while excluding longer flags like --no-verify-ssl, --no-verify-host, etc.
+if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])'; then
+  cat >&2 <<'EOF'
+Blocked: --no-verify bypasses pre-commit/pre-push hooks. Fix the underlying
+issue (lint error, failing test, formatting) or ask the user before bypassing.
+
+If the user has explicitly authorized the bypass for this specific command,
+re-run after they confirm.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa/.codex-plugin/hooks/inject-flow-context.sh
+++ b/plugins/lisa/.codex-plugin/hooks/inject-flow-context.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Tells subagents not to ask users for flow selection.
+# The parent agent has already determined the flow and work type.
+# Used by SubagentStart hook.
+set -euo pipefail
+
+jq -n '{
+  "hookSpecificOutput": {
+    "hookEventName": "SubagentStart",
+    "additionalContext": "You are a subagent operating within an established flow. Your parent agent has already determined the flow and work type. Do NOT ask the user to choose a flow or classify the request. Execute your assigned work within the context provided by your parent agent."
+  }
+}'

--- a/plugins/lisa/.codex-plugin/hooks/inject-rules.sh
+++ b/plugins/lisa/.codex-plugin/hooks/inject-rules.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Reads all .md files from the plugin's rules/eager/ directory and injects them
+# into the session context via additionalContext.
+# Used by SessionStart and SubagentStart hooks.
+#
+# The split between eager and reference rules is documented in
+# rules/eager/00-bootstrap.md (or the equivalent README). Reference bodies
+# under rules/reference/ are installed alongside but loaded only when the
+# eager breadcrumb points to them.
+set -euo pipefail
+
+RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules/eager"
+
+# Backward compatibility: if the eager subdir is absent (older Lisa install),
+# fall back to the flat rules/ directory so a partial upgrade still ships rules.
+if [ ! -d "$RULES_DIR" ]; then
+  RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules"
+fi
+
+# Bail silently if no rules directory at all
+[ -d "$RULES_DIR" ] || exit 0
+
+CONTEXT=""
+for file in "$RULES_DIR"/*.md; do
+  [ -f "$file" ] || continue
+  CONTEXT+="$(cat "$file")"$'\n\n'
+done
+
+# Bail if no rules found
+[ -n "$CONTEXT" ] || exit 0
+
+# Output as JSON — jq handles escaping
+jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'

--- a/plugins/lisa/.codex-plugin/hooks/install-pkgs.sh
+++ b/plugins/lisa/.codex-plugin/hooks/install-pkgs.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+# Only run package installation when node_modules are missing.
+# This covers remote environments, new worktrees, fresh clones, and CI.
+if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+# Detect package manager based on lock file presence
+if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
+  bun install
+elif [ -f "pnpm-lock.yaml" ]; then
+  pnpm install
+elif [ -f "yarn.lock" ]; then
+  yarn install
+elif [ -f "package-lock.json" ]; then
+  npm install
+else
+  npm install
+fi
+
+# The tools below use Linux-specific binaries and paths — skip on other platforms.
+if [ "$(uname -s)" != "Linux" ]; then
+  exit 0
+fi
+
+# Install Gitleaks for secret detection (pre-commit hook)
+echo "Installing Gitleaks for secret detection..."
+GITLEAKS_VERSION="8.18.4"
+curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
+echo "Gitleaks installed: $(gitleaks version)"
+
+# Install jira-cli for JIRA integration
+# The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
+# so we extract to a temp dir and copy the binary out.
+echo "Installing jira-cli for JIRA integration..."
+JIRA_CLI_VERSION="1.7.0"
+JIRA_TMPDIR=$(mktemp -d)
+curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
+  | tar -xz -C "${JIRA_TMPDIR}"
+cp "${JIRA_TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
+chmod +x /usr/local/bin/jira
+rm -rf "${JIRA_TMPDIR}"
+echo "jira-cli installed: $(jira version)"
+
+# Install Chromium for Lighthouse CI (pre-push hook)
+# Playwright's bundled Chromium works with @lhci/cli
+echo "Installing Chromium for Lighthouse CI..."
+npx playwright install chromium
+
+# Find and export CHROME_PATH for Lighthouse CI
+# Use sort to ensure deterministic selection of the latest version
+CHROME_PATH=$(find ~/.cache/ms-playwright -name "chrome" -type f 2>/dev/null | grep "chrome-linux" | sort | tail -n 1)
+if [ -n "$CHROME_PATH" ]; then
+  # Append to ~/.bashrc for shell sessions (idempotent)
+  if ! grep -q "export CHROME_PATH=" ~/.bashrc 2>/dev/null; then
+    echo "export CHROME_PATH=\"$CHROME_PATH\"" >> ~/.bashrc
+  else
+    # Update existing CHROME_PATH in bashrc
+    sed -i "s|^export CHROME_PATH=.*|export CHROME_PATH=\"$CHROME_PATH\"|" ~/.bashrc
+  fi
+
+  export CHROME_PATH="$CHROME_PATH"
+  echo "Chromium installed at: $CHROME_PATH"
+fi
+
+exit 0

--- a/plugins/lisa/.codex-plugin/hooks/notify-ntfy.sh
+++ b/plugins/lisa/.codex-plugin/hooks/notify-ntfy.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# ntfy.sh Notification Hook for Claude Code
+# =============================================================================
+# Sends desktop and mobile notifications via ntfy.sh when Claude needs
+# attention or finishes a task.
+#
+# Setup:
+#   1. Install ntfy app on mobile (iOS App Store / Android Play Store)
+#   2. Subscribe to your unique topic in the app
+#   3. Set NTFY_TOPIC environment variable (e.g., in ~/.bashrc or ~/.zshrc):
+#      export NTFY_TOPIC="my-claude-alerts-xyz123"
+#
+# @see https://ntfy.sh
+# =============================================================================
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract hook event name
+HOOK_EVENT=$(echo "$INPUT" | grep -o '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Extract notification type (for Notification hooks)
+NOTIFICATION_TYPE=$(echo "$INPUT" | grep -o '"notification_type"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Extract message if available
+MESSAGE=$(echo "$INPUT" | grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Extract session ID (first 8 chars for brevity)
+FULL_SESSION_ID=$(echo "$INPUT" | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+SESSION_ID="${FULL_SESSION_ID:0:8}"
+
+# Extract transcript path for task summary
+TRANSCRIPT_PATH=$(echo "$INPUT" | grep -o '"transcript_path"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"//' | sed 's/"$//')
+
+# Determine source (Web vs Local)
+if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
+    SOURCE="Web"
+else
+    SOURCE="Local"
+fi
+
+# Get project name from current directory
+PROJECT_NAME=$(basename "$CLAUDE_PROJECT_DIR" 2>/dev/null || basename "$(pwd)")
+
+# Load NTFY_TOPIC from local config if not already set
+if [ -z "$NTFY_TOPIC" ]; then
+    # Check for project-local config (gitignored)
+    if [ -f "$CLAUDE_PROJECT_DIR/.claude/env.local" ]; then
+        # shellcheck source=/dev/null
+        source "$CLAUDE_PROJECT_DIR/.claude/env.local"
+    fi
+    # Check for user-global config
+    if [ -z "$NTFY_TOPIC" ] && [ -f "$HOME/.claude/env.local" ]; then
+        # shellcheck source=/dev/null
+        source "$HOME/.claude/env.local"
+    fi
+fi
+
+# Exit silently if still not configured
+if [ -z "$NTFY_TOPIC" ]; then
+    exit 0
+fi
+
+# Extract task summary from transcript (last assistant message, truncated)
+TASK_SUMMARY=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    # Get the last assistant message from the JSONL transcript
+    # The transcript contains lines with "type":"assistant" and "message" content
+    # Use awk for cross-platform compatibility (tac is not available on macOS)
+    LAST_ASSISTANT=$(awk '/"type"[[:space:]]*:[[:space:]]*"assistant"/{line=$0} END{if(line) print line}' "$TRANSCRIPT_PATH" 2>/dev/null)
+    if [ -n "$LAST_ASSISTANT" ]; then
+        # Extract the message content - look for text content in the message
+        # Format: {"message":{"content":[{"type":"text","text":"..."}]}}
+        # Use jq for robust JSON parsing when available, fallback to grep/sed
+        if command -v jq >/dev/null 2>&1; then
+            RAW_SUMMARY=$(echo "$LAST_ASSISTANT" | jq -r '.message.content[] | select(.type == "text") | .text' 2>/dev/null | head -1)
+        else
+            # Fallback: simple regex extraction (may fail on escaped quotes)
+            RAW_SUMMARY=$(echo "$LAST_ASSISTANT" | grep -o '"text"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"//' | sed 's/"$//')
+        fi
+        if [ -n "$RAW_SUMMARY" ]; then
+            # Truncate to 100 chars and clean up newlines
+            TASK_SUMMARY=$(echo "$RAW_SUMMARY" | tr '\n' ' ' | cut -c1-100)
+            # Add ellipsis if truncated
+            if [ ${#RAW_SUMMARY} -gt 100 ]; then
+                TASK_SUMMARY="${TASK_SUMMARY}..."
+            fi
+        fi
+    fi
+fi
+
+# Build session info string (shown in body)
+SESSION_INFO=""
+if [ -n "$SESSION_ID" ]; then
+    SESSION_INFO="Session: $SESSION_ID"
+fi
+
+# Determine notification title and body based on hook type
+case "$HOOK_EVENT" in
+    "Notification")
+        case "$NOTIFICATION_TYPE" in
+            "permission_prompt")
+                TITLE="Claude [$SOURCE] - Permission Required"
+                BODY="${MESSAGE:-Claude needs your permission to continue}"
+                if [ -n "$SESSION_INFO" ]; then
+                    BODY="$SESSION_INFO
+$BODY"
+                fi
+                PRIORITY="high"
+                TAGS="warning"
+                ;;
+            "idle_prompt")
+                TITLE="Claude [$SOURCE] - Waiting"
+                BODY="${MESSAGE:-Claude is waiting for your input}"
+                if [ -n "$SESSION_INFO" ]; then
+                    BODY="$SESSION_INFO
+$BODY"
+                fi
+                PRIORITY="default"
+                TAGS="hourglass"
+                ;;
+            *)
+                TITLE="Claude [$SOURCE] - Attention"
+                BODY="${MESSAGE:-Claude needs your attention}"
+                if [ -n "$SESSION_INFO" ]; then
+                    BODY="$SESSION_INFO
+$BODY"
+                fi
+                PRIORITY="default"
+                TAGS="bell"
+                ;;
+        esac
+        ;;
+    "Stop")
+        TITLE="Claude [$SOURCE] - Finished"
+        BODY="$PROJECT_NAME"
+        if [ -n "$SESSION_INFO" ]; then
+            BODY="$SESSION_INFO | $BODY"
+        fi
+        if [ -n "$TASK_SUMMARY" ]; then
+            BODY="$BODY
+$TASK_SUMMARY"
+        fi
+        PRIORITY="default"
+        TAGS="white_check_mark"
+        ;;
+    "SubagentStop")
+        TITLE="Claude [$SOURCE] - Subagent Done"
+        BODY="$PROJECT_NAME"
+        if [ -n "$SESSION_INFO" ]; then
+            BODY="$SESSION_INFO | $BODY"
+        fi
+        if [ -n "$TASK_SUMMARY" ]; then
+            BODY="$BODY
+$TASK_SUMMARY"
+        fi
+        PRIORITY="low"
+        TAGS="checkered_flag"
+        ;;
+    *)
+        TITLE="Claude [$SOURCE]"
+        BODY="${MESSAGE:-Event: $HOOK_EVENT}"
+        if [ -n "$SESSION_INFO" ]; then
+            BODY="$SESSION_INFO
+$BODY"
+        fi
+        PRIORITY="default"
+        TAGS="robot"
+        ;;
+esac
+
+# Send notification via ntfy.sh
+curl -s \
+    -H "Title: $TITLE" \
+    -H "Priority: $PRIORITY" \
+    -H "Tags: $TAGS" \
+    -d "$BODY" \
+    "https://ntfy.sh/$NTFY_TOPIC" > /dev/null 2>&1
+
+exit 0

--- a/plugins/lisa/.codex-plugin/hooks/setup-jira-cli.sh
+++ b/plugins/lisa/.codex-plugin/hooks/setup-jira-cli.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+##
+# Writes the JIRA CLI config file from environment variables.
+# Runs on SessionStart so the config is available for every session.
+#
+# Required env vars (must be created in your Claude Code Web environment):
+#   JIRA_INSTALLATION - cloud or local
+#   JIRA_SERVER       - Atlassian instance URL
+#   JIRA_LOGIN        - login email
+#   JIRA_PROJECT      - default project key
+#   JIRA_API_TOKEN    - already expected by jira-cli natively
+#
+# Optional env vars:
+#   JIRA_BOARD        - default board name
+##
+
+set -euo pipefail
+
+# Fix jira-cli installation if install-pkgs.sh failed to extract correctly.
+# Only attempt on Linux — the binary download is Linux-only.
+if [[ "$(uname -s)" == "Linux" ]] && ! command -v jira &>/dev/null; then
+  JIRA_CLI_VERSION="1.7.0"
+  TMPDIR=$(mktemp -d)
+  curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
+    | tar -xz -C "${TMPDIR}"
+  cp "${TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
+  chmod +x /usr/local/bin/jira
+  rm -rf "${TMPDIR}"
+fi
+
+CONFIG_DIR="${HOME}/.config/.jira"
+CONFIG_FILE="${CONFIG_DIR}/.config.yml"
+
+# Skip config write if required vars are missing
+if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${CONFIG_DIR}"
+
+cat > "${CONFIG_FILE}" << EOF
+installation: ${JIRA_INSTALLATION:-cloud}
+server: ${JIRA_SERVER}
+login: ${JIRA_LOGIN}
+project: ${JIRA_PROJECT:-}
+board: "${JIRA_BOARD:-}"
+auth_type: basic
+epic:
+  name: Epic Name
+  link: Epic Link
+EOF

--- a/plugins/lisa/.codex-plugin/plugin.json
+++ b/plugins/lisa/.codex-plugin/plugin.json
@@ -12,6 +12,7 @@
     "workflow"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "Lisa",
     "shortDescription": "Universal project governance workflows",

--- a/plugins/src/typescript/hooks/format-on-edit.sh
+++ b/plugins/src/typescript/hooks/format-on-edit.sh
@@ -9,9 +9,11 @@
 # Read the JSON input from stdin
 JSON_INPUT=$(cat)
 
-# Extract the file path from the tool_input
-# The Edit tool input contains a "file_path" field in the tool_input object
-FILE_PATH=$(echo "$JSON_INPUT" | grep -o '"tool_input":{[^}]*"file_path":"[^"]*"' | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+# Extract the file path from the tool_input. Use jq for robust JSON parsing
+# (never grep/sed/cut — a JSON shape change silently skips formatting). Fail
+# open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Check if we successfully extracted a file path
 if [ -z "$FILE_PATH" ]; then

--- a/plugins/src/typescript/hooks/lint-on-edit.sh
+++ b/plugins/src/typescript/hooks/lint-on-edit.sh
@@ -19,8 +19,11 @@
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would silently skip the blocking lint gate).
+# Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/plugins/src/typescript/hooks/sg-scan-on-edit.sh
+++ b/plugins/src/typescript/hooks/sg-scan-on-edit.sh
@@ -7,8 +7,11 @@
 # Reference: https://docs.claude.com/en/docs/claude-code/hooks
 # Note: This hook is BLOCKING - it returns non-zero exit codes so Claude must fix issues
 
-# Extract file path from JSON input
-FILE_PATH=$(cat | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract file path from JSON input. Use jq for robust JSON parsing (never
+# grep/sed/cut — a shape change would turn this blocking scan into a silent
+# no-op). Fail open without jq so we never hard-block an edit.
+command -v jq >/dev/null 2>&1 || exit 0
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // empty')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
     exit 0

--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -3,18 +3,29 @@
  * Generate Codex plugin artifacts from the built Claude plugin directories.
  *
  * Claude remains Lisa's production path; this script derives the .codex-plugin
- * metadata (skills + MCP pointers) every time plugins are rebuilt.
+ * metadata (skills + MCP pointers + hooks) every time plugins are rebuilt.
  *
- * NOTE ON HOOKS: this script does NOT emit Codex hooks. Codex (codex-cli
- * 0.125.0) does not execute plugin-bundled hooks — its plugin manifest parser
- * only honors `skills`, `mcpServers`, `apps`, and interface fields, and a
- * runtime test confirmed a bundled `hooks/hooks.json` never fires. Lisa's
- * Codex hooks are instead installed into the project's `.codex/hooks.json`
- * by `src/codex/hooks-installer.ts` (run during `lisa` apply). Hooks with no
- * Codex equivalent are intentionally not ported: `enforce-team-first.sh`
- * (Claude-team-specific), `inject-flow-context.sh` and any SubagentStart hook
- * (Codex has no SubagentStart event), and the SessionEnd `entire` hook (Codex
- * has no SessionEnd event).
+ * HOOKS: as of Codex 0.125.0 (verified via codex features list showing
+ * codex_hooks as `stable`), the plugin manifest accepts a `hooks` field
+ * pointing at a sibling `hooks.json`. `emitCodexHooks` below derives the
+ * Codex-shape hooks block from the Claude manifest by applying the Wave 1
+ * per-agent ship-list audit
+ * (wiki/architecture/lisa-hook-per-agent-ship-list.md):
+ *   - Drop every `entire hooks claude-code *` command (Claude-only analytics).
+ *   - Drop every reference to `enforce-team-first.sh` (Claude-team-specific).
+ *   - Drop `inject-flow-context.sh` ONLY when targeting an agent without
+ *     SubagentStart (Codex 0.125.0 has SubagentStart, so we ship it).
+ *   - Rewrite ${CLAUDE_PLUGIN_ROOT}/hooks/<n>.sh to ./hooks/<n>.sh so the
+ *     hooks.json sibling can resolve the script path relative to itself.
+ *   - Copy the surviving scripts into .codex-plugin/hooks/.
+ *
+ * SessionEnd is documented as unsupported by Codex; the `entire hooks
+ * claude-code session-end` hook is stripped per the Claude-only rule above
+ * regardless of event support.
+ *
+ * src/codex/hooks-installer.ts remains as the documented fallback for users
+ * who install Lisa via `lisa apply` without enabling the marketplace plugin —
+ * src/codex/lisa-plugin-detection.ts is the helper that gates that fallback.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -441,8 +452,31 @@ function main() {
   const pluginName = claudeManifest.name;
 
   pruneInternalCodexSkills(pluginDir);
+  emitCodexHooks(pluginDir, claudeManifest);
   writeCodexManifest(pluginDir, claudeManifest, pluginName, versionArg);
   writeSkillAgents(pluginDir);
+}
+
+/**
+ * Per Wave 1 audit + Codex 0.125.0 supporting plugin-bundled hooks: derive
+ * a Codex-shaped hooks.json from the Claude manifest's hooks block and copy
+ * the surviving scripts into .codex-plugin/hooks/.
+ *
+ * No-op when the input has no hooks block or every entry is stripped.
+ *
+ * @param {string} pluginDir Built Claude plugin directory.
+ * @param {object} claudeManifest Parsed contents of .claude-plugin/plugin.json.
+ */
+function emitCodexHooks(pluginDir, claudeManifest) {
+  const filtered = filterCodexHooks(claudeManifest.hooks);
+  if (filtered === null) return;
+  const codexPluginDir = path.join(pluginDir, ".codex-plugin");
+  fs.mkdirSync(codexPluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(codexPluginDir, "hooks.json"),
+    `${JSON.stringify(filtered, null, 2)}\n`
+  );
+  copyCodexHookScripts(pluginDir, filtered);
 }
 
 function writeCodexManifest(pluginDir, claudeManifest, pluginName, version) {
@@ -484,7 +518,109 @@ function componentPointers(pluginDir) {
     ...(fs.existsSync(path.join(pluginDir, ".mcp.json"))
       ? { mcpServers: "./.mcp.json" }
       : {}),
+    ...(fs.existsSync(path.join(pluginDir, ".codex-plugin", "hooks.json"))
+      ? { hooks: "./hooks.json" }
+      : {}),
   };
+}
+
+/**
+ * Per the Wave 1 hook audit, derive Codex-shaped hooks.json from the
+ * Claude plugin.json hooks block:
+ *   - Drop every `entire hooks claude-code *` command (Claude-only).
+ *   - Drop every reference to `enforce-team-first.sh` (Claude-team-specific).
+ *   - Rewrite ${CLAUDE_PLUGIN_ROOT}/hooks/<script>.sh to ./hooks/<script>.sh
+ *     (Codex resolves plugin paths relative to .codex-plugin/plugin.json).
+ *   - Drop matchers that produce no surviving handlers.
+ *
+ * When the resulting block is empty, no hooks.json is written and the
+ * manifest pointer omits the hooks field.
+ *
+ * @param {object} hooksBlock The hooks field from the Claude plugin manifest.
+ * @returns {object | null} A Codex-shape hooks block or null when empty.
+ */
+function filterCodexHooks(hooksBlock) {
+  if (!hooksBlock || typeof hooksBlock !== "object") return null;
+  const codexStrip = new Set(["enforce-team-first.sh"]);
+  const isEntire = cmd =>
+    typeof cmd === "string" &&
+    /command -v entire >\/dev\/null 2>&1 && entire hooks claude-code /.test(
+      cmd
+    );
+  const scriptName = cmd => {
+    if (typeof cmd !== "string") return null;
+    const m = /\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/([^/\s]+\.sh)/.exec(cmd);
+    return m ? m[1] : null;
+  };
+  const out = {};
+  for (const [event, entries] of Object.entries(hooksBlock)) {
+    if (!Array.isArray(entries)) continue;
+    const keptEntries = [];
+    for (const entry of entries) {
+      const handlers = entry?.hooks;
+      if (!Array.isArray(handlers)) continue;
+      const keptHandlers = handlers.flatMap(h => {
+        if (!h || typeof h.command !== "string") return [];
+        if (isEntire(h.command)) return [];
+        const script = scriptName(h.command);
+        if (script !== null) {
+          if (codexStrip.has(script)) return [];
+          return [
+            {
+              ...h,
+              // Codex hook commands resolve relative to .codex-plugin/plugin.json;
+              // rewrite to a path the hooks.json sibling will find.
+              command: h.command.replaceAll(
+                "${CLAUDE_PLUGIN_ROOT}/hooks/",
+                "./hooks/"
+              ),
+            },
+          ];
+        }
+        // Unknown command shape — ship verbatim.
+        return [h];
+      });
+      if (keptHandlers.length > 0) {
+        keptEntries.push({ ...entry, hooks: keptHandlers });
+      }
+    }
+    if (keptEntries.length > 0) {
+      out[event] = keptEntries;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Copy hook scripts that survived filterCodexHooks into the Codex artifact.
+ *
+ * Scripts land at <pluginDir>/.codex-plugin/hooks/ so the hooks.json pointer
+ * "./hooks/<n>.sh" resolves correctly when Codex loads the plugin.
+ *
+ * @param {string} pluginDir Built Claude plugin directory.
+ * @param {object} hooks Codex-shaped hooks block from filterCodexHooks.
+ */
+function copyCodexHookScripts(pluginDir, hooks) {
+  const srcHooksDir = path.join(pluginDir, "hooks");
+  if (!fs.existsSync(srcHooksDir)) return;
+  const referenced = new Set();
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries) {
+      for (const h of entry.hooks ?? []) {
+        if (typeof h.command !== "string") continue;
+        const m = /^\.\/hooks\/([^/\s]+\.sh)/.exec(h.command);
+        if (m) referenced.add(m[1]);
+      }
+    }
+  }
+  if (referenced.size === 0) return;
+  const dstHooksDir = path.join(pluginDir, ".codex-plugin", "hooks");
+  fs.mkdirSync(dstHooksDir, { recursive: true });
+  for (const name of referenced) {
+    const src = path.join(srcHooksDir, name);
+    if (!fs.existsSync(src)) continue;
+    fs.copyFileSync(src, path.join(dstHooksDir, name));
+  }
 }
 
 function metadataFor(pluginName, claudeManifest) {

--- a/scripts/generate-codex-plugin-artifacts.mjs
+++ b/scripts/generate-codex-plugin-artifacts.mjs
@@ -468,15 +468,37 @@ function main() {
  * @param {object} claudeManifest Parsed contents of .claude-plugin/plugin.json.
  */
 function emitCodexHooks(pluginDir, claudeManifest) {
-  const filtered = filterCodexHooks(claudeManifest.hooks);
-  if (filtered === null) return;
   const codexPluginDir = path.join(pluginDir, ".codex-plugin");
+  const hooksJsonPath = path.join(codexPluginDir, "hooks.json");
+  const hooksScriptsDir = path.join(codexPluginDir, "hooks");
+  const filtered = filterCodexHooks(claudeManifest.hooks);
+  if (filtered === null) {
+    // Nothing survived the filter. Remove any stale hooks artifacts from a
+    // prior build so componentPointers() doesn't keep advertising removed
+    // hooks via the ./hooks.json pointer.
+    fs.rmSync(hooksJsonPath, { force: true });
+    fs.rmSync(hooksScriptsDir, { force: true, recursive: true });
+    return;
+  }
   fs.mkdirSync(codexPluginDir, { recursive: true });
   fs.writeFileSync(
-    path.join(codexPluginDir, "hooks.json"),
-    `${JSON.stringify(filtered, null, 2)}\n`
+    hooksJsonPath,
+    `${JSON.stringify(buildCodexHooksDocument(filtered), null, 2)}\n`
   );
   copyCodexHookScripts(pluginDir, filtered);
+}
+
+/**
+ * Wrap a filtered events block in the document shape Codex's hooks.json parser
+ * expects: events nested under a top-level "hooks" key (see the HooksFile
+ * contract in src/codex/hooks-merger.ts). Writing the events block at the root
+ * would not be recognized as hooks.
+ *
+ * @param {object} filtered Codex-shaped events block from filterCodexHooks.
+ * @returns {{ hooks: object }} The hooks.json document root.
+ */
+export function buildCodexHooksDocument(filtered) {
+  return { hooks: filtered };
 }
 
 function writeCodexManifest(pluginDir, claudeManifest, pluginName, version) {
@@ -539,7 +561,7 @@ function componentPointers(pluginDir) {
  * @param {object} hooksBlock The hooks field from the Claude plugin manifest.
  * @returns {object | null} A Codex-shape hooks block or null when empty.
  */
-function filterCodexHooks(hooksBlock) {
+export function filterCodexHooks(hooksBlock) {
   if (!hooksBlock || typeof hooksBlock !== "object") return null;
   const codexStrip = new Set(["enforce-team-first.sh"]);
   const isEntire = cmd =>

--- a/tests/unit/cli/update-check.test.ts
+++ b/tests/unit/cli/update-check.test.ts
@@ -38,7 +38,7 @@ afterEach(async () => {
 
 describe("getPackageVersion", () => {
   it("reads the package.json version", () => {
-    expect(getPackageVersion()).toBe("2.119.1");
+    expect(getPackageVersion()).toBe("2.120.0");
   });
 });
 

--- a/tests/unit/scripts/codex-hook-filter.test.ts
+++ b/tests/unit/scripts/codex-hook-filter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the Codex hook filter/emit helpers in
+ * scripts/generate-codex-plugin-artifacts.mjs.
+ *
+ * Locks in two behaviors the Wave 3b Codex hooks emission depends on:
+ *   1. filterCodexHooks strips Claude-only commands, rewrites plugin-root paths
+ *      to the Codex-relative ./hooks/ form, and drops empty matchers.
+ *   2. buildCodexHooksDocument wraps the events block under a top-level "hooks"
+ *      key — the root shape Codex's parser expects (HooksFile contract in
+ *      src/codex/hooks-merger.ts). A regression here ships hooks Codex ignores.
+ * @module tests/unit/scripts/codex-hook-filter
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildCodexHooksDocument,
+  filterCodexHooks,
+} from "../../../scripts/generate-codex-plugin-artifacts.mjs";
+
+/**
+ * Build a hook command referencing the Claude plugin root.
+ * @param name Hook script filename.
+ * @returns A ${CLAUDE_PLUGIN_ROOT}-prefixed command string.
+ */
+const PLUGIN_ROOT_CMD = (name: string): string =>
+  `\${CLAUDE_PLUGIN_ROOT}/hooks/${name}`;
+const ENTIRE_CMD =
+  "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-start || true";
+
+/**
+ * Build a single-event Claude hooks block for one command.
+ * @param event Hook event name (e.g. PreToolUse).
+ * @param matcher Matcher string for the entry.
+ * @param command Command the lone handler runs.
+ * @returns A minimal hooks block shaped like a Claude plugin manifest's hooks.
+ */
+const blockWith = (
+  event: string,
+  matcher: string,
+  command: string
+): Record<string, unknown> => ({
+  [event]: [{ matcher, hooks: [{ type: "command", command }] }],
+});
+
+describe("generate-codex-plugin-artifacts: filterCodexHooks", () => {
+  it("returns null for a missing or non-object hooks block", () => {
+    expect(filterCodexHooks(undefined as unknown as object)).toBeNull();
+    expect(filterCodexHooks(null as unknown as object)).toBeNull();
+    expect(filterCodexHooks("nope" as unknown as object)).toBeNull();
+  });
+
+  it("rewrites ${CLAUDE_PLUGIN_ROOT}/hooks/ to the Codex-relative ./hooks/ form", () => {
+    const out = filterCodexHooks(
+      blockWith("PreToolUse", "Bash", PLUGIN_ROOT_CMD("block-no-verify.sh"))
+    ) as Record<string, { hooks: { command: string }[] }[]>;
+    expect(out["PreToolUse"][0].hooks[0].command).toBe(
+      "./hooks/block-no-verify.sh"
+    );
+  });
+
+  it("drops `entire hooks claude-code *` commands (Claude-only)", () => {
+    expect(
+      filterCodexHooks(blockWith("SessionEnd", "", ENTIRE_CMD))
+    ).toBeNull();
+  });
+
+  it("drops enforce-team-first.sh (Claude-team-specific)", () => {
+    expect(
+      filterCodexHooks(
+        blockWith("SessionStart", "", PLUGIN_ROOT_CMD("enforce-team-first.sh"))
+      )
+    ).toBeNull();
+  });
+
+  it("drops matchers whose handlers were all stripped but keeps surviving events", () => {
+    const block = {
+      SessionStart: [
+        { matcher: "", hooks: [{ type: "command", command: ENTIRE_CMD }] },
+      ],
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command",
+              command: PLUGIN_ROOT_CMD("block-no-verify.sh"),
+            },
+          ],
+        },
+      ],
+    };
+    const out = filterCodexHooks(block) as Record<string, unknown>;
+    expect("SessionStart" in out).toBe(false);
+    expect("PreToolUse" in out).toBe(true);
+  });
+
+  it("ships unknown command shapes verbatim", () => {
+    const out = filterCodexHooks(
+      blockWith("PreToolUse", "Bash", "echo custom")
+    ) as Record<string, { hooks: { command: string }[] }[]>;
+    expect(out["PreToolUse"][0].hooks[0].command).toBe("echo custom");
+  });
+});
+
+describe("generate-codex-plugin-artifacts: buildCodexHooksDocument", () => {
+  it("nests the events block under a top-level hooks key", () => {
+    const filtered = { PreToolUse: [{ matcher: "Bash", hooks: [] }] };
+    expect(buildCodexHooksDocument(filtered)).toEqual({ hooks: filtered });
+  });
+
+  it("does not place events at the document root", () => {
+    const filtered = { Stop: [{ matcher: "", hooks: [] }] };
+    const doc = buildCodexHooksDocument(filtered) as Record<string, unknown>;
+    expect("Stop" in doc).toBe(false);
+    expect("hooks" in doc).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1045. Closes the Wave 1 audit's **Action 3**: extend `scripts/generate-codex-plugin-artifacts.mjs` to emit a Codex-shape `hooks.json` plus the surviving scripts in `.codex-plugin/hooks/`. With this PR, Codex 0.125.0 marketplace users receive Lisa's hook handlers via the plugin payload without needing to run `lisa apply` (the per-project `src/codex/hooks-installer.ts` remains as the documented fallback gated by `src/codex/lisa-plugin-detection.ts`).

These two commits were pushed to the wave-3 branch after PR #1045 auto-merged, so they need their own PR.

## Changes

**`scripts/generate-codex-plugin-artifacts.mjs`**:
- `filterCodexHooks` derives the Codex-shape hooks block from the Claude manifest applying the Wave 1 per-agent ship-list:
  - Drop every `entire hooks claude-code *` command (Claude-only analytics).
  - Drop every reference to `enforce-team-first.sh` (Claude-team-specific).
  - Rewrite `${CLAUDE_PLUGIN_ROOT}/hooks/<n>.sh` → `./hooks/<n>.sh` so `hooks.json` resolves the script path relative to itself.
- `copyCodexHookScripts` copies the surviving scripts into `.codex-plugin/hooks/`.
- `componentPointers` registers `hooks: "./hooks.json"` in the Codex manifest when the file exists.
- `emitCodexHooks` ties it together, called from the per-plugin loop after skill processing.

For `plugins/lisa/` the resulting `.codex-plugin/hooks.json` carries:

| Event | Matcher | Hook |
| --- | --- | --- |
| `PreToolUse` | `Bash` | `./hooks/block-no-verify.sh` |
| `Stop` | (none) | `./hooks/notify-ntfy.sh` |
| `SessionStart` | `startup` | `./hooks/install-pkgs.sh` |
| `SessionStart` | (none) | `./hooks/inject-rules.sh`, `./hooks/setup-jira-cli.sh` |
| `SubagentStart` | (none) | `./hooks/inject-rules.sh`, `./hooks/inject-flow-context.sh` |

Exactly the Codex column from `wiki/architecture/lisa-hook-per-agent-ship-list.md`.

**Head-comment refresh**: the old comment claimed "this script does NOT emit Codex hooks" — accurate when written against pre-0.125.0 Codex, now stale. Updated to describe the actual behavior and reference the Wave 1 audit by path.

## Test plan

- [x] `bun run build:plugins` emits `.codex-plugin/hooks.json` + the six expected scripts under `plugins/lisa/.codex-plugin/hooks/`.
- [x] All 2497 unit tests pass.
- [x] Typecheck + ESLint clean.
- [ ] CI green
- [ ] Auto-merge to main

🤖 Generated with Claude Code

Co-Authored-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated hooks for code quality and formatting across TypeScript, Rails, and NestJS plugins
  * Introduced rule injection and context management for improved workflow automation
  * Added session setup automation for dependency installation and configuration

* **Bug Fixes**
  * Added safeguards blocking unsafe operations (suppressed linting directives, database migration edits, Git pre-commit bypasses)

* **Chores**
  * Updated plugin versions across multiple packages (2.119.0 → 2.119.1)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->