### PR TITLE
docs(wiki): ingest Lisa history through 2.123.2

### DIFF
--- a/wiki/architecture/template-governance.md
+++ b/wiki/architecture/template-governance.md
@@ -23,6 +23,8 @@ When updating Lisa templates, preserve the strategy contract. A downstream proje
 
 Lisa base rules now ship as paired eager and reference material. Eager rule heads carry the mandatory short-form guidance agents should load immediately, while reference bodies preserve the full procedure and examples. Codex mirrors this split and CI checks the pairing so the two runtime surfaces do not drift.
 
+Generated per-agent stack variants must preserve the same rule-delivery semantics as the base plugin. Claude, Codex, and Copilot use the rule injection script, agy bakes startup rules into AGENTS.md, and Cursor reads rules natively; each path should load eager rules or legacy flat-layout stack rules while leaving reference rules on demand.
+
 ## Managed Wiki Ignore Block
 
 The `lisa-wiki` setup flow merges a managed `.gitignore` block for wiki-specific local artifacts instead of replacing a project's ignore file. This keeps wiki setup repairable while preserving project-owned ignore entries.

--- a/wiki/architecture/template-governance.md
+++ b/wiki/architecture/template-governance.md
@@ -18,3 +18,11 @@ Template families observed in the monorepo include all, TypeScript, Expo, NestJS
 ## Practical Rule
 
 When updating Lisa templates, preserve the strategy contract. A downstream project may rely on Lisa overwriting one file while preserving another.
+
+## Rule Distribution
+
+Lisa base rules now ship as paired eager and reference material. Eager rule heads carry the mandatory short-form guidance agents should load immediately, while reference bodies preserve the full procedure and examples. Codex mirrors this split and CI checks the pairing so the two runtime surfaces do not drift.
+
+## Managed Wiki Ignore Block
+
+The `lisa-wiki` setup flow merges a managed `.gitignore` block for wiki-specific local artifacts instead of replacing a project's ignore file. This keeps wiki setup repairable while preserving project-owned ignore entries.

--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -67,3 +67,11 @@ A managed wiki ignore block is the Lisa wiki-owned section inserted into a proje
 ## E2E Coverage Gap
 
 An e2e coverage gap is behavior found during exploratory QA that should be represented by an end-to-end regression test rather than only a human-facing bug report.
+
+## Per-Agent Plugin Variant
+
+A per-agent plugin variant is a generated Lisa plugin artifact tailored to one coding agent's plugin shape, hook model, and rule-loading behavior. Pattern B variants are built from shared `plugins/src/` source rather than hand-edited generated directories.
+
+## Eager-Or-Flat Rule Resolution
+
+Eager-or-flat rule resolution means Lisa first loads `rules/eager/` when present and otherwise falls back to flat markdown files directly under `rules/`. `rules/reference/` stays out of startup injection and is loaded only when needed.

--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -40,6 +40,14 @@ Query-first means project questions should be answered through the maintained Li
 
 The wiki knowledge source rule means Lisa wiki pages are the durable home for project knowledge, while non-wiki folders may remain valid ingestion inputs or evidence locations when their contents are synthesized back into `wiki/`.
 
+## Eager Rule
+
+An eager rule is the concise, always-on head of a Lisa rule. It gives agents the immediate operating contract and links to the matching reference rule for full detail.
+
+## Reference Rule
+
+A reference rule is the expanded rule body that holds procedure, examples, and edge-case guidance. Reference rules are paired with eager rules so runtime surfaces can stay concise without dropping detail.
+
 ## Ideation Ledger
 
 An ideation ledger is durable automation run metadata for project, PRD, or thread ideation work. It records enough context to make repeated runs idempotent and auditable.
@@ -51,6 +59,10 @@ PRD pressure is the queue condition where project ideation should not mark new P
 ## Digital Staff Roster
 
 A digital staff roster is the wiki-owned set of role pages and runtime subagents that represent domain experts for a project. Lisa wiki setup now seeds the standard roster by default when a project has not declared a custom `config.staff[]`.
