### PR TITLE
Expose plugin sync readiness result

### DIFF
--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -6,6 +6,11 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { getPluginSyncResult } from "./plugin-sync-explain.mjs";
 
 export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
 export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
@@ -33,6 +38,90 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  *   readonly groups: readonly DoctorGroup[]
  * }} DoctorReportInput
  */
+
+/**
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createPluginSyncDoctorGroup(root = process.cwd()) {
+  const repoRoot = path.resolve(root);
+  if (
+    !existsSync(path.join(repoRoot, "plugins", "src")) &&
+    !existsSync(path.join(repoRoot, "plugins"))
+  ) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "SKIP",
+          summary: "plugin sync check is not applicable",
+          observed:
+            "No plugins/ or plugins/src/ directory was found in this repository.",
+        },
+      ],
+    };
+  }
+
+  try {
+    const result = getPluginSyncResult(repoRoot);
+    if (!result.readOnly) {
+      return {
+        id: "plugin-sync",
+        title: "Plugin source/generated sync",
+        checks: [
+          {
+            id: "plugin-sync",
+            status: "FAIL",
+            summary: "plugin sync readiness check mutated the working tree",
+            observed:
+              "Git status changed while collecting plugin sync evidence.",
+            remediation:
+              "Run `git status --short`, inspect the unexpected changes, and fix plugin-sync-explain before trusting doctor output.",
+          },
+        ],
+      };
+    }
+
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: result.verdict,
+          summary:
+            result.verdict === "PASS"
+              ? "plugin source and generated artifacts are in sync"
+              : `plugin sync drift detected: ${result.driftClass}`,
+          observed: renderPluginSyncObserved(result),
+          remediation:
+            result.remediations.length > 0
+              ? result.remediations
+                  .map(item => `${item.path}: ${item.nextAction}`)
+                  .join(" ")
+              : undefined,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "FAIL",
+          summary: "plugin sync readiness check failed",
+          observed: error instanceof Error ? error.message : String(error),
+          remediation:
+            "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` to inspect plugin sync health directly.",
+        },
+      ],
+    };
+  }
+}
 
 /**
  * @param {readonly DoctorGroup[]} groups
@@ -140,4 +229,18 @@ function normalizeCheck(check) {
     ...check,
     status: normalizedStatus,
   };
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string}
+ */
+function renderPluginSyncObserved(result) {
+  if (result.verdict === "PASS") {
+    return "Drift class IN_SYNC; plugin sync evidence was collected read-only.";
+  }
+  const paths = result.affectedPaths.length
+    ? result.affectedPaths.join(", ")
+    : "none";
+  return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
 }

--- a/plugins/lisa-agy/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-agy/scripts/plugin-sync-explain.mjs
@@ -50,6 +50,25 @@ const GIT_BIN = "/usr/bin/git";
  *   readonly readOnly: boolean
  *   readonly text: string
  * }} PluginSyncReport
+ *
+ * @typedef {{
+ *   readonly path: string
+ *   readonly counterpart?: string
+ *   readonly classification: string
+ *   readonly nextAction: string
+ * }} PluginSyncRemediation
+ *
+ * @typedef {{
+ *   readonly root: string
+ *   readonly verdict: "PASS" | "WARN"
+ *   readonly driftClass: string
+ *   readonly affectedPaths: readonly string[]
+ *   readonly remediations: readonly PluginSyncRemediation[]
+ *   readonly findings: readonly PluginSyncFinding[]
+ *   readonly statusBefore: string
+ *   readonly statusAfter: string
+ *   readonly readOnly: boolean
+ * }} PluginSyncResult
  */
 
 /**
@@ -57,6 +76,25 @@ const GIT_BIN = "/usr/bin/git";
  * @returns {PluginSyncReport}
  */
 export function explainPluginSync(root = process.cwd()) {
+  const result = getPluginSyncResult(root);
+
+  return {
+    root: result.root,
+    findings: result.findings,
+    statusBefore: result.statusBefore,
+    statusAfter: result.statusAfter,
+    readOnly: result.readOnly,
+    text: renderPluginSyncReport(result),
+  };
+}
+
+/**
+ * Return a structured, read-only plugin sync result for readiness surfaces such
+ * as doctor. CLI callers should still render this through renderPluginSyncReport.
+ * @param {string} root
+ * @returns {PluginSyncResult}
+ */
+export function getPluginSyncResult(root = process.cwd()) {
   const repoRoot = path.resolve(root);
   const statusBefore = gitStatus(repoRoot);
   const statusEntries = parseGitStatus(statusBefore);
@@ -71,20 +109,23 @@ export function explainPluginSync(root = process.cwd()) {
   ];
   const statusAfter = gitStatus(repoRoot);
   const readOnly = statusAfter === statusBefore;
+  const driftClass = highestClassification(findings);
 
   return {
     root: repoRoot,
+    verdict: findings.length === 0 ? "PASS" : "WARN",
+    driftClass,
+    affectedPaths: affectedPaths(findings),
+    remediations: findings.map(finding => ({
+      path: finding.path,
+      counterpart: finding.counterpart,
+      classification: finding.classification,
+      nextAction: finding.nextAction,
+    })),
     findings,
     statusBefore,
     statusAfter,
     readOnly,
-    text: renderPluginSyncReport({
-      root: repoRoot,
-      findings,
-      statusBefore,
-      statusAfter,
-      readOnly,
-    }),
   };
 }
 
