### PR TITLE
Add doctor plugin drift guidance

### DIFF
--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -96,12 +96,7 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
               ? "plugin source and generated artifacts are in sync"
               : `plugin sync drift detected: ${result.driftClass}`,
           observed: renderPluginSyncObserved(result),
-          remediation:
-            result.remediations.length > 0
-              ? result.remediations
-                  .map(item => `${item.path}: ${item.nextAction}`)
-                  .join(" ")
-              : undefined,
+          remediation: renderPluginSyncRemediation(result),
         },
       ],
     };
@@ -243,4 +238,42 @@ function renderPluginSyncObserved(result) {
     ? result.affectedPaths.join(", ")
     : "none";
   return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string | undefined}
+ */
+function renderPluginSyncRemediation(result) {
+  if (result.verdict === "PASS") {
+    return undefined;
+  }
+
+  const nextAction = pluginSyncNextAction(result.driftClass);
+  const details = result.remediations
+    .map(item => `${item.path}: ${item.nextAction}`)
+    .join(" ");
+  const explain =
+    "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` for the detailed drift report.";
+
+  return [nextAction, details, explain].filter(Boolean).join(" ");
+}
+
+/**
+ * @param {string} driftClass
+ * @returns {string}
+ */
+function pluginSyncNextAction(driftClass) {
+  switch (driftClass) {
+    case "SOURCE_NOT_BUILT":
+      return "Next action: run `bun run build:plugins && bun run check:plugins`, then commit source plus regenerated plugin artifacts.";
+    case "OUT_OF_SYNC":
+      return "Next action: review source and generated plugin changes, keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`.";
+    case "GENERATED_ONLY":
+      return "Next action: move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift if it should not ship.";
+    case "MARKETPLACE_REGISTRATION_DRIFT":
+      return "Next action: align marketplace registration with the built plugin manifests, or remove stale marketplace entries.";
+    default:
+      return `Next action: inspect plugin sync drift class ${driftClass}.`;
+  }
 }

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -96,12 +96,7 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
               ? "plugin source and generated artifacts are in sync"
               : `plugin sync drift detected: ${result.driftClass}`,
           observed: renderPluginSyncObserved(result),
-          remediation:
-            result.remediations.length > 0
-              ? result.remediations
-                  .map(item => `${item.path}: ${item.nextAction}`)
-                  .join(" ")
-              : undefined,
+          remediation: renderPluginSyncRemediation(result),
         },
       ],
     };
@@ -243,4 +238,42 @@ function renderPluginSyncObserved(result) {
     ? result.affectedPaths.join(", ")
     : "none";
   return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string | undefined}
+ */
+function renderPluginSyncRemediation(result) {
+  if (result.verdict === "PASS") {
+    return undefined;
+  }
+
+  const nextAction = pluginSyncNextAction(result.driftClass);
+  const details = result.remediations
+    .map(item => `${item.path}: ${item.nextAction}`)
+    .join(" ");
+  const explain =
+    "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` for the detailed drift report.";
+
+  return [nextAction, details, explain].filter(Boolean).join(" ");
+}
+
+/**
+ * @param {string} driftClass
+ * @returns {string}
+ */
+function pluginSyncNextAction(driftClass) {
+  switch (driftClass) {
+    case "SOURCE_NOT_BUILT":
+      return "Next action: run `bun run build:plugins && bun run check:plugins`, then commit source plus regenerated plugin artifacts.";
+    case "OUT_OF_SYNC":
+      return "Next action: review source and generated plugin changes, keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`.";
+    case "GENERATED_ONLY":
+      return "Next action: move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift if it should not ship.";
+    case "MARKETPLACE_REGISTRATION_DRIFT":
+      return "Next action: align marketplace registration with the built plugin manifests, or remove stale marketplace entries.";
+    default:
+      return `Next action: inspect plugin sync drift class ${driftClass}.`;
+  }
 }

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -96,12 +96,7 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
               ? "plugin source and generated artifacts are in sync"
               : `plugin sync drift detected: ${result.driftClass}`,
           observed: renderPluginSyncObserved(result),
