### PR TITLE
fix(parity): enforce per-agent component coverage in routing validator (CodeRabbit #1079)

### DIFF
--- a/parity/fixtures/routing/valid/has-manifest@demo-marketplace.json
+++ b/parity/fixtures/routing/valid/has-manifest@demo-marketplace.json
@@ -37,7 +37,7 @@
     },
     "copilot": {
       "outcome": "enable-vendor-equivalent",
-      "actions": ["enable Copilot's native equivalent in the project-scoped marketplace"],
+      "actions": ["enable Copilot's native agent equivalent for has-manifest in the project-scoped marketplace"],
       "rationale": "Vendor ships a comparable capability; prefer enabling over reimplementing."
     }
   }

--- a/parity/plugin-routing/code-review@claude-plugins-official.json
+++ b/parity/plugin-routing/code-review@claude-plugins-official.json
@@ -19,7 +19,7 @@
     "codex": {
       "outcome": "reimplement",
       "actions": [
-        "scaffold Lisa-native skill (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review)"
+        "scaffold Lisa-native skill reimplementing the code-review command (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review)"
       ],
       "rationale": "Codex has no plugin command surface and is not in the fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so the reimplementation is not drift-trackable — drift tracking is manual review."
     },
@@ -31,7 +31,7 @@
     "agy": {
       "outcome": "reimplement",
       "actions": [
-        "scaffold Lisa-native skill (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review)"
+        "scaffold Lisa-native skill reimplementing the code-review command (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review)"
       ],
       "rationale": "Curated third-party plugins are not in agy's fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so it is not drift-trackable — manual review."
     },

--- a/parity/plugin-routing/code-review@claude-plugins-official.md
+++ b/parity/plugin-routing/code-review@claude-plugins-official.md
@@ -15,9 +15,9 @@
 
 | agent | outcome | actions | rationale |
 | --- | --- | --- | --- |
-| codex | `reimplement` | - scaffold Lisa-native skill (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review) | Codex has no plugin command surface and is not in the fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so the reimplementation is not drift-trackable — drift tracking is manual review. |
+| codex | `reimplement` | - scaffold Lisa-native skill reimplementing the code-review command (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review) | Codex has no plugin command surface and is not in the fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so the reimplementation is not drift-trackable — drift tracking is manual review. |
 | cursor | `claude-only` | _(none)_ | Cursor reads .claude-plugin/ natively; the command loads unchanged. |
-| agy | `reimplement` | - scaffold Lisa-native skill (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review) | Curated third-party plugins are not in agy's fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so it is not drift-trackable — manual review. |
+| agy | `reimplement` | - scaffold Lisa-native skill reimplementing the code-review command (NO synced-from pin: upstream publishes no semver, so it is not drift-trackable — record drift-tracking as manual review) | Curated third-party plugins are not in agy's fan-out; reimplement as a Lisa skill. Upstream publishes no semver, so it is not drift-trackable — manual review. |
 | copilot | `enable-vendor-equivalent` | - enable Copilot's native pull-request/code-review capability in the project-scoped marketplace | Code review is a generic capability Copilot ships natively; prefer enabling over reimplementing. |
 
 > Plan-only artifact. Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.

--- a/parity/plugin-routing/code-simplifier@claude-plugins-official.json
+++ b/parity/plugin-routing/code-simplifier@claude-plugins-official.json
@@ -38,7 +38,7 @@
     "copilot": {
       "outcome": "enable-vendor-equivalent",
       "actions": [
-        "enable Copilot's native code-simplification/refactor capability in the project-scoped marketplace"
+        "enable Copilot's native code-simplification/refactor capability for the code-simplifier agent in the project-scoped marketplace"
       ],
       "rationale": "Code simplification is a generic capability Copilot ships natively; prefer enabling over reimplementing."
     }

--- a/parity/plugin-routing/code-simplifier@claude-plugins-official.md
+++ b/parity/plugin-routing/code-simplifier@claude-plugins-official.md
@@ -18,6 +18,6 @@
 | codex | `reimplement` | - scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0 | Codex has no plugin subagent surface and curated third-party plugins are not in Codex's fan-out; reimplement the behavior as a Lisa skill. |
 | cursor | `claude-only` | _(none)_ | Cursor reads .claude-plugin/ natively; the agent loads unchanged. |
 | agy | `reimplement` | - scaffold Lisa-native skill stamped synced-from: code-simplifier@claude-plugins-official@1.0.0 | Curated third-party plugins are not in agy's fan-out, so agy receives nothing natively; reimplement as a Lisa skill. |
