### PR TITLE
feat(instructions): run canonical-files migration during lisa apply (covers /lisa-update-projects)

### DIFF
--- a/src/core/instruction-files-migration.ts
+++ b/src/core/instruction-files-migration.ts
@@ -51,6 +51,19 @@ export interface InstructionFilesMigrationResult {
   readonly actions: readonly string[];
 }
 
+/** Options controlling the instruction-files migration. */
+export interface MigrateInstructionFilesOptions {
+  /**
+   * Whether to create a `CLAUDE.md` pointer when none exists. Defaults to true
+   * (doctor's behavior — a project should have a CLAUDE.md so Claude Code reads
+   * the canonical AGENTS.md). Set false for harnesses that don't include Claude
+   * (e.g. a codex-only `lisa apply`) so no stray `CLAUDE.md` is written; an
+   * existing host-authored `CLAUDE.md` still gets the `@AGENTS.md` import either
+   * way.
+   */
+  readonly createClaudePointer?: boolean;
+}
+
 /**
  * Remove a legacy agy `LISA_RULES_START..END` block from an AGENTS.md body,
  * collapsing the whitespace left behind. Returns the original string unchanged
@@ -94,14 +107,22 @@ async function reconcileAgentsMd(destDir: string): Promise<string[]> {
 /**
  * Ensure `CLAUDE.md` imports the canonical `AGENTS.md`.
  *
- * Creates the pointer file when no `CLAUDE.md` exists, or prepends the
- * `@AGENTS.md` import to an existing host-authored file (preserving its content).
+ * Creates the pointer file when no `CLAUDE.md` exists (only when
+ * `createIfMissing` is true), or prepends the `@AGENTS.md` import to an existing
+ * host-authored file (preserving its content) regardless of `createIfMissing`.
  * @param destDir - Absolute path to the host project root.
+ * @param createIfMissing - Whether to create a pointer when no CLAUDE.md exists.
  * @returns Action strings describing what changed (empty when nothing did).
  */