-          remediation:
-            result.remediations.length > 0
-              ? result.remediations
-                  .map(item => `${item.path}: ${item.nextAction}`)
-                  .join(" ")
-              : undefined,
+          remediation: renderPluginSyncRemediation(result),
         },
       ],
     };
@@ -243,4 +238,42 @@ function renderPluginSyncObserved(result) {
     ? result.affectedPaths.join(", ")
     : "none";
   return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string | undefined}
+ */
+function renderPluginSyncRemediation(result) {
+  if (result.verdict === "PASS") {
+    return undefined;
+  }
+
+  const nextAction = pluginSyncNextAction(result.driftClass);
+  const details = result.remediations
+    .map(item => `${item.path}: ${item.nextAction}`)
+    .join(" ");
+  const explain =
+    "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` for the detailed drift report.";
+
+  return [nextAction, details, explain].filter(Boolean).join(" ");
+}
+
+/**
+ * @param {string} driftClass
+ * @returns {string}
+ */
+function pluginSyncNextAction(driftClass) {
+  switch (driftClass) {
+    case "SOURCE_NOT_BUILT":
+      return "Next action: run `bun run build:plugins && bun run check:plugins`, then commit source plus regenerated plugin artifacts.";
+    case "OUT_OF_SYNC":
+      return "Next action: review source and generated plugin changes, keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`.";
+    case "GENERATED_ONLY":
+      return "Next action: move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift if it should not ship.";
+    case "MARKETPLACE_REGISTRATION_DRIFT":
+      return "Next action: align marketplace registration with the built plugin manifests, or remove stale marketplace entries.";
+    default:
+      return `Next action: inspect plugin sync drift class ${driftClass}.`;
+  }
 }

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -96,12 +96,7 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
               ? "plugin source and generated artifacts are in sync"
               : `plugin sync drift detected: ${result.driftClass}`,
           observed: renderPluginSyncObserved(result),
-          remediation:
-            result.remediations.length > 0
-              ? result.remediations
-                  .map(item => `${item.path}: ${item.nextAction}`)
-                  .join(" ")
-              : undefined,
+          remediation: renderPluginSyncRemediation(result),
         },
       ],
     };
@@ -243,4 +238,42 @@ function renderPluginSyncObserved(result) {
     ? result.affectedPaths.join(", ")
     : "none";
   return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string | undefined}
+ */
+function renderPluginSyncRemediation(result) {
+  if (result.verdict === "PASS") {
+    return undefined;
+  }
+
+  const nextAction = pluginSyncNextAction(result.driftClass);
+  const details = result.remediations
+    .map(item => `${item.path}: ${item.nextAction}`)
+    .join(" ");
+  const explain =
+    "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` for the detailed drift report.";
+
+  return [nextAction, details, explain].filter(Boolean).join(" ");
+}
+
+/**
+ * @param {string} driftClass
+ * @returns {string}
+ */
+function pluginSyncNextAction(driftClass) {
+  switch (driftClass) {
+    case "SOURCE_NOT_BUILT":
+      return "Next action: run `bun run build:plugins && bun run check:plugins`, then commit source plus regenerated plugin artifacts.";
+    case "OUT_OF_SYNC":
+      return "Next action: review source and generated plugin changes, keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`.";
+    case "GENERATED_ONLY":
+      return "Next action: move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift if it should not ship.";
+    case "MARKETPLACE_REGISTRATION_DRIFT":
+      return "Next action: align marketplace registration with the built plugin manifests, or remove stale marketplace entries.";
+    default:
+      return `Next action: inspect plugin sync drift class ${driftClass}.`;
+  }
 }

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -96,12 +96,7 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
               ? "plugin source and generated artifacts are in sync"
               : `plugin sync drift detected: ${result.driftClass}`,
           observed: renderPluginSyncObserved(result),
-          remediation:
-            result.remediations.length > 0
-              ? result.remediations
-                  .map(item => `${item.path}: ${item.nextAction}`)
-                  .join(" ")
-              : undefined,
+          remediation: renderPluginSyncRemediation(result),
         },
       ],
     };