@@ -140,6 +181,22 @@ function highestClassification(findings) {
     return "SOURCE_NOT_BUILT";
   }
   return "IN_SYNC";
+}
+
+/**
+ * @param {readonly PluginSyncFinding[]} findings
+ * @returns {string[]}
+ */
+function affectedPaths(findings) {
+  return [
+    ...new Set(
+      findings.flatMap(finding =>
+        [finding.path, finding.counterpart].filter(
+          pathValue => typeof pathValue === "string" && pathValue.length > 0
+        )
+      )
+    ),
+  ];
 }
 
 /**

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -6,6 +6,11 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { getPluginSyncResult } from "./plugin-sync-explain.mjs";
 
 export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
 export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
@@ -33,6 +38,90 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  *   readonly groups: readonly DoctorGroup[]
  * }} DoctorReportInput
  */
+
+/**
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createPluginSyncDoctorGroup(root = process.cwd()) {
+  const repoRoot = path.resolve(root);
+  if (
+    !existsSync(path.join(repoRoot, "plugins", "src")) &&
+    !existsSync(path.join(repoRoot, "plugins"))
+  ) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "SKIP",
+          summary: "plugin sync check is not applicable",
+          observed:
+            "No plugins/ or plugins/src/ directory was found in this repository.",
+        },
+      ],
+    };
+  }
+
+  try {
+    const result = getPluginSyncResult(repoRoot);
+    if (!result.readOnly) {
+      return {
+        id: "plugin-sync",
+        title: "Plugin source/generated sync",
+        checks: [
+          {
+            id: "plugin-sync",
+            status: "FAIL",
+            summary: "plugin sync readiness check mutated the working tree",
+            observed:
+              "Git status changed while collecting plugin sync evidence.",
+            remediation:
+              "Run `git status --short`, inspect the unexpected changes, and fix plugin-sync-explain before trusting doctor output.",
+          },
+        ],
+      };
+    }
+
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: result.verdict,
+          summary:
+            result.verdict === "PASS"
+              ? "plugin source and generated artifacts are in sync"
+              : `plugin sync drift detected: ${result.driftClass}`,
+          observed: renderPluginSyncObserved(result),
+          remediation:
+            result.remediations.length > 0
+              ? result.remediations
+                  .map(item => `${item.path}: ${item.nextAction}`)
+                  .join(" ")
+              : undefined,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "FAIL",
+          summary: "plugin sync readiness check failed",
+          observed: error instanceof Error ? error.message : String(error),
+          remediation:
+            "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` to inspect plugin sync health directly.",
+        },
+      ],
+    };
+  }
+}
 
 /**
  * @param {readonly DoctorGroup[]} groups
@@ -140,4 +229,18 @@ function normalizeCheck(check) {
     ...check,
     status: normalizedStatus,
   };
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string}
+ */
+function renderPluginSyncObserved(result) {
+  if (result.verdict === "PASS") {
+    return "Drift class IN_SYNC; plugin sync evidence was collected read-only.";
+  }
+  const paths = result.affectedPaths.length
+    ? result.affectedPaths.join(", ")
+    : "none";
+  return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
 }

--- a/plugins/lisa-copilot/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-copilot/scripts/plugin-sync-explain.mjs
@@ -50,6 +50,25 @@ const GIT_BIN = "/usr/bin/git";
  *   readonly readOnly: boolean
  *   readonly text: string
  * }} PluginSyncReport
+ *
+ * @typedef {{
+ *   readonly path: string
+ *   readonly counterpart?: string
+ *   readonly classification: string
+ *   readonly nextAction: string
+ * }} PluginSyncRemediation
+ *
+ * @typedef {{
+ *   readonly root: string
+ *   readonly verdict: "PASS" | "WARN"
+ *   readonly driftClass: string
+ *   readonly affectedPaths: readonly string[]
+ *   readonly remediations: readonly PluginSyncRemediation[]
+ *   readonly findings: readonly PluginSyncFinding[]
+ *   readonly statusBefore: string
+ *   readonly statusAfter: string
+ *   readonly readOnly: boolean
+ * }} PluginSyncResult
  */
 
 /**
@@ -57,6 +76,25 @@ const GIT_BIN = "/usr/bin/git";
  * @returns {PluginSyncReport}
  */
 export function explainPluginSync(root = process.cwd()) {
+  const result = getPluginSyncResult(root);
+
+  return {
+    root: result.root,
+    findings: result.findings,
+    statusBefore: result.statusBefore,
+    statusAfter: result.statusAfter,
+    readOnly: result.readOnly,
+    text: renderPluginSyncReport(result),
+  };
+}
+
+/**
+ * Return a structured, read-only plugin sync result for readiness surfaces such
+ * as doctor. CLI callers should still render this through renderPluginSyncReport.
+ * @param {string} root
+ * @returns {PluginSyncResult}
+ */
+export function getPluginSyncResult(root = process.cwd()) {
   const repoRoot = path.resolve(root);
   const statusBefore = gitStatus(repoRoot);
   const statusEntries = parseGitStatus(statusBefore);
@@ -71,20 +109,23 @@ export function explainPluginSync(root = process.cwd()) {
   ];
   const statusAfter = gitStatus(repoRoot);
   const readOnly = statusAfter === statusBefore;
+  const driftClass = highestClassification(findings);
 
   return {
     root: repoRoot,
+    verdict: findings.length === 0 ? "PASS" : "WARN",
+    driftClass,
+    affectedPaths: affectedPaths(findings),
+    remediations: findings.map(finding => ({
+      path: finding.path,
+      counterpart: finding.counterpart,
+      classification: finding.classification,
+      nextAction: finding.nextAction,
+    })),
     findings,
     statusBefore,
     statusAfter,
     readOnly,
-    text: renderPluginSyncReport({
-      root: repoRoot,
-      findings,
-      statusBefore,
-      statusAfter,
-      readOnly,
-    }),
   };
 }
 
