### PR TITLE
docs(wiki): ingest Lisa history through 2.124.0

### DIFF
--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -75,3 +75,7 @@ A per-agent plugin variant is a generated Lisa plugin artifact tailored to one c
 ## Eager-Or-Flat Rule Resolution
 
 Eager-or-flat rule resolution means Lisa first loads `rules/eager/` when present and otherwise falls back to flat markdown files directly under `rules/`. `rules/reference/` stays out of startup injection and is loaded only when needed.
+
+## Claude Remote Routine Readiness
+
+Claude Remote routine readiness is the local-vs-cloud audit Lisa runs before a repository is expected to execute inside a Claude Code remote routine. It inventories required CLIs, package managers, environment variable names, startup hook safety, MCP transport/auth boundaries, user-scoped config gaps, and network allowlist needs without collecting secret values.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by incremental connector ingest on 2026-05-29 through Lisa release `2.123.2` and merged PR `#1053`.
+Last updated by incremental connector ingest on 2026-05-29 through Lisa release `2.124.0` and merged PR `#1060`.
 
 ## Orientation
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -155,3 +155,12 @@
 - Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
 - Skipped `memory` because the only available Claude memory directory was scoped to `/Users/cody/workspace/lisa`, not `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
 - Updated the monorepo snapshot, template-governance notes, workflow playbook, vocabulary, and index for per-agent stack variant fan-out, Codex/Copilot hook verification fixes, agy eager-or-flat rule delivery, Expo SDK 56 `/src` support, and release-history changes through `2.123.2`.
+
+## 2026-05-29 - Incremental connector ingest
+
+- Synced the durable checkout with `origin/main`, rebased the current branch without conflicts, created `wiki/ingest-2026-05-29-093858`, and ran another full no-argument ingest against every enabled non-external-write connector in `wiki/lisa-wiki.config.json`.
+- Preserved the previous same-day git and roles source notes under timestamped filenames before refreshing the current `2026-05-29` connector notes, so the prior ingestion provenance remains available.
+- Refreshed the `git` source note with 6 new commits through `a4c5901d607157b097ba4338d4695da5c7ce2902`, advanced the merged-PR cursor to `#1060`, and captured the release line through Lisa `2.124.0`.
+- Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
+- Skipped `memory` because no project-scoped Claude memory directory exists for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
+- Updated the monorepo snapshot, workflow playbook, vocabulary, and index for the new Claude Remote routine readiness audit and setup-script generator commands.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -14,6 +14,8 @@ Lisa exposes lifecycle commands and quality workflows that route work through re
 
 Lisa also supports local review, PR review handling, test coverage improvement, test hardening, code-complexity reduction, max-lines reduction, linter-error cleanup, branch pruning, and security scans.
 
