### PR TITLE
fix(parity): agy bake resolves rules like inject-rules.sh (eager OR flat)

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -895,14 +895,29 @@ export class Lisa {
 
   /**
    * Eager-rule source directories to bake into agy's AGENTS.md: the base
-   * plugin plus each detected stack plugin that ships eager rules.
+   * plugin plus each detected stack plugin.
+   *
+   * Resolution mirrors the `inject-rules.sh` hook that delivers rules on
+   * Claude/Codex/Copilot: prefer `<plugin>/rules/eager/`, but when a plugin has
+   * no `eager/` subdir fall back to its flat `<plugin>/rules/` directory (the
+   * legacy layout some stacks use, e.g. `lisa-rails/rules/rails-conventions.md`).
+   * Without this fallback agy would silently miss flat-layout stack rules that
+   * every other agent receives.
    * @param pluginRoot - Absolute path to the `plugins/` directory.
-   * @returns Existing `rules/eager` directory paths, base first.
+   * @returns Existing rule-source directory paths, base first.
    */
   private eagerRuleDirs(pluginRoot: string): string[] {
-    return ["lisa", ...this.detectedTypes.map(type => `lisa-${type}`)]
-      .map(name => path.join(pluginRoot, name, "rules", "eager"))
-      .filter(dir => existsSync(dir));
+    const resolved: string[] = [];
+    for (const name of ["lisa", ...this.detectedTypes.map(t => `lisa-${t}`)]) {
+      const eager = path.join(pluginRoot, name, "rules", "eager");
+      if (existsSync(eager)) {
+        resolved.push(eager);
+        continue;
+      }
+      const flat = path.join(pluginRoot, name, "rules");
+      if (existsSync(flat)) resolved.push(flat);
+    }
+    return resolved;
   }
 
   /**


### PR DESCRIPTION
## Why

Clarifying a documented claim surfaced a real agy-specific bug. Lisa splits rules into `rules/eager/` (always injected) and `rules/reference/` (on-demand), but some stacks use a **legacy flat layout** — e.g. `lisa-rails/rules/rails-conventions.md` sits at the `rules/` root with no `eager/` subdir.

`inject-rules.sh` (which delivers rules on Claude/Codex/Copilot) reads `rules/eager/` **and falls back to the flat `rules/` dir when there's no `eager/` subdir**. Cursor reads the whole `rules/` tree natively. But the **agy AGENTS.md bake read only `rules/eager/`** — so flat-layout stack rules were silently dropped on agy alone.

## Fix

`eagerRuleDirs` now mirrors `inject-rules.sh`: prefer `<plugin>/rules/eager/`, else fall back to `<plugin>/rules/`. agy now receives the same rules every other agent does.

## Verified by run

Rails project, `--harness fleet`: agy AGENTS.md now bakes **14 rules** (base 13 + `rails-conventions`) instead of 13; rails content confirmed present in the Lisa-managed block. No change for stacks that already use `rules/eager/` (e.g. base stays 13).

## Scope / gate

`src/core/lisa.ts` only (pure logic, no artifact change) · check:plugins green · 2569 tests pass.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the plugin rule directory resolution mechanism with enhanced fallback handling for better compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->