### PR TITLE
feat(exploratory-qa): add action-preconditions category; fix flaky cli-smoke test race

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "build": "tsc && node scripts/copy-codex-scripts.mjs && bun run build:plugins",
+    "build": "bun run build:dist && bun run build:plugins",
+    "build:dist": "tsc && node scripts/copy-codex-scripts.mjs",
     "test:integration": "vitest run tests/integration",
     "postinstall": "bash ./scripts/install-claude-plugins.sh || true; [ -d dist/configs ] || tsc || true",
     "pretest": "[ -d dist/configs ] || bun run build",

--- a/plugins/lisa-expo-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-expo/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-expo/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-harper-fabric/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-agy/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-agy/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-copilot/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-copilot/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails-cursor/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails-cursor/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/lisa-rails/skills/exploratory-qa/SKILL.md
+++ b/plugins/lisa-rails/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/expo/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/expo/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/harper-fabric/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/harper-fabric/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/plugins/src/rails/skills/exploratory-qa/SKILL.md
+++ b/plugins/src/rails/skills/exploratory-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-qa
-description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
+description: First-time-user exploratory QA walkthrough for web apps that FEEDS THE LIFECYCLE. Use when asked to experience an app the way a brand-new human user would — landing cold on the home page and clicking through to find anything confusing, broken, or hard to understand (human-facing jargon, contextless extracted data, machine-style labels, slow or unclear loads, late meaningful content, cramped or cut-off UI, inconsistent/non-standard UX, awkward scroll behavior, unclear affordances, dead-end flows that strand a user — e.g. a login page with no way to register or recover a password, or a primary action that drops the user into an incomplete/unsatisfiable state with no way to finish) across all breakpoints. Instead of writing a report file, it files every finding as a tracked work item via lisa:tracker-write (bugs and usability/UX issues). A `ready` parameter controls whether those tickets are created build-ready (auto-picked-up by lisa:intake) or left in the backlog for human triage (default). For gaps in the automated Playwright test suite, use the e2e-coverage-gaps skill instead.
 ---
 
 # Exploratory QA
@@ -80,6 +80,22 @@ mistakes, and tries the obvious thing. Cover at least these dimensions unless th
     no primary action to populate it.
   When the missing counterpart makes a core task impossible for a whole class of users (e.g. a new
   user literally cannot create an account), file a `Bug`; otherwise file a usability `Improvement`.
+- **Action preconditions & incomplete end-states:** an action whose result only makes sense with
+  multiple inputs (compare, merge, combine, bulk-edit) or with some prerequisite met should guide the
+  user to satisfy that precondition — by disabling/explaining it until it is met, by collecting the
+  inputs first (e.g. a selection tray), or by giving the destination an obvious in-place control to
+  complete it. Actually trigger these actions and watch where they land; flag when a primary action:
+  - **Fires under-satisfied and strands the user:** e.g. a per-row "Compare" that navigates to a
+    comparison of a single item, shows an "under limit / add at least 2" notice, but exposes no
+    visible "add another" control — the user is told what is wrong with no in-place means to fix it.
+  - **Lands on an incomplete / empty end-state with no next step:** a results or detail screen that
+    announces it is empty, partial, or "needs more" yet offers no affordance to add, retry, or return
+    to the selection that produced it.
+  - **Is offered where it cannot succeed:** a multi-item action exposed on a single item, or an action
+    left enabled while its precondition (a selection, a minimum count, a required field) is unmet,
+    with no explanation.
+  When the user is left unable to complete the action they started, file a `Bug`; when it eventually
+  works but the path is confusing or roundabout, file a usability `Improvement`.
 - **Visual/layout quality:** cut-off or truncated text, overlap, cramped/crowded density, offscreen or
   unreachable controls, accidental horizontal scroll, awkward empty space. **Do not judge this by
   eyeballing a screenshot alone** — a control clipped by a few pixels or pushed just past a container

