### PR TITLE
fix(claude-remote): don't re-enter committed settings.json env flags in routine UI

### DIFF
--- a/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
@@ -84,9 +84,19 @@ Group the findings as:
    `secrets.*`/`env:` in CI, and config-referenced tokens. Group by integration (GitHub, AWS,
    Atlassian/JIRA/Confluence, Notion, Linear, Anthropic, notifications, feature flags, other).
    Cross-reference `.lisa.config.json` `tracker`/`source` to mark which credentials are **active**
-   for this repo vs **dormant** (`OPTIONAL`). Always surface Claude Code feature flags actually set
-   in `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) as `REQUIRED` to match
-   local behavior, since the environment `env` block is the reliable place to set them.
+   for this repo vs **dormant** (`OPTIONAL`). Distinguish *where* each var must be set, because the
+   answer differs and getting it wrong sends the user to do redundant work:
+
+   - **Committed `.claude/settings.json` `env` flags** (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+     `ENABLE_LSP_TOOL`, `BASH_*`) — this file is repo-committed, so it reaches the cloud and Claude
+     Code applies its `env` block when it launches. These are **already provided — no action**.
+     Surface them as `OK` (cite the file), not `REQUIRED`. Do **not** tell the user to re-enter them
+     in the environment UI; a duplicate there only risks drifting from the committed value. The lone
+     caveat: the setup script runs *before* Claude Code launches, so it cannot see these — flag any
+     that the **setup script itself** would need (rare) as needing a UI value too.
+   - **Secrets** (tokens/keys) — cannot be committed, so the committed `settings.json` can't carry
+     them. These are the only vars that genuinely **must be set in the environment-variables UI**.
+     Mark active-integration secrets `REQUIRED`; dormant ones `OPTIONAL`.
 
 4a. **Tracker / PRD-source credentials** — this is the load-bearing part of the audit and must be
    driven by config, not by what the scan happens to find. Resolve the active integrations first:
@@ -199,7 +209,10 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once.
+`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
+subsection with a one-line reminder that those flags are already provided by the committed file and
+need no UI entry.
 
 End with a fenced, machine-readable inventory block (also printed when `--json` is passed) so
 `/lisa:generate-claude-remote-build-script` can consume it without re-deriving everything. Secret
