### PR TITLE
Sanitize wiki connector source notes

### DIFF
--- a/plugins/lisa-wiki-agy/scripts/_wiki-lib.mjs
+++ b/plugins/lisa-wiki-agy/scripts/_wiki-lib.mjs
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeWikiSourceText } from "./wiki-safety.mjs";
 
 /** Read and parse a JSON file, or return undefined if missing/invalid. */
 export function readJsonSafe(file) {
@@ -57,6 +58,24 @@ export function walkFiles(dir, { ext } = {}) {
     }
   }
   return out.sort();
+}
+
+/**
+ * Sanitize a wiki source note immediately before it is persisted.
+ *
+ * Connectors should keep fetched raw material in memory or temporary locations
+ * outside the repo, render the source note, then call this helper at the final
+ * `wiki/sources/**` write boundary. The return value contains safe finding
+ * metadata only; callers can include it in handoff metadata when useful.
+ */
+export function writeSanitizedSourceNote(file, rawText, sourceMetadata = {}) {
+  const result = sanitizeWikiSourceText(rawText, {
+    ...sourceMetadata,
+    path: sourceMetadata.path ?? file,
+  });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, result.text);
+  return result;
 }
 
 /**

--- a/plugins/lisa-wiki-agy/scripts/ingest-git.mjs
+++ b/plugins/lisa-wiki-agy/scripts/ingest-git.mjs
@@ -15,7 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { readJsonSafe, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import { readJsonSafe, writeSanitizedSourceNote } from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -53,12 +53,6 @@ const commitExists = c => {
     return false;
   }
 };
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
-
 if (
   !fs.existsSync(path.join(repo, ".git")) &&
   !tryGit(["rev-parse", "--is-inside-work-tree"])
@@ -165,8 +159,11 @@ ${
 }
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, redact(note));
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "git",
+  project: slug,
+});
 
 const meta = {
   connector: "git",
@@ -174,6 +171,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { lastCommit: head, lastPr },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-agy/scripts/ingest-memory.mjs
+++ b/plugins/lisa-wiki-agy/scripts/ingest-memory.mjs
@@ -15,7 +15,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadConfig, walkFiles, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -79,15 +83,10 @@ if (!(under(claudeMem) || under(projectCodexMem) || allowedRoots.some(under))) {
   );
 }
 
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
 const mdFiles = walkFiles(resolvedMem, { ext: ".md" });
 const date = new Date().toISOString().slice(0, 10);
 const entries = mdFiles.map(f => {
-  const body = redact(fs.readFileSync(f, "utf8")).trim();
+  const body = fs.readFileSync(f, "utf8").trim();
   return `### ${path.basename(f)}\n\n${body}`;
 });
 
@@ -110,8 +109,10 @@ sensitivity: internal
 ${entries.join("\n\n") || "_(no memory files)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "memory",
+});
 
 const meta = {
   connector: "memory",
@@ -119,6 +120,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { files: mdFiles.length, lastIngest: date },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-agy/scripts/ingest-roles.mjs
+++ b/plugins/lisa-wiki-agy/scripts/ingest-roles.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { loadConfig, walkFiles } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -61,8 +65,10 @@ ${rosterRows}
 ${staffPages.length ? staffPages.map(p => `- \`${path.relative(wikiRoot, p)}\``).join("\n") : "_(none)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "roles",
+});
 
 const meta = {
   connector: "roles",
@@ -74,6 +80,10 @@ const meta = {
     lastIngest: date,
   },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-agy/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-agy/scripts/ingest_slack_channel.py
@@ -22,10 +22,37 @@ from typing import Any
 
 
 TOKEN_PATTERNS = [
-    re.compile(r"xox[pbar]-[A-Za-z0-9-]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    (re.compile(r"xox[pbar]-[A-Za-z0-9-]+"), "[REDACTED:OAUTH_TOKEN]"),
+    (
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+        "[REDACTED:OAUTH_TOKEN]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:API_KEY]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED:PRIVATE_KEY]",
+    ),
+    (
+        re.compile(r"\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b"),
+        "[REDACTED:SSN]",
+    ),
+    (
+        re.compile(
+            r"\b(?:password|passwd|pwd)\s*[:=]\s*(['\"]?)([^\s'\",;]{8,})\1",
+            re.I,
+        ),
+        "[REDACTED:PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['\"]?)([A-Za-z0-9._-]{20,})\1",
+            re.I,
+        ),
+        "[REDACTED:API_KEY]",
+    ),
 ]
 
 
@@ -49,8 +76,13 @@ def ts_from_input(value: str | None) -> str | None:
 
 def redact(text: str) -> str:
     out = text
-    for pattern in TOKEN_PATTERNS:
-        out = pattern.sub("[REDACTED]", out)
+    for pattern, replacement in TOKEN_PATTERNS:
+        out = pattern.sub(
+            lambda match: match.group(0).replace(match.group(2), replacement)
+            if len(match.groups()) >= 2
+            else replacement,
+            out,
+        )
     return out
 
 
@@ -289,7 +321,7 @@ def main() -> int:
             for reply in replies:
                 lines.extend(render_message(reply))
 
-    source_path.write_text("\n".join(lines), encoding="utf-8")
+    source_path.write_text(redact("\n".join(lines)), encoding="utf-8")
 
     latest_ts = previous_state.get("latest_message_ts")
     if messages:

--- a/plugins/lisa-wiki-copilot/scripts/_wiki-lib.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/_wiki-lib.mjs
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeWikiSourceText } from "./wiki-safety.mjs";
 
 /** Read and parse a JSON file, or return undefined if missing/invalid. */
 export function readJsonSafe(file) {
@@ -57,6 +58,24 @@ export function walkFiles(dir, { ext } = {}) {
     }
   }
   return out.sort();
