### PR TITLE
fix(eslint): ignore .lisa.config.json (config data, not source)

### DIFF
--- a/eslint.ignore.config.json
+++ b/eslint.ignore.config.json
@@ -77,6 +77,7 @@
 
     "audit.ignore.config.json",
     "audit.ignore.local.json",
+    ".lisa.config.json",
 
     "wiki/**"
   ]

--- a/src/configs/eslint/base.ts
+++ b/src/configs/eslint/base.ts
@@ -77,6 +77,7 @@ export const defaultIgnores = [
   "lib/**/*.js",
   "cdk.out/**",
   "wiki/**",
+  ".lisa.config.json",
 ];
 
 /**

--- a/tests/unit/config/eslint-ignore-wiki.test.ts
+++ b/tests/unit/config/eslint-ignore-wiki.test.ts
@@ -54,3 +54,29 @@ describe("wiki/** ESLint ignore", () => {
     expect(readIgnores("eslint.ignore.config.json")).toContain("wiki/**");
   });
 });
+
+/**
+ * Same regression class as wiki/**, for `.lisa.config.json`: it is project
+ * *config data* (e.g. repeated GitHub label literals like `status:done`), not
+ * source, so linting it with code-smell rules such as
+ * `sonarjs/no-duplicate-string` is wrong. It must be ignored in lock-step
+ * across the compiled default and both shipped templates — mirroring how
+ * `audit.ignore.config.json` is already ignored.
+ */
+describe(".lisa.config.json ESLint ignore", () => {
+  const LISA_CONFIG = ".lisa.config.json";
+
+  it("compiled defaultIgnores excludes .lisa.config.json", () => {
+    expect(defaultIgnores).toContain(LISA_CONFIG);
+  });
+
+  it("the typescript copy-overwrite template excludes .lisa.config.json", () => {
+    expect(
+      readIgnores("typescript/copy-overwrite/eslint.ignore.config.json")
+    ).toContain(LISA_CONFIG);
+  });
+
+  it("Lisa's own root ignore config excludes .lisa.config.json", () => {
+    expect(readIgnores("eslint.ignore.config.json")).toContain(LISA_CONFIG);
+  });
+});

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -79,6 +79,7 @@
 
     "audit.ignore.config.json",
     "audit.ignore.local.json",
+    ".lisa.config.json",
 
     "amplify/**",
 


### PR DESCRIPTION
## Problem
`.lisa.config.json` is project **config data**, but `eslint .` lints it as source. Its GitHub label block legitimately repeats string literals (e.g. `status:done` across dev/staging/production), tripping `sonarjs/no-duplicate-string`. This is the **same regression class as `wiki/**`** (and hit the same repos: api-creator, thumbwar-frontend/-infrastructure, qualis-infrastructure) — surfaced now that every repo is gaining a `.lisa.config.json`.

## Fix
Ignore `.lisa.config.json` in lock-step across the compiled `defaultIgnores` (`src/configs/eslint/base.ts`) and **both** shipped templates (`typescript/copy-overwrite/eslint.ignore.config.json` + Lisa's own root `eslint.ignore.config.json`), mirroring how `audit.ignore.config.json` is already ignored. Regression tests added alongside the existing `wiki/**` ones.

🤖 Generated with Claude Code