### PR TITLE
docs(openclaw): document account-scoped Telegram routes

### DIFF
--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -101,18 +101,28 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 ### 6. Bind the topic
 
-Route the topic to the dispatcher: set
-`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
-topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
-is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
-Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
-you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
-See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
-tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
-root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
-worker with an explicit repo path, and return the worker result to the topic. Back up
-`~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
+Route the topic to the dispatcher. In single-account Telegram configs, set
+`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`. In
+multi-account Telegram configs, set the same route under the owning bot account:
+`channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId =
+<topic-slug>-dispatch`. Account configs do not inherit root `channels.telegram.groups` routes, so a
+root-only route can validate while the actual bot still ignores the topic-level `requireMention`,
+`agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
+root group route only as a fallback/documentation shape.
+
+Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
+Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
+the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
+friction. Set it to `true` only for a shared-workspace topic where humans also coordinate with each
+other and you don't want every line to spawn a run; the group-level `requireMention` stays `true`
+regardless. See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md)
+for the tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply root as
+an independent request context, confirm repo selection only in folder-scoped mode, spawn the worker
+with an explicit repo path, and return the worker result to the topic. If the route may return
+generated files, the prompt must also say to write or copy returnable artifacts under
+`~/.openclaw/media` before calling `message(action="send")`, because outbound local media delivery
+rejects arbitrary `/tmp` paths. Back up `~/.openclaw/openclaw.json` before editing and preserve
+unrelated routes.
 
 ### 7. Validate + self-test
 

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -70,6 +70,13 @@ repos:
 
 ## Topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If
+`channels.telegram.accounts` is configured, bind the route under the owning bot account instead:
+`channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
+inherit root `channels.telegram.groups` routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -98,6 +105,41 @@ repos:
   }
 }
 ```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<group-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<topic-id>": {
+                  "agentId": "<topic-slug>-dispatch",
+                  "requireMention": false,
+                  "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context. If generated files need to be returned as Telegram attachments, write or copy them under ~/.openclaw/media before calling message(action=\"send\"), because outbound local media delivery rejects arbitrary /tmp paths."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## File return path
+
+When a repo-topic agent returns generated files to Telegram, use the OpenClaw `message` tool with
+real local file paths. Write or copy returnable artifacts under `~/.openclaw/media` before sending;
+outbound local media delivery rejects arbitrary `/tmp` paths even when the file exists.
 
 ## Mention gating
 

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -14,6 +14,13 @@ all unrelated agents, channels, routes, and tokens.
 
 ## Telegram — facilitator topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenClaw config has
+`channels.telegram.accounts`, put the route under the owning bot account at
+`channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
+configs do not inherit root group routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -27,6 +34,34 @@ all unrelated agents, channels, routes, and tokens.
             "<facilitator-topic-id>": {
               "agentId": "<facilitator-agent-id>",
               "requireMention": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<telegram-supergroup-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<facilitator-topic-id>": {
+                  "agentId": "<facilitator-agent-id>",
+                  "requireMention": true
+                }
+              }
             }
           }
         }

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -101,18 +101,28 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 ### 6. Bind the topic
 
