### PR TITLE
fix(package-lisa): govern @codyswann/lisa version via defaults, not force

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -22,7 +22,6 @@
       "source-map-support": "^0.5.21"
     },
     "devDependencies": {
-      "@codyswann/lisa": "^2.106.0",
       "aws-cdk": "^2.1104.0",
       "vite": "^8.0.5",
       "vitest": "^4.1.0",
@@ -37,6 +36,9 @@
     "private": true
   },
   "defaults": {
+    "devDependencies": {
+      "@codyswann/lisa": "^2.106.0"
+    },
     "engines": {
       "npm": ">= 10.9.4",
       "yarn": "please-use-npm",

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -74,7 +74,6 @@
     "devDependencies": {
       "@babel/core": "^7.20.0",
       "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-      "@codyswann/lisa": "^2.106.0",
       "@graphql-codegen/cli": "^6.1.0",
       "@graphql-codegen/typescript": "^4.1.6",
       "@graphql-codegen/typescript-operations": "^4.4.2",
@@ -160,6 +159,7 @@
       "react-native-web": "^0.21.2"
     },
     "devDependencies": {
+      "@codyswann/lisa": "^2.106.0",
       "@react-native-community/cli": "^20.0.2",
       "@react-native-community/cli-platform-android": "^20.0.2",
       "@react-native-community/cli-platform-ios": "^20.0.2",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -1,5 +1,8 @@
 {
   "defaults": {
+    "devDependencies": {
+      "@codyswann/lisa": "^2.106.0"
+    },
     "scripts": {
       "migration:generate": "tsx ./node_modules/typeorm/cli.js migration:generate -d typeorm.config.ts src/database/migrations/$npm_config_name",
       "migration:run": "tsx ./node_modules/typeorm/cli.js migration:run -d typeorm.config.ts",
@@ -72,7 +75,6 @@
       "typeorm-naming-strategies": "^4.1.0"
     },
     "devDependencies": {
-      "@codyswann/lisa": "^2.106.0",
       "@graphql-codegen/cli": "^6.1.0",
       "@graphql-codegen/typescript": "^4.1.6",
       "@graphql-codegen/typescript-operations": "^4.4.2",

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -21,9 +21,18 @@ const LISA_MARKER = "node_modules/@codyswann/lisa/dist/index.js";
  * Minimal shape of a package.lisa.json for the assertions below.
  */
 interface PackageLisaShape {
-  readonly force?: { readonly scripts?: Readonly<Record<string, string>> };
-  readonly defaults?: { readonly scripts?: Readonly<Record<string, string>> };
+  readonly force?: {
+    readonly scripts?: Readonly<Record<string, string>>;
+    readonly dependencies?: Readonly<Record<string, string>>;
+    readonly devDependencies?: Readonly<Record<string, string>>;
+  };
+  readonly defaults?: {
+    readonly scripts?: Readonly<Record<string, string>>;
+    readonly devDependencies?: Readonly<Record<string, string>>;
+  };
 }
+
+const LISA_PACKAGE = "@codyswann/lisa";
 
 /**
  * Load a JSON file from disk and return its parsed contents.
@@ -61,6 +70,35 @@ describe("package.lisa.json templates guard Lisa postinstall with CI-skip prefix
         // silently re-applying templates in CI creates race conditions.
         expect(script.startsWith(CI_GUARD_PREFIX)).toBe(true);
       }
+    }
+  );
+});
+
+describe("package.lisa.json templates never force-pin Lisa's own version", () => {
+  // Background: `force.devDependencies["@codyswann/lisa"]` made every apply
+  // (run from the project's own postinstall) overwrite the project's declared
+  // Lisa version with the template's stale floor. A project upgraded via
+  // `bun add -D @codyswann/lisa@latest` had its package.json silently reverted
+  // on the very next install, so the bump never landed and looked like
+  // cross-project corruption. Lisa's presence is guaranteed via `defaults`
+  // (added when absent, preserved when present) instead — which keeps the
+  // floor without clobbering a legitimate upgrade.
+  it.each(TEMPLATE_PATHS.map(p => [p]))(
+    "%s does not declare @codyswann/lisa in any force block",
+    relPath => {
+      const template = readTemplateJson(relPath) as PackageLisaShape;
+      expect(template.force?.devDependencies?.[LISA_PACKAGE]).toBeUndefined();
+      expect(template.force?.dependencies?.[LISA_PACKAGE]).toBeUndefined();
+    }
+  );
+
+  it.each(TEMPLATE_PATHS.map(p => [p]))(
+    "%s governs @codyswann/lisa via defaults when it pins a version at all",
+    relPath => {
+      const template = readTemplateJson(relPath) as PackageLisaShape;
+      const defaultsPin = template.defaults?.devDependencies?.[LISA_PACKAGE];
+      if (defaultsPin === undefined) return;
+      expect(typeof defaultsPin).toBe("string");
     }
   );
 });

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -28,6 +28,7 @@ interface PackageLisaShape {
   };
   readonly defaults?: {
     readonly scripts?: Readonly<Record<string, string>>;
+    readonly dependencies?: Readonly<Record<string, string>>;
     readonly devDependencies?: Readonly<Record<string, string>>;
   };
 }
@@ -99,6 +100,9 @@ describe("package.lisa.json templates never force-pin Lisa's own version", () =>
       const defaultsPin = template.defaults?.devDependencies?.[LISA_PACKAGE];
       if (defaultsPin === undefined) return;
       expect(typeof defaultsPin).toBe("string");
+      // Lisa is a dev tool: it must be governed only via
+      // defaults.devDependencies, never pinned in regular `dependencies`.
+      expect(template.defaults?.dependencies?.[LISA_PACKAGE]).toBeUndefined();
     }
   );
 });

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -18,7 +18,6 @@
       "prepare": "node -e \"if (process.env.INIT_CWD && process.env.INIT_CWD.includes('.serverless')) { process.exit(0); }\" && husky install || true"
     },
     "devDependencies": {
-      "@codyswann/lisa": "^2.106.0",
       "eslint-plugin-oxlint": "^1.62.0",
       "oxlint": "^1.62.0",
       "oxlint-tsgolint": "^0.22.1"
@@ -35,6 +34,9 @@
     }
   },
   "defaults": {
+    "devDependencies": {
+      "@codyswann/lisa": "^2.106.0"
+    },
     "scripts": {
       "build": "tsc",
       "postinstall": "[ -n \"$CI\" ] || node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true",


### PR DESCRIPTION
## Problem

Lisa's own version was pinned in `force.devDependencies["@codyswann/lisa"]` of the `typescript`, `cdk`, `expo`, and `nestjs` `package.lisa.json` templates (`^2.106.0`).

`force` semantics completely replace the project's value. Since the template apply runs from each project's own `postinstall`, every install overwrote the project's declared `@codyswann/lisa` version back to the stale `^2.106.0` floor. A project upgraded via `bun add -D @codyswann/lisa@latest` had its `package.json` silently reverted on the very next install — the bump never durably landed, and it presented as cross-project `package.json` corruption during parallel batch updates.

Discovered while updating `harperstarter` to 2.140.0: `package.json` kept reverting `^2.140.0` → `^2.106.0` after each `bun install`, traced to the postinstall apply re-asserting the `force` pin.

## Fix

Move `@codyswann/lisa` from `force.devDependencies` to `defaults.devDependencies` in all four affected templates. Per the force/defaults/merge contract, `defaults` provides the value only when the project hasn't declared it (presence guarantee preserved) and preserves the project's value when present — so a legitimate upgrade is no longer clobbered. `^2.106.0` still serves as the floor for projects with no declaration yet.

## Verification

- All existing unit tests pass (`tests/unit/strategies/package-lisa.test.ts` and full suite).
- Added a regression test in `tests/unit/config/postinstall-ci-guard.test.ts` asserting no `package.lisa.json` template declares `@codyswann/lisa` in any `force` block, and that any pin lives under `defaults`.
- End-to-end: built the patched dist and re-ran the apply against a project pinned at `^2.140.0` — the version is now preserved instead of reverted to `^2.106.0`.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized dependency management configuration across project templates to standardize package resolution behavior.
  * Improved test coverage for validating dependency configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->