+Claude Remote routine setup is now covered by two base commands. `/lisa:analyze-claude-remote` is the read-only cloud-readiness audit for a repository; `/lisa:generate-claude-remote-build-script` consumes that inventory and writes a remote-environment setup script, environment-variable-name template, and network allowlist.
+
 ## Recurring Automations
 
 Codex-hosted Lisa automations should run from durable project automation checkouts, not transient task worktrees. Setup flows create or refresh a stable checkout under the Codex worktree area, verify it is a normal non-bare Git work tree, and require each automation cycle to fetch and rebase or fast-forward against the default remote branch before queue or wiki work begins. If the checkout is dirty, conflicted, stale, or has broken Git metadata, the automation reports the blocker instead of mutating queue or wiki state.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,18 +20,20 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-2026-05-28-133543` rebased onto `origin/main`
-- HEAD at 2026-05-29 incremental ingest: `ecb6a093d767203add54de4d0d703783c80abda0`
-- Current package version: `2.123.2`
-- Total commits on HEAD: 2554
-- Latest merged PR captured in the incremental git snapshot: `#1053`
-- New commits since the previous incremental git cursor: `71`
-- Project-scoped memory skipped this cycle because the only available Claude memory directory was scoped to `/Users/cody/workspace/lisa`, not this automation checkout; global Codex memory remains out of scope.
+- Ingest branch: `wiki/ingest-2026-05-29-093858` created from synced `origin/main`
+- HEAD at 2026-05-29 incremental ingest: `a4c5901d607157b097ba4338d4695da5c7ce2902`
+- Current package version: `2.124.0`
+- Total commits on HEAD: 2560
+- Latest merged PR captured in the incremental git snapshot: `#1060`
+- New commits since the previous incremental git cursor: `6`
+- Project-scoped memory skipped this cycle because no Claude memory directory exists for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
-- Release automation advanced the monorepo to `2.123.2`.
-- The prior local connector-ingest commit was rebased onto current `origin/main`, preserving the 2026-05-28 connector cursor before this 2026-05-29 ingest advanced it again.
+- Release automation advanced the monorepo to `2.124.0`.
+- The automation checkout was clean, fetched from `origin`, and rebased onto `origin/main` without conflicts before this 2026-05-29 ingest.
+- The previous same-day git and roles source notes were preserved under timestamped filenames before refreshing the current same-day connector notes.
+- Claude Remote routine readiness work added `/lisa:analyze-claude-remote` and `/lisa:generate-claude-remote-build-script` from `plugins/src/base`, with generated `lisa`, Cursor, agy, and Copilot variants. The audit inventories cloud-session requirements such as CLIs, environment variable names, startup hooks, MCP scope and auth, user-scoped config gaps, and network constraints; the generator writes an idempotent setup script, env-var template, and domain allowlist for Claude Code remote routine environments.
 - Coding-agent parity work shipped per-agent plugin variant generation, Codex plugin-bundled hook corrections, Copilot probe cache evidence, and `lisa apply --harness fleet` dispatch fixes.
 - The Pattern B fan-out now covers every built Claude plugin, producing cursor, agy, and copilot variants for the base plugin plus stack and standalone plugins.
 - Agy rule delivery now resolves rules the same way as `inject-rules.sh`: prefer `rules/eager/`, then fall back to flat `rules/`, leaving only `rules/reference/` on-demand.
@@ -53,6 +55,7 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/git/2026-05-26-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-27-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-28-lisa-monorepo-git.md`
+- `wiki/sources/git/2026-05-29-094151-lisa-monorepo-git.md`
 - `wiki/sources/git/2026-05-29-lisa-monorepo-git.md`
 - `wiki/sources/memory/2026-05-27-memory.md`
 - `wiki/sources/memory/2026-05-28-memory.md`
@@ -60,4 +63,5 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/roles/2026-05-26-roles.md`
 - `wiki/sources/roles/2026-05-27-roles.md`
 - `wiki/sources/roles/2026-05-28-roles.md`
+- `wiki/sources/roles/2026-05-29-094151-roles.md`
 - `wiki/sources/roles/2026-05-29-roles.md`

