### PR TITLE
fix(tsconfig): graceful typecheck posture for source-less repos

### DIFF
--- a/cdk/create-only/tsconfig.local.json
+++ b/cdk/create-only/tsconfig.local.json
@@ -1,4 +1,12 @@
 {
-  "include": ["lib/**/*", "bin/**/*", "test/**/*"],
-  "exclude": ["node_modules", "cdk.out"]
+  "include": [
+    "lib/**/*",
+    "bin/**/*",
+    "test/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ],
+  "files": []
 }

--- a/expo/create-only/tsconfig.local.json
+++ b/expo/create-only/tsconfig.local.json
@@ -1,10 +1,24 @@
 {
   "compilerOptions": {
     "paths": {
-      "@/graphql/*": ["./generated/*"],
-      "@/*": ["./*"]
+      "@/graphql/*": [
+        "./generated/*"
+      ],
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "nativewind-env.d.ts"],
-  "exclude": ["node_modules", "dist", "web-build", "components/ui"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "nativewind-env.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "web-build",
+    "components/ui"
+  ],
+  "files": []
 }

--- a/nestjs/create-only/tsconfig.local.json
+++ b/nestjs/create-only/tsconfig.local.json
@@ -3,9 +3,20 @@
     "outDir": ".build",
     "rootDir": "src",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", ".build", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    ".build",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ],
+  "files": []
 }

--- a/src/migrations/ensure-tsconfig-local-files-fallback.ts
+++ b/src/migrations/ensure-tsconfig-local-files-fallback.ts
@@ -1,0 +1,97 @@
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import { readJsonOrNull, writeJson } from "../utils/json-utils.js";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const TSCONFIG_LOCAL = "tsconfig.local.json";
+
+/**
+ * Minimal shape of a tsconfig file for the `files` fallback manipulation
+ */
+interface TsconfigLike {
+  readonly files?: readonly string[];
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Migration: add an empty `files` array to tsconfig.local.json.
+ *
+ * Background: the stack tsconfig.local.json templates declare
+ * `include: ["src/**\/*"]`. A source-less repo (e.g. a SOC2 / infra-config
+ * project that ships only root-level *.config.ts and no `src/`) has an
+ * `include` that matches zero files, so `tsc --noEmit` aborts with
+ * `error TS18003: No inputs were found in config file`. That failure trips
+ * the lisa-managed typecheck pre-commit hook and blocks every commit, even
+ * though there is genuinely nothing to type-check.
+ *
+ * TypeScript treats an explicit (even empty) `files` array as an intentional
+ * file list and therefore does NOT raise TS18003. Crucially, when `include`
+ * also matches real sources the compiled program is the UNION of `files` and
+ * the `include` matches — so an empty `files` is a no-op for projects that
+ * have sources (they are still fully type-checked) and a graceful success for
+ * source-less ones. This is a posture change for empty-input tolerance, NOT a
+ * relaxation of any check.
+ *
+ * The key is injected only when absent, so a project that intentionally pins a
+ * non-empty `files` list keeps it.
+ */
+export class EnsureTsconfigLocalFilesFallbackMigration implements Migration {
+  readonly name = "ensure-tsconfig-local-files-fallback";
+  readonly description =
+    "Add an empty `files` array to tsconfig.local.json so source-less projects pass tsc (TS18003) without disabling typechecking";
+
+  /**
+   * Check whether this migration should run on the project
+   * @param ctx - Migration context
+   * @returns True when tsconfig.local.json exists but has no `files` key
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    const tsconfigLocalPath = path.join(ctx.projectDir, TSCONFIG_LOCAL);
+    const existing = await readJsonOrNull<TsconfigLike>(tsconfigLocalPath);
+    if (!existing) {
+      return false;
+    }
+    return existing.files === undefined;
+  }
+
+  /**
+   * Apply the migration, injecting an empty `files` array when absent
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const tsconfigLocalPath = path.join(ctx.projectDir, TSCONFIG_LOCAL);
+    const existing = await readJsonOrNull<TsconfigLike>(tsconfigLocalPath);
+    if (!existing || existing.files !== undefined) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const patched: TsconfigLike = { ...existing, files: [] };
+    const message =
+      "Added empty `files` array to tsconfig.local.json (TS18003 fallback)";
+
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would add empty \`files\` array to ${TSCONFIG_LOCAL}`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [TSCONFIG_LOCAL],
+        message,
+      };
+    }
+
+    await fse.ensureDir(path.dirname(tsconfigLocalPath));
+    await writeJson(tsconfigLocalPath, patched);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [TSCONFIG_LOCAL],
+      message,
+    };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 import type {
   Migration,
@@ -15,6 +16,7 @@ export type {
 } from "./migration.interface.js";
 export { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 
 /**
@@ -30,6 +32,7 @@ export class MigrationRegistry {
   constructor(migrations?: readonly Migration[]) {
     this.migrations = migrations ?? [
       new EnsureTsconfigLocalIncludesMigration(),
+      new EnsureTsconfigLocalFilesFallbackMigration(),
       new EnsureAuditIgnoreLocalExclusionsMigration(),
       new EnsureLisaPostinstallMigration(),
     ];

--- a/tests/unit/migrations/ensure-tsconfig-local-files-fallback.test.ts
+++ b/tests/unit/migrations/ensure-tsconfig-local-files-fallback.test.ts
@@ -1,0 +1,142 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureTsconfigLocalFilesFallbackMigration } from "../../../src/migrations/ensure-tsconfig-local-files-fallback.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const TSCONFIG_LOCAL = "tsconfig.local.json";
+const SRC_GLOB = "src/**/*";
+const NODE_MODULES = "node_modules";
+
+describe("EnsureTsconfigLocalFilesFallbackMigration", () => {
+  let migration: EnsureTsconfigLocalFilesFallbackMigration;
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    migration = new EnsureTsconfigLocalFilesFallbackMigration();
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Build a migration context for testing
+   * @param detectedTypes - Detected project types
+   * @param dryRun - Whether to run in dry-run mode
+   * @returns A migration context suitable for tests
+   */
+  function createContext(
+    detectedTypes: readonly ProjectType[] = ["typescript"],
+    dryRun = false
+  ): MigrationContext {
+    return {
+      projectDir,
+      lisaDir: path.join(tempDir, "lisa"),
+      detectedTypes,
+      dryRun,
+      logger: new SilentLogger(),
+    };
+  }
+
+  describe("basic properties", () => {
+    it("has correct name and description", () => {
+      expect(migration.name).toBe("ensure-tsconfig-local-files-fallback");
+      expect(migration.description).toContain(TSCONFIG_LOCAL);
+    });
+  });
+
+  describe("applies()", () => {
+    it("returns false when tsconfig.local.json does not exist", async () => {
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+
+    it("returns true when files key is absent", async () => {
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), {
+        include: [SRC_GLOB],
+        exclude: [NODE_MODULES],
+      });
+
+      expect(await migration.applies(createContext())).toBe(true);
+    });
+
+    it("returns false when files key is already present", async () => {
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), {
+        include: [SRC_GLOB],
+        files: [],
+      });
+
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+  });
+
+  describe("apply()", () => {
+    it("injects an empty files array when absent", async () => {
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), {
+        compilerOptions: { outDir: "dist", rootDir: "src" },
+        include: [SRC_GLOB],
+        exclude: [NODE_MODULES],
+      });
+
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("applied");
+      expect(result.changedFiles).toEqual([TSCONFIG_LOCAL]);
+
+      const patched = await fs.readJson(path.join(projectDir, TSCONFIG_LOCAL));
+      expect(patched.files).toEqual([]);
+      // existing keys are preserved untouched
+      expect(patched.include).toEqual([SRC_GLOB]);
+      expect(patched.exclude).toEqual([NODE_MODULES]);
+      expect(patched.compilerOptions).toEqual({
+        outDir: "dist",
+        rootDir: "src",
+      });
+    });
+
+    it("preserves a project's existing non-empty files list", async () => {
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), {
+        include: [SRC_GLOB],
+        files: ["src/index.ts"],
+      });
+
+      const result = await migration.apply(createContext());
+
+      expect(result.action).toBe("noop");
+      const unchanged = await fs.readJson(
+        path.join(projectDir, TSCONFIG_LOCAL)
+      );
+      expect(unchanged.files).toEqual(["src/index.ts"]);
+    });
+
+    it("does not modify file in dry-run mode", async () => {
+      const original = { include: [SRC_GLOB], exclude: [NODE_MODULES] };
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), original);
+
+      const result = await migration.apply(createContext(["typescript"], true));
+
+      expect(result.action).toBe("applied");
+      const unchanged = await fs.readJson(
+        path.join(projectDir, TSCONFIG_LOCAL)
+      );
+      expect(unchanged).toEqual(original);
+    });
+
+    it("is idempotent when run twice", async () => {
+      await fs.writeJson(path.join(projectDir, TSCONFIG_LOCAL), {
+        include: [SRC_GLOB],
+        exclude: [NODE_MODULES],
+      });
+
+      await migration.apply(createContext());
+      const secondApplies = await migration.applies(createContext());
+      expect(secondApplies).toBe(false);
+    });
+  });
+});

