### PR TITLE
test(wiki): cover redaction safety fixtures

### DIFF
--- a/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
@@ -187,6 +187,31 @@ export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
   };
 }
 
+export function processWikiSourceNote(rawText, options = {}) {
+  const {
+    dryRun = false,
+    scannerAvailable = true,
+    scannerRequired = false,
+    ...sourceMetadata
+  } = options;
+  const sanitized = sanitizeWikiSourceText(rawText, sourceMetadata);
+  const scannerBlocked = scannerRequired && !scannerAvailable;
+
+  return {
+    ...sanitized,
+    dryRun: Boolean(dryRun),
+    writeAllowed: !dryRun && !scannerBlocked,
+    scanner: {
+      available: Boolean(scannerAvailable),
+      required: Boolean(scannerRequired),
+      blocked: scannerBlocked,
+    },
+    blockedReason: scannerBlocked
+      ? "sensitivity scanner is required but unavailable"
+      : undefined,
+  };
+}
+
 export function serializeWikiSafetyFindings(result) {
   return JSON.stringify(
     {

--- a/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
@@ -187,6 +187,31 @@ export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
   };
 }
 
+export function processWikiSourceNote(rawText, options = {}) {
+  const {
+    dryRun = false,
+    scannerAvailable = true,
+    scannerRequired = false,
+    ...sourceMetadata
+  } = options;
+  const sanitized = sanitizeWikiSourceText(rawText, sourceMetadata);
+  const scannerBlocked = scannerRequired && !scannerAvailable;
+
+  return {
+    ...sanitized,
+    dryRun: Boolean(dryRun),
+    writeAllowed: !dryRun && !scannerBlocked,
+    scanner: {
+      available: Boolean(scannerAvailable),
+      required: Boolean(scannerRequired),
+      blocked: scannerBlocked,
+    },
+    blockedReason: scannerBlocked
+      ? "sensitivity scanner is required but unavailable"
+      : undefined,
+  };
+}
+
 export function serializeWikiSafetyFindings(result) {
   return JSON.stringify(
     {

--- a/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
@@ -187,6 +187,31 @@ export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
   };
 }
 
+export function processWikiSourceNote(rawText, options = {}) {
+  const {
+    dryRun = false,
+    scannerAvailable = true,
+    scannerRequired = false,
+    ...sourceMetadata
+  } = options;
+  const sanitized = sanitizeWikiSourceText(rawText, sourceMetadata);
+  const scannerBlocked = scannerRequired && !scannerAvailable;
+
+  return {
+    ...sanitized,
+    dryRun: Boolean(dryRun),
+    writeAllowed: !dryRun && !scannerBlocked,
+    scanner: {
+      available: Boolean(scannerAvailable),
+      required: Boolean(scannerRequired),
+      blocked: scannerBlocked,
+    },
+    blockedReason: scannerBlocked
+      ? "sensitivity scanner is required but unavailable"
+      : undefined,
+  };
+}
+
 export function serializeWikiSafetyFindings(result) {
   return JSON.stringify(
     {

--- a/plugins/lisa-wiki/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki/scripts/wiki-safety.mjs
@@ -187,6 +187,31 @@ export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
   };
 }
 
+export function processWikiSourceNote(rawText, options = {}) {
+  const {
+    dryRun = false,
+    scannerAvailable = true,
+    scannerRequired = false,
+    ...sourceMetadata
+  } = options;
+  const sanitized = sanitizeWikiSourceText(rawText, sourceMetadata);
+  const scannerBlocked = scannerRequired && !scannerAvailable;
+
+  return {
+    ...sanitized,
+    dryRun: Boolean(dryRun),
+    writeAllowed: !dryRun && !scannerBlocked,
+    scanner: {
+      available: Boolean(scannerAvailable),
+      required: Boolean(scannerRequired),
+      blocked: scannerBlocked,
+    },
+    blockedReason: scannerBlocked
+      ? "sensitivity scanner is required but unavailable"
+      : undefined,
+  };
+}
+
 export function serializeWikiSafetyFindings(result) {
   return JSON.stringify(
     {

--- a/plugins/src/wiki/scripts/wiki-safety.mjs
+++ b/plugins/src/wiki/scripts/wiki-safety.mjs
@@ -187,6 +187,31 @@ export function sanitizeWikiSourceText(rawText, sourceMetadata = {}) {
   };
 }
 
+export function processWikiSourceNote(rawText, options = {}) {
+  const {
+    dryRun = false,
+    scannerAvailable = true,
+    scannerRequired = false,
+    ...sourceMetadata
+  } = options;
+  const sanitized = sanitizeWikiSourceText(rawText, sourceMetadata);
+  const scannerBlocked = scannerRequired && !scannerAvailable;
+
+  return {
+    ...sanitized,
+    dryRun: Boolean(dryRun),
+    writeAllowed: !dryRun && !scannerBlocked,
+    scanner: {
+      available: Boolean(scannerAvailable),
+      required: Boolean(scannerRequired),
+      blocked: scannerBlocked,
+    },
+    blockedReason: scannerBlocked
+      ? "sensitivity scanner is required but unavailable"
+      : undefined,
+  };
+}
+
 export function serializeWikiSafetyFindings(result) {
   return JSON.stringify(
     {

--- a/tests/fixtures/wiki-safety/allowed-contacts.md
+++ b/tests/fixtures/wiki-safety/allowed-contacts.md
@@ -1,0 +1,11 @@
+---
+type: source
+created: 2026-06-06
+updated: 2026-06-06
+sourceSystem: fixture
+---
+
+# Allowed Contact Fixture
+
+Grace Hopper <grace@example.com> owns release notes.
+Invoice reference 4111 1111 1111 1112 is not Luhn-valid.

--- a/tests/fixtures/wiki-safety/redaction-source.md
+++ b/tests/fixtures/wiki-safety/redaction-source.md
@@ -1,0 +1,23 @@
+---
+type: source
+created: 2026-06-06
+updated: 2026-06-06
+sourceSystem: fixture
+---
+
+# Sensitive Fixture
+
+Contact Ada Lovelace at ada@example.com for a normal business thread.
+
+Fake SSN: 123-45-6789.
+Test card: 4111 1111 1111 1111.
+
+-----BEGIN PRIVATE KEY-----
+abc123
+-----END PRIVATE KEY-----
+
+password = fakePassword123
+api_key = sk_test_abcdefghijklmnopqrstuvwxyz
+oauth_token: ya29.fakeOAuthTokenValue1234567890
+
+routing number 021000021 and account number 123456789012

--- a/tests/unit/strategies/wiki-safety.test.ts
+++ b/tests/unit/strategies/wiki-safety.test.ts
@@ -1,29 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
+  processWikiSourceNote,
   sanitizeWikiSourceText,
   serializeWikiSafetyFindings,
 } from "../../../plugins/src/wiki/scripts/wiki-safety.mjs";
 
 describe("wiki safety sanitizer (#1169)", () => {
   const reportSourceId = "fixtures/report.md";
+  const redactionFixture = "redaction-source.md";
+  const redactionSourceId = "fixtures/wiki-safety/redaction-source.md";
+  const fakeSsn = "123-45-6789";
+  const fixtureRoot = path.resolve("tests/fixtures/wiki-safety");
 
-  it("redacts built-in blocked values while preserving normal contacts", () => {
-    const raw = [
-      "Contact Ada Lovelace at ada@example.com.",
-      "Fake SSN: 123-45-6789.",
-      "Card: 4111 1111 1111 1111.",
-      "-----BEGIN PRIVATE KEY-----",
-      "abc123",
-      "-----END PRIVATE KEY-----",
-      "password = fakePassword123",
-      "api_key = sk_test_abcdefghijklmnopqrstuvwxyz",
-      "oauth_token: ya29.fakeOAuthTokenValue1234567890",
-      "routing number 021000021 and account number 123456789012",
-    ].join("\n");
+  const readFixture = (name: string): string =>
+    readFileSync(path.join(fixtureRoot, name), "utf8");
 
-    const result = sanitizeWikiSourceText(raw, {
-      sourceId: "fixtures/redaction.md",
+  it("redacts built-in blocked fixture values while preserving normal contacts", () => {
+    const result = sanitizeWikiSourceText(readFixture(redactionFixture), {
+      sourceId: redactionSourceId,
     });
 
     expect(result.reviewRequired).toBe(true);
@@ -37,14 +35,26 @@ describe("wiki safety sanitizer (#1169)", () => {
     expect(result.text).toContain("oauth_token: [REDACTED:OAUTH_TOKEN]");
     expect(result.text).toContain("routing number [REDACTED:ROUTING_NUMBER]");
     expect(result.text).toContain("account number [REDACTED:BANK_ACCOUNT]");
-    expect(result.text).not.toContain("123-45-6789");
+    expect(result.text).not.toContain(fakeSsn);
     expect(result.text).not.toContain("4111 1111 1111 1111");
     expect(result.text).not.toContain("fakePassword123");
+    expect(result.text).not.toContain("sk_test_abcdefghijklmnopqrstuvwxyz");
+    expect(result.text).not.toContain("ya29.fakeOAuthTokenValue1234567890");
+    expect(result.text).not.toContain("123456789012");
+    expect(result.findings.map(finding => finding.entityType)).toEqual([
+      "api_key",
+      "bank_account",
+      "credit_card",
+      "oauth_token",
+      "password",
+      "private_key",
+      "routing_number",
+      "ssn",
+    ]);
   });
 
   it("serializes only safe finding metadata", () => {
-    const raw =
-      "token: public example\napi_key = sk_test_abcdefghijklmnopqrstuvwxyz\nSSN 123-45-6789";
+    const raw = `token: public example\napi_key = sk_test_abcdefghijklmnopqrstuvwxyz\nSSN ${fakeSsn}`;
     const result = sanitizeWikiSourceText(raw, {
       sourceId: reportSourceId,
     });
@@ -70,20 +80,55 @@ describe("wiki safety sanitizer (#1169)", () => {
       ])
     );
     expect(serialized).not.toContain("sk_test_abcdefghijklmnopqrstuvwxyz");
-    expect(serialized).not.toContain("123-45-6789");
+    expect(serialized).not.toContain(fakeSsn);
     expect(serialized).not.toContain("token: public example");
   });
 
   it("does not flag names, email addresses, or invalid card-shaped numbers", () => {
-    const result = sanitizeWikiSourceText(
-      "Grace Hopper <grace@example.com> invoice 4111 1111 1111 1112",
-      { sourceId: "fixtures/allowed.md" }
-    );
+    const result = sanitizeWikiSourceText(readFixture("allowed-contacts.md"), {
+      sourceId: "fixtures/wiki-safety/allowed-contacts.md",
+    });
 
     expect(result.reviewRequired).toBe(false);
     expect(result.findings).toEqual([]);
     expect(result.text).toContain("Grace Hopper");
     expect(result.text).toContain("grace@example.com");
     expect(result.text).toContain("4111 1111 1111 1112");
+  });
+
+  it("keeps scanner-unavailable source notes blocked when policy requires a scanner", () => {
+    const result = processWikiSourceNote(readFixture(redactionFixture), {
+      sourceId: redactionSourceId,
+      scannerAvailable: false,
+      scannerRequired: true,
+    });
+
+    expect(result.scanner).toEqual({
+      available: false,
+      required: true,
+      blocked: true,
+    });
+    expect(result.writeAllowed).toBe(false);
+    expect(result.blockedReason).toBe(
+      "sensitivity scanner is required but unavailable"
+    );
+    expect(result.text).toContain("[REDACTED:SSN]");
+    expect(result.text).not.toContain(fakeSsn);
+  });
+
+  it("returns a sanitized preview without allowing writes in dry-run mode", () => {
+    const result = processWikiSourceNote(readFixture(redactionFixture), {
+      sourceId: redactionSourceId,
+      dryRun: true,
+      scannerAvailable: true,
+      scannerRequired: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.scanner.blocked).toBe(false);
+    expect(result.writeAllowed).toBe(false);
+    expect(result.reviewRequired).toBe(true);
+    expect(result.text).toContain("[REDACTED:CREDIT_CARD]");
+    expect(result.text).not.toContain("4111 1111 1111 1111");
   });
 });


### PR DESCRIPTION
## Summary
- Add committed wiki-safety fixtures for blocked sensitive classes and allowed contacts
- Add `processWikiSourceNote` policy wrapper for dry-run and scanner-unavailable write decisions
- Regenerate lisa-wiki plugin artifacts for Claude, Cursor, Agy, and Copilot variants

## Verification
- `bunx vitest run tests/unit/strategies/wiki-safety.test.ts`
- `bun run build:dist`
- `git diff --check`
- `bun run check:plugins`
- pre-commit hook: Gitleaks, `tsc --noEmit`, lint-staged, ast-grep, commitlint
- pre-push hook: `bun audit`, slow ESLint, knip, `vitest run --coverage` (178 files / 2969 tests), integration tests (3 files / 50 tests)

Closes #1172