### PR TITLE
feat(wiki): add deterministic safety sanitizer

### DIFF
--- a/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic wiki source safety helpers.
+ *
+ * This module intentionally uses only Node built-ins and pure string scanning so
+ * downstream wiki connectors can run the same redaction pass before persisting
+ * reader-safe source notes.
+ */
+
+const PLACEHOLDERS = {
+  ssn: "[REDACTED:SSN]",
+  credit_card: "[REDACTED:CREDIT_CARD]",
+  private_key: "[REDACTED:PRIVATE_KEY]",
+  password: "[REDACTED:PASSWORD]",
+  api_key: "[REDACTED:API_KEY]",
+  oauth_token: "[REDACTED:OAUTH_TOKEN]",
+  bank_account: "[REDACTED:BANK_ACCOUNT]",
+  routing_number: "[REDACTED:ROUTING_NUMBER]",
+};
+
+const PATTERNS = [
+  {
+    entityType: "private_key",
+    confidence: "high",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/g,
+  },
+  {
+    entityType: "ssn",
+    confidence: "high",
+    re: /\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g,
+  },
+  {
+    entityType: "password",
+    confidence: "high",
+    re: /\b(?:password|passwd|pwd)\s*[:=]\s*(['"]?)([^\s'",;]{8,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "api_key",
+    confidence: "medium",
+    re: /\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['"]?)([A-Za-z0-9._-]{20,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "oauth_token",
+    confidence: "high",
+    re: /\b(?:oauth[_-]?token|refresh[_-]?token|access[_-]?token|bearer)\s*[:= ]\s*(['"]?)([A-Za-z0-9._-]{24,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "routing_number",
+    confidence: "medium",
+    re: /\b(?:routing|routing_number|aba)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{9})\b/gi,
+    valueGroup: 1,
+  },
+  {
+    entityType: "bank_account",
+    confidence: "medium",
+    re: /\b(?:bank\s+)?(?:account|acct)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{6,17})\b/gi,
+    valueGroup: 1,
+  },
+];
+
+function luhnValid(candidate) {
+  const digits = candidate.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let n = Number(digits[i]);
+    if (doubleDigit) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
+function applyFinding(text, match, pattern) {
+  const raw = match[0];
+  const value = pattern.valueGroup ? match[pattern.valueGroup] : raw;
+  const valueOffset = pattern.valueGroup ? raw.indexOf(value) : 0;
+  const start = match.index + valueOffset;
+  const end = start + value.length;
+  return {
+    sanitized:
+      text.slice(0, start) + PLACEHOLDERS[pattern.entityType] + text.slice(end),
+    finding: {
+      entityType: pattern.entityType,
+      confidence: pattern.confidence,
+      range: { start, end },
+    },
+    delta: PLACEHOLDERS[pattern.entityType].length - value.length,
+  };
+}
+
+function collectCreditCardFindings(text) {
+  const findings = [];
+  const re = /\b(?:\d[ -]?){13,19}\b/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const value = match[0].trim();
+    if (!luhnValid(value)) continue;
+    findings.push({
+      entityType: "credit_card",
+      confidence: "high",
+      range: { start: match.index, end: match.index + match[0].length },
+    });
+  }
+  return findings;
+}
+
+function summarizeFindings(sourceMetadata, findings) {
+  const sourceId =
+    sourceMetadata.sourceId ??
+    sourceMetadata.id ??
+    sourceMetadata.path ??
+    sourceMetadata.url ??
+    "unknown";
+  const byType = new Map();
+  for (const finding of findings) {
+    const current = byType.get(finding.entityType) ?? {
+      sourceId,
+      entityType: finding.entityType,
+      confidence: finding.confidence,
+      count: 0,
+      ranges: [],
+    };
+    current.count += 1;
+    current.ranges.push(finding.range);
+    byType.set(finding.entityType, current);
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+function collectFindings(rawText) {
+  const text = String(rawText ?? "");
+  const findings = [];
+
+  for (const pattern of PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let match;
+    while ((match = pattern.re.exec(text)) !== null) {
+      findings.push(applyFinding(text, match, pattern).finding);
+    }
+  }
+  findings.push(...collectCreditCardFindings(text));
+  findings.sort((a, b) => a.range.start - b.range.start);
+  return findings;
+}
+
+export function scanWikiSourceText(rawText, sourceMetadata = {}) {
+  const findings = collectFindings(rawText);
+
+  return {
+    sourceId:
+      sourceMetadata.sourceId ??
+      sourceMetadata.id ??
+      sourceMetadata.path ??
+      sourceMetadata.url ??
+      "unknown",
+    reviewRequired: findings.length > 0,
+    findings: summarizeFindings(sourceMetadata, findings),
+  };
+}
+
+export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
+  let sanitized = String(rawText ?? "");
+  const rawFindings = collectFindings(rawText);
+  for (const finding of [...rawFindings].sort(
+    (a, b) => b.range.start - a.range.start
+  )) {
+    sanitized =
+      sanitized.slice(0, finding.range.start) +
+      PLACEHOLDERS[finding.entityType] +
+      sanitized.slice(finding.range.end);
+  }
+
+  return {
+    text: sanitized,
+    reviewRequired: rawFindings.length > 0,
+    findings: summarizeFindings(sourceMetadata, rawFindings),
+  };
+}
+
+export function serializeWikiSafetyFindings(result) {
+  return JSON.stringify(
+    {
+      reviewRequired: Boolean(result?.reviewRequired),
+      findings: Array.isArray(result?.findings) ? result.findings : [],
+    },
+    null,
+    2
+  );
+}

--- a/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic wiki source safety helpers.
+ *
+ * This module intentionally uses only Node built-ins and pure string scanning so
+ * downstream wiki connectors can run the same redaction pass before persisting
+ * reader-safe source notes.
+ */
+
+const PLACEHOLDERS = {
+  ssn: "[REDACTED:SSN]",
+  credit_card: "[REDACTED:CREDIT_CARD]",
+  private_key: "[REDACTED:PRIVATE_KEY]",
+  password: "[REDACTED:PASSWORD]",
+  api_key: "[REDACTED:API_KEY]",
+  oauth_token: "[REDACTED:OAUTH_TOKEN]",
+  bank_account: "[REDACTED:BANK_ACCOUNT]",
+  routing_number: "[REDACTED:ROUTING_NUMBER]",
+};
+
+const PATTERNS = [
+  {
+    entityType: "private_key",
+    confidence: "high",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/g,
+  },
+  {
+    entityType: "ssn",
+    confidence: "high",
+    re: /\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g,
+  },
+  {
+    entityType: "password",
+    confidence: "high",
+    re: /\b(?:password|passwd|pwd)\s*[:=]\s*(['"]?)([^\s'",;]{8,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "api_key",
+    confidence: "medium",
+    re: /\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['"]?)([A-Za-z0-9._-]{20,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "oauth_token",
+    confidence: "high",
+    re: /\b(?:oauth[_-]?token|refresh[_-]?token|access[_-]?token|bearer)\s*[:= ]\s*(['"]?)([A-Za-z0-9._-]{24,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "routing_number",
+    confidence: "medium",
+    re: /\b(?:routing|routing_number|aba)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{9})\b/gi,
+    valueGroup: 1,
+  },
+  {
+    entityType: "bank_account",
+    confidence: "medium",
+    re: /\b(?:bank\s+)?(?:account|acct)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{6,17})\b/gi,
+    valueGroup: 1,
+  },
+];
+
+function luhnValid(candidate) {
+  const digits = candidate.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let n = Number(digits[i]);
+    if (doubleDigit) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
+function applyFinding(text, match, pattern) {
+  const raw = match[0];
+  const value = pattern.valueGroup ? match[pattern.valueGroup] : raw;
+  const valueOffset = pattern.valueGroup ? raw.indexOf(value) : 0;
+  const start = match.index + valueOffset;
+  const end = start + value.length;
+  return {
+    sanitized:
+      text.slice(0, start) + PLACEHOLDERS[pattern.entityType] + text.slice(end),
+    finding: {
+      entityType: pattern.entityType,
+      confidence: pattern.confidence,
+      range: { start, end },
+    },
+    delta: PLACEHOLDERS[pattern.entityType].length - value.length,
+  };
+}
+
+function collectCreditCardFindings(text) {
+  const findings = [];
+  const re = /\b(?:\d[ -]?){13,19}\b/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const value = match[0].trim();
+    if (!luhnValid(value)) continue;
+    findings.push({
+      entityType: "credit_card",
+      confidence: "high",
+      range: { start: match.index, end: match.index + match[0].length },
+    });
+  }
+  return findings;
+}
+
+function summarizeFindings(sourceMetadata, findings) {
+  const sourceId =
+    sourceMetadata.sourceId ??
+    sourceMetadata.id ??
+    sourceMetadata.path ??
+    sourceMetadata.url ??
+    "unknown";
+  const byType = new Map();
+  for (const finding of findings) {
+    const current = byType.get(finding.entityType) ?? {
+      sourceId,
+      entityType: finding.entityType,
+      confidence: finding.confidence,
+      count: 0,
+      ranges: [],
+    };
+    current.count += 1;
+    current.ranges.push(finding.range);
+    byType.set(finding.entityType, current);
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+function collectFindings(rawText) {
+  const text = String(rawText ?? "");
+  const findings = [];
+
+  for (const pattern of PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let match;
+    while ((match = pattern.re.exec(text)) !== null) {
+      findings.push(applyFinding(text, match, pattern).finding);
+    }
+  }
+  findings.push(...collectCreditCardFindings(text));
+  findings.sort((a, b) => a.range.start - b.range.start);
+  return findings;
+}
+
+export function scanWikiSourceText(rawText, sourceMetadata = {}) {
+  const findings = collectFindings(rawText);
+
+  return {
+    sourceId:
+      sourceMetadata.sourceId ??
+      sourceMetadata.id ??
+      sourceMetadata.path ??
+      sourceMetadata.url ??
+      "unknown",
+    reviewRequired: findings.length > 0,
+    findings: summarizeFindings(sourceMetadata, findings),
+  };
+}
+
+export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
+  let sanitized = String(rawText ?? "");
+  const rawFindings = collectFindings(rawText);
+  for (const finding of [...rawFindings].sort(
+    (a, b) => b.range.start - a.range.start
+  )) {
+    sanitized =
+      sanitized.slice(0, finding.range.start) +
+      PLACEHOLDERS[finding.entityType] +
+      sanitized.slice(finding.range.end);
+  }
+
+  return {
+    text: sanitized,
+    reviewRequired: rawFindings.length > 0,
+    findings: summarizeFindings(sourceMetadata, rawFindings),
+  };
+}
+
+export function serializeWikiSafetyFindings(result) {
+  return JSON.stringify(
+    {
+      reviewRequired: Boolean(result?.reviewRequired),
+      findings: Array.isArray(result?.findings) ? result.findings : [],
+    },
+    null,
+    2
+  );
+}

--- a/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic wiki source safety helpers.
+ *
+ * This module intentionally uses only Node built-ins and pure string scanning so
+ * downstream wiki connectors can run the same redaction pass before persisting
+ * reader-safe source notes.
+ */
+
+const PLACEHOLDERS = {
+  ssn: "[REDACTED:SSN]",
+  credit_card: "[REDACTED:CREDIT_CARD]",
+  private_key: "[REDACTED:PRIVATE_KEY]",
+  password: "[REDACTED:PASSWORD]",
+  api_key: "[REDACTED:API_KEY]",
+  oauth_token: "[REDACTED:OAUTH_TOKEN]",
+  bank_account: "[REDACTED:BANK_ACCOUNT]",
+  routing_number: "[REDACTED:ROUTING_NUMBER]",
+};
+
+const PATTERNS = [
+  {
+    entityType: "private_key",
+    confidence: "high",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/g,
+  },
+  {
+    entityType: "ssn",
+    confidence: "high",
+    re: /\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g,
+  },
+  {
+    entityType: "password",
+    confidence: "high",
+    re: /\b(?:password|passwd|pwd)\s*[:=]\s*(['"]?)([^\s'",;]{8,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "api_key",
+    confidence: "medium",
+    re: /\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['"]?)([A-Za-z0-9._-]{20,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "oauth_token",
+    confidence: "high",
+    re: /\b(?:oauth[_-]?token|refresh[_-]?token|access[_-]?token|bearer)\s*[:= ]\s*(['"]?)([A-Za-z0-9._-]{24,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "routing_number",
+    confidence: "medium",
+    re: /\b(?:routing|routing_number|aba)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{9})\b/gi,
+    valueGroup: 1,
+  },
+  {
+    entityType: "bank_account",
+    confidence: "medium",
+    re: /\b(?:bank\s+)?(?:account|acct)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{6,17})\b/gi,
+    valueGroup: 1,
+  },
+];
+
+function luhnValid(candidate) {
+  const digits = candidate.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let n = Number(digits[i]);
+    if (doubleDigit) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
+function applyFinding(text, match, pattern) {
+  const raw = match[0];
+  const value = pattern.valueGroup ? match[pattern.valueGroup] : raw;
+  const valueOffset = pattern.valueGroup ? raw.indexOf(value) : 0;
+  const start = match.index + valueOffset;
+  const end = start + value.length;
+  return {
+    sanitized:
+      text.slice(0, start) + PLACEHOLDERS[pattern.entityType] + text.slice(end),
+    finding: {
+      entityType: pattern.entityType,
+      confidence: pattern.confidence,
+      range: { start, end },
+    },
+    delta: PLACEHOLDERS[pattern.entityType].length - value.length,
+  };
+}
+
+function collectCreditCardFindings(text) {
+  const findings = [];
+  const re = /\b(?:\d[ -]?){13,19}\b/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const value = match[0].trim();
+    if (!luhnValid(value)) continue;
+    findings.push({
+      entityType: "credit_card",
+      confidence: "high",
+      range: { start: match.index, end: match.index + match[0].length },
+    });
+  }
+  return findings;
+}
+
+function summarizeFindings(sourceMetadata, findings) {
+  const sourceId =
+    sourceMetadata.sourceId ??
+    sourceMetadata.id ??
+    sourceMetadata.path ??
+    sourceMetadata.url ??
+    "unknown";
+  const byType = new Map();
+  for (const finding of findings) {
+    const current = byType.get(finding.entityType) ?? {
+      sourceId,
+      entityType: finding.entityType,
+      confidence: finding.confidence,
+      count: 0,
+      ranges: [],
+    };
+    current.count += 1;
+    current.ranges.push(finding.range);
+    byType.set(finding.entityType, current);
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+function collectFindings(rawText) {
+  const text = String(rawText ?? "");
+  const findings = [];
+
+  for (const pattern of PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let match;
+    while ((match = pattern.re.exec(text)) !== null) {
+      findings.push(applyFinding(text, match, pattern).finding);
+    }
+  }
+  findings.push(...collectCreditCardFindings(text));
+  findings.sort((a, b) => a.range.start - b.range.start);
+  return findings;
+}
+
+export function scanWikiSourceText(rawText, sourceMetadata = {}) {
+  const findings = collectFindings(rawText);
+
+  return {
+    sourceId:
+      sourceMetadata.sourceId ??
+      sourceMetadata.id ??
+      sourceMetadata.path ??
+      sourceMetadata.url ??
+      "unknown",
+    reviewRequired: findings.length > 0,
+    findings: summarizeFindings(sourceMetadata, findings),
+  };
+}
+
+export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
+  let sanitized = String(rawText ?? "");
+  const rawFindings = collectFindings(rawText);
+  for (const finding of [...rawFindings].sort(
+    (a, b) => b.range.start - a.range.start
+  )) {
+    sanitized =
+      sanitized.slice(0, finding.range.start) +
+      PLACEHOLDERS[finding.entityType] +
+      sanitized.slice(finding.range.end);
+  }
+
+  return {
+    text: sanitized,
+    reviewRequired: rawFindings.length > 0,
+    findings: summarizeFindings(sourceMetadata, rawFindings),
+  };
+}
+
+export function serializeWikiSafetyFindings(result) {
+  return JSON.stringify(
+    {
+      reviewRequired: Boolean(result?.reviewRequired),
+      findings: Array.isArray(result?.findings) ? result.findings : [],
+    },
+    null,
+    2
+  );
+}

--- a/plugins/lisa-wiki/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki/scripts/wiki-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic wiki source safety helpers.
+ *
+ * This module intentionally uses only Node built-ins and pure string scanning so
+ * downstream wiki connectors can run the same redaction pass before persisting
+ * reader-safe source notes.
+ */
+
+const PLACEHOLDERS = {
+  ssn: "[REDACTED:SSN]",
+  credit_card: "[REDACTED:CREDIT_CARD]",
+  private_key: "[REDACTED:PRIVATE_KEY]",
+  password: "[REDACTED:PASSWORD]",
+  api_key: "[REDACTED:API_KEY]",
+  oauth_token: "[REDACTED:OAUTH_TOKEN]",
+  bank_account: "[REDACTED:BANK_ACCOUNT]",
+  routing_number: "[REDACTED:ROUTING_NUMBER]",
+};
+
+const PATTERNS = [
+  {
+    entityType: "private_key",
+    confidence: "high",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/g,
+  },
+  {
+    entityType: "ssn",
+    confidence: "high",
+    re: /\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g,
+  },
+  {
+    entityType: "password",
+    confidence: "high",
+    re: /\b(?:password|passwd|pwd)\s*[:=]\s*(['"]?)([^\s'",;]{8,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "api_key",
+    confidence: "medium",
+    re: /\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['"]?)([A-Za-z0-9._-]{20,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "oauth_token",
+    confidence: "high",
+    re: /\b(?:oauth[_-]?token|refresh[_-]?token|access[_-]?token|bearer)\s*[:= ]\s*(['"]?)([A-Za-z0-9._-]{24,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "routing_number",
+    confidence: "medium",
+    re: /\b(?:routing|routing_number|aba)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{9})\b/gi,
+    valueGroup: 1,
+  },
+  {
+    entityType: "bank_account",
+    confidence: "medium",
+    re: /\b(?:bank\s+)?(?:account|acct)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{6,17})\b/gi,
+    valueGroup: 1,
+  },
+];
+
+function luhnValid(candidate) {
+  const digits = candidate.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let n = Number(digits[i]);
+    if (doubleDigit) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
+function applyFinding(text, match, pattern) {
+  const raw = match[0];
+  const value = pattern.valueGroup ? match[pattern.valueGroup] : raw;
+  const valueOffset = pattern.valueGroup ? raw.indexOf(value) : 0;
+  const start = match.index + valueOffset;
+  const end = start + value.length;
+  return {
+    sanitized:
+      text.slice(0, start) + PLACEHOLDERS[pattern.entityType] + text.slice(end),
+    finding: {
+      entityType: pattern.entityType,
+      confidence: pattern.confidence,
+      range: { start, end },
+    },
+    delta: PLACEHOLDERS[pattern.entityType].length - value.length,
+  };
+}
+
+function collectCreditCardFindings(text) {
+  const findings = [];
+  const re = /\b(?:\d[ -]?){13,19}\b/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const value = match[0].trim();
+    if (!luhnValid(value)) continue;
+    findings.push({
+      entityType: "credit_card",
+      confidence: "high",
+      range: { start: match.index, end: match.index + match[0].length },
+    });
+  }
+  return findings;
+}
+
+function summarizeFindings(sourceMetadata, findings) {
+  const sourceId =
+    sourceMetadata.sourceId ??
+    sourceMetadata.id ??
+    sourceMetadata.path ??
+    sourceMetadata.url ??
+    "unknown";
+  const byType = new Map();
+  for (const finding of findings) {
+    const current = byType.get(finding.entityType) ?? {
+      sourceId,
+      entityType: finding.entityType,
+      confidence: finding.confidence,
+      count: 0,
+      ranges: [],
+    };
+    current.count += 1;
+    current.ranges.push(finding.range);
+    byType.set(finding.entityType, current);
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+function collectFindings(rawText) {
+  const text = String(rawText ?? "");
+  const findings = [];
+
+  for (const pattern of PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let match;
+    while ((match = pattern.re.exec(text)) !== null) {
+      findings.push(applyFinding(text, match, pattern).finding);
+    }
+  }
+  findings.push(...collectCreditCardFindings(text));
+  findings.sort((a, b) => a.range.start - b.range.start);
+  return findings;
+}
+
+export function scanWikiSourceText(rawText, sourceMetadata = {}) {
+  const findings = collectFindings(rawText);
+
+  return {
+    sourceId:
+      sourceMetadata.sourceId ??
+      sourceMetadata.id ??
+      sourceMetadata.path ??
+      sourceMetadata.url ??
+      "unknown",
+    reviewRequired: findings.length > 0,
+    findings: summarizeFindings(sourceMetadata, findings),
+  };
+}
+
+export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
+  let sanitized = String(rawText ?? "");
+  const rawFindings = collectFindings(rawText);
+  for (const finding of [...rawFindings].sort(
+    (a, b) => b.range.start - a.range.start
+  )) {
+    sanitized =
+      sanitized.slice(0, finding.range.start) +
+      PLACEHOLDERS[finding.entityType] +
+      sanitized.slice(finding.range.end);
+  }
+
+  return {
+    text: sanitized,
+    reviewRequired: rawFindings.length > 0,
+    findings: summarizeFindings(sourceMetadata, rawFindings),
+  };
+}
+
+export function serializeWikiSafetyFindings(result) {
+  return JSON.stringify(
+    {
+      reviewRequired: Boolean(result?.reviewRequired),
+      findings: Array.isArray(result?.findings) ? result.findings : [],
+    },
+    null,
+    2
+  );
+}

--- a/plugins/src/wiki/scripts/wiki-safety.mjs
+++ b/plugins/src/wiki/scripts/wiki-safety.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Deterministic wiki source safety helpers.
+ *
+ * This module intentionally uses only Node built-ins and pure string scanning so
+ * downstream wiki connectors can run the same redaction pass before persisting
+ * reader-safe source notes.
+ */
+
+const PLACEHOLDERS = {
+  ssn: "[REDACTED:SSN]",
+  credit_card: "[REDACTED:CREDIT_CARD]",
+  private_key: "[REDACTED:PRIVATE_KEY]",
+  password: "[REDACTED:PASSWORD]",
+  api_key: "[REDACTED:API_KEY]",
+  oauth_token: "[REDACTED:OAUTH_TOKEN]",
+  bank_account: "[REDACTED:BANK_ACCOUNT]",
+  routing_number: "[REDACTED:ROUTING_NUMBER]",
+};
+
+const PATTERNS = [
+  {
+    entityType: "private_key",
+    confidence: "high",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/g,
+  },
+  {
+    entityType: "ssn",
+    confidence: "high",
+    re: /\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g,
+  },
+  {
+    entityType: "password",
+    confidence: "high",
+    re: /\b(?:password|passwd|pwd)\s*[:=]\s*(['"]?)([^\s'",;]{8,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "api_key",
+    confidence: "medium",
+    re: /\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['"]?)([A-Za-z0-9._-]{20,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "oauth_token",
+    confidence: "high",
+    re: /\b(?:oauth[_-]?token|refresh[_-]?token|access[_-]?token|bearer)\s*[:= ]\s*(['"]?)([A-Za-z0-9._-]{24,})\1/gi,
+    valueGroup: 2,
+  },
+  {
+    entityType: "routing_number",
+    confidence: "medium",
+    re: /\b(?:routing|routing_number|aba)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{9})\b/gi,
+    valueGroup: 1,
+  },
+  {
+    entityType: "bank_account",
+    confidence: "medium",
+    re: /\b(?:bank\s+)?(?:account|acct)\s*(?:number|no\.?)?\s*[:#=]?\s*(\d{6,17})\b/gi,
+    valueGroup: 1,
+  },
+];
+
+function luhnValid(candidate) {
+  const digits = candidate.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let n = Number(digits[i]);
+    if (doubleDigit) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
+function applyFinding(text, match, pattern) {
+  const raw = match[0];
+  const value = pattern.valueGroup ? match[pattern.valueGroup] : raw;
+  const valueOffset = pattern.valueGroup ? raw.indexOf(value) : 0;
+  const start = match.index + valueOffset;
+  const end = start + value.length;
+  return {
+    sanitized:
+      text.slice(0, start) + PLACEHOLDERS[pattern.entityType] + text.slice(end),
+    finding: {
+      entityType: pattern.entityType,
+      confidence: pattern.confidence,
+      range: { start, end },
+    },
+    delta: PLACEHOLDERS[pattern.entityType].length - value.length,
+  };
+}
+
+function collectCreditCardFindings(text) {
+  const findings = [];
+  const re = /\b(?:\d[ -]?){13,19}\b/g;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const value = match[0].trim();
+    if (!luhnValid(value)) continue;
+    findings.push({
+      entityType: "credit_card",
+      confidence: "high",
+      range: { start: match.index, end: match.index + match[0].length },
+    });
+  }
+  return findings;
+}
+
+function summarizeFindings(sourceMetadata, findings) {
+  const sourceId =
+    sourceMetadata.sourceId ??
+    sourceMetadata.id ??
+    sourceMetadata.path ??
+    sourceMetadata.url ??
+    "unknown";
+  const byType = new Map();
+  for (const finding of findings) {
+    const current = byType.get(finding.entityType) ?? {
+      sourceId,
+      entityType: finding.entityType,
+      confidence: finding.confidence,
+      count: 0,
+      ranges: [],
+    };
+    current.count += 1;
+    current.ranges.push(finding.range);
+    byType.set(finding.entityType, current);
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+function collectFindings(rawText) {
+  const text = String(rawText ?? "");
+  const findings = [];
+
+  for (const pattern of PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let match;
+    while ((match = pattern.re.exec(text)) !== null) {
+      findings.push(applyFinding(text, match, pattern).finding);
+    }
+  }
+  findings.push(...collectCreditCardFindings(text));
+  findings.sort((a, b) => a.range.start - b.range.start);
+  return findings;
+}
+
+export function scanWikiSourceText(rawText, sourceMetadata = {}) {
+  const findings = collectFindings(rawText);
+
+  return {
+    sourceId:
+      sourceMetadata.sourceId ??
+      sourceMetadata.id ??
+      sourceMetadata.path ??
+      sourceMetadata.url ??
+      "unknown",
+    reviewRequired: findings.length > 0,
+    findings: summarizeFindings(sourceMetadata, findings),
+  };
+}
+
+export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
+  let sanitized = String(rawText ?? "");
+  const rawFindings = collectFindings(rawText);
+  for (const finding of [...rawFindings].sort(
+    (a, b) => b.range.start - a.range.start
+  )) {
+    sanitized =
+      sanitized.slice(0, finding.range.start) +
+      PLACEHOLDERS[finding.entityType] +
+      sanitized.slice(finding.range.end);
+  }
+
+  return {
+    text: sanitized,
+    reviewRequired: rawFindings.length > 0,
+    findings: summarizeFindings(sourceMetadata, rawFindings),
+  };
+}
+
+export function serializeWikiSafetyFindings(result) {
+  return JSON.stringify(
+    {
+      reviewRequired: Boolean(result?.reviewRequired),
+      findings: Array.isArray(result?.findings) ? result.findings : [],
+    },
+    null,
+    2
+  );
+}

--- a/tests/unit/strategies/wiki-safety.test.ts
+++ b/tests/unit/strategies/wiki-safety.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sanitizeWikiSourceText,
+  serializeWikiSafetyFindings,
+} from "../../../plugins/src/wiki/scripts/wiki-safety.mjs";
+
+describe("wiki safety sanitizer (#1169)", () => {
+  const reportSourceId = "fixtures/report.md";
+
+  it("redacts built-in blocked values while preserving normal contacts", () => {
+    const raw = [
+      "Contact Ada Lovelace at ada@example.com.",
+      "Fake SSN: 123-45-6789.",
+      "Card: 4111 1111 1111 1111.",
+      "-----BEGIN PRIVATE KEY-----",
+      "abc123",
+      "-----END PRIVATE KEY-----",
+      "password = fakePassword123",
+      "api_key = sk_test_abcdefghijklmnopqrstuvwxyz",
+      "oauth_token: ya29.fakeOAuthTokenValue1234567890",
+      "routing number 021000021 and account number 123456789012",
+    ].join("\n");
+
+    const result = sanitizeWikiSourceText(raw, {
+      sourceId: "fixtures/redaction.md",
+    });
+
+    expect(result.reviewRequired).toBe(true);
+    expect(result.text).toContain("Ada Lovelace");
+    expect(result.text).toContain("ada@example.com");
+    expect(result.text).toContain("[REDACTED:SSN]");
+    expect(result.text).toContain("[REDACTED:CREDIT_CARD]");
+    expect(result.text).toContain("[REDACTED:PRIVATE_KEY]");
+    expect(result.text).toContain("password = [REDACTED:PASSWORD]");
+    expect(result.text).toContain("api_key = [REDACTED:API_KEY]");
+    expect(result.text).toContain("oauth_token: [REDACTED:OAUTH_TOKEN]");
+    expect(result.text).toContain("routing number [REDACTED:ROUTING_NUMBER]");
+    expect(result.text).toContain("account number [REDACTED:BANK_ACCOUNT]");
+    expect(result.text).not.toContain("123-45-6789");
+    expect(result.text).not.toContain("4111 1111 1111 1111");
+    expect(result.text).not.toContain("fakePassword123");
+  });
+
+  it("serializes only safe finding metadata", () => {
+    const raw =
+      "token: public example\napi_key = sk_test_abcdefghijklmnopqrstuvwxyz\nSSN 123-45-6789";
+    const result = sanitizeWikiSourceText(raw, {
+      sourceId: reportSourceId,
+    });
+    const serialized = serializeWikiSafetyFindings(result);
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.reviewRequired).toBe(true);
+    expect(parsed.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: reportSourceId,
+          entityType: "api_key",
+          confidence: "medium",
+          count: 1,
+          ranges: [expect.objectContaining({ start: expect.any(Number) })],
+        }),
+        expect.objectContaining({
+          sourceId: reportSourceId,
+          entityType: "ssn",
+          confidence: "high",
+          count: 1,
+        }),
+      ])
+    );
+    expect(serialized).not.toContain("sk_test_abcdefghijklmnopqrstuvwxyz");
+    expect(serialized).not.toContain("123-45-6789");
+    expect(serialized).not.toContain("token: public example");
+  });
+
+  it("does not flag names, email addresses, or invalid card-shaped numbers", () => {
+    const result = sanitizeWikiSourceText(
+      "Grace Hopper <grace@example.com> invoice 4111 1111 1111 1112",
+      { sourceId: "fixtures/allowed.md" }
+    );
+
+    expect(result.reviewRequired).toBe(false);
+    expect(result.findings).toEqual([]);
+    expect(result.text).toContain("Grace Hopper");
+    expect(result.text).toContain("grace@example.com");
+    expect(result.text).toContain("4111 1111 1111 1112");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dependency-free wiki safety sanitizer module for deterministic redaction of blocked high-risk values.
- Return safe persisted finding summaries with source id, entity type, confidence, count, and range metadata only.
- Add unit coverage for fake SSNs, Luhn-valid test cards, private keys, password/API/OAuth assignments, bank/routing context, and allowed names/emails.
- Regenerate lisa-wiki plugin artifacts for Cursor, Agy, and Copilot variants.

## Verification
- bunx vitest run tests/unit/strategies/wiki-safety.test.ts tests/unit/strategies/wiki-status-surface.test.ts tests/unit/strategies/wiki-status-report-rendering.test.ts tests/unit/strategies/wiki-status-verdicts.test.ts tests/unit/strategies/wiki-ensure-gitignore.test.ts
- bun run build:plugins
- bun run check:plugins
- pre-commit hook: Gitleaks, tsc --noEmit, lint-staged, ESLint, Prettier, ast-grep, commitlint
- pre-push hook: bun audit, slow ESLint, knip, vitest run --coverage, vitest run tests/integration

Closes #1169