### PR TITLE
feat(parity): 3rd-party plugin parity subsystem — analyze/implement/drift-detect (#1059)

### DIFF
--- a/.claude/commands/analyze-plugin.md
+++ b/.claude/commands/analyze-plugin.md
@@ -1,0 +1,7 @@
+---
+description: "Analyze one curated third-party Claude plugin and plan its per-agent parity (Codex/Cursor/agy/Copilot) — writes a proposed routing artifact + human matrix under parity/plugin-routing/, then STOPS for approval (plan-only, no source edits)"
+allowed-tools: ["Skill"]
+argument-hint: "<plugin>@<marketplace>, e.g. code-simplifier@claude-plugins-official"
+---
+
+Use the /analyze-plugin skill to inventory the given curated plugin, classify its components, decide a per-agent routing outcome, write the proposed routing artifact + review matrix under parity/plugin-routing/, and STOP for human approval without editing the source tree. $ARGUMENTS

--- a/.claude/commands/implement-plugin-parity.md
+++ b/.claude/commands/implement-plugin-parity.md
@@ -1,0 +1,7 @@
+---
+description: "Execute an APPROVED plugin-parity routing artifact from analyze-plugin — emit MCP/LSP into agent variants via existing generators, enable vendor equivalents, and scaffold synced-from-stamped skills for reimplement cases. Hard-gates on status:approved; never ports plugin code"
+allowed-tools: ["Skill"]
+argument-hint: "<plugin>@<marketplace> (the approved artifact under parity/plugin-routing/)"
+---
+
+Use the /implement-plugin-parity skill to read the approved routing artifact for the given plugin, hard-gate on status:"approved", then perform only its declared deterministic actions by reusing Lisa's existing generators/installers and scaffolding synced-from-stamped skills for reimplement cases — never porting upstream plugin code. $ARGUMENTS

--- a/.claude/commands/plugin-parity-drift.md
+++ b/.claude/commands/plugin-parity-drift.md
@@ -1,0 +1,7 @@
+---
+description: "Detect whether any Lisa-native reimplementation of a curated third-party Claude plugin has drifted behind its upstream version (report-only, CI-gateable exit code)"
+allowed-tools: ["Skill"]
+argument-hint: "(blank for default roots) | --skills-root <dir> --cache-root <dir> --json"
+---
+
+Use the /plugin-parity-drift skill to scan `synced-from`-stamped skills, resolve each curated plugin's current upstream version from the installed plugin cache, and report any drift via the script's exit code. $ARGUMENTS

--- a/.claude/skills/analyze-plugin/SKILL.md
+++ b/.claude/skills/analyze-plugin/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: analyze-plugin
+description: This skill should be used to analyze a single curated third-party Claude plugin (one of Lisa's enabledPlugins) and plan how to bring it to parity across the non-Claude agents Lisa distributes to (Codex, Cursor, agy, Copilot). It inventories the plugin's components, classifies each, decides a per-agent routing outcome, and writes a machine-readable routing artifact plus a human review matrix under parity/plugin-routing/. It is PLAN-ONLY: it STOPS for human approval and makes no source-tree edits — the sibling skill implement-plugin-parity executes an approved artifact.
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill"]
+---
+
+# Analyze Plugin (PLAN-ONLY)
+
+Lisa curates a small set of third-party Claude plugins in `enabledPlugins`
+(`.claude/settings.json` at the repo root and `all/merge/.claude/settings.json`):
+
+```
+lisa@lisa, safety-net@cc-marketplace, code-simplifier@claude-plugins-official,
+code-review@claude-plugins-official, coderabbit@claude-plugins-official,
+sentry@claude-plugins-official, skill-creator@claude-plugins-official
+```
+
+(+ `typescript-lsp@claude-plugins-official` in stack settings.) These reach
+Claude — and Cursor, which reads `.claude-plugin/` natively — but **not**
+Codex / agy / Copilot. This skill analyzes one curated plugin and produces a
+parity plan: what each component is, and how each agent should obtain
+equivalent behavior.
+
+**This skill is plan-only.** It writes a routing artifact and a human matrix and
+then **STOPS**. It does not emit MCP, scaffold skills, run generators, or edit
+any source. If asked to "implement", "apply", or "build" the parity, reject the
+request and point at the sibling skill `implement-plugin-parity` — analysis and
+execution are deliberately separated by a human approval gate (mirroring how
+`lisa-coding-agent-parity` refuses implementation and points at its sibling).
+
+## Input
+
+One curated plugin's canonical id: `<name>@<marketplace>` — e.g.
+`code-simplifier@claude-plugins-official`. This is byte-identical to the
+`enabledPlugins` key and to the cache path `<marketplace>/<name>/`.
+
+## Procedure
+
+### 1. Locate the installed plugin
+
+Find the plugin tree in the cache (no network):
+
+```
+~/.claude/plugins/cache/<marketplace>/<name>/<version>/
+```
+
+Resolve the **current upstream version** the same way the drift detector does —
+read each version subdir's `.claude-plugin/plugin.json` `version` field and take
+the max valid semver. Record it as `upstreamVersion`.
+
+### 2. Inventory the components
+
+Walk the plugin tree and inventory every component. Each entry records its
+`kind`, an `id`, the `path` within the plugin, a `classification`, and free-form
+`notes`:
+
+- `kind`: `skill` | `agent` | `command` | `hook` | `mcp` | `lsp`
+- `classification`: `claude-skill` | `claude-agent` | `claude-command` |
+  `hook` | `mcp-server` | `lsp-server`
+
+Look for: `skills/*/SKILL.md`, `agents/*.md`, `commands/*.md`, a `hooks` block in
+`.claude-plugin/plugin.json` (or `hooks/hooks.json`), `.mcp.json` (MCP servers),
+and any LSP declaration.
+
+### 3. Decide a per-agent routing outcome
+
+Produce **exactly one** routing entry per non-Claude-native agent: `codex`,
+`cursor`, `agy`, `copilot`. Each entry has an `outcome` from the locked enum, a
+list of declarative `actions`, and a `rationale`.
+
+**Outcome enum (locked):**
+
+- `already-native` — the agent already gets the behavior via the existing
+  per-agent fan-out; no action.
+- `re-point-mcp-lsp` — the component is (or carries) an MCP/LSP server; emit it
+  into that agent's variant via the existing generator/installer (Codex
+  `.codex-plugin` MCP pointer; Cursor `mcp.json`; agy → `src/agy/mcp-installer.ts`
+  user-global; Copilot → inline `mcpServers` / `lspServers` on the manifest).
+- `enable-vendor-equivalent` — enable the agent's native equivalent capability
+  in its project-scoped marketplace.
+- `claude-only` — intentionally not ported (e.g. Cursor already covers it via
+  native `.claude-plugin/` loading, or there is no equivalent). Documented, no
+  action.
+- `reimplement` — scaffold a Lisa-native skill stamped
+  `synced-from: <name>@<marketplace>@<upstreamVersion>`. **This is the only
+  outcome that creates a drift-tracked artifact.** v1 plans the scaffold only —
+  the actual reimplementation logic is out of scope per the issue.
+
+**Decision rule (locked preference order):** for each `(plugin × agent)` cell,
+choose the **first applicable** outcome in this order:
+
+```
+already-native  >  re-point-mcp-lsp  >  enable-vendor-equivalent  >  claude-only  >  reimplement
+```
+
+`reimplement` is the **last resort**: every reimplementation signs Lisa up to
+track another vendor's release cadence (a standing drift liability surfaced by
+`plugin-parity-drift`). Prefer any earlier outcome that reaches parity without
+forking — only reimplement when no native fan-out, MCP/LSP re-point, vendor
+equivalent, or accepted Claude-only coverage applies.
+
+Routing heuristics:
+
+- An MCP/LSP-bearing plugin → `re-point-mcp-lsp` for Codex/agy/Copilot; Cursor
+  is usually `already-native` (its variant emits `mcp.json` from `.mcp.json`).
+- A pure subagent/skill/command with no MCP → `reimplement` for Codex and agy
+  (no equivalent plugin subagent surface), `claude-only` for Cursor (loads the
+  `.claude-plugin/` natively), and `enable-vendor-equivalent` for Copilot when
+  the vendor ships a comparable capability.
+- Note any first-of-its-kind emission path (e.g. the first LSP routed to
+  Copilot `lspServers`) in `actions` as a flagged follow-up rather than assuming
+  the generator already handles it.
+
+### 4. Write the artifact + matrix, then STOP
+
+Write two paired files (the full `<name>@<marketplace>` id keeps one artifact
+per plugin so re-running never clobbers another):
+
+- `parity/plugin-routing/<name>@<marketplace>.json` — the machine-readable
+  routing artifact, `"status": "proposed"`.
+- `parity/plugin-routing/<name>@<marketplace>.md` — a human review matrix (a
+  markdown table of components and per-agent routing).
+
+Then **STOP** and tell the human to review the artifact and flip
+`"status": "proposed"` → `"approved"` (a one-line edit, visible in the git diff)
+before running `implement-plugin-parity`.
+
+## Routing artifact schema
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "plugin": "code-simplifier@claude-plugins-official", // canonical id (== synced-from plugin-ref)
+  "pluginName": "code-simplifier",
+  "marketplace": "claude-plugins-official",
+  "upstreamVersion": "1.0.0",          // resolved from the cache at analysis time
+  "analyzedAt": "2026-05-30",          // informational only (not load-bearing)
+  "status": "proposed",                // "proposed" | "approved" (human flips to approved)
+  "components": [
+    {
+      "kind": "agent",
+      "id": "code-simplifier",
+      "path": "agents/code-simplifier.md",
+      "classification": "claude-agent",
+      "notes": "single subagent; no MCP/LSP"
+    }
+  ],
+  "routing": {
+    "codex":   { "outcome": "reimplement",             "actions": ["scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0"], "rationale": "Codex has no plugin subagent surface; behavior reimplemented as a Lisa skill." },
+    "cursor":  { "outcome": "claude-only",             "actions": [],                                                                                                  "rationale": "Cursor reads .claude-plugin/ natively; the agent loads unchanged." },
+    "agy":     { "outcome": "reimplement",             "actions": ["scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0"], "rationale": "agy converts commands to skills but has no equivalent subagent plugin surface." },
+    "copilot": { "outcome": "enable-vendor-equivalent","actions": ["enable copilot's native simplifier equivalent in the project-scoped marketplace"],                "rationale": "vendor ships a comparable capability; prefer enabling over reimplementing." }
+  }
+}
+```
+
+The human matrix `.md` presents the same `components` + `routing` as readable
+tables so a reviewer can approve without parsing JSON.
+
+## Constraints
+
+- **Plan-only.** No source edits, no generator runs, no MCP emission, no skill
+  scaffolding. The only writes are the two `parity/plugin-routing/` files.
+- The artifact is a **durable, committed contract** between this skill and
+  `implement-plugin-parity` — it must survive across sessions, machines, and
+  reviewers (hence `parity/`, not `/tmp`).
+- An MCP-only plugin (no `reimplement` outcome) produces **no** `synced-from`
+  skill and therefore never appears in the drift report — drift tracking is
+  scoped exactly to reimplementations.
+
+## Definition of done
+
+- `parity/plugin-routing/<name>@<marketplace>.json` exists, validates against the
+  schema above, is `status:"proposed"`, and has exactly one routing entry per
+  agent (codex/cursor/agy/copilot).
+- The sibling `.md` matrix is written.
+- No source-tree edits were made.
+- The skill STOPPED with the approval instruction.

--- a/.claude/skills/implement-plugin-parity/SKILL.md
+++ b/.claude/skills/implement-plugin-parity/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: implement-plugin-parity
+description: This skill should be used to execute an APPROVED plugin-parity routing artifact produced by analyze-plugin. It hard-gates on `status:"approved"`, then performs only the artifact's declared deterministic actions — emitting MCP/LSP into agent variants via the existing generators/installers, enabling vendor equivalents, and scaffolding `synced-from`-stamped Lisa skills for approved reimplement cases. It reuses Lisa's existing generators/installers as black boxes and NEVER ports upstream plugin code. An un-approved or schema-invalid artifact is a no-op error.
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill"]
+---
+
+# Implement Plugin Parity (EXECUTION)
+
+This skill consumes an **approved** routing artifact written by `analyze-plugin`
+and executes its plan. It is the execution half of the parity subsystem; the
+planning half (`analyze-plugin`) and the drift check (`plugin-parity-drift`) are
+its siblings.
+
+## Hard approval gate (do this first)
+
+1. Read `parity/plugin-routing/<plugin>@<marketplace>.json`.
+2. If the file is missing, malformed, or fails the routing-artifact schema
+   (embedded below) → **STOP** with an error. Do nothing else.
+3. If `status` is not exactly `"approved"` → **STOP** and print:
+   _"Artifact is `<status>`, not `approved`. A human must review the matrix and
+   flip `status` to `approved` (visible in the git diff) before
+   implement-plugin-parity will run."_ Make **no** changes.
+4. Only when `status === "approved"` do you perform the actions below.
+
+This gate is the whole point of separating analyze from implement: nothing
+deterministic happens to the source tree until a human has approved the routing
+in the committed artifact. **The gate is human/CI-enforced, not a programmatic
+interlock** — "approval" is a committed, git-diff-visible `status` flag a
+reviewer flips, and this skill simply refuses to act unless it reads
+`"approved"`. There is no separate lock; the audit trail is the git history of
+the artifact.
+
+## Routing artifact schema (the contract this skill validates)
+
+The artifact this skill consumes is written by `analyze-plugin`; this is a
+compact copy of its schema so an executor reading this skill alone can validate
+it (the authoritative copy lives in `analyze-plugin/SKILL.md` and the design
+doc). Reject the artifact if any required field is missing or mistyped:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "plugin": "code-simplifier@claude-plugins-official", // canonical id == synced-from plugin-ref
+  "pluginName": "code-simplifier",
+  "marketplace": "claude-plugins-official",
+  "upstreamVersion": "1.0.0",      // resolved from the cache; used for the synced-from stamp
+  "analyzedAt": "2026-05-30",      // informational only
+  "status": "proposed",            // "proposed" | "approved" — MUST be "approved" to run
+  "components": [                  // inventory; each: { kind, id, path, classification, notes }
+    { "kind": "agent", "id": "code-simplifier", "path": "agents/code-simplifier.md", "classification": "claude-agent", "notes": "" }
+  ],
+  "routing": {                     // exactly one entry per agent; outcome from the locked enum
+    "codex":   { "outcome": "reimplement",              "actions": ["..."], "rationale": "..." },
+    "cursor":  { "outcome": "claude-only",              "actions": [],      "rationale": "..." },
+    "agy":     { "outcome": "reimplement",              "actions": ["..."], "rationale": "..." },
+    "copilot": { "outcome": "enable-vendor-equivalent", "actions": ["..."], "rationale": "..." }
+  }
+}
+```
+
+Outcome enum (locked): `already-native | re-point-mcp-lsp |
+enable-vendor-equivalent | claude-only | reimplement`.
+
+## What it does (deterministic actions only)
+
+For each agent's routing entry, perform **only** the declared `actions`,
+according to the `outcome`:
+
+- `already-native` — no action; the existing fan-out already covers it.
+- `re-point-mcp-lsp` — emit the MCP/LSP server into that agent's variant by
+  invoking the **existing** generator/installer as a black box (see "Reused
+  building blocks"). Do not hand-write variant manifests.
+- `enable-vendor-equivalent` — enable the agent's native equivalent in its
+  project-scoped marketplace per the declared action.
+- `claude-only` — no action; documented as intentionally not ported.
+- `reimplement` — scaffold a Lisa-native skill stamped
+  `synced-from: <name>@<marketplace>@<upstreamVersion>` (the value from the
+  artifact). **v1 scaffolds only** — create the skill shell + frontmatter pin;
+  the actual reimplementation logic is out of scope per the issue. This is the
+  only action that creates a drift-tracked artifact.
+
+After any `re-point-mcp-lsp` work that flows through the build, run
+`bun run build:plugins` so the agent variants regenerate deterministically, and
+confirm `bun run check:plugins` still passes.
+
+## Reused building blocks (cite, never reimplement)
+
+These are invoked as black boxes — this skill never edits them and never copies
+upstream plugin source into them:
+
+- `scripts/build-plugins.sh` — `build_plugin` (Claude→Codex derive) and the
+  per-agent fan-out (`build_per_agent_variant`). Triggered via
+  `bun run build:plugins`.
+- `scripts/generate-codex-plugin-artifacts.mjs` — Codex `.codex-plugin/`
+  derivation (skills + MCP pointer + hooks).
+- `scripts/generate-cursor-plugin-artifacts.mjs` — Cursor variant (`.mdc`
+  rules, `mcp.json`, native hooks).
+- `scripts/generate-agy-plugin-artifacts.mjs` (`generateAgyVariant`) — agy
+  variant; **drops** `.mcp.json`/`mcpServers` (MCP is user-global only).
+- `scripts/generate-copilot-plugin-artifacts.mjs` — Copilot surfaces a bundled
+  `.mcp.json`'s servers as an **inline `mcpServers`** object on the manifest;
+  also uniquely supports `lspServers`.
+- `src/agy/mcp-installer.ts` — agy runtime MCP delivery
+  (`~/.gemini/config/mcp_config.json`, `serverUrl` shape, `_lisaManaged`
+  tagged-merge). The non-plugin path for agy MCP.
+
+If a routed action needs a **new** emission path that none of these already
+provides (e.g. the first LSP routed to Copilot `lspServers`), do **not** silently
+attempt it — that is a separate work item. Surface it, leave it for a follow-up,
+and complete the rest.
+
+## Placement constraints
+
+- Scaffolded reimplementation skills are **Lisa-repo-internal** and live at root
+  `.claude/skills/<name>/SKILL.md` — NEVER in `plugins/src/` or
+  `all/copy-overwrite/` (per PROJECT_RULES.md, same rule that keeps the parity
+  skills root-only).
+- Never port upstream plugin code. A `reimplement` scaffold is a Lisa-native
+  shell carrying the `synced-from` pin so `plugin-parity-drift` can track it; the
+  behavior is authored separately, not copied from the upstream plugin.
+
+## The `synced-from` stamp
+
+Every scaffolded reimplement skill carries exactly:
+
+```yaml
+synced-from: <name>@<marketplace>@<upstreamVersion>
+```
+
+where the three fields come from the approved artifact's `pluginName`,
+`marketplace`, and `upstreamVersion`. This stamp is what `plugin-parity-drift`
+reads to detect when upstream has advanced past the pinned version.
+
+## Definition of done
+
+- The artifact was `status:"approved"` (otherwise this skill was a no-op error).
+- Only the artifact's declared `actions` were performed.
+- Any `reimplement` produced a root `.claude/skills/<name>/SKILL.md` stamped with
+  the correct `synced-from` pin.
+- No upstream plugin source was copied; no generator/installer file was edited.
+- If the build was involved, `bun run build:plugins` is deterministic and
+  `bun run check:plugins` passes.
+- Any required new emission path was flagged as a follow-up rather than
+  improvised.

--- a/.claude/skills/plugin-parity-drift/SKILL.md
+++ b/.claude/skills/plugin-parity-drift/SKILL.md
@@ -19,8 +19,9 @@ to run in CI. The sibling skills are `analyze-plugin` (plans parity work) and
 
 ## The `synced-from` pin grammar
 
-A Lisa-native skill that reimplements an upstream plugin carries exactly one
-frontmatter key:
+A Lisa-native skill that reimplements an upstream plugin carries a `synced-from`
+pin **in addition to** the frontmatter every skill requires (`name`,
+`description`, `allowed-tools`; note `$ARGUMENTS` is not substituted in skills):
 
 ```yaml
 synced-from: <name>@<marketplace>@<version>

--- a/.claude/skills/plugin-parity-drift/SKILL.md
+++ b/.claude/skills/plugin-parity-drift/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: plugin-parity-drift
+description: This skill should be used to check whether any Lisa-native reimplementation of a curated third-party Claude plugin has drifted behind its upstream version. It wraps the deterministic detector at scripts/plugin-parity-drift.mjs, which scans `synced-from`-stamped SKILL.md files, resolves each plugin's current upstream version from the installed plugin cache, and reports stale/ahead/missing pins via a CI-gateable exit code. Use it in CI, before a release, or any time the curated plugin set is updated. It only reports — it never edits a skill or auto-bumps a pin.
+allowed-tools: ["Bash", "Read"]
+---
+
+# Plugin Parity Drift Detector
+
+Lisa reimplements some curated third-party Claude plugins as Lisa-native skills
+so the behavior reaches agents that can't load the Claude plugin (Codex, agy,
+Copilot). Each such skill is **version-pinned** to the upstream plugin it
+mirrors. When upstream advances, the Lisa reimplementation silently falls
+behind. This skill detects that drift deterministically.
+
+It is the empirical core of the parity subsystem (issue #1059) and is designed
+to run in CI. The sibling skills are `analyze-plugin` (plans parity work) and
+`implement-plugin-parity` (executes an approved plan, including stamping the
+`synced-from` pins this detector reads).
+
+## The `synced-from` pin grammar
+
+A Lisa-native skill that reimplements an upstream plugin carries exactly one
+frontmatter key:
+
+```yaml
+synced-from: <name>@<marketplace>@<version>
+```
+
+Examples:
+
+```yaml
+synced-from: code-simplifier@claude-plugins-official@1.0.0
+synced-from: coderabbit@claude-plugins-official@1.1.1
+```
+
+**Grammar (EBNF):**
+
+```
+synced-from   = plugin-ref "@" version
+plugin-ref    = name "@" marketplace      ; the canonical Claude plugin id, exactly as in enabledPlugins
+name          = 1*( ALPHA / DIGIT / "-" / "_" )
+marketplace   = 1*( ALPHA / DIGIT / "-" / "_" )
+version       = semver                    ; MAJOR.MINOR.PATCH[-prerelease][+build], semver 2.0.0
+```
+
+**Parse rule:** semver never contains `@`, so the value is split on the **last**
+`@` (right side = version, remainder = `plugin-ref`), then the `plugin-ref` is
+split once more on its single `@`. The `plugin-ref` is byte-identical to the
+`enabledPlugins` key and to the cache path `<marketplace>/<name>/`, so it
+doubles as the resolver lookup key. A malformed value is reported `unparseable`.
+
+## How "current upstream" is resolved (deterministic)
+
+For each `plugin-ref = name@marketplace`, the detector resolves the current
+version purely from the installed-plugin cache tree — **no network, no `Date`,
+no `installed_plugins.json`**:
+
+```
+cacheRoot/<marketplace>/<name>/<version-subdir>/.claude-plugin/plugin.json
+```
+
+It reads each subdir's manifest `version` field (NOT the directory name),
+collects the valid semver values, and picks the **max** by semver precedence.
+Non-semver dirs (`unknown`, git hashes) are skipped because the manifest
+`version` is authoritative. "Highest installed version" is the
+machine-independent definition of current upstream.
+
+## Running it
+
+```bash
+node scripts/plugin-parity-drift.mjs [--skills-root <dir>]... [--cache-root <dir>] [--json]
+```
+
+- `--skills-root <dir>` (repeatable; default `<repo>/.claude/skills`): roots
+  scanned recursively for `**/SKILL.md`.
+- `--cache-root <dir>` (default `$CLAUDE_PLUGIN_CACHE`, else
+  `~/.claude/plugins/cache`): the installed-plugin cache root.
+- `--json`: emit the machine-readable report (§3.5 of the design) instead of the
+  human markdown table. The exit code is identical in both modes.
+
+Default invocation (what CI runs):
+
+```bash
+node scripts/plugin-parity-drift.mjs
+```
+
+## Per-skill statuses
+
+| Condition                          | status          | drift? |
+| ---------------------------------- | --------------- | ------ |
+| current == pinned                  | `ok`            | no     |
+| current > pinned                   | `stale`         | yes    |
+| current < pinned                   | `ahead`         | yes    |
+| plugin not in the cache            | `not-installed` | yes    |
+| installed but no parseable semver  | `unresolved`    | yes    |
+| `synced-from` value malformed      | `unparseable`   | yes    |
+
+## Exit codes (CI contract)
+
+- `0` — no drift: every synced skill is `ok`.
+- `1` — drift found: ≥1 skill is `stale` / `ahead` / `not-installed` /
+  `unresolved` / `unparseable`.
+- `2` — operational/usage error: unknown flag, missing `--cache-root` path, or
+  no resolvable `--skills-root`. Distinct from drift so CI can tell a real drift
+  from a broken invocation.
+
+## CI usage
+
+Add a CI step that fails the build on exit 1:
+
+```yaml
+- name: Plugin parity drift
+  run: node scripts/plugin-parity-drift.mjs
+```
+
+The CI step needs the installed plugin cache present (default
+`~/.claude/plugins/cache`, or set `CLAUDE_PLUGIN_CACHE` / pass `--cache-root`) so
+that synced skills can be resolved. **Exception:** a repo with zero
+reimplementations (no `synced-from` skills) passes cleanly with exit `0` even
+when the cache is absent — the detector scans skills first and short-circuits to
+"no drift" before requiring the cache, so a fresh runner without the cache never
+fails the build for a project that has nothing to track.
+
+A `stale` result is the signal to run `analyze-plugin` for that plugin and then
+`implement-plugin-parity` to refresh the reimplementation and re-stamp the pin.
+
+## What it never does
+
+The detector is **report-only**. It never edits a skill, never bumps a pin, and
+never touches the cache. Re-pinning is a deliberate human/`implement-plugin-parity`
+action so that "we re-reviewed the upstream change" is always an explicit step,
+never an automatic one.
+
+## Verifying the detector itself
+
+The committed fixture under `parity/fixtures/drift/` plus
+`tests/unit/scripts/plugin-parity-drift.test.ts` (run via `bun run test:unit`)
+prove the stale/ok/ignored classification, the max-semver resolution across
+sibling version dirs, the exit-code contract, and that the detector leaves the
+scanned skill bytes unchanged.

--- a/parity/DESIGN-plugin-parity-subsystem.md
+++ b/parity/DESIGN-plugin-parity-subsystem.md
@@ -1,0 +1,327 @@
+# Design — Third-party Plugin Parity Subsystem (issue #1059)
+
+**Status:** design complete, ready for builder. **Scope:** the *subsystem* (3 skills + 3 commands + 1 drift script + tests). The actual per-plugin reimplementations are OUT OF SCOPE per the issue — the subsystem only *schedules* them.
+
+Author: architect teammate. Builds on the locked decisions in task #2 and the verified codebase facts cited below.
+
+---
+
+## 0. Problem & placement (locked)
+
+Lisa curates a small set of third-party Claude plugins in `enabledPlugins` (verified `all/merge/.claude/settings.json:6-14` and root `.claude/settings.json:22-31`):
+
+```
+lisa@lisa, safety-net@cc-marketplace, code-simplifier@claude-plugins-official,
+code-review@claude-plugins-official, coderabbit@claude-plugins-official,
+sentry@claude-plugins-official, skill-creator@claude-plugins-official
+```
+(+ `typescript-lsp@claude-plugins-official` in stack settings.) These reach Claude (and Cursor, which reads `.claude-plugin/` natively) but **not** Codex/agy/Copilot. This subsystem analyzes each curated plugin, routes per-agent parity actions, and detects when a Lisa reimplementation has drifted behind its upstream plugin.
+
+All three skills are **Lisa-repo-internal** — they operate on Lisa's own generation pipeline and curated list. They live next to the siblings at root `.claude/skills/<name>/SKILL.md` + `.claude/commands/<name>.md` (matching `lisa-codex-parity`, `lisa-coding-agent-parity`). **NOT** `plugins/src/base` — no `build:plugins`, not downstream-distributable, no artifact regeneration (`bun run check:plugins` is unaffected).
+
+---
+
+## 1. Final file list
+
+### Created
+| Path | Purpose |
+|------|---------|
+| `.claude/skills/analyze-plugin/SKILL.md` | Plan-only analyzer: inventory one curated plugin, classify components, emit per-agent routing artifact + human matrix, STOP for review. |
+| `.claude/commands/analyze-plugin.md` | Pass-through command (`argument-hint`, `$ARGUMENTS`) → `/analyze-plugin` skill. |
+| `.claude/skills/implement-plugin-parity/SKILL.md` | Consumes an **approved** routing artifact; deterministic changes only (emit MCP/LSP into agent variants via existing generators/installers; enable vendor equivalents; scaffold `synced-from`-stamped Lisa skills for approved reimplements). Never ports plugin code. |
+| `.claude/commands/implement-plugin-parity.md` | Pass-through command → skill. |
+| `scripts/plugin-parity-drift.mjs` | Deterministic, unit-testable drift detector. Scans `synced-from` skills, resolves each plugin's current upstream version from the cache, emits a stale report. Never auto-bumps. **Empirical-verification core.** |
+| `.claude/skills/plugin-parity-drift/SKILL.md` | Wraps the script; documents grammar, exit codes, CI usage. |
+| `.claude/commands/plugin-parity-drift.md` | Pass-through command → skill. |
+| `tests/unit/scripts/plugin-parity-drift.test.ts` | Vitest unit tests (proves Scenario 3 against a fixture). |
+| `parity/plugin-routing/.gitkeep` | Durable home for routing artifacts (see §5). |
+| `parity/fixtures/drift/` | Test fixture cache + skills tree (see §4.4). |
+
+### Modified
+- **None required for v1.** The implement skill *reuses* the existing generators/installers as black boxes; no generator edit is needed to ship the subsystem. (If a specific reimplement case later needs a generator change, that is a separate work item, not part of this subsystem.)
+
+### Referenced (read-only, not modified) — verified citations
+- `scripts/build-plugins.sh:24-49` — `build_plugin` (Claude→Codex derive) and per-agent fan-out (`build_per_agent_variant`, lines ~52-115). Standalone variant build path the implement skill triggers via `bun run build:plugins`.
+- `scripts/generate-codex-plugin-artifacts.mjs` — Codex `.codex-plugin/{plugin.json,hooks.json,mcp}` derivation (skills + MCP pointer + hooks).
+- `scripts/generate-cursor-plugin-artifacts.mjs` — Cursor variant (`.mdc` rules, `mcp.json`, native hooks).
+- `scripts/generate-agy-plugin-artifacts.mjs:113 generateAgyVariant` — agy variant; **drops** `.mcp.json` + `mcpServers` (line 134-173); MCP is user-global only.
+- `scripts/generate-copilot-plugin-artifacts.mjs:203-238` — Copilot surfaces a bundled `.mcp.json`'s servers as an **inline `mcpServers`** object on the manifest (bare `.mcp.json`/path-pointer is ignored). Copilot also uniquely supports `lspServers` (re-point-LSP target — not currently emitted; an implement-side hook only if a curated LSP plugin is routed there).
+- `src/agy/mcp-installer.ts` — `defaultUserMcpConfigPath()` `~/.gemini/config/mcp_config.json`; agy MCP shape uses `serverUrl` (not `url`); `_lisaManaged` tagged-merge. Runtime (non-plugin) MCP delivery for agy.
+- `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/.claude-plugin/plugin.json` — installed plugin tree; `version` field is source of truth (verified: `claude-plugins-official/code-simplifier/1.0.0/.claude-plugin/plugin.json` → `{"name":"code-simplifier","version":"1.0.0"}`).
+- `~/.claude/plugins/installed_plugins.json` — authoritative install records (`version`, `installPath`, `lastUpdated` per project). Used only as a cross-check, NOT the primary resolver (see §3.2 rationale).
+
+---
+
+## 2. `synced-from` frontmatter grammar (ambiguity (a), part 1)
+
+A Lisa-native skill that reimplements an upstream plugin carries one frontmatter key:
+
+```yaml
+synced-from: <plugin>@<marketplace>@<version>
+```
+
+Examples:
+```yaml
+synced-from: code-simplifier@claude-plugins-official@1.0.0
+synced-from: coderabbit@claude-plugins-official@1.1.1
+```
+
+**Grammar (EBNF):**
+```
+synced-from   = plugin-ref "@" version
+plugin-ref    = name "@" marketplace          ; the canonical Claude plugin id, exactly as in enabledPlugins
+name          = 1*( ALPHA / DIGIT / "-" / "_" )
+marketplace   = 1*( ALPHA / DIGIT / "-" / "_" )
+version       = semver                        ; MAJOR.MINOR.PATCH[-prerelease][+build], semver 2.0.0
+```
+
+**Parse rule (deterministic, unambiguous):** semver never contains `@`, so split on the **last** `@`:
+- right of last `@` = `version`
+- remainder = `plugin-ref` (itself `name@marketplace`; split once more on its single `@`).
+
+`plugin-ref` is byte-identical to the `enabledPlugins` key and to the cache path `<marketplace>/<name>/`, so it doubles as the resolver lookup key — no separate marketplace field needed. This honors the task's `synced-from: <plugin>@<version>` intent where `<plugin>` is the fully-qualified plugin id.
+
+A SKILL.md is "synced" iff its frontmatter has a parseable `synced-from`. Malformed values are reported as `unparseable` (see exit codes).
+
+---
+
+## 3. Drift detector — `scripts/plugin-parity-drift.mjs` (ambiguity (a), part 2)
+
+### 3.1 CLI contract
+```
+node scripts/plugin-parity-drift.mjs [--skills-root <dir>]... [--cache-root <dir>] [--json]
+```
+- `--skills-root <dir>` (repeatable; default `<repo>/.claude/skills`): roots scanned recursively for `**/SKILL.md`. **Injectable so tests point at a fixture.**
+- `--cache-root <dir>` (default `$CLAUDE_PLUGIN_CACHE` env, else `~/.claude/plugins/cache`): the installed-plugin cache root. **Injectable so tests point at a fixture.**
+- `--json`: emit the machine-readable report to stdout instead of the human table. Exit code identical in both modes.
+
+### 3.2 Upstream-version resolution (deterministic + testable)
+Resolve "current upstream version" for `plugin-ref = name@marketplace` purely from the cache tree (no network, no `Date`, no `installed_plugins.json` — the cache is the offline source of truth and is trivially reproducible as a fixture):
+
+```
+resolveCurrentVersion(cacheRoot, name, marketplace):
+  dir = cacheRoot/marketplace/name
+  if dir not a directory:                    -> { status: "not-installed", version: null }
+  versions = []
+  for each immediate subdir D of dir:
+     manifest = D/.claude-plugin/plugin.json
+     if manifest readable and JSON.parse ok and typeof .version == "string":
+        if isValidSemver(.version): versions.push(.version)
+  if versions empty:                          -> { status: "unresolved", version: null }
+  return { status: "ok", version: max(versions, by semver precedence) }
+```
+
+Rationale for picking **max semver across version subdirs** (verified: a single plugin like `coderabbit` has multiple subdirs `1.1.0`, `1.1.1`, `a81eb76a1539`, and `code-review` has `unknown`): the manifest `version` field — not the directory name — is authoritative; non-semver dirs (`unknown`, git-hashes) are skipped because their manifest version is what counts, and "the highest installed version" is the deterministic, machine-independent definition of "current upstream." `installed_plugins.json` is per-project and time-ordered (needs `Date`), so it is intentionally NOT the resolver — it's only an optional cross-check the human can consult.
+
+`isValidSemver` + `compareSemver`: tiny in-script implementation (split core on `.`, numeric compare MAJOR/MINOR/PATCH; a prerelease (`-`) sorts *below* its release; build (`+`) ignored). No dependencies. Pure functions — directly unit-tested.
+
+### 3.3 Comparison & statuses
+For each synced skill, compare pinned `version` (from `synced-from`) to resolved current:
+
+| Condition | per-skill status | contributes to exit 1? |
+|-----------|------------------|------------------------|
+| current == pinned | `ok` | no |
+| current > pinned | `stale` (upstream advanced — Lisa reimpl behind) | **yes** |
+| current < pinned | `ahead` (pin newer than installed — anomaly) | **yes** |
+| resolve = `not-installed` | `not-installed` | **yes** |
+| resolve = `unresolved` | `unresolved` (installed but no parseable semver) | **yes** |
+| `synced-from` unparseable | `unparseable` | **yes** |
+
+The detector **never auto-bumps** and never edits any skill — it only reports.
+
+### 3.4 Exit codes (CI contract)
+- `0` — no drift: every synced skill is `ok`.
+- `1` — drift found: ≥1 skill is `stale`/`ahead`/`not-installed`/`unresolved`/`unparseable`.
+- `2` — operational/usage error: unknown flag, `--cache-root` path missing, no `--skills-root` resolvable. (Distinct from drift so CI can tell "drift" from "broken invocation.")
+
+### 3.5 `--json` report shape
+```json
+{
+  "schemaVersion": 1,
+  "cacheRoot": "/abs/cache",
+  "skillsRoots": ["/abs/.claude/skills"],
+  "summary": { "scanned": 3, "ok": 1, "drift": 2 },
+  "results": [
+    {
+      "skillPath": ".claude/skills/code-simplifier/SKILL.md",
+      "plugin": "code-simplifier@claude-plugins-official",
+      "pinnedVersion": "1.0.0",
+      "currentVersion": "2.0.0",
+      "status": "stale"
+    },
+    {
+      "skillPath": ".claude/skills/coderabbit/SKILL.md",
+      "plugin": "coderabbit@claude-plugins-official",
+      "pinnedVersion": "1.1.1",
+      "currentVersion": "1.1.1",
+      "status": "ok"
+    }
+  ]
+}
+```
+Human mode: a markdown table of the same rows + a one-line summary (`2 of 3 synced skills drifted`).
+
+### 3.6 Pseudo-code (top level)
+```
+main(argv):
+  opts = parseArgs(argv)                      // throws -> exit 2
+  if !isDir(opts.cacheRoot): exit 2
+  skills = []
+  for root in opts.skillsRoots:
+     for file in walk(root, "**/SKILL.md"):
+        fm = parseFrontmatter(file)
+        if !fm["synced-from"]: continue
+        skills.push({ file, raw: fm["synced-from"] })
+  results = skills.map(s => {
+     ref = parseSyncedFrom(s.raw)              // {name,marketplace,version} | null
+     if !ref: return { ...s, status: "unparseable" }
+     cur = resolveCurrentVersion(opts.cacheRoot, ref.name, ref.marketplace)
+     status = classify(ref.version, cur)       // table §3.3
+     return { skillPath, plugin, pinnedVersion, currentVersion: cur.version, status }
+  })
+  report = build(results)
+  print(opts.json ? JSON.stringify(report) : humanTable(report))
+  exit(results.every(r => r.status == "ok") ? 0 : 1)
+```
+
+---
+
+## 4. Acceptance criteria → verification mapping
+
+> Scenario numbering matches the issue. **Scenario 3 is the empirical core** and maps to a concrete `vitest`-runnable test against a committed fixture.
+
+| # | Acceptance criterion | Verification (runnable) |
+|---|----------------------|-------------------------|
+| 1 | `analyze-plugin` inventories a curated plugin's components and emits a routing artifact + human matrix, then STOPS | Run `/analyze-plugin code-simplifier@claude-plugins-official`; assert `parity/plugin-routing/code-simplifier@claude-plugins-official.json` exists, validates against §6 schema (`status:"proposed"`, one routing entry per agent), and a sibling `.md` matrix is written; skill makes **no** source-tree edits. |
+| 2 | `implement-plugin-parity` refuses an un-approved artifact | Run the skill against a `status:"proposed"` artifact → it exits without changes and prints the approval instruction. Flip to `status:"approved"` → it performs only the artifact's declared deterministic actions. |
+| 2b | implement reuses existing generators/installers; never ports plugin code | After an approved MCP re-point, `bun run build:plugins` is deterministic and `bun run check:plugins` passes; assert the agent variant manifests carry the expected `mcpServers`/`mcp.json` and that no upstream plugin source was copied (grep for absence of ported code). |
+| **3** | **Reimplementations are version-pinned and drift is detected** | **`node scripts/plugin-parity-drift.mjs --cache-root parity/fixtures/drift/cache --skills-root parity/fixtures/drift/skills --json` exits `1` and reports `code-simplifier` `stale` `1.0.0 → 2.0.0`.** Encoded as the vitest test in §4.4. |
+| 3b | No drift → exit 0 | Same script against the `no-drift` fixture (pin == current) exits `0`, summary `0 drift`. |
+| 3c | Detector never auto-bumps | Test asserts the fixture skill file bytes are unchanged after the run (read before/after). |
+| 4 | `synced-from` grammar is enforced | Unit test: `parseSyncedFrom` accepts `name@mkt@1.2.3`, splits on last `@`, rejects malformed → `unparseable` status surfaces and forces exit 1. |
+| 5 | CI can gate on drift | The exit-code contract (§3.4) is the gate; a CI step `node scripts/plugin-parity-drift.mjs` (default roots) fails the build on exit 1. |
+
+### 4.4 Scenario-3 test (concrete, runnable)
+**Fixture (committed under `parity/fixtures/drift/`):**
+```
+parity/fixtures/drift/
+  cache/claude-plugins-official/code-simplifier/2.0.0/.claude-plugin/plugin.json   # {"name":"code-simplifier","version":"2.0.0"}
+  cache/claude-plugins-official/code-simplifier/1.0.0/.claude-plugin/plugin.json   # older sibling -> resolver must pick max (2.0.0)
+  cache/claude-plugins-official/coderabbit/1.1.1/.claude-plugin/plugin.json        # {"version":"1.1.1"}
+  skills/code-simplifier/SKILL.md     # frontmatter synced-from: code-simplifier@claude-plugins-official@1.0.0   (STALE)
+  skills/coderabbit/SKILL.md          # frontmatter synced-from: coderabbit@claude-plugins-official@1.1.1         (OK)
+  skills/plain/SKILL.md               # no synced-from -> ignored
+```
+**`tests/unit/scripts/plugin-parity-drift.test.ts` (vitest) asserts:**
+1. Spawn the script with the fixture roots + `--json`; capture stdout + exit code.
+2. `expect(exitCode).toBe(1)`.
+3. Report `summary` = `{ scanned: 2, ok: 1, drift: 1 }` (plain ignored).
+4. `code-simplifier` result `{ pinnedVersion:"1.0.0", currentVersion:"2.0.0", status:"stale" }` — proving **max-semver resolution across the 1.0.0/2.0.0 sibling dirs**.
+5. `coderabbit` result `status:"ok"`.
+6. A "no-drift" variant (bump the pin to `2.0.0`) exits `0`.
+7. File-bytes-unchanged assertion (3c).
+8. Pure-function tests for `compareSemver`/`isValidSemver`/`parseSyncedFrom` (hardcoded known values per the Test Isolation house rule — do NOT compute expected values by calling the function under test).
+
+Run: `bun run test:unit` (vitest; `tests/unit/scripts/` is an existing dir).
+
+---
+
+## 5. On-disk location for routing artifacts + drift (ambiguity (c)) — DECISION
+
+**Decision: durable, committed `parity/` directory at repo root — NOT `/tmp`.**
+
+```
+parity/
+  plugin-routing/<plugin>@<marketplace>.json   # machine-readable routing artifact (analyze writes, implement reads)
+  plugin-routing/<plugin>@<marketplace>.md      # human matrix (review companion)
+  fixtures/drift/...                            # committed test fixtures
+  DESIGN-plugin-parity-subsystem.md             # this doc
+```
+
+**Justification (vs the siblings' `/tmp/parity-research.md`):** the sibling parity skills are *pure research* — their `/tmp` artifact is ephemeral scratch consumed in one session. This routing artifact is different in kind:
+1. **It is an approval gate / contract between two skills** (`analyze` → human → `implement`). The approval must survive across sessions, machines, and reviewers.
+2. **It is an auditable decision record** — reviewers see exactly what parity routing was approved, in the PR diff.
+3. **`implement-plugin-parity` must read it deterministically** later; `/tmp` is not reliable across runs/agents.
+4. **It pairs naturally with the committed drift fixtures and the `synced-from` stamps**, which are themselves durable repo state.
+
+The filename uses the full `<plugin>@<marketplace>` id (one artifact per curated plugin) so re-running `analyze` for one plugin never clobbers another. Artifacts are committed; the human "approval" is simply flipping `"status": "proposed"` → `"approved"` (and is visible in git history).
+
+---
+
+## 6. Routing artifact schema (ambiguity (b)) + worked example
+
+### 6.1 Schema (`parity/plugin-routing/<plugin>@<marketplace>.json`)
+```jsonc
+{
+  "schemaVersion": 1,
+  "plugin": "code-simplifier@claude-plugins-official", // canonical id (== synced-from plugin-ref)
+  "pluginName": "code-simplifier",
+  "marketplace": "claude-plugins-official",
+  "upstreamVersion": "1.0.0",          // resolved by analyze from the cache at analysis time
+  "analyzedAt": "2026-05-30",          // informational only (not load-bearing; no Date dependency in drift)
+  "status": "proposed",                // "proposed" | "approved"  (human flips to approved)
+  "components": [                      // inventory of the plugin's parts, each classified
+    {
+      "kind": "agent",                 // "skill"|"agent"|"command"|"hook"|"mcp"|"lsp"
+      "id": "code-simplifier",
+      "path": "agents/code-simplifier.md",
+      "classification": "claude-agent",// "claude-skill"|"claude-agent"|"claude-command"|"hook"|"mcp-server"|"lsp-server"
+      "notes": "single subagent; no MCP/LSP"
+    }
+  ],
+  "routing": {                         // exactly one entry per agent; outcome is the locked enum
+    "codex":   { "outcome": "reimplement",             "actions": ["scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0"], "rationale": "Codex has no plugin subagent surface; behavior reimplemented as a Lisa skill." },
+    "cursor":  { "outcome": "claude-only",             "actions": [],                                                                                                  "rationale": "Cursor reads .claude-plugin/ natively; the agent loads unchanged." },
+    "agy":     { "outcome": "reimplement",             "actions": ["scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0"], "rationale": "agy converts commands→skills but has no equivalent subagent plugin surface." },
+    "copilot": { "outcome": "enable-vendor-equivalent","actions": ["enable copilot's native simplifier equivalent in the project-scoped marketplace"],                "rationale": "vendor ships a comparable capability; prefer enabling over reimplementing." }
+  }
+}
+```
+
+**Outcome enum (locked by task #2):** `already-native | re-point-mcp-lsp | enable-vendor-equivalent | claude-only | reimplement`.
+- `already-native` — agent already gets it via the existing fan-out; no action.
+- `re-point-mcp-lsp` — the plugin is (or carries) an MCP/LSP server; emit it into that agent's variant via the existing generator/installer (Codex `.codex-plugin` MCP pointer; Cursor `mcp.json`; agy → `src/agy/mcp-installer.ts` user-global; Copilot → inline `mcpServers` / `lspServers` on the manifest).
+- `enable-vendor-equivalent` — enable the agent's native equivalent in its project-scoped marketplace.
+- `claude-only` — intentionally not ported (e.g. Cursor already covered, or no equivalent); documented, no action.
+- `reimplement` — scaffold a Lisa-native skill stamped `synced-from` (the only case that creates a drift-tracked artifact). **v1 scaffolds only — the actual reimplementation logic is out of scope.**
+
+### 6.2 Worked example — `coderabbit@claude-plugins-official` (an MCP-bearing plugin)
+```jsonc
+{
+  "schemaVersion": 1,
+  "plugin": "coderabbit@claude-plugins-official",
+  "pluginName": "coderabbit",
+  "marketplace": "claude-plugins-official",
+  "upstreamVersion": "1.1.1",
+  "analyzedAt": "2026-05-30",
+  "status": "proposed",
+  "components": [
+    { "kind": "command", "id": "coderabbit-review", "path": "commands/coderabbit-review.md", "classification": "claude-command", "notes": "user-facing review trigger" },
+    { "kind": "mcp",     "id": "coderabbit",        "path": ".mcp.json",                     "classification": "mcp-server",     "notes": "HTTP MCP server" }
+  ],
+  "routing": {
+    "codex":   { "outcome": "re-point-mcp-lsp",        "actions": ["emit coderabbit MCP into .codex-plugin via generate-codex-plugin-artifacts.mjs"], "rationale": "Codex consumes the .codex-plugin MCP pointer." },
+    "cursor":  { "outcome": "already-native",          "actions": [],                                                                                  "rationale": "Cursor variant already emits mcp.json from .mcp.json." },
+    "agy":     { "outcome": "re-point-mcp-lsp",        "actions": ["register coderabbit MCP via src/agy/mcp-installer.ts (user-global, serverUrl shape)"], "rationale": "agy ignores plugin MCP; runtime installer delivers it." },
+    "copilot": { "outcome": "re-point-mcp-lsp",        "actions": ["surface coderabbit as inline mcpServers on the copilot manifest (generator already does this from .mcp.json)"], "rationale": "Copilot only reads inline mcpServers, not bundled .mcp.json." }
+  }
+}
+```
+This example produces **no** `synced-from` skill (no `reimplement`), so it never appears in the drift report — illustrating that drift tracking is scoped exactly to reimplementations.
+
+---
+
+## 7. Skill/command house-style notes (for the builder)
+
+- **Skills** (`.claude/skills/<name>/SKILL.md`): hyphen names; frontmatter `name` + `description` (siblings also set `allowed-tools`). No `argument-hint`/`$ARGUMENTS` in skills. `analyze-plugin` & `plugin-parity-drift` → `allowed-tools: ["Bash","Read","Write","Edit","Glob","Grep","Skill"]`; `implement-plugin-parity` same set (it edits/builds).
+- **Commands** (`.claude/commands/<name>.md`): frontmatter `description`, `argument-hint`, optional `allowed-tools: ["Skill"]`; body is a one-line pass-through: `Use the /<skill> skill ... $ARGUMENTS` (verified pattern in `.claude/commands/lisa-codex-parity.md`).
+- Plan-only skills must explicitly STOP and refuse implementation requests (mirror `lisa-coding-agent-parity` "reject and point at the sibling").
+- These three skills live ONLY in root `.claude/` (Lisa-internal), never in `all/copy-overwrite/` or `plugins/src/` (per PROJECT_RULES.md — same rule that keeps `lisa-codex-parity` root-only).
+
+---
+
+## 8. Risks
+- **Multiple cache version dirs / `unknown` dirs** — resolver picks max valid semver from manifest `version` fields, skipping non-semver dirs; if a plugin only has non-semver manifests the status is `unresolved` (exit 1, surfaced — not silently OK). Mitigation: behavior is explicit and fixture-tested.
+- **Marketplace ambiguity in `synced-from`** — solved by embedding the full `name@marketplace` id and splitting on the last `@`; verified semver never contains `@`.
+- **Approval bypass** — `implement-plugin-parity` hard-gates on `status:"approved"`; an un-approved or schema-invalid artifact is a no-op error.
+- **Generator drift** — implement reuses generators as-is; if a curated plugin needs a *new* emission path (e.g. first LSP routed to Copilot `lspServers`), that's a separate work item, flagged in the artifact `actions`, not silently attempted.

--- a/parity/fixtures/drift/cache/claude-plugins-official/code-simplifier/1.0.0/.claude-plugin/plugin.json
+++ b/parity/fixtures/drift/cache/claude-plugins-official/code-simplifier/1.0.0/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "code-simplifier",
+  "version": "1.0.0",
+  "description": "Fixture manifest — older sibling; resolver must NOT pick this (max-semver wins)."
+}

--- a/parity/fixtures/drift/cache/claude-plugins-official/code-simplifier/2.0.0/.claude-plugin/plugin.json
+++ b/parity/fixtures/drift/cache/claude-plugins-official/code-simplifier/2.0.0/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "code-simplifier",
+  "version": "2.0.0",
+  "description": "Fixture manifest — newer installed version; resolver must pick this over the 1.0.0 sibling."
+}

--- a/parity/fixtures/drift/cache/claude-plugins-official/coderabbit/1.1.1/.claude-plugin/plugin.json
+++ b/parity/fixtures/drift/cache/claude-plugins-official/coderabbit/1.1.1/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "coderabbit",
+  "version": "1.1.1",
+  "description": "Fixture manifest — matches the coderabbit skill pin (no drift)."
+}

--- a/parity/fixtures/drift/cache/claude-plugins-official/unresolved-plugin/unknown/.claude-plugin/plugin.json
+++ b/parity/fixtures/drift/cache/claude-plugins-official/unresolved-plugin/unknown/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "unresolved-plugin",
+  "version": "unknown",
+  "description": "Fixture manifest — installed but its only version subdir carries a NON-semver version, so resolveCurrentVersion must report `unresolved`."
+}

--- a/parity/fixtures/drift/skills/code-simplifier/SKILL.md
+++ b/parity/fixtures/drift/skills/code-simplifier/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-simplifier
+description: Drift fixture — a Lisa-native reimplementation pinned BEHIND its upstream (pin 1.0.0, cache 2.0.0 → STALE).
+synced-from: code-simplifier@claude-plugins-official@1.0.0
+---
+
+# Fixture skill (STALE)
+
+This file is a committed test fixture for `scripts/plugin-parity-drift.mjs`.
+Its `synced-from` pin (`1.0.0`) is older than the version resolvable from the
+fixture cache (`2.0.0`), so the detector must classify it `stale`.

--- a/parity/fixtures/drift/skills/coderabbit/SKILL.md
+++ b/parity/fixtures/drift/skills/coderabbit/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: coderabbit
+description: Drift fixture — a Lisa-native reimplementation pinned EXACTLY at its upstream (pin 1.1.1, cache 1.1.1 → OK).
+synced-from: coderabbit@claude-plugins-official@1.1.1
+---
+
+# Fixture skill (OK)
+
+This file is a committed test fixture for `scripts/plugin-parity-drift.mjs`.
+Its `synced-from` pin (`1.1.1`) matches the version resolvable from the fixture
+cache, so the detector must classify it `ok`.

--- a/parity/fixtures/drift/skills/plain/SKILL.md
+++ b/parity/fixtures/drift/skills/plain/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: plain
+description: Drift fixture — an ordinary Lisa skill with NO synced-from pin; the detector must ignore it entirely (not counted in `scanned`).
+---
+
+# Fixture skill (ignored)
+
+This file is a committed test fixture for `scripts/plugin-parity-drift.mjs`.
+It carries no `synced-from` frontmatter, so it is not a reimplementation and is
+excluded from the drift scan.

--- a/scripts/plugin-parity-drift.mjs
+++ b/scripts/plugin-parity-drift.mjs
@@ -516,7 +516,10 @@ export function parseArgs(argv) {
  */
 function collectSyncedSkills(roots) {
   const skills = [];
-  for (const root of roots) {
+  // Sort roots and the final result by path so the report is deterministic:
+  // readdirSync() traversal order is filesystem-dependent, which would otherwise
+  // reshuffle rows across environments even for an unchanged skills set.
+  for (const root of [...roots].sort((a, b) => a.localeCompare(b))) {
     for (const file of walkSkillFiles(root)) {
       const frontmatter = parseFrontmatter(fs.readFileSync(file, "utf8"));
       const raw = frontmatter["synced-from"];
@@ -525,7 +528,7 @@ function collectSyncedSkills(roots) {
       }
     }
   }
-  return skills;
+  return skills.sort((a, b) => a.file.localeCompare(b.file));
 }
 
 /**

--- a/scripts/plugin-parity-drift.mjs
+++ b/scripts/plugin-parity-drift.mjs
@@ -1,0 +1,605 @@
+#!/usr/bin/env node
+/**
+ * Deterministic drift detector for Lisa's third-party plugin parity subsystem
+ * (issue #1059).
+ *
+ * A Lisa-native skill that reimplements an upstream Claude plugin carries a
+ * `synced-from: <name>@<marketplace>@<version>` frontmatter pin. This script
+ * scans for those pins, resolves each plugin's *current* upstream version from
+ * the installed plugin cache, and reports whether the Lisa reimplementation has
+ * drifted behind (or ahead of) its upstream. It NEVER auto-bumps and never
+ * edits any skill — it only reports, so CI can gate on its exit code.
+ *
+ * Design: parity/DESIGN-plugin-parity-subsystem.md §2–§3.
+ *
+ * Determinism guarantees (so the unit test is reproducible and CI is stable):
+ *   - zero dependencies (Node built-ins only),
+ *   - no network access,
+ *   - no `Date` / `Math.random` — "current upstream" is defined purely as the
+ *     MAX valid semver across the cache version subdirs (read from each
+ *     manifest's `version` field, not the directory name).
+ *
+ * The cache root and skills roots are injectable via flags so tests point at a
+ * committed fixture instead of the machine's real `~/.claude/plugins/cache`.
+ *
+ * CLI:
+ *   node scripts/plugin-parity-drift.mjs [--skills-root <dir>]... [--cache-root <dir>] [--json]
+ *
+ * Exit codes (CI contract, §3.4):
+ *   0 — no drift: every synced skill is `ok` (also when there are zero synced
+ *       skills, in which case the cache need not exist — a fresh CI runner with
+ *       no reimplementations passes cleanly).
+ *   1 — drift found: ≥1 skill is stale/ahead/not-installed/unresolved/unparseable.
+ *   2 — operational/usage error: unknown flag, a flag missing its value, no
+ *       resolvable skills root, a filesystem error during the scan, or — only
+ *       when ≥1 synced skill must be resolved — a missing cache root.
+ *
+ * @module scripts/plugin-parity-drift
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+/**
+ * Semver 2.0.0 grammar. Build metadata (`+...`) is accepted but ignored in
+ * comparison; prerelease (`-...`) is accepted and sorts below its release.
+ */
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/** A plugin name / marketplace token: `1*(ALPHA / DIGIT / "-" / "_")`. */
+const TOKEN_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Usage error — thrown by `parseArgs` for an invalid invocation so `main` can
+ * distinguish it (exit 2) from a drift result (exit 1).
+ */
+export class UsageError extends Error {}
+
+/**
+ * True iff `value` is a valid semver 2.0.0 string.
+ *
+ * @param {unknown} value - candidate version string.
+ * @returns {boolean} whether `value` parses as semver.
+ */
+export function isValidSemver(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return SEMVER_RE.test(value);
+}
+
+/**
+ * Split a semver string into its numeric `[major, minor, patch]` core and the
+ * raw prerelease string (build metadata stripped).
+ *
+ * @param {string} version - a valid semver string.
+ * @returns {{ core: readonly number[], prerelease: string }} parsed parts.
+ */
+function splitSemver(version) {
+  const withoutBuild = version.split("+", 1)[0];
+  const dashIndex = withoutBuild.indexOf("-");
+  const coreStr =
+    dashIndex === -1 ? withoutBuild : withoutBuild.slice(0, dashIndex);
+  const prerelease = dashIndex === -1 ? "" : withoutBuild.slice(dashIndex + 1);
+  const core = coreStr.split(".").map(part => Number.parseInt(part, 10));
+  return { core, prerelease };
+}
+
+/**
+ * Compare two prerelease strings per semver precedence rules.
+ *
+ * @param {string} a - first prerelease (may be empty = "is a release").
+ * @param {string} b - second prerelease (may be empty = "is a release").
+ * @returns {number} -1, 0, or 1.
+ */
+function comparePrerelease(a, b) {
+  if (a === b) {
+    return 0;
+  }
+  if (a === "") {
+    return 1; // a is a full release; it outranks any prerelease b.
+  }
+  if (b === "") {
+    return -1;
+  }
+  const aIds = a.split(".");
+  const bIds = b.split(".");
+  for (let i = 0; i < Math.max(aIds.length, bIds.length); i++) {
+    const ai = aIds[i];
+    const bi = bIds[i];
+    if (ai === undefined) {
+      return -1; // shorter set of identifiers has lower precedence.
+    }
+    if (bi === undefined) {
+      return 1;
+    }
+    const aNum = /^\d+$/.test(ai);
+    const bNum = /^\d+$/.test(bi);
+    if (aNum && bNum) {
+      const diff = Number.parseInt(ai, 10) - Number.parseInt(bi, 10);
+      if (diff !== 0) {
+        return diff < 0 ? -1 : 1;
+      }
+      continue;
+    }
+    if (aNum !== bNum) {
+      return aNum ? -1 : 1; // numeric identifiers rank below alphanumeric.
+    }
+    if (ai !== bi) {
+      return ai < bi ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Compare two semver strings. Build metadata is ignored; a prerelease sorts
+ * below its associated release.
+ *
+ * @param {string} a - first valid semver string.
+ * @param {string} b - second valid semver string.
+ * @returns {number} -1 if a < b, 0 if equal precedence, 1 if a > b.
+ */
+export function compareSemver(a, b) {
+  const pa = splitSemver(a);
+  const pb = splitSemver(b);
+  for (let i = 0; i < 3; i++) {
+    const diff = pa.core[i] - pb.core[i];
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1;
+    }
+  }
+  return comparePrerelease(pa.prerelease, pb.prerelease);
+}
+
+/**
+ * Parse a `synced-from` value of the form `name@marketplace@version`.
+ *
+ * Semver never contains `@`, so the version is everything right of the LAST
+ * `@`; the remainder is the canonical plugin id `name@marketplace`, split once
+ * more on its single `@`.
+ *
+ * @param {unknown} raw - the raw frontmatter value.
+ * @returns {{ name: string, marketplace: string, version: string, plugin: string } | null}
+ *   parsed reference, or `null` if malformed.
+ */
+export function parseSyncedFrom(raw) {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const value = raw.trim();
+  const lastAt = value.lastIndexOf("@");
+  if (lastAt <= 0 || lastAt === value.length - 1) {
+    return null;
+  }
+  const version = value.slice(lastAt + 1);
+  const pluginRef = value.slice(0, lastAt);
+  if (!isValidSemver(version)) {
+    return null;
+  }
+  const refAt = pluginRef.indexOf("@");
+  if (refAt <= 0 || refAt === pluginRef.length - 1) {
+    return null;
+  }
+  const name = pluginRef.slice(0, refAt);
+  const marketplace = pluginRef.slice(refAt + 1);
+  if (!TOKEN_RE.test(name) || !TOKEN_RE.test(marketplace)) {
+    return null;
+  }
+  return { marketplace, name, plugin: pluginRef, version };
+}
+
+/**
+ * Parse a minimal YAML frontmatter block (leading `--- ... ---`) into a flat
+ * map of `key: value` strings. Surrounding quotes are stripped. This is
+ * intentionally tiny — the detector only needs the `synced-from` scalar.
+ *
+ * @param {string} content - full file contents.
+ * @returns {Record<string, string>} the parsed frontmatter keys.
+ */
+export function parseFrontmatter(content) {
+  const text = String(content);
+  if (!text.startsWith("---")) {
+    return {};
+  }
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) {
+    return {};
+  }
+  const block = text.slice(text.indexOf("\n") + 1, end);
+  const result = {};
+  for (const line of block.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      continue;
+    }
+    const colon = trimmed.indexOf(":");
+    if (colon === -1) {
+      continue;
+    }
+    const key = trimmed.slice(0, colon).trim();
+    const rawValue = trimmed.slice(colon + 1).trim();
+    const value = rawValue.replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * True iff `target` is an existing directory.
+ *
+ * @param {string} target - filesystem path.
+ * @returns {boolean} whether `target` resolves to a directory.
+ */
+function isDirectory(target) {
+  try {
+    return fs.statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a plugin manifest's `version` field, or `null` if unreadable / invalid.
+ *
+ * @param {string} manifestPath - path to a `.claude-plugin/plugin.json`.
+ * @returns {string | null} the manifest version string, or `null`.
+ */
+function readManifestVersion(manifestPath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the current upstream version of `name@marketplace` purely from the
+ * cache tree: the MAX valid semver across the immediate version subdirs, read
+ * from each subdir's `.claude-plugin/plugin.json` `version` field. Non-semver
+ * dirs (`unknown`, git hashes) are skipped because the manifest version is what
+ * counts.
+ *
+ * @param {string} cacheRoot - the installed-plugin cache root.
+ * @param {string} name - plugin name.
+ * @param {string} marketplace - marketplace id.
+ * @returns {{ status: "ok" | "not-installed" | "unresolved", version: string | null }}
+ *   the resolution outcome.
+ */
+export function resolveCurrentVersion(cacheRoot, name, marketplace) {
+  // Defense-in-depth path-traversal guard: only single-token names/marketplaces
+  // (no `.`, `/`, `..`) can map to a cache subdir. parseSyncedFrom already
+  // enforces this, but resolveCurrentVersion is a public export that no longer
+  // co-locates with its validating caller.
+  if (!TOKEN_RE.test(name) || !TOKEN_RE.test(marketplace)) {
+    return { status: "not-installed", version: null };
+  }
+  const dir = path.join(cacheRoot, marketplace, name);
+  if (!isDirectory(dir)) {
+    return { status: "not-installed", version: null };
+  }
+  const versions = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const manifest = path.join(
+      dir,
+      entry.name,
+      ".claude-plugin",
+      "plugin.json"
+    );
+    const version = readManifestVersion(manifest);
+    if (version !== null && isValidSemver(version)) {
+      versions.push(version);
+    }
+  }
+  if (versions.length === 0) {
+    return { status: "unresolved", version: null };
+  }
+  const max = versions.reduce((acc, v) =>
+    compareSemver(v, acc) > 0 ? v : acc
+  );
+  return { status: "ok", version: max };
+}
+
+/**
+ * Classify a synced skill by comparing its pinned version to the resolved
+ * current version (§3.3).
+ *
+ * @param {string} pinnedVersion - the `synced-from` pinned semver.
+ * @param {{ status: string, version: string | null }} cur - resolver output.
+ * @returns {"ok" | "stale" | "ahead" | "not-installed" | "unresolved"} the status.
+ */
+export function classify(pinnedVersion, cur) {
+  if (cur.status === "not-installed") {
+    return "not-installed";
+  }
+  // Defense-in-depth: any non-`ok` resolver state, or an `ok` state without a
+  // string version, is treated as `unresolved` so compareSemver is never called
+  // with a null/undefined operand. resolveCurrentVersion guarantees
+  // `ok` ⇒ string version, so this only fires on contract misuse.
+  if (cur.status !== "ok" || typeof cur.version !== "string") {
+    return "unresolved";
+  }
+  const cmp = compareSemver(cur.version, pinnedVersion);
+  if (cmp === 0) {
+    return "ok";
+  }
+  return cmp > 0 ? "stale" : "ahead";
+}
+
+/**
+ * Recursively collect every `SKILL.md` path beneath `root`.
+ *
+ * @param {string} root - a skills root directory.
+ * @returns {string[]} absolute paths to discovered SKILL.md files.
+ */
+function walkSkillFiles(root) {
+  const out = [];
+  if (!isDirectory(root)) {
+    return out;
+  }
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name === "SKILL.md") {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Render a filesystem path relative to the repo root using POSIX separators,
+ * falling back to the absolute path when the file lives outside the repo.
+ *
+ * @param {string} absPath - an absolute path.
+ * @returns {string} a stable, display-friendly path.
+ */
+function displayPath(absPath) {
+  const rel = path.relative(REPO_ROOT, absPath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return absPath;
+  }
+  return rel.split(path.sep).join("/");
+}
+
+/**
+ * Build one result row for a discovered synced skill.
+ *
+ * @param {{ file: string, raw: string }} skill - the skill file + raw pin.
+ * @param {string} cacheRoot - the installed-plugin cache root.
+ * @returns {{ skillPath: string, plugin: string, pinnedVersion: string | null, currentVersion: string | null, status: string }}
+ *   the classified result.
+ */
+function buildResult(skill, cacheRoot) {
+  const skillPath = displayPath(skill.file);
+  const ref = parseSyncedFrom(skill.raw);
+  if (ref === null) {
+    return {
+      currentVersion: null,
+      pinnedVersion: null,
+      plugin: skill.raw,
+      skillPath,
+      status: "unparseable",
+    };
+  }
+  const cur = resolveCurrentVersion(cacheRoot, ref.name, ref.marketplace);
+  return {
+    currentVersion: cur.version,
+    pinnedVersion: ref.version,
+    plugin: ref.plugin,
+    skillPath,
+    status: classify(ref.version, cur),
+  };
+}
+
+/**
+ * Assemble the machine-readable report (§3.5).
+ *
+ * @param {ReadonlyArray<Record<string, unknown>>} results - per-skill results.
+ * @param {{ cacheRoot: string, skillsRoots: readonly string[] }} opts - options.
+ * @returns {Record<string, unknown>} the report object.
+ */
+export function buildReport(results, opts) {
+  const ok = results.filter(r => r.status === "ok").length;
+  return {
+    cacheRoot: opts.cacheRoot,
+    results,
+    schemaVersion: 1,
+    skillsRoots: opts.skillsRoots,
+    summary: { drift: results.length - ok, ok, scanned: results.length },
+  };
+}
+
+/**
+ * Render the human-readable markdown table + summary line.
+ *
+ * @param {{ results: ReadonlyArray<Record<string, unknown>>, summary: { scanned: number, drift: number } }} report - report object.
+ * @returns {string} the rendered table.
+ */
+function humanTable(report) {
+  const header =
+    "| skill | plugin | pinned | current | status |\n" +
+    "| --- | --- | --- | --- | --- |";
+  const rows = report.results.map(
+    r =>
+      `| ${cell(r.skillPath)} | ${cell(r.plugin)} | ${cell(r.pinnedVersion)} | ${cell(r.currentVersion)} | ${cell(r.status)} |`
+  );
+  const summary = `\n${report.summary.drift} of ${report.summary.scanned} synced skills drifted`;
+  return [header, ...rows].join("\n") + summary;
+}
+
+/**
+ * Sanitize a value for a markdown-table cell: a `|` in an `unparseable` raw
+ * `synced-from` string would otherwise break the column layout, and newlines
+ * would split the row. Pipes are escaped and newlines collapsed to spaces.
+ *
+ * @param {string | null | undefined} value - the raw cell value.
+ * @returns {string} a table-safe string (`-` for null/undefined).
+ */
+function cell(value) {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+}
+
+/**
+ * Parse argv into resolved options. Throws `UsageError` on a bad invocation.
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @returns {{ skillsRoots: string[], cacheRoot: string, json: boolean }} options.
+ */
+export function parseArgs(argv) {
+  const skillsRoots = [];
+  let cacheRoot = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--skills-root") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new UsageError("--skills-root requires a value");
+      }
+      skillsRoots.push(next);
+      i += 1;
+    } else if (arg === "--cache-root") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new UsageError("--cache-root requires a value");
+      }
+      cacheRoot = next;
+      i += 1;
+    } else {
+      throw new UsageError(`unknown argument: ${arg}`);
+    }
+  }
+  const resolvedCache =
+    cacheRoot ??
+    process.env.CLAUDE_PLUGIN_CACHE ??
+    path.join(os.homedir(), ".claude", "plugins", "cache");
+  const resolvedSkills =
+    skillsRoots.length > 0
+      ? skillsRoots
+      : [path.join(REPO_ROOT, ".claude", "skills")];
+  return {
+    cacheRoot: path.resolve(resolvedCache),
+    json,
+    skillsRoots: resolvedSkills.map(r => path.resolve(r)),
+  };
+}
+
+/**
+ * Scan the skills roots and collect every SKILL.md carrying a non-empty
+ * `synced-from` pin. May throw on a filesystem error (caller handles it).
+ *
+ * @param {readonly string[]} roots - resolved skills-root directories.
+ * @returns {{ file: string, raw: string }[]} discovered synced skills.
+ */
+function collectSyncedSkills(roots) {
+  const skills = [];
+  for (const root of roots) {
+    for (const file of walkSkillFiles(root)) {
+      const frontmatter = parseFrontmatter(fs.readFileSync(file, "utf8"));
+      const raw = frontmatter["synced-from"];
+      if (typeof raw === "string" && raw !== "") {
+        skills.push({ file, raw });
+      }
+    }
+  }
+  return skills;
+}
+
+/**
+ * Render a report to the chosen stream.
+ *
+ * @param {{ write(s: string): void }} out - the output stream.
+ * @param {Record<string, unknown>} report - the report object.
+ * @param {boolean} json - whether to emit JSON instead of the human table.
+ * @returns {void}
+ */
+function emitReport(out, report, json) {
+  out.write(
+    (json ? JSON.stringify(report, null, 2) : humanTable(report)) + "\n"
+  );
+}
+
+/**
+ * Run the detector. Returns the process exit code (does not call `exit`).
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @param {{ stdout?: { write(s: string): void }, stderr?: { write(s: string): void } }} [io]
+ *   injectable streams (defaults to process streams).
+ * @returns {number} the exit code (0 ok, 1 drift, 2 usage error).
+ */
+export function main(argv, io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    err.write(`error: ${error.message}\n`);
+    return 2;
+  }
+  if (!opts.skillsRoots.some(isDirectory)) {
+    err.write("error: no --skills-root resolved to a directory\n");
+    return 2;
+  }
+  // Scan for synced skills first. Wrapped in try/catch so a filesystem race
+  // (TOCTOU) during the walk/read surfaces as a clean usage error (exit 2)
+  // rather than an uncaught throw escaping main().
+  let skills;
+  try {
+    skills = collectSyncedSkills(opts.skillsRoots);
+  } catch (error) {
+    err.write(`error: failed to scan skills roots: ${error.message}\n`);
+    return 2;
+  }
+  // With zero reimplementations there is trivially no drift, so succeed even if
+  // the plugin cache is absent — a fresh CI runner with no synced skills (and
+  // no cache yet) must not fail the build.
+  if (skills.length === 0) {
+    emitReport(out, buildReport([], opts), opts.json);
+    return 0;
+  }
+  // There is ≥1 synced skill to resolve, so the cache is now required.
+  if (!isDirectory(opts.cacheRoot)) {
+    err.write(`error: --cache-root is not a directory: ${opts.cacheRoot}\n`);
+    return 2;
+  }
+  let results;
+  try {
+    results = skills.map(skill => buildResult(skill, opts.cacheRoot));
+  } catch (error) {
+    err.write(`error: failed to resolve plugin versions: ${error.message}\n`);
+    return 2;
+  }
+  emitReport(out, buildReport(results, opts), opts.json);
+  return results.every(r => r.status === "ok") ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tests/unit/scripts/plugin-parity-drift-helpers.ts
+++ b/tests/unit/scripts/plugin-parity-drift-helpers.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared fixtures, constants, and helpers for the plugin-parity-drift unit
+ * tests. Extracted from the test file to keep it under the max-lines budget and
+ * to mirror the repo's `cursor-artifact-helpers.ts` convention.
+ *
+ * @module tests/unit/scripts/plugin-parity-drift-helpers
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import process from "node:process";
+
+export const REPO_ROOT = path.resolve(__dirname, "../../..");
+export const SCRIPT = path.join(
+  REPO_ROOT,
+  "scripts",
+  "plugin-parity-drift.mjs"
+);
+export const CACHE_ROOT = path.join(REPO_ROOT, "parity/fixtures/drift/cache");
+export const SKILLS_ROOT = path.join(REPO_ROOT, "parity/fixtures/drift/skills");
+export const STALE_SKILL = path.join(SKILLS_ROOT, "code-simplifier/SKILL.md");
+export const ABSENT_CACHE = path.join(
+  REPO_ROOT,
+  "parity/fixtures/drift/does-not-exist"
+);
+
+// Literals repeated ≥3 times at assertion sites — hoisted to satisfy
+// sonarjs/no-duplicate-string while keeping the expected values explicit.
+export const CACHE_FLAG = "--cache-root";
+export const SKILLS_FLAG = "--skills-root";
+export const MARKETPLACE = "claude-plugins-official";
+export const SIMPLIFIER = "code-simplifier";
+export const RC_VERSION = "1.0.0-rc.1";
+export const NOT_INSTALLED = "not-installed";
+export const UNRESOLVED = "unresolved";
+export const UNRESOLVED_PLUGIN = "unresolved-plugin";
+export const SIMPLIFIER_ID = `${SIMPLIFIER}@${MARKETPLACE}`;
+export const CODERABBIT_ID = `coderabbit@${MARKETPLACE}`;
+
+/** One classified row of the drift report (matches the script's §3.5 shape). */
+export interface DriftResult {
+  readonly skillPath: string;
+  readonly plugin: string;
+  readonly pinnedVersion: string | null;
+  readonly currentVersion: string | null;
+  readonly status: string;
+}
+
+/** The machine-readable drift report emitted with `--json`. */
+export interface DriftReport {
+  readonly schemaVersion: number;
+  readonly summary: {
+    readonly scanned: number;
+    readonly ok: number;
+    readonly drift: number;
+  };
+  readonly results: readonly DriftResult[];
+}
+
+/**
+ * Run the drift script and capture stdout + exit code. `execFileSync` throws on
+ * a non-zero exit, exposing `status` and `stdout` on the error object.
+ *
+ * @param args - CLI arguments after the script path.
+ * @returns The exit code and parsed JSON report (empty when no stdout).
+ */
+export function runDrift(args: readonly string[]): {
+  code: number;
+  report: DriftReport;
+} {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+    });
+    return { code: 0, report: JSON.parse(stdout) as DriftReport };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string };
+    const stdout = e.stdout ?? "";
+    return {
+      code: typeof e.status === "number" ? e.status : -1,
+      report: (stdout.trim() === "" ? {} : JSON.parse(stdout)) as DriftReport,
+    };
+  }
+}
+
+/**
+ * Find a result row by its canonical plugin id.
+ *
+ * @param report - the drift report.
+ * @param plugin - the canonical `name@marketplace` id.
+ * @returns The matching result, or undefined.
+ */
+export const findResult = (
+  report: DriftReport,
+  plugin: string
+): DriftResult | undefined => report.results.find(r => r.plugin === plugin);
+
+/**
+ * Write a one-skill skills root in a temp dir whose SKILL.md carries the given
+ * frontmatter lines, returning the temp root. Caller cleans it up.
+ *
+ * @param frontmatterLines - YAML frontmatter lines (between the `---` fences).
+ * @returns The created temp skills-root directory.
+ */
+export function makeTempSkill(frontmatterLines: readonly string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "drift-fixture-"));
+  const skillDir = path.join(root, "skill");
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    ["---", ...frontmatterLines, "---", "body", ""].join("\n"),
+    "utf8"
+  );
+  return root;
+}

--- a/tests/unit/scripts/plugin-parity-drift.test.ts
+++ b/tests/unit/scripts/plugin-parity-drift.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for scripts/plugin-parity-drift.mjs (issue #1059).
+ *
+ * The empirical core of the parity subsystem: proves Scenario 3 (version-pinned
+ * reimplementations + drift detection) against the committed fixture under
+ * `parity/fixtures/drift/`, the exit-code contract, the drift-status coverage
+ * (unresolved/unparseable), the zero-synced-skills CI footgun, and the pure
+ * helpers.
+ *
+ * Two test surfaces:
+ *   1. End-to-end: spawn the real script with fixture roots and assert stdout
+ *      JSON + exit code + that it never edits the fixture (3c).
+ *   2. Pure functions imported directly, asserted against HARDCODED expected
+ *      values per the Test Isolation house rule (never compute an expectation
+ *      by calling the function under test).
+ *
+ * Shared fixtures/constants/helpers live in ./plugin-parity-drift-helpers.
+ *
+ * @module tests/unit/scripts/plugin-parity-drift
+ */
+import * as fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  classify,
+  compareSemver,
+  isValidSemver,
+  parseFrontmatter,
+  parseSyncedFrom,
+  resolveCurrentVersion,
+} from "../../../scripts/plugin-parity-drift.mjs";
+import {
+  ABSENT_CACHE,
+  CACHE_FLAG,
+  CACHE_ROOT,
+  CODERABBIT_ID,
+  MARKETPLACE,
+  makeTempSkill,
+  NOT_INSTALLED,
+  RC_VERSION,
+  SIMPLIFIER,
+  SIMPLIFIER_ID,
+  SKILLS_FLAG,
+  SKILLS_ROOT,
+  STALE_SKILL,
+  UNRESOLVED,
+  UNRESOLVED_PLUGIN,
+  findResult,
+  runDrift,
+} from "./plugin-parity-drift-helpers";
+
+describe("plugin-parity-drift end-to-end (Scenario 3)", () => {
+  it("exits 1 and reports code-simplifier stale 1.0.0 -> 2.0.0 (max-semver resolution)", () => {
+    const { code, report } = runDrift([
+      CACHE_FLAG,
+      CACHE_ROOT,
+      SKILLS_FLAG,
+      SKILLS_ROOT,
+      "--json",
+    ]);
+
+    expect(code).toBe(1);
+    expect(report.summary).toEqual({ scanned: 2, ok: 1, drift: 1 });
+
+    const simplifier = findResult(report, SIMPLIFIER_ID);
+    expect(simplifier).toBeDefined();
+    expect(simplifier?.pinnedVersion).toBe("1.0.0");
+    expect(simplifier?.currentVersion).toBe("2.0.0");
+    expect(simplifier?.status).toBe("stale");
+
+    const coderabbit = findResult(report, CODERABBIT_ID);
+    expect(coderabbit?.status).toBe("ok");
+
+    // The `plain` skill (no synced-from) is ignored, not counted.
+    expect(report.results).toHaveLength(2);
+  });
+
+  it("does not modify the fixture skill file (never auto-bumps, 3c)", () => {
+    const before = fs.readFileSync(STALE_SKILL);
+    runDrift([CACHE_FLAG, CACHE_ROOT, SKILLS_FLAG, SKILLS_ROOT, "--json"]);
+    const after = fs.readFileSync(STALE_SKILL);
+    expect(after.equals(before)).toBe(true);
+  });
+});
+
+describe("plugin-parity-drift temp-fixture scenarios", () => {
+  const tempRoots: string[] = [];
+
+  const addSkill = (lines: readonly string[]): string => {
+    const root = makeTempSkill(lines);
+    tempRoots.push(root);
+    return root;
+  };
+
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      fs.rmSync(tempRoots.pop() as string, { force: true, recursive: true });
+    }
+  });
+
+  it("exits 0 with zero drift when the pin equals the current version (3b)", () => {
+    const root = addSkill([`synced-from: ${SIMPLIFIER_ID}@2.0.0`]);
+    const { code, report } = runDrift([
+      CACHE_FLAG,
+      CACHE_ROOT,
+      SKILLS_FLAG,
+      root,
+      "--json",
+    ]);
+
+    expect(code).toBe(0);
+    expect(report.summary).toEqual({ scanned: 1, ok: 1, drift: 0 });
+    expect(report.results[0]?.status).toBe("ok");
+  });
+
+  it("reports `unresolved` (exit 1) when the only cache version dir has a non-semver manifest (W1)", () => {
+    const root = addSkill([
+      `synced-from: ${UNRESOLVED_PLUGIN}@${MARKETPLACE}@1.0.0`,
+    ]);
+    const { code, report } = runDrift([
+      CACHE_FLAG,
+      CACHE_ROOT,
+      SKILLS_FLAG,
+      root,
+      "--json",
+    ]);
+
+    expect(code).toBe(1);
+    expect(report.summary).toEqual({ scanned: 1, ok: 0, drift: 1 });
+    expect(report.results[0]?.status).toBe(UNRESOLVED);
+    expect(report.results[0]?.currentVersion).toBeNull();
+  });
+
+  it("reports `unparseable` (exit 1) for a malformed synced-from value (W1)", () => {
+    const root = addSkill(["synced-from: not-a-valid-pin"]);
+    const { code, report } = runDrift([
+      CACHE_FLAG,
+      CACHE_ROOT,
+      SKILLS_FLAG,
+      root,
+      "--json",
+    ]);
+
+    expect(code).toBe(1);
+    expect(report.summary).toEqual({ scanned: 1, ok: 0, drift: 1 });
+    expect(report.results[0]?.status).toBe("unparseable");
+  });
+
+  it("exits 0 when there are no synced skills, even if the cache root is absent (W2)", () => {
+    const root = addSkill(["name: plain-skill"]);
+    const { code, report } = runDrift([
+      CACHE_FLAG,
+      ABSENT_CACHE,
+      SKILLS_FLAG,
+      root,
+      "--json",
+    ]);
+
+    expect(code).toBe(0);
+    expect(report.summary).toEqual({ scanned: 0, ok: 0, drift: 0 });
+  });
+});
+
+describe("plugin-parity-drift exit-code contract", () => {
+  it("exits 2 on an unknown flag (usage error, distinct from drift)", () => {
+    expect(runDrift(["--bogus"]).code).toBe(2);
+  });
+
+  it("exits 2 when the cache root is absent but synced skills exist", () => {
+    expect(
+      runDrift([CACHE_FLAG, ABSENT_CACHE, SKILLS_FLAG, SKILLS_ROOT]).code
+    ).toBe(2);
+  });
+
+  it("exits 2 when a flag is given without a value", () => {
+    expect(runDrift([CACHE_FLAG, SKILLS_FLAG, SKILLS_ROOT]).code).toBe(2);
+  });
+});
+
+describe("isValidSemver", () => {
+  it("accepts canonical semver strings", () => {
+    expect(isValidSemver("1.0.0")).toBe(true);
+    expect(isValidSemver("2.0.0")).toBe(true);
+    expect(isValidSemver("1.1.1")).toBe(true);
+    expect(isValidSemver("10.20.30")).toBe(true);
+    expect(isValidSemver(RC_VERSION)).toBe(true);
+    expect(isValidSemver("1.0.0+build.5")).toBe(true);
+  });
+
+  it("rejects non-semver values", () => {
+    expect(isValidSemver("unknown")).toBe(false);
+    expect(isValidSemver("a81eb76a1539")).toBe(false);
+    expect(isValidSemver("1.0")).toBe(false);
+    expect(isValidSemver("1")).toBe(false);
+    expect(isValidSemver("v1.0.0")).toBe(false);
+    expect(isValidSemver("")).toBe(false);
+    expect(isValidSemver(undefined)).toBe(false);
+  });
+});
+
+describe("compareSemver", () => {
+  it("orders by major, minor, patch", () => {
+    expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+    expect(compareSemver("2.0.0", "1.0.0")).toBe(1);
+    expect(compareSemver("1.1.1", "1.1.1")).toBe(0);
+    expect(compareSemver("1.2.0", "1.10.0")).toBe(-1);
+    expect(compareSemver("1.0.10", "1.0.2")).toBe(1);
+  });
+
+  it("sorts a prerelease below its release and ignores build metadata", () => {
+    expect(compareSemver(RC_VERSION, "1.0.0")).toBe(-1);
+    expect(compareSemver("1.0.0", RC_VERSION)).toBe(1);
+    expect(compareSemver("1.0.0-alpha", "1.0.0-beta")).toBe(-1);
+    expect(compareSemver("1.0.0+build.9", "1.0.0+build.1")).toBe(0);
+  });
+});
+
+describe("parseSyncedFrom", () => {
+  it("splits name@marketplace@version on the LAST @", () => {
+    expect(parseSyncedFrom(`${SIMPLIFIER_ID}@1.0.0`)).toEqual({
+      name: SIMPLIFIER,
+      marketplace: MARKETPLACE,
+      version: "1.0.0",
+      plugin: SIMPLIFIER_ID,
+    });
+  });
+
+  it("accepts a prerelease version", () => {
+    expect(parseSyncedFrom(`${CODERABBIT_ID}@1.1.1-rc.2`)).toEqual({
+      name: "coderabbit",
+      marketplace: MARKETPLACE,
+      version: "1.1.1-rc.2",
+      plugin: CODERABBIT_ID,
+    });
+  });
+
+  it("rejects malformed values", () => {
+    expect(parseSyncedFrom(`${SIMPLIFIER}@1.0.0`)).toBeNull();
+    expect(parseSyncedFrom(`${SIMPLIFIER_ID}@notsemver`)).toBeNull();
+    expect(parseSyncedFrom(`${SIMPLIFIER_ID}@`)).toBeNull();
+    expect(parseSyncedFrom(`@${MARKETPLACE}@1.0.0`)).toBeNull();
+    expect(parseSyncedFrom("noatsign")).toBeNull();
+    expect(parseSyncedFrom("")).toBeNull();
+    expect(parseSyncedFrom(undefined)).toBeNull();
+  });
+});
+
+describe("parseFrontmatter", () => {
+  it("extracts a synced-from scalar from a frontmatter block", () => {
+    const content = [
+      "---",
+      `name: ${SIMPLIFIER}`,
+      `synced-from: ${SIMPLIFIER_ID}@1.0.0`,
+      "---",
+      "# body",
+      "",
+    ].join("\n");
+    expect(parseFrontmatter(content)["synced-from"]).toBe(
+      `${SIMPLIFIER_ID}@1.0.0`
+    );
+  });
+
+  it("strips surrounding quotes", () => {
+    const content = ["---", 'synced-from: "x@y@1.0.0"', "---", ""].join("\n");
+    expect(parseFrontmatter(content)["synced-from"]).toBe("x@y@1.0.0");
+  });
+
+  it("returns an empty object when there is no frontmatter", () => {
+    expect(parseFrontmatter("# just a heading\n")).toEqual({});
+  });
+});
+
+describe("classify", () => {
+  it("maps the resolver outcome + version comparison to a status", () => {
+    expect(classify("1.0.0", { status: "ok", version: "2.0.0" })).toBe("stale");
+    expect(classify("2.0.0", { status: "ok", version: "1.0.0" })).toBe("ahead");
+    expect(classify("1.1.1", { status: "ok", version: "1.1.1" })).toBe("ok");
+    expect(classify("1.0.0", { status: NOT_INSTALLED, version: null })).toBe(
+      NOT_INSTALLED
+    );
+    expect(classify("1.0.0", { status: UNRESOLVED, version: null })).toBe(
+      UNRESOLVED
+    );
+  });
+
+  it("defensively treats `ok` without a version as unresolved (no null compare)", () => {
+    expect(classify("1.0.0", { status: "ok", version: null })).toBe(UNRESOLVED);
+  });
+});
+
+describe("resolveCurrentVersion", () => {
+  it("picks the max valid semver across the fixture cache version subdirs", () => {
+    expect(resolveCurrentVersion(CACHE_ROOT, SIMPLIFIER, MARKETPLACE)).toEqual({
+      status: "ok",
+      version: "2.0.0",
+    });
+  });
+
+  it("reports unresolved when the only version dir has a non-semver manifest", () => {
+    expect(
+      resolveCurrentVersion(CACHE_ROOT, UNRESOLVED_PLUGIN, MARKETPLACE)
+    ).toEqual({ status: UNRESOLVED, version: null });
+  });
+
+  it("reports not-installed for an unknown plugin", () => {
+    expect(resolveCurrentVersion(CACHE_ROOT, "nope", MARKETPLACE)).toEqual({
+      status: NOT_INSTALLED,
+      version: null,
+    });
+  });
+
+  it("reports not-installed for a path-traversal name (defense-in-depth)", () => {
+    expect(resolveCurrentVersion(CACHE_ROOT, "..", MARKETPLACE)).toEqual({
+      status: NOT_INSTALLED,
+      version: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Lisa-internal **3rd-party plugin parity subsystem** from #1059: classify each curated 3rd-party plugin and route it to every coding agent (Codex/Cursor/agy/Copilot) by the cheapest viable mechanism — **re-point or reimplement, never port** — and track upstream versions so reimplementations don't silently drift.

Three skills live at root `.claude/` (Lisa-internal, like `lisa-codex-parity` — **not** distributed downstream, no `plugins/src`/`build:plugins` impact):

- **`/analyze-plugin`** (plan-only) — inventories a curated plugin's components, classifies each, and emits one routing decision per agent (`already-native | re-point-mcp-lsp | enable-vendor-equivalent | claude-only | reimplement`), records the upstream version, and **stops for human review**. Preference order is first-applicable; reimplement is last resort (drift liability).
- **`/implement-plugin-parity`** (execute) — consumes an **approved** routing artifact; deterministic changes only, reusing the existing per-agent generators/installers as black boxes; scaffolds `synced-from`-stamped skills for reimplement cases only. Hard-gated on `status:"approved"`. Never ports plugin code.
- **`/plugin-parity-drift`** — wraps `scripts/plugin-parity-drift.mjs`: scans skills carrying `synced-from: <plugin>@<marketplace>@<version>`, resolves the current upstream version from the plugin cache (max valid semver across version dirs), and flags **stale** reimplementations **without auto-bumping**. CI-gateable exit codes (`0` ok / `1` drift / `2` usage).

Version pinning + drift tracking apply to **reimplementations only**; MCP/LSP re-points and vendor-equivalents carry no pin. Claude keeps using native plugins directly. **Per-plugin reimplementations are out of scope** — the subsystem only schedules them. Reuses (does not supersede) the per-agent MCP plumbing from #1054–#1058.

## Issue / Tracker link

Closes CodySwannGT/lisa#1059

## Test plan

- `bun run test:unit` — 25 drift tests (max-semver resolution across sibling version dirs, prerelease ordering, build-metadata stripping, path-traversal guard, `unresolved`/`unparseable`/`not-installed`/`ahead`/`stale` states, exit-0 when no reimplementations so fresh CI runners pass, flag-value guard, TOCTOU → exit 2).
- Drift proof (empirical core):
  ```
  node scripts/plugin-parity-drift.mjs --cache-root parity/fixtures/drift/cache --skills-root parity/fixtures/drift/skills --json
  # → exit 1, summary {scanned:2, ok:1, drift:1}, code-simplifier stale 1.0.0→2.0.0, coderabbit ok
  ```
- `bun run check:plugins` passes (no plugin artifacts touched).

## Reviews

Built via agent-team flow (explore → design → build → review). Parallel review pass: quality (no blockers), security (no critical/high; path-traversal closed by token regex), spec-conformance (**CONFORMS**, no scope creep), CodeRabbit — all triaged findings applied (CLI guard, flag-value guard, TOCTOU exit code, table escaping, defensive guards, expanded test coverage, doc self-containment).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin parity analysis workflow to map third-party plugin compatibility across different agents.
  * Version drift detection system for plugin implementations with exit-code reporting.
  * Plugin routing determination to decide implementation strategies (reimplementation, vendor equivalents, native support).

* **Documentation**
  * Plugin parity subsystem design specification and workflow documentation.

* **Tests**
  * Comprehensive drift detection test suite with fixtures and helper utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->