@@ -216,7 +229,7 @@ so the generator can render acquisition comments into its template:
   "tracker": "github",
   "source": "github",
   "env": [
-    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": true, "secret": false, "reason": "set in .claude/settings.json" },
+    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": false, "secret": false, "providedBy": "settings.json", "uiAction": "none", "reason": "committed in .claude/settings.json env — applied automatically; do not re-enter in the UI" },
     {
       "name": "GH_TOKEN", "required": true, "secret": true, "integration": "github",
       "reason": "active tracker+source; gh scripts gate on gh auth status",

--- a/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
@@ -209,7 +209,7 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+`tracker` and `source` resolve to the same vendor (e.g. both GitHub), render it once. List **only
 secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
 subsection with a one-line reminder that those flags are already provided by the committed file and
 need no UI entry.

--- a/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
@@ -51,9 +51,12 @@ tracker/source, plus the host project's own package manager and tooling — not 
 3. **Emit the environment-variable template.** Write a commented block listing every `env` entry
    from the inventory grouped by integration, marked `REQUIRED`/`OPTIONAL` and `secret`/`plain`,
    with the reason. **Never write real secret values** — only names and placeholders, because the
-   environment config is visible to anyone who can edit it. Include feature flags actually set in
-   `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) so cloud behavior matches
-   local. For every secret entry that carries `acquireUrl`/`accessScope`/`headlessSubstrate` (the
+   environment config is visible to anyone who can edit it. Entries flagged `providedBy: settings.json`
+   (the committed `.claude/settings.json` `env` flags, e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) are
+   **already applied from the committed file** — list them under an `# Already provided by committed
+   .claude/settings.json — no UI entry needed` heading, not as values to set. The "set in the
+   environment UI" template is for **secrets only**. For every secret entry that carries
+   `acquireUrl`/`accessScope`/`headlessSubstrate` (the
    active tracker/source credentials from the analysis's group 4a), render those as comment lines
    directly above the name — `# Acquire: <url>` and `# Access: <scope>` — so the user knows exactly
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
@@ -83,8 +86,9 @@ shape, not a fixed payload):
 #
 # GAPS this script cannot fix (configure separately):
 #   - <gaps from analysis, e.g. auto-memory is machine-local and not synced to cloud routines>
-# ENV VARS to set in the environment config (names only — set real values there, not here):
-#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # REQUIRED, matches .claude/settings.json
+# Already provided by committed .claude/settings.json (applied automatically — no UI entry needed):
+#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+# SECRETS to set in the environment config (names only — set real values there, not here):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R

--- a/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
@@ -84,9 +84,19 @@ Group the findings as:
    `secrets.*`/`env:` in CI, and config-referenced tokens. Group by integration (GitHub, AWS,
    Atlassian/JIRA/Confluence, Notion, Linear, Anthropic, notifications, feature flags, other).
    Cross-reference `.lisa.config.json` `tracker`/`source` to mark which credentials are **active**
-   for this repo vs **dormant** (`OPTIONAL`). Always surface Claude Code feature flags actually set
-   in `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) as `REQUIRED` to match
-   local behavior, since the environment `env` block is the reliable place to set them.
+   for this repo vs **dormant** (`OPTIONAL`). Distinguish *where* each var must be set, because the
+   answer differs and getting it wrong sends the user to do redundant work:
+
+   - **Committed `.claude/settings.json` `env` flags** (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+     `ENABLE_LSP_TOOL`, `BASH_*`) — this file is repo-committed, so it reaches the cloud and Claude
+     Code applies its `env` block when it launches. These are **already provided — no action**.
+     Surface them as `OK` (cite the file), not `REQUIRED`. Do **not** tell the user to re-enter them
+     in the environment UI; a duplicate there only risks drifting from the committed value. The lone
+     caveat: the setup script runs *before* Claude Code launches, so it cannot see these — flag any
+     that the **setup script itself** would need (rare) as needing a UI value too.
+   - **Secrets** (tokens/keys) — cannot be committed, so the committed `settings.json` can't carry
+     them. These are the only vars that genuinely **must be set in the environment-variables UI**.
+     Mark active-integration secrets `REQUIRED`; dormant ones `OPTIONAL`.
 
 4a. **Tracker / PRD-source credentials** — this is the load-bearing part of the audit and must be
    driven by config, not by what the scan happens to find. Resolve the active integrations first:
@@ -199,7 +209,10 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once.
+`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
+subsection with a one-line reminder that those flags are already provided by the committed file and
+need no UI entry.
 
 End with a fenced, machine-readable inventory block (also printed when `--json` is passed) so
 `/lisa:generate-claude-remote-build-script` can consume it without re-deriving everything. Secret
@@ -216,7 +229,7 @@ so the generator can render acquisition comments into its template:
   "tracker": "github",
   "source": "github",
   "env": [
-    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": true, "secret": false, "reason": "set in .claude/settings.json" },
+    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": false, "secret": false, "providedBy": "settings.json", "uiAction": "none", "reason": "committed in .claude/settings.json env — applied automatically; do not re-enter in the UI" },
     {
       "name": "GH_TOKEN", "required": true, "secret": true, "integration": "github",
       "reason": "active tracker+source; gh scripts gate on gh auth status",

--- a/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
@@ -209,7 +209,7 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+`tracker` and `source` resolve to the same vendor (e.g. both GitHub), render it once. List **only
 secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
 subsection with a one-line reminder that those flags are already provided by the committed file and
 need no UI entry.

--- a/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
@@ -51,9 +51,12 @@ tracker/source, plus the host project's own package manager and tooling — not 
 3. **Emit the environment-variable template.** Write a commented block listing every `env` entry
    from the inventory grouped by integration, marked `REQUIRED`/`OPTIONAL` and `secret`/`plain`,
    with the reason. **Never write real secret values** — only names and placeholders, because the
-   environment config is visible to anyone who can edit it. Include feature flags actually set in
-   `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) so cloud behavior matches
-   local. For every secret entry that carries `acquireUrl`/`accessScope`/`headlessSubstrate` (the
+   environment config is visible to anyone who can edit it. Entries flagged `providedBy: settings.json`
+   (the committed `.claude/settings.json` `env` flags, e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) are
+   **already applied from the committed file** — list them under an `# Already provided by committed
+   .claude/settings.json — no UI entry needed` heading, not as values to set. The "set in the
+   environment UI" template is for **secrets only**. For every secret entry that carries
+   `acquireUrl`/`accessScope`/`headlessSubstrate` (the
    active tracker/source credentials from the analysis's group 4a), render those as comment lines
    directly above the name — `# Acquire: <url>` and `# Access: <scope>` — so the user knows exactly
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
@@ -83,8 +86,9 @@ shape, not a fixed payload):
 #
 # GAPS this script cannot fix (configure separately):
 #   - <gaps from analysis, e.g. auto-memory is machine-local and not synced to cloud routines>
-# ENV VARS to set in the environment config (names only — set real values there, not here):
-#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # REQUIRED, matches .claude/settings.json
+# Already provided by committed .claude/settings.json (applied automatically — no UI entry needed):
+#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+# SECRETS to set in the environment config (names only — set real values there, not here):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R

--- a/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
@@ -84,9 +84,19 @@ Group the findings as:
    `secrets.*`/`env:` in CI, and config-referenced tokens. Group by integration (GitHub, AWS,
    Atlassian/JIRA/Confluence, Notion, Linear, Anthropic, notifications, feature flags, other).
    Cross-reference `.lisa.config.json` `tracker`/`source` to mark which credentials are **active**
-   for this repo vs **dormant** (`OPTIONAL`). Always surface Claude Code feature flags actually set
-   in `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) as `REQUIRED` to match
-   local behavior, since the environment `env` block is the reliable place to set them.
+   for this repo vs **dormant** (`OPTIONAL`). Distinguish *where* each var must be set, because the
+   answer differs and getting it wrong sends the user to do redundant work:
+
+   - **Committed `.claude/settings.json` `env` flags** (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+     `ENABLE_LSP_TOOL`, `BASH_*`) — this file is repo-committed, so it reaches the cloud and Claude
+     Code applies its `env` block when it launches. These are **already provided — no action**.
+     Surface them as `OK` (cite the file), not `REQUIRED`. Do **not** tell the user to re-enter them
+     in the environment UI; a duplicate there only risks drifting from the committed value. The lone
+     caveat: the setup script runs *before* Claude Code launches, so it cannot see these — flag any
+     that the **setup script itself** would need (rare) as needing a UI value too.
+   - **Secrets** (tokens/keys) — cannot be committed, so the committed `settings.json` can't carry
+     them. These are the only vars that genuinely **must be set in the environment-variables UI**.
+     Mark active-integration secrets `REQUIRED`; dormant ones `OPTIONAL`.
 
 4a. **Tracker / PRD-source credentials** — this is the load-bearing part of the audit and must be
    driven by config, not by what the scan happens to find. Resolve the active integrations first:
@@ -199,7 +209,10 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once.
+`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
+subsection with a one-line reminder that those flags are already provided by the committed file and
+need no UI entry.
 
 End with a fenced, machine-readable inventory block (also printed when `--json` is passed) so
 `/lisa:generate-claude-remote-build-script` can consume it without re-deriving everything. Secret
@@ -216,7 +229,7 @@ so the generator can render acquisition comments into its template:
   "tracker": "github",
   "source": "github",
   "env": [
-    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": true, "secret": false, "reason": "set in .claude/settings.json" },
+    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": false, "secret": false, "providedBy": "settings.json", "uiAction": "none", "reason": "committed in .claude/settings.json env — applied automatically; do not re-enter in the UI" },
     {
       "name": "GH_TOKEN", "required": true, "secret": true, "integration": "github",
       "reason": "active tracker+source; gh scripts gate on gh auth status",

--- a/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
@@ -209,7 +209,7 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+`tracker` and `source` resolve to the same vendor (e.g. both GitHub), render it once. List **only
 secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
 subsection with a one-line reminder that those flags are already provided by the committed file and
 need no UI entry.

--- a/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
@@ -51,9 +51,12 @@ tracker/source, plus the host project's own package manager and tooling — not 
 3. **Emit the environment-variable template.** Write a commented block listing every `env` entry
    from the inventory grouped by integration, marked `REQUIRED`/`OPTIONAL` and `secret`/`plain`,
    with the reason. **Never write real secret values** — only names and placeholders, because the
-   environment config is visible to anyone who can edit it. Include feature flags actually set in
-   `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) so cloud behavior matches
-   local. For every secret entry that carries `acquireUrl`/`accessScope`/`headlessSubstrate` (the
+   environment config is visible to anyone who can edit it. Entries flagged `providedBy: settings.json`
+   (the committed `.claude/settings.json` `env` flags, e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) are
+   **already applied from the committed file** — list them under an `# Already provided by committed
+   .claude/settings.json — no UI entry needed` heading, not as values to set. The "set in the
+   environment UI" template is for **secrets only**. For every secret entry that carries
+   `acquireUrl`/`accessScope`/`headlessSubstrate` (the
    active tracker/source credentials from the analysis's group 4a), render those as comment lines
    directly above the name — `# Acquire: <url>` and `# Access: <scope>` — so the user knows exactly
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
@@ -83,8 +86,9 @@ shape, not a fixed payload):
 #
 # GAPS this script cannot fix (configure separately):
 #   - <gaps from analysis, e.g. auto-memory is machine-local and not synced to cloud routines>
-# ENV VARS to set in the environment config (names only — set real values there, not here):
-#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # REQUIRED, matches .claude/settings.json
+# Already provided by committed .claude/settings.json (applied automatically — no UI entry needed):
+#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+# SECRETS to set in the environment config (names only — set real values there, not here):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R

--- a/plugins/lisa/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/analyze-claude-remote/SKILL.md
@@ -84,9 +84,19 @@ Group the findings as:
    `secrets.*`/`env:` in CI, and config-referenced tokens. Group by integration (GitHub, AWS,
    Atlassian/JIRA/Confluence, Notion, Linear, Anthropic, notifications, feature flags, other).
    Cross-reference `.lisa.config.json` `tracker`/`source` to mark which credentials are **active**
-   for this repo vs **dormant** (`OPTIONAL`). Always surface Claude Code feature flags actually set
-   in `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) as `REQUIRED` to match
-   local behavior, since the environment `env` block is the reliable place to set them.
+   for this repo vs **dormant** (`OPTIONAL`). Distinguish *where* each var must be set, because the
+   answer differs and getting it wrong sends the user to do redundant work:
+
+   - **Committed `.claude/settings.json` `env` flags** (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+     `ENABLE_LSP_TOOL`, `BASH_*`) — this file is repo-committed, so it reaches the cloud and Claude
+     Code applies its `env` block when it launches. These are **already provided — no action**.
+     Surface them as `OK` (cite the file), not `REQUIRED`. Do **not** tell the user to re-enter them
+     in the environment UI; a duplicate there only risks drifting from the committed value. The lone
+     caveat: the setup script runs *before* Claude Code launches, so it cannot see these — flag any
+     that the **setup script itself** would need (rare) as needing a UI value too.
+   - **Secrets** (tokens/keys) — cannot be committed, so the committed `settings.json` can't carry
+     them. These are the only vars that genuinely **must be set in the environment-variables UI**.
+     Mark active-integration secrets `REQUIRED`; dormant ones `OPTIONAL`.
 
 4a. **Tracker / PRD-source credentials** — this is the load-bearing part of the audit and must be
    driven by config, not by what the scan happens to find. Resolve the active integrations first:
@@ -199,7 +209,10 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once.
+`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
+subsection with a one-line reminder that those flags are already provided by the committed file and
+need no UI entry.
 
 End with a fenced, machine-readable inventory block (also printed when `--json` is passed) so
 `/lisa:generate-claude-remote-build-script` can consume it without re-deriving everything. Secret
@@ -216,7 +229,7 @@ so the generator can render acquisition comments into its template:
   "tracker": "github",
   "source": "github",
   "env": [
-    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": true, "secret": false, "reason": "set in .claude/settings.json" },
+    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": false, "secret": false, "providedBy": "settings.json", "uiAction": "none", "reason": "committed in .claude/settings.json env — applied automatically; do not re-enter in the UI" },
     {
       "name": "GH_TOKEN", "required": true, "secret": true, "integration": "github",
       "reason": "active tracker+source; gh scripts gate on gh auth status",

--- a/plugins/lisa/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/analyze-claude-remote/SKILL.md
@@ -209,7 +209,7 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+`tracker` and `source` resolve to the same vendor (e.g. both GitHub), render it once. List **only
 secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
 subsection with a one-line reminder that those flags are already provided by the committed file and
 need no UI entry.

--- a/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
@@ -51,9 +51,12 @@ tracker/source, plus the host project's own package manager and tooling — not 
 3. **Emit the environment-variable template.** Write a commented block listing every `env` entry
    from the inventory grouped by integration, marked `REQUIRED`/`OPTIONAL` and `secret`/`plain`,
    with the reason. **Never write real secret values** — only names and placeholders, because the
-   environment config is visible to anyone who can edit it. Include feature flags actually set in
-   `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) so cloud behavior matches
-   local. For every secret entry that carries `acquireUrl`/`accessScope`/`headlessSubstrate` (the
+   environment config is visible to anyone who can edit it. Entries flagged `providedBy: settings.json`
+   (the committed `.claude/settings.json` `env` flags, e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) are
+   **already applied from the committed file** — list them under an `# Already provided by committed
+   .claude/settings.json — no UI entry needed` heading, not as values to set. The "set in the
+   environment UI" template is for **secrets only**. For every secret entry that carries
+   `acquireUrl`/`accessScope`/`headlessSubstrate` (the
    active tracker/source credentials from the analysis's group 4a), render those as comment lines
    directly above the name — `# Acquire: <url>` and `# Access: <scope>` — so the user knows exactly
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
@@ -83,8 +86,9 @@ shape, not a fixed payload):
 #
 # GAPS this script cannot fix (configure separately):
 #   - <gaps from analysis, e.g. auto-memory is machine-local and not synced to cloud routines>
-# ENV VARS to set in the environment config (names only — set real values there, not here):
-#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # REQUIRED, matches .claude/settings.json
+# Already provided by committed .claude/settings.json (applied automatically — no UI entry needed):
+#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+# SECRETS to set in the environment config (names only — set real values there, not here):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R

--- a/plugins/src/base/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/analyze-claude-remote/SKILL.md
@@ -84,9 +84,19 @@ Group the findings as:
    `secrets.*`/`env:` in CI, and config-referenced tokens. Group by integration (GitHub, AWS,
    Atlassian/JIRA/Confluence, Notion, Linear, Anthropic, notifications, feature flags, other).
    Cross-reference `.lisa.config.json` `tracker`/`source` to mark which credentials are **active**
-   for this repo vs **dormant** (`OPTIONAL`). Always surface Claude Code feature flags actually set
-   in `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) as `REQUIRED` to match
-   local behavior, since the environment `env` block is the reliable place to set them.
+   for this repo vs **dormant** (`OPTIONAL`). Distinguish *where* each var must be set, because the
+   answer differs and getting it wrong sends the user to do redundant work:
+
+   - **Committed `.claude/settings.json` `env` flags** (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+     `ENABLE_LSP_TOOL`, `BASH_*`) — this file is repo-committed, so it reaches the cloud and Claude
+     Code applies its `env` block when it launches. These are **already provided — no action**.
+     Surface them as `OK` (cite the file), not `REQUIRED`. Do **not** tell the user to re-enter them
+     in the environment UI; a duplicate there only risks drifting from the committed value. The lone
+     caveat: the setup script runs *before* Claude Code launches, so it cannot see these — flag any
+     that the **setup script itself** would need (rare) as needing a UI value too.
+   - **Secrets** (tokens/keys) — cannot be committed, so the committed `settings.json` can't carry
+     them. These are the only vars that genuinely **must be set in the environment-variables UI**.
+     Mark active-integration secrets `REQUIRED`; dormant ones `OPTIONAL`.
 
 4a. **Tracker / PRD-source credentials** — this is the load-bearing part of the audit and must be
    driven by config, not by what the scan happens to find. Resolve the active integrations first:
@@ -199,7 +209,10 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once.
+`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
+subsection with a one-line reminder that those flags are already provided by the committed file and
+need no UI entry.
 
 End with a fenced, machine-readable inventory block (also printed when `--json` is passed) so
 `/lisa:generate-claude-remote-build-script` can consume it without re-deriving everything. Secret
@@ -216,7 +229,7 @@ so the generator can render acquisition comments into its template:
   "tracker": "github",
   "source": "github",
   "env": [
-    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": true, "secret": false, "reason": "set in .claude/settings.json" },
+    { "name": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "required": false, "secret": false, "providedBy": "settings.json", "uiAction": "none", "reason": "committed in .claude/settings.json env — applied automatically; do not re-enter in the UI" },
     {
       "name": "GH_TOKEN", "required": true, "secret": true, "integration": "github",
       "reason": "active tracker+source; gh scripts gate on gh auth status",

--- a/plugins/src/base/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/analyze-claude-remote/SKILL.md
@@ -209,7 +209,7 @@ checklist of the secrets the user must set in the routine's environment for the 
 `tracker`/`source` (from group 4a). One block per active integration, each with its env-var name(s),
 an `Acquire:` URL, and an `Access:` scope line, plus a one-line note that the environment UI is where
 these are set (the generated build script only emits a names-only template, never values). If both
-`tracker` and `source` resolve to the same vendor (e.g. both `github`), render it once. List **only
+`tracker` and `source` resolve to the same vendor (e.g. both GitHub), render it once. List **only
 secrets** here — do not include the committed `.claude/settings.json` `env` flags; close the
 subsection with a one-line reminder that those flags are already provided by the committed file and
 need no UI entry.

--- a/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
@@ -51,9 +51,12 @@ tracker/source, plus the host project's own package manager and tooling — not 
 3. **Emit the environment-variable template.** Write a commented block listing every `env` entry
    from the inventory grouped by integration, marked `REQUIRED`/`OPTIONAL` and `secret`/`plain`,
    with the reason. **Never write real secret values** — only names and placeholders, because the
-   environment config is visible to anyone who can edit it. Include feature flags actually set in
-   `.claude/settings.json` (e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) so cloud behavior matches
-   local. For every secret entry that carries `acquireUrl`/`accessScope`/`headlessSubstrate` (the
+   environment config is visible to anyone who can edit it. Entries flagged `providedBy: settings.json`
+   (the committed `.claude/settings.json` `env` flags, e.g. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) are
+   **already applied from the committed file** — list them under an `# Already provided by committed
+   .claude/settings.json — no UI entry needed` heading, not as values to set. The "set in the
+   environment UI" template is for **secrets only**. For every secret entry that carries
+   `acquireUrl`/`accessScope`/`headlessSubstrate` (the
    active tracker/source credentials from the analysis's group 4a), render those as comment lines
    directly above the name — `# Acquire: <url>` and `# Access: <scope>` — so the user knows exactly
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
@@ -83,8 +86,9 @@ shape, not a fixed payload):
 #
 # GAPS this script cannot fix (configure separately):
 #   - <gaps from analysis, e.g. auto-memory is machine-local and not synced to cloud routines>
-# ENV VARS to set in the environment config (names only — set real values there, not here):
-#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # REQUIRED, matches .claude/settings.json
+# Already provided by committed .claude/settings.json (applied automatically — no UI entry needed):
+#   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+# SECRETS to set in the environment config (names only — set real values there, not here):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R

--- a/scripts/claude-remote-setup.sh
+++ b/scripts/claude-remote-setup.sh
@@ -13,12 +13,10 @@
 #   - linear-server MCP is OAuth (browser) → unusable headless. Dormant here (tracker=github);
 #     if you switch to Linear, use LINEAR_API_KEY + Linear GraphQL instead.
 #
-# ENV VARS to set in the environment config (names only — set real values in the UI, NOT here):
-#   Plain config flags (match .claude/settings.json):
-#     - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-#     - ENABLE_LSP_TOOL=1
-#     - BASH_DEFAULT_TIMEOUT_MS=1800000
-#     - BASH_MAX_TIMEOUT_MS=7200000
+# Already provided by committed .claude/settings.json env (applied automatically — do NOT re-enter in the UI):
+#     - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ENABLE_LSP_TOOL, BASH_DEFAULT_TIMEOUT_MS, BASH_MAX_TIMEOUT_MS
+#
+# SECRETS to set in the environment config (names only — set real values in the UI, NOT here):
 #   Credentials for the active tracker/source (tracker=github, source=github):
 #     # Acquire: https://github.com/settings/personal-access-tokens
 #     # Access:  fine-grained PAT on CodySwannGT/lisa — Contents R/W, Issues R/W,


### PR DESCRIPTION
## What

Follow-up to #1157. The claude-remote skills told users to set the committed `.claude/settings.json` `env` flags (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_LSP_TOOL`, `BASH_*`) in the routine's environment-variables UI. That's redundant: `settings.json` is repo-committed, reaches the cloud, and Claude Code applies its `env` block when it launches — so those flags are already set. Re-entering them in the UI is busywork and risks drifting from the committed value.

## Changes

- **`analyze-claude-remote`** group 4 now splits env reporting:
  - Committed `settings.json` flags → `OK` / already-provided / **no UI action** (inventory: `providedBy: settings.json`, `uiAction: none`).
  - **Secrets** → the only vars that must be set in the UI (`REQUIRED` for active integrations).
  - "Credentials to provision" output lists secrets only, with a closing reminder that committed flags need no UI entry.
- **`generate-claude-remote-build-script`** template separates an "Already provided by committed `.claude/settings.json`" note from the secrets-to-set block.
- Regenerated `scripts/claude-remote-setup.sh` header to match.

## Verification

- `bun run check:plugins` ✓ (artifacts in sync; marketplace registers every plugin)
- `bash -n scripts/claude-remote-setup.sh` ✓
- Pre-commit: gitleaks clean, `tsc --noEmit` ✓

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code remote setup instructions to clarify which environment variables are pre-configured and don't require manual UI entry.
  * Enhanced credentials provisioning documentation across skill plugins to better distinguish between automatic settings and manual secret configuration.
  * Restructured environment variable guidance in generated setup scripts for clearer separation of pre-configured versus user-required entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->