--- a/tests/integration/cli-smoke.test.ts
+++ b/tests/integration/cli-smoke.test.ts
@@ -25,8 +25,15 @@ function run(command: string, args: readonly string[]): string {
 }
 
 describe("built Lisa CLI smoke", () => {
+  // Build ONLY the dist CLI (`build:dist` = tsc + copy-codex-scripts), NOT the
+  // full `bun run build`. The full build ends in `build:plugins`, which deletes
+  // and regenerates plugins/** in place; when this integration test shares a
+  // `vitest run` with the unit suite (test / test:cov), that rebuild
+  // intermittently removes plugins/** out from under unit tests reading those
+  // generated artifacts (flaky ENOENT). The CLI smoke only needs dist/index.js,
+  // so it must never run build:plugins. Keep this as build:dist.
   beforeAll(() => {
-    run("bun", ["run", "build"]);
+    run("bun", ["run", "build:dist"]);
   }, 120_000);
 
   it("prints help for the built artifact with every public subcommand", () => {


### PR DESCRIPTION
Two changes (independent commits).

## 1. New exploratory-QA category — "Action preconditions & incomplete end-states"

Clicking a per-row **Compare** on a single advisor navigates to a comparison of *one* item that shows "under limit — add at least 2 advisors" but exposes no in-place "add another" control — the user is told what's wrong with no way to fix it. The skill had no category naming "a primary action fired without its precondition, stranding the user in an incomplete result."

Adds a §3 dimension covering: actions that only make sense with multiple inputs (compare/merge/combine/bulk-edit) or a prerequisite must guide the user to satisfy it (disable+explain, collect inputs first, or give the destination an in-place control). Tells the runner to actually trigger such actions and flag: fires-under-satisfied-and-strands, lands-on-incomplete-end-state, offered-where-it-cannot-succeed. Bug when the user can't complete what they started, else Improvement. Applied to harper-fabric/expo/rails; variants regenerated; `check:plugins` green.

## 2. Fix flaky test race (latent bug, affects CI too)

While verifying #1, the pre-push suite failed intermittently. Root-caused it:

- `tests/integration/cli-smoke.test.ts` rebuilt the **real repo** in `beforeAll` via `bun run build`, whose last step `build:plugins` deletes+regenerates `plugins/**` in place.
- The project's vitest `include: ["tests/**"]` runs that integration test in the **same `vitest run`** as the unit suite (`test`/`test:cov`), so the in-place plugin rebuild intermittently removed `plugins/**` out from under unit tests reading those generated artifacts → flaky `ENOENT` (e.g. intake-explain reading `plugins/lisa/skills/.../SKILL.md`). Reproduces only under full-suite concurrency; serial/unit-only runs pass. Caught the offending `bash scripts/build-plugins.sh` (cwd = real repo) red-handed via process-tree capture.

**Fix:** the CLI smoke only needs the built `dist/index.js`, never the plugin artifacts. Add a non-destructive `build:dist` (`tsc + copy-codex-scripts`), compose `build` from it (`build:dist && build:plugins`, behavior identical), and have cli-smoke run `build:dist`. No unit test reads `dist/` at runtime, so the in-place tsc output doesn't race. Integration tests still run under coverage, so thresholds are unaffected (an earlier attempt that excluded integration from `test:cov` dropped coverage 75%→69%, so that approach was rejected).

**Verified:** full `bun run test:cov` (incl. integration) green twice — 175 files / 2923 tests, no ENOENT, coverage thresholds met; `bun run typecheck` clean; `bun run test:integration` green in isolation.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered build pipeline to run TypeScript compilation before plugin build.

* **Documentation**
  * Enhanced exploratory QA skill documentation across plugins with expanded guidance on action preconditions and incomplete end-states, including criteria for Bug vs Improvement classification.

* **Tests**
  * Updated CLI smoke test to build only distribution files to prevent flaky failures during concurrent test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->