+}
+
+/**
+ * Sanitize a wiki source note immediately before it is persisted.
+ *
+ * Connectors should keep fetched raw material in memory or temporary locations
+ * outside the repo, render the source note, then call this helper at the final
+ * `wiki/sources/**` write boundary. The return value contains safe finding
+ * metadata only; callers can include it in handoff metadata when useful.
+ */
+export function writeSanitizedSourceNote(file, rawText, sourceMetadata = {}) {
+  const result = sanitizeWikiSourceText(rawText, {
+    ...sourceMetadata,
+    path: sourceMetadata.path ?? file,
+  });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, result.text);
+  return result;
 }
 
 /**

--- a/plugins/lisa-wiki-copilot/scripts/ingest-git.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/ingest-git.mjs
@@ -15,7 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { readJsonSafe, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import { readJsonSafe, writeSanitizedSourceNote } from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -53,12 +53,6 @@ const commitExists = c => {
     return false;
   }
 };
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
-
 if (
   !fs.existsSync(path.join(repo, ".git")) &&
   !tryGit(["rev-parse", "--is-inside-work-tree"])
@@ -165,8 +159,11 @@ ${
 }
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, redact(note));
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "git",
+  project: slug,
+});
 
 const meta = {
   connector: "git",
@@ -174,6 +171,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { lastCommit: head, lastPr },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-copilot/scripts/ingest-memory.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/ingest-memory.mjs
@@ -15,7 +15,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadConfig, walkFiles, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -79,15 +83,10 @@ if (!(under(claudeMem) || under(projectCodexMem) || allowedRoots.some(under))) {
   );
 }
 
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
 const mdFiles = walkFiles(resolvedMem, { ext: ".md" });
 const date = new Date().toISOString().slice(0, 10);
 const entries = mdFiles.map(f => {
-  const body = redact(fs.readFileSync(f, "utf8")).trim();
+  const body = fs.readFileSync(f, "utf8").trim();
   return `### ${path.basename(f)}\n\n${body}`;
 });
 
@@ -110,8 +109,10 @@ sensitivity: internal
 ${entries.join("\n\n") || "_(no memory files)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "memory",
+});
 
 const meta = {
   connector: "memory",
@@ -119,6 +120,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { files: mdFiles.length, lastIngest: date },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-copilot/scripts/ingest-roles.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/ingest-roles.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { loadConfig, walkFiles } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -61,8 +65,10 @@ ${rosterRows}
 ${staffPages.length ? staffPages.map(p => `- \`${path.relative(wikiRoot, p)}\``).join("\n") : "_(none)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "roles",
+});
 
 const meta = {
   connector: "roles",
@@ -74,6 +80,10 @@ const meta = {
     lastIngest: date,
   },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-copilot/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-copilot/scripts/ingest_slack_channel.py
@@ -22,10 +22,37 @@ from typing import Any
 
 
 TOKEN_PATTERNS = [
-    re.compile(r"xox[pbar]-[A-Za-z0-9-]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    (re.compile(r"xox[pbar]-[A-Za-z0-9-]+"), "[REDACTED:OAUTH_TOKEN]"),
+    (
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+        "[REDACTED:OAUTH_TOKEN]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:API_KEY]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED:PRIVATE_KEY]",
+    ),
+    (
+        re.compile(r"\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b"),
+        "[REDACTED:SSN]",
+    ),
+    (
+        re.compile(
+            r"\b(?:password|passwd|pwd)\s*[:=]\s*(['\"]?)([^\s'\",;]{8,})\1",
+            re.I,
+        ),
+        "[REDACTED:PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['\"]?)([A-Za-z0-9._-]{20,})\1",
+            re.I,
+        ),
+        "[REDACTED:API_KEY]",
+    ),
 ]
 
 
@@ -49,8 +76,13 @@ def ts_from_input(value: str | None) -> str | None:
 
 def redact(text: str) -> str:
     out = text
-    for pattern in TOKEN_PATTERNS:
-        out = pattern.sub("[REDACTED]", out)
+    for pattern, replacement in TOKEN_PATTERNS:
+        out = pattern.sub(
+            lambda match: match.group(0).replace(match.group(2), replacement)
+            if len(match.groups()) >= 2
+            else replacement,
+            out,
+        )
     return out
 
 
@@ -289,7 +321,7 @@ def main() -> int:
             for reply in replies:
                 lines.extend(render_message(reply))
 
-    source_path.write_text("\n".join(lines), encoding="utf-8")
+    source_path.write_text(redact("\n".join(lines)), encoding="utf-8")
 
     latest_ts = previous_state.get("latest_message_ts")
     if messages:

--- a/plugins/lisa-wiki-cursor/scripts/_wiki-lib.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/_wiki-lib.mjs
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeWikiSourceText } from "./wiki-safety.mjs";
 
 /** Read and parse a JSON file, or return undefined if missing/invalid. */
 export function readJsonSafe(file) {
@@ -57,6 +58,24 @@ export function walkFiles(dir, { ext } = {}) {
     }
   }
   return out.sort();
