### PR TITLE
fix(expo,eslint): ignore wiki/** and pin apollo-link-sentry compatible with apollo-client v3

### DIFF
--- a/eslint.ignore.config.json
+++ b/eslint.ignore.config.json
@@ -76,6 +76,8 @@
     "cdk.out/**",
 
     "audit.ignore.config.json",
-    "audit.ignore.local.json"
+    "audit.ignore.local.json",
+
+    "wiki/**"
   ]
 }

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -56,7 +56,7 @@
     "dependencies": {
       "@apollo/client": "^3.10.8",
       "@hookform/resolvers": "^3.9.0",
-      "apollo-link-sentry": "^4.0.0",
+      "apollo-link-sentry": "^3.3.0",
       "base-64": "^1.0.0",
       "date-fns": "^3.6.0",
       "date-fns-tz": "^3.1.3",

--- a/tests/unit/config/eslint-ignore-wiki.test.ts
+++ b/tests/unit/config/eslint-ignore-wiki.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests that pin `wiki/**` into both the shared `defaultIgnores` and the
+ * copy-overwrite `eslint.ignore.config.json` template Lisa ships to projects.
+ *
+ * Background: the compiled `defaultIgnores` (src/configs/eslint/base.ts)
+ * already excludes `wiki/**`, but the copy-overwrite template that Lisa stamps
+ * into every project did NOT. Because a project that supplies its own
+ * `eslint.ignore.config.json` REPLACES `defaultIgnores` (see the
+ * `ignorePatterns = defaultIgnores` default param in the stack configs), and
+ * because the template is copy-overwrite, every Lisa update clobbered any
+ * project's hand-added `wiki/**` entry. `eslint .` then linted
+ * `wiki/lisa-wiki.config.json` and failed `sonarjs/no-duplicate-string` on the
+ * schema-required enum literals — hitting thumbwar-infrastructure, api-creator,
+ * qualis-infrastructure, and thumbwar-frontend.
+ *
+ * These tests keep the template and the compiled default in lock-step so the
+ * regression cannot return silently.
+ */
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { defaultIgnores } from "../../../src/configs/eslint/base.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/**
+ * Read an `eslint.ignore.config.json` template and return its `ignores` array.
+ * @param relativePath - Path relative to the Lisa repo root
+ * @returns The `ignores` string array from the template
+ */
+function readIgnores(relativePath: string): readonly string[] {
+  const absolute = path.join(REPO_ROOT, relativePath);
+  const parsed = JSON.parse(fs.readFileSync(absolute, "utf-8")) as {
+    ignores?: readonly string[];
+  };
+  return parsed.ignores ?? [];
+}
+
+describe("wiki/** ESLint ignore", () => {
+  it("compiled defaultIgnores excludes wiki/**", () => {
+    expect(defaultIgnores).toContain("wiki/**");
+  });
+
+  it("the typescript copy-overwrite template excludes wiki/**", () => {
+    // This is the file copied into every project; it must carry wiki/** so an
+    // update never clobbers a project's wiki exclusion.
+    expect(
+      readIgnores("typescript/copy-overwrite/eslint.ignore.config.json")
+    ).toContain("wiki/**");
+  });
+
+  it("Lisa's own root ignore config excludes wiki/**", () => {
+    expect(readIgnores("eslint.ignore.config.json")).toContain("wiki/**");
+  });
+});

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -822,6 +822,16 @@ describe("PackageLisaStrategy", () => {
       const template = readExpoTemplate();
       // Pure JS tooling stays forced (governance-critical).
       expect(template.force.dependencies["@apollo/client"]).toBeDefined();
+      // The forced apollo-link-sentry range must stay on the 3.x line so its
+      // `@apollo/client` peer (`^3.2.3`) is satisfiable by the forced
+      // `@apollo/client` major (v3). apollo-link-sentry 4.5.0 bumped that peer
+      // to `@apollo/client@^4.0.10`, so a `^4.0.0` pin let a fresh, lockfile-less
+      // Expo install resolve an apollo pair where SentryLink fails to typecheck
+      // against @apollo/client v3 (blocked expostarter).
+      expect(template.force.dependencies["@apollo/client"]).toMatch(/^\^?3\./);
+      expect(template.force.dependencies["apollo-link-sentry"]).toMatch(
+        /^\^?3\./
+      );
       expect(template.force.dependencies["zod"]).toBeDefined();
       expect(template.force.dependencies["tailwindcss"]).toBeDefined();
       expect(template.force.devDependencies["jest"]).toBeDefined();

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -80,6 +80,8 @@
     "audit.ignore.config.json",
     "audit.ignore.local.json",
 
-    "amplify/**"
+    "amplify/**",
+
+    "wiki/**"
   ]
 }


