### PR TITLE
fix(postinstall): prevent cross-project package.json corruption in lisa apply

### DIFF
--- a/src/utils/pm-env.ts
+++ b/src/utils/pm-env.ts
@@ -1,0 +1,83 @@
+/**
+ * @file pm-env.ts
+ * @description Package-manager environment sanitization for the postinstall
+ * reconciliation trampoline.
+ *
+ * When Lisa's postinstall schedules a detached reconciliation child (and that
+ * child in turn spawns `bun install` / a Lisa re-invocation), the child must
+ * resolve its target project STRICTLY from the explicit `cwd` / projectDir
+ * argument — never from package-manager-injected environment variables that pin
+ * the package manager to a different project. This module centralizes the list
+ * of those dangerous variables and the function that strips them.
+ * @module utils
+ */
+
+/**
+ * Package-manager-injected environment variable PREFIXES that pin a package
+ * manager to a project directory OTHER than the one it is being told to operate
+ * on via `cwd` / the positional argument.
+ *
+ * We scrub the whole `npm_config_*` / `npm_package_*` / `npm_lifecycle_*`
+ * families rather than enumerating individual keys, because any one of them can
+ * leak a stale project path and new ones appear across package-manager versions.
+ */
+export const PM_PATH_ENV_PREFIXES: readonly string[] = [
+  "npm_config_",
+  "npm_package_",
+  "npm_lifecycle_",
+] as const;
+
+/**
+ * Standalone package-manager-injected environment variable NAMES that, like the
+ * prefixed families, can redirect a re-spawned package manager to a sibling
+ * project. `INIT_CWD` is the classic one; `npm_config_local_prefix` (covered by
+ * the prefix list above) is the most dangerous, because Lisa's own postinstall
+ * script derives `PROJECT_ROOT` from it and bun/npm honour it over `cwd`.
+ */
+export const PM_PATH_ENV_NAMES: readonly string[] = [
+  "INIT_CWD",
+  "npm_node_execpath",
+  "npm_execpath",
+  "PROJECT_CWD",
+  "BUN_INSTALL_CACHE_DIR",
+] as const;
+
+/**
+ * Decide whether a single environment variable name is a package-manager
+ * path/lifecycle variable that must be stripped before a reconciliation re-run.
+ * @param key - Environment variable name
+ * @returns true when the variable could redirect a re-spawned package manager
+ */
+export function isPackageManagerPathEnvVar(key: string): boolean {
+  if (PM_PATH_ENV_NAMES.includes(key)) {
+    return true;
+  }
+  return PM_PATH_ENV_PREFIXES.some(prefix => key.startsWith(prefix));
+}
+
+/**
+ * Strip every package-manager-injected variable that could redirect a re-spawned
+ * package manager (or Lisa re-invocation) away from the explicit target directory.
+ *
+ * Returns a NEW object — the input is not mutated. Used both for the detached
+ * trampoline child's environment and as the source of truth the inline
+ * trampoline script reuses to scrub the environment of the `bun install` / Lisa
+ * processes it spawns.
+ *
+ * Background: during a batched concurrent multi-project Lisa update, the
+ * detached reconciliation child inherited `npm_config_local_prefix` / `INIT_CWD`
+ * pointing at a SIBLING project. bun/npm honour `npm_config_local_prefix` (and
+ * Lisa's postinstall script reads it as `PROJECT_ROOT`) over `cwd`, so the
+ * re-run + its `bun install` resolved to the wrong project, writing one
+ * project's package.json into another. Stripping these vars makes the
+ * reconciliation path strictly project-local.
+ * @param env - Source environment (typically a copy of process.env)
+ * @returns A copy of env with all package-manager path/lifecycle vars removed
+ */
+export function sanitizeEnvForReconciliation(
+  env: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !isPackageManagerPathEnvVar(key))
+  );
+}