+
+## Managed Wiki Ignore Block
+
+A managed wiki ignore block is the Lisa wiki-owned section inserted into a project's `.gitignore` during setup or repair. It is merged by marker so wiki-local artifacts can be ignored without overwriting project-owned entries.
 
 ## E2E Coverage Gap
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,7 +18,7 @@ Last updated by coding-agent parity research ingest on 2026-05-28. Latest connec
 - [Documentation Index](documentation/index.md)
 - [Overview](documentation/overview.md)
 - [Contributing](documentation/contributing.md)
-- [PRD Lifecycle Rollup Vendor Matrix](../plugins/src/base/rules/prd-lifecycle-rollup.md)
+- [PRD Lifecycle Rollup Vendor Matrix](../plugins/src/base/rules/reference/prd-lifecycle-rollup.md)
 - [Testing Documentation](documentation/testing/)
 - [Workflow Documentation](documentation/workflows/)
 - [Specifications](documentation/specs/)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by coding-agent parity research ingest on 2026-05-28. Latest connector-ingest baseline is Lisa release `2.116.0` and merged PR `#1035`.
+Last updated by incremental connector ingest on 2026-05-29 through Lisa release `2.123.2` and merged PR `#1053`.
 
 ## Orientation
 
@@ -28,6 +28,8 @@ Last updated by coding-agent parity research ingest on 2026-05-28. Latest connec
 - [Lisa Architecture](architecture/lisa-architecture.md)
 - [Template Governance](architecture/template-governance.md)
 - [Coding-Agent Parity Architecture](architecture/coding-agent-parity.md)
+- [Lisa Hook Per-Agent Ship List](architecture/lisa-hook-per-agent-ship-list.md)
+- [Pattern B Per-Agent Plugin Fan-Out Specification](architecture/pattern-b-fan-out-spec.md)
 
 ## Requirements
 
@@ -35,6 +37,7 @@ Last updated by coding-agent parity research ingest on 2026-05-28. Latest connec
 
 ## Decisions
 
+- [2026-05-28 — Codex Skills Canonical Path](decisions/2026-05-28-codex-skills-canonical-path.md)
 - [2026-05-28 — Pattern B Per-Agent Plugin Variants](decisions/2026-05-28-pattern-b-per-agent-plugin-variants.md)
 
 ## Playbooks

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -119,6 +119,13 @@
 - Ingested the Lisa project-scoped Claude memory directory into `wiki/sources/memory/2026-05-28-memory.md`; global Codex memory remained out of scope.
 - Updated the monorepo snapshot, workflow playbook, vocabulary, and index for the wiki-as-knowledge-source rule and release-history changes through `2.116.0`.
 