--- a/wiki/sources/git/2026-05-29-094151-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-29-094151-lisa-monorepo-git.md
@@ -1,0 +1,90 @@
+---
+type: source
+created: 2026-05-29
+updated: 2026-05-29
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-05-29)
+
+- Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
+- HEAD: `ecb6a093d767203add54de4d0d703783c80abda0`
+- Total commits on HEAD: 2554
+- New commits since last ingest (`13d703327a00a157f1c9e8d546ec1c30df62c797`): 71
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1053 "docs(wiki): document stack fan-out + correct rule-delivery model"
+
+## New commits
+- ecb6a093 · 2026-05-28 · docs(wiki): ingest incremental Lisa history
+- 80147b77 · 2026-05-29 · chore(release): 2.123.2 [skip ci]
+- 1da8a8dd · 2026-05-29 · Merge pull request #1053 from CodySwannGT/followup/fix-rule-delivery-doc
+- 9e851262 · 2026-05-29 · Merge branch 'main' into followup/fix-rule-delivery-doc
+- af9595bb · 2026-05-29 · docs(wiki): document stack fan-out + correct rule-delivery model
+- 6fd72bf2 · 2026-05-29 · chore(release): 2.123.1 [skip ci]
+- 2771e847 · 2026-05-29 · Merge pull request #1052 from CodySwannGT/followup/agy-bake-flat-rules-fallback
+- 8a7bd436 · 2026-05-29 · fix(parity): agy bake resolves rules like inject-rules.sh (eager OR flat)
+- 8b6da02f · 2026-05-29 · chore(release): 2.123.0 [skip ci]
+- 5ab6110c · 2026-05-28 · Merge pull request #1044 from CodySwannGT/expo-sdk-56-support
+- 8a2c3952 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- 18784e9d · 2026-05-28 · build(plugins): rebuild artifacts after main merge (v2.121.1 + /src skill variants)
+- 14f565e4 · 2026-05-29 · chore(release): 2.122.0 [skip ci]
+- be2895dd · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- d02d9f56 · 2026-05-28 · Merge pull request #1050 from CodySwannGT/followup/stack-per-agent-fanout
+- 29c80d14 · 2026-05-29 · Merge branch 'main' into followup/stack-per-agent-fanout
+- b8e55dc1 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- d1eb0648 · 2026-05-28 · feat(parity): install matching stack variant per detected type on agy/copilot
+- e3ed805c · 2026-05-28 · feat(parity): fan out every Lisa plugin to cursor/agy/copilot variants
+- 264fb8fd · 2026-05-29 · chore(release): 2.121.1 [skip ci]
+- c08b3403 · 2026-05-28 · Merge pull request #1049 from CodySwannGT/followup/coding-agent-parity-verification
+- 84623091 · 2026-05-28 · test(cli): de-brittle getPackageVersion (read live version, not a literal)
+- 9f7f836d · 2026-05-28 · docs(expo): address CodeRabbit — SDK 56 doc consistency + validator path reporting
+- 393c6d06 · 2026-05-29 · Merge branch 'main' into followup/coding-agent-parity-verification
+- 517b475f · 2026-05-28 · docs(wiki): record Codex/Copilot parity findings verified by run
+- c767b024 · 2026-05-28 · fix(parity): include Codex in fleet emit + bake agy rules from base plugin
+- 9903d4c4 · 2026-05-28 · fix(parity): execFile for plugin installs + agy MCP scope resolver
+- a45dce25 · 2026-05-28 · fix(parity): pin Codex plugin key to lisa@lisa + populate Copilot probe cache
+- eaae96ef · 2026-05-28 · fix(parity): emit Codex hooks where Codex actually discovers them
+- c91536b5 · 2026-05-28 · fix(expo): apply directory-structure /src edits to plugin source
+- 2b7b3d8c · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.121.0
+- e3cebf22 · 2026-05-29 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
+- 26847556 · 2026-05-28 · fix(expo): make knip/prettier/eslint-ignore templates /src-aware
+- 546fc795 · 2026-05-28 · fix(expo): wire sourceRoot into jest/eslint entry templates (auto-detect /src)
+- 02c3d76d · 2026-05-29 · chore(release): 2.121.0 [skip ci]
+- f3cd2b27 · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- 165e4901 · 2026-05-28 · Merge pull request #1046 from CodySwannGT/implement/coding-agent-parity-wave-3b
+- 2fc7b327 · 2026-05-28 · fix(parity): correct Codex hooks.json root shape + harden hook parsing
+- 2040775a · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.120.0
+- 3f0214de · 2026-05-29 · docs(expo): fix eas:publish script examples in upgrade guide
+- e57ba245 · 2026-05-28 · feat(parity): wave 3b — emit plugin-bundled Codex hooks (Action 3)
+- 299fb91b · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
+- c56911fc · 2026-05-28 · Merge pull request #1042 from CodySwannGT/implement/coding-agent-parity-wave-1
+- d322e616 · 2026-05-28 · Merge pull request #1043 from CodySwannGT/implement/coding-agent-parity-wave-2
+- 359b1ffe · 2026-05-28 · chore(release): 2.120.0 [skip ci]
+- 0485f8f7 · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
+- b1d81c0b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
+- 6665f3de · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
+- 58aa6634 · 2026-05-28 · Merge pull request #1045 from CodySwannGT/implement/coding-agent-parity-wave-3
+- 32cf1a7a · 2026-05-28 · test(cli): bump getPackageVersion expectation to 2.119.1
+- 5a9a8b8e · 2026-05-28 · feat(parity): wave 3 part 7 — wire installers into lisa apply + unit tests
+- 8d59241b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-3
+- c80c03a7 · 2026-05-28 · fix(parity): wave 3 part 5b — TOML detection tolerance + dual-key
+- a1f207cb · 2026-05-28 · test(parity): wave 3 part 6 — per-cluster verification probe script
+- 93773d1d · 2026-05-28 · feat(parity): wave 3 part 5 — Codex plugin-install detection
+- 21ccd891 · 2026-05-28 · feat(parity): wave 3 part 4 — Claude memory installer
+- 2c68de09 · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
+- 8dac2a22 · 2026-05-28 · feat(parity): wave 3 part 3 — Copilot per-project installers
+- 3524c1b8 · 2026-05-28 · feat(parity): wave 3 part 2 — agy per-project installers
+- eb9a731e · 2026-05-28 · test: align config tests with SDK 56 resolver + fix stale version assertion
+- b262f398 · 2026-05-28 · feat(expo): support Expo SDK 56 + /src directory convention
+- d02c8877 · 2026-05-28 · feat(parity): wave 3 part 1 — Pattern B per-agent plugin variant build pipeline
+- 6713279e · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
+- 640d4cef · 2026-05-28 · docs(parity): wave 2 — architecture decisions + Pattern B fan-out spec
+- 89b44cbc · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
+- 374d6259 · 2026-05-28 · docs(parity): wave 1 — per-agent hook ship-list audit
+- fedef014 · 2026-05-28 · chore(release): 2.119.1 [skip ci]
+- 93891999 · 2026-05-28 · Merge pull request #1041 from CodySwannGT/wiki/ingest-2026-05-28-coding-agent-parity
+- b37f07c9 · 2026-05-28 · docs(wiki): fix Codex installer module count from nine to ten
+- f3deca06 · 2026-05-28 · test(cli): update getPackageVersion expectation to 2.119.0
+- 066f4b56 · 2026-05-28 · docs(wiki): ingest coding-agent parity research artifact

