### PR TITLE
fix(expo): close SDK 56 template gaps (react-navigation, worklets, a11y mock)

### DIFF
--- a/expo/copy-overwrite/knip.json
+++ b/expo/copy-overwrite/knip.json
@@ -118,6 +118,7 @@
     "react-hook-form",
     "react-native-element-dropdown",
     "react-native-keyboard-controller",
+    "react-native-worklets",
     "tailwind-variants",
     "tar",
     "text-encoding-polyfill",

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -119,8 +119,6 @@
       "@legendapp/motion": "^2.4.0",
       "@react-native-async-storage/async-storage": "2.2.0",
       "@react-native-masked-view/masked-view": "^0.3.2",
-      "@react-navigation/drawer": "^7.5.0",
-      "@react-navigation/elements": "^1.3.31",
       "@sentry/react-native": "~7.11.0",
       "@shopify/flash-list": "2.0.2",
       "@shopify/react-native-skia": "2.6.2",

--- a/src/migrations/ensure-jest-rn-mock-accessibility-manager.ts
+++ b/src/migrations/ensure-jest-rn-mock-accessibility-manager.ts
@@ -1,0 +1,130 @@
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const MOCK_FILE = "jest.config.react-native-mock.js";
+
+/** Anchor marking the start of the mocked TurboModule registry object */
+const ANCHOR = "module.exports = {\n";
+
+/** Presence of this key means the AccessibilityManager mock is already wired */
+const MARKER = "AccessibilityManager:";
+
+/**
+ * The AccessibilityManager TurboModule mock block, inserted as the first entry
+ * of the mocked module registry. Kept byte-for-byte in sync with the
+ * `expo/create-only/jest.config.react-native-mock.js` template.
+ */
+const ACCESSIBILITY_MANAGER_BLOCK = `  // SDK 56 / RN 0.85: AccessibilityInfo eagerly reads the AccessibilityManager
+  // TurboModule. Without a mock the module resolves to null and AccessibilityInfo
+  // methods reject with "NativeAccessibilityManagerIOS is not available", which
+  // the unhandledRejection handler escalates into a Jest worker crash that takes
+  // down every suite touching accessibility.
+  AccessibilityManager: {
+    getCurrentBoldTextState: onSuccess => onSuccess(false),
+    getCurrentGrayscaleState: onSuccess => onSuccess(false),
+    getCurrentInvertColorsState: onSuccess => onSuccess(false),
+    getCurrentReduceMotionState: onSuccess => onSuccess(false),
+    getCurrentDarkerSystemColorsState: onSuccess => onSuccess(false),
+    getCurrentPrefersCrossFadeTransitionsState: onSuccess => onSuccess(false),
+    getCurrentReduceTransparencyState: onSuccess => onSuccess(false),
+    getCurrentVoiceOverState: onSuccess => onSuccess(false),
+    setAccessibilityContentSizeMultipliers: () => {},
+    setAccessibilityFocus: () => {},
+    announceForAccessibility: () => {},
+    announceForAccessibilityWithOptions: () => {},
+    addListener: () => {},
+    removeListeners: () => {},
+    getConstants: () => ({}),
+  },
+`;
+
+/**
+ * Migration: add the RN 0.85 `AccessibilityManager` TurboModule mock to an
+ * existing project's `jest.config.react-native-mock.js`.
+ *
+ * That file is create-only, so Lisa never overwrites it once a project has been
+ * scaffolded. Projects created before the AccessibilityManager mock was added to
+ * the template therefore keep a stale copy. After the Expo SDK 56 / React Native
+ * 0.85 upgrade, `AccessibilityInfo` eagerly reads the `AccessibilityManager`
+ * TurboModule; without the mock it resolves to null and every test suite that
+ * touches accessibility crashes the Jest worker with
+ * "NativeAccessibilityManagerIOS is not available".
+ *
+ * Idempotent and conservative: only acts on Expo projects whose mock file exists,
+ * still exposes the `module.exports = {` registry anchor, and does not already
+ * define `AccessibilityManager`. The block is inserted as the first registry
+ * entry so it is unaffected by any project-specific module mocks that follow.
+ */
+export class EnsureJestRnMockAccessibilityManagerMigration implements Migration {
+  readonly name = "ensure-jest-rn-mock-accessibility-manager";
+  readonly description =
+    "Add the RN 0.85 AccessibilityManager TurboModule mock to jest.config.react-native-mock.js";
+
+  /**
+   * Applies to Expo projects whose create-only mock file exists, exposes the
+   * registry anchor, and does not already define the AccessibilityManager mock.
+   * @param ctx - Migration context
+   * @returns True when the mock is missing and can be safely inserted
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    if (!ctx.detectedTypes.includes("expo")) {
+      return false;
+    }
+    const mockPath = path.join(ctx.projectDir, MOCK_FILE);
+    if (!(await fse.pathExists(mockPath))) {
+      return false;
+    }
+    const content = await fse.readFile(mockPath, "utf8");
+    return content.includes(ANCHOR) && !content.includes(MARKER);
+  }
+
+  /**
+   * Insert the AccessibilityManager mock block immediately after the
+   * `module.exports = {` anchor. Re-checks the marker so the operation is
+   * idempotent even if `applies` and `apply` are called out of step.
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const mockPath = path.join(ctx.projectDir, MOCK_FILE);
+
+    if (!(await fse.pathExists(mockPath))) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const content = await fse.readFile(mockPath, "utf8");
+    if (content.includes(MARKER) || !content.includes(ANCHOR)) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const updated = content.replace(
+      ANCHOR,
+      ANCHOR + ACCESSIBILITY_MANAGER_BLOCK
+    );
+    const message = `Added AccessibilityManager TurboModule mock to ${MOCK_FILE}`;
+
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would add AccessibilityManager mock to ${MOCK_FILE}`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [MOCK_FILE],
+        message,
+      };
+    }
+
+    await fse.writeFile(mockPath, updated);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [MOCK_FILE],
+      message,
+    };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,4 +1,5 @@
 import { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
+import { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-mock-accessibility-manager.js";
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
@@ -15,6 +16,7 @@ export type {
   MigrationResult,
 } from "./migration.interface.js";
 export { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
+export { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-mock-accessibility-manager.js";
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
@@ -34,6 +36,7 @@ export class MigrationRegistry {
       new EnsureTsconfigLocalIncludesMigration(),
       new EnsureTsconfigLocalFilesFallbackMigration(),
       new EnsureAuditIgnoreLocalExclusionsMigration(),
+      new EnsureJestRnMockAccessibilityManagerMigration(),
       new EnsureLisaPostinstallMigration(),
     ];
   }

--- a/tests/unit/migrations/ensure-jest-rn-mock-accessibility-manager.test.ts
+++ b/tests/unit/migrations/ensure-jest-rn-mock-accessibility-manager.test.ts
@@ -1,0 +1,146 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureJestRnMockAccessibilityManagerMigration } from "../../../src/migrations/ensure-jest-rn-mock-accessibility-manager.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const MOCK_FILE = "jest.config.react-native-mock.js";
+
+/** A mock file as it looked before the AccessibilityManager block was added */
+const STALE_MOCK = `module.exports = {
+  PlatformConstants: {
+    getConstants: () => ({}),
+  },
+  AccessibilityInfo: {
+    getConstants: () => ({}),
+    isScreenReaderEnabled: () => Promise.resolve(false),
+  },
+};
+`;
+
+describe("EnsureJestRnMockAccessibilityManagerMigration", () => {
+  let migration: EnsureJestRnMockAccessibilityManagerMigration;
+  let tempDir: string;
+  let lisaDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    migration = new EnsureJestRnMockAccessibilityManagerMigration();
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Build a migration context for testing.
+   * @param detectedTypes - Detected project types
+   * @param dryRun - Whether to run in dry-run mode
+   * @returns A migration context suitable for tests
+   */
+  function createContext(
+    detectedTypes: readonly ProjectType[] = ["expo"],
+    dryRun = false
+  ): MigrationContext {
+    return {
+      projectDir,
+      lisaDir,
+      detectedTypes,
+      dryRun,
+      logger: new SilentLogger(),
+    };
+  }
+
+  /**
+   * Write a mock file into the project dir.
+   * @param content - File contents
+   */
+  async function seedMock(content: string): Promise<void> {
+    await fs.writeFile(path.join(projectDir, MOCK_FILE), content);
+  }
+
+  /**
+   * Read the project's mock file.
+   * @returns File contents
+   */
+  async function readMock(): Promise<string> {
+    return fs.readFile(path.join(projectDir, MOCK_FILE), "utf8");
+  }
+
+  it("applies to an Expo project whose mock lacks AccessibilityManager", async () => {
+    await seedMock(STALE_MOCK);
+    expect(await migration.applies(createContext())).toBe(true);
+  });
+
+  it("does not apply to non-Expo projects", async () => {
+    await seedMock(STALE_MOCK);
+    expect(await migration.applies(createContext(["typescript"]))).toBe(false);
+  });
+
+  it("does not apply when the mock file is absent", async () => {
+    expect(await migration.applies(createContext())).toBe(false);
+  });
+
+  it("does not apply when AccessibilityManager is already present", async () => {
+    await seedMock(
+      STALE_MOCK.replace("PlatformConstants:", "AccessibilityManager:")
+    );
+    expect(await migration.applies(createContext())).toBe(false);
+  });
+
+  it("does not apply when the module.exports anchor is missing", async () => {
+    await seedMock("export default {\n  PlatformConstants: {},\n};\n");
+    expect(await migration.applies(createContext())).toBe(false);
+  });
+
+  it("inserts the AccessibilityManager block as the first registry entry", async () => {
+    await seedMock(STALE_MOCK);
+
+    const result = await migration.apply(createContext());
+
+    expect(result.action).toBe("applied");
+    expect(result.changedFiles).toEqual([MOCK_FILE]);
+
+    const content = await readMock();
+    expect(content).toContain("AccessibilityManager: {");
+    expect(content).toContain(
+      "getCurrentVoiceOverState: onSuccess => onSuccess(false)"
+    );
+    // Inserted immediately after the registry anchor, before existing entries
+    expect(content.indexOf("AccessibilityManager:")).toBeLessThan(
+      content.indexOf("PlatformConstants:")
+    );
+    // Existing mocks are preserved
+    expect(content).toContain("AccessibilityInfo: {");
+  });
+
+  it("is idempotent (second apply is a noop)", async () => {
+    await seedMock(STALE_MOCK);
+    await migration.apply(createContext());
+    const afterFirst = await readMock();
+
+    const result = await migration.apply(createContext());
+
+    expect(result.action).toBe("noop");
+    expect(await readMock()).toBe(afterFirst);
+    // Exactly one AccessibilityManager entry
+    expect(afterFirst.match(/AccessibilityManager:/g)).toHaveLength(1);
+  });
+
+  it("does not write in dry-run mode but reports the change", async () => {
+    await seedMock(STALE_MOCK);
+
+    const result = await migration.apply(createContext(["expo"], true));
+
+    expect(result.action).toBe("applied");
+    expect(result.changedFiles).toEqual([MOCK_FILE]);
+    expect(await readMock()).toBe(STALE_MOCK);
+  });
+});

--- a/tests/unit/migrations/migration-registry.test.ts
+++ b/tests/unit/migrations/migration-registry.test.ts
@@ -65,6 +65,7 @@ describe("MigrationRegistry", () => {
     expect(names).toContain("ensure-tsconfig-local-includes");
     expect(names).toContain("ensure-tsconfig-local-files-fallback");
     expect(names).toContain("ensure-audit-ignore-local-exclusions");
+    expect(names).toContain("ensure-jest-rn-mock-accessibility-manager");
     expect(names).toContain("ensure-lisa-postinstall");
   });
 


### PR DESCRIPTION
## Summary
Closes three Expo SDK 56 gaps surfaced while upgrading host projects (thumbwar-frontend, expostarter):

1. **Drop `@react-navigation/drawer` + `@react-navigation/elements` from the expo package defaults** (`expo/package-lisa/package.lisa.json`). expo-router decoupled from react-navigation in SDK 56, so installing them alongside expo-router fails `expo-doctor`; the starter doesn't use them. Defaults are fill-if-missing, so projects that genuinely need drawer still add it explicitly.
2. **Ignore `react-native-worklets` in knip** (`expo/copy-overwrite/knip.json`). It's a required `react-native-reanimated` 4 peer that's never imported directly, so knip's dead-code check flagged it as unused after the SDK 54+ bump.
3. **New migration `ensure-jest-rn-mock-accessibility-manager`** to backfill existing projects. `jest.config.react-native-mock.js` is create-only, so projects scaffolded before the `AccessibilityManager` mock was added keep a stale copy — and under RN 0.85 every accessibility-touching jest suite crashes the worker (`NativeAccessibilityManagerIOS is not available`). The migration idempotently inserts the mock as the first registry entry on Expo projects that still expose the `module.exports` anchor and lack the mock; no-op otherwise.

## Why these were gaps
Each required a manual repo-level patch during the host-project upgrades. Fixing them upstream means future installs/forks are clean without intervention. (The template itself already had the `AccessibilityManager` mock — the gap was create-only staleness in existing projects, hence the migration rather than a template edit.)

## Test plan
- `vitest run tests/unit/migrations/` — 6 files / 81 tests pass (new suite covers applies/insert/idempotency/dry-run/non-expo/missing-file/missing-anchor; registry default-list updated).
- `tsc --noEmit` — passes.
- JSON templates validated.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new migration for Jest React Native mock accessibility configuration.

* **Chores**
  * Updated dependency configuration.
  * Extended dependency analysis tool configuration.

* **Tests**
  * Added comprehensive test coverage for the new migration, including idempotency and dry-run mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->