### PR TITLE
fix(repair-intake): clear is-blocked-by deps at any env-staged done, not just prod

### DIFF
--- a/plugins/lisa-agy/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/repair-intake/SKILL.md
@@ -559,8 +559,19 @@ is no normalized `is blocked by` field. Read the bundle, then extract blockers p
 
 Then classify each blocker:
 
-- **Closed / Done** (its true terminal role) → **cleared**.
-- **Open** in any non-terminal role (`ready` / `claimed` / `review` / unknown) → **still
+- **Closed, or shipped to any environment** → **cleared**. A blocker is cleared at **any**
+  env-staged `done` role — not only the production terminal. The `done` role is configured
+  per-env as a `{dev, staging, production}` map (`config-resolution`), so `On Dev`, `On Stg`,
+  **and** production `Done` all mean the blocker's code is merged and deployed to ≥1 environment.
+  A post-build `review` role (e.g. `Code Review`) is likewise cleared — the change exists and is
+  in flight. An `is blocked by` link is a **development** dependency: it is satisfied once the
+  blocker's code is in trunk; it must NOT wait for the blocker to reach production. (This matches
+  the intake-path dependency-hold gate in `lisa:intake-explain`, which already treats
+  `code-review` / `on-dev` / `on-stg` / `done` as cleared — repair-intake must not be stricter.
+  In an env-staged workflow where `Done` means "in production", a strict production-terminal
+  check strands every dependent forever behind a blocker that is already merged and sitting at
+  `On Stg` / `On Dev`.)
+- **Open** in a pre-merge role (`ready` / `claimed` / unknown — code not yet in trunk) → **still
   blocking**.
 - **Inaccessible** (deleted, cross-org, permission denied) → **still blocking**, unless the item
   body or a newer human comment explicitly states the dependency is resolved.

--- a/plugins/lisa-copilot/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/repair-intake/SKILL.md
@@ -559,8 +559,19 @@ is no normalized `is blocked by` field. Read the bundle, then extract blockers p
 
 Then classify each blocker:
 
-- **Closed / Done** (its true terminal role) → **cleared**.
-- **Open** in any non-terminal role (`ready` / `claimed` / `review` / unknown) → **still
+- **Closed, or shipped to any environment** → **cleared**. A blocker is cleared at **any**
+  env-staged `done` role — not only the production terminal. The `done` role is configured
+  per-env as a `{dev, staging, production}` map (`config-resolution`), so `On Dev`, `On Stg`,
+  **and** production `Done` all mean the blocker's code is merged and deployed to ≥1 environment.
+  A post-build `review` role (e.g. `Code Review`) is likewise cleared — the change exists and is
+  in flight. An `is blocked by` link is a **development** dependency: it is satisfied once the
+  blocker's code is in trunk; it must NOT wait for the blocker to reach production. (This matches
+  the intake-path dependency-hold gate in `lisa:intake-explain`, which already treats
+  `code-review` / `on-dev` / `on-stg` / `done` as cleared — repair-intake must not be stricter.
+  In an env-staged workflow where `Done` means "in production", a strict production-terminal
+  check strands every dependent forever behind a blocker that is already merged and sitting at
+  `On Stg` / `On Dev`.)
+- **Open** in a pre-merge role (`ready` / `claimed` / unknown — code not yet in trunk) → **still
   blocking**.
 - **Inaccessible** (deleted, cross-org, permission denied) → **still blocking**, unless the item
   body or a newer human comment explicitly states the dependency is resolved.

--- a/plugins/lisa-cursor/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/repair-intake/SKILL.md
@@ -559,8 +559,19 @@ is no normalized `is blocked by` field. Read the bundle, then extract blockers p
 
 Then classify each blocker:
 
-- **Closed / Done** (its true terminal role) → **cleared**.
-- **Open** in any non-terminal role (`ready` / `claimed` / `review` / unknown) → **still
+- **Closed, or shipped to any environment** → **cleared**. A blocker is cleared at **any**
+  env-staged `done` role — not only the production terminal. The `done` role is configured
+  per-env as a `{dev, staging, production}` map (`config-resolution`), so `On Dev`, `On Stg`,
+  **and** production `Done` all mean the blocker's code is merged and deployed to ≥1 environment.
+  A post-build `review` role (e.g. `Code Review`) is likewise cleared — the change exists and is
+  in flight. An `is blocked by` link is a **development** dependency: it is satisfied once the
+  blocker's code is in trunk; it must NOT wait for the blocker to reach production. (This matches
+  the intake-path dependency-hold gate in `lisa:intake-explain`, which already treats
+  `code-review` / `on-dev` / `on-stg` / `done` as cleared — repair-intake must not be stricter.
+  In an env-staged workflow where `Done` means "in production", a strict production-terminal
+  check strands every dependent forever behind a blocker that is already merged and sitting at
+  `On Stg` / `On Dev`.)
+- **Open** in a pre-merge role (`ready` / `claimed` / unknown — code not yet in trunk) → **still
   blocking**.
 - **Inaccessible** (deleted, cross-org, permission denied) → **still blocking**, unless the item
   body or a newer human comment explicitly states the dependency is resolved.

