### PR TITLE
refactor(cli): split runLisa into apply subcommand + positional default (#974)

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1,0 +1,135 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { LisaConfig } from "../core/config.js";
+import { HARNESS_VALUES } from "../core/config.js";
+import { Lisa } from "../core/lisa.js";
+import {
+  readProjectConfig,
+  resolveHarness,
+  writeProjectConfig,
+} from "../core/project-config.js";
+import { ConsoleLogger } from "../logging/index.js";
+import { toAbsolutePath } from "../utils/path-utils.js";
+import { type CLIOptions, createDependencies } from "./shared-options.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Get Lisa directory (where configs are stored)
+ * @returns Path to Lisa directory
+ */
+function getLisaDir(): string {
+  // Go up from dist/cli to project root
+  return path.resolve(__dirname, "..", "..");
+}
+
+/**
+ * Print usage help and exit
+ */
+function printUsageAndExit(): never {
+  console.error("Error: destination path is required");
+  console.log("");
+  console.log("Usage: lisa [options] <destination-path>");
+  console.log("");
+  console.log("Options:");
+  console.log(
+    "  -n, --dry-run     Show what would be done without making changes"
+  );
+  console.log(
+    "  -y, --yes         Non-interactive mode (auto-accept defaults, overwrite on conflict)"
+  );
+  console.log(
+    "  -v, --validate    Validate project compatibility without applying changes"
+  );
+  console.log(
+    "  --skip-git-check  Skip dirty git working directory check (for postinstall use)"
+  );
+  console.log("  --no-update-check Skip the npm latest-version check");
+  console.log(
+    `  --harness <h>     Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (persisted in .lisa.config.json)`
+  );
+  console.log("  -h, --help        Show this help message");
+  console.log("");
+  console.log("Examples:");
+  console.log("  lisa /path/to/my-project");
+  console.log("  lisa --dry-run .");
+  console.log("  lisa --yes /path/to/project          # CI/CD pipeline usage");
+  console.log(
+    "  lisa --validate .                    # Check compatibility only"
+  );
+  console.log("  lisa --harness=codex .               # Emit Codex artifacts");
+  console.log(
+    "  lisa --harness=both .                # Emit both Claude and Codex artifacts"
+  );
+  process.exit(1);
+}
+
+/**
+ * Apply Lisa to the given destination with the given options.
+ *
+ * This is the relocated action that previously lived inline in
+ * `src/cli/index.ts` as `runLisa`. It backs both the explicit `apply`
+ * subcommand and the backwards-compatible positional default, so the two
+ * invocation forms produce identical results.
+ * @param destination - Path to destination directory
+ * @param options - CLI options
+ * @returns Promise that completes when Lisa finishes
+ */
+export async function runApply(
+  destination: string | undefined,
+  options: CLIOptions
+): Promise<void> {
+  if (!destination) {
+    printUsageAndExit();
+  }
+
+  const dryRun = options.dryRun ?? options.validate ?? false;
+  const yesMode = options.yes ?? false;
+  const destDir = toAbsolutePath(destination);
+
+  // Resolve harness with precedence: CLI flag > .lisa.config.json > default
+  const projectConfig = await readProjectConfig(destDir);
+  const harness = resolveHarness(options.harness, projectConfig);
+
+  const config: LisaConfig = {
+    lisaDir: getLisaDir(),
+    destDir,
+    dryRun,
+    yesMode,
+    validateOnly: options.validate ?? false,
+    skipGitCheck: options.skipGitCheck ?? false,
+    harness,
+  };
+
+  const logger = new ConsoleLogger();
+  const deps = createDependencies(dryRun, yesMode, logger);
+  const lisa = new Lisa(config, deps);
+
+  try {
+    const result = options.validate
+      ? await lisa.validate()
+      : await lisa.apply();
+
+    if (!result.success) {
+      result.errors.forEach(error => logger.error(error));
+      process.exit(1);
+    }
+
+    // Persist resolved harness on apply (not validate, not dry-run) so the
+    // choice survives to the next run without requiring the flag every time.
+    // Only write when the user actually supplied --harness, so existing
+    // host projects don't gain a brand-new .lisa.config.json with the
+    // default value just by running `lisa` once.
+    if (
+      !options.validate &&
+      !dryRun &&
+      options.harness !== undefined &&
+      projectConfig.harness !== harness
+    ) {
+      await writeProjectConfig(destDir, { harness });
+    }
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,58 +1,48 @@
-import { Command, InvalidArgumentError } from "commander";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-import type { Harness, LisaConfig } from "../core/config.js";
-import { HARNESS_VALUES } from "../core/config.js";
-import { GitService } from "../core/git-service.js";
-import { Lisa, type LisaDependencies } from "../core/lisa.js";
-import {
-  isHarness,
-  readProjectConfig,
-  resolveHarness,
-  writeProjectConfig,
-} from "../core/project-config.js";
-import { DetectorRegistry } from "../detection/index.js";
-import { ConsoleLogger } from "../logging/index.js";
-import { MigrationRegistry } from "../migrations/index.js";
-import { StrategyRegistry } from "../strategies/index.js";
-import { BackupService, DryRunBackupService } from "../transaction/index.js";
-import { toAbsolutePath } from "../utils/path-utils.js";
+import { Command } from "commander";
+import { runApply } from "./apply.js";
+import { printUpdateWarning } from "./print-update-warning.js";
+import { addSharedOptions, type CLIOptions } from "./shared-options.js";
+import { runUpdateCheck } from "./update-check.js";
 import { getPackageVersion } from "./version.js";
-import { createPrompter } from "./prompts.js";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Get Lisa directory (where configs are stored)
- * @returns Path to Lisa directory
+ * Injectable collaborators for {@link createProgram}. Defaults wire the real
+ * apply action and npm update-check; tests override them to observe the program
+ * wiring without touching the registry or the orchestrator.
  */
-function getLisaDir(): string {
-  // Go up from dist/cli to project root
-  return path.resolve(__dirname, "..", "..");
+export interface ProgramDependencies {
+  /** Applies Lisa to a destination (defaults to the real {@link runApply}). */
+  runApply: typeof runApply;
+  /** Runs the non-fatal npm update check (defaults to {@link runUpdateCheck}). */
+  runUpdateCheck: typeof runUpdateCheck;
+  /** Prints the update warning (defaults to {@link printUpdateWarning}). */
+  printUpdateWarning: typeof printUpdateWarning;
 }
 
-/**
- * Validate the --harness CLI argument. Commander invokes this with the raw
- * user-supplied string and expects either the parsed value or a thrown
- * InvalidArgumentError.
- * @param value - Raw argument value
- * @returns The validated harness
- */
-function parseHarnessArg(value: string): Harness {
-  if (!isHarness(value)) {
-    const allowed = HARNESS_VALUES.join(" | ");
-    throw new InvalidArgumentError(
-      `expected ${allowed}, got ${JSON.stringify(value)}`
-    );
-  }
-  return value;
-}
+const DEFAULT_DEPENDENCIES: ProgramDependencies = {
+  runApply,
+  runUpdateCheck,
+  printUpdateWarning,
+};
 
 /**
- * Create and configure the CLI program
+ * Create and configure the CLI program.
+ *
+ * The root program is subcommand-style: `apply` is the explicit subcommand and
+ * also the default command, so the historical positional `lisa <dest>`
+ * invocation keeps working. Both forms call the same apply action. A
+ * `preAction` hook runs the npm update-check exactly once per invocation before
+ * any action fires.
+ * @param dependencies - Optional collaborator overrides for testing
  * @returns Configured Commander program
  */
-export function createProgram(): Command {
+export function createProgram(
+  dependencies: Partial<ProgramDependencies> = {}
+): Command {
+  const deps: ProgramDependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...dependencies,
+  };
   const program = new Command();
 
   program
@@ -61,174 +51,33 @@ export function createProgram(): Command {
       "Claude Code / Codex CLI governance framework - apply guardrails and guidance to projects"
     )
     .version(getPackageVersion())
-    .argument("[destination]", "Path to the project directory")
-    .option("--no-update-check", "Skip the npm latest-version check")
-    .option("-n, --dry-run", "Show what would be done without making changes")
-    .option(
-      "-y, --yes",
-      "Non-interactive mode (auto-accept defaults, overwrite on conflict)"
-    )
-    .option(
-      "-v, --validate",
-      "Validate project compatibility without applying changes"
-    )
-    .option(
-      "--skip-git-check",
-      "Skip dirty git working directory check (for postinstall use)"
-    )
-    .option(
-      "--harness <harness>",
-      `Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (default: claude, or value from .lisa.config.json)`,
-      parseHarnessArg
-    )
-    .action(async (destination: string | undefined, options: CLIOptions) => {
-      await runLisa(destination, options);
-    });
+    .option("--no-update-check", "Skip the npm latest-version check");
+
+  // Run the npm update-check once per invocation, before the matched action.
+  // It is non-fatal: a failed check never blocks the action from running.
+  program.hook("preAction", async () => {
+    if (program.opts().updateCheck === false) {
+      return;
+    }
+    const result = await deps.runUpdateCheck();
+    deps.printUpdateWarning(result);
+  });
+
+  // `apply` is both the explicit subcommand and the default command, so the
+  // historical positional form `lisa <destination>` routes here unchanged and
+  // produces the same result as `lisa apply <destination>`. Commander rejects a
+  // root-level positional `argument` once subcommands exist, so the default
+  // command is the supported way to keep the bare-positional invocation.
+  addSharedOptions(
+    program
+      .command("apply", { isDefault: true })
+      .description("Apply Lisa to an existing project (backwards-compatible)")
+      .argument("[destination]", "Path to the project directory")
+  ).action(async (destination: string | undefined, options: CLIOptions) => {
+    await deps.runApply(destination, options);
+  });
 
   return program;
-}
-
-/**
- * CLI options parsed from command line arguments
- */
-interface CLIOptions {
-  dryRun?: boolean;
-  yes?: boolean;
-  validate?: boolean;
-  skipGitCheck?: boolean;
-  updateCheck?: boolean;
-  harness?: Harness;
-}
-
-/**
- * Print usage help and exit
- */
-function printUsageAndExit(): never {
-  console.error("Error: destination path is required");
-  console.log("");
-  console.log("Usage: lisa [options] <destination-path>");
-  console.log("");
-  console.log("Options:");
-  console.log(
-    "  -n, --dry-run     Show what would be done without making changes"
-  );
-  console.log(
-    "  -y, --yes         Non-interactive mode (auto-accept defaults, overwrite on conflict)"
-  );
-  console.log(
-    "  -v, --validate    Validate project compatibility without applying changes"
-  );
-  console.log(
-    "  --skip-git-check  Skip dirty git working directory check (for postinstall use)"
-  );
-  console.log("  --no-update-check Skip the npm latest-version check");
-  console.log(
-    `  --harness <h>     Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (persisted in .lisa.config.json)`
-  );
-  console.log("  -h, --help        Show this help message");
-  console.log("");
-  console.log("Examples:");
-  console.log("  lisa /path/to/my-project");
-  console.log("  lisa --dry-run .");
-  console.log("  lisa --yes /path/to/project          # CI/CD pipeline usage");
-  console.log(
-    "  lisa --validate .                    # Check compatibility only"
-  );
-  console.log("  lisa --harness=codex .               # Emit Codex artifacts");
-  console.log(
-    "  lisa --harness=both .                # Emit both Claude and Codex artifacts"
-  );
-  process.exit(1);
-}
-
-/**
- * Create Lisa dependencies based on options
- * @param dryRun - Whether in dry run mode
- * @param yesMode - Whether in non-interactive mode
- * @param logger - Logger instance
- * @returns Dependencies for Lisa
- */
-function createDependencies(
-  dryRun: boolean,
-  yesMode: boolean,
-  logger: ConsoleLogger
-): LisaDependencies {
-  return {
-    logger,
-    prompter: createPrompter(yesMode),
-    backupService: dryRun
-      ? new DryRunBackupService()
-      : new BackupService(logger),
-    detectorRegistry: new DetectorRegistry(),
-    strategyRegistry: new StrategyRegistry(),
-    gitService: new GitService(),
-    migrationRegistry: new MigrationRegistry(),
-  };
-}
-
-/**
- * Run Lisa with the given options
- * @param destination - Path to destination directory
- * @param options - CLI options
- * @returns Promise that completes when Lisa finishes
- */
-async function runLisa(
-  destination: string | undefined,
-  options: CLIOptions
-): Promise<void> {
-  if (!destination) {
-    printUsageAndExit();
-  }
-
-  const dryRun = options.dryRun ?? options.validate ?? false;
-  const yesMode = options.yes ?? false;
-  const destDir = toAbsolutePath(destination);
-
-  // Resolve harness with precedence: CLI flag > .lisa.config.json > default
-  const projectConfig = await readProjectConfig(destDir);
-  const harness = resolveHarness(options.harness, projectConfig);
-
-  const config: LisaConfig = {
-    lisaDir: getLisaDir(),
-    destDir,
-    dryRun,
-    yesMode,
-    validateOnly: options.validate ?? false,
-    skipGitCheck: options.skipGitCheck ?? false,
-    harness,
-  };
-
-  const logger = new ConsoleLogger();
-  const deps = createDependencies(dryRun, yesMode, logger);
-  const lisa = new Lisa(config, deps);
-
-  try {
-    const result = options.validate
-      ? await lisa.validate()
-      : await lisa.apply();
-
-    if (!result.success) {
-      result.errors.forEach(error => logger.error(error));
-      process.exit(1);
-    }
-
-    // Persist resolved harness on apply (not validate, not dry-run) so the
-    // choice survives to the next run without requiring the flag every time.
-    // Only write when the user actually supplied --harness, so existing
-    // host projects don't gain a brand-new .lisa.config.json with the
-    // default value just by running `lisa` once.
-    if (
-      !options.validate &&
-      !dryRun &&
-      options.harness !== undefined &&
-      projectConfig.harness !== harness
-    ) {
-      await writeProjectConfig(destDir, { harness });
-    }
-  } catch (error) {
-    logger.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
 }
 
 export { createPrompter } from "./prompts.js";

--- a/src/cli/shared-options.ts
+++ b/src/cli/shared-options.ts
@@ -1,0 +1,94 @@
+import { type Command, InvalidArgumentError } from "commander";
+import type { Harness } from "../core/config.js";
+import { HARNESS_VALUES } from "../core/config.js";
+import { GitService } from "../core/git-service.js";
+import type { LisaDependencies } from "../core/lisa.js";
+import { DetectorRegistry } from "../detection/index.js";
+import type { ConsoleLogger } from "../logging/index.js";
+import { MigrationRegistry } from "../migrations/index.js";
+import { isHarness } from "../core/project-config.js";
+import { StrategyRegistry } from "../strategies/index.js";
+import { BackupService, DryRunBackupService } from "../transaction/index.js";
+import { createPrompter } from "./prompts.js";
+
+/**
+ * CLI options parsed from command line arguments. Shared by the `apply`
+ * subcommand and the backwards-compatible positional default.
+ */
+export interface CLIOptions {
+  dryRun?: boolean;
+  yes?: boolean;
+  validate?: boolean;
+  skipGitCheck?: boolean;
+  harness?: Harness;
+}
+
+/**
+ * Validate the --harness CLI argument. Commander invokes this with the raw
+ * user-supplied string and expects either the parsed value or a thrown
+ * InvalidArgumentError.
+ * @param value - Raw argument value
+ * @returns The validated harness
+ */
+export function parseHarnessArg(value: string): Harness {
+  if (!isHarness(value)) {
+    const allowed = HARNESS_VALUES.join(" | ");
+    throw new InvalidArgumentError(
+      `expected ${allowed}, got ${JSON.stringify(value)}`
+    );
+  }
+  return value;
+}
+
+/**
+ * Register the apply-flow flags shared by every entry point that applies Lisa
+ * to a project. Mutates and returns the command for chaining.
+ * @param command - Command to decorate with shared options
+ * @returns The same command instance
+ */
+export function addSharedOptions(command: Command): Command {
+  return command
+    .option("-n, --dry-run", "Show what would be done without making changes")
+    .option(
+      "-y, --yes",
+      "Non-interactive mode (auto-accept defaults, overwrite on conflict)"
+    )
+    .option(
+      "-v, --validate",
+      "Validate project compatibility without applying changes"
+    )
+    .option(
+      "--skip-git-check",
+      "Skip dirty git working directory check (for postinstall use)"
+    )
+    .option(
+      "--harness <harness>",
+      `Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (default: claude, or value from .lisa.config.json)`,
+      parseHarnessArg
+    );
+}
+
+/**
+ * Create Lisa dependencies based on options
+ * @param dryRun - Whether in dry run mode
+ * @param yesMode - Whether in non-interactive mode
+ * @param logger - Logger instance
+ * @returns Dependencies for Lisa
+ */
+export function createDependencies(
+  dryRun: boolean,
+  yesMode: boolean,
+  logger: ConsoleLogger
+): LisaDependencies {
+  return {
+    logger,
+    prompter: createPrompter(yesMode),
+    backupService: dryRun
+      ? new DryRunBackupService()
+      : new BackupService(logger),
+    detectorRegistry: new DetectorRegistry(),
+    strategyRegistry: new StrategyRegistry(),
+    gitService: new GitService(),
+    migrationRegistry: new MigrationRegistry(),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
 
 import { createProgram } from "./cli/index.js";
-import { printUpdateWarning } from "./cli/print-update-warning.js";
-import { runUpdateCheck } from "./cli/update-check.js";
 
 /**
  * Run the Lisa CLI entrypoint.
+ *
+ * The npm update-check now runs inside the program's `preAction` hook (wired in
+ * {@link createProgram}) so it fires exactly once per invocation before the
+ * matched action, for every subcommand and the positional default alike.
  * @returns Promise that resolves after Commander completes
  */
 async function main(): Promise<void> {
-  const updateCheck = await runUpdateCheck();
   const program = createProgram();
-
-  printUpdateWarning(updateCheck);
   await program.parseAsync();
 }
 

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../../src/cli/index.js";
+import { getPackageVersion } from "../../../src/cli/version.js";
+import type { UpdateCheckResult } from "../../../src/cli/update-check.js";
+
+const DEST = "./sample-proj";
+
+const SKIPPED_RESULT: UpdateCheckResult = {
+  current: "0.0.0",
+  latest: null,
+  isOutdated: false,
+  reason: "skipped",
+};
+
+/**
+ * Build a program whose update-check and apply action are stubbed so tests can
+ * observe wiring without touching the npm registry or the real orchestrator.
+ * @returns The program plus the injected spies
+ */
+function createTestProgram(): {
+  program: ReturnType<typeof createProgram>;
+  runApply: ReturnType<typeof vi.fn>;
+  runUpdateCheck: ReturnType<typeof vi.fn>;
+  printUpdateWarning: ReturnType<typeof vi.fn>;
+} {
+  const runApply = vi.fn(async () => undefined);
+  const runUpdateCheck = vi.fn(async () => SKIPPED_RESULT);
+  const printUpdateWarning = vi.fn();
+  const program = createProgram({
+    runApply,
+    runUpdateCheck,
+    printUpdateWarning,
+  }).exitOverride();
+  return { program, runApply, runUpdateCheck, printUpdateWarning };
+}
+
+describe("createProgram", () => {
+  it("names the program lisa and reports the package.json version (not the hardcoded 1.0.0)", () => {
+    const { program } = createTestProgram();
+    expect(program.name()).toBe("lisa");
+    expect(program.version()).toBe(getPackageVersion());
+    expect(program.version()).not.toBe("1.0.0");
+  });
+
+  it("registers an explicit apply subcommand", () => {
+    const { program } = createTestProgram();
+    const subcommandNames = program.commands.map(command => command.name());
+    expect(subcommandNames).toContain("apply");
+  });
+
+  it("exposes the root --no-update-check option", () => {
+    const { program } = createTestProgram();
+    const rootLongs = program.options.map(option => option.long);
+    expect(rootLongs).toContain("--no-update-check");
+  });
+});
+
+describe("backwards-compatible invocation", () => {
+  it("routes the bare positional form `lisa <destination>` to runApply", async () => {
+    const { program, runApply } = createTestProgram();
+
+    await program.parseAsync([DEST, "--yes"], { from: "user" });
+
+    expect(runApply).toHaveBeenCalledTimes(1);
+    expect(runApply.mock.calls[0][0]).toBe(DEST);
+    expect(runApply.mock.calls[0][1]).toMatchObject({ yes: true });
+  });
+
+  it("routes `lisa apply <destination>` to the same runApply with the same options", async () => {
+    const { program, runApply } = createTestProgram();
+
+    await program.parseAsync(["apply", DEST, "--yes"], {
+      from: "user",
+    });
+
+    expect(runApply).toHaveBeenCalledTimes(1);
+    expect(runApply.mock.calls[0][0]).toBe(DEST);
+    expect(runApply.mock.calls[0][1]).toMatchObject({ yes: true });
+  });
+
+  it("forwards every shared flag through the positional form", async () => {
+    const { program, runApply } = createTestProgram();
+
+    await program.parseAsync(
+      [DEST, "--yes", "--dry-run", "--skip-git-check", "--harness", "codex"],
+      { from: "user" }
+    );
+
+    expect(runApply.mock.calls[0][1]).toMatchObject({
+      yes: true,
+      dryRun: true,
+      skipGitCheck: true,
+      harness: "codex",
+    });
+  });
+});
+
+describe("update-check pre-action hook", () => {
+  it("runs the update check exactly once before the apply action", async () => {
+    const { program, runApply, runUpdateCheck, printUpdateWarning } =
+      createTestProgram();
+
+    await program.parseAsync(["apply", DEST, "--yes"], {
+      from: "user",
+    });
+
+    expect(runUpdateCheck).toHaveBeenCalledTimes(1);
+    expect(printUpdateWarning).toHaveBeenCalledTimes(1);
+    expect(runApply).toHaveBeenCalledTimes(1);
+    expect(runUpdateCheck.mock.invocationCallOrder[0]).toBeLessThan(
+      runApply.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("runs the update check once for the positional form too", async () => {
+    const { program, runUpdateCheck } = createTestProgram();
+
+    await program.parseAsync([DEST, "--yes"], { from: "user" });
+
+    expect(runUpdateCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run the update check when --no-update-check is passed", async () => {
+    const { program, runUpdateCheck } = createTestProgram();
+
+    await program.parseAsync(["apply", DEST, "--yes", "--no-update-check"], {
+      from: "user",
+    });
+
+    expect(runUpdateCheck).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/shared-options.test.ts
+++ b/tests/unit/cli/shared-options.test.ts
@@ -1,0 +1,72 @@
+import { Command, InvalidArgumentError } from "commander";
+import { describe, expect, it } from "vitest";
+import { HARNESS_VALUES } from "../../../src/core/config.js";
+import {
+  addSharedOptions,
+  parseHarnessArg,
+} from "../../../src/cli/shared-options.js";
+
+describe("parseHarnessArg", () => {
+  it("returns the value unchanged for every supported harness", () => {
+    for (const harness of HARNESS_VALUES) {
+      expect(parseHarnessArg(harness)).toBe(harness);
+    }
+  });
+
+  it("throws InvalidArgumentError listing the allowed values for an unknown harness", () => {
+    expect(() => parseHarnessArg("nonsense")).toThrow(InvalidArgumentError);
+    try {
+      parseHarnessArg("nonsense");
+    } catch (error) {
+      expect((error as Error).message).toContain(HARNESS_VALUES.join(" | "));
+      expect((error as Error).message).toContain('"nonsense"');
+    }
+  });
+});
+
+describe("addSharedOptions", () => {
+  it("registers the shared apply flags on a command", () => {
+    const command = addSharedOptions(new Command("apply"));
+    const optionFlags = command.options.map(option => option.long);
+
+    expect(optionFlags).toEqual(
+      expect.arrayContaining([
+        "--dry-run",
+        "--yes",
+        "--validate",
+        "--skip-git-check",
+        "--harness",
+      ])
+    );
+  });
+
+  it("returns the same command instance for chaining", () => {
+    const command = new Command("apply");
+    expect(addSharedOptions(command)).toBe(command);
+  });
+
+  it("parses the shared flags into the documented CLIOptions shape", () => {
+    const command = addSharedOptions(new Command("apply"))
+      .argument("[destination]")
+      .exitOverride();
+
+    command.parse(
+      [
+        "./sample-proj",
+        "--yes",
+        "--dry-run",
+        "--skip-git-check",
+        "--harness",
+        "codex",
+      ],
+      { from: "user" }
+    );
+
+    expect(command.opts()).toMatchObject({
+      yes: true,
+      dryRun: true,
+      skipGitCheck: true,
+      harness: "codex",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refactors the single-action `lisa [options] <destination>` Commander program into a subcommand-style root, so subsequent stories (1.2 / 1.3 / 1.4) have a clean place to hang new subcommands — while preserving every existing invocation exactly.

- Extracted the apply action into `src/cli/apply.ts` (`runApply`), relocated verbatim from the old inline `runLisa`.
- Moved `parseHarnessArg`, `CLIOptions`, `createDependencies`, and the shared flag set into `src/cli/shared-options.ts` with an `addSharedOptions(cmd)` helper reused by every entry point.
- Made `apply` both an explicit subcommand and Commander's **default command**, so `lisa <dest>` and `lisa apply <dest>` route to the same action with identical options and exit codes. (Commander v12 rejects a root-level positional `argument` once subcommands exist, so the default-command pattern is the supported way to keep the bare-positional form.)
- Wired the npm update-check (Story 1.0) into a `preAction` hook so it fires exactly once per invocation before any action, honoring `--no-update-check`; the entrypoint (`src/index.ts`) no longer runs it inline.
- Root `--version` reads from `package.json` via `getPackageVersion()` (not the hardcoded `1.0.0`).

**Out of scope (separate stories):** the new subcommands themselves (`setup-project`, `setup-wiki`, `doctor`, `version`, `update`) and starter-repo creation.

Refs #974

## Test plan

New unit tests:
- `tests/unit/cli/index.test.ts` — program name/version, `apply` subcommand registration, `--no-update-check` option, positional-vs-`apply` routing parity, full flag forwarding, and the update-check `preAction` hook (fires once, before the action, skipped on `--no-update-check`).
- `tests/unit/cli/shared-options.test.ts` — `parseHarnessArg` valid/invalid (error message content), `addSharedOptions` flag registration + parsing.

Validation journey (built CLI, scratch git repo):
- `lisa --version` → `2.130.3` (matches `package.json`, not `1.0.0`). ✅
- `lisa --help` → lists the `apply` subcommand. ✅
- `lisa <dest> --yes --dry-run` → exit 0. ✅
- `lisa apply <dest> --yes --dry-run` → exit 0; stdout **byte-identical** to the positional form. ✅
- Postinstall sim `lisa <dest> --yes --skip-git-check` → exit 0. ✅
- Real (non-dry-run) `lisa <dest> --yes --skip-git-check` → exit 0. ✅

Suite: `bun run typecheck`, `bun run lint` (0 errors), `bun run knip` (0 unused exports), full `bun run test:cov` (2808 passed, thresholds met). No `plugins/` artifacts were touched (no plugin source changed).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--no-update-check` flag to skip npm package update checks during command execution.

* **Improvements**  
  * Enhanced harness argument validation to display clearer error messages listing all allowed harness values when invalid input is provided.

* **Refactor**
  * Restructured internal CLI module organization to improve code maintainability and testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->