--- a/wiki/sources/git/2026-05-29-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-05-29-lisa-monorepo-git.md
@@ -11,80 +11,15 @@ project: lisa-monorepo
 # git history — lisa-monorepo (2026-05-29)
 
 - Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
-- HEAD: `ecb6a093d767203add54de4d0d703783c80abda0`
-- Total commits on HEAD: 2554
-- New commits since last ingest (`13d703327a00a157f1c9e8d546ec1c30df62c797`): 71
-- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1053 "docs(wiki): document stack fan-out + correct rule-delivery model"
+- HEAD: `a4c5901d607157b097ba4338d4695da5c7ce2902`
+- Total commits on HEAD: 2560
+- New commits since last ingest (`ecb6a093d767203add54de4d0d703783c80abda0`): 6
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1060 "feat(base): add claude-remote readiness skills"
 
 ## New commits
-- ecb6a093 · 2026-05-28 · docs(wiki): ingest incremental Lisa history
-- 80147b77 · 2026-05-29 · chore(release): 2.123.2 [skip ci]
-- 1da8a8dd · 2026-05-29 · Merge pull request #1053 from CodySwannGT/followup/fix-rule-delivery-doc
-- 9e851262 · 2026-05-29 · Merge branch 'main' into followup/fix-rule-delivery-doc
-- af9595bb · 2026-05-29 · docs(wiki): document stack fan-out + correct rule-delivery model
-- 6fd72bf2 · 2026-05-29 · chore(release): 2.123.1 [skip ci]
-- 2771e847 · 2026-05-29 · Merge pull request #1052 from CodySwannGT/followup/agy-bake-flat-rules-fallback
-- 8a7bd436 · 2026-05-29 · fix(parity): agy bake resolves rules like inject-rules.sh (eager OR flat)
-- 8b6da02f · 2026-05-29 · chore(release): 2.123.0 [skip ci]
-- 5ab6110c · 2026-05-28 · Merge pull request #1044 from CodySwannGT/expo-sdk-56-support
-- 8a2c3952 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
-- 18784e9d · 2026-05-28 · build(plugins): rebuild artifacts after main merge (v2.121.1 + /src skill variants)
-- 14f565e4 · 2026-05-29 · chore(release): 2.122.0 [skip ci]
-- be2895dd · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
-- d02d9f56 · 2026-05-28 · Merge pull request #1050 from CodySwannGT/followup/stack-per-agent-fanout
-- 29c80d14 · 2026-05-29 · Merge branch 'main' into followup/stack-per-agent-fanout
-- b8e55dc1 · 2026-05-28 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
-- d1eb0648 · 2026-05-28 · feat(parity): install matching stack variant per detected type on agy/copilot
-- e3ed805c · 2026-05-28 · feat(parity): fan out every Lisa plugin to cursor/agy/copilot variants
-- 264fb8fd · 2026-05-29 · chore(release): 2.121.1 [skip ci]
-- c08b3403 · 2026-05-28 · Merge pull request #1049 from CodySwannGT/followup/coding-agent-parity-verification
-- 84623091 · 2026-05-28 · test(cli): de-brittle getPackageVersion (read live version, not a literal)
-- 9f7f836d · 2026-05-28 · docs(expo): address CodeRabbit — SDK 56 doc consistency + validator path reporting
-- 393c6d06 · 2026-05-29 · Merge branch 'main' into followup/coding-agent-parity-verification
-- 517b475f · 2026-05-28 · docs(wiki): record Codex/Copilot parity findings verified by run
-- c767b024 · 2026-05-28 · fix(parity): include Codex in fleet emit + bake agy rules from base plugin
-- 9903d4c4 · 2026-05-28 · fix(parity): execFile for plugin installs + agy MCP scope resolver
-- a45dce25 · 2026-05-28 · fix(parity): pin Codex plugin key to lisa@lisa + populate Copilot probe cache
-- eaae96ef · 2026-05-28 · fix(parity): emit Codex hooks where Codex actually discovers them
-- c91536b5 · 2026-05-28 · fix(expo): apply directory-structure /src edits to plugin source
-- 2b7b3d8c · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.121.0
-- e3cebf22 · 2026-05-29 · Merge remote-tracking branch 'origin/main' into expo-sdk-56-support
-- 26847556 · 2026-05-28 · fix(expo): make knip/prettier/eslint-ignore templates /src-aware
-- 546fc795 · 2026-05-28 · fix(expo): wire sourceRoot into jest/eslint entry templates (auto-detect /src)
-- 02c3d76d · 2026-05-29 · chore(release): 2.121.0 [skip ci]
-- f3cd2b27 · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
-- 165e4901 · 2026-05-28 · Merge pull request #1046 from CodySwannGT/implement/coding-agent-parity-wave-3b
-- 2fc7b327 · 2026-05-28 · fix(parity): correct Codex hooks.json root shape + harden hook parsing
-- 2040775a · 2026-05-29 · test(cli): bump getPackageVersion expectation to 2.120.0
-- 3f0214de · 2026-05-29 · docs(expo): fix eas:publish script examples in upgrade guide
-- e57ba245 · 2026-05-28 · feat(parity): wave 3b — emit plugin-bundled Codex hooks (Action 3)
-- 299fb91b · 2026-05-29 · Merge branch 'main' into expo-sdk-56-support
-- c56911fc · 2026-05-28 · Merge pull request #1042 from CodySwannGT/implement/coding-agent-parity-wave-1
-- d322e616 · 2026-05-28 · Merge pull request #1043 from CodySwannGT/implement/coding-agent-parity-wave-2
-- 359b1ffe · 2026-05-28 · chore(release): 2.120.0 [skip ci]
-- 0485f8f7 · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
-- b1d81c0b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
-- 6665f3de · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
-- 58aa6634 · 2026-05-28 · Merge pull request #1045 from CodySwannGT/implement/coding-agent-parity-wave-3
-- 32cf1a7a · 2026-05-28 · test(cli): bump getPackageVersion expectation to 2.119.1
-- 5a9a8b8e · 2026-05-28 · feat(parity): wave 3 part 7 — wire installers into lisa apply + unit tests
-- 8d59241b · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-3
-- c80c03a7 · 2026-05-28 · fix(parity): wave 3 part 5b — TOML detection tolerance + dual-key
-- a1f207cb · 2026-05-28 · test(parity): wave 3 part 6 — per-cluster verification probe script
-- 93773d1d · 2026-05-28 · feat(parity): wave 3 part 5 — Codex plugin-install detection
-- 21ccd891 · 2026-05-28 · feat(parity): wave 3 part 4 — Claude memory installer
-- 2c68de09 · 2026-05-28 · Merge branch 'main' into expo-sdk-56-support
-- 8dac2a22 · 2026-05-28 · feat(parity): wave 3 part 3 — Copilot per-project installers
-- 3524c1b8 · 2026-05-28 · feat(parity): wave 3 part 2 — agy per-project installers
-- eb9a731e · 2026-05-28 · test: align config tests with SDK 56 resolver + fix stale version assertion
-- b262f398 · 2026-05-28 · feat(expo): support Expo SDK 56 + /src directory convention
-- d02c8877 · 2026-05-28 · feat(parity): wave 3 part 1 — Pattern B per-agent plugin variant build pipeline
-- 6713279e · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-2
-- 640d4cef · 2026-05-28 · docs(parity): wave 2 — architecture decisions + Pattern B fan-out spec
-- 89b44cbc · 2026-05-28 · Merge branch 'main' into implement/coding-agent-parity-wave-1
-- 374d6259 · 2026-05-28 · docs(parity): wave 1 — per-agent hook ship-list audit
-- fedef014 · 2026-05-28 · chore(release): 2.119.1 [skip ci]
-- 93891999 · 2026-05-28 · Merge pull request #1041 from CodySwannGT/wiki/ingest-2026-05-28-coding-agent-parity
-- b37f07c9 · 2026-05-28 · docs(wiki): fix Codex installer module count from nine to ten
-- f3deca06 · 2026-05-28 · test(cli): update getPackageVersion expectation to 2.119.0
-- 066f4b56 · 2026-05-28 · docs(wiki): ingest coding-agent parity research artifact
+- a4c5901d · 2026-05-29 · chore(release): 2.124.0 [skip ci]
+- fd52a4de · 2026-05-29 · Merge pull request #1060 from CodySwannGT/claude/upbeat-chatelet-8d6b67
+- 997ee130 · 2026-05-29 · feat(base): add claude-remote readiness skills
+- f7395114 · 2026-05-29 · chore(release): 2.123.3 [skip ci]
+- 1c21f123 · 2026-05-29 · Merge pull request #1057 from CodySwannGT/wiki/ingest-2026-05-28-133543
+- be868bfb · 2026-05-29 · docs(wiki): ingest Lisa history through 2.123.2

