### PR TITLE
fix(copilot): drop invalid subagentStart event + inline MCP pointer (#1056)

### DIFF
--- a/evidence/copilot-hook-mcp-probe-1056.md
+++ b/evidence/copilot-hook-mcp-probe-1056.md
@@ -1,0 +1,91 @@
+# Copilot plugin hook-firing + MCP probe (issue #1056)
+
+Empirical, install-path verification of the GitHub Copilot plugin variant against
+the **GitHub Copilot CLI 1.0.56** (verified by run; the probe cache in
+`scripts/internal-copilot-runtime-probe.json` was captured on 1.0.55 and the
+results below reconfirm them on 1.0.56).
+
+Method: register the local repo as a Copilot marketplace
+(`copilot plugin marketplace add <local path>`), `copilot plugin install` the
+real built artifacts, instrument the bundled hook scripts with a sentinel
+side-effect, then run a non-interactive `copilot -p` session that begins a
+session (`sessionStart`) and runs a Bash tool call (`preToolUse`). Hook firing is
+observed via the sentinel file; MCP load is observed in `~/.copilot/logs`. All
+probe state (marketplace + installs) was removed afterward.
+
+`--plugin-dir` headless mode does NOT load plugin hooks or plugin MCP, so a real
+`copilot plugin install` is required — that is why the original ticket marked
+these "unverified".
+
+## Item #2 / #1 — `subagentStart` invalidates the whole hooks config → zero hooks fire
+
+The base manifest's `SubagentStart` group carries `inject-rules.sh`, which ships
+to Copilot. Translated, it becomes a `subagentStart` event with an empty
+`matcher`. Copilot has no `subagentStart` event and rejects the **entire** inline
+hooks config on the empty matcher, so NONE of the plugin's hooks fire.
+
+**Probe A — buggy (`subagentStart` present), CLI 1.0.56:**
+
+```
+Plugin "lisa-copilot-buggy" installed successfully. Installed 123 skills.
+hooks fired (buggy):  NONE — zero hooks fired
+[ERROR] Invalid inline hooks config for plugin "lisa-copilot-buggy": hooks.subagentStart[0].matcher: matcher cannot be empty
+```
+
+**Probe B — fixed (`subagentStart` dropped, this PR), CLI 1.0.56:**
+
+```
+Plugin "lisa-copilot-fixed" installed successfully. Installed 123 skills.
+hooks fired (fixed):
+fired:lisa-copilot-fixed:install-pkgs.sh
+fired:lisa-copilot-fixed:inject-rules.sh
+fired:lisa-copilot-fixed:setup-jira-cli.sh
+```
+
+→ With `subagentStart` removed, the `sessionStart` hooks fire and
+`${CLAUDE_PLUGIN_ROOT}` resolves (to `~/.copilot/installed-plugins/.../lisa-copilot`).
+`inject-rules.sh` fires under `sessionStart`, so **Lisa rules are delivered**
+(AC-1). The `subagentStart` fix is the thing that unblocks hook firing — items #1
+and #2 are the same root cause.
+
+## Item #3 — bundled `.mcp.json` is not auto-discovered; only an inline `mcpServers` object loads
+
+`copilot mcp --help` lists the MCP config sources as `User`
+(`~/.copilot/mcp-config.json`), `Workspace` (project-root `.mcp.json`), and
+`Plugin` (installed plugins with MCP servers). A plugin's bundled `.mcp.json` is
+NOT the workspace file. Tested shapes (CLI 1.0.55 + reconfirmed 1.0.56):
+
+| Plugin manifest / files | `expo` server loaded? |
+|---|---|
+| bundled `.mcp.json`, no manifest field | NO ("No MCP servers configured") |
+| `"mcpServers": ".mcp.json"` (path string) | NO |
+| root `plugin.json` with inline `mcpServers` | NO (via `mcp list`) |
+| `mcp.json` / `.github/mcp.json` files | NO |
+| **`.claude-plugin/plugin.json` inline `mcpServers` object** | **YES** |
+
+**Probe C — inline `mcpServers` object (this PR), CLI 1.0.56:**
+
+```
+Plugin "lisa-expo-copilot" installed successfully. Installed 44 skills.
+[ERROR] Server expo requires authentication, initiating OAuth flow
+[ERROR] OAuth authentication required for expo
+[ERROR] OAuth required for expo with no cached tokens; marking as needs-auth
+```
+
+→ Copilot loads the plugin's `expo` server and initiates its connection (the
+OAuth step is expected — the public expo MCP requires auth). Note `copilot mcp
+list` does NOT enumerate plugin-provided servers in 1.0.55/1.0.56 (only User +
+Workspace), so the load is observed via the session log, not `mcp list`. The fix
+mirrors `.mcp.json`'s `mcpServers` into the manifest as an inline object.
+
+## Conclusion
+
+- **AC-1 (hooks fire):** PASS — `sessionStart` hooks fire after install once the
+  invalid `subagentStart` is dropped; `inject-rules.sh` delivers rules.
+- **AC-2 (only valid events shipped):** PASS — `subagentStart` removed from every
+  copilot variant; cursor (which supports it) is unaffected.
+- **AC-3 (MCP discovery):** PASS — inline `mcpServers` object loads the server;
+  bare `.mcp.json` and the path-string pointer do not.
+
+Residual note: `copilot mcp list` not enumerating plugin servers is a Copilot CLI
+display limitation, not a Lisa defect — the server is loaded in-session.

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -45,17 +45,6 @@
           }
         ]
       }