--- a/tests/unit/migrations/migration-registry.test.ts
+++ b/tests/unit/migrations/migration-registry.test.ts
@@ -63,6 +63,7 @@ describe("MigrationRegistry", () => {
     const names = registry.getAll().map(m => m.name);
 
     expect(names).toContain("ensure-tsconfig-local-includes");
+    expect(names).toContain("ensure-tsconfig-local-files-fallback");
     expect(names).toContain("ensure-audit-ignore-local-exclusions");
     expect(names).toContain("ensure-lisa-postinstall");
   });

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -6,6 +6,14 @@
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "configs"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "configs"
+  ],
+  "files": []
 }

--- a/typescript/create-only/tsconfig.local.json
+++ b/typescript/create-only/tsconfig.local.json
@@ -3,6 +3,15 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", ".build", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    ".build",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ],
+  "files": []
 }


### PR DESCRIPTION
## Problem

A **source-less** repo (e.g. a SOC2 / infra-config project that ships only root-level `*.config.ts` and no `src/`) has `tsconfig.local.json`'s `include: ["src/**/*"]` match **zero files**, so `tsc --noEmit` aborts with:

```
error TS18003: No inputs were found in config file '.../tsconfig.json'.
```

That failure trips the lisa-managed typecheck pre-commit hook and **blocks every commit**, even though there is genuinely nothing to type-check. Observed in `aws-soc2-setup` during the 2026-06-06 batch update.