--- a/plugins/lisa/skills/repair-intake/SKILL.md
+++ b/plugins/lisa/skills/repair-intake/SKILL.md
@@ -559,8 +559,19 @@ is no normalized `is blocked by` field. Read the bundle, then extract blockers p
 
 Then classify each blocker:
 
-- **Closed / Done** (its true terminal role) → **cleared**.
-- **Open** in any non-terminal role (`ready` / `claimed` / `review` / unknown) → **still
+- **Closed, or shipped to any environment** → **cleared**. A blocker is cleared at **any**
+  env-staged `done` role — not only the production terminal. The `done` role is configured
+  per-env as a `{dev, staging, production}` map (`config-resolution`), so `On Dev`, `On Stg`,
+  **and** production `Done` all mean the blocker's code is merged and deployed to ≥1 environment.
+  A post-build `review` role (e.g. `Code Review`) is likewise cleared — the change exists and is
+  in flight. An `is blocked by` link is a **development** dependency: it is satisfied once the
+  blocker's code is in trunk; it must NOT wait for the blocker to reach production. (This matches
+  the intake-path dependency-hold gate in `lisa:intake-explain`, which already treats
+  `code-review` / `on-dev` / `on-stg` / `done` as cleared — repair-intake must not be stricter.
+  In an env-staged workflow where `Done` means "in production", a strict production-terminal
+  check strands every dependent forever behind a blocker that is already merged and sitting at
+  `On Stg` / `On Dev`.)
+- **Open** in a pre-merge role (`ready` / `claimed` / unknown — code not yet in trunk) → **still
   blocking**.
 - **Inaccessible** (deleted, cross-org, permission denied) → **still blocking**, unless the item
   body or a newer human comment explicitly states the dependency is resolved.

--- a/plugins/src/base/skills/repair-intake/SKILL.md
+++ b/plugins/src/base/skills/repair-intake/SKILL.md
@@ -559,8 +559,19 @@ is no normalized `is blocked by` field. Read the bundle, then extract blockers p
 
 Then classify each blocker:
 
-- **Closed / Done** (its true terminal role) → **cleared**.
-- **Open** in any non-terminal role (`ready` / `claimed` / `review` / unknown) → **still
+- **Closed, or shipped to any environment** → **cleared**. A blocker is cleared at **any**
+  env-staged `done` role — not only the production terminal. The `done` role is configured
+  per-env as a `{dev, staging, production}` map (`config-resolution`), so `On Dev`, `On Stg`,
+  **and** production `Done` all mean the blocker's code is merged and deployed to ≥1 environment.
+  A post-build `review` role (e.g. `Code Review`) is likewise cleared — the change exists and is
+  in flight. An `is blocked by` link is a **development** dependency: it is satisfied once the
+  blocker's code is in trunk; it must NOT wait for the blocker to reach production. (This matches
+  the intake-path dependency-hold gate in `lisa:intake-explain`, which already treats
+  `code-review` / `on-dev` / `on-stg` / `done` as cleared — repair-intake must not be stricter.
+  In an env-staged workflow where `Done` means "in production", a strict production-terminal
+  check strands every dependent forever behind a blocker that is already merged and sitting at
+  `On Stg` / `On Dev`.)
+- **Open** in a pre-merge role (`ready` / `claimed` / unknown — code not yet in trunk) → **still
   blocking**.
 - **Inaccessible** (deleted, cross-org, permission denied) → **still blocking**, unless the item
   body or a newer human comment explicitly states the dependency is resolved.


### PR DESCRIPTION
## Summary
Fixes a cross-project bug where `repair-intake` leaves a build item **`blocked` forever** behind a dependency that is already merged and shipped to a non-production environment.

## The bug
`repair-intake` "Class A — dependency blockers" classified an `is blocked by` dependency as cleared only when the blocker reached its **"true terminal role"** (production `Done`):
```
- Closed / Done (its true terminal role) → cleared.
- Open in any non-terminal role (ready / claimed / review / unknown) → still blocking.
```
But `done` is configured **per-env** as a map (`config-resolution`): `{dev: On Dev, staging: On Stg, production: Done}`. A blocker that's merged and sitting at **`On Stg`** (or `On Dev`) is neither the production terminal nor one of the listed non-terminal roles, so it fell through to **"still blocking"** — even though the code the dependent needs is already in trunk. The dependent stays `blocked` indefinitely.

Hit in the wild: a backend ticket stayed `Blocked` behind a dependency that was already `On Stg` (config helper merged + on staging); the dependent was fully buildable.

## The fix
An `is blocked by` link is a **development** dependency — satisfied once the blocker's code is **merged (any env-staged `done`)** or in post-build `review`, not when it ships to production. Class A now clears on any env-staged `done` (`On Dev` / `On Stg` / `Done`) or `review`, and only stays blocking for pre-merge states (`ready` / `claimed` / unknown / inaccessible).

This **aligns `repair-intake` with `intake-explain`**, whose dependency-hold gate *already* treats `code-review` / `on-dev` / `on-stg` / `done` as cleared (line 193). `repair-intake` was the strict outlier; now the intake and repair paths agree.

Generic across vendors — it reasons over the configured `done` map, not hardcoded status names.

## Test plan
- `bun run build:plugins` → only `repair-intake` artifacts changed (src + lisa/agy/copilot/cursor), no other churn.

🤖 Generated with Claude Code
