### PR TITLE
fix: preserve Harper schema knip suppression

### DIFF
--- a/harper-fabric/copy-overwrite/knip.json
+++ b/harper-fabric/copy-overwrite/knip.json
@@ -17,6 +17,9 @@
     "harper-app/resource-*.js",
     "harper-app/web/**/*.js"
   ],
+  "ignoreIssues": {
+    "src/types/harper-schema.ts": ["types"]
+  },
   "ignoreDependencies": ["@types/node", "@vitest/coverage-v8"],
   "ignoreBinaries": ["audit", "harperdb", "knip", "playwright", "tsx"],
   "rules": {

--- a/tests/unit/config/harper-fabric-template.test.ts
+++ b/tests/unit/config/harper-fabric-template.test.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HARPER_FABRIC_KNIP_TEMPLATE = "harper-fabric/copy-overwrite/knip.json";
 
 /**
  * Read a JSON template from the Lisa repository.
@@ -37,12 +38,22 @@ describe("Harper/Fabric templates", () => {
   });
 
   it("ignore hook-invoked binaries in Knip", () => {
-    const knip = readJson("harper-fabric/copy-overwrite/knip.json") as {
+    const knip = readJson(HARPER_FABRIC_KNIP_TEMPLATE) as {
       readonly ignoreBinaries?: readonly string[];
     };
 
     expect(knip.ignoreBinaries).toEqual(
       expect.arrayContaining(["audit", "knip"])
+    );
+  });
+
+  it("suppresses generated Harper schema row types in Knip", () => {
+    const knip = readJson(HARPER_FABRIC_KNIP_TEMPLATE) as {
+      readonly ignoreIssues?: Readonly<Record<string, readonly string[]>>;
+    };
+
+    expect(knip.ignoreIssues?.["src/types/harper-schema.ts"]).toContain(
+      "types"
     );
   });
 
@@ -76,7 +87,7 @@ describe("Harper/Fabric templates", () => {
     const oxlintMerge = readJson("harper-fabric/merge/.oxlintrc.json") as {
       readonly ignorePatterns?: readonly string[];
     };
-    const knip = readJson("harper-fabric/copy-overwrite/knip.json") as {
+    const knip = readJson(HARPER_FABRIC_KNIP_TEMPLATE) as {
       readonly ignore?: readonly string[];
     };
     const tsconfigEslint = readJson(


### PR DESCRIPTION
## Summary
- restore the Harper/Fabric Knip template suppression for generated Harper schema row types
- add a regression test so the Harper template keeps suppressing src/types/harper-schema.ts type-only exports

## Verification
- bun run test -- tests/unit/config/harper-fabric-template.test.ts
- bun run typecheck
- bun run format:check
- bun run lint
- bun run knip
- pre-push: bun audit, slow lint, knip, vitest coverage, integration tests