--- a/wiki/sources/roles/2026-05-29-094151-roles.md
+++ b/wiki/sources/roles/2026-05-29-094151-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-05-29
+updated: 2026-05-29
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-05-29)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,10 +1,10 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-05-29T09:41:51.299Z",
+  "ingested_at": "2026-05-29T13:39:19.997Z",
   "cursor": {
-    "lastCommit": "ecb6a093d767203add54de4d0d703783c80abda0",
-    "lastPr": 1053
+    "lastCommit": "a4c5901d607157b097ba4338d4695da5c7ce2902",
+    "lastPr": 1060
   },
   "source_notes": [
     "wiki/sources/git/2026-05-29-lisa-monorepo-git.md"

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,7 +1,7 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-05-29T09:41:50.632Z",
+  "ingested_at": "2026-05-29T13:39:20.028Z",
   "cursor": {
     "roles": 0,
     "pages": 0,


### PR DESCRIPTION
## Summary
- Ingest latest Lisa git history through release 2.124.0 and merged PR #1060
- Preserve previous same-day git/roles source notes before refreshing current connector notes
- Update wiki synthesis for Claude Remote routine readiness audit and setup-script generator commands

## Ingested sources
- git: 6 new commits through a4c5901d607157b097ba4338d4695da5c7ce2902; latest merged PR #1060
- roles: 0 declared roles, 0 staff pages
- memory: skipped; no project-scoped Claude memory dir for this worktree and global Codex memory is out of scope

## Verification
- git diff --check
- node plugins/src/wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json (0 fail, 22 pre-existing warnings)
- commit hook: gitleaks, tsc --noEmit, lint-staged, commitlint, AI co-authorship
- pre-push hook: bun audit, slow ESLint, knip, vitest coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new vocabulary entry defining Claude Remote Routine Readiness, a local-vs-cloud audit that inventories setup requirements.
  * Updated playbook with guidance on Claude Remote routine setup commands for repository cloud-readiness analysis and environment configuration.
  * Refreshed wiki with latest release information (2.124.0) and updated project snapshots with current repository state and recent changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->