### PR TITLE
feat(openclaw): default repo-topic requireMention to false

### DIFF
--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -103,8 +103,13 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 Route the topic to the dispatcher: set
 `channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-`requireMention = true` and allowlist policy, and add `allowFrom` only when membership must be
-narrower than the group. The topic `systemPrompt` must state the scope mode, treat each native-reply
+allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
+topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
+is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
+Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
+you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
+See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
+tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
 root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
 worker with an explicit repo path, and return the worker result to the topic. Back up
 `~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
@@ -118,11 +123,14 @@ openclaw gateway status
 openclaw channels status --probe
 ```
 
-Then from the target topic: mention the bot and ask for an exact-token reply with **no** file
-changes, commits, PRs, or merges, e.g. `<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`. Confirm
-the visible reply, that the dispatcher spawned the worker, and that the worker ran in the intended
-repo. For folder-scoped topics, also send a request that implies but doesn't name a repo and confirm
-the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
+Then from the target topic, send a plain message with **no** @mention (the default
+`requireMention = false` means the agent must activate without one) asking for an exact-token reply
+with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
+Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
+intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
+(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
+message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
+repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
 <id> ...` as proof a topic route works — use the visible topic reply.
 
 ## Output standard

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -77,12 +77,18 @@ repos:
       "groups": {
         "<group-id>": {
           "groupPolicy": "allowlist",
+          // Group-level gate stays on: messages in the group that are NOT inside a
+          // routed topic still require an explicit mention.
           "requireMention": true,
           "allowFrom": ["<telegram-user-id>"],
           "topics": {
             "<topic-id>": {
               "agentId": "<topic-slug>-dispatch",
-              "requireMention": true,
+              // Default false: the topic is bound 1:1 to this agent, so every message
+              // in it is already addressed to the agent — an @mention carries no routing
+              // information. Flip to true only for shared-workspace topics where humans
+              // also coordinate with each other (see "Mention gating" below).
+              "requireMention": false,
               "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context."
             }
           }
@@ -92,6 +98,28 @@ repos:
   }
 }
 ```
+
+## Mention gating
+
+`requireMention` controls whether a message must @-mention the bot before the agent activates. It is
+set independently at the group level and the topic level; the topic-level value wins for messages
+inside a routed topic.
+
+- **Topic level — default `false`.** A repo-coding topic is bound 1:1 to its dispatcher
+  (`agentId`), so the topic itself already determines the agent. Every message in the topic is
+  addressed to that agent and the @mention adds nothing but friction. This is the "inbox topic"
+  shape: the topic *is* the conversation with the agent.
+- **Set the topic level to `true`** only for a **shared-workspace topic** — one where humans also
+  talk *to each other* (status updates, coordination) and you do not want every stray line to spawn
+  an agent run. The mention then acts as an explicit "this one is for the bot" intent signal.
+- **Group level — keep `true`.** It gates messages posted in the group but outside any routed
+  topic, where there is no 1:1 agent binding to lean on.
+
+Tradeoff to weigh before leaving a topic at `false`: with no mention required, **every** top-level
+message and **every** native reply in the topic wakes the dispatcher (and can spawn a worker run). In
+an inbox topic that is exactly what you want; in a topic people also chat in, it is noise and cost.
+When in doubt, keep code-work topics as dedicated inbox topics (`false`) and push human coordination
+to a separate topic or the group body.
 
 ## Worker launcher form
 

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -103,8 +103,13 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 Route the topic to the dispatcher: set
 `channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-`requireMention = true` and allowlist policy, and add `allowFrom` only when membership must be
-narrower than the group. The topic `systemPrompt` must state the scope mode, treat each native-reply
+allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
+topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
+is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
+Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
+you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
+See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
+tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
 root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
 worker with an explicit repo path, and return the worker result to the topic. Back up
 `~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
@@ -118,11 +123,14 @@ openclaw gateway status
 openclaw channels status --probe
 ```
 