+## 2026-05-28 - Incremental connector ingest
+
+- Synced the durable checkout to `origin/main`, created the dedicated branch `wiki/ingest-2026-05-28-133543`, and ran another full no-argument ingest against every enabled non-external-write connector.
+- Refreshed the `git` source note with 17 new commits through `13d703327a00a157f1c9e8d546ec1c30df62c797`, advanced the merged-PR cursor to `#1040`, and confirmed that `roles` still had no roster pages to ingest.
+- Skipped `memory` because the available Claude memory directory was not provably project-scoped for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
+- Updated the monorepo snapshot, template-governance notes, workflow playbook, vocabulary, and index for the CLI package-version update check, managed wiki `.gitignore` setup, eager/reference rule split, wiki ESLint ignore behavior, and release-history changes through `2.119.0`.
+
 ## 2026-05-28 - Coding-agent parity research ingest
 
 - Ingested the `lisa-coding-agent-parity` research artifact produced on the `worktree-coding-agent-parity` worktree at `/tmp/parity-research.md`. The artifact contains the universal feature catalog (170 features across 12 categories) for Claude Code, Codex, Cursor (`cursor-agent`), Antigravity (`agy`), and GitHub Copilot, plus the per-agent support matrix, plugin-distributability matrix, and Lisa polyfill designs across 16 gap-cell clusters.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -147,3 +147,11 @@
 
 - Closed the parity gap where per-agent variants existed only for the base plugin (PRs #1050, #1052). build-plugins.sh now fans out every built Claude plugin (base + 6 stacks + 2 standalones) to cursor/agy/copilot via the generic generators (27 variant dirs total); all registered in `.claude-plugin/marketplace.json`. `lisa apply` installs the base variant plus `lisa-<detected-type>-<agent>` for each detected stack (existence-filtered). Spec section "Stack fan-out" added to `wiki/architecture/pattern-b-fan-out-spec.md`.
 - Fixed an agy-only rule-delivery gap (#1052): the AGENTS.md bake read only `rules/eager/`, dropping legacy flat-layout stack rules (e.g. `lisa-rails/rules/rails-conventions.md`) that inject-rules.sh delivers to Claude/Codex/Copilot via its eager-or-flat fallback and cursor via native rules load. agy's bake (`eagerRuleDirs`) now mirrors that resolution. Verified: a Rails project bakes 14 rules into agy's AGENTS.md (base 13 + rails-conventions) instead of 13. Only `rules/reference/` remains on-demand on all agents.
+
+## 2026-05-29 - Incremental connector ingest
+
+- Resolved the prior local connector-ingest rebase conflict by preserving the 2026-05-28 connector log entry alongside newer wiki parity entries, then ran a full no-argument ingest against every enabled non-external-write connector available in `wiki/lisa-wiki.config.json`.
+- Refreshed the `git` source note with 71 new commits through `ecb6a093d767203add54de4d0d703783c80abda0`, advanced the merged-PR cursor to `#1053`, and captured the release line through Lisa `2.123.2`.
+- Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
+- Skipped `memory` because the only available Claude memory directory was scoped to `/Users/cody/workspace/lisa`, not `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
+- Updated the monorepo snapshot, template-governance notes, workflow playbook, vocabulary, and index for per-agent stack variant fan-out, Codex/Copilot hook verification fixes, agy eager-or-flat rule delivery, Expo SDK 56 `/src` support, and release-history changes through `2.123.2`.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -38,6 +38,14 @@ Project ideation may document new PRD candidates while the build queue is busy, 
 
 Claude receives Lisa plugin hooks through the GitHub marketplace copy of the plugin, which tracks committed generated plugin artifacts on `main`. Codex receives hooks when `lisa apply` installs them into a project's `.codex/hooks.json`; a package update alone is not the delivery mechanism for Codex hooks.
 
+Codex plugin-bundled hooks now use the plugin root and hook manifest shape Codex discovers in current releases. Fleet apply paths must include Codex explicitly so `lisa apply --harness fleet` does not silently skip the Codex emitter.
+
+## Per-Agent Stack Variants
+
+Lisa's plugin build now fans out stack and standalone plugins to Cursor, Antigravity, and Copilot variants in addition to the base plugin. `lisa apply` should install the base per-agent variant plus each detected stack variant that exists for the target agent, while Cursor consumes the published variants through its native plugin loader.
+
+Rule delivery should use the same eager-or-flat resolution across agents: prefer `rules/eager/`, fall back to flat `rules/`, and keep `rules/reference/` on demand.
+
 ## Exploratory QA
 
 Exploratory QA now separates human-experience findings from e2e coverage gaps. Use the human-experience pass for product-facing behavior, friction, and visible issues; use the e2e-coverage-gaps pass for regression coverage opportunities that should become tests or backlog work.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -24,6 +24,12 @@ Agents should use the Lisa wiki query flow as the primary way to answer project 
 
 For Lisa wiki work specifically, `wiki/` is the durable knowledge source. Other repository folders such as `docs/`, `research/`, `docs/wiki-inbox/`, and `transcripts/` can still provide ingestion inputs, source evidence, fixtures, or scratch material, but successful ingestions preserve reader-safe evidence under `wiki/sources/` and record the run in `wiki/log.md`.
 
+Wiki setup owns its local ignore hygiene through a managed `.gitignore` block. Setup and repair should merge that block instead of replacing the file, so project-owned ignore rules remain intact.
+
+## Rule Loading
+
+Lisa rules are now organized into eager heads and full reference bodies. Agents should treat the eager heads as the immediate operating contract and use the linked reference body when they need detailed procedure, examples, or edge-case policy.
+
 ## Project Ideation Pressure Gate
 
 Project ideation may document new PRD candidates while the build queue is busy, but it should not auto-mark them ready when queue-status reports PRD pressure. The pressure helper keeps ideation throughput from bypassing the one-item build-intake discipline.
@@ -43,3 +49,5 @@ Repair intake treats work as stuck after a two-hour threshold and records PR or 
 ## Quality Gate Habit
 
 Before shipping Lisa changes, expect local hooks and CI to run typecheck, formatting, linting, slow lint, dead-code detection, tests, coverage, security audit, and integration checks depending on the action.
+
+The wiki has a separate lint path. Normal ESLint defaults ignore `wiki/**`, while wiki integrity continues to be checked through the Lisa wiki lint scripts.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,22 +20,22 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-28-133543` from `origin/main`
-- HEAD at 2026-05-28 incremental ingest: `13d703327a00a157f1c9e8d546ec1c30df62c797`
-- Current package version: `2.119.0`
-- Total commits on HEAD: 2483
-- Latest merged PR captured in the incremental git snapshot: `#1040`
-- New commits since the previous incremental git cursor: `17`
-- Project-scoped memory skipped this cycle because no memory directory was provably scoped to `/Users/cody/.codex/worktrees/lisa-automation-main`; unrelated Claude project memory and global Codex memory remain out of scope.
+- Ingest branch: `wiki/ingest-2026-05-28-133543` rebased onto `origin/main`
+- HEAD at 2026-05-29 incremental ingest: `ecb6a093d767203add54de4d0d703783c80abda0`
+- Current package version: `2.123.2`
+- Total commits on HEAD: 2554
+- Latest merged PR captured in the incremental git snapshot: `#1053`
+- New commits since the previous incremental git cursor: `71`
+- Project-scoped memory skipped this cycle because the only available Claude memory directory was scoped to `/Users/cody/workspace/lisa`, not this automation checkout; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#1036`.
-- Release automation advanced the monorepo to `2.119.0`.
-- Lisa added a CLI package-version update check and hardened its cached-version handling by validating semver and swallowing cache-write failures.
-- Lisa wiki setup now merges a managed `.gitignore` block so wiki-local ignored files can be installed or repaired without clobbering project-owned ignore rules.
-- Base rules were split into eager heads and reference bodies, with Codex and CI surfaces kept paired so agents can load concise always-on guidance while retaining full reference material.
-- ESLint default ignores now include `wiki/**`, keeping the in-repository knowledge base out of normal code lint scope while the wiki keeps its own lint path.
+- Release automation advanced the monorepo to `2.123.2`.
+- The prior local connector-ingest commit was rebased onto current `origin/main`, preserving the 2026-05-28 connector cursor before this 2026-05-29 ingest advanced it again.
+- Coding-agent parity work shipped per-agent plugin variant generation, Codex plugin-bundled hook corrections, Copilot probe cache evidence, and `lisa apply --harness fleet` dispatch fixes.
+- The Pattern B fan-out now covers every built Claude plugin, producing cursor, agy, and copilot variants for the base plugin plus stack and standalone plugins.
+- Agy rule delivery now resolves rules the same way as `inject-rules.sh`: prefer `rules/eager/`, then fall back to flat `rules/`, leaving only `rules/reference/` on-demand.
+- Expo support advanced to SDK 56 and `/src` directory conventions, including Jest, ESLint, prettier, knip, and documentation updates.
 
 ## Workspace Packages
 
@@ -53,9 +53,11 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/git/2026-05-26-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-27-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-28-lisa-monorepo-git.md`
+- `wiki/sources/git/2026-05-29-lisa-monorepo-git.md`
 - `wiki/sources/memory/2026-05-27-memory.md`
 - `wiki/sources/memory/2026-05-28-memory.md`
 - `wiki/sources/roles/2026-05-25-roles.md`
 - `wiki/sources/roles/2026-05-26-roles.md`
 - `wiki/sources/roles/2026-05-27-roles.md`
 - `wiki/sources/roles/2026-05-28-roles.md`
+- `wiki/sources/roles/2026-05-29-roles.md`

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,20 +20,22 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-28-013419` from `origin/main`
-- HEAD at 2026-05-28 incremental ingest: `3e99859c0c73e29c341c441f2c34976f4fab2806`
-- Current package version: `2.116.0`
-- Total commits on HEAD: 2466
-- Latest merged PR captured in the incremental git snapshot: `#1035`
-- New commits since the previous incremental git cursor: `6`
-- Project-scoped memory files captured: `22` from the Lisa Claude project memory directory; global Codex memory remains out of scope.
+- Ingest branch: `wiki/ingest-2026-05-28-133543` from `origin/main`
+- HEAD at 2026-05-28 incremental ingest: `13d703327a00a157f1c9e8d546ec1c30df62c797`
+- Current package version: `2.119.0`
+- Total commits on HEAD: 2483
+- Latest merged PR captured in the incremental git snapshot: `#1040`
+- New commits since the previous incremental git cursor: `17`
+- Project-scoped memory skipped this cycle because no memory directory was provably scoped to `/Users/cody/.codex/worktrees/lisa-automation-main`; unrelated Claude project memory and global Codex memory remain out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#1034`.
-- Release automation advanced the monorepo to `2.116.0`.
-- Lisa added a base rule that makes `wiki/` the durable knowledge source for wiki work while preserving `docs/`, `research/`, `docs/wiki-inbox/`, and `transcripts/` as possible ingestion inputs or evidence locations.
-- The new documentation-source-path guidance reinforces that successful ingestions preserve reader-safe evidence under `wiki/sources/` and record runs in `wiki/log.md`.
+- The previous wiki ingest PR merged, advancing the wiki cursor through PR `#1036`.
+- Release automation advanced the monorepo to `2.119.0`.
+- Lisa added a CLI package-version update check and hardened its cached-version handling by validating semver and swallowing cache-write failures.
+- Lisa wiki setup now merges a managed `.gitignore` block so wiki-local ignored files can be installed or repaired without clobbering project-owned ignore rules.
+- Base rules were split into eager heads and reference bodies, with Codex and CI surfaces kept paired so agents can load concise always-on guidance while retaining full reference material.
+- ESLint default ignores now include `wiki/**`, keeping the in-repository knowledge base out of normal code lint scope while the wiki keeps its own lint path.
 
 ## Workspace Packages
 

--- a/wiki/sources/git/2026-05-28-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-28-lisa-monorepo-git.md
@@ -11,15 +11,26 @@ project: lisa-monorepo
 # git history — lisa-monorepo (2026-05-28)
 
 - Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
-- HEAD: `3e99859c0c73e29c341c441f2c34976f4fab2806`
-- Total commits on HEAD: 2466
-- New commits since last ingest (`6dbfeb7ec507cfbb56bc905db47ea14f5bce9762`): 6
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1035 "feat(rules): add wiki-as-knowledge-source rule to base plugin"
+- HEAD: `13d703327a00a157f1c9e8d546ec1c30df62c797`
+- Total commits on HEAD: 2483
+- New commits since last ingest (`3e99859c0c73e29c341c441f2c34976f4fab2806`): 17
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1040 "feat(cli): add package version update check"
 
 ## New commits
-- 3e99859c · 2026-05-28 · chore(release): 2.116.0 [skip ci]
-- a62c461b · 2026-05-27 · Merge pull request #1035 from CodySwannGT/rules/wiki-knowledge-source
-- dbf21edb · 2026-05-27 · feat(rules): add wiki-as-knowledge-source rule to base plugin
-- cc0f2fb3 · 2026-05-27 · chore(release): 2.115.4 [skip ci]
-- ef932031 · 2026-05-27 · Merge pull request #1034 from CodySwannGT/wiki/ingest-2026-05-27-213503
-- b4a1bd30 · 2026-05-27 · docs(wiki): ingest incremental Lisa history
+- 13d70332 · 2026-05-28 · chore(release): 2.119.0 [skip ci]
+- 28607a6c · 2026-05-28 · Merge pull request #1040 from CodySwannGT/build/973-cli-version-update-check
+- 0da89db8 · 2026-05-28 · fix(cli): validate semver in readCachedLatest and swallow writeCache errors
+- f1d424eb · 2026-05-28 · feat(cli): add package version update check
+- 12e3ebb7 · 2026-05-28 · chore(release): 2.118.0 [skip ci]
+- c3fee80f · 2026-05-28 · Merge pull request #1039 from CodySwannGT/feat/lisa-wiki-gitignore-merge
+- 5a0d76dc · 2026-05-28 · feat(wiki): merge a managed .gitignore block during /setup
+- 48f5cff9 · 2026-05-28 · chore(release): 2.117.0 [skip ci]
+- b681d859 · 2026-05-28 · Merge pull request #1038 from CodySwannGT/feat/rules-eager-reference-split
+- 80ca00b9 · 2026-05-28 · feat(codex,ci): mirror eager/reference subdirs and add pairing check
+- 040acf54 · 2026-05-28 · feat(rules): split rules into eager heads and reference bodies
+- 492d2b99 · 2026-05-28 · chore(release): 2.116.2 [skip ci]
+- 36952444 · 2026-05-28 · Merge pull request #1037 from CodySwannGT/chore/eslint-default-ignore-wiki
+- d7ef6998 · 2026-05-28 · chore(eslint): add wiki/** to defaultIgnores
+- c68291b0 · 2026-05-28 · chore(release): 2.116.1 [skip ci]
+- 012e6532 · 2026-05-27 · Merge pull request #1036 from CodySwannGT/wiki/ingest-2026-05-28-013419
+- 666971e6 · 2026-05-27 · docs(wiki): ingest incremental Lisa history

--- a/wiki/sources/git/2026-05-29-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-29-lisa-monorepo-git.md
@@ -1,0 +1,90 @@
+---
+type: source
+created: 2026-05-29
+updated: 2026-05-29
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-05-29)
+
+- Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
+- HEAD: `ecb6a093d767203add54de4d0d703783c80abda0`
+- Total commits on HEAD: 2554
+- New commits since last ingest (`13d703327a00a157f1c9e8d546ec1c30df62c797`): 71
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1053 "docs(wiki): document stack fan-out + correct rule-delivery model"
+
+## New commits
+- ecb6a093 · 2026-05-28 · docs(wiki): ingest incremental Lisa history
+- 80147b77 · 2026-05-29 · chore(release): 2.123.2 [skip ci]
+- 1da8a8dd · 2026-05-29 · Merge pull request #1053 from CodySwannGT/followup/fix-rule-delivery-doc
+- 9e851262 · 2026-05-29 · Merge branch 'main' into followup/fix-rule-delivery-doc
+- af9595bb · 2026-05-29 · docs(wiki): document stack fan-out + correct rule-delivery model
+- 6fd72bf2 · 2026-05-29 · chore(release): 2.123.1 [skip ci]
+- 2771e847 · 2026-05-29 · Merge pull request #1052 from CodySwannGT/followup/agy-bake-flat-rules-fallback
+- 8a7bd436 · 2026-05-29 · fix(parity): agy bake resolves rules like inject-rules.sh (eager OR flat)
+- 8b6da02f · 2026-05-29 · chore(release): 2.123.0 [skip ci]
+- 5ab6110c · 2026-05-28 · Merge pull request #1044 from CodySwannGT/expo-sdk-56-support
+- 8a2c3952 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- 18784e9d · 2026-05-28 · build(plugins): rebuild artifacts after main merge (v2.121.1 + /src skill variants)
+- 14f565e4 · 2026-05-29 · chore(release): 2.122.0 [skip ci]
+- be2895dd · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- d02d9f56 · 2026-05-28 · Merge pull request #1050 from CodySwannGT/followup/stack-per-agent-fanout
+- 29c80d14 · 2026-05-29 · Merge branch 'main' into followup/stack-per-agent-fanout
+- b8e55dc1 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- d1eb0648 · 2026-05-28 · feat(parity): install matching stack variant per detected type on agy/copilot
+- e3ed805c · 2026-05-28 · feat(parity): fan out every Lisa plugin to cursor/agy/copilot variants
+- 264fb8fd · 2026-05-29 · chore(release): 2.121.1 [skip ci]
+- c08b3403 · 2026-05-28 · Merge pull request #1049 from CodySwannGT/followup/coding-agent-parity-verification
+- 84623091 · 2026-05-28 · test(cli): de-brittle getPackageVersion (read live version, not a literal)
+- 9f7f836d · 2026-05-28 · docs(expo): address CodeRabbit — SDK 56 doc consistency + validator path reporting
+- 393c6d06 · 2026-05-29 · Merge branch 'main' into followup/coding-agent-parity-verification
+- 517b475f · 2026-05-28 · docs(wiki): record Codex/Copilot parity findings verified by run
+- c767b024 · 2026-05-28 · fix(parity): include Codex in fleet emit + bake agy rules from base plugin
+- 9903d4c4 · 2026-05-28 · fix(parity): execFile for plugin installs + agy MCP scope resolver
+- a45dce25 · 2026-05-28 · fix(parity): pin Codex plugin key to lisa@lisa + populate Copilot probe cache
+- eaae96ef · 2026-05-28 · fix(parity): emit Codex hooks where Codex actually discovers them
+- c91536b5 · 2026-05-28 · fix(expo): apply directory-structure /src edits to plugin source
+- 2b7b3d8c · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.121.0
+- e3cebf22 · 2026-05-29 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- 26847556 · 2026-05-28 · fix(expo): make knip/prettier/eslint-ignore templates /src-aware
+- 546fc795 · 2026-05-28 · fix(expo): wire sourceRoot into jest/eslint entry templates (auto-detect /src)
+- 02c3d76d · 2026-05-29 · chore(release): 2.121.0 [skip ci]
+- f3cd2b27 · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- 165e4901 · 2026-05-28 · Merge pull request #1046 from CodySwannGT/implement/coding-agent-parity-wave-3b
+- 2fc7b327 · 2026-05-28 · fix(parity): correct Codex hooks.json root shape + harden hook parsing
+- 2040775a · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.120.0
+- 3f0214de · 2026-05-29 · docs(expo): fix eas:publish script examples in upgrade guide
+- e57ba245 · 2026-05-28 · feat(parity): wave 3b — emit plugin-bundled Codex hooks (Action 3)
+- 299fb91b · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- c56911fc · 2026-05-28 · Merge pull request #1042 from CodySwannGT/implement/coding-agent-parity-wave-1
+- d322e616 · 2026-05-28 · Merge pull request #1043 from CodySwannGT/implement/coding-agent-parity-wave-2
+- 359b1ffe · 2026-05-28 · chore(release): 2.120.0 [skip ci]
+- 0485f8f7 · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
+- b1d81c0b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
+- 6665f3de · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
+- 58aa6634 · 2026-05-28 · Merge pull request #1045 from CodySwannGT/implement/coding-agent-parity-wave-3
+- 32cf1a7a · 2026-05-28 · test(cli): bump getPackageVersion expectation to 2.119.1
+- 5a9a8b8e · 2026-05-28 · feat(parity): wave 3 part 7 — wire installers into lisa apply + unit tests
+- 8d59241b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-3
+- c80c03a7 · 2026-05-28 · fix(parity): wave 3 part 5b — TOML detection tolerance + dual-key
+- a1f207cb · 2026-05-28 · test(parity): wave 3 part 6 — per-cluster verification probe script
+- 93773d1d · 2026-05-28 · feat(parity): wave 3 part 5 — Codex plugin-install detection
+- 21ccd891 · 2026-05-28 · feat(parity): wave 3 part 4 — Claude memory installer
+- 2c68de09 · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
+- 8dac2a22 · 2026-05-28 · feat(parity): wave 3 part 3 — Copilot per-project installers
+- 3524c1b8 · 2026-05-28 · feat(parity): wave 3 part 2 — agy per-project installers
+- eb9a731e · 2026-05-28 · test: align config tests with SDK 56 resolver + fix stale version assertion
+- b262f398 · 2026-05-28 · feat(expo): support Expo SDK 56 + /src directory convention
+- d02c8877 · 2026-05-28 · feat(parity): wave 3 part 1 — Pattern B per-agent plugin variant build pipeline
+- 6713279e · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
+- 640d4cef · 2026-05-28 · docs(parity): wave 2 — architecture decisions + Pattern B fan-out spec
+- 89b44cbc · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
+- 374d6259 · 2026-05-28 · docs(parity): wave 1 — per-agent hook ship-list audit
+- fedef014 · 2026-05-28 · chore(release): 2.119.1 [skip ci]
+- 93891999 · 2026-05-28 · Merge pull request #1041 from CodySwannGT/wiki/ingest-2026-05-28-coding-agent-parity
+- b37f07c9 · 2026-05-28 · docs(wiki): fix Codex installer module count from nine to ten
+- f3deca06 · 2026-05-28 · test(cli): update getPackageVersion expectation to 2.119.0
+- 066f4b56 · 2026-05-28 · docs(wiki): ingest coding-agent parity research artifact

--- a/wiki/sources/roles/2026-05-29-roles.md
+++ b/wiki/sources/roles/2026-05-29-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-05-29
+updated: 2026-05-29
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-05-29)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-28T01:34:28.919Z",
+  "ingested_at": "2026-05-28T13:35:57.183Z",
   "cursor": {
-    "lastCommit": "3e99859c0c73e29c341c441f2c34976f4fab2806",
-    "lastPr": 1035
+    "lastCommit": "13d703327a00a157f1c9e8d546ec1c30df62c797",
+    "lastPr": 1040
   },
   "source_notes": [
     "wiki/sources/git/2026-05-28-lisa-monorepo-git.md"

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-28T13:35:57.183Z",
+  "ingested_at": "2026-05-29T09:41:51.299Z",
   "cursor": {
-    "lastCommit": "13d703327a00a157f1c9e8d546ec1c30df62c797",
-    "lastPr": 1040
+    "lastCommit": "ecb6a093d767203add54de4d0d703783c80abda0",
+    "lastPr": 1053
   },
   "source_notes": [
-    "wiki/sources/git/2026-05-28-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-05-29-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-28T01:34:28.376Z",
+  "ingested_at": "2026-05-28T13:35:56.040Z",
   "cursor": {
     "roles": 0,
     "pages": 0,

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-28T13:35:56.040Z",
+  "ingested_at": "2026-05-29T09:41:50.632Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-05-28"
+    "lastIngest": "2026-05-29"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-05-28-roles.md"
+    "wiki/sources/roles/2026-05-29-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- resolve the prior local wiki ingest rebase conflict and preserve the 2026-05-28 connector entry
- ingest git history through Lisa 2.123.2 / merged PR #1053 and refresh roles source notes
- update wiki snapshot, index, log, vocabulary, workflow, and connector state

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/validate-config.mjs wiki/lisa-wiki.config.json
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --config wiki/lisa-wiki.config.json (0 fail, 22 pre-existing warnings)
- targeted secret scan on changed files
- commit hooks: gitleaks, tsc --noEmit, prettier/lint-staged, commitlint
- pre-push: bun audit, eslint slow config, knip, vitest run --coverage, vitest run tests/integration

Memory connector skipped because no memory directory was provably scoped to /Users/cody/.codex/worktrees/lisa-automation-main; the available Claude memory path was scoped to /Users/cody/workspace/lisa.