### PR TITLE
fix(postinstall): resolve cross-project package.json merge from sibling/cached source

### DIFF
--- a/harper-fabric/package-lisa/package.lisa.json
+++ b/harper-fabric/package-lisa/package.lisa.json
@@ -21,7 +21,6 @@
       "prepare": "husky install || true"
     },
     "dependencies": {
-      "cheerio": "^1.1.2",
       "harperdb": "^4.7.29"
     },
     "devDependencies": {
@@ -76,23 +75,8 @@
       "build": "tsc && node dist/build/build.js",
       "seed": "bun run build && node dist/scripts/seed.js",
       "verify": "bun run build && node dist/scripts/verify.js",
-      "seed:rest": "bun run build && node dist/scripts/seed_via_rest.js",
-      "verify:rest": "bun run build && node dist/scripts/verify_via_rest.js",
-      "preview": "bun run build && node dist/scripts/preview_feed.js",
       "dev:server": "bun run build && node dist/scripts/dev_server.js",
-      "deploy": "bun run build && node dist/scripts/deploy.js",
-      "smoke": "bun run build && bun tests/web_smoke.ts",
-      "smoke:brokercheck": "bun run build && bun tests/brokercheck_web_smoke.ts",
-      "token": "bun run build && node dist/scripts/get_token.js",
-      "crawl:wpjson": "bun run build && node dist/scripts/crawl_via_wpjson.js",
-      "crawl:html": "bun run build && node dist/scripts/crawl_html.js",
-      "crawl:playwright": "bun run build && node dist/scripts/crawl_playwright.js",
-      "extract:fields": "bun run build && node dist/scripts/extract_fields.js",
-      "extract:helper": "bun run build && node dist/scripts/extract_helper.js",
-      "ingest": "bun run build && node dist/scripts/ingest.js",
-      "load:extractions": "bun run build && node dist/scripts/load_extractions.js",
-      "brokercheck": "bun run build && node dist/scripts/fetch_brokercheck.js",
-      "brokercheck:crawl": "bun run build && node dist/scripts/brokercheck_crawl_all.js"
+      "deploy": "bun run build && node dist/scripts/deploy.js"
     }
   }
 }

--- a/tests/unit/strategies/harper-fabric-template-no-advisory-pollution.test.ts
+++ b/tests/unit/strategies/harper-fabric-template-no-advisory-pollution.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @file harper-fabric-template-no-advisory-pollution.test.ts
+ * @description Regression guard for the cross-project package.json corruption bug.
+ *
+ * Root cause: the `harper-fabric/package-lisa/package.lisa.json` template was
+ * originally seeded wholesale from the `advisory-rankings` project's package.json
+ * (advisory-rankings was the first harper-fabric project). That copy dragged in
+ * advisory-rankings *application* content — a `cheerio` dependency and ~15
+ * project-specific scripts (`brokercheck`, `crawl:*`, `seed:rest`, `ingest`,
+ * etc.) — into the SHARED governance template.
+ *
+ * Because `package.lisa.json` is applied to every harper-fabric project on
+ * install (`force` / `defaults` semantics), every other harper-fabric project
+ * (e.g. harperstarter) had advisory-rankings' scripts and `cheerio` merged into
+ * its own package.json during Lisa's postinstall apply. This reproduced in full
+ * isolation with no concurrent install, because the pollution lives in committed
+ * template data, not in any runtime race.
+ *
+ * This test reads the REAL shipped template (not a synthetic fixture) and asserts
+ * that no advisory-rankings application script or dependency is present. It fails
+ * on the polluted template and passes once the advisory content is removed.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HARPER_FABRIC_TEMPLATE = path.join(
+  REPO_ROOT,
+  "harper-fabric",
+  "package-lisa",
+  "package.lisa.json"
+);
+
+/**
+ * One force/defaults section of a package.lisa.json template (the subset this
+ * test inspects).
+ */
+interface PackageLisaSection {
+  readonly scripts?: Record<string, string>;
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+}
+
+/**
+ * Minimal shape of a package.lisa.json governance template.
+ */
+interface PackageLisaTemplate {
+  readonly force?: PackageLisaSection;
+  readonly defaults?: PackageLisaSection;
+  readonly merge?: Record<string, unknown[]>;
+}
+
+/**
+ * advisory-rankings application-specific script names that leaked into the
+ * shared harper-fabric governance template. None of these belong in a generic
+ * harper-fabric starter — they reference dist/scripts/*.js files that only exist
+ * in the advisory-rankings project.
+ */
+const ADVISORY_ONLY_SCRIPTS: readonly string[] = [
+  "seed:rest",
+  "verify:rest",
+  "preview",
+  "smoke",
+  "smoke:brokercheck",
+  "token",
+  "crawl:wpjson",
+  "crawl:html",
+  "crawl:playwright",
+  "extract:fields",
+  "extract:helper",
+  "ingest",
+  "load:extractions",
+  "brokercheck",
+  "brokercheck:crawl",
+];
+
+/**
+ * advisory-rankings application dependencies that must not be forced onto every
+ * harper-fabric project. `cheerio` is an HTML-scraping library specific to the
+ * advisory-rankings crawlers; a generic harper-fabric project has no use for it.
+ */
+const ADVISORY_ONLY_DEPENDENCIES: readonly string[] = ["cheerio"];
+
+describe("harper-fabric package.lisa.json — no advisory-rankings pollution", () => {
+  const template = JSON.parse(
+    readFileSync(HARPER_FABRIC_TEMPLATE, "utf-8")
+  ) as PackageLisaTemplate;
+
+  const allScriptNames = [
+    ...Object.keys(template.force?.scripts ?? {}),
+    ...Object.keys(template.defaults?.scripts ?? {}),
+  ];
+
+  const allDependencyNames = [
+    ...Object.keys(template.force?.dependencies ?? {}),
+    ...Object.keys(template.defaults?.dependencies ?? {}),
+  ];
+
+  it.each(ADVISORY_ONLY_SCRIPTS)(
+    "does not contain advisory-rankings script %s",
+    scriptName => {
+      expect(allScriptNames).not.toContain(scriptName);
+    }
+  );
+
+  it.each(ADVISORY_ONLY_DEPENDENCIES)(
+    "does not contain advisory-rankings dependency %s",
+    depName => {
+      expect(allDependencyNames).not.toContain(depName);
+    }
+  );
+
+  it("keeps the legitimate generic harper-fabric scaffolding scripts", () => {
+    // These scripts have backing source files in a generic harper-fabric
+    // starter (harperstarter): build, seed, verify, dev:server, deploy.
+    const defaultsScripts = Object.keys(template.defaults?.scripts ?? {});
+    expect(defaultsScripts).toEqual(
+      expect.arrayContaining([
+        "build",
+        "seed",
+        "verify",
+        "dev:server",
+        "deploy",
+      ])
+    );
+  });
+
+  it("forces only harperdb as a runtime dependency", () => {
+    expect(template.force?.dependencies).toEqual({ harperdb: "^4.7.29" });
+  });
+});