@@ -243,4 +238,42 @@ function renderPluginSyncObserved(result) {
     ? result.affectedPaths.join(", ")
     : "none";
   return `Drift class ${result.driftClass}; affected paths: ${paths}.`;
+}
+
+/**
+ * @param {import("./plugin-sync-explain.mjs").PluginSyncResult} result
+ * @returns {string | undefined}
+ */
+function renderPluginSyncRemediation(result) {
+  if (result.verdict === "PASS") {
+    return undefined;
+  }
+
+  const nextAction = pluginSyncNextAction(result.driftClass);
+  const details = result.remediations
+    .map(item => `${item.path}: ${item.nextAction}`)
+    .join(" ");
+  const explain =
+    "Run `/lisa:plugin-sync-explain` or `bun run check:plugins` for the detailed drift report.";
+
+  return [nextAction, details, explain].filter(Boolean).join(" ");
+}
+
+/**
+ * @param {string} driftClass
+ * @returns {string}
+ */
+function pluginSyncNextAction(driftClass) {
+  switch (driftClass) {
+    case "SOURCE_NOT_BUILT":
+      return "Next action: run `bun run build:plugins && bun run check:plugins`, then commit source plus regenerated plugin artifacts.";
+    case "OUT_OF_SYNC":
+      return "Next action: review source and generated plugin changes, keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`.";
+    case "GENERATED_ONLY":
+      return "Next action: move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift if it should not ship.";
+    case "MARKETPLACE_REGISTRATION_DRIFT":
+      return "Next action: align marketplace registration with the built plugin manifests, or remove stale marketplace entries.";
+    default:
+      return `Next action: inspect plugin sync drift class ${driftClass}.`;
+  }
 }

--- a/tests/unit/strategies/doctor-plugin-sync-guidance.test.ts
+++ b/tests/unit/strategies/doctor-plugin-sync-guidance.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression coverage for doctor plugin-sync next-action guidance.
+ *
+ * Issue #1095: doctor should surface the smallest useful action for every
+ * plugin drift class while keeping /lisa:plugin-sync-explain as deeper context.
+ * @module tests/unit/strategies/doctor-plugin-sync-guidance
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  createPluginSyncDoctorGroup,
+  renderDoctorReport,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+const SOURCE_SKILL = "plugins/src/base/skills/example/SKILL.md";
+const GENERATED_SKILL = "plugins/lisa/skills/example/SKILL.md";
+
+describe("doctor plugin sync guidance (#1095)", () => {
+  it.each([
+    [
+      "SOURCE_NOT_BUILT",
+      (root: string) =>
+        writeFileSync(path.join(root, SOURCE_SKILL), "\nSource drift.\n", {
+          flag: "a",
+        }),
+      "Next action: run `bun run build:plugins && bun run check:plugins`",
+    ],
+    [
+      "OUT_OF_SYNC",
+      (root: string) => {
+        writeFileSync(path.join(root, SOURCE_SKILL), "\nSource drift.\n", {
+          flag: "a",
+        });
+        writeFileSync(
+          path.join(root, GENERATED_SKILL),
+          "\nDifferent generated drift.\n",
+          { flag: "a" }
+        );
+      },
+      "keep `plugins/src` authoritative, then run `bun run build:plugins && bun run check:plugins`",
+    ],
+    [
+      "GENERATED_ONLY",
+      (root: string) =>
+        writeFileSync(
+          path.join(root, GENERATED_SKILL),
+          "\nGenerated drift.\n",
+          {
+            flag: "a",
+          }
+        ),
+      "move generated-only edits upstream to `plugins/src`, or remove the generated artifact drift",
+    ],
+    [
+      "MARKETPLACE_REGISTRATION_DRIFT",
+      (root: string) =>
+        writeFileSync(
+          path.join(root, ".claude-plugin/marketplace.json"),
+          JSON.stringify({ plugins: [] })
+        ),
+      "align marketplace registration with the built plugin manifests",
+    ],
+  ])(
+    "renders %s with class-specific next action",
+    (driftClass, mutate, expected) => {
+      const root = seedPluginRepo();
+      try {
+        mutate(root);
+
+        const group = createPluginSyncDoctorGroup(root);
+        const report = renderDoctorReport({ groups: [group] });
+
+        expect(group.checks[0]).toMatchObject({
+          id: "plugin-sync",
+          status: "WARN",
+          summary: `plugin sync drift detected: ${driftClass}`,
+        });
+        expect(report.verdict).toBe("READY_WITH_WARNINGS");
+        expect(report.text).toContain(expected);
+        expect(report.text).toContain(
+          "Run `/lisa:plugin-sync-explain` or `bun run check:plugins`"
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    }
+  );
+});
+
+/**
+ * Seed a minimal committed plugin tree for doctor plugin-sync checks.
+ * @returns Fixture repository root.
+ */
+function seedPluginRepo(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-doctor-plugin-sync-"));
+  const skill =
+    "---\nname: example\ndescription: Fixture source.\n---\n\n# Example\n";
+  mkdirSync(path.join(root, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    path.join(root, ".claude-plugin/marketplace.json"),
+    JSON.stringify({ plugins: [{ name: "lisa", source: "./plugins/lisa" }] })
+  );
+  mkdirSync(path.join(root, "plugins/src/base/skills/example"), {
+    recursive: true,
+  });
+  mkdirSync(path.join(root, "plugins/lisa/skills/example"), {
+    recursive: true,
+  });
+  writeFileSync(path.join(root, SOURCE_SKILL), skill);
+  writeFileSync(path.join(root, GENERATED_SKILL), skill);
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(root, "scripts/build-plugins.sh"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+      'rm -rf "$ROOT_DIR/plugins/lisa"',
+      'mkdir -p "$ROOT_DIR/plugins/lisa"',
+      'cp -R "$ROOT_DIR/plugins/src/base/." "$ROOT_DIR/plugins/lisa/"',
+      "",
+    ].join("\n")
+  );
+  git(root, "init");
+  git(root, "config", "user.email", "lisa-fixture@example.com");
+  git(root, "config", "user.name", "Lisa Fixture");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "seed plugin fixture");
+  return root;
+}
+
+/**
+ * Run a git command in a fixture repository.
+ * @param cwd Fixture repository root.
+ * @param args Git command arguments.
+ * @returns Standard output from git.
+ */
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("/usr/bin/git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" },
+  });
+}

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -222,31 +222,6 @@ describe("doctor report rendering (#750)", () => {
       rmSync(root, { force: true, recursive: true });
     }
   });