## Fix

TypeScript treats an explicit (even empty) `files` array as an intentional file list and therefore does **not** raise TS18003. Crucially, when `include` also matches real sources the compiled program is the **union** of `files` and the `include` matches — so an empty `files`:

- is a **no-op for repos with sources** (still fully type-checked — verified: a `src/bad.ts` type error is still caught with `files: []` present), and
- a **graceful success for source-less ones** (empty program, exit 0).

This is an empty-input-tolerance posture, **not** a relaxation of any check.

### Changes
- New `EnsureTsconfigLocalFilesFallbackMigration` backfills `files: []` into `tsconfig.local.json` when absent (propagates to existing repos on apply; preserves a project's existing non-empty `files` list).
- Add `files: []` to the create-only `tsconfig.local.json` templates (typescript/cdk/expo/nestjs + root) so freshly scaffolded projects carry it too.
- Unit tests for the migration; registry test updated.

### Verification
- Empirically reproduced TS18003 in aws-soc2-setup and confirmed `files: []` → exit 0; with a `src/bad.ts` type error → still TS2322 exit 2 (checks preserved).
- `tsc --noEmit` on the lisa repo itself still passes with the root `tsconfig.local.json` change (real repo with sources).
- 35 migration/template unit tests pass; typecheck + eslint clean.

🤖 Generated with Claude Code