### PR DESCRIPTION
## Definitive Root Cause

The harperstarter data-corruption bug is **not** a runtime race, cwd glob, or `.lisabak` issue. It is **committed template pollution** in `harper-fabric/package-lisa/package.lisa.json`.

When the harper-fabric project type was first added (commit `dfe5e966`), its `package.lisa.json` governance template was seeded wholesale from the `advisory-rankings` project's actual `package.json` (advisory-rankings was the first harper-fabric project). That copy dragged advisory-rankings **application** content into the **shared** template:

- `force.dependencies.cheerio` (`^1.1.2`) — an advisory-rankings HTML-scraping lib
- `defaults.scripts`: `brokercheck`, `brokercheck:crawl`, `crawl:wpjson`, `crawl:html`, `crawl:playwright`, `extract:fields`, `extract:helper`, `ingest`, `load:extractions`, `seed:rest`, `verify:rest`, `preview`, `smoke`, `smoke:brokercheck`, `token` — all advisory-rankings-only scripts referencing `dist/scripts/*.js` files that don't exist in a generic harper-fabric project.

Because `package.lisa.json` is applied to **every** harper-fabric project on install (`force`/`defaults` merge), every other harper-fabric project (harperstarter) had advisory-rankings' scripts + `cheerio` merged into its own `package.json` during Lisa's postinstall apply.

### Traced-path evidence

The merge in `src/strategies/package-lisa.ts` reads the target project's own `package.json` only — so the advisory content could only come from a template Lisa loads. `loadAndMergeTemplates` reads `<lisaDir>/<type>/package-lisa/package.lisa.json`. Inspecting the **installed** template in a corrupted harperstarter and the **published** `@codyswann/lisa@2.133.1` bun cache both showed the advisory content present in `harper-fabric/package-lisa/package.lisa.json` `force.dependencies` and `defaults.scripts`. The canonical source template on `main` has it too.

This explains every clue:
- **Reproduces in isolation** — committed data, no concurrent install needed.
- **`@codyswann/lisa` pinned `^2.106.0`** in the leaked snapshot — that's the governance floor from the `typescript` template's `force.devDependencies`, applied alongside.
- **Only a subset of advisory scripts transferred** — `scrape:*`/`research:advisors`/`media:backfill` were added to advisory-rankings *after* the template was extracted, so they're absent from the template.
- **No advisory strings in `dist/index.js`** — correct, the content lives in the shipped JSON data file, not compiled code.

This is why **PR #1127 ("env sanitization") did not fix it** — it assumed a live concurrent-install env race, which was the wrong hypothesis.

### A/B reproduction (outside ~/workspace, in `/tmp/harper-repro`)

A clean scratch harper-fabric project (bare package.json, no lockfile) run through the local Lisa apply:

| Template | `cheerio` in deps | advisory scripts leaked |
|----------|-------------------|-------------------------|
| polluted (before) | **true** | `brokercheck, brokercheck:crawl, crawl:wpjson, seed:rest, ingest, token, smoke` |
| fixed (after) | false | none |

## Fix

Strip the advisory-rankings-specific dependency and scripts from the harper-fabric template, leaving only the generic harper-fabric scaffolding (`build`, `seed`, `verify`, `dev:server`, `deploy`) that has backing files in the canonical harperstarter starter.

## Regression test

`tests/unit/strategies/harper-fabric-template-no-advisory-pollution.test.ts` reads the **real shipped** `harper-fabric/package-lisa/package.lisa.json` and asserts no advisory-rankings script or dependency is present. It fails on the polluted template (17 failures) and passes after this change.

## Verification

- New regression test: GREEN (was RED on polluted template)
- `bun run test:unit` — 2855 passed
- Strategy suites — 1704 passed
- `bun run typecheck` — clean
- `bun run lint` — clean on changed files
- `bun run check:plugins` — in sync
- End-to-end local apply on `/tmp/harper-repro` — advisory content no longer applied

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused dependency from package configuration
  * Streamlined build and deployment scripts, retaining core development and deployment functionality

* **Tests**
  * Added regression test to verify package configuration integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->