### PR TITLE
feat(cli): add setup-project command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import { runApply } from "./apply.js";
 import { printUpdateWarning } from "./print-update-warning.js";
+import { runSetupProject } from "./setup-project.js";
 import { addSharedOptions, type CLIOptions } from "./shared-options.js";
+import { SETUP_TYPES } from "./starters.js";
 import { runUpdateCheck } from "./update-check.js";
 import { getPackageVersion } from "./version.js";
 
@@ -13,6 +15,8 @@ import { getPackageVersion } from "./version.js";
 export interface ProgramDependencies {
   /** Applies Lisa to a destination (defaults to the real {@link runApply}). */
   runApply: typeof runApply;
+  /** Creates a starter-backed project and applies Lisa overlays. */
+  runSetupProject: typeof runSetupProject;
   /** Runs the non-fatal npm update check (defaults to {@link runUpdateCheck}). */
   runUpdateCheck: typeof runUpdateCheck;
   /** Prints the update warning (defaults to {@link printUpdateWarning}). */
@@ -21,6 +25,7 @@ export interface ProgramDependencies {
 
 const DEFAULT_DEPENDENCIES: ProgramDependencies = {
   runApply,
+  runSetupProject,
   runUpdateCheck,
   printUpdateWarning,
 };
@@ -76,6 +81,24 @@ export function createProgram(
   ).action(async (destination: string | undefined, options: CLIOptions) => {
     await deps.runApply(destination, options);
   });
+
+  addSharedOptions(
+    program
+      .command("setup-project")
+      .description("Create a new Lisa-managed project from a starter repo")
+      .requiredOption(
+        "--type <type>",
+        `Project type: ${SETUP_TYPES.join(" | ")}`
+      )
+      .argument("[destination]", "Project name or path (default: ./<type>-app)")
+  ).action(
+    async (
+      destination: string | undefined,
+      options: CLIOptions & { type?: string }
+    ) => {
+      await deps.runSetupProject(destination, options);
+    }
+  );
 
   return program;
 }

--- a/src/cli/setup-project.ts
+++ b/src/cli/setup-project.ts
@@ -1,0 +1,199 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
+import * as path from "node:path";
+import { type CLIOptions } from "./shared-options.js";
+import { isSetupType, resolveStarter, SETUP_TYPES } from "./starters.js";
+
+/**
+ * Parsed options for the setup-project command.
+ */
+export interface SetupProjectOptions extends CLIOptions {
+  type?: string;
+}
+
+/**
+ * Injectable collaborators for setup-project.
+ */
+export interface SetupProjectDependencies {
+  runApply: (
+    destination: string | undefined,
+    options: CLIOptions
+  ) => Promise<void>;
+  runCommand: (
+    command: string,
+    args: readonly string[],
+    options?: { cwd?: string }
+  ) => Promise<void>;
+}
+
+/**
+ * Remove setup-project-only fields from the options forwarded to apply.
+ * @param options - Parsed setup-project options
+ * @returns Shared apply options without undefined optional properties
+ */
+function toCliOptions(options: SetupProjectOptions): CLIOptions {
+  return {
+    ...(options.dryRun !== undefined ? { dryRun: options.dryRun } : {}),
+    ...(options.yes !== undefined ? { yes: options.yes } : {}),
+    ...(options.validate !== undefined ? { validate: options.validate } : {}),
+    ...(options.skipGitCheck !== undefined
+      ? { skipGitCheck: options.skipGitCheck }
+      : {}),
+    ...(options.harness !== undefined ? { harness: options.harness } : {}),
+  };
+}
+
+export const DEFAULT_SETUP_PROJECT_DEPENDENCIES: SetupProjectDependencies = {
+  runApply: async () => {
+    throw new Error("runApply dependency was not configured");
+  },
+  runCommand,
+};
+
+/**
+ * Run a command as a child process and reject on non-zero exit.
+ * @param command - Executable name
+ * @param args - Command arguments
+ * @param options - Spawn options
+ * @param options.cwd - Optional working directory for the command
+ * @returns Promise that resolves when the command exits successfully
+ */
+async function runCommand(
+  command: string,
+  args: readonly string[],
+  options: { cwd?: string } = {}
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", code => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} exited ${code ?? 1}`));
+    });
+  });
+}
+
+/**
+ * Check whether a destination exists and contains files.
+ * @param destination - Project destination path
+ * @returns True when the destination directory is non-empty
+ */
+async function directoryIsNonEmpty(destination: string): Promise<boolean> {
+  if (!existsSync(destination)) {
+    return false;
+  }
+  return (await readdir(destination)).length > 0;
+}
+
+/**
+ * Detect whether the GitHub CLI is authenticated.
+ * @param deps - Injectable setup-project dependencies
+ * @returns True when `gh auth status` succeeds
+ */
+async function ghIsAuthenticated(
+  deps: SetupProjectDependencies
+): Promise<boolean> {
+  try {
+    await deps.runCommand("gh", ["auth", "status"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clone or create the starter project for a setup type.
+ * @param type - Lisa setup type
+ * @param destination - Project destination path
+ * @param deps - Injectable setup-project dependencies
+ * @returns Promise that resolves after the starter is available locally
+ */
+async function cloneStarter(
+  type: string,
+  destination: string,
+  deps: SetupProjectDependencies
+): Promise<void> {
+  if (!isSetupType(type)) {
+    throw new Error(
+      `Unknown setup type ${JSON.stringify(type)}. Valid types: ${SETUP_TYPES.join(", ")}`
+    );
+  }
+
+  const starter = resolveStarter(type);
+  const parentDir = path.dirname(destination);
+  const projectName = path.basename(destination);
+  const starterRef = `${starter.owner}/${starter.repo}`;
+
+  if (await ghIsAuthenticated(deps)) {
+    await deps.runCommand(
+      "gh",
+      [
+        "repo",
+        "create",
+        projectName,
+        "--template",
+        starterRef,
+        "--public",
+        "--clone",
+      ],
+      { cwd: parentDir }
+    );
+    return;
+  }
+
+  await deps.runCommand("git", [
+    "clone",
+    "--depth=1",
+    `https://github.com/${starterRef}.git`,
+    destination,
+  ]);
+  await rm(path.join(destination, ".git"), { recursive: true, force: true });
+  await deps.runCommand("git", ["init", "-b", "main"], { cwd: destination });
+}
+
+/**
+ * Create a Lisa-managed project from a starter and then apply overlays.
+ * @param destination - Optional project name or path
+ * @param options - Parsed setup-project options
+ * @param dependencies - Injectable collaborators
+ * @returns Promise that resolves after setup and apply complete
+ */
+export async function runSetupProject(
+  destination: string | undefined,
+  options: SetupProjectOptions,
+  dependencies: SetupProjectDependencies = DEFAULT_SETUP_PROJECT_DEPENDENCIES
+): Promise<void> {
+  if (!options.type) {
+    throw new Error(
+      `Missing required --type. Valid types: ${SETUP_TYPES.join(", ")}`
+    );
+  }
+  if (!isSetupType(options.type)) {
+    throw new Error(
+      `Unknown setup type ${JSON.stringify(options.type)}. Valid types: ${SETUP_TYPES.join(", ")}`
+    );
+  }
+
+  const resolvedDestination = path.resolve(
+    destination ?? `./${options.type}-app`
+  );
+
+  if (!(await directoryIsNonEmpty(resolvedDestination))) {
+    if (options.dryRun || options.validate) {
+      console.log(
+        `Would create ${resolvedDestination} from ${resolveStarter(options.type).owner}/${resolveStarter(options.type).repo}`
+      );
+    } else {
+      await cloneStarter(options.type, resolvedDestination, dependencies);
+    }
+  }
+
+  await dependencies.runApply(resolvedDestination, toCliOptions(options));
+}

--- a/src/cli/starters.ts
+++ b/src/cli/starters.ts
@@ -1,0 +1,59 @@
+export const SETUP_TYPES = [
+  "rails",
+  "typescript",
+  "expo",
+  "nestjs",
+  "cdk",
+  "wiki",
+  "harper-wiki",
+] as const;
+
+/**
+ * Supported starter-backed project setup types.
+ */
+export type SetupType = (typeof SETUP_TYPES)[number];
+
+/**
+ * Metadata for a starter repository used by setup-project.
+ */
+export interface Starter {
+  readonly owner: string;
+  readonly repo: string;
+  readonly template: true;
+}
+
+export const STARTERS: Record<SetupType, Starter> = {
+  rails: { owner: "CodySwannGT", repo: "railsstarter", template: true },
+  typescript: {
+    owner: "CodySwannGT",
+    repo: "typescriptstarter",
+    template: true,
+  },
+  expo: { owner: "CodySwannGT", repo: "expostarter", template: true },
+  nestjs: { owner: "CodySwannGT", repo: "nestjsstarter", template: true },
+  cdk: { owner: "CodySwannGT", repo: "cdkstarter", template: true },
+  wiki: { owner: "CodySwannGT", repo: "wikistarter", template: true },
+  "harper-wiki": {
+    owner: "CodySwannGT",
+    repo: "harperwikistarter",
+    template: true,
+  },
+};
+
+/**
+ * Check whether a raw string is a supported setup type.
+ * @param value - Raw setup type value
+ * @returns True when value is a supported setup type
+ */
+export function isSetupType(value: string): value is SetupType {
+  return SETUP_TYPES.includes(value as SetupType);
+}
+
+/**
+ * Resolve the configured starter template for a setup type.
+ * @param type - Valid Lisa setup type
+ * @returns Starter repository metadata
+ */
+export function resolveStarter(type: SetupType): Starter {
+  return STARTERS[type];
+}

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -20,18 +20,27 @@ const SKIPPED_RESULT: UpdateCheckResult = {
 function createTestProgram(): {
   program: ReturnType<typeof createProgram>;
   runApply: ReturnType<typeof vi.fn>;
+  runSetupProject: ReturnType<typeof vi.fn>;
   runUpdateCheck: ReturnType<typeof vi.fn>;
   printUpdateWarning: ReturnType<typeof vi.fn>;
 } {
   const runApply = vi.fn(async () => undefined);
+  const runSetupProject = vi.fn(async () => undefined);
   const runUpdateCheck = vi.fn(async () => SKIPPED_RESULT);
   const printUpdateWarning = vi.fn();
   const program = createProgram({
     runApply,
+    runSetupProject,
     runUpdateCheck,
     printUpdateWarning,
   }).exitOverride();
-  return { program, runApply, runUpdateCheck, printUpdateWarning };
+  return {
+    program,
+    runApply,
+    runSetupProject,
+    runUpdateCheck,
+    printUpdateWarning,
+  };
 }
 
 describe("createProgram", () => {
@@ -46,6 +55,12 @@ describe("createProgram", () => {
     const { program } = createTestProgram();
     const subcommandNames = program.commands.map(command => command.name());
     expect(subcommandNames).toContain("apply");
+  });
+
+  it("registers the setup-project subcommand", () => {
+    const { program } = createTestProgram();
+    const subcommandNames = program.commands.map(command => command.name());
+    expect(subcommandNames).toContain("setup-project");
   });
 
   it("exposes the root --no-update-check option", () => {
@@ -128,5 +143,25 @@ describe("update-check pre-action hook", () => {
     });
 
     expect(runUpdateCheck).not.toHaveBeenCalled();
+  });
+});
+
+describe("setup-project invocation", () => {
+  it("routes setup-project to the setup action with shared options", async () => {
+    const { program, runSetupProject } = createTestProgram();
+
+    await program.parseAsync(
+      ["setup-project", "--type", "rails", DEST, "--yes", "--harness", "codex"],
+      { from: "user" }
+    );
+
+    expect(runSetupProject).toHaveBeenCalledWith(
+      DEST,
+      expect.objectContaining({
+        type: "rails",
+        yes: true,
+        harness: "codex",
+      })
+    );
   });
 });

--- a/tests/unit/cli/setup-project.test.ts
+++ b/tests/unit/cli/setup-project.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  runSetupProject,
+  type SetupProjectDependencies,
+} from "../../../src/cli/setup-project.js";
+
+/**
+ * Create an isolated temporary directory for setup-project tests.
+ * @returns Temporary directory path
+ */
+async function createTempDir(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "lisa-setup-project-"));
+}
+
+/**
+ * Build fake setup-project dependencies.
+ * @param authenticated - Whether `gh auth status` should succeed
+ * @returns Injectable dependencies and their spies
+ */
+function createDeps(authenticated: boolean): {
+  deps: SetupProjectDependencies;
+  runApply: ReturnType<typeof vi.fn>;
+  runCommand: ReturnType<typeof vi.fn>;
+} {
+  const runApply = vi.fn(async () => undefined);
+  const runCommand = vi.fn(async (command: string, args: readonly string[]) => {
+    if (
+      command === "gh" &&
+      args.join(" ") === "auth status" &&
+      !authenticated
+    ) {
+      throw new Error("not authenticated");
+    }
+  });
+
+  return { deps: { runApply, runCommand }, runApply, runCommand };
+}
+
+describe("runSetupProject", () => {
+  it("requires --type", async () => {
+    const { deps } = createDeps(true);
+
+    await expect(runSetupProject("my-app", {}, deps)).rejects.toThrow(
+      "Missing required --type"
+    );
+  });
+
+  it("rejects unknown setup types with the valid type list", async () => {
+    const { deps } = createDeps(true);
+
+    await expect(
+      runSetupProject("my-app", { type: "fortran" }, deps)
+    ).rejects.toThrow("Valid types: rails, typescript, expo");
+  });
+
+  it("creates from a GitHub template when gh is authenticated", async () => {
+    const root = await createTempDir();
+    const destination = path.join(root, "my-app");
+    const { deps, runApply, runCommand } = createDeps(true);
+
+    await runSetupProject(destination, { type: "rails", yes: true }, deps);
+
+    expect(runCommand).toHaveBeenCalledWith("gh", ["auth", "status"]);
+    expect(runCommand).toHaveBeenCalledWith(
+      "gh",
+      [
+        "repo",
+        "create",
+        "my-app",
+        "--template",
+        "CodySwannGT/railsstarter",
+        "--public",
+        "--clone",
+      ],
+      { cwd: root }
+    );
+    expect(runApply).toHaveBeenCalledWith(
+      destination,
+      expect.objectContaining({ yes: true })
+    );
+  });
+
+  it("falls back to git clone when gh is not authenticated", async () => {
+    const root = await createTempDir();
+    const destination = path.join(root, "my-app");
+    const { deps, runCommand } = createDeps(false);
+
+    await runSetupProject(destination, { type: "rails", yes: true }, deps);
+
+    expect(runCommand).toHaveBeenCalledWith("git", [
+      "clone",
+      "--depth=1",
+      "https://github.com/CodySwannGT/railsstarter.git",
+      destination,
+    ]);
+    expect(runCommand).toHaveBeenCalledWith("git", ["init", "-b", "main"], {
+      cwd: destination,
+    });
+  });
+
+  it("treats an existing non-empty destination as an apply target", async () => {
+    const root = await createTempDir();
+    const destination = path.join(root, "my-app");
+    await mkdir(destination);
+    await writeFile(path.join(destination, "package.json"), "{}\n");
+    const { deps, runApply, runCommand } = createDeps(true);
+
+    await runSetupProject(destination, { type: "rails", yes: true }, deps);
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(runApply).toHaveBeenCalledWith(
+      destination,
+      expect.objectContaining({ yes: true })
+    );
+  });
+});

--- a/tests/unit/cli/starters.test.ts
+++ b/tests/unit/cli/starters.test.ts
@@ -34,6 +34,10 @@ describe("starter registry", () => {
   });
 
   it("resolves a starter by setup type", () => {
-    expect(resolveStarter("rails")).toEqual(STARTERS.rails);
+    expect(resolveStarter("rails")).toEqual({
+      owner: "CodySwannGT",
+      repo: "railsstarter",
+      template: true,
+    });
   });
 });