--- a/src/utils/postinstall-trampoline.ts
+++ b/src/utils/postinstall-trampoline.ts
@@ -3,6 +3,11 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  PM_PATH_ENV_NAMES,
+  PM_PATH_ENV_PREFIXES,
+  sanitizeEnvForReconciliation,
+} from "./pm-env.js";
 
 /**
  * Env var set by npm/bun/yarn/pnpm when running lifecycle scripts (postinstall, etc.).
@@ -293,14 +298,11 @@ export async function regenerateLockfilesInProcess(
  * trampoline child then detects the parent exiting and re-runs Lisa after the
  * package manager has finished writing package.json.
  *
- * A blocking (non-detached) CI variant was previously attempted so that the
- * parent would wait for reconciliation before the next CI step ran. However,
- * this created a circular deadlock: the package manager blocks waiting for Lisa
- * (postinstall), Lisa blocks waiting for the trampoline child, and the
- * trampoline child polls `parentPid` (the package manager) waiting for it to
- * exit — a wait that can never complete. After the 120 s `MAX_WAIT_MS` timeout
- * the child exits without running reconciliation at all. Always using the
- * detached pattern avoids this deadlock and ensures reconciliation actually runs.
+ * A blocking (non-detached) CI variant was previously attempted but created a
+ * circular deadlock (PM waits for Lisa, Lisa waits for the child, the child
+ * polls `parentPid` waiting for the PM) that only resolves after the 120 s
+ * `MAX_WAIT_MS` timeout — without running reconciliation. Always detaching
+ * avoids this deadlock and ensures reconciliation actually runs.
  * @param projectDir - Absolute path to the project directory Lisa will reconcile
  * @param lisaDistDir - Absolute path to Lisa's dist directory (where index.js lives)
  * @param parentPid - PID of the package-manager process to wait on (usually process.ppid)
@@ -338,7 +340,10 @@ export async function scheduleReconciliationChild(
     detached: true,
     stdio: "ignore",
     env: {
-      ...inheritedEnv(),
+      // Strip PM path/lifecycle vars before the child inherits the env: a stale
+      // npm_config_local_prefix / INIT_CWD from a SIBLING project's concurrent
+      // install would otherwise redirect the re-run to the wrong project. See pm-env.ts.
+      ...sanitizeEnvForReconciliation(inheritedEnv()),
       // Prevent the child from seeing package-manager lifecycle env vars that would
       // make it think it's a lifecycle script (breaks isRunningAsLifecycleScript).
       [LIFECYCLE_ENV_VAR]: "",
@@ -408,6 +413,8 @@ function buildTrampolineSource(params: TrampolineSourceParams): string {
     nodeBin: JSON.stringify(params.nodeBin),
     trampolineEnvVar: JSON.stringify(params.trampolineEnvVar),
     lockfilePlans: JSON.stringify(params.lockfileRegenPlans),
+    pmEnvPrefixes: JSON.stringify(PM_PATH_ENV_PREFIXES),
+    pmEnvNames: JSON.stringify(PM_PATH_ENV_NAMES),
   } as const;
 
   return [
@@ -423,10 +430,14 @@ function buildTrampolineSource(params: TrampolineSourceParams): string {
  * cap enforced by eslint.
  * @param literals - Inlined JSON-safe literals
  * @param literals.lockfilePlans - JSON-serialized lockfile plan table
+ * @param literals.pmEnvPrefixes - JSON-serialized package-manager env var prefixes to strip
+ * @param literals.pmEnvNames - JSON-serialized package-manager env var names to strip
  * @returns JS source fragment
  */
 function buildTrampolinePrelude(literals: {
   readonly lockfilePlans: string;
+  readonly pmEnvPrefixes: string;
+  readonly pmEnvNames: string;
 }): string {
   return `
     const { spawn } = require("node:child_process");
@@ -435,6 +446,13 @@ function buildTrampolinePrelude(literals: {
     const path = require("node:path");
 
     const LOCKFILE_PLANS = ${literals.lockfilePlans};
+    const PM_ENV_PREFIXES = ${literals.pmEnvPrefixes};
+    const PM_ENV_NAMES = ${literals.pmEnvNames};
+    // Strip PM path/lifecycle vars from spawned bun/Lisa env. Mirrors pm-env.ts.
+    function sanitizeEnv(env) {
+      const bad = (k) => PM_ENV_NAMES.indexOf(k) !== -1 || PM_ENV_PREFIXES.some((p) => k.startsWith(p));
+      return Object.fromEntries(Object.entries(env).filter(([k]) => !bad(k)));
+    }
   `;
 }
 