@@ -140,6 +181,22 @@ function highestClassification(findings) {
     return "SOURCE_NOT_BUILT";
   }
   return "IN_SYNC";
+}
+
+/**
+ * @param {readonly PluginSyncFinding[]} findings
+ * @returns {string[]}
+ */
+function affectedPaths(findings) {
+  return [
+    ...new Set(
+      findings.flatMap(finding =>
+        [finding.path, finding.counterpart].filter(
+          pathValue => typeof pathValue === "string" && pathValue.length > 0
+        )
+      )
+    ),
+  ];
 }
 
 /**

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -6,6 +6,11 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { getPluginSyncResult } from "./plugin-sync-explain.mjs";
 
 export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
 export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
@@ -33,6 +38,90 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  *   readonly groups: readonly DoctorGroup[]
  * }} DoctorReportInput
  */
+
+/**
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createPluginSyncDoctorGroup(root = process.cwd()) {
+  const repoRoot = path.resolve(root);
+  if (
+    !existsSync(path.join(repoRoot, "plugins", "src")) &&
+    !existsSync(path.join(repoRoot, "plugins"))
+  ) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "SKIP",
+          summary: "plugin sync check is not applicable",
+          observed:
+            "No plugins/ or plugins/src/ directory was found in this repository.",
+        },
+      ],
+    };
+  }
+
+  try {
+    const result = getPluginSyncResult(repoRoot);
+    if (!result.readOnly) {
+      return {
+        id: "plugin-sync",
+        title: "Plugin source/generated sync",
+        checks: [
+          {
+            id: "plugin-sync",
+            status: "FAIL",
+            summary: "plugin sync readiness check mutated the working tree",
+            observed:
+              "Git status changed while collecting plugin sync evidence.",
+            remediation:
+              "Run `git status --short`, inspect the unexpected changes, and fix plugin-sync-explain before trusting doctor output.",
+          },
+        ],
+      };
+    }
+
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: result.verdict,
+          summary:
+            result.verdict === "PASS"
+              ? "plugin source and generated artifacts are in sync"
+              : `plugin sync drift detected: ${result.driftClass}`,
+          observed: renderPluginSyncObserved(result),
+          remediation:
+            result.remediations.length > 0
+              ? result.remediations
+                  .map(item => `${item.path}: ${item.nextAction}`)
+                  .join(" ")
+              : undefined,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "FAIL",
+          summary: "plugin sync readiness check failed",
+          observed: error instanceof Error ? error.message : String(error),
+          remediation:
+            "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` to inspect plugin sync health directly.",
+        },
+      ],
+    };
+  }
+}
 
 /**
  * @param {readonly DoctorGroup[]} groups
@@ -140,4 +229,18 @@ function normalizeCheck(check) {
     ...check,
     status: normalizedStatus,
   };
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string}
+ */
+function renderPluginSyncObserved(result) {
+  if (result.verdict === "PASS") {
+    return "Drift class IN_SYNC; plugin sync evidence was collected read-only.";
+  }
+  const paths = result.affectedPaths.length
+    ? result.affectedPaths.join(", ")
+    : "none";
+  return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
 }

--- a/plugins/lisa-cursor/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-cursor/scripts/plugin-sync-explain.mjs
@@ -50,6 +50,25 @@ const GIT_BIN = "/usr/bin/git";
  *   readonly readOnly: boolean
  *   readonly text: string
  * }} PluginSyncReport