+}
+
+/**
+ * Sanitize a wiki source note immediately before it is persisted.
+ *
+ * Connectors should keep fetched raw material in memory or temporary locations
+ * outside the repo, render the source note, then call this helper at the final
+ * `wiki/sources/**` write boundary. The return value contains safe finding
+ * metadata only; callers can include it in handoff metadata when useful.
+ */
+export function writeSanitizedSourceNote(file, rawText, sourceMetadata = {}) {
+  const result = sanitizeWikiSourceText(rawText, {
+    ...sourceMetadata,
+    path: sourceMetadata.path ?? file,
+  });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, result.text);
+  return result;
 }
 
 /**

--- a/plugins/lisa-wiki-cursor/scripts/ingest-git.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/ingest-git.mjs
@@ -15,7 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { readJsonSafe, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import { readJsonSafe, writeSanitizedSourceNote } from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -53,12 +53,6 @@ const commitExists = c => {
     return false;
   }
 };
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
-
 if (
   !fs.existsSync(path.join(repo, ".git")) &&
   !tryGit(["rev-parse", "--is-inside-work-tree"])
@@ -165,8 +159,11 @@ ${
 }
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, redact(note));
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "git",
+  project: slug,
+});
 
 const meta = {
   connector: "git",
@@ -174,6 +171,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { lastCommit: head, lastPr },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-cursor/scripts/ingest-memory.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/ingest-memory.mjs
@@ -15,7 +15,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadConfig, walkFiles, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -79,15 +83,10 @@ if (!(under(claudeMem) || under(projectCodexMem) || allowedRoots.some(under))) {
   );
 }
 
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
 const mdFiles = walkFiles(resolvedMem, { ext: ".md" });
 const date = new Date().toISOString().slice(0, 10);
 const entries = mdFiles.map(f => {
-  const body = redact(fs.readFileSync(f, "utf8")).trim();
+  const body = fs.readFileSync(f, "utf8").trim();
   return `### ${path.basename(f)}\n\n${body}`;
 });
 
@@ -110,8 +109,10 @@ sensitivity: internal
 ${entries.join("\n\n") || "_(no memory files)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "memory",
+});
 
 const meta = {
   connector: "memory",
@@ -119,6 +120,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { files: mdFiles.length, lastIngest: date },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-cursor/scripts/ingest-roles.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/ingest-roles.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { loadConfig, walkFiles } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -61,8 +65,10 @@ ${rosterRows}
 ${staffPages.length ? staffPages.map(p => `- \`${path.relative(wikiRoot, p)}\``).join("\n") : "_(none)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "roles",
+});
 
 const meta = {
   connector: "roles",
@@ -74,6 +80,10 @@ const meta = {
     lastIngest: date,
   },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki-cursor/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-cursor/scripts/ingest_slack_channel.py
@@ -22,10 +22,37 @@ from typing import Any
 
 
 TOKEN_PATTERNS = [
-    re.compile(r"xox[pbar]-[A-Za-z0-9-]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    (re.compile(r"xox[pbar]-[A-Za-z0-9-]+"), "[REDACTED:OAUTH_TOKEN]"),
+    (
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+        "[REDACTED:OAUTH_TOKEN]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:API_KEY]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED:PRIVATE_KEY]",
+    ),
+    (
+        re.compile(r"\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b"),
+        "[REDACTED:SSN]",
+    ),
+    (
+        re.compile(
+            r"\b(?:password|passwd|pwd)\s*[:=]\s*(['\"]?)([^\s'\",;]{8,})\1",
+            re.I,
+        ),
+        "[REDACTED:PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['\"]?)([A-Za-z0-9._-]{20,})\1",
+            re.I,
+        ),
+        "[REDACTED:API_KEY]",
+    ),
 ]
 
 
@@ -49,8 +76,13 @@ def ts_from_input(value: str | None) -> str | None:
 
 def redact(text: str) -> str:
     out = text
-    for pattern in TOKEN_PATTERNS:
-        out = pattern.sub("[REDACTED]", out)
+    for pattern, replacement in TOKEN_PATTERNS:
+        out = pattern.sub(
+            lambda match: match.group(0).replace(match.group(2), replacement)
+            if len(match.groups()) >= 2
+            else replacement,
+            out,
+        )
     return out
 
 
@@ -289,7 +321,7 @@ def main() -> int:
             for reply in replies:
                 lines.extend(render_message(reply))
 
-    source_path.write_text("\n".join(lines), encoding="utf-8")
+    source_path.write_text(redact("\n".join(lines)), encoding="utf-8")
 
     latest_ts = previous_state.get("latest_message_ts")
     if messages:

--- a/plugins/lisa-wiki/scripts/_wiki-lib.mjs
+++ b/plugins/lisa-wiki/scripts/_wiki-lib.mjs
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeWikiSourceText } from "./wiki-safety.mjs";
 
 /** Read and parse a JSON file, or return undefined if missing/invalid. */
 export function readJsonSafe(file) {
@@ -57,6 +58,24 @@ export function walkFiles(dir, { ext } = {}) {
     }
   }
   return out.sort();
