### PR TITLE
feat(cli): add maintenance commands

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,275 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { createDetectorRegistry } from "../detection/index.js";
+import { STARTERS } from "./starters.js";
+import { runUpdateCheck } from "./update-check.js";
+
+/** Status values emitted by Lisa doctor checks. */
+type DoctorStatus = "ok" | "warn" | "fail";
+
+const VERSION_CHECK_NAME = "Lisa version current?";
+const STARTER_HEALTH_NAME = "Starter health";
+const PROJECT_CONFIG_CHECK_NAME = "Project Lisa config present?";
+
+/** One Lisa doctor check result. */
+export interface DoctorCheck {
+  name: string;
+  status: DoctorStatus;
+  detail: string;
+}
+
+/** Machine-readable doctor result. */
+export interface DoctorResult {
+  checks: DoctorCheck[];
+}
+
+/** Options parsed for `lisa doctor`. */
+export interface DoctorOptions {
+  json?: boolean;
+  offline?: boolean;
+}
+
+/** Runtime collaborators for doctor. */
+export interface DoctorDependencies {
+  fetchImpl: typeof fetch;
+  runUpdateCheck: typeof runUpdateCheck;
+  setExitCode: (code: number) => void;
+  write: (message: string) => void;
+}
+
+const DEFAULT_DEPENDENCIES: DoctorDependencies = {
+  fetchImpl: fetch,
+  runUpdateCheck,
+  setExitCode: code => {
+    process.exitCode = code;
+  },
+  write: message => console.log(message),
+};
+
+/**
+ * Check Lisa's installed version against npm.
+ * @param deps - Runtime dependencies
+ * @param offline - Skip network check
+ * @returns Doctor check result
+ */
+async function checkVersion(
+  deps: DoctorDependencies,
+  offline: boolean
+): Promise<DoctorCheck> {
+  if (offline) {
+    return {
+      name: VERSION_CHECK_NAME,
+      status: "ok",
+      detail: "Skipped network check in offline mode",
+    };
+  }
+
+  const result = await deps.runUpdateCheck();
+  if (result.isOutdated && result.latest) {
+    return {
+      name: VERSION_CHECK_NAME,
+      status: "warn",
+      detail: `Installed ${result.current}; latest is ${result.latest}`,
+    };
+  }
+
+  return {
+    name: VERSION_CHECK_NAME,
+    status: result.latest ? "ok" : "warn",
+    detail: result.latest
+      ? `Installed ${result.current}; latest is ${result.latest}`
+      : `Latest version unavailable${result.reason ? ` (${result.reason})` : ""}`,
+  };
+}
+
+/**
+ * Validate Lisa project configuration files.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+async function checkProjectConfig(targetPath: string): Promise<DoctorCheck> {
+  const configPaths = [".lisa.config.json", ".lisa.config.local.json"]
+    .map(fileName => path.join(targetPath, fileName))
+    .filter(configPath => existsSync(configPath));
+
+  if (configPaths.length === 0) {
+    return {
+      name: PROJECT_CONFIG_CHECK_NAME,
+      status: "warn",
+      detail: "No .lisa.config.json or .lisa.config.local.json found",
+    };
+  }
+
+  for (const configPath of configPaths) {
+    try {
+      JSON.parse(await readFile(configPath, "utf8"));
+    } catch (error) {
+      return {
+        name: PROJECT_CONFIG_CHECK_NAME,
+        status: "fail",
+        detail: `${path.basename(configPath)} is not parseable JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+  }
+
+  return {
+    name: PROJECT_CONFIG_CHECK_NAME,
+    status: "ok",
+    detail: configPaths.map(configPath => path.basename(configPath)).join(", "),
+  };
+}
+
+/**
+ * Detect the target project type.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+async function checkProjectType(targetPath: string): Promise<DoctorCheck> {
+  const detectorRegistry = createDetectorRegistry();
+  const detectedTypes = detectorRegistry.expandAndOrderTypes(
+    await detectorRegistry.detectAll(targetPath)
+  );
+  if (detectedTypes.length === 0) {
+    return {
+      name: "Project type detection",
+      status: "warn",
+      detail: "No Lisa project type detected",
+    };
+  }
+
+  return {
+    name: "Project type detection",
+    status: "ok",
+    detail: detectedTypes.join(", "),
+  };
+}
+
+/**
+ * Confirm starter repositories are reachable and marked as templates.
+ * @param deps - Runtime dependencies
+ * @param offline - Skip network checks
+ * @returns Doctor check result
+ */
+async function checkStarterHealth(
+  deps: DoctorDependencies,
+  offline: boolean
+): Promise<DoctorCheck> {
+  if (offline) {
+    return {
+      name: STARTER_HEALTH_NAME,
+      status: "ok",
+      detail: "Skipped GitHub starter checks in offline mode",
+    };
+  }
+
+  const checks = await Promise.all(
+    Object.values(STARTERS).map(async starter => {
+      const failurePrefix = `${starter.repo}:`;
+      try {
+        const response = await deps.fetchImpl(
+          `https://api.github.com/repos/${starter.owner}/${starter.repo}`
+        );
+        if (!response.ok) {
+          return `${failurePrefix} http-${response.status}`;
+        }
+        const body = (await response.json()) as { is_template?: unknown };
+        if (body.is_template !== true) {
+          return `${failurePrefix} not-template`;
+        }
+      } catch {
+        return `${failurePrefix} unreachable`;
+      }
+      return null;
+    })
+  );
+  const failures = checks.filter((check): check is string => check !== null);
+
+  return {
+    name: STARTER_HEALTH_NAME,
+    status: failures.length === 0 ? "ok" : "warn",
+    detail:
+      failures.length === 0
+        ? "Starter repositories are reachable templates"
+        : failures.join(", "),
+  };
+}
+
+/**
+ * Check basic wiki contract files when a wiki exists.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+function checkWiki(targetPath: string): DoctorCheck {
+  const wikiPath = path.join(targetPath, "wiki");
+  if (!existsSync(wikiPath)) {
+    return {
+      name: "Wiki health",
+      status: "ok",
+      detail: "No wiki directory present",
+    };
+  }
+
+  const required = [
+    "lisa-wiki.config.json",
+    "schema/llm-wiki-contract.md",
+    "index.md",
+  ];
+  const missing = required.filter(fileName => {
+    return !existsSync(path.join(wikiPath, fileName));
+  });
+
+  return {
+    name: "Wiki health",
+    status: missing.length === 0 ? "ok" : "fail",
+    detail:
+      missing.length === 0
+        ? "Required wiki files are present"
+        : `Missing ${missing.join(", ")}`,
+  };
+}
+
+/**
+ * Run Lisa doctor checks.
+ * @param targetPath - Optional project path
+ * @param options - Parsed command options
+ * @param dependencies - Optional collaborators for tests
+ * @returns Doctor result
+ */
+export async function runDoctor(
+  targetPath: string | undefined,
+  options: DoctorOptions,
+  dependencies: Partial<DoctorDependencies> = {}
+): Promise<DoctorResult> {
+  const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
+  const resolvedTarget = path.resolve(targetPath ?? process.cwd());
+  const checks = [
+    await checkVersion(deps, options.offline === true),
+    await checkProjectConfig(resolvedTarget),
+    await checkProjectType(resolvedTarget),
+    await checkStarterHealth(deps, options.offline === true),
+    checkWiki(resolvedTarget),
+  ];
+  const result = { checks };
+
+  if (options.json) {
+    deps.write(JSON.stringify(result, null, 2));
+  } else {
+    deps.write(
+      checks
+        .map(
+          check =>
+            `${check.status.toUpperCase()} ${check.name}: ${check.detail}`
+        )
+        .join("\n")
+    );
+  }
+
+  if (checks.some(check => check.status === "fail")) {
+    deps.setExitCode(1);
+  }
+
+  return result;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,10 +1,13 @@
 import { Command } from "commander";
 import { runApply } from "./apply.js";
+import { runDoctor } from "./doctor.js";
 import { printUpdateWarning } from "./print-update-warning.js";
 import { runSetupProject } from "./setup-project.js";
 import { addSharedOptions, type CLIOptions } from "./shared-options.js";
 import { SETUP_TYPES } from "./starters.js";
+import { runUpdate } from "./update-cmd.js";
 import { runUpdateCheck } from "./update-check.js";
+import { runVersion } from "./version-cmd.js";
 import { getPackageVersion } from "./version.js";
 
 /**
@@ -17,6 +20,12 @@ export interface ProgramDependencies {
   runApply: typeof runApply;
   /** Creates a starter-backed project and applies Lisa overlays. */
   runSetupProject: typeof runSetupProject;
+  /** Prints Lisa CLI version metadata. */
+  runVersion: typeof runVersion;
+  /** Prints or runs the package-manager update command. */
+  runUpdate: typeof runUpdate;
+  /** Diagnoses Lisa project health. */
+  runDoctor: typeof runDoctor;
   /** Runs the non-fatal npm update check (defaults to {@link runUpdateCheck}). */
   runUpdateCheck: typeof runUpdateCheck;
   /** Prints the update warning (defaults to {@link printUpdateWarning}). */
@@ -26,9 +35,55 @@ export interface ProgramDependencies {
 const DEFAULT_DEPENDENCIES: ProgramDependencies = {
   runApply,
   runSetupProject,
+  runVersion,
+  runUpdate,
+  runDoctor,
   runUpdateCheck,
   printUpdateWarning,
 };
+
+/**
+ * Register CLI maintenance commands that do not run the root update warning.
+ * @param program - Commander program to mutate
+ * @param deps - Program dependencies
+ * @returns The same Commander program
+ */
+function addMaintenanceCommands(
+  program: Command,
+  deps: ProgramDependencies
+): Command {
+  program
+    .command("version")
+    .description("Print Lisa CLI version info")
+    .action(async () => {
+      await deps.runVersion();
+    });
+
+  program
+    .command("update")
+    .description(
+      "Print (or run with --yes) the recommended package-manager update command"
+    )
+    .option("--yes", "Execute the update command after printing it")
+    .action(async (options: { yes?: boolean }) => {
+      const code = await deps.runUpdate(options);
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    });
+
+  program
+    .command("doctor")
+    .description("Diagnose Lisa, project, starter, and wiki health")
+    .argument("[path]", "Project path to inspect")
+    .option("--json", "Emit JSON")
+    .option("--offline", "Skip network checks")
+    .action(async (targetPath: string | undefined, options) => {
+      await deps.runDoctor(targetPath, options);
+    });
+
+  return program;
+}
 
 /**
  * Create and configure the CLI program.
@@ -60,7 +115,10 @@ export function createProgram(
 
   // Run the npm update-check once per invocation, before the matched action.
   // It is non-fatal: a failed check never blocks the action from running.
-  program.hook("preAction", async () => {
+  program.hook("preAction", async (_thisCommand, actionCommand) => {
+    if (["doctor", "update", "version"].includes(actionCommand.name())) {
+      return;
+    }
     if (program.opts().updateCheck === false) {
       return;
     }
@@ -99,6 +157,8 @@ export function createProgram(
       await deps.runSetupProject(destination, options);
     }
   );
+
+  addMaintenanceCommands(program, deps);
 
   return program;
 }

--- a/src/cli/update-cmd.ts
+++ b/src/cli/update-cmd.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
+const LISA_LATEST_PACKAGE = "@codyswann/lisa@latest";
+
+/** Options parsed for `lisa update`. */
+export interface UpdateCommandOptions {
+  yes?: boolean;
+}
+
+/** Runtime collaborators for the update command. */
+export interface UpdateCommandDependencies {
+  /** Current working directory. */
+  cwd: string;
+  /** Environment map used for package-manager detection. */
+  env: NodeJS.ProcessEnv;
+  /** Spawn implementation used when --yes is passed. */
+  spawn: typeof spawn;
+  /** Write user-facing output. */
+  write: (message: string) => void;
+}
+
+const DEFAULT_DEPENDENCIES: UpdateCommandDependencies = {
+  cwd: process.cwd(),
+  env: getProcessEnv(),
+  spawn,
+  write: message => console.log(message),
+};
+
+/**
+ * Read process.env through one explicit, reviewable exception to the app-template
+ * env rule. The CLI needs externally supplied package-manager metadata.
+ * @returns Current process environment
+ */
+function getProcessEnv(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line no-restricted-syntax -- CLI package-manager detection must read externally supplied process env once
+  return process.env;
+}
+
+/**
+ * Detect the preferred package manager from the user agent or lockfiles.
+ * @param deps - Runtime dependencies
+ * @returns Package manager command
+ */
+export function detectPackageManager(
+  deps: Pick<UpdateCommandDependencies, "cwd" | "env">
+): "npm" | "pnpm" | "yarn" | "bun" {
+  const userAgent = deps.env.npm_config_user_agent ?? "";
+  if (userAgent.startsWith("pnpm")) {
+    return "pnpm";
+  }
+  if (userAgent.startsWith("yarn")) {
+    return "yarn";
+  }
+  if (userAgent.startsWith("bun")) {
+    return "bun";
+  }
+  if (userAgent.startsWith("npm")) {
+    return "npm";
+  }
+
+  if (existsSync(path.join(deps.cwd, "bun.lockb"))) {
+    return "bun";
+  }
+  if (existsSync(path.join(deps.cwd, "pnpm-lock.yaml"))) {
+    return "pnpm";
+  }
+  if (existsSync(path.join(deps.cwd, "yarn.lock"))) {
+    return "yarn";
+  }
+
+  return "npm";
+}
+
+/**
+ * Compose the global Lisa update command for a package manager.
+ * @param packageManager - Detected package manager
+ * @returns Command and arguments ready for spawn
+ */
+export function getUpdateCommand(packageManager: string): {
+  command: string;
+  args: string[];
+} {
+  switch (packageManager) {
+    case "bun":
+      return { command: "bun", args: ["add", "-g", LISA_LATEST_PACKAGE] };
+    case "pnpm":
+      return {
+        command: "pnpm",
+        args: ["add", "-g", LISA_LATEST_PACKAGE],
+      };
+    case "yarn":
+      return {
+        command: "yarn",
+        args: ["global", "add", LISA_LATEST_PACKAGE],
+      };
+    default:
+      return {
+        command: "npm",
+        args: ["install", "-g", LISA_LATEST_PACKAGE],
+      };
+  }
+}
+
+/**
+ * Execute a child command and resolve to its exit code.
+ * @param deps - Runtime dependencies
+ * @param command - Executable name
+ * @param args - Command arguments
+ * @returns Child process exit code
+ */
+async function runSpawn(
+  deps: UpdateCommandDependencies,
+  command: string,
+  args: readonly string[]
+): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const child = deps.spawn(command, args, { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", code => resolve(code ?? 1));
+  });
+}
+
+/**
+ * Run `lisa update`.
+ * @param options - Parsed command options
+ * @param dependencies - Optional collaborators for tests
+ * @returns Child exit code when --yes runs, otherwise 0
+ */
+export async function runUpdate(
+  options: UpdateCommandOptions,
+  dependencies: Partial<UpdateCommandDependencies> = {}
+): Promise<number> {
+  const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
+  const updateCommand = getUpdateCommand(detectPackageManager(deps));
+  deps.write([updateCommand.command, ...updateCommand.args].join(" "));
+
+  if (!options.yes) {
+    return 0;
+  }
+
+  return await runSpawn(deps, updateCommand.command, updateCommand.args);
+}

--- a/src/cli/version-cmd.ts
+++ b/src/cli/version-cmd.ts
@@ -1,0 +1,96 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type UpdateCheckResult, runUpdateCheck } from "./update-check.js";
+import { getPackageVersion } from "./version.js";
+
+/** Runtime collaborators for the version command. */
+export interface VersionCommandDependencies {
+  /** Resolve the installed Lisa package version. */
+  getPackageVersion: typeof getPackageVersion;
+  /** Run Lisa's non-fatal latest-version check. */
+  runUpdateCheck: typeof runUpdateCheck;
+  /** Write user-facing output. */
+  write: (message: string) => void;
+}
+
+const DEFAULT_DEPENDENCIES: VersionCommandDependencies = {
+  getPackageVersion,
+  runUpdateCheck,
+  write: message => console.log(message),
+};
+
+/**
+ * Find the nearest package.json above the current module path.
+ * @param startDir - Directory to start from
+ * @returns Absolute package.json path or null
+ */
+function findPackageJson(startDir: string): string | null {
+  const candidate = path.join(startDir, "package.json");
+  if (existsSync(candidate)) {
+    return candidate;
+  }
+
+  const parent = path.dirname(startDir);
+  return parent === startDir ? null : findPackageJson(parent);
+}
+
+/**
+ * Resolve the installed package path for the running CLI.
+ * @returns Absolute package root when discoverable
+ */
+export function getCliInstallPath(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageJson = findPackageJson(moduleDir);
+  return packageJson ? path.dirname(packageJson) : moduleDir;
+}
+
+/**
+ * Resolve the configured default harness for the current project.
+ * @param cwd - Project directory to inspect
+ * @returns Harness string used by Lisa when no flag overrides it
+ */
+export async function readDefaultHarness(cwd = process.cwd()): Promise<string> {
+  for (const fileName of [".lisa.config.local.json", ".lisa.config.json"]) {
+    const configPath = path.join(cwd, fileName);
+    try {
+      const parsed = JSON.parse(await readFile(configPath, "utf8")) as {
+        harness?: unknown;
+      };
+      if (typeof parsed.harness === "string" && parsed.harness !== "") {
+        return parsed.harness;
+      }
+    } catch {
+      // Missing or malformed project config falls back to the CLI default.
+    }
+  }
+
+  return "claude";
+}
+
+/**
+ * Run `lisa version`.
+ * @param dependencies - Optional collaborators for tests
+ * @returns Promise that resolves after output is written
+ */
+export async function runVersion(
+  dependencies: Partial<VersionCommandDependencies> = {}
+): Promise<void> {
+  const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
+  const localVersion = deps.getPackageVersion();
+  const updateResult: UpdateCheckResult = await deps.runUpdateCheck({
+    currentVersion: localVersion,
+  });
+  const latestVersion = updateResult.latest ?? "unavailable";
+  const harness = await readDefaultHarness();
+
+  deps.write(
+    [
+      `local: ${localVersion}`,
+      `latest: ${latestVersion}`,
+      `installPath: ${getCliInstallPath()}`,
+      `defaultHarness: ${harness}`,
+    ].join("\n")
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { CommanderError } from "commander";
 import { createProgram } from "./cli/index.js";
 
 /**
@@ -12,7 +13,16 @@ import { createProgram } from "./cli/index.js";
  */
 async function main(): Promise<void> {
   const program = createProgram();
-  await program.parseAsync();
+  program.exitOverride();
+  try {
+    await program.parseAsync();
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      process.exitCode = error.exitCode;
+      return;
+    }
+    throw error;
+  }
 }
 
 main().catch(error => {

--- a/tests/unit/cli/doctor.test.ts
+++ b/tests/unit/cli/doctor.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runDoctor } from "../../../src/cli/doctor.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve the temporary directory for one doctor test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-doctor-"));
+  return tempDir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("runDoctor", () => {
+  it("emits structured JSON and warns on stale Lisa versions", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, ".lisa.config.json"), "{}\n");
+    const write = vi.fn();
+
+    const result = await runDoctor(
+      cwd,
+      { json: true },
+      {
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue({
+          ok: true,
+          json: async () => ({ is_template: true }),
+        } as Response),
+        runUpdateCheck: vi.fn(async () => ({
+          current: "2.63.2",
+          latest: "2.64.0",
+          isOutdated: true,
+        })),
+        write,
+      }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: "Lisa version current?",
+        status: "warn",
+      })
+    );
+    expect(() => JSON.parse(write.mock.calls[0][0])).not.toThrow();
+  });
+
+  it("sets a failing exit code when config JSON is malformed", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, ".lisa.config.json"), "{");
+    const setExitCode = vi.fn();
+
+    await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), setExitCode, write: vi.fn() }
+    );
+
+    expect(setExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it("warns when starter repositories are missing or not templates", async () => {
+    const cwd = await getTempDir();
+    const result = await runDoctor(
+      cwd,
+      {},
+      {
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue({
+          ok: true,
+          json: async () => ({ is_template: false }),
+        } as Response),
+        runUpdateCheck: vi.fn(async () => ({
+          current: "2.63.2",
+          latest: "2.63.2",
+          isOutdated: false,
+        })),
+        write: vi.fn(),
+      }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: "Starter health",
+        status: "warn",
+      })
+    );
+  });
+});

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -21,16 +21,25 @@ function createTestProgram(): {
   program: ReturnType<typeof createProgram>;
   runApply: ReturnType<typeof vi.fn>;
   runSetupProject: ReturnType<typeof vi.fn>;
+  runVersion: ReturnType<typeof vi.fn>;
+  runUpdate: ReturnType<typeof vi.fn>;
+  runDoctor: ReturnType<typeof vi.fn>;
   runUpdateCheck: ReturnType<typeof vi.fn>;
   printUpdateWarning: ReturnType<typeof vi.fn>;
 } {
   const runApply = vi.fn(async () => undefined);
   const runSetupProject = vi.fn(async () => undefined);
+  const runVersion = vi.fn(async () => undefined);
+  const runUpdate = vi.fn(async () => 0);
+  const runDoctor = vi.fn(async () => ({ checks: [] }));
   const runUpdateCheck = vi.fn(async () => SKIPPED_RESULT);
   const printUpdateWarning = vi.fn();
   const program = createProgram({
     runApply,
     runSetupProject,
+    runVersion,
+    runUpdate,
+    runDoctor,
     runUpdateCheck,
     printUpdateWarning,
   }).exitOverride();
@@ -38,6 +47,9 @@ function createTestProgram(): {
     program,
     runApply,
     runSetupProject,
+    runVersion,
+    runUpdate,
+    runDoctor,
     runUpdateCheck,
     printUpdateWarning,
   };
@@ -61,6 +73,14 @@ describe("createProgram", () => {
     const { program } = createTestProgram();
     const subcommandNames = program.commands.map(command => command.name());
     expect(subcommandNames).toContain("setup-project");
+  });
+
+  it("registers version, update, and doctor subcommands", () => {
+    const { program } = createTestProgram();
+    const subcommandNames = program.commands.map(command => command.name());
+    expect(subcommandNames).toEqual(
+      expect.arrayContaining(["version", "update", "doctor"])
+    );
   });
 
   it("exposes the root --no-update-check option", () => {
@@ -144,6 +164,14 @@ describe("update-check pre-action hook", () => {
 
     expect(runUpdateCheck).not.toHaveBeenCalled();
   });
+
+  it("does not run the root update warning for maintenance commands", async () => {
+    const { program, runUpdateCheck } = createTestProgram();
+
+    await program.parseAsync(["version"], { from: "user" });
+
+    expect(runUpdateCheck).not.toHaveBeenCalled();
+  });
 });
 
 describe("setup-project invocation", () => {
@@ -162,6 +190,39 @@ describe("setup-project invocation", () => {
         yes: true,
         harness: "codex",
       })
+    );
+  });
+});
+
+describe("maintenance command invocation", () => {
+  it("routes version to the version action", async () => {
+    const { program, runVersion } = createTestProgram();
+
+    await program.parseAsync(["version"], { from: "user" });
+
+    expect(runVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes update --yes to the update action", async () => {
+    const { program, runUpdate } = createTestProgram();
+
+    await program.parseAsync(["update", "--yes"], { from: "user" });
+
+    expect(runUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ yes: true })
+    );
+  });
+
+  it("routes doctor options to the doctor action", async () => {
+    const { program, runDoctor } = createTestProgram();
+
+    await program.parseAsync(["doctor", DEST, "--json", "--offline"], {
+      from: "user",
+    });
+
+    expect(runDoctor).toHaveBeenCalledWith(
+      DEST,
+      expect.objectContaining({ json: true, offline: true })
     );
   });
 });