+ *
+ * @typedef {{
+ *   readonly path: string
+ *   readonly counterpart?: string
+ *   readonly classification: string
+ *   readonly nextAction: string
+ * }} PluginSyncRemediation
+ *
+ * @typedef {{
+ *   readonly root: string
+ *   readonly verdict: "PASS" | "WARN"
+ *   readonly driftClass: string
+ *   readonly affectedPaths: readonly string[]
+ *   readonly remediations: readonly PluginSyncRemediation[]
+ *   readonly findings: readonly PluginSyncFinding[]
+ *   readonly statusBefore: string
+ *   readonly statusAfter: string
+ *   readonly readOnly: boolean
+ * }} PluginSyncResult
  */
 
 /**
@@ -57,6 +76,25 @@ const GIT_BIN = "/usr/bin/git";
  * @returns {PluginSyncReport}
  */
 export function explainPluginSync(root = process.cwd()) {
+  const result = getPluginSyncResult(root);
+
+  return {
+    root: result.root,
+    findings: result.findings,
+    statusBefore: result.statusBefore,
+    statusAfter: result.statusAfter,
+    readOnly: result.readOnly,
+    text: renderPluginSyncReport(result),
+  };
+}
+
+/**
+ * Return a structured, read-only plugin sync result for readiness surfaces such
+ * as doctor. CLI callers should still render this through renderPluginSyncReport.
+ * @param {string} root
+ * @returns {PluginSyncResult}
+ */
+export function getPluginSyncResult(root = process.cwd()) {
   const repoRoot = path.resolve(root);
   const statusBefore = gitStatus(repoRoot);
   const statusEntries = parseGitStatus(statusBefore);
@@ -71,20 +109,23 @@ export function explainPluginSync(root = process.cwd()) {
   ];
   const statusAfter = gitStatus(repoRoot);
   const readOnly = statusAfter === statusBefore;
+  const driftClass = highestClassification(findings);
 
   return {
     root: repoRoot,
+    verdict: findings.length === 0 ? "PASS" : "WARN",
+    driftClass,
+    affectedPaths: affectedPaths(findings),
+    remediations: findings.map(finding => ({
+      path: finding.path,
+      counterpart: finding.counterpart,
+      classification: finding.classification,
+      nextAction: finding.nextAction,
+    })),
     findings,
     statusBefore,
     statusAfter,
     readOnly,
-    text: renderPluginSyncReport({
-      root: repoRoot,
-      findings,
-      statusBefore,
-      statusAfter,
-      readOnly,
-    }),
   };
 }
 
@@ -140,6 +181,22 @@ function highestClassification(findings) {
     return "SOURCE_NOT_BUILT";
   }
   return "IN_SYNC";
+}
+
+/**
+ * @param {readonly PluginSyncFinding[]} findings
+ * @returns {string[]}
+ */
+function affectedPaths(findings) {
+  return [
+    ...new Set(
+      findings.flatMap(finding =>
+        [finding.path, finding.counterpart].filter(
+          pathValue => typeof pathValue === "string" && pathValue.length > 0
+        )
+      )
+    ),
+  ];
 }
 
 /**

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -6,6 +6,11 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { getPluginSyncResult } from "./plugin-sync-explain.mjs";
 
 export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
 export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
@@ -33,6 +38,90 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  *   readonly groups: readonly DoctorGroup[]
  * }} DoctorReportInput
  */
+
+/**
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createPluginSyncDoctorGroup(root = process.cwd()) {
+  const repoRoot = path.resolve(root);
+  if (
+    !existsSync(path.join(repoRoot, "plugins", "src")) &&
+    !existsSync(path.join(repoRoot, "plugins"))
+  ) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "SKIP",
+          summary: "plugin sync check is not applicable",
+          observed:
+            "No plugins/ or plugins/src/ directory was found in this repository.",
+        },
+      ],
+    };
+  }
+
+  try {
+    const result = getPluginSyncResult(repoRoot);
+    if (!result.readOnly) {
+      return {
+        id: "plugin-sync",
+        title: "Plugin source/generated sync",
+        checks: [
+          {
+            id: "plugin-sync",
+            status: "FAIL",
+            summary: "plugin sync readiness check mutated the working tree",
+            observed:
+              "Git status changed while collecting plugin sync evidence.",
+            remediation:
+              "Run `git status --short`, inspect the unexpected changes, and fix plugin-sync-explain before trusting doctor output.",
+          },
+        ],
+      };
+    }
+
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: result.verdict,
+          summary:
+            result.verdict === "PASS"
+              ? "plugin source and generated artifacts are in sync"
+              : `plugin sync drift detected: ${result.driftClass}`,
+          observed: renderPluginSyncObserved(result),
+          remediation:
+            result.remediations.length > 0
+              ? result.remediations
+                  .map(item => `${item.path}: ${item.nextAction}`)
+                  .join(" ")
+              : undefined,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "FAIL",
+          summary: "plugin sync readiness check failed",
+          observed: error instanceof Error ? error.message : String(error),
+          remediation:
+            "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` to inspect plugin sync health directly.",
+        },
+      ],
+    };
+  }
+}
 
 /**
  * @param {readonly DoctorGroup[]} groups
@@ -140,4 +229,18 @@ function normalizeCheck(check) {
     ...check,
     status: normalizedStatus,
   };
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string}
+ */
+function renderPluginSyncObserved(result) {
+  if (result.verdict === "PASS") {
+    return "Drift class IN_SYNC; plugin sync evidence was collected read-only.";
+  }
+  const paths = result.affectedPaths.length
+    ? result.affectedPaths.join(", ")
+    : "none";
+  return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
 }

--- a/plugins/lisa/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa/scripts/plugin-sync-explain.mjs
@@ -50,6 +50,25 @@ const GIT_BIN = "/usr/bin/git";
  *   readonly readOnly: boolean
  *   readonly text: string
  * }} PluginSyncReport