+}
+
+/**
+ * Sanitize a wiki source note immediately before it is persisted.
+ *
+ * Connectors should keep fetched raw material in memory or temporary locations
+ * outside the repo, render the source note, then call this helper at the final
+ * `wiki/sources/**` write boundary. The return value contains safe finding
+ * metadata only; callers can include it in handoff metadata when useful.
+ */
+export function writeSanitizedSourceNote(file, rawText, sourceMetadata = {}) {
+  const result = sanitizeWikiSourceText(rawText, {
+    ...sourceMetadata,
+    path: sourceMetadata.path ?? file,
+  });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, result.text);
+  return result;
 }
 
 /**

--- a/plugins/lisa-wiki/scripts/ingest-git.mjs
+++ b/plugins/lisa-wiki/scripts/ingest-git.mjs
@@ -15,7 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { readJsonSafe, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import { readJsonSafe, writeSanitizedSourceNote } from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -53,12 +53,6 @@ const commitExists = c => {
     return false;
   }
 };
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
-
 if (
   !fs.existsSync(path.join(repo, ".git")) &&
   !tryGit(["rev-parse", "--is-inside-work-tree"])
@@ -165,8 +159,11 @@ ${
 }
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, redact(note));
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "git",
+  project: slug,
+});
 
 const meta = {
   connector: "git",
@@ -174,6 +171,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { lastCommit: head, lastPr },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki/scripts/ingest-memory.mjs
+++ b/plugins/lisa-wiki/scripts/ingest-memory.mjs
@@ -15,7 +15,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadConfig, walkFiles, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -79,15 +83,10 @@ if (!(under(claudeMem) || under(projectCodexMem) || allowedRoots.some(under))) {
   );
 }
 
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
 const mdFiles = walkFiles(resolvedMem, { ext: ".md" });
 const date = new Date().toISOString().slice(0, 10);
 const entries = mdFiles.map(f => {
-  const body = redact(fs.readFileSync(f, "utf8")).trim();
+  const body = fs.readFileSync(f, "utf8").trim();
   return `### ${path.basename(f)}\n\n${body}`;
 });
 
@@ -110,8 +109,10 @@ sensitivity: internal
 ${entries.join("\n\n") || "_(no memory files)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "memory",
+});
 
 const meta = {
   connector: "memory",
@@ -119,6 +120,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { files: mdFiles.length, lastIngest: date },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki/scripts/ingest-roles.mjs
+++ b/plugins/lisa-wiki/scripts/ingest-roles.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { loadConfig, walkFiles } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -61,8 +65,10 @@ ${rosterRows}
 ${staffPages.length ? staffPages.map(p => `- \`${path.relative(wikiRoot, p)}\``).join("\n") : "_(none)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "roles",
+});
 
 const meta = {
   connector: "roles",
@@ -74,6 +80,10 @@ const meta = {
     lastIngest: date,
   },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/lisa-wiki/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki/scripts/ingest_slack_channel.py
@@ -22,10 +22,37 @@ from typing import Any
 
 
 TOKEN_PATTERNS = [
-    re.compile(r"xox[pbar]-[A-Za-z0-9-]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    (re.compile(r"xox[pbar]-[A-Za-z0-9-]+"), "[REDACTED:OAUTH_TOKEN]"),
+    (
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+        "[REDACTED:OAUTH_TOKEN]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:API_KEY]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED:PRIVATE_KEY]",
+    ),
+    (
+        re.compile(r"\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b"),
+        "[REDACTED:SSN]",
+    ),
+    (
+        re.compile(
+            r"\b(?:password|passwd|pwd)\s*[:=]\s*(['\"]?)([^\s'\",;]{8,})\1",
+            re.I,
+        ),
+        "[REDACTED:PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['\"]?)([A-Za-z0-9._-]{20,})\1",
+            re.I,
+        ),
+        "[REDACTED:API_KEY]",
+    ),
 ]
 
 
@@ -49,8 +76,13 @@ def ts_from_input(value: str | None) -> str | None:
 
 def redact(text: str) -> str:
     out = text
-    for pattern in TOKEN_PATTERNS:
-        out = pattern.sub("[REDACTED]", out)
+    for pattern, replacement in TOKEN_PATTERNS:
+        out = pattern.sub(
+            lambda match: match.group(0).replace(match.group(2), replacement)
+            if len(match.groups()) >= 2
+            else replacement,
+            out,
+        )
     return out
 
 
@@ -289,7 +321,7 @@ def main() -> int:
             for reply in replies:
                 lines.extend(render_message(reply))
 
-    source_path.write_text("\n".join(lines), encoding="utf-8")
+    source_path.write_text(redact("\n".join(lines)), encoding="utf-8")
 
     latest_ts = previous_state.get("latest_message_ts")
     if messages:

--- a/plugins/src/wiki/scripts/_wiki-lib.mjs
+++ b/plugins/src/wiki/scripts/_wiki-lib.mjs
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeWikiSourceText } from "./wiki-safety.mjs";
 
 /** Read and parse a JSON file, or return undefined if missing/invalid. */
 export function readJsonSafe(file) {
@@ -57,6 +58,24 @@ export function walkFiles(dir, { ext } = {}) {
     }
   }
   return out.sort();
