### PR TITLE
docs(openclaw): note account-scoped topic runtime support

### DIFF
--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -110,6 +110,11 @@ root-only route can validate while the actual bot still ignores the topic-level 
 `agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
 root group route only as a fallback/documentation shape.
 
+Account-scoped topic `agentId` routes also require an OpenClaw runtime that treats the topic agent as
+an explicit group route for non-default Telegram accounts. If the self-test logs
+`drop non-default account requires explicit binding`, update or rebuild OpenClaw before adding config
+workarounds; do not create persistent ACP bindings solely to bypass that guard.
+
 Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
 Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
 the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
@@ -137,11 +142,14 @@ Then from the target topic, send a plain message with **no** @mention (the defau
 `requireMention = false` means the agent must activate without one) asking for an exact-token reply
 with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
 Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
-intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
-(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
-message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
-repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
-<id> ...` as proof a topic route works — use the visible topic reply.
+intended repo. If there is no dispatcher session, inspect `/tmp/openclaw/openclaw-YYYY-MM-DD.log`;
+`drop non-default account requires explicit binding` means the OpenClaw runtime is too old for
+account-scoped topic-agent routing. If the topic was deliberately left at `requireMention = true`,
+mention the bot instead (`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally
+confirm that an un-mentioned message is **ignored**. For folder-scoped topics, also send a request
+that implies but doesn't name a repo and confirm the dispatcher asks for confirmation before
+proceeding. Do **not** treat `openclaw agent --agent <id> ...` as proof a topic route works — use the
+visible topic reply.
 
 ## Output standard
 

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -75,6 +75,12 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If
 `channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
 inherit root `channels.telegram.groups` routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real topic self-test is delivered to the
+bot but the logs show `drop non-default account requires explicit binding`, update or rebuild
+OpenClaw. Do not add a persistent ACP binding as a workaround; the configured topic `agentId` is the
+intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -19,6 +19,11 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenC
 `channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
 configs do not inherit root group routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real Telegram topic test reaches the bot
+but logs `drop non-default account requires explicit binding`, update or rebuild OpenClaw before
+adding config workarounds; the topic `agentId` is the intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-agy/skills/lisa-openclaw-setup/SKILL.md
+++ b/plugins/lisa-openclaw-agy/skills/lisa-openclaw-setup/SKILL.md
@@ -83,6 +83,9 @@ loudly, do not silently proceed) if any is missing:
   root (Slack channel + root `thread_ts`; Telegram supergroup + forum topic + root `message_id`), and
   replies in that thread continue the same session, so concurrent threads don't share short-term
   context.
+- **Account-scoped Telegram topic agents** — in multi-account Telegram configs,
+  `channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId` routes group
+  messages as an explicit topic route instead of dropping them as a non-default account fallback.
 - **`NO_REPLY` sentinel** — after an agent sends a message with the platform message tool, returning
   exactly `NO_REPLY` as its assistant final prevents the gateway from posting a duplicate loose
   message.

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -110,6 +110,11 @@ root-only route can validate while the actual bot still ignores the topic-level 
 `agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
 root group route only as a fallback/documentation shape.
 
+Account-scoped topic `agentId` routes also require an OpenClaw runtime that treats the topic agent as
+an explicit group route for non-default Telegram accounts. If the self-test logs
+`drop non-default account requires explicit binding`, update or rebuild OpenClaw before adding config
+workarounds; do not create persistent ACP bindings solely to bypass that guard.
+
 Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
 Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
 the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
@@ -137,11 +142,14 @@ Then from the target topic, send a plain message with **no** @mention (the defau
 `requireMention = false` means the agent must activate without one) asking for an exact-token reply
 with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
 Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
-intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
-(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
-message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
-repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
-<id> ...` as proof a topic route works — use the visible topic reply.
+intended repo. If there is no dispatcher session, inspect `/tmp/openclaw/openclaw-YYYY-MM-DD.log`;
+`drop non-default account requires explicit binding` means the OpenClaw runtime is too old for
+account-scoped topic-agent routing. If the topic was deliberately left at `requireMention = true`,
+mention the bot instead (`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally
+confirm that an un-mentioned message is **ignored**. For folder-scoped topics, also send a request
+that implies but doesn't name a repo and confirm the dispatcher asks for confirmation before
+proceeding. Do **not** treat `openclaw agent --agent <id> ...` as proof a topic route works — use the
+visible topic reply.
 
 ## Output standard
 

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -75,6 +75,12 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If
 `channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
 inherit root `channels.telegram.groups` routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real topic self-test is delivered to the
+bot but the logs show `drop non-default account requires explicit binding`, update or rebuild
+OpenClaw. Do not add a persistent ACP binding as a workaround; the configured topic `agentId` is the
+intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -19,6 +19,11 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenC
 `channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
 configs do not inherit root group routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real Telegram topic test reaches the bot
+but logs `drop non-default account requires explicit binding`, update or rebuild OpenClaw before
+adding config workarounds; the topic `agentId` is the intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-setup/SKILL.md
+++ b/plugins/lisa-openclaw-copilot/skills/lisa-openclaw-setup/SKILL.md
@@ -83,6 +83,9 @@ loudly, do not silently proceed) if any is missing:
   root (Slack channel + root `thread_ts`; Telegram supergroup + forum topic + root `message_id`), and
   replies in that thread continue the same session, so concurrent threads don't share short-term
   context.
+- **Account-scoped Telegram topic agents** — in multi-account Telegram configs,
+  `channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId` routes group
+  messages as an explicit topic route instead of dropping them as a non-default account fallback.
 - **`NO_REPLY` sentinel** — after an agent sends a message with the platform message tool, returning
   exactly `NO_REPLY` as its assistant final prevents the gateway from posting a duplicate loose
   message.

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -110,6 +110,11 @@ root-only route can validate while the actual bot still ignores the topic-level 
 `agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
 root group route only as a fallback/documentation shape.
 
+Account-scoped topic `agentId` routes also require an OpenClaw runtime that treats the topic agent as
+an explicit group route for non-default Telegram accounts. If the self-test logs
+`drop non-default account requires explicit binding`, update or rebuild OpenClaw before adding config
+workarounds; do not create persistent ACP bindings solely to bypass that guard.
+
 Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
 Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
 the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
@@ -137,11 +142,14 @@ Then from the target topic, send a plain message with **no** @mention (the defau
 `requireMention = false` means the agent must activate without one) asking for an exact-token reply
 with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
 Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
-intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
-(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
-message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
-repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
-<id> ...` as proof a topic route works — use the visible topic reply.
+intended repo. If there is no dispatcher session, inspect `/tmp/openclaw/openclaw-YYYY-MM-DD.log`;
+`drop non-default account requires explicit binding` means the OpenClaw runtime is too old for
+account-scoped topic-agent routing. If the topic was deliberately left at `requireMention = true`,
+mention the bot instead (`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally
+confirm that an un-mentioned message is **ignored**. For folder-scoped topics, also send a request
+that implies but doesn't name a repo and confirm the dispatcher asks for confirmation before
+proceeding. Do **not** treat `openclaw agent --agent <id> ...` as proof a topic route works — use the
+visible topic reply.
 
 ## Output standard
 

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -75,6 +75,12 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If
 `channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
 inherit root `channels.telegram.groups` routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real topic self-test is delivered to the
+bot but the logs show `drop non-default account requires explicit binding`, update or rebuild
+OpenClaw. Do not add a persistent ACP binding as a workaround; the configured topic `agentId` is the
+intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -19,6 +19,11 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenC
 `channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
 configs do not inherit root group routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real Telegram topic test reaches the bot
+but logs `drop non-default account requires explicit binding`, update or rebuild OpenClaw before
+adding config workarounds; the topic `agentId` is the intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-setup/SKILL.md
+++ b/plugins/lisa-openclaw-cursor/skills/lisa-openclaw-setup/SKILL.md
@@ -83,6 +83,9 @@ loudly, do not silently proceed) if any is missing:
   root (Slack channel + root `thread_ts`; Telegram supergroup + forum topic + root `message_id`), and
   replies in that thread continue the same session, so concurrent threads don't share short-term
   context.
+- **Account-scoped Telegram topic agents** — in multi-account Telegram configs,
+  `channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId` routes group
+  messages as an explicit topic route instead of dropping them as a non-default account fallback.
 - **`NO_REPLY` sentinel** — after an agent sends a message with the platform message tool, returning
   exactly `NO_REPLY` as its assistant final prevents the gateway from posting a duplicate loose
   message.

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -110,6 +110,11 @@ root-only route can validate while the actual bot still ignores the topic-level 
 `agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
 root group route only as a fallback/documentation shape.
 
+Account-scoped topic `agentId` routes also require an OpenClaw runtime that treats the topic agent as
+an explicit group route for non-default Telegram accounts. If the self-test logs
+`drop non-default account requires explicit binding`, update or rebuild OpenClaw before adding config
+workarounds; do not create persistent ACP bindings solely to bypass that guard.
+
 Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
 Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
 the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
@@ -137,11 +142,14 @@ Then from the target topic, send a plain message with **no** @mention (the defau
 `requireMention = false` means the agent must activate without one) asking for an exact-token reply
 with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
 Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
-intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
-(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
-message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
-repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
-<id> ...` as proof a topic route works — use the visible topic reply.
+intended repo. If there is no dispatcher session, inspect `/tmp/openclaw/openclaw-YYYY-MM-DD.log`;
+`drop non-default account requires explicit binding` means the OpenClaw runtime is too old for
+account-scoped topic-agent routing. If the topic was deliberately left at `requireMention = true`,
+mention the bot instead (`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally
+confirm that an un-mentioned message is **ignored**. For folder-scoped topics, also send a request
+that implies but doesn't name a repo and confirm the dispatcher asks for confirmation before
+proceeding. Do **not** treat `openclaw agent --agent <id> ...` as proof a topic route works — use the
+visible topic reply.
 
 ## Output standard
 

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -75,6 +75,12 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If
 `channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
 inherit root `channels.telegram.groups` routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real topic self-test is delivered to the
+bot but the logs show `drop non-default account requires explicit binding`, update or rebuild
+OpenClaw. Do not add a persistent ACP binding as a workaround; the configured topic `agentId` is the
+intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -19,6 +19,11 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenC
 `channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
 configs do not inherit root group routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real Telegram topic test reaches the bot
+but logs `drop non-default account requires explicit binding`, update or rebuild OpenClaw before
+adding config workarounds; the topic `agentId` is the intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/lisa-openclaw/skills/lisa-openclaw-setup/SKILL.md
+++ b/plugins/lisa-openclaw/skills/lisa-openclaw-setup/SKILL.md
@@ -83,6 +83,9 @@ loudly, do not silently proceed) if any is missing:
   root (Slack channel + root `thread_ts`; Telegram supergroup + forum topic + root `message_id`), and
   replies in that thread continue the same session, so concurrent threads don't share short-term
   context.
+- **Account-scoped Telegram topic agents** — in multi-account Telegram configs,
+  `channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId` routes group
+  messages as an explicit topic route instead of dropping them as a non-default account fallback.
 - **`NO_REPLY` sentinel** — after an agent sends a message with the platform message tool, returning
   exactly `NO_REPLY` as its assistant final prevents the gateway from posting a duplicate loose
   message.

--- a/plugins/lisa-wiki-agy/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-agy/scripts/ingest_slack_channel.py
@@ -57,12 +57,12 @@ TOKEN_PATTERNS = [
 
 
 def utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
 
 
 def iso_from_ts(ts: str) -> str:
     seconds = float(ts)
-    return dt.datetime.fromtimestamp(seconds, dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ts_from_input(value: str | None) -> str | None:

--- a/plugins/lisa-wiki-copilot/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-copilot/scripts/ingest_slack_channel.py
@@ -57,12 +57,12 @@ TOKEN_PATTERNS = [
 
 
 def utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
 
 
 def iso_from_ts(ts: str) -> str:
     seconds = float(ts)
-    return dt.datetime.fromtimestamp(seconds, dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ts_from_input(value: str | None) -> str | None:

--- a/plugins/lisa-wiki-cursor/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki-cursor/scripts/ingest_slack_channel.py
@@ -57,12 +57,12 @@ TOKEN_PATTERNS = [
 
 
 def utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
 
 
 def iso_from_ts(ts: str) -> str:
     seconds = float(ts)
-    return dt.datetime.fromtimestamp(seconds, dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ts_from_input(value: str | None) -> str | None:

--- a/plugins/lisa-wiki/scripts/ingest_slack_channel.py
+++ b/plugins/lisa-wiki/scripts/ingest_slack_channel.py
@@ -57,12 +57,12 @@ TOKEN_PATTERNS = [
 
 
 def utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
 
 
 def iso_from_ts(ts: str) -> str:
     seconds = float(ts)
-    return dt.datetime.fromtimestamp(seconds, dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ts_from_input(value: str | None) -> str | None:

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md
@@ -110,6 +110,11 @@ root-only route can validate while the actual bot still ignores the topic-level 
 `agentId`, and prompt. When in doubt, mirror the route under the owning account and keep any existing
 root group route only as a fallback/documentation shape.
 
+Account-scoped topic `agentId` routes also require an OpenClaw runtime that treats the topic agent as
+an explicit group route for non-default Telegram accounts. If the self-test logs
+`drop non-default account requires explicit binding`, update or rebuild OpenClaw before adding config
+workarounds; do not create persistent ACP bindings solely to bypass that guard.
+
 Keep allowlist policy, and add `allowFrom` only when membership must be narrower than the group.
 Leave the topic-level `requireMention = false` (the default) so the agent activates on any message —
 the topic is bound 1:1 to this dispatcher, so an @mention carries no routing information and is pure
@@ -137,11 +142,14 @@ Then from the target topic, send a plain message with **no** @mention (the defau
 `requireMention = false` means the agent must activate without one) asking for an exact-token reply
 with **no** file changes, commits, PRs, or merges, e.g. `reply with exactly TELEGRAM-ROUTE-OK`.
 Confirm the visible reply, that the dispatcher spawned the worker, and that the worker ran in the
-intended repo. If the topic was deliberately left at `requireMention = true`, mention the bot instead
-(`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally confirm that an un-mentioned
-message is **ignored**. For folder-scoped topics, also send a request that implies but doesn't name a
-repo and confirm the dispatcher asks for confirmation before proceeding. Do **not** treat `openclaw agent --agent
-<id> ...` as proof a topic route works — use the visible topic reply.
+intended repo. If there is no dispatcher session, inspect `/tmp/openclaw/openclaw-YYYY-MM-DD.log`;
+`drop non-default account requires explicit binding` means the OpenClaw runtime is too old for
+account-scoped topic-agent routing. If the topic was deliberately left at `requireMention = true`,
+mention the bot instead (`<bot-handle> reply with exactly TELEGRAM-ROUTE-OK`) and additionally
+confirm that an un-mentioned message is **ignored**. For folder-scoped topics, also send a request
+that implies but doesn't name a repo and confirm the dispatcher asks for confirmation before
+proceeding. Do **not** treat `openclaw agent --agent <id> ...` as proof a topic route works — use the
+visible topic reply.
 
 ## Output standard
 

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/references/repo-topic-config.md
@@ -75,6 +75,12 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If
 `channels.telegram.accounts.<account-id>.groups.<group-id>`. Account-scoped Telegram configs do not
 inherit root `channels.telegram.groups` routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real topic self-test is delivered to the
+bot but the logs show `drop non-default account requires explicit binding`, update or rebuild
+OpenClaw. Do not add a persistent ACP binding as a workaround; the configured topic `agentId` is the
+intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/src/openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-connect-staff/references/platform-routing.md
@@ -19,6 +19,11 @@ Use `channels.telegram.groups` for a single-account Telegram setup. If the OpenC
 `channels.telegram.accounts.<account-id>.groups.<telegram-supergroup-id>`; account-scoped Telegram
 configs do not inherit root group routes.
 
+Account-scoped topic `agentId` routes require an OpenClaw runtime that treats the topic agent as an
+explicit group route for non-default Telegram accounts. If a real Telegram topic test reaches the bot
+but logs `drop non-default account requires explicit binding`, update or rebuild OpenClaw before
+adding config workarounds; the topic `agentId` is the intended route.
+
 ### Single-account route
 
 ```json5

--- a/plugins/src/openclaw/skills/lisa-openclaw-setup/SKILL.md
+++ b/plugins/src/openclaw/skills/lisa-openclaw-setup/SKILL.md
@@ -83,6 +83,9 @@ loudly, do not silently proceed) if any is missing:
   root (Slack channel + root `thread_ts`; Telegram supergroup + forum topic + root `message_id`), and
   replies in that thread continue the same session, so concurrent threads don't share short-term
   context.
+- **Account-scoped Telegram topic agents** — in multi-account Telegram configs,
+  `channels.telegram.accounts.<account-id>.groups.<group-id>.topics.<topic-id>.agentId` routes group
+  messages as an explicit topic route instead of dropping them as a non-default account fallback.
 - **`NO_REPLY` sentinel** — after an agent sends a message with the platform message tool, returning
   exactly `NO_REPLY` as its assistant final prevents the gateway from posting a duplicate loose
   message.

--- a/plugins/src/wiki/scripts/ingest_slack_channel.py
+++ b/plugins/src/wiki/scripts/ingest_slack_channel.py
@@ -57,12 +57,12 @@ TOKEN_PATTERNS = [
 
 
 def utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
 
 
 def iso_from_ts(ts: str) -> str:
     seconds = float(ts)
-    return dt.datetime.fromtimestamp(seconds, dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def ts_from_input(value: str | None) -> str | None:


### PR DESCRIPTION
## Summary

- Document that account-scoped Telegram topic `agentId` routes require OpenClaw runtime support that treats the topic agent as an explicit group route for non-default Telegram accounts.
- Add validation guidance for the `drop non-default account requires explicit binding` log, pointing maintainers to update/rebuild OpenClaw instead of adding persistent ACP binding workarounds.
- Fix Lisa wiki Slack ingestion on Python 3.9 by using `datetime.timezone.utc` instead of the Python 3.11-only `datetime.UTC` constant.

## Reviewer replay

1. Open `plugins/src/openclaw/skills/lisa-openclaw-connect-repo-topic/SKILL.md` and verify the self-test guidance calls out account-scoped topic runtime support and the non-default account drop log.
2. Open a generated variant, such as `plugins/lisa-openclaw-cursor/skills/lisa-openclaw-connect-repo-topic/SKILL.md`, and verify the same guidance is present.
3. Open `plugins/src/openclaw/skills/lisa-openclaw-setup/SKILL.md` and verify account-scoped Telegram topic agents are listed as a required OpenClaw capability.
4. On Python 3.9, import `plugins/src/wiki/scripts/ingest_slack_channel.py` and call `render_message(...)`; it should not fail on `datetime.UTC`.

## Verification

- `git diff --check`
- `./node_modules/.bin/prettier --check` on the OpenClaw skill files touched by this branch
- Source-to-generated variant `cmp` checks for the OpenClaw skill files
- `./node_modules/.bin/vitest run tests/unit/strategies/wiki-connector-source-sanitization.test.ts`
- Commit hook: `tsc --noEmit`, lint-staged, commitlint, AI co-authorship check
- Push hook: Bun audit, slow ESLint rules, knip, full coverage suite, integration tests
