### PR TITLE
docs(wiki): ingest Lisa wiki state

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by connector ingest on 2026-06-03 for Lisa `2.134.5` and carried-forward wiki ingestion provenance.
+Last updated by connector ingest on 2026-06-04 for Lisa `2.134.6` and carried-forward wiki ingestion provenance.
 
 ## Orientation
 
@@ -12,7 +12,7 @@ Last updated by connector ingest on 2026-06-03 for Lisa `2.134.5` and carried-fo
 
 - [Project Registry](projects/registry.md)
 - [Lisa Monorepo Snapshot](projects/lisa-monorepo.md)
-  - Current package version: `2.134.5`; latest captured merged PR: `#1136`.
+  - Current package version: `2.134.6`; latest captured merged PR: `#1137`.
 
 ## Documentation
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -378,3 +378,12 @@
 - Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
 - Skipped `memory` because no project-scoped Claude memory directory exists for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
 - Updated the monorepo snapshot and index for the prior wiki ingest merge, two-way PR ticket links, the `setup-project` CLI command, Expo SDK 54/56 template compatibility, package.json corruption guards, Harper Fabric template cleanup, and release-history changes through `2.133.3`.
+
+## 2026-06-04 - Incremental connector ingest
+
+- Synced the checkout with `origin/main` by fetching `origin` and rebasing the current wiki branch onto `origin/main` without conflicts, then created `wiki/ingest-20260604T065711Z` from synced `origin/main` for this ingestion PR.
+- No same-day git or roles source notes existed for `2026-06-04`, so no provenance preservation copy was needed before writing the new connector notes.
+- Refreshed the `git` source note with 3 new commits through `e672acca43a7f954bdaf7ed7d97b0035f82445cc`, advanced the merged-PR cursor to `#1137`, and captured the release line through Lisa `2.134.6`.
+- Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
+- Skipped `memory` because no project-scoped Claude memory directory exists for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
+- Updated the monorepo snapshot and index for the prior wiki ingest merge and release-history changes through `2.134.6`.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,16 +20,18 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-20260603T235654Z` created from synced `origin/main`
-- HEAD at 2026-06-03 incremental ingest: `dea1ec2f81ae424a1914964f27542fff22412d13`
-- Current package version: `2.134.5`
-- Total commits on HEAD: 2804
-- Latest merged PR captured in the incremental git snapshot: `#1136`
+- Ingest branch: `wiki/ingest-20260604T065711Z` created from synced `origin/main`
+- HEAD at 2026-06-04 incremental ingest: `e672acca43a7f954bdaf7ed7d97b0035f82445cc`
+- Current package version: `2.134.6`
+- Total commits on HEAD: 2807
+- Latest merged PR captured in the incremental git snapshot: `#1137`
 - New commits since the previous incremental git cursor: `3`
 - Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists for `/Users/cody/.codex/worktrees/lisa-automation-main`; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
+- Release automation advanced the monorepo to `2.134.6`.
+- PR `#1137` merged the prior wiki ingestion through Lisa `2.134.5`.
 - Release automation advanced the monorepo to `2.134.5`.
 - PR `#1136` merged the prior wiki ingestion through Lisa `2.134.4`.
 - Release automation advanced the monorepo to `2.134.4`.
@@ -167,6 +169,7 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/git/2026-06-03-lisa-monorepo-git-previous-20260603T165711Z.md`
 - `wiki/sources/git/2026-06-03-lisa-monorepo-git-previous-20260603T235654Z.md`
 - `wiki/sources/git/2026-06-03-lisa-monorepo-git.md`
+- `wiki/sources/git/2026-06-04-lisa-monorepo-git.md`
 - `wiki/sources/memory/2026-05-27-memory.md`
 - `wiki/sources/memory/2026-05-28-memory.md`
 - `wiki/sources/roles/2026-05-25-roles.md`
@@ -195,3 +198,4 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - `wiki/sources/roles/2026-06-03-roles-previous-20260603T165711Z.md`
 - `wiki/sources/roles/2026-06-03-roles-previous-20260603T235654Z.md`
 - `wiki/sources/roles/2026-06-03-roles.md`
+- `wiki/sources/roles/2026-06-04-roles.md`

--- a/wiki/sources/git/2026-06-04-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-06-04-lisa-monorepo-git.md
@@ -1,0 +1,22 @@
+---
+type: source
+created: 2026-06-04
+updated: 2026-06-04
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-06-04)
+
+- Repo: `/Users/cody/.codex/worktrees/lisa-automation-main`
+- HEAD: `e672acca43a7f954bdaf7ed7d97b0035f82445cc`
+- Total commits on HEAD: 2807
+- New commits since last ingest (`dea1ec2f81ae424a1914964f27542fff22412d13`): 3
+- Merged PRs: 20 recent merged PR(s) in CodySwannGT/lisa; latest #1137 "docs(wiki): ingest Lisa wiki state"
+
+## New commits
+- e672acca · 2026-06-04 · chore(release): 2.134.6 [skip ci]
+- f649c055 · 2026-06-03 · Merge pull request #1137 from CodySwannGT/wiki/ingest-20260603T235654Z
+- d7752fa8 · 2026-06-03 · docs(wiki): ingest Lisa wiki state

--- a/wiki/sources/roles/2026-06-04-roles.md
+++ b/wiki/sources/roles/2026-06-04-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-06-04
+updated: 2026-06-04
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-06-04)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-06-03T23:57:38.135Z",
+  "ingested_at": "2026-06-04T06:57:39.252Z",
   "cursor": {
-    "lastCommit": "dea1ec2f81ae424a1914964f27542fff22412d13",
-    "lastPr": 1136
+    "lastCommit": "e672acca43a7f954bdaf7ed7d97b0035f82445cc",
+    "lastPr": 1137
   },
   "source_notes": [
-    "wiki/sources/git/2026-06-03-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-06-04-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-06-03T23:57:41.208Z",
+  "ingested_at": "2026-06-04T06:57:39.278Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-06-03"
+    "lastIngest": "2026-06-04"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-06-03-roles.md"
+    "wiki/sources/roles/2026-06-04-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- ingest git and roles wiki sources for 2026-06-04
- advance git cursor through e672acca / PR #1137 and roles cursor to 2026-06-04
- update wiki index, log, and monorepo snapshot for Lisa 2.134.6

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json
- commit hook: gitleaks, typecheck, lint-staged, commitlint, AI co-author
- pre-push hook: bun audit, slow lint, knip, unit coverage, integration tests

Memory connector skipped because no project-scoped Claude memory directory exists for this checkout; global Codex memory remains out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wiki documentation to reflect version 2.134.6 release
  * Added new ingestion cycle documentation for the latest data refresh

* **Chores**
  * Updated metadata and state tracking to reflect current package version and recent ingestion run

<!-- end of auto-generated comment: release notes by coderabbit.ai -->