### PR TITLE
docs(rules): add auto-merge ancestry-check rule (#1055)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -265,3 +265,15 @@ This sequence is necessary because:
 - Pre-commit hooks (lint/typecheck) run on every commit and will fail if barrel exports reference missing files
 
 Deviating from this sequence (e.g., deleting source without removing barrel export, or adding barrel export before implementation exists) causes pre-commit hook failures.
+
+## Verify Auto-Merge Actually Shipped Your Fix (Ancestry Check)
+
+Enabling auto-merge and pushing a fix commit does NOT guarantee the fix ships. GitHub auto-merge can merge the PRIOR head the instant required checks go green — before your new commit becomes the PR head. This shipped a real bug: release 2.124.5 shipped the `./hooks/` Cursor bug because a CodeRabbit fix commit raced past PR #1069's merge; it had to be fixed forward in 2.124.6 (issue #1055).
+
+Before declaring any auto-merge PR done — do NOT rely on "pushed + thread resolved + checks green" as proof:
+
+1. `git fetch origin`
+2. Confirm the fix commit is an ancestor of the merged base: `git merge-base --is-ancestor <fix-sha> origin/main` (exit 0 = shipped).
+3. Confirm the merge commit's parent is your fixed commit, not a stale head.
+
+If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confirm the merged head includes it.


### PR DESCRIPTION
## Summary

Adds a project rule (`.claude/rules/PROJECT_RULES.md`) capturing the #1055 process learning: **enabling auto-merge + pushing a fix does not guarantee the fix ships** — GitHub can merge the prior head the instant required checks go green, before the new commit becomes the PR head.

Refs CodySwannGT/lisa#1055

## Why

During #1055, release 2.124.5 shipped the `./hooks/` Cursor bug because a CodeRabbit fix commit raced past PR #1069's auto-merge; it had to be fixed forward in 2.124.6. The new rule mandates an ancestry check (`git merge-base --is-ancestor <fix-sha> origin/main`) and a merge-parent check before declaring any auto-merge PR done.

Scoped to root `.claude/rules/` only (not `plugins/src`) since it cites Lisa's own release versions/PRs.

## Test plan

Docs-only change; CI quality gates + CodeRabbit apply. This PR will itself be validated with the ancestry check it introduces.

🤖 Generated with Claude Code