-Route the topic to the dispatcher: set
-`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
-topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
-is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
-Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
-you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
-See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
-tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
-root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
-worker with an explicit repo path, and return the worker result to the topic. Back up
-`~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
+Route the topic to the dispatcher. In single-account Telegram configs, set
+`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`. In
+multi-account Telegram configs, set the same route under the owning bot account:
+`channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId =
+<topic-slug>-dispatch`. Account configs do not inherit root `channels.telegram.groups` routes, so a
+root-only route can validate while the actual bot still ignores the topic-level `requireMention`,
+`agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
+root group route only as a fallback/documentation shape.
+
+Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
+Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
+the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
+friction. Set it to `true` only for a shared-workspace topic where humans also coordinate with each
+other and you don't want every line to spawn a run; the group-level `requireMention` stays `true`
+regardless. See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md)
+for the tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply root as
+an independent request context, confirm repo selection only in folder-scoped mode, spawn the worker
+with an explicit repo path, and return the worker result to the topic. If the route may return
+generated files, the prompt must also say to write or copy returnable artifacts under
+`~/.openclaw/media` before calling `message(action="send")`, because outbound local media delivery
+rejects arbitrary `/tmp` paths. Back up `~/.openclaw/openclaw.json` before editing and preserve
+unrelated routes.
 
 ### 7. Validate + self-test
 

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -70,6 +70,13 @@ repos:
 
 ## Topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If
+`channels.telegram.accounts` is configured, bind the route under the owning bot account instead:
+`channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
+inherit root `channels.telegram.groups` routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -98,6 +105,41 @@ repos:
   }
 }
 ```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<group-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<topic-id>": {
+                  "agentId": "<topic-slug>-dispatch",
+                  "requireMention": false,
+                  "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context. If generated files need to be returned as Telegram attachments, write or copy them under ~/.openclaw/media before calling message(action=\"send\"), because outbound local media delivery rejects arbitrary /tmp paths."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## File return path
+
+When a repo-topic agent returns generated files to Telegram, use the OpenClaw `message` tool with
+real local file paths. Write or copy returnable artifacts under `~/.openclaw/media` before sending;
+outbound local media delivery rejects arbitrary `/tmp` paths even when the file exists.
 
 ## Mention gating
 

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -14,6 +14,13 @@ all unrelated agents, channels, routes, and tokens.
 
 ## Telegram — facilitator topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenClaw config has
+`channels.telegram.accounts`, put the route under the owning bot account at
+`channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
+configs do not inherit root group routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -27,6 +34,34 @@ all unrelated agents, channels, routes, and tokens.
             "<facilitator-topic-id>": {
               "agentId": "<facilitator-agent-id>",
               "requireMention": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<telegram-supergroup-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<facilitator-topic-id>": {
+                  "agentId": "<facilitator-agent-id>",
+                  "requireMention": true
+                }
+              }
             }
           }
         }

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -101,18 +101,28 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 ### 6. Bind the topic
 
-Route the topic to the dispatcher: set
-`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
-topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
-is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
-Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
-you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
-See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
-tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
-root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
-worker with an explicit repo path, and return the worker result to the topic. Back up
-`~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
+Route the topic to the dispatcher. In single-account Telegram configs, set
+`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`. In
+multi-account Telegram configs, set the same route under the owning bot account:
+`channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId =
+<topic-slug>-dispatch`. Account configs do not inherit root `channels.telegram.groups` routes, so a
+root-only route can validate while the actual bot still ignores the topic-level `requireMention`,
+`agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
+root group route only as a fallback/documentation shape.
+
+Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
+Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
+the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
+friction. Set it to `true` only for a shared-workspace topic where humans also coordinate with each
+other and you don't want every line to spawn a run; the group-level `requireMention` stays `true`
+regardless. See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md)
+for the tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply root as
+an independent request context, confirm repo selection only in folder-scoped mode, spawn the worker
+with an explicit repo path, and return the worker result to the topic. If the route may return
+generated files, the prompt must also say to write or copy returnable artifacts under
+`~/.openclaw/media` before calling `message(action="send")`, because outbound local media delivery
+rejects arbitrary `/tmp` paths. Back up `~/.openclaw/openclaw.json` before editing and preserve
+unrelated routes.
 
 ### 7. Validate + self-test
 

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -70,6 +70,13 @@ repos:
 
 ## Topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If
+`channels.telegram.accounts` is configured, bind the route under the owning bot account instead:
+`channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
+inherit root `channels.telegram.groups` routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -98,6 +105,41 @@ repos:
   }
 }
 ```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<group-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<topic-id>": {
+                  "agentId": "<topic-slug>-dispatch",
+                  "requireMention": false,
+                  "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context. If generated files need to be returned as Telegram attachments, write or copy them under ~/.openclaw/media before calling message(action=\"send\"), because outbound local media delivery rejects arbitrary /tmp paths."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## File return path
+
+When a repo-topic agent returns generated files to Telegram, use the OpenClaw `message` tool with
+real local file paths. Write or copy returnable artifacts under `~/.openclaw/media` before sending;
+outbound local media delivery rejects arbitrary `/tmp` paths even when the file exists.
 
 ## Mention gating
 

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -14,6 +14,13 @@ all unrelated agents, channels, routes, and tokens.
 
 ## Telegram — facilitator topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenClaw config has
+`channels.telegram.accounts`, put the route under the owning bot account at
+`channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
+configs do not inherit root group routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -27,6 +34,34 @@ all unrelated agents, channels, routes, and tokens.
             "<facilitator-topic-id>": {
               "agentId": "<facilitator-agent-id>",
               "requireMention": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<telegram-supergroup-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<facilitator-topic-id>": {
+                  "agentId": "<facilitator-agent-id>",
+                  "requireMention": true
+                }
+              }
             }
           }
         }

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -101,18 +101,28 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 ### 6. Bind the topic
 