+ *
+ * @typedef {{
+ *   readonly path: string
+ *   readonly counterpart?: string
+ *   readonly classification: string
+ *   readonly nextAction: string
+ * }} PluginSyncRemediation
+ *
+ * @typedef {{
+ *   readonly root: string
+ *   readonly verdict: "PASS" | "WARN"
+ *   readonly driftClass: string
+ *   readonly affectedPaths: readonly string[]
+ *   readonly remediations: readonly PluginSyncRemediation[]
+ *   readonly findings: readonly PluginSyncFinding[]
+ *   readonly statusBefore: string
+ *   readonly statusAfter: string
+ *   readonly readOnly: boolean
+ * }} PluginSyncResult
  */
 
 /**
@@ -57,6 +76,25 @@ const GIT_BIN = "/usr/bin/git";
  * @returns {PluginSyncReport}
  */
 export function explainPluginSync(root = process.cwd()) {
+  const result = getPluginSyncResult(root);
+
+  return {
+    root: result.root,
+    findings: result.findings,
+    statusBefore: result.statusBefore,
+    statusAfter: result.statusAfter,
+    readOnly: result.readOnly,
+    text: renderPluginSyncReport(result),
+  };
+}
+
+/**
+ * Return a structured, read-only plugin sync result for readiness surfaces such
+ * as doctor. CLI callers should still render this through renderPluginSyncReport.
+ * @param {string} root
+ * @returns {PluginSyncResult}
+ */
+export function getPluginSyncResult(root = process.cwd()) {
   const repoRoot = path.resolve(root);
   const statusBefore = gitStatus(repoRoot);
   const statusEntries = parseGitStatus(statusBefore);
@@ -71,20 +109,23 @@ export function explainPluginSync(root = process.cwd()) {
   ];
   const statusAfter = gitStatus(repoRoot);
   const readOnly = statusAfter === statusBefore;
+  const driftClass = highestClassification(findings);
 
   return {
     root: repoRoot,
+    verdict: findings.length === 0 ? "PASS" : "WARN",
+    driftClass,
+    affectedPaths: affectedPaths(findings),
+    remediations: findings.map(finding => ({
+      path: finding.path,
+      counterpart: finding.counterpart,
+      classification: finding.classification,
+      nextAction: finding.nextAction,
+    })),
     findings,
     statusBefore,
     statusAfter,
     readOnly,
-    text: renderPluginSyncReport({
-      root: repoRoot,
-      findings,
-      statusBefore,
-      statusAfter,
-      readOnly,
-    }),
   };
 }
 
@@ -140,6 +181,22 @@ function highestClassification(findings) {
     return "SOURCE_NOT_BUILT";
   }
   return "IN_SYNC";
+}
+
+/**
+ * @param {readonly PluginSyncFinding[]} findings
+ * @returns {string[]}
+ */
+function affectedPaths(findings) {
+  return [
+    ...new Set(
+      findings.flatMap(finding =>
+        [finding.path, finding.counterpart].filter(
+          pathValue => typeof pathValue === "string" && pathValue.length > 0
+        )
+      )
+    ),
+  ];
 }
 
 /**

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -6,6 +6,11 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { getPluginSyncResult } from "./plugin-sync-explain.mjs";
 
 export const DOCTOR_STATUSES = ["PASS", "WARN", "FAIL", "SKIP"];
 export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
@@ -33,6 +38,90 @@ export const DOCTOR_VERDICTS = ["READY", "READY_WITH_WARNINGS", "NOT_READY"];
  *   readonly groups: readonly DoctorGroup[]
  * }} DoctorReportInput
  */
+
+/**
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createPluginSyncDoctorGroup(root = process.cwd()) {
+  const repoRoot = path.resolve(root);
+  if (
+    !existsSync(path.join(repoRoot, "plugins", "src")) &&
+    !existsSync(path.join(repoRoot, "plugins"))
+  ) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "SKIP",
+          summary: "plugin sync check is not applicable",
+          observed:
+            "No plugins/ or plugins/src/ directory was found in this repository.",
+        },
+      ],
+    };
+  }
+
+  try {
+    const result = getPluginSyncResult(repoRoot);
+    if (!result.readOnly) {
+      return {
+        id: "plugin-sync",
+        title: "Plugin source/generated sync",
+        checks: [
+          {
+            id: "plugin-sync",
+            status: "FAIL",
+            summary: "plugin sync readiness check mutated the working tree",
+            observed:
+              "Git status changed while collecting plugin sync evidence.",
+            remediation:
+              "Run `git status --short`, inspect the unexpected changes, and fix plugin-sync-explain before trusting doctor output.",
+          },
+        ],
+      };
+    }
+
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: result.verdict,
+          summary:
+            result.verdict === "PASS"
+              ? "plugin source and generated artifacts are in sync"
+              : `plugin sync drift detected: ${result.driftClass}`,
+          observed: renderPluginSyncObserved(result),
+          remediation:
+            result.remediations.length > 0
+              ? result.remediations
+                  .map(item => `${item.path}: ${item.nextAction}`)
+                  .join(" ")
+              : undefined,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      id: "plugin-sync",
+      title: "Plugin source/generated sync",
+      checks: [
+        {
+          id: "plugin-sync",
+          status: "FAIL",
+          summary: "plugin sync readiness check failed",
+          observed: error instanceof Error ? error.message : String(error),
+          remediation:
+            "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` to inspect plugin sync health directly.",
+        },
+      ],
+    };
+  }
+}
 
 /**
  * @param {readonly DoctorGroup[]} groups
@@ -140,4 +229,18 @@ function normalizeCheck(check) {
     ...check,
     status: normalizedStatus,
   };
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string}
+ */
+function renderPluginSyncObserved(result) {
+  if (result.verdict === "PASS") {
+    return "Drift class IN_SYNC; plugin sync evidence was collected read-only.";
+  }
+  const paths = result.affectedPaths.length
+    ? result.affectedPaths.join(", ")
+    : "none";
+  return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
 }

