### PR TITLE
fix(vitest): pass with no tests so source-less repos don't fail the gate

### DIFF
--- a/src/configs/vitest/cdk.ts
+++ b/src/configs/vitest/cdk.ts
@@ -63,6 +63,9 @@ export const getCdkVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
+    // Repos with no test files must not fail the pre-push/CI gate; vitest exits 1
+    // on "No test files found" otherwise. See typescript.ts for rationale.
+    passWithNoTests: true,
     include: [
       "test/**/*.test.ts",
       "test/**/*.spec.ts",

--- a/src/configs/vitest/harper-fabric.ts
+++ b/src/configs/vitest/harper-fabric.ts
@@ -46,6 +46,9 @@ export const getHarperFabricVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
+    // Repos with no test files must not fail the pre-push/CI gate; vitest exits 1
+    // on "No test files found" otherwise. See typescript.ts for rationale.
+    passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     exclude: [...defaultTestExclusions],
     testTimeout: 10000,

--- a/src/configs/vitest/nestjs.ts
+++ b/src/configs/vitest/nestjs.ts
@@ -85,6 +85,9 @@ export const getNestjsVitestConfig = ({
     globals: true,
     environment: "node",
     root: "src",
+    // Repos with no spec files must not fail the pre-push/CI gate; vitest exits 1
+    // on "No test files found" otherwise. See typescript.ts for rationale.
+    passWithNoTests: true,
     include: ["**/*.spec.ts"],
     exclude: [...defaultTestExclusions],
     testTimeout: 10000,

--- a/src/configs/vitest/typescript.ts
+++ b/src/configs/vitest/typescript.ts
@@ -58,6 +58,11 @@ export const getTypescriptVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
+    // Source-less/test-less repos (e.g. infra-only TypeScript projects) have no
+    // test files; vitest exits 1 on "No test files found", which fails the
+    // pre-push/CI gates with nothing to fix. Treat zero tests as intentional —
+    // the test-world analog of allowing `files: []` in tsconfig for zero sources.
+    passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     exclude: [...defaultTestExclusions],
     testTimeout: 10000,

--- a/tests/unit/config/vitest-typescript.test.ts
+++ b/tests/unit/config/vitest-typescript.test.ts
@@ -38,6 +38,12 @@ describe("vitest.typescript", () => {
       expect(config.test?.testTimeout).toBe(10000);
     });
 
+    it("passes with no tests so source-less repos do not fail the gate", () => {
+      const config = getTypescriptVitestConfig();
+
+      expect(config.test?.passWithNoTests).toBe(true);
+    });
+
     it("uses v8 coverage provider", () => {
       const config = getTypescriptVitestConfig();
       const coverage = config.test?.coverage as Record<string, unknown>;


### PR DESCRIPTION
## Problem

Source-less / test-less TypeScript repos (infra-only projects with no src/ or tests/, e.g. aws-soc2-setup) caused `vitest run` (and `vitest run --coverage`) to exit 1 with "No test files found". The Lisa-forced `test`, `test:unit`, and `test:cov` scripts therefore failed the pre-push hook and CI gate with nothing the project could legitimately fix (the scripts are force-managed; thresholds must not be lowered; bypassing hooks is forbidden).

This is the test-world analog of the `files: []` typecheck fix shipped in 2.142.0 (ensure-tsconfig-local-files-fallback), which let zero-source repos pass `tsc --noEmit`.

## Fix

Set `passWithNoTests: true` in every stack's vitest config factory:
- src/configs/vitest/typescript.ts
- src/configs/vitest/nestjs.ts
- src/configs/vitest/cdk.ts
- src/configs/vitest/harper-fabric.ts

A repo with zero tests is now treated as intentional rather than a failure. When tests exist they still run and coverage thresholds still apply unchanged. `test:integration` already passed the flag explicitly; this makes the behavior consistent across all test scripts and stacks.

## Tests

Added an assertion to tests/unit/config/vitest-typescript.test.ts verifying passWithNoTests is true. Full factory suite (11 tests) passes; pre-push suite (50 tests) passes.

🤖 Generated with Claude Code