### PR TITLE
test(agy): de-flake block-no-verify hook test under parallel coverage load

### DIFF
--- a/tests/unit/agy/block-no-verify-agy.test.ts
+++ b/tests/unit/agy/block-no-verify-agy.test.ts
@@ -6,12 +6,22 @@
  * (`{"decision":"deny"|"allow"}`) on stdout. Since headless firing is
  * quota-blocked, this script-logic test is the real verification. Payloads are
  * hardcoded (no coupling). Requires `jq` on PATH (used across the repo).
+ *
+ * The hook is invoked via a fixed interpreter (`/bin/bash <script>`), the same
+ * way the sibling block-no-verify.test.ts runs the Claude hook. Running the
+ * script directly by its absolute path relied on the `#!/usr/bin/env bash`
+ * shebang, which adds an extra `execve` of `/usr/bin/env`, a PATH lookup for
+ * `bash`, and a load-bearing executable bit. Under the fork/exec pressure of a
+ * full `--coverage` run that indirect spawn could transiently fail to start;
+ * because `cat` then never drained the stdin pipe, Node surfaced the failed
+ * write as an EPIPE/spawn error and the test errored intermittently (it always
+ * passed in isolation). Spawning a fixed interpreter removes the shebang, the
+ * PATH lookup, and the exec-bit dependency, so the spawn is deterministic.
  * @module tests/unit/agy/block-no-verify-agy
  */
-import { execFileSync } from "node:child_process";
-import { chmodSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import * as path from "node:path";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const SCRIPT = path.join(
   process.cwd(),
@@ -22,15 +32,21 @@ const SCRIPT = path.join(
   "block-no-verify.agy.sh"
 );
 
+const BASH_PATH = "/bin/bash";
+
 // Run the hook with the given stdin and return the parsed `decision` field.
-// Invokes the script by absolute path (executable via its shebang) so no
-// command is resolved from PATH.
+// Invokes the script through a fixed bash interpreter (not the shebang) so the
+// spawn does not depend on the executable bit or a PATH lookup. A spawn failure
+// is surfaced explicitly rather than masquerading as a JSON parse error.
 const decide = (stdin: string): string => {
-  const out = execFileSync(SCRIPT, [], {
+  const result = spawnSync(BASH_PATH, [SCRIPT], {
     input: stdin,
     encoding: "utf8",
   });
-  return (JSON.parse(out) as { decision: string }).decision;
+  if (result.error) {
+    throw result.error;
+  }
+  return (JSON.parse(result.stdout) as { decision: string }).decision;
 };
 
 // Build an agy PreToolUse stdin payload for a run_command tool call.
@@ -40,12 +56,6 @@ const payload = (commandLine: string): string =>
   });
 
 describe("block-no-verify.agy.sh", () => {
-  // Ensure the script is executable regardless of checkout mode bits, so it can
-  // be invoked directly by its absolute path (no PATH lookup).
-  beforeAll(() => {
-    chmodSync(SCRIPT, 0o755);
-  });
-
   it("denies a git commit with --no-verify", () => {
     expect(decide(payload("git commit --no-verify -m wip"))).toBe("deny");
   });


### PR DESCRIPTION
## Summary

Makes `tests/unit/agy/block-no-verify-agy.test.ts` deterministic. It intermittently errored under the fork/exec pressure of a full `bun run test:cov` run while always passing in isolation, and bounced a push during the build of #974 (PR #1114).

## Root cause

By contrast with the never-flaking sibling `tests/unit/hooks/block-no-verify.test.ts`, the agy test spawned the script **directly by absolute path** via `execFileSync(SCRIPT, [], { input })`, relying on the `#!/usr/bin/env bash` shebang. That indirect path adds three load-sensitive failure points the sibling test doesn't have:

1. an extra `execve` of `/usr/bin/env`,
2. a PATH lookup for `bash` inside `env`, and
3. a load-bearing executable bit (the `beforeAll` `chmodSync`).

Under saturation, if that indirect spawn transiently fails to start, the script's `cat` never drains the stdin pipe, so Node surfaces the failed write as an EPIPE/spawn error and `execFileSync` throws — an intermittent test error. The sibling Claude-hook test never flakes because it spawns a **fixed interpreter directly**: `spawnSync("/bin/bash", [HOOK], { input })`.

## Fix

Not retries or timeout bumps — the fragile spawn path is removed:

- `decide()` now uses `spawnSync("/bin/bash", [SCRIPT], { input })`, matching the proven-stable sibling test.
- Removed the now-unneeded `chmodSync` / `beforeAll` (exec bit is irrelevant when bash reads the file).
- A genuine spawn failure is thrown explicitly instead of masquerading as a JSON parse error.

Behavior is byte-identical: all 17 assertions preserved and unchanged.

## Verification

- 17/17 unit assertions pass; `typecheck` and `eslint` clean.
- Behavior-equivalence confirmed across all 14 decision cases + 3 fail-open edge cases under direct `/bin/bash` (bash 3.2 macOS and 5.x).
- **10 consecutive full `test:cov` runs** all green (165 files each) post-fix.
- Diff scoped to the single test file — no plugin artifacts (`plugins/lisa*`) or the hook script touched.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution reliability and error handling for block verification tests, ensuring more deterministic test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->