### PR TITLE
fix(expo): make jest resolver + react-test-renderer SDK-54/56 aware

### DIFF
--- a/expo/copy-overwrite/knip.json
+++ b/expo/copy-overwrite/knip.json
@@ -87,6 +87,7 @@
     "@react-native-community/cli-platform-ios",
     "@react-native-community/netinfo",
     "@react-native-masked-view/masked-view",
+    "@react-navigation/drawer",
     "@react-navigation/elements",
     "@react-navigation/native",
     "@shopify/flash-list",

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -167,8 +167,7 @@
       "@types/react": "~19.2.15",
       "@types/react-dom": "~19.2.3",
       "expo-atlas": "^0.4.0",
-      "jest-expo": "~56.0.4",
-      "react-test-renderer": "19.2.3"
+      "jest-expo": "~56.0.4"
     }
   }
 }

--- a/src/configs/jest/expo.ts
+++ b/src/configs/jest/expo.ts
@@ -31,6 +31,8 @@
  * @see https://github.com/expo/expo/issues/40184
  * @module configs/jest/expo
  */
+import { createRequire } from "node:module";
+
 import type { Config } from "jest";
 
 import {
@@ -49,6 +51,49 @@ export {
   mergeThresholds,
   worktreeTestPathIgnorePatterns,
 };
+
+/**
+ * SDK 56 / RN 0.85 relocated the React Native Jest resolver. On SDK 56 it
+ * lives at `@react-native/jest-preset/jest/resolver.js`; on SDK 54 / RN 0.81
+ * `@react-native/jest-preset` is not installed and the resolver still lives at
+ * `react-native/jest/resolver.js`. Picking the wrong one aborts Jest with a
+ * "module not found" error, so the choice must be made against what the
+ * consuming project actually has installed.
+ */
+const SDK56_RESOLVER = "@react-native/jest-preset/jest/resolver.js";
+const LEGACY_RESOLVER = "react-native/jest/resolver.js";
+
+/**
+ * Predicate that reports whether a module specifier can be resolved from the
+ * consuming project. Mirrors the runtime auto-detection style this factory
+ * already uses (e.g. `existsSync` for the `/src` convention) and is injectable
+ * so the choice can be exercised in tests without an installed RN toolchain.
+ * @param specifier - The module specifier to attempt to resolve.
+ * @returns `true` when the specifier resolves from the project's `node_modules`.
+ */
+const canResolveFromProject = (specifier: string): boolean => {
+  // Resolve relative to the consuming project's CWD (where Jest runs) rather
+  // than Lisa's own `node_modules`, so hoisted/nested installs are honored.
+  const projectRequire = createRequire(`${process.cwd()}/noop.js`);
+  try {
+    projectRequire.resolve(specifier);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Selects the React Native Jest resolver path appropriate for the installed
+ * Expo SDK. Prefers the SDK 56 location when `@react-native/jest-preset` is
+ * present, otherwise falls back to the SDK 54 location.
+ * @param canResolve - Resolution predicate (defaults to a real project-scoped
+ * `require.resolve` check); injectable for testing both SDKs.
+ * @returns The resolver module path for the project's installed SDK.
+ */
+export const selectExpoJestResolver = (
+  canResolve: (specifier: string) => boolean = canResolveFromProject
+): string => (canResolve(SDK56_RESOLVER) ? SDK56_RESOLVER : LEGACY_RESOLVER);
 
 /**
  * Options for configuring the Expo Jest config factory.
@@ -85,11 +130,11 @@ export const getExpoJestConfig = ({
     defaultPlatform: "ios",
     platforms: ["android", "ios", "native"],
   },
-  // SDK 56 / RN 0.85 relocated the React Native Jest resolver out of
-  // `react-native/jest/resolver.js` and into `@react-native/jest-preset`.
-  // This resolver is what teaches Jest to resolve platform-extension files
+  // This resolver teaches Jest to resolve platform-extension files
   // (`.ios`/`.native`/`.web`); without it those variants do not resolve.
-  resolver: "@react-native/jest-preset/jest/resolver.js",
+  // Its location moved between SDK 54 and SDK 56, so the path is chosen at
+  // config-build time against what the consuming project has installed.
+  resolver: selectExpoJestResolver(),
   setupFiles: ["<rootDir>/jest.setup.pre.js"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   transform: {

--- a/tests/unit/config/jest-expo.test.ts
+++ b/tests/unit/config/jest-expo.test.ts
@@ -1,5 +1,11 @@
-import { getExpoJestConfig } from "../../../src/configs/jest/expo.js";
+import {
+  getExpoJestConfig,
+  selectExpoJestResolver,
+} from "../../../src/configs/jest/expo.js";
 import { defaultThresholds } from "../../../src/configs/jest/base.js";
+
+const SDK56_RESOLVER = "@react-native/jest-preset/jest/resolver.js";
+const LEGACY_RESOLVER = "react-native/jest/resolver.js";
 
 describe("jest.expo", () => {
   describe("getExpoJestConfig", () => {
@@ -20,10 +26,31 @@ describe("jest.expo", () => {
       });
     });
 
-    it("uses React Native resolver", () => {
-      expect(config.resolver).toBe(
-        "@react-native/jest-preset/jest/resolver.js"
-      );
+    it("uses a valid React Native resolver path for the installed SDK", () => {
+      expect([SDK56_RESOLVER, LEGACY_RESOLVER]).toContain(config.resolver);
+    });
+
+    describe("selectExpoJestResolver (SDK-aware resolver selection)", () => {
+      it("uses the SDK 56 resolver when @react-native/jest-preset is present", () => {
+        const resolver = selectExpoJestResolver(
+          specifier => specifier === SDK56_RESOLVER
+        );
+        expect(resolver).toBe(SDK56_RESOLVER);
+      });
+
+      it("falls back to the SDK 54 resolver when the preset is absent", () => {
+        const resolver = selectExpoJestResolver(() => false);
+        expect(resolver).toBe(LEGACY_RESOLVER);
+      });
+
+      it("only probes for the SDK 56 preset (not the legacy path)", () => {
+        const probed: string[] = [];
+        selectExpoJestResolver(specifier => {
+          probed.push(specifier);
+          return false;
+        });
+        expect(probed).toEqual([SDK56_RESOLVER]);
+      });
     });
 
     it("registers base pre-setup file in setupFiles", () => {

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -801,12 +801,18 @@ describe("PackageLisaStrategy", () => {
           expect(template.force.dependencies[pkg]).toBeUndefined();
         }
       }
-      // SDK-coupled devDependencies (jest-expo, react-test-renderer) are defaults.
+      // SDK-coupled jest-expo stays a default (never forced).
       expect(template.defaults.devDependencies["jest-expo"]).toBeDefined();
       expect(template.force.devDependencies["jest-expo"]).toBeUndefined();
+      // react-test-renderer must NOT be pinned by Lisa at all. @testing-library/
+      // react-native v13 requires react-test-renderer to match the project's
+      // installed React exactly, and jest-expo already brings the matched version
+      // transitively (54 → 19.1.0, 56 → 19.2.3). A hardcoded default (e.g. 19.2.3)
+      // would override jest-expo's 19.1.0 on an SDK-54 project and break its test
+      // suite with "Expected 19.1.0, but found 19.2.3".
       expect(
         template.defaults.devDependencies["react-test-renderer"]
-      ).toBeDefined();
+      ).toBeUndefined();
       expect(
         template.force.devDependencies["react-test-renderer"]
       ).toBeUndefined();


### PR DESCRIPTION
## Context

Release **2.132.6** stopped force-bumping the Expo SDK, so SDK-54 projects now correctly stay on SDK 54. But the Expo test toolchain still assumed SDK 56, breaking the **test gate on every SDK-54 project**. Downstream evidence: `propswap/frontend` and `thumbwar/frontend` (both Expo SDK 54) failed their jest gates on 2.132.6 — the resolver-not-found abort and the react-test-renderer version mismatch below.

This makes the Expo stack truly support BOTH SDK 54 and SDK 56.

## Fix 1 (primary) — SDK-aware jest resolver

`getExpoJestConfig` (`src/configs/jest/expo.ts`, imported by every Expo project's `jest.config.ts` via `@codyswann/lisa/jest/expo`) hardcoded:

```ts
resolver: "@react-native/jest-preset/jest/resolver.js"
```

That path only exists on **SDK 56 / RN 0.85**. On **SDK 54 / RN 0.81** the resolver lives at `react-native/jest/resolver.js` and `@react-native/jest-preset` isn't installed, so Jest aborted with *"Module @react-native/jest-preset/jest/resolver.js … was not found"*.

The path is now chosen at config-build time:

```ts
export const selectExpoJestResolver = (
  canResolve: (specifier: string) => boolean = canResolveFromProject
): string => (canResolve(SDK56_RESOLVER) ? SDK56_RESOLVER : LEGACY_RESOLVER);
```

`canResolveFromProject` resolves against the **consuming project's** node_modules (`createRequire(\`${process.cwd()}/noop.js\`)` + `require.resolve(...)` wrapped in try/catch) — mirroring the existing `existsSync`-based `sourceRoot` auto-detection style. It prefers the SDK-56 preset when present and falls back to the SDK-54 legacy path otherwise. Correct for BOTH SDKs. The helper is exported and unit-tested for both branches.

## Fix 2 — react-test-renderer must not break SDK 54

`expo/package-lisa/package.lisa.json` had `react-test-renderer: "19.2.3"` in `defaults.devDependencies`. Because `defaults` injects when the key is absent, an SDK-54 project (React 19.1.0) without it got `19.2.3` added — and `@testing-library/react-native` v13 requires react-test-renderer to match the installed React **exactly** → *"Expected 19.1.0, but found 19.2.3"*.

**Verified against the published tarballs:**
- `@testing-library/react-native@13.3.3` lists `react-test-renderer` as a **required (non-optional) peer** with version `>=18.2.0` (no exact pin).
- `jest-expo` already brings the React-matched `react-test-renderer` **transitively**: `jest-expo@54.0.17` → `19.1.0`, `jest-expo@56.0.4` → `19.2.3`.
- (`@react-native/jest-preset@^0.85.0` is a peer of `jest-expo@56` and absent from `jest-expo@54` — independently confirming Fix 1's SDK split.)

So Lisa must **not pin react-test-renderer at all**. Removed it from `defaults.devDependencies`; the SDK's own `jest-expo` governs the React-matched version on both SDKs.

## Fix 3 (minor) — knip ignore

SDK-56 expo now pulls in `@react-navigation/drawer`, causing a per-project knip failure. Added it to `expo/copy-overwrite/knip.json` `ignoreDependencies` (alphabetical placement).

## Verification

- `tsc --noEmit`: clean
- Full `vitest run`: **2868 tests passed** (166 files)
- Pre-commit (secret scan, typecheck, lint-staged eslint/prettier/ast-grep, commitlint) and pre-push (coverage + integration) hooks: green
- None of the changed files feed `plugins/src`, so no `build:plugins`/`check:plugins` needed
- Updated only the two assertions whose behavior legitimately changed: the resolver selection test (now covers both SDKs) and the package.lisa.json test (react-test-renderer no longer pinned)

🤖 Generated with Claude Code