### PR DESCRIPTION
Fixes two upstream Lisa template bugs discovered while updating downstream projects.

## Fix 1 — eslint ignore template missing `wiki/**`

The compiled `defaultIgnores` (`src/configs/eslint/base.ts`) excludes `wiki/**`, but the **copy-overwrite** `eslint.ignore.config.json` template did **not**.

A project that ships its own `eslint.ignore.config.json` **replaces** `defaultIgnores` (the stack configs default `ignorePatterns = defaultIgnores`), and because the template is copy-overwrite, **every Lisa update clobbered** any project's hand-added `wiki/**` entry. `eslint .` then linted `wiki/lisa-wiki.config.json` and failed `sonarjs/no-duplicate-string` on the schema-required enum literals.

**Downstream evidence:** hit `thumbwar-infrastructure`, `api-creator`, `qualis-infrastructure`, and `thumbwar-frontend` — all had to re-add `wiki/**` by hand.

**Change:** added `"wiki/**"` to:
- `typescript/copy-overwrite/eslint.ignore.config.json` (the file stamped into projects)
- `eslint.ignore.config.json` (Lisa's own root config — Lisa itself has a `wiki/`)

so both match `defaultIgnores`. Added `tests/unit/config/eslint-ignore-wiki.test.ts` to keep the compiled default and both templates in lock-step.

> Only two `eslint.ignore.config.json` files exist in the repo (root + typescript). The expo/nestjs/cdk/rails stacks inherit the typescript ignore set via the shared `defaultIgnores`/stack factories — they do not ship their own ignore template — so the typescript fix covers every stack a project could legitimately have a `wiki/` in.

## Fix 2 — Expo template forced an incompatible apollo pair

`expo/package-lisa/package.lisa.json` `force.dependencies` pinned `@apollo/client: ^3.10.8` **and** `apollo-link-sentry: ^4.0.0`.

`apollo-link-sentry@4.5.0` bumped its `@apollo/client` peer to `^4.0.10`, so a fresh, lockfile-less Expo install resolved `4.5.0` and `SentryLink` failed to typecheck against `@apollo/client` v3.

**Downstream evidence:** blocked `expostarter`.

**npm peer-dependency evidence:**

| version | `@apollo/client` peer |
| --- | --- |
| 3.3.0 (latest 3.x) | `^3.2.3` ✅ |
| 4.0.0 – 4.4.0 | `^3.2.3` |
| **4.5.0** | `^4.0.10` ❌ (what `^4.0.0` let resolve) |

```
$ npm view apollo-link-sentry@3.3.0 peerDependencies
{ graphql: '15 - 16', '@apollo/client': '^3.2.3', '@sentry/browser': '^7.41.0' }

$ npm view apollo-link-sentry@4.5.0 peerDependencies
{ graphql: '^15 || ^16', '@sentry/core': '^8.33 || ^9 || ^10', '@apollo/client': '^4.0.10' }
```

`SentryLink` export confirmed present in 3.3.0 via `npm pack` tarball `package/lib-esm/index.d.ts`:
```
export { SentryLink } from './SentryLink';
```

**Change:** repinned `apollo-link-sentry` to `^3.3.0` — the latest 3.x release, whose `@apollo/client` peer (`^3.2.3`) is satisfied by the forced `@apollo/client ^3.10.8`, and which still exports `SentryLink`. Did **not** bump `@apollo/client` to v4 (breaking app change). Capping below 4.x prevents the incompatible `4.5.0` from ever resolving. Updated the `package.lisa` governance test (`tests/unit/strategies/package-lisa.test.ts`) to assert both pins stay on the v3 line.

## Verification

- Full vitest suite green: **169 files / 2884 tests passed**.
- `bun run check:plugins`: artifacts in sync (no `plugins/src` feeders touched).
- Dependency facts verified via `npm view` / `npm pack` registry metadata — no installs run inside any sibling project.

🤖 Generated with Claude Code