-| copilot | `enable-vendor-equivalent` | - enable Copilot's native code-simplification/refactor capability in the project-scoped marketplace | Code simplification is a generic capability Copilot ships natively; prefer enabling over reimplementing. |
+| copilot | `enable-vendor-equivalent` | - enable Copilot's native code-simplification/refactor capability for the code-simplifier agent in the project-scoped marketplace | Code simplification is a generic capability Copilot ships natively; prefer enabling over reimplementing. |
 
 > Plan-only artifact. Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.

--- a/scripts/plugin-routing-validate.mjs
+++ b/scripts/plugin-routing-validate.mjs
@@ -293,6 +293,73 @@ function validateRouting(routing, plugin, upstreamVersion) {
 }
 
 /**
+ * True iff at least one of `lowerActions` references `kind` — either by the kind
+ * keyword itself (case-insensitive) or by the id of any component of that kind.
+ *
+ * @param {string} kind - the component kind (e.g. "mcp", "agent").
+ * @param {ReadonlyArray<Record<string, unknown>>} typedComponents - components with a string kind.
+ * @param {readonly string[]} lowerActions - the agent's actions, lowercased.
+ * @returns {boolean} whether the kind group is referenced.
+ */
+function isKindCovered(kind, typedComponents, lowerActions) {
+  const kindLower = kind.toLowerCase();
+  const ids = typedComponents
+    .filter(c => c.kind === kind)
+    .map(c => c.id)
+    .filter(id => typeof id === "string" && id !== "")
+    .map(id => id.toLowerCase());
+  return lowerActions.some(
+    action => action.includes(kindLower) || ids.some(id => action.includes(id))
+  );
+}
+
+/**
+ * Positively enforce the "drop nothing" rule: every distinct component kind must
+ * be covered by each agent that actually has to act on it. Agents whose outcome
+ * is `already-native` (covered by the existing fan-out) or `claude-only`
+ * (intentionally nothing) are exempt; every other outcome must reference every
+ * component group in its actions.
+ *
+ * @param {unknown} components - the artifact's `components` array.
+ * @param {unknown} routing - the artifact's `routing` object.
+ * @returns {string[]} validation error messages (empty when valid).
+ */
+function validateCoverage(components, routing) {
+  if (
+    !Array.isArray(components) ||
+    routing === null ||
+    typeof routing !== "object"
+  ) {
+    return [];
+  }
+  const typed = components.filter(
+    c => c !== null && typeof c === "object" && typeof c.kind === "string"
+  );
+  const distinctKinds = [...new Set(typed.map(c => c.kind))];
+  const errors = [];
+  for (const agent of AGENTS) {
+    const entry = routing[agent];
+    if (entry === null || entry === undefined || typeof entry !== "object") {
+      continue;
+    }
+    if (entry.outcome === "already-native" || entry.outcome === "claude-only") {
+      continue;
+    }
+    const lowerActions = (
+      Array.isArray(entry.actions) ? entry.actions : []
+    ).map(action => String(action).toLowerCase());
+    for (const kind of distinctKinds) {
+      if (!isKindCovered(kind, typed, lowerActions)) {
+        errors.push(
+          `routing.${agent}: no action covers component group ${kind}`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+/**
  * Validate a parsed routing artifact against the analyze-plugin schema + the
  * version contract + anti-pattern gates. Pure — all filesystem facts are passed
  * in via `context`, so it is directly unit-testable.
@@ -339,6 +406,7 @@ export function validateArtifact(artifact, context) {
       artifact.upstreamVersion
     )
   );
+  errors.push(...validateCoverage(artifact.components, artifact.routing));
   if (mdExists === false) {
     errors.push("paired .md companion file is missing");
   }

--- a/tests/unit/scripts/plugin-routing-validate-helpers.ts
+++ b/tests/unit/scripts/plugin-routing-validate-helpers.ts
@@ -154,9 +154,56 @@ export function baseArtifact(): Artifact {
       agy: reimplement(),
       copilot: {
         outcome: "enable-vendor-equivalent",
-        actions: ["enable the vendor equivalent"],
+        actions: [
+          `enable the vendor's native agent equivalent for ${PLUGIN_NAME}`,
+        ],
         rationale: "vendor ships a comparable capability",
       },
+    },
+  };
+}
+
+/**
+ * Build a multi-kind (mcp + command) artifact for the coverage gate. codex + agy
+ * cover both groups via the kind keywords; cursor stays claude-only (exempt);
+ * copilot's actions are caller-supplied to exercise coverage. upstream is
+ * "unknown" so no `synced-from` stamp is owed.
+ *
+ * @param copilotActions - copilot's action list.
+ * @returns A multi-kind artifact.
+ */
+export function multiKind(copilotActions: readonly string[]): Artifact {
+  const rePoint = (actions: readonly string[]): RoutingEntry => ({
+    outcome: "re-point-mcp-lsp",
+    actions: [...actions],
+    rationale: "coverage fixture",
+  });
+  const coverBoth = ["re-point the mcp server and emit the command"];
+  const base = baseArtifact();
+  return {
+    ...base,
+    upstreamVersion: "unknown",
+    components: [
+      {
+        kind: "mcp",
+        id: "demo-mcp",
+        path: ".mcp.json",
+        classification: "mcp-server",
+        notes: "",
+      },
+      {
+        kind: "command",
+        id: "demo-cmd",
+        path: "commands/demo.md",
+        classification: "claude-command",
+        notes: "",
+      },
+    ],
+    routing: {
+      ...base.routing,
+      codex: rePoint(coverBoth),
+      agy: rePoint(coverBoth),
+      copilot: rePoint(copilotActions),
     },
   };
 }

--- a/tests/unit/scripts/plugin-routing-validate.test.ts
+++ b/tests/unit/scripts/plugin-routing-validate.test.ts
@@ -25,6 +25,7 @@ import {
   DEMO_MKT,
   FIXTURE_CACHE,
   INVALID_DIR,
+  multiKind,
   PLUGIN_NAME,
   ROUTING_DIR_FLAG,
   runValidate,
@@ -323,5 +324,35 @@ describe("cacheMaxVersion", () => {
 
   it("returns null for a path-traversal name (defense-in-depth)", () => {
     expect(cacheMaxVersion(FIXTURE_CACHE, "..", DEMO_MKT)).toBeNull();
+  });
+});
+
+describe("validateArtifact coverage gate (drop nothing)", () => {
+  const ctx = { cacheMax: null, filename: undefined, mdExists: true };
+
+  it("flags an agent whose actions omit a component group (codex/agy cover both via keyword)", () => {
+    const errors = validateArtifact(multiKind(["handle the mcp only"]), ctx);
+    expect(errors).toContain(
+      "routing.copilot: no action covers component group command"
+    );
+    expect(has(errors, "no action covers component group mcp")).toBe(false);
+  });
+
+  it("passes when actions cover every group (copilot references by component id)", () => {
+    expect(
+      validateArtifact(multiKind(["wire up demo-mcp and demo-cmd"]), ctx)
+    ).toEqual([]);
+  });
+
+  it("exempts already-native and claude-only agents from coverage", () => {
+    const a = multiKind([]);
+    a.routing.copilot = {
+      outcome: "already-native",
+      actions: [],
+      rationale: "covered by the existing fan-out",
+    };
+    expect(has(validateArtifact(a, ctx), "routing.copilot: no action")).toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit Major finding on #1079: the routing validator checked `components[]` and `routing` independently, so a multi-component artifact could **silently drop a component group** and still pass — defeating the "drop nothing" rule the analyze-plugin skill states. (The finding was auto-marked resolved on #1079 but never actually fixed in code; this is the real fix.)

- `validateCoverage` + `isKindCovered` in `scripts/plugin-routing-validate.mjs`: derive the distinct component kinds from `components[]`; for each agent whose outcome is not `already-native` / `claude-only`, require every kind to be referenced (by kind keyword or component id) in at least one `action`, else a clear `no action covers component group <kind>` error.
- The strengthened gate immediately caught **two real under-specified actions** in the committed plans — `code-review` codex/agy and `code-simplifier` copilot had actions that didn't name the component they covered. Fixed the wording so each names its group (routing decisions unchanged).
- Coverage unit tests (omit-a-kind → fail; cover-by-id → pass; exempt outcomes).
- (CodeRabbit's 2nd finding — empty-stdout `RoutingReport` type — was already fixed in the merged validator commit; confirmed, no change.)

## Test plan
- `node scripts/plugin-routing-validate.mjs --routing-dir parity/plugin-routing` → **exit 0, 7/7** (the gate now positively enforces coverage).
- `bun run test:unit` passes (incl. the new coverage tests).
- `bun run check:plugins` passes (no plugin artifacts touched).

Refs #1059.

🤖 Generated with Claude Code