--- a/plugins/src/base/scripts/plugin-sync-explain.mjs
+++ b/plugins/src/base/scripts/plugin-sync-explain.mjs
@@ -50,6 +50,25 @@ const GIT_BIN = "/usr/bin/git";
  *   readonly readOnly: boolean
  *   readonly text: string
  * }} PluginSyncReport
+ *
+ * @typedef {{
+ *   readonly path: string
+ *   readonly counterpart?: string
+ *   readonly classification: string
+ *   readonly nextAction: string
+ * }} PluginSyncRemediation
+ *
+ * @typedef {{
+ *   readonly root: string
+ *   readonly verdict: "PASS" | "WARN"
+ *   readonly driftClass: string
+ *   readonly affectedPaths: readonly string[]
+ *   readonly remediations: readonly PluginSyncRemediation[]
+ *   readonly findings: readonly PluginSyncFinding[]
+ *   readonly statusBefore: string
+ *   readonly statusAfter: string
+ *   readonly readOnly: boolean
+ * }} PluginSyncResult
  */
 
 /**
@@ -57,6 +76,25 @@ const GIT_BIN = "/usr/bin/git";
  * @returns {PluginSyncReport}
  */
 export function explainPluginSync(root = process.cwd()) {
+  const result = getPluginSyncResult(root);
+
+  return {
+    root: result.root,
+    findings: result.findings,
+    statusBefore: result.statusBefore,
+    statusAfter: result.statusAfter,
+    readOnly: result.readOnly,
+    text: renderPluginSyncReport(result),
+  };
+}
+
+/**
+ * Return a structured, read-only plugin sync result for readiness surfaces such
+ * as doctor. CLI callers should still render this through renderPluginSyncReport.
+ * @param {string} root
+ * @returns {PluginSyncResult}
+ */
+export function getPluginSyncResult(root = process.cwd()) {
   const repoRoot = path.resolve(root);
   const statusBefore = gitStatus(repoRoot);
   const statusEntries = parseGitStatus(statusBefore);
@@ -71,20 +109,23 @@ export function explainPluginSync(root = process.cwd()) {
   ];
   const statusAfter = gitStatus(repoRoot);
   const readOnly = statusAfter === statusBefore;
+  const driftClass = highestClassification(findings);
 
   return {
     root: repoRoot,
+    verdict: findings.length === 0 ? "PASS" : "WARN",
+    driftClass,
+    affectedPaths: affectedPaths(findings),
+    remediations: findings.map(finding => ({
+      path: finding.path,
+      counterpart: finding.counterpart,
+      classification: finding.classification,
+      nextAction: finding.nextAction,
+    })),
     findings,
     statusBefore,
     statusAfter,
     readOnly,
-    text: renderPluginSyncReport({
-      root: repoRoot,
-      findings,
-      statusBefore,
-      statusAfter,
-      readOnly,
-    }),
   };
 }
 
@@ -140,6 +181,22 @@ function highestClassification(findings) {
     return "SOURCE_NOT_BUILT";
   }
   return "IN_SYNC";
+}
+
+/**
+ * @param {readonly PluginSyncFinding[]} findings
+ * @returns {string[]}
+ */
+function affectedPaths(findings) {
+  return [
+    ...new Set(
+      findings.flatMap(finding =>
+        [finding.path, finding.counterpart].filter(
+          pathValue => typeof pathValue === "string" && pathValue.length > 0
+        )
+      )
+    ),
+  ];
 }
 
 /**

--- a/tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
+++ b/tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts
@@ -7,12 +7,19 @@
  * the `plugins/src/base` source assets after `bun run build:plugins`.
  * @module tests/unit/strategies/doctor-fixture-smoke-and-parity
  */
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import * as fs from "fs-extra";
 import path from "node:path";