-async function reconcileClaudeMd(destDir: string): Promise<string[]> {
+async function reconcileClaudeMd(
+  destDir: string,
+  createIfMissing: boolean
+): Promise<string[]> {
   const filePath = path.join(destDir, CLAUDE_MD_FILENAME);
   if (!existsSync(filePath)) {
+    if (!createIfMissing) {
+      return [];
+    }
     const result = await installClaudeMd(destDir);
     return result.created ? [`created ${CLAUDE_MD_FILENAME} pointer`] : [];
   }
@@ -117,13 +138,16 @@ async function reconcileClaudeMd(destDir: string): Promise<string[]> {
 /**
  * Run the instruction-files migration against a host project root.
  * @param destDir - Absolute path to the host project root.
+ * @param options - Migration options (see {@link MigrateInstructionFilesOptions}).
  * @returns Whether anything changed plus a description of each action.
  */
 export async function migrateInstructionFiles(
-  destDir: string
+  destDir: string,
+  options: MigrateInstructionFilesOptions = {}
 ): Promise<InstructionFilesMigrationResult> {
+  const createClaudePointer = options.createClaudePointer ?? true;
   const agentsActions = await reconcileAgentsMd(destDir);
-  const claudeActions = await reconcileClaudeMd(destDir);
+  const claudeActions = await reconcileClaudeMd(destDir, createClaudePointer);
   const actions = [...agentsActions, ...claudeActions];
   return { changed: actions.length > 0, actions };
 }

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -65,6 +65,7 @@ import {
   createInitialCounters,
   harnessIncludesAgent,
 } from "./config.js";
+import { migrateInstructionFiles } from "./instruction-files-migration.js";
 import type { IGitService } from "./git-service.js";
 
 /**
@@ -677,6 +678,7 @@ export class Lisa {
       await this.processClaudeEmit();
       await this.processAgyEmit();
       await this.processCopilotEmit();
+      await this.processInstructionFilesMigration();
       await this.registerPlugins();
       await this.finalize();
       this.printSummary();
@@ -998,6 +1000,37 @@ export class Lisa {
         }`
       )
     );
+  }
+
+  /**
+   * Reconcile the project's agent instruction files onto Lisa's canonical
+   * pattern after the per-harness emits run.
+   *
+   * The per-agent emits write `AGENTS.md` / `CLAUDE.md` create-only, so they
+   * can't repair files that already exist from older Lisa versions. This step
+   * runs the same non-destructive migration `lisa doctor` uses — stripping the
+   * legacy agy baked-rules block from an existing `AGENTS.md` and adding the
+   * `@AGENTS.md` import to an existing `CLAUDE.md`. Without it, updating an
+   * existing project would create a canonical `AGENTS.md` that its stale
+   * `CLAUDE.md` never imports.
+   *
+   * Harness-aware: a `CLAUDE.md` pointer is only *created* when the harness
+   * includes Claude, so a codex/cursor/copilot/agy-only project never gets a
+   * stray `CLAUDE.md`. An existing host-authored `CLAUDE.md` still gets the
+   * import regardless. Skipped in dry-run mode.
+   */
+  private async processInstructionFilesMigration(): Promise<void> {
+    if (this.config.dryRun) {
+      return;
+    }
+    const result = await migrateInstructionFiles(this.config.destDir, {
+      createClaudePointer: harnessIncludesAgent(this.config.harness, "claude"),
+    });
+    if (result.changed) {
+      this.deps.logger.info(
+        pc.cyan(`Instruction files: ${result.actions.join("; ")}`)
+      );
+    }
   }
 
   /**

--- a/tests/unit/core/instruction-files-migration.test.ts
+++ b/tests/unit/core/instruction-files-migration.test.ts
@@ -6,6 +6,7 @@
 import * as fs from "fs-extra";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CLAUDE_MD_AGENTS_IMPORT } from "../../../src/claude/claude-md-installer.js";
 import {
   LISA_RULES_END_MARKER,
   LISA_RULES_START_MARKER,
@@ -34,7 +35,7 @@ describe("core/instruction-files-migration", () => {
     expect(result.changed).toBe(true);
     expect(await fs.pathExists(agentsPath())).toBe(true);
     const claude = await fs.readFile(claudePath(), "utf8");
-    expect(claude).toContain("@AGENTS.md");
+    expect(claude).toContain(CLAUDE_MD_AGENTS_IMPORT);
   });
 
   it("prepends the @AGENTS.md import to an existing host CLAUDE.md without losing content", async () => {
@@ -44,7 +45,7 @@ describe("core/instruction-files-migration", () => {
     const result = await migrateInstructionFiles(dir);
 
     const claude = await fs.readFile(claudePath(), "utf8");
-    expect(claude).toContain("@AGENTS.md");
+    expect(claude).toContain(CLAUDE_MD_AGENTS_IMPORT);
     expect(claude).toContain("Use tabs, not spaces.");
     expect(result.actions.some(a => a.includes("CLAUDE.md"))).toBe(true);
   });
@@ -73,6 +74,29 @@ describe("core/instruction-files-migration", () => {
     expect(agents).not.toContain("Lots of baked rule text.");
     expect(agents).toContain("Host note above.");
     expect(result.actions.some(a => a.includes("baked-rules"))).toBe(true);
+  });
+
+  it("with createClaudePointer:false, does not create CLAUDE.md but still writes canonical AGENTS.md", async () => {
+    const result = await migrateInstructionFiles(dir, {
+      createClaudePointer: false,
+    });
+
+    expect(await fs.pathExists(agentsPath())).toBe(true);
+    expect(await fs.pathExists(claudePath())).toBe(false);
+    expect(result.actions.some(a => a.includes("CLAUDE.md"))).toBe(false);
+  });
+
+  it("with createClaudePointer:false, still adds the import to an existing CLAUDE.md", async () => {
+    await fs.writeFile(claudePath(), "# Host Claude\n\nNotes.\n", "utf8");
+
+    const result = await migrateInstructionFiles(dir, {
+      createClaudePointer: false,
+    });
+
+    const claude = await fs.readFile(claudePath(), "utf8");
+    expect(claude).toContain(CLAUDE_MD_AGENTS_IMPORT);
+    expect(claude).toContain("Notes.");
+    expect(result.actions.some(a => a.includes("CLAUDE.md"))).toBe(true);
   });
 
   it("is idempotent — a second run reports no changes", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1150. That PR added the canonical AGENTS.md + CLAUDE.md-pointer migration but wired it only into `lisa doctor`. This makes it run during **`lisa apply`** too, so it reaches every project via `@codyswann/lisa` postinstall and `/lisa-update-projects` — not just when someone manually runs `doctor`.

**Why it was needed:** the per-harness emits write `AGENTS.md`/`CLAUDE.md` create-only, so on an existing project they skip files that already exist. Without this, an update would create a fresh canonical `AGENTS.md` that the project's stale `CLAUDE.md` never imports (an incoherent half-migration).

- Runs `migrateInstructionFiles` as a post-emit step in `apply`: strips legacy agy baked-rules blocks from an existing `AGENTS.md` and prepends the `@AGENTS.md` import to an existing `CLAUDE.md` (host content preserved).
- **Harness-aware**: a `CLAUDE.md` pointer is only *created* when the harness includes Claude, so codex/cursor/copilot/agy-only projects never get a stray `CLAUDE.md`; an existing host `CLAUDE.md` still gets the import regardless.
- Idempotent; skipped in dry-run.

## Test plan

- `bun run typecheck` / `bun run lint` — clean
- `vitest run` — **176 files / 2935 tests pass** (2 new: harness-aware `createClaudePointer` behavior)
- Real `lisa apply` e2e verified:
  - existing claude project (old full `CLAUDE.md` + agy-baked `AGENTS.md`) → agy block stripped, `@AGENTS.md` import prepended, host content preserved
  - codex-only project with no `CLAUDE.md` → canonical `AGENTS.md` created, **no** stray `CLAUDE.md`

## Answer to "does /lisa-update-projects take care of this?"
With this change: **yes.** update-projects → `@codyswann/lisa@latest` → postinstall `lisa apply` → this migration self-heals each project as part of the normal update PR.

🤖 Generated with Claude Code