### PR TITLE
Require review for redacted wiki ingests

### DIFF
--- a/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-agy/scripts/wiki-safety.mjs
@@ -236,6 +236,82 @@ export function serializeWikiSafetyFindings(result) {
   );
 }
 
+function normalizeSafetyResults(results) {
+  if (Array.isArray(results)) return results;
+  if (!results) return [];
+  return [results];
+}
+
+function summarizeEntityTypes(results) {
+  const byType = new Map();
+  for (const result of results) {
+    for (const finding of result?.findings ?? []) {
+      const entityType = finding?.entityType ?? "unknown";
+      const current = byType.get(entityType) ?? {
+        entityType,
+        confidence: finding?.confidence ?? "unknown",
+        count: 0,
+      };
+      current.count += Number.isFinite(finding?.count) ? finding.count : 1;
+      if (current.confidence !== "high" && finding?.confidence === "high") {
+        current.confidence = "high";
+      }
+      byType.set(entityType, current);
+    }
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+export function createWikiIngestPublicationPolicy(options = {}) {
+  const safetyResults = normalizeSafetyResults(options.safetyResults);
+  const externalWrite = Boolean(options.externalWrite);
+  const entityTypes = summarizeEntityTypes(safetyResults);
+  const findingCount = entityTypes.reduce((sum, item) => sum + item.count, 0);
+  const reviewRequired =
+    externalWrite ||
+    findingCount > 0 ||
+    safetyResults.some(result => Boolean(result?.reviewRequired));
+  const reasons = [
+    ...(externalWrite ? ["external-write source"] : []),
+    ...(findingCount > 0 ? ["redacted or sensitive findings"] : []),
+    ...(!externalWrite &&
+    findingCount === 0 &&
+    safetyResults.some(result => Boolean(result?.reviewRequired))
+      ? ["source safety review requested"]
+      : []),
+  ];
+
+  const findingLines =
+    entityTypes.length > 0
+      ? entityTypes.map(
+          item =>
+            `- ${item.entityType}: ${item.count} ${item.count === 1 ? "finding" : "findings"} (${item.confidence})`
+        )
+      : ["- none"];
+
+  return {
+    autoMergeAllowed: !reviewRequired,
+    reviewRequired,
+    reasons,
+    findingCount,
+    entityTypes,
+    prSummaryMarkdown: [
+      "## Wiki Safety Review",
+      "",
+      `Auto-merge: ${reviewRequired ? "disabled" : "allowed"}`,
+      `Human review required: ${reviewRequired ? "yes" : "no"}`,
+      `Reason: ${reasons.length > 0 ? reasons.join("; ") : "no redactions or sensitive findings"}`,
+      "",
+      "Finding summary:",
+      ...findingLines,
+      "",
+      "Raw sensitive values are intentionally omitted from this summary.",
+    ].join("\n"),
+  };
+}
+
 export function isWikiSafetyScanTarget(filePath, options = {}) {
   const pathModule = options.pathModule;
   if (!pathModule) {

--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
@@ -50,11 +50,14 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 7. **Commit/PR**: commit only the ingestion changes per `config.git` policy. If the ingest started on
    the default branch, create a dedicated ingestion branch first — never commit ingestion straight to
    the default. Push the branch and **open a PR targeting the default remote branch** (via the host's
-   PR mechanism — e.g. `gh pr create --base <default>`), then **enable auto-merge when possible**
-   (`gh pr merge --auto`, or the host's equivalent). `external-write` runs and sensitive content are
-   the exception — open the PR **without** auto-merge so a human reviews them before it lands. If
-   auto-merge cannot be enabled (the host doesn't support it, or branch protection forbids it), leave
-   the PR open and note that a human must merge.
+   PR mechanism — e.g. `gh pr create --base <default>`). Before enabling auto-merge, feed the safety
+   scan output into `createWikiIngestPublicationPolicy` from `scripts/wiki-safety.mjs`. Enable
+   auto-merge only when `autoMergeAllowed` is true. `external-write` runs, redacted runs, and any run
+   with sensitive findings are the exception — open the PR **without** auto-merge so a human reviews
+   them before it lands. The PR summary must include the policy's safe review summary: counts and
+   entity types only, never raw values, ranges, tokens, source snippets, or scanner output. If
+   auto-merge cannot be enabled (the host doesn't support it, branch protection forbids it, or the
+   policy requires review), leave the PR open and note that a human must merge.
 
 ## Rules
 - **Bookend every ingest with git hygiene:** sync the branch with the default remote branch *before*
@@ -71,6 +74,10 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
   select `--scanner gitleaks` for local parity with Gitleaks, and may use
   `--scanner trufflehog` as a stricter optional verification pass when installed;
   if a selected scanner is unavailable, keep the ingest blocked for review.
+- Redaction and review policy is centralized in `scripts/wiki-safety.mjs`. Treat
+  `reviewRequired` or any summarized finding as a hard auto-merge stop. Use the
+  generated PR summary text as-is or preserve its shape so reviewers see entity
+  types and counts without raw sensitive values.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/wiki-safety.mjs
@@ -236,6 +236,82 @@ export function serializeWikiSafetyFindings(result) {
   );
 }
 
+function normalizeSafetyResults(results) {
+  if (Array.isArray(results)) return results;
+  if (!results) return [];
+  return [results];
+}
+
+function summarizeEntityTypes(results) {
+  const byType = new Map();
+  for (const result of results) {
+    for (const finding of result?.findings ?? []) {
+      const entityType = finding?.entityType ?? "unknown";
+      const current = byType.get(entityType) ?? {
+        entityType,
+        confidence: finding?.confidence ?? "unknown",
+        count: 0,
+      };
+      current.count += Number.isFinite(finding?.count) ? finding.count : 1;
+      if (current.confidence !== "high" && finding?.confidence === "high") {
+        current.confidence = "high";
+      }
+      byType.set(entityType, current);
+    }
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+export function createWikiIngestPublicationPolicy(options = {}) {
+  const safetyResults = normalizeSafetyResults(options.safetyResults);
+  const externalWrite = Boolean(options.externalWrite);
+  const entityTypes = summarizeEntityTypes(safetyResults);
+  const findingCount = entityTypes.reduce((sum, item) => sum + item.count, 0);
+  const reviewRequired =
+    externalWrite ||
+    findingCount > 0 ||
+    safetyResults.some(result => Boolean(result?.reviewRequired));
+  const reasons = [
+    ...(externalWrite ? ["external-write source"] : []),
+    ...(findingCount > 0 ? ["redacted or sensitive findings"] : []),
+    ...(!externalWrite &&
+    findingCount === 0 &&
+    safetyResults.some(result => Boolean(result?.reviewRequired))
+      ? ["source safety review requested"]
+      : []),
+  ];
+
+  const findingLines =
+    entityTypes.length > 0
+      ? entityTypes.map(
+          item =>
+            `- ${item.entityType}: ${item.count} ${item.count === 1 ? "finding" : "findings"} (${item.confidence})`
+        )
+      : ["- none"];
+
+  return {
+    autoMergeAllowed: !reviewRequired,
+    reviewRequired,
+    reasons,
+    findingCount,
+    entityTypes,
+    prSummaryMarkdown: [
+      "## Wiki Safety Review",
+      "",
+      `Auto-merge: ${reviewRequired ? "disabled" : "allowed"}`,
+      `Human review required: ${reviewRequired ? "yes" : "no"}`,
+      `Reason: ${reasons.length > 0 ? reasons.join("; ") : "no redactions or sensitive findings"}`,
+      "",
+      "Finding summary:",
+      ...findingLines,
+      "",
+      "Raw sensitive values are intentionally omitted from this summary.",
+    ].join("\n"),
+  };
+}
+
 export function isWikiSafetyScanTarget(filePath, options = {}) {
   const pathModule = options.pathModule;
   if (!pathModule) {

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
@@ -50,11 +50,14 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 7. **Commit/PR**: commit only the ingestion changes per `config.git` policy. If the ingest started on
    the default branch, create a dedicated ingestion branch first — never commit ingestion straight to
    the default. Push the branch and **open a PR targeting the default remote branch** (via the host's
-   PR mechanism — e.g. `gh pr create --base <default>`), then **enable auto-merge when possible**
-   (`gh pr merge --auto`, or the host's equivalent). `external-write` runs and sensitive content are
-   the exception — open the PR **without** auto-merge so a human reviews them before it lands. If
-   auto-merge cannot be enabled (the host doesn't support it, or branch protection forbids it), leave
-   the PR open and note that a human must merge.
+   PR mechanism — e.g. `gh pr create --base <default>`). Before enabling auto-merge, feed the safety
+   scan output into `createWikiIngestPublicationPolicy` from `scripts/wiki-safety.mjs`. Enable
+   auto-merge only when `autoMergeAllowed` is true. `external-write` runs, redacted runs, and any run
+   with sensitive findings are the exception — open the PR **without** auto-merge so a human reviews
+   them before it lands. The PR summary must include the policy's safe review summary: counts and
+   entity types only, never raw values, ranges, tokens, source snippets, or scanner output. If
+   auto-merge cannot be enabled (the host doesn't support it, branch protection forbids it, or the
+   policy requires review), leave the PR open and note that a human must merge.
 
 ## Rules
 - **Bookend every ingest with git hygiene:** sync the branch with the default remote branch *before*
@@ -71,6 +74,10 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
   select `--scanner gitleaks` for local parity with Gitleaks, and may use
   `--scanner trufflehog` as a stricter optional verification pass when installed;
   if a selected scanner is unavailable, keep the ingest blocked for review.
+- Redaction and review policy is centralized in `scripts/wiki-safety.mjs`. Treat
+  `reviewRequired` or any summarized finding as a hard auto-merge stop. Use the
+  generated PR summary text as-is or preserve its shape so reviewers see entity
+  types and counts without raw sensitive values.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/wiki-safety.mjs
@@ -236,6 +236,82 @@ export function serializeWikiSafetyFindings(result) {
   );
 }
 
+function normalizeSafetyResults(results) {
+  if (Array.isArray(results)) return results;
+  if (!results) return [];
+  return [results];
+}
+
+function summarizeEntityTypes(results) {
+  const byType = new Map();
+  for (const result of results) {
+    for (const finding of result?.findings ?? []) {
+      const entityType = finding?.entityType ?? "unknown";
+      const current = byType.get(entityType) ?? {
+        entityType,
+        confidence: finding?.confidence ?? "unknown",
+        count: 0,
+      };
+      current.count += Number.isFinite(finding?.count) ? finding.count : 1;
+      if (current.confidence !== "high" && finding?.confidence === "high") {
+        current.confidence = "high";
+      }
+      byType.set(entityType, current);
+    }
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+export function createWikiIngestPublicationPolicy(options = {}) {
+  const safetyResults = normalizeSafetyResults(options.safetyResults);
+  const externalWrite = Boolean(options.externalWrite);
+  const entityTypes = summarizeEntityTypes(safetyResults);
+  const findingCount = entityTypes.reduce((sum, item) => sum + item.count, 0);
+  const reviewRequired =
+    externalWrite ||
+    findingCount > 0 ||
+    safetyResults.some(result => Boolean(result?.reviewRequired));
+  const reasons = [
+    ...(externalWrite ? ["external-write source"] : []),
+    ...(findingCount > 0 ? ["redacted or sensitive findings"] : []),
+    ...(!externalWrite &&
+    findingCount === 0 &&
+    safetyResults.some(result => Boolean(result?.reviewRequired))
+      ? ["source safety review requested"]
+      : []),
+  ];
+
+  const findingLines =
+    entityTypes.length > 0
+      ? entityTypes.map(
+          item =>
+            `- ${item.entityType}: ${item.count} ${item.count === 1 ? "finding" : "findings"} (${item.confidence})`
+        )
+      : ["- none"];
+
+  return {
+    autoMergeAllowed: !reviewRequired,
+    reviewRequired,
+    reasons,
+    findingCount,
+    entityTypes,
+    prSummaryMarkdown: [
+      "## Wiki Safety Review",
+      "",
+      `Auto-merge: ${reviewRequired ? "disabled" : "allowed"}`,
+      `Human review required: ${reviewRequired ? "yes" : "no"}`,
+      `Reason: ${reasons.length > 0 ? reasons.join("; ") : "no redactions or sensitive findings"}`,
+      "",
+      "Finding summary:",
+      ...findingLines,
+      "",
+      "Raw sensitive values are intentionally omitted from this summary.",
+    ].join("\n"),
+  };
+}
+
 export function isWikiSafetyScanTarget(filePath, options = {}) {
   const pathModule = options.pathModule;
   if (!pathModule) {

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
@@ -50,11 +50,14 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 7. **Commit/PR**: commit only the ingestion changes per `config.git` policy. If the ingest started on
    the default branch, create a dedicated ingestion branch first — never commit ingestion straight to
    the default. Push the branch and **open a PR targeting the default remote branch** (via the host's
-   PR mechanism — e.g. `gh pr create --base <default>`), then **enable auto-merge when possible**
-   (`gh pr merge --auto`, or the host's equivalent). `external-write` runs and sensitive content are
-   the exception — open the PR **without** auto-merge so a human reviews them before it lands. If
-   auto-merge cannot be enabled (the host doesn't support it, or branch protection forbids it), leave
-   the PR open and note that a human must merge.
+   PR mechanism — e.g. `gh pr create --base <default>`). Before enabling auto-merge, feed the safety
+   scan output into `createWikiIngestPublicationPolicy` from `scripts/wiki-safety.mjs`. Enable
+   auto-merge only when `autoMergeAllowed` is true. `external-write` runs, redacted runs, and any run
+   with sensitive findings are the exception — open the PR **without** auto-merge so a human reviews
+   them before it lands. The PR summary must include the policy's safe review summary: counts and
+   entity types only, never raw values, ranges, tokens, source snippets, or scanner output. If
+   auto-merge cannot be enabled (the host doesn't support it, branch protection forbids it, or the
+   policy requires review), leave the PR open and note that a human must merge.
 
 ## Rules
 - **Bookend every ingest with git hygiene:** sync the branch with the default remote branch *before*
@@ -71,6 +74,10 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
   select `--scanner gitleaks` for local parity with Gitleaks, and may use
   `--scanner trufflehog` as a stricter optional verification pass when installed;
   if a selected scanner is unavailable, keep the ingest blocked for review.
+- Redaction and review policy is centralized in `scripts/wiki-safety.mjs`. Treat
+  `reviewRequired` or any summarized finding as a hard auto-merge stop. Use the
+  generated PR summary text as-is or preserve its shape so reviewers see entity
+  types and counts without raw sensitive values.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/lisa-wiki/scripts/wiki-safety.mjs
+++ b/plugins/lisa-wiki/scripts/wiki-safety.mjs
@@ -236,6 +236,82 @@ export function serializeWikiSafetyFindings(result) {
   );
 }
 
+function normalizeSafetyResults(results) {
+  if (Array.isArray(results)) return results;
+  if (!results) return [];
+  return [results];
+}
+
+function summarizeEntityTypes(results) {
+  const byType = new Map();
+  for (const result of results) {
+    for (const finding of result?.findings ?? []) {
+      const entityType = finding?.entityType ?? "unknown";
+      const current = byType.get(entityType) ?? {
+        entityType,
+        confidence: finding?.confidence ?? "unknown",
+        count: 0,
+      };
+      current.count += Number.isFinite(finding?.count) ? finding.count : 1;
+      if (current.confidence !== "high" && finding?.confidence === "high") {
+        current.confidence = "high";
+      }
+      byType.set(entityType, current);
+    }
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+export function createWikiIngestPublicationPolicy(options = {}) {
+  const safetyResults = normalizeSafetyResults(options.safetyResults);
+  const externalWrite = Boolean(options.externalWrite);
+  const entityTypes = summarizeEntityTypes(safetyResults);
+  const findingCount = entityTypes.reduce((sum, item) => sum + item.count, 0);
+  const reviewRequired =
+    externalWrite ||
+    findingCount > 0 ||
+    safetyResults.some(result => Boolean(result?.reviewRequired));
+  const reasons = [
+    ...(externalWrite ? ["external-write source"] : []),
+    ...(findingCount > 0 ? ["redacted or sensitive findings"] : []),
+    ...(!externalWrite &&
+    findingCount === 0 &&
+    safetyResults.some(result => Boolean(result?.reviewRequired))
+      ? ["source safety review requested"]
+      : []),
+  ];
+
+  const findingLines =
+    entityTypes.length > 0
+      ? entityTypes.map(
+          item =>
+            `- ${item.entityType}: ${item.count} ${item.count === 1 ? "finding" : "findings"} (${item.confidence})`
+        )
+      : ["- none"];
+
+  return {
+    autoMergeAllowed: !reviewRequired,
+    reviewRequired,
+    reasons,
+    findingCount,
+    entityTypes,
+    prSummaryMarkdown: [
+      "## Wiki Safety Review",
+      "",
+      `Auto-merge: ${reviewRequired ? "disabled" : "allowed"}`,
+      `Human review required: ${reviewRequired ? "yes" : "no"}`,
+      `Reason: ${reasons.length > 0 ? reasons.join("; ") : "no redactions or sensitive findings"}`,
+      "",
+      "Finding summary:",
+      ...findingLines,
+      "",
+      "Raw sensitive values are intentionally omitted from this summary.",
+    ].join("\n"),
+  };
+}
+
 export function isWikiSafetyScanTarget(filePath, options = {}) {
   const pathModule = options.pathModule;
   if (!pathModule) {

--- a/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -50,11 +50,14 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 7. **Commit/PR**: commit only the ingestion changes per `config.git` policy. If the ingest started on
    the default branch, create a dedicated ingestion branch first — never commit ingestion straight to
    the default. Push the branch and **open a PR targeting the default remote branch** (via the host's
-   PR mechanism — e.g. `gh pr create --base <default>`), then **enable auto-merge when possible**
-   (`gh pr merge --auto`, or the host's equivalent). `external-write` runs and sensitive content are
-   the exception — open the PR **without** auto-merge so a human reviews them before it lands. If
-   auto-merge cannot be enabled (the host doesn't support it, or branch protection forbids it), leave
-   the PR open and note that a human must merge.
+   PR mechanism — e.g. `gh pr create --base <default>`). Before enabling auto-merge, feed the safety
+   scan output into `createWikiIngestPublicationPolicy` from `scripts/wiki-safety.mjs`. Enable
+   auto-merge only when `autoMergeAllowed` is true. `external-write` runs, redacted runs, and any run
+   with sensitive findings are the exception — open the PR **without** auto-merge so a human reviews
+   them before it lands. The PR summary must include the policy's safe review summary: counts and
+   entity types only, never raw values, ranges, tokens, source snippets, or scanner output. If
+   auto-merge cannot be enabled (the host doesn't support it, branch protection forbids it, or the
+   policy requires review), leave the PR open and note that a human must merge.
 
 ## Rules
 - **Bookend every ingest with git hygiene:** sync the branch with the default remote branch *before*
@@ -71,6 +74,10 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
   select `--scanner gitleaks` for local parity with Gitleaks, and may use
   `--scanner trufflehog` as a stricter optional verification pass when installed;
   if a selected scanner is unavailable, keep the ingest blocked for review.
+- Redaction and review policy is centralized in `scripts/wiki-safety.mjs`. Treat
+  `reviewRequired` or any summarized finding as a hard auto-merge stop. Use the
+  generated PR summary text as-is or preserve its shape so reviewers see entity
+  types and counts without raw sensitive values.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/plugins/src/wiki/scripts/wiki-safety.mjs
+++ b/plugins/src/wiki/scripts/wiki-safety.mjs
@@ -236,6 +236,82 @@ export function serializeWikiSafetyFindings(result) {
   );
 }
 
+function normalizeSafetyResults(results) {
+  if (Array.isArray(results)) return results;
+  if (!results) return [];
+  return [results];
+}
+
+function summarizeEntityTypes(results) {
+  const byType = new Map();
+  for (const result of results) {
+    for (const finding of result?.findings ?? []) {
+      const entityType = finding?.entityType ?? "unknown";
+      const current = byType.get(entityType) ?? {
+        entityType,
+        confidence: finding?.confidence ?? "unknown",
+        count: 0,
+      };
+      current.count += Number.isFinite(finding?.count) ? finding.count : 1;
+      if (current.confidence !== "high" && finding?.confidence === "high") {
+        current.confidence = "high";
+      }
+      byType.set(entityType, current);
+    }
+  }
+  return [...byType.values()].sort((a, b) =>
+    a.entityType.localeCompare(b.entityType)
+  );
+}
+
+export function createWikiIngestPublicationPolicy(options = {}) {
+  const safetyResults = normalizeSafetyResults(options.safetyResults);
+  const externalWrite = Boolean(options.externalWrite);
+  const entityTypes = summarizeEntityTypes(safetyResults);
+  const findingCount = entityTypes.reduce((sum, item) => sum + item.count, 0);
+  const reviewRequired =
+    externalWrite ||
+    findingCount > 0 ||
+    safetyResults.some(result => Boolean(result?.reviewRequired));
+  const reasons = [
+    ...(externalWrite ? ["external-write source"] : []),
+    ...(findingCount > 0 ? ["redacted or sensitive findings"] : []),
+    ...(!externalWrite &&
+    findingCount === 0 &&
+    safetyResults.some(result => Boolean(result?.reviewRequired))
+      ? ["source safety review requested"]
+      : []),
+  ];
+
+  const findingLines =
+    entityTypes.length > 0
+      ? entityTypes.map(
+          item =>
+            `- ${item.entityType}: ${item.count} ${item.count === 1 ? "finding" : "findings"} (${item.confidence})`
+        )
+      : ["- none"];
+
+  return {
+    autoMergeAllowed: !reviewRequired,
+    reviewRequired,
+    reasons,
+    findingCount,
+    entityTypes,
+    prSummaryMarkdown: [
+      "## Wiki Safety Review",
+      "",
+      `Auto-merge: ${reviewRequired ? "disabled" : "allowed"}`,
+      `Human review required: ${reviewRequired ? "yes" : "no"}`,
+      `Reason: ${reasons.length > 0 ? reasons.join("; ") : "no redactions or sensitive findings"}`,
+      "",
+      "Finding summary:",
+      ...findingLines,
+      "",
+      "Raw sensitive values are intentionally omitted from this summary.",
+    ].join("\n"),
+  };
+}
+
 export function isWikiSafetyScanTarget(filePath, options = {}) {
   const pathModule = options.pathModule;
   if (!pathModule) {

--- a/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -50,11 +50,14 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
 7. **Commit/PR**: commit only the ingestion changes per `config.git` policy. If the ingest started on
    the default branch, create a dedicated ingestion branch first — never commit ingestion straight to
    the default. Push the branch and **open a PR targeting the default remote branch** (via the host's
-   PR mechanism — e.g. `gh pr create --base <default>`), then **enable auto-merge when possible**
-   (`gh pr merge --auto`, or the host's equivalent). `external-write` runs and sensitive content are
-   the exception — open the PR **without** auto-merge so a human reviews them before it lands. If
-   auto-merge cannot be enabled (the host doesn't support it, or branch protection forbids it), leave
-   the PR open and note that a human must merge.
+   PR mechanism — e.g. `gh pr create --base <default>`). Before enabling auto-merge, feed the safety
+   scan output into `createWikiIngestPublicationPolicy` from `scripts/wiki-safety.mjs`. Enable
+   auto-merge only when `autoMergeAllowed` is true. `external-write` runs, redacted runs, and any run
+   with sensitive findings are the exception — open the PR **without** auto-merge so a human reviews
+   them before it lands. The PR summary must include the policy's safe review summary: counts and
+   entity types only, never raw values, ranges, tokens, source snippets, or scanner output. If
+   auto-merge cannot be enabled (the host doesn't support it, branch protection forbids it, or the
+   policy requires review), leave the PR open and note that a human must merge.
 
 ## Rules
 - **Bookend every ingest with git hygiene:** sync the branch with the default remote branch *before*
@@ -71,6 +74,10 @@ writes nothing). The point is to ingest on top of fresh state, never stale state
   select `--scanner gitleaks` for local parity with Gitleaks, and may use
   `--scanner trufflehog` as a stricter optional verification pass when installed;
   if a selected scanner is unavailable, keep the ingest blocked for review.
+- Redaction and review policy is centralized in `scripts/wiki-safety.mjs`. Treat
+  `reviewRequired` or any summarized finding as a hard auto-merge stop. Use the
+  generated PR summary text as-is or preserve its shape so reviewers see entity
+  types and counts without raw sensitive values.
 - Connector execution and the connector contract are detailed in the connector skills (M2+); this
   router defines and enforces the ordering and side-effect rules above.
 

--- a/tests/unit/strategies/wiki-safety.test.ts
+++ b/tests/unit/strategies/wiki-safety.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  createWikiIngestPublicationPolicy,
   processWikiSourceNote,
   sanitizeWikiSourceText,
   scanWikiGeneratedFiles,
@@ -86,6 +87,70 @@ describe("wiki safety sanitizer (#1169)", () => {
     expect(serialized).not.toContain("sk_test_abcdefghijklmnopqrstuvwxyz");
     expect(serialized).not.toContain(fakeSsn);
     expect(serialized).not.toContain("token: public example");
+  });
+
+  it("requires human review and disables auto-merge for redacted ingest summaries", () => {
+    const raw = `api_key = sk_test_abcdefghijklmnopqrstuvwxyz\nSSN ${fakeSsn}`;
+    const safetyResult = sanitizeWikiSourceText(raw, {
+      sourceId: reportSourceId,
+    });
+
+    const policy = createWikiIngestPublicationPolicy({
+      safetyResults: safetyResult,
+    });
+
+    expect(policy.reviewRequired).toBe(true);
+    expect(policy.autoMergeAllowed).toBe(false);
+    expect(policy.findingCount).toBe(2);
+    expect(policy.entityTypes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ entityType: "api_key", count: 1 }),
+        expect.objectContaining({ entityType: "ssn", count: 1 }),
+      ])
+    );
+    expect(policy.prSummaryMarkdown).toContain("Auto-merge: disabled");
+    expect(policy.prSummaryMarkdown).toContain(
+      "Reason: redacted or sensitive findings"
+    );
+    expect(policy.prSummaryMarkdown).toContain("api_key: 1 finding");
+    expect(policy.prSummaryMarkdown).toContain("ssn: 1 finding");
+    expect(policy.prSummaryMarkdown).not.toContain(
+      "sk_test_abcdefghijklmnopqrstuvwxyz"
+    );
+    expect(policy.prSummaryMarkdown).not.toContain(fakeSsn);
+  });
+
+  it("allows auto-merge for clean non-external ingest summaries", () => {
+    const safetyResult = sanitizeWikiSourceText("Reader-safe source note", {
+      sourceId: reportSourceId,
+    });
+
+    const policy = createWikiIngestPublicationPolicy({
+      safetyResults: safetyResult,
+    });
+
+    expect(policy.reviewRequired).toBe(false);
+    expect(policy.autoMergeAllowed).toBe(true);
+    expect(policy.findingCount).toBe(0);
+    expect(policy.prSummaryMarkdown).toContain("Auto-merge: allowed");
+    expect(policy.prSummaryMarkdown).toContain("- none");
+  });
+
+  it("keeps external-write ingests review-only even without redactions", () => {
+    const safetyResult = sanitizeWikiSourceText("Reader-safe source note", {
+      sourceId: reportSourceId,
+    });
+
+    const policy = createWikiIngestPublicationPolicy({
+      externalWrite: true,
+      safetyResults: safetyResult,
+    });
+
+    expect(policy.reviewRequired).toBe(true);
+    expect(policy.autoMergeAllowed).toBe(false);
+    expect(policy.findingCount).toBe(0);
+    expect(policy.prSummaryMarkdown).toContain("Auto-merge: disabled");
+    expect(policy.prSummaryMarkdown).toContain("external-write source");
   });
 
   it("does not flag names, email addresses, or invalid card-shaped numbers", () => {

--- a/wiki/documentation/index.md
+++ b/wiki/documentation/index.md
@@ -38,6 +38,7 @@ Root package landing content can remain in `README.md`, local ingestion inbox fi
 - [Task Management System](workflows/task-management-system.md)
 - [Claude Code Web Notifications](workflows/claude-code-web-notifications.md)
 - [PRD To Ticket Intake](workflows/prd-to-ticket-intake.md)
+- [Wiki Ingestion Safety](workflows/wiki-ingestion-safety.md)
 
 ## Assets
 

--- a/wiki/documentation/workflows/wiki-ingestion-safety.md
+++ b/wiki/documentation/workflows/wiki-ingestion-safety.md
@@ -1,0 +1,38 @@
+---
+type: documentation
+created: 2026-06-06
+updated: 2026-06-06
+---
+
+# Wiki Ingestion Safety
+
+Lisa wiki ingestion preserves reader-safe source notes under `wiki/sources/` before synthesis. Source notes must be useful for future readers without exposing secrets, credentials, financial identifiers, private personal identifiers, or raw sensitive source snippets.
+
+## Safety Model
+
+Wiki connectors must sanitize source-note text before writing it. The shared helper in `plugins/src/wiki/scripts/wiki-safety.mjs` redacts built-in sensitive classes such as private keys, access tokens, API keys, passwords, SSNs, credit cards, bank account numbers, and routing numbers. The safety result stores safe metadata only: entity type, confidence, count, and source identity. It must not store raw values.
+
+Before committing an ingest, run the generated-output safety gate against the touched wiki output. The built-in scanner is dependency-free. Projects may also select Gitleaks for local parity, or TruffleHog as a stricter optional pass when installed. If a required scanner is unavailable, keep the ingest blocked for review instead of writing around the check.
+
+## Review And Auto-Merge
+
+Redacted or sensitive ingest PRs require human review. The PR publisher must call `createWikiIngestPublicationPolicy` with the safety scan results before enabling auto-merge.
+
+- Clean, non-external-write ingest: auto-merge may be enabled when verification passes.
+- External-write ingest: auto-merge stays disabled.
+- Redacted ingest: auto-merge stays disabled.
+- Sensitive finding summary present: auto-merge stays disabled.
+
+The PR summary should report only safe metadata: total counts and entity types. It must not include raw values, scanner excerpts, token strings, secret fragments, or source snippets. Reviewers should inspect the sanitized source notes and the originating system if they need to decide whether the redactions are acceptable.
+
+## Local Overrides
+
+Local scanner selection belongs in operator commands or project-local configuration. Use local overrides to require an installed scanner, to add a stricter optional scanner, or to force dry-run behavior while evaluating a new source. Do not commit local secrets, OAuth artifacts, or scanner credentials to the repository.
+
+When a local override marks a scanner as required and the scanner is unavailable, ingestion should remain blocked. The correct repair is to install the scanner, relax the local requirement intentionally, or run a dry run that writes nothing.
+
+## False Positives And False Negatives
+
+For false positives, keep the redacted source note and document the reviewer decision in the PR. A reviewer may allow the PR to merge manually after confirming that no useful raw sensitive value was lost or exposed. Do not replace placeholders with raw values just to preserve source fidelity.
+
+For false negatives, add a focused fixture or scanner rule before re-running the ingest. The source-note contract favors conservative redaction over perfect recall. If a raw sensitive value reaches generated wiki output, treat it as blocking until the output is rewritten safely and the safety gate passes.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -23,6 +23,7 @@ Last updated by connector ingest on 2026-06-06 for Lisa `2.140.0` and current mo
 - [PRD Lifecycle Rollup Vendor Matrix](../plugins/src/base/rules/reference/prd-lifecycle-rollup.md)
 - [Testing Documentation](documentation/testing/)
 - [Workflow Documentation](documentation/workflows/)
+  - [Wiki Ingestion Safety](documentation/workflows/wiki-ingestion-safety.md)
 - [Specifications](documentation/specs/)
 
 ## Architecture


### PR DESCRIPTION
## Summary
- add a deterministic wiki ingest publication policy that disables auto-merge for external-write, redacted, or sensitive-finding runs
- keep PR safety summaries limited to entity types and counts, with raw sensitive values intentionally omitted
- document scanner installation, local overrides, review handling, and false-positive/false-negative guidance

Refs #1174

## Verification
- bunx vitest run tests/unit/strategies/wiki-safety.test.ts
- bun run build:dist
- bun run build:plugins
- bun run check:plugins
- git diff --check
- node plugins/src/wiki/scripts/verify-wiki-safety.mjs --path wiki/documentation/workflows/wiki-ingestion-safety.md --path wiki/documentation/index.md --path wiki/index.md
- pre-commit hook: Gitleaks, tsc --noEmit, lint-staged, ESLint, Prettier, ast-grep, commitlint
- pre-push hook: bun audit, slow ESLint, knip, vitest run --coverage, vitest run tests/integration