-Route the topic to the dispatcher: set
-`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
-topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
-is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
-Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
-you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
-See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
-tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
-root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
-worker with an explicit repo path, and return the worker result to the topic. Back up
-`~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
+Route the topic to the dispatcher. In single-account Telegram configs, set
+`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`. In
+multi-account Telegram configs, set the same route under the owning bot account:
+`channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId =
+<topic-slug>-dispatch`. Account configs do not inherit root `channels.telegram.groups` routes, so a
+root-only route can validate while the actual bot still ignores the topic-level `requireMention`,
+`agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
+root group route only as a fallback/documentation shape.
+
+Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
+Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
+the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
+friction. Set it to `true` only for a shared-workspace topic where humans also coordinate with each
+other and you don't want every line to spawn a run; the group-level `requireMention` stays `true`
+regardless. See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md)
+for the tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply root as
+an independent request context, confirm repo selection only in folder-scoped mode, spawn the worker
+with an explicit repo path, and return the worker result to the topic. If the route may return
+generated files, the prompt must also say to write or copy returnable artifacts under
+`~/.openclaw/media` before calling `message(action="send")`, because outbound local media delivery
+rejects arbitrary `/tmp` paths. Back up `~/.openclaw/openclaw.json` before editing and preserve
+unrelated routes.
 
 ### 7. Validate + self-test
 

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -70,6 +70,13 @@ repos:
 
 ## Topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If
+`channels.telegram.accounts` is configured, bind the route under the owning bot account instead:
+`channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
+inherit root `channels.telegram.groups` routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -98,6 +105,41 @@ repos:
   }
 }
 ```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<group-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<topic-id>": {
+                  "agentId": "<topic-slug>-dispatch",
+                  "requireMention": false,
+                  "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context. If generated files need to be returned as Telegram attachments, write or copy them under ~/.openclaw/media before calling message(action=\"send\"), because outbound local media delivery rejects arbitrary /tmp paths."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## File return path
+
+When a repo-topic agent returns generated files to Telegram, use the OpenClaw `message` tool with
+real local file paths. Write or copy returnable artifacts under `~/.openclaw/media` before sending;
+outbound local media delivery rejects arbitrary `/tmp` paths even when the file exists.
 
 ## Mention gating
 

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -14,6 +14,13 @@ all unrelated agents, channels, routes, and tokens.
 
 ## Telegram — facilitator topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenClaw config has
+`channels.telegram.accounts`, put the route under the owning bot account at
+`channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
+configs do not inherit root group routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -27,6 +34,34 @@ all unrelated agents, channels, routes, and tokens.
             "<facilitator-topic-id>": {
               "agentId": "<facilitator-agent-id>",
               "requireMention": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<telegram-supergroup-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<facilitator-topic-id>": {
+                  "agentId": "<facilitator-agent-id>",
+                  "requireMention": true
+                }
+              }
             }
           }
         }

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -101,18 +101,28 @@ The worker prepares the safe target and launches the CLI; it does not edit files
 
 ### 6. Bind the topic
 
