### PR TITLE
test(cli): add global command smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,28 @@ jobs:
       package_manager: 'bun'
       skip_jobs: ''
     secrets: inherit
+  bin_smoke:
+    name: Lisa CLI bin smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: '22.21.1'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build package
+        run: bun run build
+      - name: Verify built Lisa CLI
+        env:
+          LISA_SKIP_UPDATE_CHECK: '1'
+        run: |
+          test "$(node -p "require('./package.json').bin.lisa")" = "dist/index.js"
+          node dist/index.js --version
+          node dist/index.js --help | grep -q "setup-project"
+          node dist/index.js --help | grep -q "setup-wiki"

--- a/README.md
+++ b/README.md
@@ -51,14 +51,53 @@ Templates follow governance rules: some files are overwritten on every update (e
 ## Quick Start
 
 ```bash
-curl -fsSL https://claude.ai/install.sh | bash
+npm install -g @codyswann/lisa
+lisa setup-project --type rails my-app
+cd my-app
 ```
 
-> Ask Claude: "I just cloned this repo. Walk me through setup."
+To add Lisa to an existing project instead, run:
+
+```bash
+lisa apply /path/to/project
+```
+
+The historical positional form still works for backwards compatibility:
+
+```bash
+lisa /path/to/project
+```
 
 ## Working With Lisa
 
-Lisa exposes a small set of top-level commands that map to the work lifecycle. Run them in Claude Code; everything underneath — agents, sub-flows, and the supporting libraries that power each step — happens automatically.
+Lisa exposes a small global CLI for project setup plus slash commands for the work lifecycle. Everything underneath — agents, sub-flows, and the supporting libraries that power each step — happens automatically.
+
+### Global CLI
+
+Install Lisa once and use the explicit setup commands for new or existing projects:
+
+```bash
+npm install -g @codyswann/lisa
+lisa setup-project --type rails my-app
+lisa setup-wiki
+lisa apply /path/to/project
+```
+
+Supported starter-backed setup types are `rails`, `typescript`, `expo`, `nestjs`, `cdk`, `wiki`, and `harper-wiki`. `setup-project --type wiki` creates a wiki-first repository; `setup-wiki` adds or repairs an embedded `wiki/` in the current project.
+
+Maintenance commands are intentionally small:
+
+```bash
+lisa doctor [path]
+lisa version
+lisa update
+```
+
+`lisa version` reports the installed package version, latest npm version, install path, and default harness. `lisa update` prints the package-manager update command and only runs it when `--yes` is supplied. Normal commands perform a non-fatal npm update check unless `--no-update-check` or `LISA_SKIP_UPDATE_CHECK=1` is set.
+
+### Lisa Workflow Commands
+
+Run these in Claude Code or the supported harness for the project.
 
 ### The Lifecycle
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { runApply } from "./apply.js";
 import { runDoctor } from "./doctor.js";
 import { printUpdateWarning } from "./print-update-warning.js";
 import { runSetupProject } from "./setup-project.js";
+import { runSetupWiki } from "./setup-wiki.js";
 import { addSharedOptions, type CLIOptions } from "./shared-options.js";
 import { SETUP_TYPES } from "./starters.js";
 import { runUpdate } from "./update-cmd.js";
@@ -20,6 +21,8 @@ export interface ProgramDependencies {
   runApply: typeof runApply;
   /** Creates a starter-backed project and applies Lisa overlays. */
   runSetupProject: typeof runSetupProject;
+  /** Prepares an existing project for embedded wiki setup. */
+  runSetupWiki: typeof runSetupWiki;
   /** Prints Lisa CLI version metadata. */
   runVersion: typeof runVersion;
   /** Prints or runs the package-manager update command. */
@@ -35,6 +38,7 @@ export interface ProgramDependencies {
 const DEFAULT_DEPENDENCIES: ProgramDependencies = {
   runApply,
   runSetupProject,
+  runSetupWiki,
   runVersion,
   runUpdate,
   runDoctor,
@@ -157,6 +161,15 @@ export function createProgram(
       await deps.runSetupProject(destination, options);
     }
   );
+
+  addSharedOptions(
+    program
+      .command("setup-wiki")
+      .description("Prepare an existing project for embedded Lisa wiki setup")
+      .argument("[path]", "Project path (default: current directory)")
+  ).action(async (destination: string | undefined, options: CLIOptions) => {
+    await deps.runSetupWiki(destination, options);
+  });
 
   addMaintenanceCommands(program, deps);
 

--- a/src/cli/setup-wiki.ts
+++ b/src/cli/setup-wiki.ts
@@ -1,0 +1,37 @@
+import { type CLIOptions } from "./shared-options.js";
+import { runApply } from "./apply.js";
+
+/** Options parsed for the setup-wiki command. */
+export type SetupWikiOptions = CLIOptions;
+
+/** Runtime collaborators for setup-wiki. */
+export interface SetupWikiDependencies {
+  runApply: (
+    destination: string | undefined,
+    options: CLIOptions
+  ) => Promise<void>;
+}
+
+const DEFAULT_DEPENDENCIES: SetupWikiDependencies = {
+  runApply,
+};
+
+/**
+ * Prepare an existing project for embedded Lisa wiki setup.
+ *
+ * The wiki kernel is delivered through Lisa's plugin and skill overlay, so the
+ * CLI command reuses the normal apply path against the target project. After
+ * apply, the runtime-specific `/setup:wiki` or `$lisa-wiki-setup` command owns
+ * the interactive wiki scaffold/repair workflow.
+ * @param destination - Optional project path, defaults to the current directory
+ * @param options - Parsed shared Lisa options
+ * @param dependencies - Injectable collaborators
+ * @returns Promise that resolves after Lisa apply completes
+ */
+export async function runSetupWiki(
+  destination: string | undefined,
+  options: SetupWikiOptions,
+  dependencies: SetupWikiDependencies = DEFAULT_DEPENDENCIES
+): Promise<void> {
+  await dependencies.runApply(destination ?? ".", options);
+}

--- a/tests/integration/cli-smoke.test.ts
+++ b/tests/integration/cli-smoke.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const DIST_CLI = path.join(REPO_ROOT, "dist", "index.js");
+
+/**
+ * Run a repo command and return stdout as a string.
+ * @param command - Executable name
+ * @param args - Command arguments
+ * @returns Captured stdout
+ */
+function run(command: string, args: readonly string[]): string {
+  return execFileSync(command, [...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      LISA_SKIP_UPDATE_CHECK: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+describe("built Lisa CLI smoke", () => {
+  beforeAll(() => {
+    run("bun", ["run", "build"]);
+  }, 120_000);
+
+  it("prints help for the built artifact with every public subcommand", () => {
+    const help = run("node", [DIST_CLI, "--help"]);
+
+    expect(help).toContain("apply");
+    expect(help).toContain("setup-project");
+    expect(help).toContain("setup-wiki");
+    expect(help).toContain("doctor");
+    expect(help).toContain("version");
+    expect(help).toContain("update");
+  });
+
+  it("prints the package version from the built artifact", () => {
+    const version = run("node", [DIST_CLI, "--version"]).trim();
+
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(version).not.toBe("1.0.0");
+  });
+
+  it("documents setup-project types in the built command help", () => {
+    const help = run("node", [DIST_CLI, "setup-project", "--help"]);
+
+    expect(help).toContain("Project type:");
+    expect(help).toContain("rails");
+    expect(help).toContain("harper-wiki");
+  });
+});

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -21,6 +21,7 @@ function createTestProgram(): {
   program: ReturnType<typeof createProgram>;
   runApply: ReturnType<typeof vi.fn>;
   runSetupProject: ReturnType<typeof vi.fn>;
+  runSetupWiki: ReturnType<typeof vi.fn>;
   runVersion: ReturnType<typeof vi.fn>;
   runUpdate: ReturnType<typeof vi.fn>;
   runDoctor: ReturnType<typeof vi.fn>;
@@ -29,6 +30,7 @@ function createTestProgram(): {
 } {
   const runApply = vi.fn(async () => undefined);
   const runSetupProject = vi.fn(async () => undefined);
+  const runSetupWiki = vi.fn(async () => undefined);
   const runVersion = vi.fn(async () => undefined);
   const runUpdate = vi.fn(async () => 0);
   const runDoctor = vi.fn(async () => ({ checks: [] }));
@@ -37,6 +39,7 @@ function createTestProgram(): {
   const program = createProgram({
     runApply,
     runSetupProject,
+    runSetupWiki,
     runVersion,
     runUpdate,
     runDoctor,
@@ -47,6 +50,7 @@ function createTestProgram(): {
     program,
     runApply,
     runSetupProject,
+    runSetupWiki,
     runVersion,
     runUpdate,
     runDoctor,
@@ -73,6 +77,12 @@ describe("createProgram", () => {
     const { program } = createTestProgram();
     const subcommandNames = program.commands.map(command => command.name());
     expect(subcommandNames).toContain("setup-project");
+  });
+
+  it("registers the setup-wiki subcommand", () => {
+    const { program } = createTestProgram();
+    const subcommandNames = program.commands.map(command => command.name());
+    expect(subcommandNames).toContain("setup-wiki");
   });
 
   it("registers version, update, and doctor subcommands", () => {
@@ -190,6 +200,19 @@ describe("setup-project invocation", () => {
         yes: true,
         harness: "codex",
       })
+    );
+  });
+});
+
+describe("setup-wiki invocation", () => {
+  it("routes setup-wiki to the setup-wiki action with shared options", async () => {
+    const { program, runSetupWiki } = createTestProgram();
+
+    await program.parseAsync(["setup-wiki", DEST, "--yes"], { from: "user" });
+
+    expect(runSetupWiki).toHaveBeenCalledWith(
+      DEST,
+      expect.objectContaining({ yes: true })
     );
   });
 });

--- a/tests/unit/cli/setup-wiki.test.ts
+++ b/tests/unit/cli/setup-wiki.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { runSetupWiki } from "../../../src/cli/setup-wiki.js";
+
+describe("runSetupWiki", () => {
+  it("applies Lisa to the current directory when no path is supplied", async () => {
+    const runApply = vi.fn(async () => undefined);
+
+    await runSetupWiki(undefined, { yes: true }, { runApply });
+
+    expect(runApply).toHaveBeenCalledWith(
+      ".",
+      expect.objectContaining({ yes: true })
+    );
+  });
+
+  it("applies Lisa to the requested project path", async () => {
+    const runApply = vi.fn(async () => undefined);
+
+    await runSetupWiki("my-app", { dryRun: true }, { runApply });
+
+    expect(runApply).toHaveBeenCalledWith(
+      "my-app",
+      expect.objectContaining({ dryRun: true })
+    );
+  });
+});

--- a/wiki/documentation/index.md
+++ b/wiki/documentation/index.md
@@ -6,7 +6,7 @@ Root package landing content can remain in `README.md`, local ingestion inbox fi
 
 ## Core Documentation
 
-- [Overview](overview.md)
+- [Overview](overview.md) — includes global CLI setup, embedded/wiki-first setup, maintenance commands, and update-check behavior.
 - [Contributing](contributing.md)
 
 ## Claude Notes

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -60,9 +60,33 @@ Without Lisa, Claude Code can:
 # Install globally
 npm install -g @codyswann/lisa
 
-# Or use with npx (no install)
-npx @codyswann/lisa /path/to/project
+# Create a new starter-backed project
+lisa setup-project --type rails my-app
+
+# Add or repair an embedded wiki in the current project
+lisa setup-wiki
+
+# Apply Lisa to an existing project
+lisa apply /path/to/project
 ```
+
+The backwards-compatible positional invocation remains supported:
+
+```bash
+lisa /path/to/project
+```
+
+`setup-project` supports `rails`, `typescript`, `expo`, `nestjs`, `cdk`, `wiki`, and `harper-wiki`. The `wiki` and `harper-wiki` setup types create wiki-first repositories, while `setup-wiki` operates inside an existing repository.
+
+Lisa also ships small maintenance commands:
+
+```bash
+lisa doctor [path]
+lisa version
+lisa update
+```
+
+Every normal command performs a timeout-bound npm latest-version check before it runs. The check is non-fatal when offline and can be skipped with `--no-update-check` or `LISA_SKIP_UPDATE_CHECK=1`; `lisa update --yes` is the only command that executes an update.
 
 ### The Workflow
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by incremental connector ingest on 2026-06-01 through Lisa release `2.133.3` and merged PR `#1129`.
+Last updated by repair-intake documentation update on 2026-06-01 for the global Lisa CLI command surface.
 
 ## Orientation
 
@@ -17,6 +17,7 @@ Last updated by incremental connector ingest on 2026-06-01 through Lisa release 
 
 - [Documentation Index](documentation/index.md)
 - [Overview](documentation/overview.md)
+  - Global CLI setup commands: `setup-project`, `setup-wiki`, `apply`, `doctor`, `version`, and `update`.
 - [Contributing](documentation/contributing.md)
 - [PRD Lifecycle Rollup Vendor Matrix](../plugins/src/base/rules/reference/prd-lifecycle-rollup.md)
 - [Testing Documentation](documentation/testing/)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Lisa Wiki Log
 
+## 2026-06-01 - CLI command surface documentation update
+
+- Updated README and wiki overview documentation to make the global Lisa CLI command surface primary.
+- Documented `setup-project`, `setup-wiki`, `apply`, `doctor`, `version`, `update`, supported starter types, backwards compatibility, and update-check opt-outs.
+- Added built-artifact CLI smoke coverage and a CI bin smoke job so `bin.lisa -> dist/index.js` remains executable.
+
 ## 2026-05-14 - In-repository wiki setup
 
 - Created the initial Lisa LLM Wiki structure inside the existing monorepo.


### PR DESCRIPTION
## Summary
- add `setup-wiki` to the public CLI command surface and cover its wiring
- add a built-artifact CLI smoke test for `dist/index.js` help/version output
- add a CI bin-smoke job for `package.json` bin.lisa and command help checks
- update README and wiki overview/index/log docs for the global CLI surface

## Verification
- bun run test:unit -- tests/unit/cli/index.test.ts tests/unit/cli/setup-project.test.ts tests/unit/cli/setup-wiki.test.ts tests/unit/cli/starters.test.ts tests/unit/cli/update-check.test.ts tests/unit/cli/version-cmd.test.ts tests/unit/cli/update-cmd.test.ts tests/unit/cli/doctor.test.ts
- bunx vitest run tests/integration/cli-smoke.test.ts
- bun run typecheck
- bun run build
- bun run lint
- pre-push hook: bun audit, slow lint, knip, vitest --coverage, tests/integration

Closes #979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `setup-wiki` CLI command for embedding wikis into projects.

* **Documentation**
  * Updated Quick Start guide with simplified installation and setup workflows.
  * Expanded documentation covering project creation, wiki setup, and applying Lisa to existing repositories.
  * Clarified CLI command surface and backwards-compatible invocations.

* **Tests**
  * Added smoke tests and CI verification for CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->