-
-  it("renders plugin sync drift with affected paths and next action", () => {
-    const root = seedPluginRepo();
-    try {
-      writeFileSync(
-        path.join(root, SOURCE_SKILL),
-        "\nSource-only doctor drift.\n",
-        { flag: "a" }
-      );
-
-      const group = createPluginSyncDoctorGroup(root);
-      const report = renderDoctorReport({ groups: [group] });
-
-      expect(group.checks[0]).toMatchObject({
-        id: "plugin-sync",
-        status: "WARN",
-        summary: "plugin sync drift detected: SOURCE_NOT_BUILT",
-      });
-      expect(report.verdict).toBe("READY_WITH_WARNINGS");
-      expect(report.text).toContain(SOURCE_SKILL);
-      expect(report.text).toContain("Run `bun run build:plugins`");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add class-level next-action guidance for doctor plugin sync drift.
- Keep per-file remediation details and point operators to /lisa:plugin-sync-explain or check:plugins for deeper context.
- Add fixture coverage for SOURCE_NOT_BUILT, OUT_OF_SYNC, GENERATED_ONLY, and MARKETPLACE_REGISTRATION_DRIFT.

## Verification
- bun vitest run tests/unit/strategies/doctor-plugin-sync-guidance.test.ts tests/unit/strategies/doctor-report-rendering.test.ts
- bun vitest run tests/unit/strategies/doctor-report-rendering.test.ts tests/unit/strategies/doctor-plugin-sync-guidance.test.ts tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts tests/unit/strategies/plugin-sync-explain-fixtures.test.ts
- bun run typecheck
- bun run lint
- bun run check:plugins
- pre-push hook: bun audit, slow lint, knip, vitest --coverage, integration tests

Closes #1095