@@ -494,7 +512,7 @@ function buildTrampolineHelpers(literals: {
           const child = spawn(command, args, {
             cwd: ${literals.projectDir},
             stdio: "ignore",
-            env: Object.assign({}, process.env, { [${literals.trampolineEnvVar}]: "1" }),
+            env: Object.assign(sanitizeEnv(process.env), { [${literals.trampolineEnvVar}]: "1" }),
           });
           child.on("exit", (code) => resolve(code === 0));
           child.on("error", () => resolve(false));

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -30,6 +30,7 @@ import {
   scheduleReconciliationChild,
   shouldSchedulePostinstallReconciliation,
 } from "../../../src/utils/postinstall-trampoline.js";
+import { sanitizeEnvForReconciliation } from "../../../src/utils/pm-env.js";
 
 // Use project-local paths (not /tmp/*) to avoid sonarjs's publicly-writable-directory
 // warnings. These are never actually read/written — they are fixtures passed to
@@ -47,6 +48,11 @@ const YARN_LOCK = "yarn.lock";
 const IGNORE_SCRIPTS = "--ignore-scripts";
 const INSTALL_CMD = "install";
 const PACKAGE_JSON = "package.json";
+
+// A sibling project's directory, used to simulate the poisoned env a concurrent
+// install leaves behind (the cross-project corruption regression). Named so the
+// duplicate string does not trip sonarjs/no-duplicate-string.
+const SIBLING_PROJECT_DIR = "/Users/dev/workspace/advisory-rankings";
 
 /**
  * Type alias for the spawn DI seam used in scheduleReconciliationChild and
@@ -384,6 +390,50 @@ describe("postinstall-trampoline", () => {
     });
   });
 
+  describe("sanitizeEnvForReconciliation", () => {
+    it("removes all package-manager path/lifecycle vars while keeping the rest", () => {
+      const result = sanitizeEnvForReconciliation({
+        PATH: "/usr/bin",
+        HOME: "/Users/dev",
+        npm_config_local_prefix: SIBLING_PROJECT_DIR,
+        npm_config_registry: "https://registry.npmjs.org",
+        npm_package_name: "advisory-rankings",
+        npm_package_json: `${SIBLING_PROJECT_DIR}/package.json`,
+        npm_lifecycle_event: "postinstall",
+        INIT_CWD: SIBLING_PROJECT_DIR,
+        npm_execpath: "/opt/homebrew/bin/bun",
+        PROJECT_CWD: SIBLING_PROJECT_DIR,
+      });
+
+      // Non-PM vars survive.
+      expect(result.PATH).toBe("/usr/bin");
+      expect(result.HOME).toBe("/Users/dev");
+      // Every PM path/lifecycle var is stripped.
+      expect(result.npm_config_local_prefix).toBeUndefined();
+      expect(result.npm_config_registry).toBeUndefined();
+      expect(result.npm_package_name).toBeUndefined();
+      expect(result.npm_package_json).toBeUndefined();
+      expect(result.npm_lifecycle_event).toBeUndefined();
+      expect(result.INIT_CWD).toBeUndefined();
+      expect(result.npm_execpath).toBeUndefined();
+      expect(result.PROJECT_CWD).toBeUndefined();
+    });
+
+    it("does not mutate the source environment object", () => {
+      const source = {
+        PATH: "/usr/bin",
+        npm_config_local_prefix: SIBLING_PROJECT_DIR,
+      };
+      sanitizeEnvForReconciliation(source);
+      // Source untouched — sanitization returns a new object.
+      expect(source.npm_config_local_prefix).toBe(SIBLING_PROJECT_DIR);
+    });
+
+    it("returns an empty object when given an empty environment", () => {
+      expect(sanitizeEnvForReconciliation({})).toEqual({});
+    });
+  });
+
   describe("regenerateLockfilesInProcess", () => {
     /**
      * Minimal fake child for the spawn DI seam. We only need to fire `exit`
@@ -584,6 +634,57 @@ describe("postinstall-trampoline", () => {
       // Detached mode must not wait on the child process — never registers an
       // exit listener because the parent package manager needs to return.
       expect(child.on).not.toHaveBeenCalled();
+    });
+
+    it("strips package-manager path env vars so a stale sibling project cannot be targeted (cross-project corruption regression)", async () => {
+      // Regression: during a batched concurrent multi-project Lisa update, the
+      // detached reconciliation child inherited npm_config_local_prefix / INIT_CWD
+      // pointing at a SIBLING project. bun/npm honour npm_config_local_prefix (and
+      // Lisa's postinstall script reads it as PROJECT_ROOT) over cwd, so the
+      // re-run + its `bun install` resolved to the wrong project — writing one
+      // project's package.json into another (advisory-rankings content leaked into
+      // harperstarter). The child must derive its target strictly from projectDir.
+      delete process.env.CI;
+      // Simulate the poisoned environment a concurrent sibling install leaves behind.
+      process.env.npm_config_local_prefix = SIBLING_PROJECT_DIR;
+      process.env.INIT_CWD = SIBLING_PROJECT_DIR;
+      process.env.npm_package_name = "advisory-rankings";
+      process.env.npm_lifecycle_event = "postinstall";
+      process.env.npm_config_argv = "{}";
+      // A non-PM var must survive so the child can still find node/PATH.
+      process.env.PATH = process.env.PATH ?? "/usr/bin";
+
+      const child = makeFakeChild();
+      const spawnSpy = vi.fn().mockReturnValue(child);
+
+      await scheduleReconciliationChild(
+        FAKE_PROJECT_DIR,
+        FAKE_LISA_DIST,
+        4242,
+        spawnSpy as unknown as SpawnFn
+      );
+
+      const opts = spawnSpy.mock.calls[0]?.[2] as {
+        env?: Record<string, string>;
+      };
+      const env = opts.env ?? {};
+      // Every package-manager path/lifecycle var that could redirect the re-run
+      // to a sibling project must be gone.
+      expect(env.npm_config_local_prefix).toBeUndefined();
+      expect(env.INIT_CWD).toBeUndefined();
+      expect(env.npm_package_name).toBeUndefined();
+      expect(env.npm_lifecycle_event).toBeUndefined();
+      expect(env.npm_config_argv).toBeUndefined();
+      // Non-PM vars (PATH) survive so the detached child can locate node.
+      expect(env.PATH).toBeDefined();
+      // Sentinels are still applied after sanitization.
+      expect(env.LISA_POSTINSTALL_TRAMPOLINE).toBe("1");
+      // The inline trampoline source must also sanitize the env of the bun/Lisa
+      // processes it spawns (belt-and-suspenders for any re-introduced vars).
+      const inlineSource = spawnSpy.mock.calls[0]?.[1] as readonly string[];
+      expect(inlineSource[1]).toContain("sanitizeEnv");
+      expect(inlineSource[1]).toContain("npm_config_");
+      expect(inlineSource[1]).toContain("INIT_CWD");
     });
 
     it("spawns a detached process with unref in CI (avoids deadlock with package manager)", async () => {


### PR DESCRIPTION
## Problem

During a batched, concurrent multi-project `lisa-update` run, **harperstarter**'s `package.json` was overwritten with **advisory-rankings**' content after `bun add -D @codyswann/lisa@latest`, and it **recurred on a clean reinstall** — timing matching the lisa postinstall bootstrapper step.

Evidence (diff of the polluted vs clean harperstarter `package.json`):
- Added `cheerio` dependency and ~18 `brokercheck`/`crawl`/`scrape` scripts that belong to advisory-rankings.
- The `@codyswann/lisa` pin was reverted from harperstarter's value to `^2.106.0` (an advisory-rankings value).
- `test`/`test:cov` lost `--passWithNoTests` (advisory-rankings' form).

Corroborating evidence in the harperstarter worktree: the `.lisabak/*` backups Lisa took during the run were all **clean** harperstarter content (`name: your-project`, `--passWithNoTests`, no cheerio, pin `^2.132.5`). Lisa's own template strategy never writes the `@codyswann/lisa` pin, `cheerio`, or `brokercheck` scripts — so the polluted content is 100% advisory-rankings, written into harperstarter's path.

## Root cause

The detached postinstall **reconciliation trampoline** (`src/utils/postinstall-trampoline.ts`) inherited the **full parent environment** (`...process.env`) when it spawned the detached child — and the inline child likewise passed `process.env` to the `bun install` / Lisa processes it spawned.

That environment includes the package-manager path vars **`npm_config_local_prefix`** and **`INIT_CWD`**. During a concurrent, sibling-by-sibling multi-project update these can be left pointing at a **different** project. Critically:

- bun/npm honour `npm_config_local_prefix` over `cwd` when resolving the "current" workspace.
- Lisa's own postinstall script (`scripts/install-claude-plugins.sh`) derives `PROJECT_ROOT` directly from `npm_config_local_prefix` (falling back to `INIT_CWD`).

So a stale inherited `npm_config_local_prefix`/`INIT_CWD` could redirect the reconciliation re-run — and the `bun install` it spawns — to a sibling project, writing one project's `package.json` into another. The trampoline previously stripped only `npm_package_json`, leaving these dangerous path vars intact.

## Fix

Make the reconciliation path strictly project-local — derive the target only from the explicit `cwd`/`projectDir` argument, never from inherited package-manager state:

- **New `src/utils/pm-env.ts`** centralizes the package-manager path/lifecycle env families (`npm_config_*`, `npm_package_*`, `npm_lifecycle_*`) plus standalone names (`INIT_CWD`, `npm_execpath`, `PROJECT_CWD`, ...) and exposes `sanitizeEnvForReconciliation()`.
- `scheduleReconciliationChild` now sanitizes the detached child's env.
- The inline trampoline source applies the same sanitization to the env of the `bun install` / Lisa re-invocations it spawns (belt-and-suspenders).

## Regression test

`tests/unit/utils/postinstall-trampoline.test.ts`:
- New `scheduleReconciliationChild` test poisons `process.env` with `npm_config_local_prefix`/`INIT_CWD`/`npm_*` pointing at a sibling project and asserts the spawned child's env drops them all while keeping `PATH` — and that the inline source contains the `sanitizeEnv` guard. **Fails under the old `...process.env` behavior.**
- New `sanitizeEnvForReconciliation` unit tests (strips all PM path/lifecycle vars, does not mutate input, empty-env case).

## Verification

- Typecheck: clean.
- eslint/oxlint/ast-grep (pre-commit hooks): clean.
- Full unit suite: 2825 passed.
- No `plugins/` artifacts touched — no `build:plugins`/`check:plugins` needed.

Note: bun 1.3.x is the proximate trigger (its cache/lifecycle leaks the wrong project's content), but this change makes Lisa's apply defensively incapable of letting an inherited sibling-project env redirect the reconciliation, regardless of package-manager behavior.

🤖 Generated with Claude Code