--- a/tests/unit/cli/update-cmd.test.ts
+++ b/tests/unit/cli/update-cmd.test.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  detectPackageManager,
+  getUpdateCommand,
+  runUpdate,
+} from "../../../src/cli/update-cmd.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve the temporary directory for one update-command test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-update-cmd-"));
+  return tempDir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("detectPackageManager", () => {
+  it("uses npm_config_user_agent before lockfiles", () => {
+    expect(
+      detectPackageManager({
+        cwd: "/tmp",
+        env: { npm_config_user_agent: "pnpm/10.0.0 npm/? node/22" },
+      })
+    ).toBe("pnpm");
+  });
+
+  it("detects bun from bun.lockb", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, "bun.lockb"), "");
+
+    expect(detectPackageManager({ cwd, env: {} })).toBe("bun");
+  });
+});
+
+describe("getUpdateCommand", () => {
+  it("defaults to npm global install", () => {
+    expect(getUpdateCommand("npm")).toEqual({
+      command: "npm",
+      args: ["install", "-g", "@codyswann/lisa@latest"],
+    });
+  });
+});
+
+describe("runUpdate", () => {
+  it("prints the command and does not spawn without --yes", async () => {
+    const write = vi.fn();
+    const spawn = vi.fn();
+
+    await expect(
+      runUpdate({ yes: false }, { cwd: "/tmp", env: {}, spawn, write })
+    ).resolves.toBe(0);
+
+    expect(write).toHaveBeenCalledWith("npm install -g @codyswann/lisa@latest");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("spawns the update command with inherited stdio when --yes is set", async () => {
+    const child = new EventEmitter();
+    const spawn = vi.fn(() => child);
+    const promise = runUpdate(
+      { yes: true },
+      { cwd: "/tmp", env: {}, spawn: spawn as never, write: vi.fn() }
+    );
+
+    child.emit("exit", 7);
+
+    await expect(promise).resolves.toBe(7);
+    expect(spawn).toHaveBeenCalledWith(
+      "npm",
+      ["install", "-g", "@codyswann/lisa@latest"],
+      { stdio: "inherit" }
+    );
+  });
+});

--- a/tests/unit/cli/version-cmd.test.ts
+++ b/tests/unit/cli/version-cmd.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { runVersion } from "../../../src/cli/version-cmd.js";
+
+describe("runVersion", () => {
+  it("prints local version, latest version, install path, and default harness", async () => {
+    const write = vi.fn();
+
+    await runVersion({
+      getPackageVersion: () => "2.63.2",
+      runUpdateCheck: vi.fn(async () => ({
+        current: "2.63.2",
+        latest: "2.64.0",
+        isOutdated: true,
+      })),
+      write,
+    });
+
+    expect(write).toHaveBeenCalledWith(
+      expect.stringContaining("local: 2.63.2")
+    );
+    expect(write).toHaveBeenCalledWith(
+      expect.stringContaining("latest: 2.64.0")
+    );
+    expect(write).toHaveBeenCalledWith(
+      expect.stringContaining("installPath: ")
+    );
+    expect(write).toHaveBeenCalledWith(
+      expect.stringContaining("defaultHarness: claude")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `lisa version`, `lisa update`, and `lisa doctor` command implementations
- wire maintenance commands into the CLI without duplicate root update-warning checks
- add focused unit coverage for command wiring and command behavior

## Verification
- `bun test tests/unit/cli/index.test.ts tests/unit/cli/update-cmd.test.ts tests/unit/cli/version-cmd.test.ts tests/unit/cli/doctor.test.ts tests/unit/cli/update-check.test.ts tests/unit/cli/setup-project.test.ts`
- `bun run typecheck`
- `bun run lint` (passes; existing oxlint warnings remain outside this change)
- `bun run build`
- built CLI smoke: `node dist/index.js --no-update-check --help`, `version`, `update`, `doctor --offline --json`
- pre-push hook: slow lint, knip, unit coverage, integration tests

Closes #977