-    ],
-    "subagentStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh"
-          }
-        ]
-      }
     ]
   }
 }

--- a/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
@@ -7,5 +7,11 @@
   },
   "dependencies": [
     "lisa-typescript"
-  ]
+  ],
+  "mcpServers": {
+    "expo": {
+      "type": "http",
+      "url": "https://mcp.expo.dev/mcp"
+    }
+  }
 }

--- a/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
@@ -19,17 +19,6 @@
           }
         ]
       }
-    ],
-    "subagentStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh"
-          }
-        ]
-      }
     ]
   }
 }

--- a/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
@@ -20,17 +20,6 @@
         ]
       }
     ],
-    "subagentStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh"
-          }
-        ]
-      }
-    ],
     "postToolUse": [
       {
         "matcher": "Write|Edit",

--- a/scripts/generate-copilot-plugin-artifacts.mjs
+++ b/scripts/generate-copilot-plugin-artifacts.mjs
@@ -199,6 +199,35 @@ export function generateCopilotVariant(srcDir, outDir, version) {
   } else {
     delete manifest.hooks;
   }
+
+  // 3b. Surface a bundled `.mcp.json`'s servers as an INLINE `mcpServers` object
+  // in the manifest. Copilot does NOT auto-discover a plugin's bundled
+  // `.mcp.json` (it reads `.mcp.json` only at the WORKSPACE root), and a
+  // `".mcp.json"` path-string pointer is ignored; only an inline `mcpServers`
+  // OBJECT in the manifest is honored. Verified by run (GitHub Copilot CLI
+  // 1.0.55, issue #1056): after `copilot plugin install`, the inline object made
+  // Copilot load the bundled server (the expo server initiated its OAuth
+  // connect), whereas bare `.mcp.json` and the path-string form both left
+  // Copilot reporting "No MCP servers configured". The `.mcp.json` file is kept
+  // (it is the source of truth and harmless to Copilot) and mirrored inline.
+  const mcpJsonPath = path.join(outDir, ".mcp.json");
+  if (fs.existsSync(mcpJsonPath)) {
+    try {
+      const mcpDoc = JSON.parse(fs.readFileSync(mcpJsonPath, "utf8"));
+      const servers = mcpDoc?.mcpServers;
+      if (servers && Object.keys(servers).length > 0) {
+        manifest.mcpServers = servers;
+      }
+    } catch (err) {
+      // Malformed `.mcp.json` — leave the manifest without an mcpServers pointer
+      // rather than emitting a broken one, but surface it so a broken MCP file
+      // doesn't ship silently without its servers.
+      console.warn(
+        `[copilot] skipping mcpServers pointer: could not parse ${mcpJsonPath}: ${err.message}`
+      );
+    }
+  }
+
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 
   // 4. Filter the hooks/ directory.

--- a/scripts/generate-copilot-plugin-artifacts.mjs
+++ b/scripts/generate-copilot-plugin-artifacts.mjs
@@ -215,8 +215,20 @@ export function generateCopilotVariant(srcDir, outDir, version) {
     try {
       const mcpDoc = JSON.parse(fs.readFileSync(mcpJsonPath, "utf8"));
       const servers = mcpDoc?.mcpServers;
-      if (servers && Object.keys(servers).length > 0) {
+      if (
+        servers &&
+        typeof servers === "object" &&
+        !Array.isArray(servers) &&
+        Object.keys(servers).length > 0
+      ) {
         manifest.mcpServers = servers;
+      } else if (mcpDoc && "mcpServers" in mcpDoc) {
+        // Present but not a non-empty plain object (e.g. `[]`, a string) — a
+        // parseable-but-invalid file. Skip the pointer rather than emit a broken
+        // one, and surface why.
+        console.warn(
+          `[copilot] skipping mcpServers pointer: invalid mcpServers shape in ${mcpJsonPath}`
+        );
       }
     } catch (err) {
       // Malformed `.mcp.json` — leave the manifest without an mcpServers pointer

--- a/scripts/lib/per-agent-hook-filter.mjs
+++ b/scripts/lib/per-agent-hook-filter.mjs
@@ -148,7 +148,9 @@ const COPILOT_EVENTS = {
   SessionEnd: "sessionEnd",
   UserPromptSubmit: "userPromptSubmitted",
   Stop: "agentStop",
-  SubagentStart: "subagentStart", // not supported but include for symmetry
+  // No `SubagentStart`: Copilot has no such event. It is dropped wholesale by
+  // AGENT_UNSUPPORTED_EVENTS before translation ever runs (see
+  // filterHooksForAgent), so it never needs a mapping here.
   SubagentStop: "subagentStop",
 };
 
@@ -168,6 +170,40 @@ const CURSOR_EVENTS = {
   SubagentStop: "subagentStop",
   PreCompact: "preCompact",
 };
+
+/**
+ * Events a target agent's hook runner does NOT recognize. A hook block under one
+ * of these events is dropped wholesale for that agent — even when an individual
+ * handler script would otherwise ship — because emitting the event yields a
+ * manifest the agent rejects.
+ *
+ * Copilot has no `SubagentStart` event. Worse, the emitted `subagentStart` entry
+ * carries an empty `matcher`, and GitHub Copilot CLI (verified against 1.0.55)
+ * rejects the ENTIRE inline hooks config on it — `Invalid inline hooks config
+ * ...: hooks.subagentStart[0].matcher: matcher cannot be empty` — so NONE of the
+ * plugin's hooks fire, not just the subagent one. Dropping the event restores
+ * Copilot hook firing; `inject-rules.sh` still ships under `SessionStart`, so no
+ * rule delivery is lost. (Issue #1056, verified by run: with `subagentStart`
+ * present zero hooks fired; with it removed the `SessionStart` hooks fired and
+ * `${CLAUDE_PLUGIN_ROOT}` resolved.)
+ *
+ * @type {Record<string, Set<string>>}
+ */
+const AGENT_UNSUPPORTED_EVENTS = {
+  copilot: new Set(["SubagentStart"]),
+};
+
+/**
+ * Whether a Claude event name is unsupported by the target agent and must be
+ * dropped wholesale (not translated, not partially filtered).
+ *
+ * @param {string} claudeEventName Claude event name (e.g. "SubagentStart")
+ * @param {"cursor"|"agy"|"copilot"|"codex"} agent Target agent slug
+ * @returns {boolean}
+ */
+export function isUnsupportedEvent(claudeEventName, agent) {
+  return Boolean(AGENT_UNSUPPORTED_EVENTS[agent]?.has(claudeEventName));
+}
 
 /**
  * Translate Claude PascalCase event names to a target agent's native casing.
@@ -278,6 +314,7 @@ export function filterHooksForAgent(hookBlock, agent, opts = {}) {
   const out = {};
 
   for (const [claudeEventName, entries] of Object.entries(hookBlock)) {
+    if (isUnsupportedEvent(claudeEventName, agent)) continue;
     if (!Array.isArray(entries)) continue;
     const filteredEntries = [];
     for (const entry of entries) {

--- a/tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts
+++ b/tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Behavior tests for scripts/generate-copilot-plugin-artifacts.mjs (issue #1056).
+ *
+ * Two verified-by-run mismatches against GitHub Copilot CLI 1.0.55:
+ *   1. subagentStart: an emitted `subagentStart` hook (empty matcher) makes
+ *      Copilot reject the ENTIRE inline hooks config, so NO hooks fire. The
+ *      generator must drop the event for Copilot while keeping inject-rules.sh
+ *      under sessionStart (no rule-delivery loss).
+ *   2. MCP: Copilot does not auto-discover a plugin's bundled `.mcp.json`, nor a
+ *      `".mcp.json"` path-string pointer; only an inline `mcpServers` OBJECT in
+ *      the manifest loads. The generator must mirror `.mcp.json`'s servers inline.
+ *
+ * The fixture is scaffolded with the shared `scaffoldSource` helper; the
+ * generator reads the repo's committed probe cache (rulesAutoLoads:false), so
+ * inject-rules.sh ships — the realistic path that reproduced the bug.
+ * @module tests/unit/scripts/generate-copilot-plugin-artifacts
+ */
+import * as fs from "fs-extra";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { generateCopilotVariant } from "../../../scripts/generate-copilot-plugin-artifacts.mjs";
+import {
+  BLOCK_NO_VERIFY,
+  CLAUDE_PLUGIN_DIR,
+  INJECT_RULES,
+  PLUGIN_JSON,
+  scaffoldSource,
+} from "./cursor-artifact-helpers";
+
+const ROOT = "${CLAUDE_PLUGIN_ROOT}/hooks/";
+
+const entry = (matcher: string, ...scripts: readonly string[]) => ({
+  matcher,
+  hooks: scripts.map(s => ({ type: "command", command: `${ROOT}${s}` })),
+});
+
+// A base-style hook block carrying the buggy SubagentStart(inject-rules) entry.
+const HOOK_BLOCK_WITH_SUBAGENT_START = {
+  PreToolUse: [entry("Bash", BLOCK_NO_VERIFY)],
+  SessionStart: [entry("", INJECT_RULES)],
+  SubagentStart: [entry("", INJECT_RULES)],
+};
+
+const readManifest = (outDir: string): Record<string, unknown> =>
+  fs.readJsonSync(path.join(outDir, CLAUDE_PLUGIN_DIR, PLUGIN_JSON));
+
+describe("generate-copilot-plugin-artifacts (issue #1056)", () => {
+  let tempDir: string;
+  let srcDir: string;
+  let outDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "copilot-gen-test-"));
+    srcDir = path.join(tempDir, "src");
+    outDir = path.join(tempDir, "lisa-copilot");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  });
+
+  describe("subagentStart stripping (hook-firing fix)", () => {
+    beforeEach(async () => {
+      await scaffoldSource(srcDir, {
+        hooks: HOOK_BLOCK_WITH_SUBAGENT_START,
+        withMcp: false,
+      });
+      generateCopilotVariant(srcDir, outDir, "1.2.3");
+    });
+
+    it("omits subagentStart but keeps camelCase preToolUse + sessionStart", () => {
+      const hooks = (readManifest(outDir).hooks ?? {}) as Record<
+        string,
+        unknown
+      >;
+      expect("subagentStart" in hooks).toBe(false);
+      expect("SubagentStart" in hooks).toBe(false);
+      expect("preToolUse" in hooks).toBe(true);
+      expect("sessionStart" in hooks).toBe(true);
+    });
+
+    it("still delivers inject-rules.sh via sessionStart (no rule-delivery loss)", () => {
+      const hooks = (readManifest(outDir).hooks ?? {}) as Record<
+        string,
+        ReadonlyArray<{ hooks: ReadonlyArray<{ command: string }> }>
+      >;
+      const sessionCmds = (hooks.sessionStart ?? []).flatMap(e =>
+        e.hooks.map(h => h.command)
+      );
+      expect(sessionCmds.some(c => c.includes(INJECT_RULES))).toBe(true);
+    });
+  });
+
+  describe("MCP inline pointer", () => {
+    it("mirrors a bundled .mcp.json's servers into an inline manifest mcpServers object", async () => {
+      await scaffoldSource(srcDir, { hooks: {}, withMcp: true });
+      generateCopilotVariant(srcDir, outDir, "1.2.3");
+      const manifest = readManifest(outDir);
+      expect(manifest.mcpServers).toEqual({
+        expo: { type: "http", url: "https://mcp.expo.dev/mcp" },
+      });
+      // The .mcp.json file is retained as the source of truth.
+      expect(fs.existsSync(path.join(outDir, ".mcp.json"))).toBe(true);
+    });
+
+    it("adds no mcpServers field when the variant ships no .mcp.json", async () => {
+      await scaffoldSource(srcDir, { hooks: {}, withMcp: false });
+      generateCopilotVariant(srcDir, outDir, "1.2.3");
+      expect("mcpServers" in readManifest(outDir)).toBe(false);
+    });
+
+    it("degrades gracefully on a malformed .mcp.json (no pointer, no throw)", async () => {
+      await scaffoldSource(srcDir, { hooks: {}, withMcp: true });
+      // Corrupt the .mcp.json the scaffold wrote.
+      await fs.writeFile(path.join(srcDir, ".mcp.json"), "{ not json", "utf8");
+      expect(() =>
+        generateCopilotVariant(srcDir, outDir, "1.2.3")
+      ).not.toThrow();
+      expect("mcpServers" in readManifest(outDir)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts
+++ b/tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts
@@ -119,5 +119,12 @@ describe("generate-copilot-plugin-artifacts (issue #1056)", () => {
       ).not.toThrow();
       expect("mcpServers" in readManifest(outDir)).toBe(false);
     });
+
+    it("emits no pointer when mcpServers is a parseable-but-invalid shape (array)", async () => {
+      await scaffoldSource(srcDir, { hooks: {}, withMcp: true });
+      await fs.writeJson(path.join(srcDir, ".mcp.json"), { mcpServers: [] });
+      generateCopilotVariant(srcDir, outDir, "1.2.3");
+      expect("mcpServers" in readManifest(outDir)).toBe(false);
+    });
   });
 });

--- a/tests/unit/scripts/per-agent-hook-filter.test.ts
+++ b/tests/unit/scripts/per-agent-hook-filter.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterHooksForAgent,
   filterScriptsForAgent,
+  isUnsupportedEvent,
   shouldShipHook,
   shouldShipScript,
   translateEventName,
@@ -298,6 +299,53 @@ describe("per-agent-hook-filter", () => {
       expect(cursorKeep).toContain(INSTALL_PKGS);
       expect(cursorKeep).not.toContain(INJECT_RULES);
       expect(cursorKeep).not.toContain(ENFORCE_TEAM_FIRST);
+    });
+  });
+
+  describe("isUnsupportedEvent (issue #1056)", () => {
+    it("marks SubagentStart unsupported for copilot only", () => {
+      expect(isUnsupportedEvent("SubagentStart", "copilot")).toBe(true);
+      expect(isUnsupportedEvent("SubagentStart", "cursor")).toBe(false);
+      expect(isUnsupportedEvent("SubagentStart", "codex")).toBe(false);
+      expect(isUnsupportedEvent("SessionStart", "copilot")).toBe(false);
+    });
+  });
+
+  describe("filterHooksForAgent — Copilot subagentStart drop (issue #1056)", () => {
+    // The base SubagentStart group carries inject-rules.sh, which ships to
+    // Copilot — so without the guard the group survives and emits `subagentStart`
+    // (empty matcher), which makes Copilot reject the ENTIRE hooks config (no
+    // hooks fire). The event must be dropped wholesale; inject-rules still
+    // reaches Copilot via SessionStart so no rule delivery is lost.
+    const block = {
+      SessionStart: [scriptEntry(INJECT_RULES)],
+      SubagentStart: [scriptEntry(INJECT_RULES)],
+      PreToolUse: [scriptEntry(BLOCK_NO_VERIFY)],
+    };
+
+    it("drops subagentStart but keeps inject-rules under sessionStart", () => {
+      const out = filterHooksForAgent(block, "copilot", {
+        copilotRulesAutoLoads: false,
+      }) as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      expect(out).toBeDefined();
+      expect("subagentStart" in out).toBe(false);
+      expect("SubagentStart" in out).toBe(false);
+      expect("sessionStart" in out).toBe(true);
+      expect("preToolUse" in out).toBe(true);
+      const sessionCmds = out.sessionStart.flatMap(e =>
+        e.hooks.map(h => h.command)
+      );
+      expect(sessionCmds.some(c => c.includes(INJECT_RULES))).toBe(true);
+    });
+
+    it("does NOT drop SubagentStart for cursor (cursor supports it)", () => {
+      const cursorBlock = { SubagentStart: [scriptEntry(BLOCK_NO_VERIFY)] };
+      const out = filterHooksForAgent(cursorBlock, "cursor") as Record<
+        string,
+        unknown
+      >;
+      expect(out).toBeDefined();
+      expect("subagentStart" in out).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves the three open items in #1056 for the GitHub Copilot plugin variant — and the three turned out to share one root cause for hook firing.

### Item #2 / #1 — `subagentStart` was blocking ALL Copilot hooks (load-bearing)
The base manifest's `SubagentStart` group carries `inject-rules.sh`, which ships to Copilot. Translated, it became a `subagentStart` event with an **empty matcher**. Copilot has no `subagentStart` event and **rejects the entire inline hooks config** on the empty matcher:

```
[ERROR] Invalid inline hooks config for plugin "lisa-copilot": hooks.subagentStart[0].matcher: matcher cannot be empty
```

So **no plugin hooks fired at all** — meaning `inject-rules.sh` never ran and Lisa rules never reached Copilot. The fix drops the unsupported `SubagentStart` event wholesale for Copilot (new `AGENT_UNSUPPORTED_EVENTS` guard in `per-agent-hook-filter.mjs`). `inject-rules.sh` still ships under `sessionStart`, so **no rule delivery is lost**.

### Item #3 — bundled `.mcp.json` is not auto-discovered
Copilot reads `.mcp.json` only at the **workspace root**; a plugin's bundled `.mcp.json` is not that file, and a `".mcp.json"` path-string pointer is ignored. Only an inline `mcpServers` **object** in the manifest loads. The generator now mirrors `.mcp.json`'s servers into the manifest inline (affects `lisa-expo-copilot`).

## Verified by run — GitHub Copilot CLI 1.0.56
Full install-path probe (`copilot plugin install` + sentinel-instrumented hooks + real `copilot -p` session). See `evidence/copilot-hook-mcp-probe-1056.md`.

| Acceptance criterion | Result |
|---|---|
| AC-1 hooks fire | ✅ with `subagentStart` removed, `sessionStart` hooks (`install-pkgs`/`inject-rules`/`setup-jira-cli`) fire; `${CLAUDE_PLUGIN_ROOT}` resolves |
| AC-2 only valid events shipped | ✅ `subagentStart` removed from every copilot variant; cursor (supports it) unaffected |
| AC-3 MCP discovered | ✅ inline `mcpServers` object → Copilot loads the `expo` server (OAuth flow initiated); bare `.mcp.json` and path-string do **not** |

Before/after on 1.0.56:
- `subagentStart` present → **0 hooks fire** + `Invalid inline hooks config`
- `subagentStart` removed → `fired:inject-rules.sh`, `fired:install-pkgs.sh`, `fired:setup-jira-cli.sh`

## Changes
- `scripts/lib/per-agent-hook-filter.mjs` — `AGENT_UNSUPPORTED_EVENTS` + `isUnsupportedEvent()`; drop `SubagentStart` for copilot; remove bogus `SubagentStart` from `COPILOT_EVENTS`.
- `scripts/generate-copilot-plugin-artifacts.mjs` — inline `mcpServers` object when `.mcp.json` is present (graceful on malformed files).
- Unit tests (extended + new) and regenerated artifacts: `lisa-copilot`, `lisa-rails-copilot`, `lisa-harper-fabric-copilot` (no `subagentStart`), `lisa-expo-copilot` (inline `mcpServers`).
- `evidence/copilot-hook-mcp-probe-1056.md` — captured probe.

## Gate
`lint` ✅ · `typecheck` ✅ · `test` ✅ (2642) · `check:plugins` ✅ (artifacts in sync)

## Out of scope (per #1056)
agy (#1054), Cursor (#1055), 3rd-party plugin enablement (#1059).

Residual note: `copilot mcp list` does not enumerate plugin-provided servers in 1.0.55/1.0.56 (display limitation) — the server is confirmed loaded in-session via logs.

Closes #1056

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP server integration for the Expo plugin and support for inlining bundled MCP servers into generated manifests.

* **Updates**
  * Refined plugin hook configurations to move rule injection to session start and remove deprecated subagentStart usage for Copilot.
  * Enhanced hook-filtering to treat certain subagent events as unsupported for Copilot, improving hook delivery reliability.

* **Tests**
  * Added unit tests covering manifest generation, MCP handling, and Copilot-specific hook filtering.

* **Documentation**
  * Added an evidence probe documenting observed hook and MCP behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->