-Route the topic to the dispatcher: set
-`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`, keep
-allowlist policy, and add `allowFrom` only when membership must be narrower than the group. Leave the
-topic-level `requireMention = false` (the default) so the agent activates on any message — the topic
-is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure friction.
-Set it to `true` only for a shared-workspace topic where humans also coordinate with each other and
-you don't want every line to spawn a run; the group-level `requireMention` stays `true` regardless.
-See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md) for the
-tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply
-root as an independent request context, confirm repo selection only in folder-scoped mode, spawn the
-worker with an explicit repo path, and return the worker result to the topic. Back up
-`~/.openclaw/openclaw.json` before editing and preserve unrelated routes.
+Route the topic to the dispatcher. In single-account Telegram configs, set
+`channels.telegram.groups.<group-id>.topics.<topic-id>.agentId = <topic-slug>-dispatch`. In
+multi-account Telegram configs, set the same route under the owning bot account:
+`channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId =
+<topic-slug>-dispatch`. Account configs do not inherit root `channels.telegram.groups` routes, so a
+root-only route can validate while the actual bot still ignores the topic-level `requireMention`,
+`agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
+root group route only as a fallback/documentation shape.
+
+Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
+Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
+the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
+friction. Set it to `true` only for a shared-workspace topic where humans also coordinate with each
+other and you don't want every line to spawn a run; the group-level `requireMention` stays `true`
+regardless. See "Mention gating" in [references/repo-topic-config.md](references/repo-topic-config.md)
+for the tradeoff. The topic `systemPrompt` must state the scope mode, treat each native-reply root as
+an independent request context, confirm repo selection only in folder-scoped mode, spawn the worker
+with an explicit repo path, and return the worker result to the topic. If the route may return
+generated files, the prompt must also say to write or copy returnable artifacts under
+`~/.openclaw/media` before calling `message(action="send")`, because outbound local media delivery
+rejects arbitrary `/tmp` paths. Back up `~/.openclaw/openclaw.json` before editing and preserve
+unrelated routes.
 
 ### 7. Validate + self-test
 

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -70,6 +70,13 @@ repos:
 
 ## Topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If
+`channels.telegram.accounts` is configured, bind the route under the owning bot account instead:
+`channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
+inherit root `channels.telegram.groups` routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -98,6 +105,41 @@ repos:
   }
 }
 ```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<group-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<topic-id>": {
+                  "agentId": "<topic-slug>-dispatch",
+                  "requireMention": false,
+                  "systemPrompt": "Use the topic's configured scope mode. For single-repo, pass the fixed repo path to <topic-slug>-codex. For folder-scoped, confirm the inferred repo or repo set unless the user already named it explicitly, then pass the explicit repo path(s) to <topic-slug>-codex. Treat each native reply root as an independent request context. If generated files need to be returned as Telegram attachments, write or copy them under ~/.openclaw/media before calling message(action=\"send\"), because outbound local media delivery rejects arbitrary /tmp paths."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## File return path
+
+When a repo-topic agent returns generated files to Telegram, use the OpenClaw `message` tool with
+real local file paths. Write or copy returnable artifacts under `~/.openclaw/media` before sending;
+outbound local media delivery rejects arbitrary `/tmp` paths even when the file exists.
 
 ## Mention gating
 

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -14,6 +14,13 @@ all unrelated agents, channels, routes, and tokens.
 
 ## Telegram — facilitator topic route
 
+Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenClaw config has
+`channels.telegram.accounts`, put the route under the owning bot account at
+`channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
+configs do not inherit root group routes.
+
+### Single-account route
+
 ```json5
 {
   "channels": {
@@ -27,6 +34,34 @@ all unrelated agents, channels, routes, and tokens.
             "<facilitator-topic-id>": {
               "agentId": "<facilitator-agent-id>",
               "requireMention": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Multi-account route
+
+```json5
+{
+  "channels": {
+    "telegram": {
+      "accounts": {
+        "<account-id>": {
+          "groups": {
+            "<telegram-supergroup-id>": {
+              "groupPolicy": "allowlist",
+              "requireMention": true,
+              "allowFrom": ["<telegram-user-id>"],
+              "topics": {
+                "<facilitator-topic-id>": {
+                  "agentId": "<facilitator-agent-id>",
+                  "requireMention": true
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Document account-scoped Telegram group routes for multi-account OpenClaw configs
- Add multi-account route examples for repo-topic and staff facilitator topics
- Document the ~/.openclaw/media requirement for generated Telegram attachments
- Rebuild generated OpenClaw plugin variants

## Validation
- `mise x bun@1.3.8 -- bun run build:plugins`
- `./node_modules/.bin/prettier --check ...`
- `git diff --check`
- `cmp` source/generated OpenClaw skill files
- `mise x bun@1.3.8 -- bun run check:plugins`
- Commit hook passed `tsc --noEmit` and lint-staged prettier

## Note
- Full pre-push coverage failed on an unrelated existing `wiki-connector-source-sanitization` test in the full suite; the focused test passed under the expected Bun toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Telegram routing configuration guidance for single-account and multi-account setups, clarifying that multi-account configurations require routes under account-scoped paths.
  * Added new file return path requirements, specifying that generated files must be written to `~/.openclaw/media` instead of temporary directories.
  * Expanded topic configuration requirements with clearer activation controls and artifact handling instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->