-Then from the target topic: mention the bot and ask for an exact-token reply with **no** file
-changes, commits, PRs, or merges, e.g. `<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`. Confirm
-the visible reply, that the dispatcher spawned the worker, and that the worker ran in the intended
-repo. For folder-scoped topics, also send a request that implies but doesn't name a repo and confirm
-the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
+Then from the target topic, send a plain message with **no** @mention (the default
+`requireMention = false` means the agent must activate without one) asking for an exact-token reply
+with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
+Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
+intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
+(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
+message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
+repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
 <id> ...` as proof a topic route works — use the visible topic reply.
 
 ## Output standard

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -77,12 +77,18 @@ repos:
       "groups": {
         "<group-id>": {
           "groupPolicy": "allowlist",
+          // Group-level gate stays on: messages in the group that are NOT inside a
+          // routed topic still require an explicit mention.
           "requireMention": true,
           "allowFrom": ["<telegram-user-id>"],
           "topics": {
             "<topic-id>": {
               "agentId": "<topic-slug>-dispatch",
-              "requireMention": true,
+              // Default false: the topic is bound 1:1 to this agent, so every message
+              // in it is already addressed to the agent — an @mention carries no routing
+              // information. Flip to true only for shared-workspace topics where humans
+              // also coordinate with each other (see "Mention gating" below).
+              "requireMention": false,
               "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context."
             }
           }
@@ -92,6 +98,28 @@ repos:
   }
 }
 ```
+
+## Mention gating
+
+`requireMention` controls whether a message must @-mention the bot before the agent activates. It is
+set independently at the group level and the topic level; the topic-level value wins for messages
+inside a routed topic.
+
+- **Topic level — default `false`.** A repo-coding topic is bound 1:1 to its dispatcher
+  (`agentId`), so the topic itself already determines the agent. Every message in the topic is
+  addressed to that agent and the @mention adds nothing but friction. This is the "inbox topic"
+  shape: the topic *is* the conversation with the agent.
+- **Set the topic level to `true`** only for a **shared-workspace topic** — one where humans also
+  talk *to each other* (status updates, coordination) and you do not want every stray line to spawn
+  an agent run. The mention then acts as an explicit "this one is for the bot" intent signal.
+- **Group level — keep `true`.** It gates messages posted in the group but outside any routed
+  topic, where there is no 1:1 agent binding to lean on.
+
+Tradeoff to weigh before leaving a topic at `false`: with no mention required, **every** top-level
+message and **every** native reply in the topic wakes the dispatcher (and can spawn a worker run). In
+an inbox topic that is exactly what you want; in a topic people also chat in, it is noise and cost.
+When in doubt, keep code-work topics as dedicated inbox topics (`false`) and push human coordination
+to a separate topic or the group body.
 
 ## Worker launcher form
 

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -103,8 +103,13 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 Route the topic to the dispatcher: set
 `channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-`requireMention = true` and allowlist policy, and add `allowFrom` only when membership must be
-narrower than the group. The topic `systemPrompt` must state the scope mode, treat each native-reply
+allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
+topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
+is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
+Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
+you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
+See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
+tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
 root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
 worker with an explicit repo path, and return the worker result to the topic. Back up
 `~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
@@ -118,11 +123,14 @@ openclaw gateway status
 openclaw channels status --probe
 ```
 
-Then from the target topic: mention the bot and ask for an exact-token reply with **no** file
-changes, commits, PRs, or merges, e.g. `<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`. Confirm
-the visible reply, that the dispatcher spawned the worker, and that the worker ran in the intended
-repo. For folder-scoped topics, also send a request that implies but doesn't name a repo and confirm
-the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
+Then from the target topic, send a plain message with **no** @mention (the default
+`requireMention = false` means the agent must activate without one) asking for an exact-token reply
+with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
+Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
+intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
+(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
+message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
+repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
 <id> ...` as proof a topic route works — use the visible topic reply.
 
 ## Output standard

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -77,12 +77,18 @@ repos:
       "groups": {
         "<group-id>": {
           "groupPolicy": "allowlist",
+          // Group-level gate stays on: messages in the group that are NOT inside a
+          // routed topic still require an explicit mention.
           "requireMention": true,
           "allowFrom": ["<telegram-user-id>"],
           "topics": {
             "<topic-id>": {
               "agentId": "<topic-slug>-dispatch",
-              "requireMention": true,
+              // Default false: the topic is bound 1:1 to this agent, so every message
+              // in it is already addressed to the agent — an @mention carries no routing
+              // information. Flip to true only for shared-workspace topics where humans
+              // also coordinate with each other (see "Mention gating" below).
+              "requireMention": false,
               "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context."
             }
           }
@@ -92,6 +98,28 @@ repos:
   }
 }
 ```
+
+## Mention gating
+
+`requireMention` controls whether a message must @-mention the bot before the agent activates. It is
+set independently at the group level and the topic level; the topic-level value wins for messages
+inside a routed topic.
+
+- **Topic level — default `false`.** A repo-coding topic is bound 1:1 to its dispatcher
+  (`agentId`), so the topic itself already determines the agent. Every message in the topic is
+  addressed to that agent and the @mention adds nothing but friction. This is the "inbox topic"
+  shape: the topic *is* the conversation with the agent.
+- **Set the topic level to `true`** only for a **shared-workspace topic** — one where humans also
+  talk *to each other* (status updates, coordination) and you do not want every stray line to spawn
+  an agent run. The mention then acts as an explicit "this one is for the bot" intent signal.
+- **Group level — keep `true`.** It gates messages posted in the group but outside any routed
+  topic, where there is no 1:1 agent binding to lean on.
+
+Tradeoff to weigh before leaving a topic at `false`: with no mention required, **every** top-level
+message and **every** native reply in the topic wakes the dispatcher (and can spawn a worker run). In
+an inbox topic that is exactly what you want; in a topic people also chat in, it is noise and cost.
+When in doubt, keep code-work topics as dedicated inbox topics (`false`) and push human coordination
+to a separate topic or the group body.
 
 ## Worker launcher form
 

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -103,8 +103,13 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 Route the topic to the dispatcher: set
 `channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-`requireMention = true` and allowlist policy, and add `allowFrom` only when membership must be
-narrower than the group. The topic `systemPrompt` must state the scope mode, treat each native-reply
+allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
+topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
+is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
+Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
+you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
+See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
+tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
 root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
 worker with an explicit repo path, and return the worker result to the topic. Back up
 `~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
@@ -118,11 +123,14 @@ openclaw gateway status
 openclaw channels status --probe
 ```
 
-Then from the target topic: mention the bot and ask for an exact-token reply with **no** file
-changes, commits, PRs, or merges, e.g. `<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`. Confirm
-the visible reply, that the dispatcher spawned the worker, and that the worker ran in the intended
-repo. For folder-scoped topics, also send a request that implies but doesn't name a repo and confirm
-the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
+Then from the target topic, send a plain message with **no** @mention (the default
+`requireMention = false` means the agent must activate without one) asking for an exact-token reply
+with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
+Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
+intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
+(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
+message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
+repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
 <id> ...` as proof a topic route works — use the visible topic reply.
 
 ## Output standard

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -77,12 +77,18 @@ repos:
       "groups": {
         "<group-id>": {
           "groupPolicy": "allowlist",
+          // Group-level gate stays on: messages in the group that are NOT inside a
+          // routed topic still require an explicit mention.
           "requireMention": true,
           "allowFrom": ["<telegram-user-id>"],
           "topics": {
             "<topic-id>": {
               "agentId": "<topic-slug>-dispatch",
-              "requireMention": true,
+              // Default false: the topic is bound 1:1 to this agent, so every message
+              // in it is already addressed to the agent — an @mention carries no routing
+              // information. Flip to true only for shared-workspace topics where humans
+              // also coordinate with each other (see "Mention gating" below).
+              "requireMention": false,
               "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context."
             }
           }
@@ -92,6 +98,28 @@ repos:
   }
 }
 ```
+
+## Mention gating
+
+`requireMention` controls whether a message must @-mention the bot before the agent activates. It is
+set independently at the group level and the topic level; the topic-level value wins for messages
+inside a routed topic.
+
+- **Topic level — default `false`.** A repo-coding topic is bound 1:1 to its dispatcher
+  (`agentId`), so the topic itself already determines the agent. Every message in the topic is
+  addressed to that agent and the @mention adds nothing but friction. This is the "inbox topic"
+  shape: the topic *is* the conversation with the agent.
+- **Set the topic level to `true`** only for a **shared-workspace topic** — one where humans also
+  talk *to each other* (status updates, coordination) and you do not want every stray line to spawn
+  an agent run. The mention then acts as an explicit "this one is for the bot" intent signal.
+- **Group level — keep `true`.** It gates messages posted in the group but outside any routed
+  topic, where there is no 1:1 agent binding to lean on.
+
+Tradeoff to weigh before leaving a topic at `false`: with no mention required, **every** top-level
+message and **every** native reply in the topic wakes the dispatcher (and can spawn a worker run). In
+an inbox topic that is exactly what you want; in a topic people also chat in, it is noise and cost.
+When in doubt, keep code-work topics as dedicated inbox topics (`false`) and push human coordination
+to a separate topic or the group body.
 
 ## Worker launcher form
 

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -103,8 +103,13 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 Route the topic to the dispatcher: set
 `channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-`requireMention = true` and allowlist policy, and add `allowFrom` only when membership must be
-narrower than the group. The topic `systemPrompt` must state the scope mode, treat each native-reply
+allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
+topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
+is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
+Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
+you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
+See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
+tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
 root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
 worker with an explicit repo path, and return the worker result to the topic. Back up
 `~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
@@ -118,11 +123,14 @@ openclaw gateway status
 openclaw channels status --probe
 ```
 
-Then from the target topic: mention the bot and ask for an exact-token reply with **no** file
-changes, commits, PRs, or merges, e.g. `<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`. Confirm
-the visible reply, that the dispatcher spawned the worker, and that the worker ran in the intended
-repo. For folder-scoped topics, also send a request that implies but doesn't name a repo and confirm
-the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
+Then from the target topic, send a plain message with **no** @mention (the default
+`requireMention = false` means the agent must activate without one) asking for an exact-token reply
+with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
+Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
+intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
+(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
+message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
+repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
 <id> ...` as proof a topic route works — use the visible topic reply.
 
 ## Output standard

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -77,12 +77,18 @@ repos:
       "groups": {
         "<group-id>": {
           "groupPolicy": "allowlist",
+          // Group-level gate stays on: messages in the group that are NOT inside a
+          // routed topic still require an explicit mention.
           "requireMention": true,
           "allowFrom": ["<telegram-user-id>"],
           "topics": {
             "<topic-id>": {
               "agentId": "<topic-slug>-dispatch",
-              "requireMention": true,
+              // Default false: the topic is bound 1:1 to this agent, so every message
+              // in it is already addressed to the agent — an @mention carries no routing
+              // information. Flip to true only for shared-workspace topics where humans
+              // also coordinate with each other (see "Mention gating" below).
+              "requireMention": false,
               "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context."
             }
           }
@@ -92,6 +98,28 @@ repos:
   }
 }
 ```
+
+## Mention gating
+
+`requireMention` controls whether a message must @-mention the bot before the agent activates. It is
+set independently at the group level and the topic level; the topic-level value wins for messages
+inside a routed topic.
+
+- **Topic level — default `false`.** A repo-coding topic is bound 1:1 to its dispatcher
+  (`agentId`), so the topic itself already determines the agent. Every message in the topic is
+  addressed to that agent and the @mention adds nothing but friction. This is the "inbox topic"
+  shape: the topic *is* the conversation with the agent.
+- **Set the topic level to `true`** only for a **shared-workspace topic** — one where humans also
+  talk *to each other* (status updates, coordination) and you do not want every stray line to spawn
+  an agent run. The mention then acts as an explicit "this one is for the bot" intent signal.
+- **Group level — keep `true`.** It gates messages posted in the group but outside any routed
+  topic, where there is no 1:1 agent binding to lean on.
+
+Tradeoff to weigh before leaving a topic at `false`: with no mention required, **every** top-level
+message and **every** native reply in the topic wakes the dispatcher (and can spawn a worker run). In
+an inbox topic that is exactly what you want; in a topic people also chat in, it is noise and cost.
+When in doubt, keep code-work topics as dedicated inbox topics (`false`) and push human coordination
+to a separate topic or the group body.
 
 ## Worker launcher form
 


### PR DESCRIPTION
## Summary

- A repo-coding Telegram forum topic is bound 1:1 to its dispatcher agent (`agentId`), so requiring an `@mention` carries no routing information — it is pure friction. Flip the **topic-level** `requireMention` default to `false` ("inbox topic" shape) so the agent activates on any message in the topic.
- Document the tradeoff in a new **"Mention gating"** section: group-level gate stays `true` (messages outside a routed topic have no 1:1 binding), and topic level should be `true` only for shared-workspace topics where humans also coordinate with each other.
- Update the self-test to exercise no-mention activation (send a plain message; the mention path remains the fallback for topics deliberately left at `true`).

Changes are in the `lisa-openclaw` source (`plugins/src/openclaw/...`) and the regenerated base/cursor/agy/copilot artifacts.

## Test plan

- `bun run check:plugins` — confirms artifacts match a fresh rebuild from source (passes).
- Manual: in a repo-coding topic, send a message **without** an @mention and confirm the dispatcher activates and spawns the worker.

🤖 Generated with Claude Code