### PR TITLE
feat(wiki): add generated output safety gate

### DIFF
--- a/plugins/lisa-wiki-agy/scripts/verify-wiki-safety.mjs
+++ b/plugins/lisa-wiki-agy/scripts/verify-wiki-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit safety gate for generated wiki output.
+ *
+ * Scans only explicit wiki paths, or current git changes under the configured
+ * wiki root when no paths are passed. Reports safe metadata only.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./_wiki-lib.mjs";
+import { scanWikiGeneratedFiles } from "./wiki-safety.mjs";
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(name);
+const opt = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const repeated = name => {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+};
+
+const { config } = loadConfig(opt("--config"));
+const wikiRoot = path.resolve(opt("--wiki") ?? config?.wikiRoot ?? "wiki");
+const asJson = flag("--json");
+const scanner = opt("--scanner") ?? "builtin";
+
+function commandExists(command) {
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitChangedPaths() {
+  let out = "";
+  try {
+    out = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+      encoding: "utf8",
+    });
+  } catch {
+    return [];
+  }
+  const entries = out.split("\0").filter(Boolean);
+  const paths = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (!file || status.includes("D")) continue;
+    paths.push(file);
+    if (status[0] === "R" || status[0] === "C") i += 1;
+  }
+  return paths;
+}
+
+const explicitPaths = repeated("--path");
+const files = explicitPaths.length > 0 ? explicitPaths : gitChangedPaths();
+
+const externalScanner =
+  scanner === "gitleaks" || scanner === "trufflehog" ? scanner : undefined;
+const externalScannerMissing =
+  externalScanner !== undefined && !commandExists(externalScanner);
+
+const result = scanWikiGeneratedFiles(files, {
+  fsModule: fs,
+  pathModule: path,
+  wikiRoot,
+});
+
+const finalResult = {
+  ...result,
+  scanner: {
+    selected: scanner,
+    externalAvailable: externalScanner ? !externalScannerMissing : undefined,
+  },
+  ok: result.ok && !externalScannerMissing,
+  errors: [
+    ...result.errors,
+    ...(externalScannerMissing
+      ? [
+          {
+            file: path.relative(process.cwd(), wikiRoot) || ".",
+            message: `${externalScanner} scanner selected but unavailable`,
+          },
+        ]
+      : []),
+  ],
+};
+
+if (asJson) {
+  console.log(JSON.stringify(finalResult, null, 2));
+} else {
+  for (const finding of finalResult.findings) {
+    console.log(
+      `x [wiki-safety] possible ${finding.entityType} (${finding.confidence}) in ${finding.sourceId}; count=${finding.count}`
+    );
+  }
+  for (const error of finalResult.errors) {
+    console.log(`x [wiki-safety] ${error.message} (${error.file})`);
+  }
+  console.log(
+    `\n${finalResult.findings.length} finding${finalResult.findings.length === 1 ? "" : "s"}, ${finalResult.errors.length} error${finalResult.errors.length === 1 ? "" : "s"} across ${finalResult.scanned.length} wiki file${finalResult.scanned.length === 1 ? "" : "s"} — ${finalResult.ok ? "OK" : "BLOCKING"}`
+  );
+}
+
+process.exitCode = finalResult.ok ? 0 : 1;

--- a/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
@@ -61,6 +61,19 @@ const PATTERNS = [
   },
 ];
 
