### PR TITLE
feat(exploratory-qa): add flow-completeness / missing-counterpart category

### DIFF
--- a/plugins/lisa-expo-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/expo/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/expo/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/harper-fabric/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/harper-fabric/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/rails/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/rails/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -63,6 +63,23 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
   from the default UI or add context such as excerpts, labels, grouping, or provenance.
 - **Navigation clarity:** is it obvious how to get somewhere and back? Dead ends, hidden entry points,
   surprising redirects, broken links, no clear "home".
+- **Flow completeness & expected counterparts:** a screen that gates access or shows one side of a
+  standard paired flow must offer the other side — or a clear path to it. A brand-new user must never
+  hit a dead end with no next step. Flag missing companion actions, especially on auth and entry
+  screens:
+  - **Sign-in with no sign-up:** a login page with no "Create account" / "Register" link strands
+    anyone who does not already have an account; likewise a registration page with no link back to
+    sign in.
+  - **No account recovery:** login with no "Forgot password?", no way to reset, and no way to resend a
+    verification email.
+  - **No exit from a state:** a signed-in app with no visible sign-out, or a modal / wizard / detail
+    view with no back, close, or cancel.
+  - **One-way actions:** create/add with no matching edit or delete (or the reverse) where a user
+    would reasonably expect both.
+  - **Unreachable entry points:** a feature only reachable by guessing a URL, or an empty state with
+    no primary action to populate it.
+  When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
+  user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container


### PR DESCRIPTION
## Problem

A login page with **no way to register** (and no "forgot password") strands any brand-new user. The `exploratory-qa` skill had no category that named the pattern *"the other half of a standard paired flow is missing"*, so a pass could walk right past it. Real example: the AdvisorBook dev `login.html` offers sign-in only — no register link, no recovery.

## Fix

Adds a **"Flow completeness & expected counterparts"** dimension to §3 of the skill — the generic rule: a screen that gates access or shows one side of a standard paired flow must offer the other side, or a clear path to it; a brand-new user must never hit a dead end with no next step. Concrete cases it tells the runner to flag:

- **Sign-in with no sign-up** (and a registration page with no link back to sign in)
- **No account recovery** — no "Forgot password?", reset, or resend-verification
- **No exit from a state** — no sign-out; modal/wizard/detail with no back/close/cancel
- **One-way actions** — create/add with no matching edit/delete where both are expected
- **Unreachable entry points** — a feature only reachable by guessing a URL; an empty state with no primary action

Classification: a **Bug** when the missing counterpart blocks a core task for a whole class of users (e.g. a new user literally cannot create an account); otherwise a usability **Improvement**. Also surfaced in the frontmatter description for discoverability.

Applied to all three stacks that ship the skill (**harper-fabric, expo, rails**); cursor/agy/copilot variants regenerated via `bun run build:plugins`. `bun run check:plugins` passes.

## Note — stacks on #1142

This branch is based on #1142 (the expo/rails layout-integrity fix), since the expo/rails flow-completeness edit sits on top of that change. Until #1142 merges, this PR's diff also shows the #1142 commit; once #1142 lands, the diff reduces to just the new category. Merge #1142 first.

🤖 Generated with Claude Code