+}
+
+/**
+ * Sanitize a wiki source note immediately before it is persisted.
+ *
+ * Connectors should keep fetched raw material in memory or temporary locations
+ * outside the repo, render the source note, then call this helper at the final
+ * `wiki/sources/**` write boundary. The return value contains safe finding
+ * metadata only; callers can include it in handoff metadata when useful.
+ */
+export function writeSanitizedSourceNote(file, rawText, sourceMetadata = {}) {
+  const result = sanitizeWikiSourceText(rawText, {
+    ...sourceMetadata,
+    path: sourceMetadata.path ?? file,
+  });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, result.text);
+  return result;
 }
 
 /**

--- a/plugins/src/wiki/scripts/ingest-git.mjs
+++ b/plugins/src/wiki/scripts/ingest-git.mjs
@@ -15,7 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { readJsonSafe, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import { readJsonSafe, writeSanitizedSourceNote } from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -53,12 +53,6 @@ const commitExists = c => {
     return false;
   }
 };
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
-
 if (
   !fs.existsSync(path.join(repo, ".git")) &&
   !tryGit(["rev-parse", "--is-inside-work-tree"])
@@ -165,8 +159,11 @@ ${
 }
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, redact(note));
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "git",
+  project: slug,
+});
 
 const meta = {
   connector: "git",
@@ -174,6 +171,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { lastCommit: head, lastPr },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/src/wiki/scripts/ingest-memory.mjs
+++ b/plugins/src/wiki/scripts/ingest-memory.mjs
@@ -15,7 +15,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadConfig, walkFiles, SECRET_PATTERNS } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -79,15 +83,10 @@ if (!(under(claudeMem) || under(projectCodexMem) || allowedRoots.some(under))) {
   );
 }
 
-const redact = t =>
-  SECRET_PATTERNS.reduce(
-    (acc, { re }) => acc.replace(new RegExp(re, "g"), "[REDACTED]"),
-    t
-  );
 const mdFiles = walkFiles(resolvedMem, { ext: ".md" });
 const date = new Date().toISOString().slice(0, 10);
 const entries = mdFiles.map(f => {
-  const body = redact(fs.readFileSync(f, "utf8")).trim();
+  const body = fs.readFileSync(f, "utf8").trim();
   return `### ${path.basename(f)}\n\n${body}`;
 });
 
@@ -110,8 +109,10 @@ sensitivity: internal
 ${entries.join("\n\n") || "_(no memory files)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "memory",
+});
 
 const meta = {
   connector: "memory",
@@ -119,6 +120,10 @@ const meta = {
   ranAt: new Date().toISOString(),
   proposedCursor: { files: mdFiles.length, lastIngest: date },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/src/wiki/scripts/ingest-roles.mjs
+++ b/plugins/src/wiki/scripts/ingest-roles.mjs
@@ -10,7 +10,11 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { loadConfig, walkFiles } from "./_wiki-lib.mjs";
+import {
+  loadConfig,
+  walkFiles,
+  writeSanitizedSourceNote,
+} from "./_wiki-lib.mjs";
 
 const argv = process.argv.slice(2);
 const opt = (n, d) => {
@@ -61,8 +65,10 @@ ${rosterRows}
 ${staffPages.length ? staffPages.map(p => `- \`${path.relative(wikiRoot, p)}\``).join("\n") : "_(none)_"}
 `;
 
-fs.mkdirSync(sourceDir, { recursive: true });
-fs.writeFileSync(notePath, note);
+const safety = writeSanitizedSourceNote(notePath, note, {
+  sourceId: path.relative(process.cwd(), notePath),
+  sourceSystem: "roles",
+});
 
 const meta = {
   connector: "roles",
@@ -74,6 +80,10 @@ const meta = {
     lastIngest: date,
   },
   sourceNotes: [path.relative(process.cwd(), notePath)],
+  safety: {
+    reviewRequired: safety.reviewRequired,
+    findings: safety.findings,
+  },
 };
 if (emitMeta) {
   fs.mkdirSync(path.dirname(emitMeta), { recursive: true });

--- a/plugins/src/wiki/scripts/ingest_slack_channel.py
+++ b/plugins/src/wiki/scripts/ingest_slack_channel.py
@@ -22,10 +22,37 @@ from typing import Any
 
 
 TOKEN_PATTERNS = [
-    re.compile(r"xox[pbar]-[A-Za-z0-9-]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+    (re.compile(r"xox[pbar]-[A-Za-z0-9-]+"), "[REDACTED:OAUTH_TOKEN]"),
+    (
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{20,}"),
+        "[REDACTED:OAUTH_TOKEN]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:API_KEY]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED:PRIVATE_KEY]",
+    ),
+    (
+        re.compile(r"\b(?!000|666|9\d\d)\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b"),
+        "[REDACTED:SSN]",
+    ),
+    (
+        re.compile(
+            r"\b(?:password|passwd|pwd)\s*[:=]\s*(['\"]?)([^\s'\",;]{8,})\1",
+            re.I,
+        ),
+        "[REDACTED:PASSWORD]",
+    ),
+    (
+        re.compile(
+            r"\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|client[_-]?secret)\s*[:=]\s*(['\"]?)([A-Za-z0-9._-]{20,})\1",
+            re.I,
+        ),
+        "[REDACTED:API_KEY]",
+    ),
 ]
 
 
@@ -49,8 +76,13 @@ def ts_from_input(value: str | None) -> str | None:
 
 def redact(text: str) -> str:
     out = text
-    for pattern in TOKEN_PATTERNS:
-        out = pattern.sub("[REDACTED]", out)
+    for pattern, replacement in TOKEN_PATTERNS:
+        out = pattern.sub(
+            lambda match: match.group(0).replace(match.group(2), replacement)
+            if len(match.groups()) >= 2
+            else replacement,
+            out,
+        )
     return out
 
 
@@ -289,7 +321,7 @@ def main() -> int:
             for reply in replies:
                 lines.extend(render_message(reply))
 
-    source_path.write_text("\n".join(lines), encoding="utf-8")
+    source_path.write_text(redact("\n".join(lines)), encoding="utf-8")
 
     latest_ts = previous_state.get("latest_message_ts")
     if messages:

--- a/tests/unit/strategies/wiki-connector-source-sanitization.test.ts
+++ b/tests/unit/strategies/wiki-connector-source-sanitization.test.ts
@@ -1,0 +1,186 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeSanitizedSourceNote } from "../../../plugins/src/wiki/scripts/_wiki-lib.mjs";
+
+const FIXTURE_SECRET = "sk_test_abcdefghijklmnopqrstuvwxyz";
+const API_KEY_PLACEHOLDER = "api_key = [REDACTED:API_KEY]";
+const GIT_BIN = "/usr/bin/git";
+const PYTHON_BIN =
+  "/Users/cody/.local/share/mise/installs/python/3.14.3/bin/python3";
+
+describe("lisa-wiki connector source sanitization (#1171)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-wiki-sources-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { force: true, recursive: true });
+  });
+
+  it("sanitizes git source notes immediately before writing wiki/sources", () => {
+    const repo = path.join(tmp, "repo");
+    fs.mkdirSync(repo);
+    execFileSync(GIT_BIN, ["init"], { cwd: repo });
+    execFileSync(GIT_BIN, ["config", "user.email", "test@example.com"], {
+      cwd: repo,
+    });
+    execFileSync(GIT_BIN, ["config", "user.name", "Test User"], { cwd: repo });
+    fs.writeFileSync(path.join(repo, "README.md"), "fixture\n");
+    execFileSync(GIT_BIN, ["add", "README.md"], { cwd: repo });
+    execFileSync(
+      GIT_BIN,
+      ["commit", "-m", `record fixture api_key = ${FIXTURE_SECRET}`],
+      { cwd: repo }
+    );
+
+    const sourceDir = path.join(tmp, "wiki", "sources", "git");
+    const metaPath = path.join(tmp, "wiki", "state", "handoff", "git.json");
+    execFileSync(
+      process.execPath,
+      [
+        path.resolve("plugins/src/wiki/scripts/ingest-git.mjs"),
+        "--repo",
+        repo,
+        "--slug",
+        "fixture",
+        "--source-dir",
+        sourceDir,
+        "--emit-meta",
+        metaPath,
+      ],
+      { cwd: tmp }
+    );
+
+    const note = fs.readFileSync(
+      path.join(
+        sourceDir,
+        `${new Date().toISOString().slice(0, 10)}-fixture-git.md`
+      ),
+      "utf8"
+    );
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+
+    expect(note).toContain(API_KEY_PLACEHOLDER);
+    expect(note).not.toContain(FIXTURE_SECRET);
+    expect(meta.safety.reviewRequired).toBe(true);
+    expect(meta.safety.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ entityType: "api_key", count: 1 }),
+      ])
+    );
+  });
+
+  it("sanitizes project memory notes and leaves raw memory outside wiki/sources", () => {
+    const memoryDir = path.join(tmp, "project-memory");
+    const repo = path.join(tmp, "repo");
+    const sourceDir = path.join(tmp, "wiki", "sources", "memory");
+    const metaPath = path.join(tmp, "wiki", "state", "handoff", "memory.json");
+    const configPath = path.join(tmp, "wiki", "lisa-wiki.config.json");
+    fs.mkdirSync(memoryDir, { recursive: true });
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.mkdirSync(repo, { recursive: true });
+    fs.writeFileSync(
+      path.join(memoryDir, "MEMORY.md"),
+      `Customer SSN 123-45-6789 and api_key = ${FIXTURE_SECRET}\n`
+    );
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ memory: { allowedRoots: [memoryDir] } }, null, 2)
+    );
+
+    execFileSync(
+      process.execPath,
+      [
+        path.resolve("plugins/src/wiki/scripts/ingest-memory.mjs"),
+        "--memory-dir",
+        memoryDir,
+        "--repo",
+        repo,
+        "--config",
+        configPath,
+        "--source-dir",
+        sourceDir,
+        "--emit-meta",
+        metaPath,
+      ],
+      { cwd: tmp }
+    );
+
+    const note = fs.readFileSync(
+      path.join(
+        sourceDir,
+        `${new Date().toISOString().slice(0, 10)}-memory.md`
+      ),
+      "utf8"
+    );
+    const rawMemory = fs.readFileSync(
+      path.join(memoryDir, "MEMORY.md"),
+      "utf8"
+    );
+
+    expect(rawMemory).toContain(FIXTURE_SECRET);
+    expect(note).toContain("[REDACTED:SSN]");
+    expect(note).toContain(API_KEY_PLACEHOLDER);
+    expect(note).not.toContain("123-45-6789");
+    expect(note).not.toContain(FIXTURE_SECRET);
+  });
+
+  it("sanitizes Slack message text with typed placeholders", () => {
+    const script = path.resolve(
+      "plugins/src/wiki/scripts/ingest_slack_channel.py"
+    );
+    const result = spawnSync(
+      PYTHON_BIN,
+      [
+        "-c",
+        [
+          "import importlib.util, json, sys",
+          "spec = importlib.util.spec_from_file_location('slack_ingest', sys.argv[1])",
+          "mod = importlib.util.module_from_spec(spec)",
+          "spec.loader.exec_module(mod)",
+          "print(json.dumps(mod.render_message({'ts':'1.000000','user':'U1','text':sys.argv[2]})))",
+        ].join(";"),
+        script,
+        `token xoxp-secret-token and SSN 123-45-6789 and api_key = ${FIXTURE_SECRET}`,
+      ],
+      { encoding: "utf8" }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("[REDACTED:OAUTH_TOKEN]");
+    expect(result.stdout).toContain("[REDACTED:SSN]");
+    expect(result.stdout).toContain(API_KEY_PLACEHOLDER);
+    expect(result.stdout).not.toContain("xoxp-secret-token");
+    expect(result.stdout).not.toContain(FIXTURE_SECRET);
+  });
+
+  it("sanitizes Jira-style source notes through the shared writer", () => {
+    const notePath = path.join(tmp, "wiki", "sources", "jira", "fixture.md");
+    const result = writeSanitizedSourceNote(
+      notePath,
+      [
+        "---",
+        "type: source",
+        "source_system: jira",
+        "---",
+        "",
+        "# Jira Ingest",
+        "",
+        `Source: LISA-123 with client_secret = ${FIXTURE_SECRET}`,
+      ].join("\n"),
+      { sourceId: "jira/LISA-123", sourceSystem: "jira" }
+    );
+    const note = fs.readFileSync(notePath, "utf8");
+
+    expect(result.reviewRequired).toBe(true);
+    expect(note).toContain("client_secret = [REDACTED:API_KEY]");
+    expect(note).not.toContain(FIXTURE_SECRET);
+  });
+});

--- a/tests/unit/strategies/wiki-connector-source-sanitization.test.ts
+++ b/tests/unit/strategies/wiki-connector-source-sanitization.test.ts
@@ -10,8 +10,8 @@ import { writeSanitizedSourceNote } from "../../../plugins/src/wiki/scripts/_wik
 const FIXTURE_SECRET = "sk_test_abcdefghijklmnopqrstuvwxyz";
 const API_KEY_PLACEHOLDER = "api_key = [REDACTED:API_KEY]";
 const GIT_BIN = "/usr/bin/git";
-const PYTHON_BIN =
-  "/Users/cody/.local/share/mise/installs/python/3.14.3/bin/python3";
+const PYTHON_BIN = process.env.PYTHON ?? "python3";
+const CLEAN_GIT_ENV = cleanGitEnv();
 
 describe("lisa-wiki connector source sanitization (#1171)", () => {
   let tmp: string;
@@ -27,17 +27,24 @@ describe("lisa-wiki connector source sanitization (#1171)", () => {
   it("sanitizes git source notes immediately before writing wiki/sources", () => {
     const repo = path.join(tmp, "repo");
     fs.mkdirSync(repo);
-    execFileSync(GIT_BIN, ["init"], { cwd: repo });
+    execFileSync(GIT_BIN, ["init"], { cwd: repo, env: CLEAN_GIT_ENV });
     execFileSync(GIT_BIN, ["config", "user.email", "test@example.com"], {
       cwd: repo,
+      env: CLEAN_GIT_ENV,
     });
-    execFileSync(GIT_BIN, ["config", "user.name", "Test User"], { cwd: repo });
+    execFileSync(GIT_BIN, ["config", "user.name", "Test User"], {
+      cwd: repo,
+      env: CLEAN_GIT_ENV,
+    });
     fs.writeFileSync(path.join(repo, "README.md"), "fixture\n");
-    execFileSync(GIT_BIN, ["add", "README.md"], { cwd: repo });
+    execFileSync(GIT_BIN, ["add", "README.md"], {
+      cwd: repo,
+      env: CLEAN_GIT_ENV,
+    });
     execFileSync(
       GIT_BIN,
       ["commit", "-m", `record fixture api_key = ${FIXTURE_SECRET}`],
-      { cwd: repo }
+      { cwd: repo, env: CLEAN_GIT_ENV }
     );
 
     const sourceDir = path.join(tmp, "wiki", "sources", "git");
@@ -55,7 +62,7 @@ describe("lisa-wiki connector source sanitization (#1171)", () => {
         "--emit-meta",
         metaPath,
       ],
-      { cwd: tmp }
+      { cwd: tmp, env: CLEAN_GIT_ENV }
     );
 
     const note = fs.readFileSync(
@@ -153,6 +160,7 @@ describe("lisa-wiki connector source sanitization (#1171)", () => {
       { encoding: "utf8" }
     );
 
+    expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("[REDACTED:OAUTH_TOKEN]");
     expect(result.stdout).toContain("[REDACTED:SSN]");
@@ -184,3 +192,16 @@ describe("lisa-wiki connector source sanitization (#1171)", () => {
     expect(note).not.toContain(FIXTURE_SECRET);
   });
 });
+
+/**
+ * Remove parent-hook Git environment so fixture commands use the temp repo.
+ *
+ * @returns Process environment for nested Git commands.
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, GIT_CONFIG_NOSYSTEM: "1" };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  return env;
+}


### PR DESCRIPTION
## Summary
- add a shared wiki source-note writer that sanitizes at the final wiki/sources write boundary
- route git, memory, and roles connectors through the shared writer and include safe findings in handoff metadata
- strengthen Slack source-note sanitization with typed placeholders and add connector fixture tests

Closes #1171

## Verification
- bunx vitest run tests/unit/strategies/wiki-safety.test.ts tests/unit/strategies/wiki-connector-source-sanitization.test.ts
- bunx eslint tests/unit/strategies/wiki-connector-source-sanitization.test.ts --quiet
- bunx oxlint plugins/src/wiki/scripts/_wiki-lib.mjs plugins/src/wiki/scripts/ingest-git.mjs plugins/src/wiki/scripts/ingest-memory.mjs plugins/src/wiki/scripts/ingest-roles.mjs tests/unit/strategies/wiki-connector-source-sanitization.test.ts --disable-nested-config
- bun run build:dist
- git diff --check
- bun run check:plugins
- git push pre-push hook: bun audit, slow ESLint, knip, vitest coverage, integration tests