### PR TITLE
feat(apply): ensure every project has a .lisa.config.json

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -4,8 +4,10 @@ import type { LisaConfig } from "../core/config.js";
 import { HARNESS_VALUES } from "../core/config.js";
 import { Lisa } from "../core/lisa.js";
 import {
+  projectConfigExists,
   readProjectConfig,
   resolveHarness,
+  shouldPersistProjectConfig,
   writeProjectConfig,
 } from "../core/project-config.js";
 import { ConsoleLogger } from "../logging/index.js";
@@ -89,6 +91,7 @@ export async function runApply(
 
   // Resolve harness with precedence: CLI flag > .lisa.config.json > default
   const projectConfig = await readProjectConfig(destDir);
+  const configFileExists = await projectConfigExists(destDir);
   const harness = resolveHarness(options.harness, projectConfig);
 
   const config: LisaConfig = {
@@ -115,16 +118,20 @@ export async function runApply(
       process.exit(1);
     }
 
-    // Persist resolved harness on apply (not validate, not dry-run) so the
-    // choice survives to the next run without requiring the flag every time.
-    // Only write when the user actually supplied --harness, so existing
-    // host projects don't gain a brand-new .lisa.config.json with the
-    // default value just by running `lisa` once.
+    // Ensure every applied project carries a .lisa.config.json (not on
+    // validate / dry-run). A missing file is always backfilled with the
+    // resolved harness (the default when no --harness was passed) so no
+    // project is left config-less; an existing file is only rewritten when
+    // --harness actually changes the persisted value, avoiding churn.
     if (
       !options.validate &&
       !dryRun &&
-      options.harness !== undefined &&
-      projectConfig.harness !== harness
+      shouldPersistProjectConfig({
+        fileExists: configFileExists,
+        flagHarness: options.harness,
+        existingHarness: projectConfig.harness,
+        resolvedHarness: harness,
+      })
     ) {
       await writeProjectConfig(destDir, { harness });
     }

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -68,6 +68,50 @@ export async function writeProjectConfig(
 }
 
 /**
+ * Whether a `.lisa.config.json` file exists at the destination project root.
+ *
+ * Distinct from `readProjectConfig`, which returns `{}` both when the file is
+ * absent and when it exists but declares no recognized keys — callers that
+ * need to know whether the file physically exists (e.g. to backfill a missing
+ * one) must use this.
+ * @param destDir - Absolute path to the destination project root
+ * @returns True when the config file is present on disk
+ */
+export async function projectConfigExists(destDir: string): Promise<boolean> {
+  return fse.pathExists(path.join(destDir, PROJECT_CONFIG_FILENAME));
+}
+
+/**
+ * Decide whether `apply` should write `.lisa.config.json`.
+ *
+ * Policy: every applied project must carry a `.lisa.config.json`, so a missing
+ * file is always backfilled (with the resolved harness — the default when no
+ * `--harness` flag was passed). An existing file is only rewritten when the
+ * user supplied `--harness` and it actually changes the persisted value, so
+ * routine applies don't churn a project's committed config.
+ * @param params - File presence and resolved/declared harness values
+ * @param params.fileExists - Whether `.lisa.config.json` already exists on disk
+ * @param params.flagHarness - Harness from the `--harness` CLI flag, if passed
+ * @param params.existingHarness - Harness currently persisted in the config
+ * @param params.resolvedHarness - Effective harness resolved for this run
+ * @returns True when the config should be (re)written
+ */
+export function shouldPersistProjectConfig(params: {
+  readonly fileExists: boolean;
+  readonly flagHarness: Harness | undefined;
+  readonly existingHarness: Harness | undefined;
+  readonly resolvedHarness: Harness;
+}): boolean {
+  if (!params.fileExists) {
+    return true;
+  }
+  return (
+    params.flagHarness !== undefined &&
+    params.existingHarness !== params.resolvedHarness
+  );
+}
+
+/**
  * Read `.lisa.config.json` and return its raw parsed object, preserving
  * unknown fields. Unlike `readProjectConfig`, this does NOT strip the
  * result down to the recognized `ProjectConfig` keys — used by

--- a/tests/unit/core/project-config.test.ts
+++ b/tests/unit/core/project-config.test.ts
@@ -13,8 +13,10 @@ import {
 import {
   PROJECT_CONFIG_FILENAME,
   isHarness,
+  projectConfigExists,
   readProjectConfig,
   resolveHarness,
+  shouldPersistProjectConfig,
   writeProjectConfig,
 } from "../../../src/core/project-config.js";
 import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
@@ -163,6 +165,83 @@ describe("project-config", () => {
         await fs.readFile(path.join(tempDir, PROJECT_CONFIG_FILENAME), "utf8")
       );
       expect(written).toEqual({ harness: "both" });
+    });
+  });
+
+  describe("projectConfigExists", () => {
+    it("returns false when the file is absent", async () => {
+      expect(await projectConfigExists(tempDir)).toBe(false);
+    });
+
+    it("returns true when the file is present", async () => {
+      await writeProjectConfig(tempDir, { harness: "claude" });
+      expect(await projectConfigExists(tempDir)).toBe(true);
+    });
+
+    it("returns true even for a file with no recognized keys", async () => {
+      await fs.writeFile(
+        path.join(tempDir, PROJECT_CONFIG_FILENAME),
+        JSON.stringify({ deploy: { branches: { production: "main" } } }),
+        "utf8"
+      );
+      expect(await projectConfigExists(tempDir)).toBe(true);
+    });
+  });
+
+  describe("shouldPersistProjectConfig", () => {
+    it("backfills when the config file is absent (no flag)", () => {
+      expect(
+        shouldPersistProjectConfig({
+          fileExists: false,
+          flagHarness: undefined,
+          existingHarness: undefined,
+          resolvedHarness: DEFAULT_HARNESS,
+        })
+      ).toBe(true);
+    });
+
+    it("does not rewrite an existing file on a routine apply (no flag)", () => {
+      expect(
+        shouldPersistProjectConfig({
+          fileExists: true,
+          flagHarness: undefined,
+          existingHarness: "claude",
+          resolvedHarness: "claude",
+        })
+      ).toBe(false);
+    });
+
+    it("does not rewrite an existing file when --harness matches the persisted value", () => {
+      expect(
+        shouldPersistProjectConfig({
+          fileExists: true,
+          flagHarness: "both",
+          existingHarness: "both",
+          resolvedHarness: "both",
+        })
+      ).toBe(false);
+    });
+
+    it("rewrites an existing file when --harness changes the value", () => {
+      expect(
+        shouldPersistProjectConfig({
+          fileExists: true,
+          flagHarness: "codex",
+          existingHarness: "claude",
+          resolvedHarness: "codex",
+        })
+      ).toBe(true);
+    });
+
+    it("backfills a missing file even when --harness is supplied", () => {
+      expect(
+        shouldPersistProjectConfig({
+          fileExists: false,
+          flagHarness: "codex",
+          existingHarness: undefined,
+          resolvedHarness: "codex",
+        })
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Problem

`lisa apply` only wrote `.lisa.config.json` when the user explicitly passed `--harness` **and** it differed from the persisted value. A routine apply (no flag) on a config-less repo never created one — leaving the file that skills and the sync-down chain derivation expect absent. The 2026-06-06 batch surfaced ~9 workspace repos with no `.lisa.config.json` for exactly this reason.

## Fix

`apply` now **backfills a baseline `{ harness: <resolved> }` whenever the file is absent** (resolved harness defaults to `claude` when no `--harness` is passed), while still only rewriting an *existing* file when `--harness` actually changes the value — so existing committed configs aren't churned. `tracker`/`source`/`deploy` are intentionally left to runtime defaults rather than guessed.

- New `projectConfigExists()` and a pure, unit-tested `shouldPersistProjectConfig()` policy helper in `project-config.ts`.
- `apply.ts` rewired to ensure-exists; the old 'only on --harness' comment replaced.

## Verification
- 39 project-config unit tests pass (5 new for the policy, 3 for existence); typecheck + eslint clean.
- **E2E**: ran the built CLI against a fresh config-less project → `.lisa.config.json` = `{ "harness": "claude" }` created (was absent before).

Companion to the per-repo backfills done in the same batch; this prevents the gap from recurring on any future apply.

🤖 Generated with Claude Code