+const TEXTISH_EXTS = new Set([
+  ".md",
+  ".mdx",
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".csv",
+  ".tsv",
+]);
+
 function luhnValid(candidate) {
   const digits = candidate.replace(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
@@ -221,4 +234,69 @@ export function serializeWikiSafetyFindings(result) {
     null,
     2
   );
+}
+
+export function isWikiSafetyScanTarget(filePath, options = {}) {
+  const pathModule = options.pathModule;
+  if (!pathModule) {
+    throw new Error("isWikiSafetyScanTarget requires options.pathModule");
+  }
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const resolved = pathModule.resolve(filePath);
+  const relative = pathModule.relative(wikiRoot, resolved);
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    pathModule.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  const ext = pathModule.extname(resolved);
+  return TEXTISH_EXTS.has(ext);
+}
+
+export function scanWikiGeneratedFiles(files, options = {}) {
+  const fsModule = options.fsModule;
+  const pathModule = options.pathModule;
+  if (!fsModule || !pathModule) {
+    throw new Error("scanWikiGeneratedFiles requires fsModule and pathModule");
+  }
+
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const candidates = [...new Set(files.map(file => pathModule.resolve(file)))]
+    .filter(file => isWikiSafetyScanTarget(file, { wikiRoot, pathModule }))
+    .sort();
+
+  const scanned = [];
+  const findings = [];
+  const errors = [];
+
+  for (const file of candidates) {
+    let text;
+    try {
+      if (!fsModule.existsSync(file) || !fsModule.statSync(file).isFile()) {
+        continue;
+      }
+      text = fsModule.readFileSync(file, "utf8");
+    } catch (error) {
+      errors.push({
+        file: pathModule.relative(process.cwd(), file),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const sourceId = pathModule.relative(wikiRoot, file);
+    scanned.push(sourceId);
+    const result = scanWikiSourceText(text, { sourceId });
+    findings.push(...result.findings);
+  }
+
+  return {
+    ok: findings.length === 0 && errors.length === 0,
+    wikiRoot: pathModule.relative(process.cwd(), wikiRoot) || ".",
+    scanned,
+    findings,
+    errors,
+  };
 }

--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 - Source-note-before-synthesis; state advanced **only** after verification.
 - Project-scoped only; memory ingestion never touches global/Codex-global stores.
 - Respect `sourceRetention` and `sensitivity`; do not invent facts.
+- Before advancing state or committing, run the generated-output safety gate
+  (`scripts/verify-wiki-safety.mjs`) against the wiki files/source notes produced by
+  the ingest. The default built-in scan blocks unredacted private keys, tokens, and
+  common financial/person identifiers without printing raw values. Projects may
+  select `--scanner gitleaks` for local parity with Gitleaks, and may use
+  `--scanner trufflehog` as a stricter optional verification pass when installed;
+  if a selected scanner is unavailable, keep the ingest blocked for review.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki-copilot/scripts/verify-wiki-safety.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/verify-wiki-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit safety gate for generated wiki output.
+ *
+ * Scans only explicit wiki paths, or current git changes under the configured
+ * wiki root when no paths are passed. Reports safe metadata only.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./_wiki-lib.mjs";
+import { scanWikiGeneratedFiles } from "./wiki-safety.mjs";
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(name);
+const opt = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const repeated = name => {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+};
+
+const { config } = loadConfig(opt("--config"));
+const wikiRoot = path.resolve(opt("--wiki") ?? config?.wikiRoot ?? "wiki");
+const asJson = flag("--json");
+const scanner = opt("--scanner") ?? "builtin";
+
+function commandExists(command) {
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitChangedPaths() {
+  let out = "";
+  try {
+    out = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+      encoding: "utf8",
+    });
+  } catch {
+    return [];
+  }
+  const entries = out.split("\0").filter(Boolean);
+  const paths = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (!file || status.includes("D")) continue;
+    paths.push(file);
+    if (status[0] === "R" || status[0] === "C") i += 1;
+  }
+  return paths;
+}
+
+const explicitPaths = repeated("--path");
+const files = explicitPaths.length > 0 ? explicitPaths : gitChangedPaths();
+
+const externalScanner =
+  scanner === "gitleaks" || scanner === "trufflehog" ? scanner : undefined;
+const externalScannerMissing =
+  externalScanner !== undefined && !commandExists(externalScanner);
+
+const result = scanWikiGeneratedFiles(files, {
+  fsModule: fs,
+  pathModule: path,
+  wikiRoot,
+});
+
+const finalResult = {
+  ...result,
+  scanner: {
+    selected: scanner,
+    externalAvailable: externalScanner ? !externalScannerMissing : undefined,
+  },
+  ok: result.ok && !externalScannerMissing,
+  errors: [
+    ...result.errors,
+    ...(externalScannerMissing
+      ? [
+          {
+            file: path.relative(process.cwd(), wikiRoot) || ".",
+            message: `${externalScanner} scanner selected but unavailable`,
+          },
+        ]
+      : []),
+  ],
+};
+
+if (asJson) {
+  console.log(JSON.stringify(finalResult, null, 2));
+} else {
+  for (const finding of finalResult.findings) {
+    console.log(
+      `x [wiki-safety] possible ${finding.entityType} (${finding.confidence}) in ${finding.sourceId}; count=${finding.count}`
+    );
+  }
+  for (const error of finalResult.errors) {
+    console.log(`x [wiki-safety] ${error.message} (${error.file})`);
+  }
+  console.log(
+    `\n${finalResult.findings.length} finding${finalResult.findings.length === 1 ? "" : "s"}, ${finalResult.errors.length} error${finalResult.errors.length === 1 ? "" : "s"} across ${finalResult.scanned.length} wiki file${finalResult.scanned.length === 1 ? "" : "s"} — ${finalResult.ok ? "OK" : "BLOCKING"}`
+  );
+}
+
+process.exitCode = finalResult.ok ? 0 : 1;

--- a/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
@@ -61,6 +61,19 @@ const PATTERNS = [
   },
 ];
 
+const TEXTISH_EXTS = new Set([
+  ".md",
+  ".mdx",
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".csv",
+  ".tsv",
+]);
+
 function luhnValid(candidate) {
   const digits = candidate.replace(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
@@ -221,4 +234,69 @@ export function serializeWikiSafetyFindings(result) {
     null,
     2
   );
+}
+
+export function isWikiSafetyScanTarget(filePath, options = {}) {
+  const pathModule = options.pathModule;
+  if (!pathModule) {
+    throw new Error("isWikiSafetyScanTarget requires options.pathModule");
+  }
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const resolved = pathModule.resolve(filePath);
+  const relative = pathModule.relative(wikiRoot, resolved);
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    pathModule.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  const ext = pathModule.extname(resolved);
+  return TEXTISH_EXTS.has(ext);
+}
+
+export function scanWikiGeneratedFiles(files, options = {}) {
+  const fsModule = options.fsModule;
+  const pathModule = options.pathModule;
+  if (!fsModule || !pathModule) {
+    throw new Error("scanWikiGeneratedFiles requires fsModule and pathModule");
+  }
+
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const candidates = [...new Set(files.map(file => pathModule.resolve(file)))]
+    .filter(file => isWikiSafetyScanTarget(file, { wikiRoot, pathModule }))
+    .sort();
+
+  const scanned = [];
+  const findings = [];
+  const errors = [];
+
+  for (const file of candidates) {
+    let text;
+    try {
+      if (!fsModule.existsSync(file) || !fsModule.statSync(file).isFile()) {
+        continue;
+      }
+      text = fsModule.readFileSync(file, "utf8");
+    } catch (error) {
+      errors.push({
+        file: pathModule.relative(process.cwd(), file),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const sourceId = pathModule.relative(wikiRoot, file);
+    scanned.push(sourceId);
+    const result = scanWikiSourceText(text, { sourceId });
+    findings.push(...result.findings);
+  }
+
+  return {
+    ok: findings.length === 0 && errors.length === 0,
+    wikiRoot: pathModule.relative(process.cwd(), wikiRoot) || ".",
+    scanned,
+    findings,
+    errors,
+  };
 }

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 - Source-note-before-synthesis; state advanced **only** after verification.
 - Project-scoped only; memory ingestion never touches global/Codex-global stores.
 - Respect `sourceRetention` and `sensitivity`; do not invent facts.
+- Before advancing state or committing, run the generated-output safety gate
+  (`scripts/verify-wiki-safety.mjs`) against the wiki files/source notes produced by
+  the ingest. The default built-in scan blocks unredacted private keys, tokens, and
+  common financial/person identifiers without printing raw values. Projects may
+  select `--scanner gitleaks` for local parity with Gitleaks, and may use
+  `--scanner trufflehog` as a stricter optional verification pass when installed;
+  if a selected scanner is unavailable, keep the ingest blocked for review.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki-cursor/scripts/verify-wiki-safety.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/verify-wiki-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit safety gate for generated wiki output.
+ *
+ * Scans only explicit wiki paths, or current git changes under the configured
+ * wiki root when no paths are passed. Reports safe metadata only.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./_wiki-lib.mjs";
+import { scanWikiGeneratedFiles } from "./wiki-safety.mjs";
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(name);
+const opt = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const repeated = name => {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+};
+
+const { config } = loadConfig(opt("--config"));
+const wikiRoot = path.resolve(opt("--wiki") ?? config?.wikiRoot ?? "wiki");
+const asJson = flag("--json");
+const scanner = opt("--scanner") ?? "builtin";
+
+function commandExists(command) {
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitChangedPaths() {
+  let out = "";
+  try {
+    out = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+      encoding: "utf8",
+    });
+  } catch {
+    return [];
+  }
+  const entries = out.split("\0").filter(Boolean);
+  const paths = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (!file || status.includes("D")) continue;
+    paths.push(file);
+    if (status[0] === "R" || status[0] === "C") i += 1;
+  }
+  return paths;
+}
+
+const explicitPaths = repeated("--path");
+const files = explicitPaths.length > 0 ? explicitPaths : gitChangedPaths();
+
+const externalScanner =
+  scanner === "gitleaks" || scanner === "trufflehog" ? scanner : undefined;
+const externalScannerMissing =
+  externalScanner !== undefined && !commandExists(externalScanner);
+
+const result = scanWikiGeneratedFiles(files, {
+  fsModule: fs,
+  pathModule: path,
+  wikiRoot,
+});
+
+const finalResult = {
+  ...result,
+  scanner: {
+    selected: scanner,
+    externalAvailable: externalScanner ? !externalScannerMissing : undefined,
+  },
+  ok: result.ok && !externalScannerMissing,
+  errors: [
+    ...result.errors,
+    ...(externalScannerMissing
+      ? [
+          {
+            file: path.relative(process.cwd(), wikiRoot) || ".",
+            message: `${externalScanner} scanner selected but unavailable`,
+          },
+        ]
+      : []),
+  ],
+};
+
+if (asJson) {
+  console.log(JSON.stringify(finalResult, null, 2));
+} else {
+  for (const finding of finalResult.findings) {
+    console.log(
+      `x [wiki-safety] possible ${finding.entityType} (${finding.confidence}) in ${finding.sourceId}; count=${finding.count}`
+    );
+  }
+  for (const error of finalResult.errors) {
+    console.log(`x [wiki-safety] ${error.message} (${error.file})`);
+  }
+  console.log(
+    `\n${finalResult.findings.length} finding${finalResult.findings.length === 1 ? "" : "s"}, ${finalResult.errors.length} error${finalResult.errors.length === 1 ? "" : "s"} across ${finalResult.scanned.length} wiki file${finalResult.scanned.length === 1 ? "" : "s"} — ${finalResult.ok ? "OK" : "BLOCKING"}`
+  );
+}
+
+process.exitCode = finalResult.ok ? 0 : 1;

--- a/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
@@ -61,6 +61,19 @@ const PATTERNS = [
   },
 ];
 
+const TEXTISH_EXTS = new Set([
+  ".md",
+  ".mdx",
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".csv",
+  ".tsv",
+]);
+
 function luhnValid(candidate) {
   const digits = candidate.replace(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
@@ -221,4 +234,69 @@ export function serializeWikiSafetyFindings(result) {
     null,
     2
   );
+}
+
+export function isWikiSafetyScanTarget(filePath, options = {}) {
+  const pathModule = options.pathModule;
+  if (!pathModule) {
+    throw new Error("isWikiSafetyScanTarget requires options.pathModule");
+  }
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const resolved = pathModule.resolve(filePath);
+  const relative = pathModule.relative(wikiRoot, resolved);
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    pathModule.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  const ext = pathModule.extname(resolved);
+  return TEXTISH_EXTS.has(ext);
+}
+
+export function scanWikiGeneratedFiles(files, options = {}) {
+  const fsModule = options.fsModule;
+  const pathModule = options.pathModule;
+  if (!fsModule || !pathModule) {
+    throw new Error("scanWikiGeneratedFiles requires fsModule and pathModule");
+  }
+
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const candidates = [...new Set(files.map(file => pathModule.resolve(file)))]
+    .filter(file => isWikiSafetyScanTarget(file, { wikiRoot, pathModule }))
+    .sort();
+
+  const scanned = [];
+  const findings = [];
+  const errors = [];
+
+  for (const file of candidates) {
+    let text;
+    try {
+      if (!fsModule.existsSync(file) || !fsModule.statSync(file).isFile()) {
+        continue;
+      }
+      text = fsModule.readFileSync(file, "utf8");
+    } catch (error) {
+      errors.push({
+        file: pathModule.relative(process.cwd(), file),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const sourceId = pathModule.relative(wikiRoot, file);
+    scanned.push(sourceId);
+    const result = scanWikiSourceText(text, { sourceId });
+    findings.push(...result.findings);
+  }
+
+  return {
+    ok: findings.length === 0 && errors.length === 0,
+    wikiRoot: pathModule.relative(process.cwd(), wikiRoot) || ".",
+    scanned,
+    findings,
+    errors,
+  };
 }

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 - Source-note-before-synthesis; state advanced **only** after verification.
 - Project-scoped only; memory ingestion never touches global/Codex-global stores.
 - Respect `sourceRetention` and `sensitivity`; do not invent facts.
+- Before advancing state or committing, run the generated-output safety gate
+  (`scripts/verify-wiki-safety.mjs`) against the wiki files/source notes produced by
+  the ingest. The default built-in scan blocks unredacted private keys, tokens, and
+  common financial/person identifiers without printing raw values. Projects may
+  select `--scanner gitleaks` for local parity with Gitleaks, and may use
+  `--scanner trufflehog` as a stricter optional verification pass when installed;
+  if a selected scanner is unavailable, keep the ingest blocked for review.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki/scripts/verify-wiki-safety.mjs
+++ b/plugins/lisa-wiki/scripts/verify-wiki-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit safety gate for generated wiki output.
+ *
+ * Scans only explicit wiki paths, or current git changes under the configured
+ * wiki root when no paths are passed. Reports safe metadata only.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./_wiki-lib.mjs";
+import { scanWikiGeneratedFiles } from "./wiki-safety.mjs";
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(name);
+const opt = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const repeated = name => {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+};
+
+const { config } = loadConfig(opt("--config"));
+const wikiRoot = path.resolve(opt("--wiki") ?? config?.wikiRoot ?? "wiki");
+const asJson = flag("--json");
+const scanner = opt("--scanner") ?? "builtin";
+
+function commandExists(command) {
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitChangedPaths() {
+  let out = "";
+  try {
+    out = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+      encoding: "utf8",
+    });
+  } catch {
+    return [];
+  }
+  const entries = out.split("\0").filter(Boolean);
+  const paths = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (!file || status.includes("D")) continue;
+    paths.push(file);
+    if (status[0] === "R" || status[0] === "C") i += 1;
+  }
+  return paths;
+}
+
+const explicitPaths = repeated("--path");
+const files = explicitPaths.length > 0 ? explicitPaths : gitChangedPaths();
+
+const externalScanner =
+  scanner === "gitleaks" || scanner === "trufflehog" ? scanner : undefined;
+const externalScannerMissing =
+  externalScanner !== undefined && !commandExists(externalScanner);
+
+const result = scanWikiGeneratedFiles(files, {
+  fsModule: fs,
+  pathModule: path,
+  wikiRoot,
+});
+
+const finalResult = {
+  ...result,
+  scanner: {
+    selected: scanner,
+    externalAvailable: externalScanner ? !externalScannerMissing : undefined,
+  },
+  ok: result.ok && !externalScannerMissing,
+  errors: [
+    ...result.errors,
+    ...(externalScannerMissing
+      ? [
+          {
+            file: path.relative(process.cwd(), wikiRoot) || ".",
+            message: `${externalScanner} scanner selected but unavailable`,
+          },
+        ]
+      : []),
+  ],
+};
+
+if (asJson) {
+  console.log(JSON.stringify(finalResult, null, 2));
+} else {
+  for (const finding of finalResult.findings) {
+    console.log(
+      `x [wiki-safety] possible ${finding.entityType} (${finding.confidence}) in ${finding.sourceId}; count=${finding.count}`
+    );
+  }
+  for (const error of finalResult.errors) {
+    console.log(`x [wiki-safety] ${error.message} (${error.file})`);
+  }
+  console.log(
+    `\n${finalResult.findings.length} finding${finalResult.findings.length === 1 ? "" : "s"}, ${finalResult.errors.length} error${finalResult.errors.length === 1 ? "" : "s"} across ${finalResult.scanned.length} wiki file${finalResult.scanned.length === 1 ? "" : "s"} — ${finalResult.ok ? "OK" : "BLOCKING"}`
+  );
+}
+
+process.exitCode = finalResult.ok ? 0 : 1;

--- a/plugins/lisa-wiki/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki/scripts/wiki-safety.mjs
@@ -61,6 +61,19 @@ const PATTERNS = [
   },
 ];
 
+const TEXTISH_EXTS = new Set([
+  ".md",
+  ".mdx",
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".csv",
+  ".tsv",
+]);
+
 function luhnValid(candidate) {
   const digits = candidate.replace(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
@@ -221,4 +234,69 @@ export function serializeWikiSafetyFindings(result) {
     null,
     2
   );
+}
+
+export function isWikiSafetyScanTarget(filePath, options = {}) {
+  const pathModule = options.pathModule;
+  if (!pathModule) {
+    throw new Error("isWikiSafetyScanTarget requires options.pathModule");
+  }
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const resolved = pathModule.resolve(filePath);
+  const relative = pathModule.relative(wikiRoot, resolved);
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    pathModule.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  const ext = pathModule.extname(resolved);
+  return TEXTISH_EXTS.has(ext);
+}
+
+export function scanWikiGeneratedFiles(files, options = {}) {
+  const fsModule = options.fsModule;
+  const pathModule = options.pathModule;
+  if (!fsModule || !pathModule) {
+    throw new Error("scanWikiGeneratedFiles requires fsModule and pathModule");
+  }
+
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const candidates = [...new Set(files.map(file => pathModule.resolve(file)))]
+    .filter(file => isWikiSafetyScanTarget(file, { wikiRoot, pathModule }))
+    .sort();
+
+  const scanned = [];
+  const findings = [];
+  const errors = [];
+
+  for (const file of candidates) {
+    let text;
+    try {
+      if (!fsModule.existsSync(file) || !fsModule.statSync(file).isFile()) {
+        continue;
+      }
+      text = fsModule.readFileSync(file, "utf8");
+    } catch (error) {
+      errors.push({
+        file: pathModule.relative(process.cwd(), file),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const sourceId = pathModule.relative(wikiRoot, file);
+    scanned.push(sourceId);
+    const result = scanWikiSourceText(text, { sourceId });
+    findings.push(...result.findings);
+  }
+
+  return {
+    ok: findings.length === 0 && errors.length === 0,
+    wikiRoot: pathModule.relative(process.cwd(), wikiRoot) || ".",
+    scanned,
+    findings,
+    errors,
+  };
 }

--- a/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 - Source-note-before-synthesis; state advanced **only** after verification.
 - Project-scoped only; memory ingestion never touches global/Codex-global stores.
 - Respect `sourceRetention` and `sensitivity`; do not invent facts.
+- Before advancing state or committing, run the generated-output safety gate
+  (`scripts/verify-wiki-safety.mjs`) against the wiki files/source notes produced by
+  the ingest. The default built-in scan blocks unredacted private keys, tokens, and
+  common financial/person identifiers without printing raw values. Projects may
+  select `--scanner gitleaks` for local parity with Gitleaks, and may use
+  `--scanner trufflehog` as a stricter optional verification pass when installed;
+  if a selected scanner is unavailable, keep the ingest blocked for review.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/src/wiki/scripts/verify-wiki-safety.mjs
+++ b/plugins/src/wiki/scripts/verify-wiki-safety.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit safety gate for generated wiki output.
+ *
+ * Scans only explicit wiki paths, or current git changes under the configured
+ * wiki root when no paths are passed. Reports safe metadata only.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./_wiki-lib.mjs";
+import { scanWikiGeneratedFiles } from "./wiki-safety.mjs";
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(name);
+const opt = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const repeated = name => {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+};
+
+const { config } = loadConfig(opt("--config"));
+const wikiRoot = path.resolve(opt("--wiki") ?? config?.wikiRoot ?? "wiki");
+const asJson = flag("--json");
+const scanner = opt("--scanner") ?? "builtin";
+
+function commandExists(command) {
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitChangedPaths() {
+  let out = "";
+  try {
+    out = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+      encoding: "utf8",
+    });
+  } catch {
+    return [];
+  }
+  const entries = out.split("\0").filter(Boolean);
+  const paths = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (!file || status.includes("D")) continue;
+    paths.push(file);
+    if (status[0] === "R" || status[0] === "C") i += 1;
+  }
+  return paths;
+}
+
+const explicitPaths = repeated("--path");
+const files = explicitPaths.length > 0 ? explicitPaths : gitChangedPaths();
+
+const externalScanner =
+  scanner === "gitleaks" || scanner === "trufflehog" ? scanner : undefined;
+const externalScannerMissing =
+  externalScanner !== undefined && !commandExists(externalScanner);
+
+const result = scanWikiGeneratedFiles(files, {
+  fsModule: fs,
+  pathModule: path,
+  wikiRoot,
+});
+
+const finalResult = {
+  ...result,
+  scanner: {
+    selected: scanner,
+    externalAvailable: externalScanner ? !externalScannerMissing : undefined,
+  },
+  ok: result.ok && !externalScannerMissing,
+  errors: [
+    ...result.errors,
+    ...(externalScannerMissing
+      ? [
+          {
+            file: path.relative(process.cwd(), wikiRoot) || ".",
+            message: `${externalScanner} scanner selected but unavailable`,
+          },
+        ]
+      : []),
+  ],
+};
+
+if (asJson) {
+  console.log(JSON.stringify(finalResult, null, 2));
+} else {
+  for (const finding of finalResult.findings) {
+    console.log(
+      `x [wiki-safety] possible ${finding.entityType} (${finding.confidence}) in ${finding.sourceId}; count=${finding.count}`
+    );
+  }
+  for (const error of finalResult.errors) {
+    console.log(`x [wiki-safety] ${error.message} (${error.file})`);
+  }
+  console.log(
+    `\n${finalResult.findings.length} finding${finalResult.findings.length === 1 ? "" : "s"}, ${finalResult.errors.length} error${finalResult.errors.length === 1 ? "" : "s"} across ${finalResult.scanned.length} wiki file${finalResult.scanned.length === 1 ? "" : "s"} — ${finalResult.ok ? "OK" : "BLOCKING"}`
+  );
+}
+
+process.exitCode = finalResult.ok ? 0 : 1;

--- a/plugins/src/wiki/scripts/wiki-safety.mjs
+++ b/plugins/src/wiki/scripts/wiki-safety.mjs
@@ -61,6 +61,19 @@ const PATTERNS = [
   },
 ];
 
+const TEXTISH_EXTS = new Set([
+  ".md",
+  ".mdx",
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".csv",
+  ".tsv",
+]);
+
 function luhnValid(candidate) {
   const digits = candidate.replace(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
@@ -221,4 +234,69 @@ export function serializeWikiSafetyFindings(result) {
     null,
     2
   );
+}
+
+export function isWikiSafetyScanTarget(filePath, options = {}) {
+  const pathModule = options.pathModule;
+  if (!pathModule) {
+    throw new Error("isWikiSafetyScanTarget requires options.pathModule");
+  }
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const resolved = pathModule.resolve(filePath);
+  const relative = pathModule.relative(wikiRoot, resolved);
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    pathModule.isAbsolute(relative)
+  ) {
+    return false;
+  }
+  const ext = pathModule.extname(resolved);
+  return TEXTISH_EXTS.has(ext);
+}
+
+export function scanWikiGeneratedFiles(files, options = {}) {
+  const fsModule = options.fsModule;
+  const pathModule = options.pathModule;
+  if (!fsModule || !pathModule) {
+    throw new Error("scanWikiGeneratedFiles requires fsModule and pathModule");
+  }
+
+  const wikiRoot = pathModule.resolve(options.wikiRoot ?? "wiki");
+  const candidates = [...new Set(files.map(file => pathModule.resolve(file)))]
+    .filter(file => isWikiSafetyScanTarget(file, { wikiRoot, pathModule }))
+    .sort();
+
+  const scanned = [];
+  const findings = [];
+  const errors = [];
+
+  for (const file of candidates) {
+    let text;
+    try {
+      if (!fsModule.existsSync(file) || !fsModule.statSync(file).isFile()) {
+        continue;
+      }
+      text = fsModule.readFileSync(file, "utf8");
+    } catch (error) {
+      errors.push({
+        file: pathModule.relative(process.cwd(), file),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const sourceId = pathModule.relative(wikiRoot, file);
+    scanned.push(sourceId);
+    const result = scanWikiSourceText(text, { sourceId });
+    findings.push(...result.findings);
+  }
+
+  return {
+    ok: findings.length === 0 && errors.length === 0,
+    wikiRoot: pathModule.relative(process.cwd(), wikiRoot) || ".",
+    scanned,
+    findings,
+    errors,
+  };
 }

--- a/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 - Source-note-before-synthesis; state advanced **only** after verification.
 - Project-scoped only; memory ingestion never touches global/Codex-global stores.
 - Respect `sourceRetention` and `sensitivity`; do not invent facts.
+- Before advancing state or committing, run the generated-output safety gate
+  (`scripts/verify-wiki-safety.mjs`) against the wiki files/source notes produced by
+  the ingest. The default built-in scan blocks unredacted private keys, tokens, and
+  common financial/person identifiers without printing raw values. Projects may
+  select `--scanner gitleaks` for local parity with Gitleaks, and may use
+  `--scanner trufflehog` as a stricter optional verification pass when installed;
+  if a selected scanner is unavailable, keep the ingest blocked for review.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/tests/unit/strategies/wiki-safety.test.ts
+++ b/tests/unit/strategies/wiki-safety.test.ts
@@ -1,4 +1,7 @@
+import fs from "node:fs";
 import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -6,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   processWikiSourceNote,
   sanitizeWikiSourceText,
+  scanWikiGeneratedFiles,
   serializeWikiSafetyFindings,
 } from "../../../plugins/src/wiki/scripts/wiki-safety.mjs";
 
@@ -130,5 +134,66 @@ describe("wiki safety sanitizer (#1169)", () => {
     expect(result.reviewRequired).toBe(true);
     expect(result.text).toContain("[REDACTED:CREDIT_CARD]");
     expect(result.text).not.toContain("4111 1111 1111 1111");
+  });
+
+  it("blocks unredacted generated wiki secrets before commit", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "wiki-safety-"));
+    const wikiRoot = path.join(root, "wiki");
+    const sourcePath = path.join(wikiRoot, "sources", "fixture.md");
+    mkdirSync(path.dirname(sourcePath), { recursive: true });
+    writeFileSync(
+      sourcePath,
+      [
+        "---",
+        "type: source",
+        "created: 2026-06-06",
+        "updated: 2026-06-06",
+        "---",
+        "-----BEGIN PRIVATE KEY-----",
+        "abc123",
+        "-----END PRIVATE KEY-----",
+      ].join("\n")
+    );
+
+    const result = scanWikiGeneratedFiles([sourcePath], {
+      fsModule: fs,
+      pathModule: path,
+      wikiRoot,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.scanned).toEqual(["sources/fixture.md"]);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        sourceId: "sources/fixture.md",
+        entityType: "private_key",
+        count: 1,
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain("abc123");
+  });
+
+  it("scopes generated wiki verification to wiki output paths", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "wiki-safety-scope-"));
+    const wikiRoot = path.join(root, "wiki");
+    const sourcePath = path.join(wikiRoot, "sources", "clean.md");
+    const unrelatedPath = path.join(root, "notes", "dirty.md");
+    mkdirSync(path.dirname(sourcePath), { recursive: true });
+    mkdirSync(path.dirname(unrelatedPath), { recursive: true });
+    writeFileSync(sourcePath, "# Reader-safe source\n\nNo findings here.\n");
+    writeFileSync(
+      unrelatedPath,
+      "api_key = sk_test_abcdefghijklmnopqrstuvwxyz\n"
+    );
+
+    const result = scanWikiGeneratedFiles([sourcePath, unrelatedPath], {
+      fsModule: fs,
+      pathModule: path,
+      wikiRoot,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.scanned).toEqual(["sources/clean.md"]);
+    expect(result.findings).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add a dependency-free `verify-wiki-safety.mjs` gate for generated wiki files/source notes before state advancement and commit.
- Export scoped wiki generated-file scanning helpers that emit safe finding metadata only.
- Document Gitleaks selection and optional TruffleHog stricter verification in wiki ingest guidance.
- Regenerate shipped lisa-wiki plugin variants.

Closes #1173.

## Verification
- `bunx vitest run tests/unit/strategies/wiki-safety.test.ts`
- `node plugins/src/wiki/scripts/verify-wiki-safety.mjs --wiki tests/fixtures/wiki-safety --path tests/fixtures/wiki-safety/redaction-source.md --json` (expected blocking result)
- `node plugins/src/wiki/scripts/verify-wiki-safety.mjs --wiki tests/fixtures/wiki-safety --path tests/fixtures/wiki-safety/allowed-contacts.md --json`
- `bun run build:dist`
- `git diff --check`
- `bun run check:plugins`
- Commit hook: Gitleaks, `tsc --noEmit`, lint-staged/ESLint/Prettier/ast-grep/commitlint
- Pre-push hook: `bun audit`, slow ESLint, knip, `vitest run --coverage` (178 files / 2971 tests), integration tests (3 files / 50 tests)