--- a/tests/unit/cli/starters.test.ts
+++ b/tests/unit/cli/starters.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveStarter,
+  SETUP_TYPES,
+  STARTERS,
+} from "../../../src/cli/starters.js";
+
+describe("starter registry", () => {
+  it("maps every setup type to a CodySwannGT template repository", () => {
+    const sortStrings = (left: string, right: string): number =>
+      left.localeCompare(right);
+
+    expect(Object.keys(STARTERS).sort(sortStrings)).toEqual(
+      [...SETUP_TYPES].sort(sortStrings)
+    );
+
+    expect(STARTERS).toMatchObject({
+      rails: { owner: "CodySwannGT", repo: "railsstarter", template: true },
+      typescript: {
+        owner: "CodySwannGT",
+        repo: "typescriptstarter",
+        template: true,
+      },
+      expo: { owner: "CodySwannGT", repo: "expostarter", template: true },
+      nestjs: { owner: "CodySwannGT", repo: "nestjsstarter", template: true },
+      cdk: { owner: "CodySwannGT", repo: "cdkstarter", template: true },
+      wiki: { owner: "CodySwannGT", repo: "wikistarter", template: true },
+      "harper-wiki": {
+        owner: "CodySwannGT",
+        repo: "harperwikistarter",
+        template: true,
+      },
+    });
+  });
+
+  it("resolves a starter by setup type", () => {
+    expect(resolveStarter("rails")).toEqual(STARTERS.rails);
+  });
+});


### PR DESCRIPTION
## Summary
- add the setup-project command and starter registry for supported Lisa project types
- route starter-backed projects through the existing apply flow after creation
- cover command wiring, starter resolution, authenticated template creation, git fallback, and existing-directory apply behavior

## Verification
- bun test tests/unit/cli/index.test.ts tests/unit/cli/setup-project.test.ts tests/unit/cli/starters.test.ts
- bun run typecheck
- bun run build
- pre-push hook: slow lint, knip, unit coverage suite, integration tests

Fixes #975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new setup-project CLI subcommand to scaffold projects from supported starter types; requires --type and accepts an optional destination (defaults to ./{type}-app).
  * Validates supported types and supports dry-run/validate modes; initializes git and runs post-creation apply steps.
  * Uses authenticated GitHub template creation when available, falling back to a shallow git clone otherwise.

* **Tests**
  * Added unit tests covering type validation, auth vs fallback flows, destination handling, and post-creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->