+import process from "node:process";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { renderDoctorReport } from "../../../plugins/src/base/scripts/doctor-report.mjs";
+import {
+  createPluginSyncDoctorGroup,
+  renderDoctorReport,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
 
 /**
  *
@@ -47,6 +54,10 @@ type DoctorReportFixture = {
 const BASE_PLUGIN_ROOT = path.resolve("plugins/src/base");
 const GENERATED_PLUGIN_ROOT = path.resolve("plugins/lisa");
 const DOCTOR_FIXTURES = path.resolve("tests/fixtures/doctor");
+const MARKETPLACE = ".claude-plugin/marketplace.json";
+const GIT_BIN = "/usr/bin/git";
+const SOURCE_SKILL = "plugins/src/base/skills/example/SKILL.md";
+const GENERATED_SKILL = "plugins/lisa/skills/example/SKILL.md";
 
 const readUtf8 = (filePath: string): string => readFileSync(filePath, "utf8");
 
@@ -99,6 +110,40 @@ describe("doctor fixture smoke coverage (#756)", () => {
   });
 });
 
+describe("doctor plugin sync readiness (#1097)", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await createTempDir();
+    await seedPluginRepo(root);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(root);
+  });
+
+  it("collects plugin sync evidence without mutating tracked plugin state", async () => {
+    await fs.appendFile(
+      path.join(root, SOURCE_SKILL),
+      "\nDoctor-visible source update.\n"
+    );
+    const before = gitStatus(root);
+
+    const group = createPluginSyncDoctorGroup(root);
+
+    expect(group.checks).toContainEqual(
+      expect.objectContaining({
+        id: "plugin-sync",
+        status: "WARN",
+        summary: "plugin sync drift detected: SOURCE_NOT_BUILT",
+        observed:
+          "Drift class SOURCE_NOT_BUILT; affected paths: plugins/src/base/skills/example/SKILL.md, plugins/lisa/skills/example/SKILL.md.",
+      })
+    );
+    expect(gitStatus(root)).toBe(before);
+  });
+});
+
 describe("doctor source/generated parity (#756)", () => {
   it("keeps the distributed doctor command in lockstep with the source asset", () => {
     expect(
@@ -121,4 +166,89 @@ describe("doctor source/generated parity (#756)", () => {
       readUtf8(path.join(BASE_PLUGIN_ROOT, "scripts", "doctor-report.mjs"))
     );
   });
+
+  it("keeps the distributed plugin sync helper in lockstep with the source asset", () => {
+    expect(
+      readUtf8(
+        path.join(GENERATED_PLUGIN_ROOT, "scripts", "plugin-sync-explain.mjs")
+      )
+    ).toBe(
+      readUtf8(
+        path.join(BASE_PLUGIN_ROOT, "scripts", "plugin-sync-explain.mjs")
+      )
+    );
+  });
 });
+
+/**
+ * Seed a minimal committed Lisa plugin tree for doctor plugin-sync checks.
+ * @param root Fixture repository root.
+ */
+async function seedPluginRepo(root: string): Promise<void> {
+  await fs.ensureDir(path.join(root, ".claude-plugin"));
+  await fs.writeJson(path.join(root, MARKETPLACE), {
+    plugins: [{ name: "lisa", source: "./plugins/lisa" }],
+  });
+  await fs.ensureDir(path.join(root, "plugins/src/base/skills/example"));
+  await fs.ensureDir(path.join(root, "plugins/lisa/skills/example"));
+  await fs.writeFile(
+    path.join(root, SOURCE_SKILL),
+    "---\nname: example\ndescription: Fixture source.\n---\n\n# Example\n"
+  );
+  await fs.writeFile(
+    path.join(root, GENERATED_SKILL),
+    "---\nname: example\ndescription: Fixture source.\n---\n\n# Example\n"
+  );
+  await fs.ensureDir(path.join(root, "scripts"));
+  await fs.writeFile(
+    path.join(root, "scripts/build-plugins.sh"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+      'rm -rf "$ROOT_DIR/plugins/lisa"',
+      'mkdir -p "$ROOT_DIR/plugins/lisa"',
+      'cp -R "$ROOT_DIR/plugins/src/base/." "$ROOT_DIR/plugins/lisa/"',
+      "",
+    ].join("\n")
+  );
+  git(root, "init");
+  git(root, "config", "user.email", "lisa-fixture@example.com");
+  git(root, "config", "user.name", "Lisa Fixture");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "seed plugin fixture");
+}
+
+/**
+ * Return plugin-relevant porcelain status for the fixture repo.
+ * @param cwd Fixture repository root.
+ * @returns Porcelain status output.
+ */
+function gitStatus(cwd: string): string {
+  return git(cwd, "status", "--porcelain", "--", "plugins", MARKETPLACE);
+}
+
+/**
+ * Run git against a fixture repo with a fixed executable path for lint safety.
+ * @param cwd Fixture repository root.
+ * @param args Git arguments.
+ * @returns Command stdout.
+ */
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync(GIT_BIN, args, {
+    cwd,
+    encoding: "utf8",
+    env: gitEnv(),
+  });
+}
+
+/**
+ * Remove parent-hook Git environment so fixture commands use the temp repo.
+ * @returns Process environment for nested git commands.
+ */
+function gitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  return env;
+}

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -7,13 +7,21 @@
  * separate from remediation text, and computes the overall verdict ladder.
  * @module tests/unit/strategies/doctor-report-rendering
  */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
   computeDoctorVerdict,
   countDoctorStatuses,
+  createPluginSyncDoctorGroup,
   renderDoctorReport,
 } from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+const SOURCE_SKILL = "plugins/src/base/skills/example/SKILL.md";
+const GENERATED_SKILL = "plugins/lisa/skills/example/SKILL.md";
 
 describe("doctor report rendering (#750)", () => {
   it("renders grouped sections with PASS, WARN, FAIL, and SKIP checks", () => {
@@ -195,4 +203,104 @@ describe("doctor report rendering (#750)", () => {
       "- SKIP empty-group: no checks registered yet"
     );
   });
+
+  it("renders healthy plugin sync as a PASS readiness group", () => {
+    const root = seedPluginRepo();
+    try {
+      const group = createPluginSyncDoctorGroup(root);
+      const report = renderDoctorReport({ groups: [group] });
+
+      expect(group.title).toBe("Plugin source/generated sync");
+      expect(group.checks[0]).toMatchObject({
+        id: "plugin-sync",
+        status: "PASS",
+        summary: "plugin source and generated artifacts are in sync",
+      });
+      expect(report.verdict).toBe("READY");
+      expect(report.text).toContain("Drift class IN_SYNC");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("renders plugin sync drift with affected paths and next action", () => {
+    const root = seedPluginRepo();
+    try {
+      writeFileSync(
+        path.join(root, SOURCE_SKILL),
+        "\nSource-only doctor drift.\n",
+        { flag: "a" }
+      );
+
+      const group = createPluginSyncDoctorGroup(root);
+      const report = renderDoctorReport({ groups: [group] });
+
+      expect(group.checks[0]).toMatchObject({
+        id: "plugin-sync",
+        status: "WARN",
+        summary: "plugin sync drift detected: SOURCE_NOT_BUILT",
+      });
+      expect(report.verdict).toBe("READY_WITH_WARNINGS");
+      expect(report.text).toContain(SOURCE_SKILL);
+      expect(report.text).toContain("Run `bun run build:plugins`");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
 });
+
+/**
+ * Seed a minimal committed plugin tree for doctor plugin-sync checks.
+ * @returns Fixture repository root.
+ */
+function seedPluginRepo(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-doctor-plugin-sync-"));
+  const skill =
+    "---\nname: example\ndescription: Fixture source.\n---\n\n# Example\n";
+  mkdirSync(path.join(root, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    path.join(root, ".claude-plugin/marketplace.json"),
+    JSON.stringify({ plugins: [{ name: "lisa", source: "./plugins/lisa" }] })
+  );
+  mkdirSync(path.join(root, "plugins/src/base/skills/example"), {
+    recursive: true,
+  });
+  mkdirSync(path.join(root, "plugins/lisa/skills/example"), {
+    recursive: true,
+  });
+  writeFileSync(path.join(root, SOURCE_SKILL), skill);
+  writeFileSync(path.join(root, GENERATED_SKILL), skill);
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(root, "scripts/build-plugins.sh"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+      'rm -rf "$ROOT_DIR/plugins/lisa"',
+      'mkdir -p "$ROOT_DIR/plugins/lisa"',
+      'cp -R "$ROOT_DIR/plugins/src/base/." "$ROOT_DIR/plugins/lisa/"',
+      "",
+    ].join("\n")
+  );
+  git(root, "init");
+  git(root, "config", "user.email", "lisa-fixture@example.com");
+  git(root, "config", "user.name", "Lisa Fixture");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "seed plugin fixture");
+  return root;
+}
+
+/**
+ * Run a git command in a fixture repository.
+ * @param cwd Fixture repository root.
+ * @param args Git command arguments.
+ * @returns Standard output from git.
+ */
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("/usr/bin/git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" },
+  });
+}

--- a/tests/unit/strategies/plugin-sync-explain-fixtures.test.ts
+++ b/tests/unit/strategies/plugin-sync-explain-fixtures.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   explainPluginSync,
+  getPluginSyncResult,
   renderPluginSyncReport,
 } from "../../../plugins/src/base/scripts/plugin-sync-explain.mjs";
 import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
@@ -124,6 +125,30 @@ describe("plugin-sync-explain fixture classifications (#990)", () => {
     expect(report.findings).toHaveLength(0);
     expect(report.readOnly).toBe(true);
     expect(renderPluginSyncReport(report)).toContain("Verdict: IN_SYNC");
+  });
+
+  it("exports structured readiness data for doctor consumers", async () => {
+    await fs.appendFile(
+      path.join(root, SOURCE_SKILL),
+      "\nDoctor-visible update.\n"
+    );
+    const before = gitStatus(root);
+
+    const result = getPluginSyncResult(root);
+
+    expect(result.verdict).toBe("WARN");
+    expect(result.driftClass).toBe("SOURCE_NOT_BUILT");
+    expect(result.affectedPaths).toEqual([SOURCE_SKILL, GENERATED_SKILL]);
+    expect(result.remediations).toContainEqual({
+      path: SOURCE_SKILL,
+      counterpart: GENERATED_SKILL,
+      classification: "SOURCE_NOT_BUILT",
+      nextAction:
+        "Run `bun run build:plugins`, then `bun run check:plugins`, and commit source plus regenerated artifacts.",
+    });
+    expect(result.readOnly).toBe(true);
+    expect(result.statusAfter).toBe(before);
+    expect(gitStatus(root)).toBe(before);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `getPluginSyncResult` as a structured, read-only plugin sync result for doctor/readiness consumers
- expose verdict, drift class, affected paths, and remediation actions while preserving CLI explain output
- rebuild generated plugin variants and add fixture coverage

## Verification
- `bun test tests/unit/strategies/plugin-sync-explain-fixtures.test.ts`
- `node plugins/src/base/scripts/plugin-sync-explain.mjs .`
- `bun test tests/unit/strategies/plugin-sync-explain-fixtures.test.ts tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts`
- `bun run typecheck`
- pre-push hook: security audit, slow lint, `knip`, unit tests with coverage, integration tests

Refs #1093

## Additional build-intake work
- render plugin sync readiness in doctor output via `createPluginSyncDoctorGroup`
- preserve read-only plugin sync evidence and surface drift class, affected paths, and next actions
- add doctor renderer fixture coverage for healthy and drifted plugin sync states

Refs #1094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin sync diagnostics to detect when generated files are out of sync with source files.
  * Plugin sync checks now provide drift classification and identify affected file paths.
  * Automated remediation guidance is available for plugin sync issues.

* **Tests**
  * Added test coverage for plugin sync diagnostics and drift detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodySwannGT/lisa/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->