### PR TITLE
feat(opencode): add OpenCode as a fleet coding-agent harness

### DIFF
--- a/scripts/internal-opencode-skill-policy.json
+++ b/scripts/internal-opencode-skill-policy.json
@@ -1,0 +1,3 @@
+{
+  "denylistedSkills": ["harness-parity-council"]
+}

--- a/src/codex/command-skill-transformer.ts
+++ b/src/codex/command-skill-transformer.ts
@@ -20,12 +20,15 @@ interface CommandFrontmatter {
  * @param commandSource - Raw contents of the command .md file
  * @param skillName - Target skill name (already includes the `lisa-` prefix)
  * @param displayName - Human-readable name used as a fallback description
- * @returns The Codex skill SKILL.md content as a string
+ * @param runtimeLabel - Runtime the compatibility note targets (e.g. "Codex",
+ *   "OpenCode"). Defaults to "Codex" so existing Codex output is unchanged.
+ * @returns The skill SKILL.md content as a string
  */
 export function convertCommandToSkill(
   commandSource: string,
   skillName: string,
-  displayName: string
+  displayName: string,
+  runtimeLabel = "Codex"
 ): string {
   const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(
     commandSource
@@ -61,7 +64,8 @@ export function convertCommandToSkill(
   return `${frontmatter}${formatCommandCompatibilityBlock(
     parsedFrontmatter,
     skillName,
-    displayName
+    displayName,
+    runtimeLabel
   )}\n${body}\n`;
 }
 
@@ -118,20 +122,22 @@ function parseAllowedTools(raw: unknown): readonly string[] {
 /**
  * Emit command compatibility notes at the top of generated Codex skills.
  * @param frontmatter - Parsed Claude command metadata
- * @param skillName - Generated Codex skill name
+ * @param skillName - Generated skill name
  * @param displayName - Original Lisa command display name
+ * @param runtimeLabel - Runtime the note targets (e.g. "Codex", "OpenCode")
  * @returns Markdown block
  */
 function formatCommandCompatibilityBlock(
   frontmatter: CommandFrontmatter,
   skillName: string,
-  displayName: string
+  displayName: string,
+  runtimeLabel: string
 ): string {
   const baseLines = [
     "## Lisa Command Compatibility",
     "",
     `- Original Claude command: \`/${displayName}\``,
-    `- Codex invocation: \`$${skillName}\` or a plain-English request that matches this skill.`,
+    `- ${runtimeLabel} invocation: \`$${skillName}\` or a plain-English request that matches this skill.`,
     "- Treat the user's surrounding request as the command arguments.",
   ];
   const argumentLines =
@@ -146,7 +152,7 @@ function formatCommandCompatibilityBlock(
             .map(t => `\`${t}\``)
             .join(
               ", "
-            )}. Codex tool access is governed by the active Codex runtime and project policy.`,
+            )}. ${runtimeLabel} tool access is governed by the active ${runtimeLabel} runtime and project policy.`,
         ];
   return `${[...baseLines, ...argumentLines, ...toolLines].join("\n")}\n`;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -69,8 +69,9 @@ export const COPY_STRATEGIES: readonly CopyStrategy[] = [
  * - "cursor":  emit Cursor artifacts (Cursor reads .claude-plugin/ natively; no per-project files)
  * - "agy":     emit Antigravity artifacts (~/.gemini/config/mcp_config.json + AGENTS.md with baked rules)
  * - "copilot": emit GitHub Copilot artifacts (.github/copilot-instructions.md + plugin install)
+ * - "opencode": emit OpenCode artifacts (.opencode/skills/lisa/ + AGENTS.md, read natively)
  * - "both":    emit both Claude and Codex (back-compat — predates the per-agent expansion)
- * - "fleet":   emit for every supported agent (Claude + Codex + Cursor + agy + Copilot)
+ * - "fleet":   emit for every supported agent (Claude + Codex + Cursor + agy + Copilot + OpenCode)
  */
 export type Harness =
   | "claude"
@@ -78,6 +79,7 @@ export type Harness =
   | "cursor"
   | "agy"
   | "copilot"
+  | "opencode"
   | "both"
   | "fleet";
 
@@ -90,6 +92,7 @@ export const HARNESS_VALUES: readonly Harness[] = [
   "cursor",
   "agy",
   "copilot",
+  "opencode",
   "both",
   "fleet",
 ] as const;
@@ -99,7 +102,7 @@ export const HARNESS_VALUES: readonly Harness[] = [
  * (Cursor is intentionally absent — it needs no per-project writes; it consumes
  * the `lisa-cursor` plugin variant directly via its marketplace/loader.)
  */
-export type EmitAgent = "claude" | "codex" | "agy" | "copilot";
+export type EmitAgent = "claude" | "codex" | "agy" | "copilot" | "opencode";
 
 /**
  * Whether a configured harness should emit artifacts for a given agent.

--- a/src/core/lisa-skill-sources.ts
+++ b/src/core/lisa-skill-sources.ts
@@ -1,0 +1,264 @@
+/**
+ * Agent-agnostic discovery of Lisa-bundled skill and command sources.
+ *
+ * Both the Codex overlay (`src/codex/skills-installer.ts`) and the OpenCode
+ * overlay (`src/opencode/skills-installer.ts`) install skills into a host
+ * project's per-agent config folder (`.codex/skills/lisa/`,
+ * `.opencode/skills/lisa/`). The *discovery* half — walking
+ * `plugins/<plugin>/skills/` and `plugins/<plugin>/commands/`, de-duplicating
+ * across plugins, and applying the maintainer-only denylist — is identical for
+ * every agent. It lives here so the per-agent installers share one source of
+ * truth and can't drift apart.
+ *
+ * Discovery is pure with respect to the destination: it only reads from the
+ * Lisa package's `plugins/` tree and returns source descriptors. The copy /
+ * stale-cleanup / target-directory logic stays in each per-agent installer,
+ * because that is where the agents genuinely differ.
+ * @module core/lisa-skill-sources
+ */
+import * as fse from "fs-extra";
+import { readFile, readdir, stat } from "node:fs/promises";
+import * as path from "node:path";
+
+/** Prefix applied to Lisa command-as-skill names (e.g. `lisa-git-commit`). */
+export const LISA_COMMAND_SKILL_PREFIX = "lisa-";
+
+/** A single discovered bundled-skill folder source. */
+export interface BundledSkillSource {
+  /** Skill name (matches the SKILL.md `name` frontmatter and folder name). */
+  readonly skillName: string;
+  /** Absolute path to the source skill folder. */
+  readonly sourceDir: string;
+  /** Relative file paths inside the skill folder (recursive). */
+  readonly files: readonly string[];
+}
+
+/** A discovered Lisa command source to be converted into a skill. */
+export interface LisaCommandSource {
+  /** Final skill name including the `lisa-` prefix. */
+  readonly skillName: string;
+  /** Absolute path to the source command `.md` file. */
+  readonly sourcePath: string;
+  /** Original path components for display (e.g. "lisa:jira:create"). */
+  readonly displayName: string;
+}
+
+/**
+ * Load a skill distribution policy file that marks Lisa-maintainer-only skills
+ * as non-distributable.
+ *
+ * Missing or malformed policy files fail open to an empty set so tests and
+ * minimal package layouts remain usable.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package.
+ * @param policyRelativePath - Path to the policy JSON, relative to `lisaDir`.
+ * @returns Skill directory names that must not be installed into host projects.
+ */
+export async function loadSkillDenylist(
+  lisaDir: string,
+  policyRelativePath: string
+): Promise<ReadonlySet<string>> {
+  const policyPath = path.join(lisaDir, policyRelativePath);
+  if (!(await fse.pathExists(policyPath))) {
+    return new Set();
+  }
+  try {
+    const raw = await readFile(policyPath, "utf8");
+    const parsed = JSON.parse(raw) as { denylistedSkills?: unknown };
+    if (!Array.isArray(parsed.denylistedSkills)) {
+      return new Set();
+    }
+    return new Set(
+      parsed.denylistedSkills.filter(
+        (name): name is string => typeof name === "string"
+      )
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Walk `plugins/<plugin>/skills/<name>/` discovering each skill folder.
+ *
+ * De-duplicates by skill name with last-wins semantics: the base `lisa` plugin
+ * is always processed first, then remaining plugins in alphabetical order, so
+ * any stack-specific or third-party plugin overrides the base regardless of how
+ * the name sorts.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package.
+ * @param denylistedSkills - Skill names that must not ship to host projects.
+ * @returns De-duplicated bundled-skill sources, sorted by skill name.
+ */
+export async function discoverBundledSkills(
+  lisaDir: string,
+  denylistedSkills: ReadonlySet<string>
+): Promise<readonly BundledSkillSource[]> {
+  const pluginsDir = path.join(lisaDir, "plugins");
+  if (!(await fse.pathExists(pluginsDir))) {
+    return [];
+  }
+  const plugins = await orderedPluginNames(pluginsDir);
+  const candidatesByPlugin = await Promise.all(
+    plugins.map(pluginName => discoverSkillsInPlugin(pluginsDir, pluginName))
+  );
+  // Base-first iteration order + last-wins Map → stack-specific (and any
+  // other non-base plugin) overrides base for duplicate skill names.
+  const flat = candidatesByPlugin.flat();
+  const deduped = Array.from(
+    new Map(flat.map(source => [source.skillName, source])).values()
+  );
+  return Object.freeze(
+    [...deduped]
+      .filter(source => !denylistedSkills.has(source.skillName))
+      .sort((a, b) => a.skillName.localeCompare(b.skillName))
+  );
+}
+
+/**
+ * Walk `plugins/<plugin>/commands/**\/*.md` discovering each command file.
+ * Nested directories produce dash-joined skill names: `commands/git/commit.md`
+ * → `lisa-git-commit`.
+ *
+ * De-duplicates by final skill name with last-wins semantics (base `lisa`
+ * first, then remaining plugins alphabetically) so stack-specific plugins
+ * override the base regardless of name sort order.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package.
+ * @returns De-duplicated command-derived skill sources, sorted by skill name.
+ */
+export async function discoverLisaCommands(
+  lisaDir: string
+): Promise<readonly LisaCommandSource[]> {
+  const pluginsDir = path.join(lisaDir, "plugins");
+  if (!(await fse.pathExists(pluginsDir))) {
+    return [];
+  }
+  const plugins = await orderedPluginNames(pluginsDir);
+  const candidatesByPlugin = await Promise.all(
+    plugins.map(pluginName => discoverCommandsInPlugin(pluginsDir, pluginName))
+  );
+  const flat = candidatesByPlugin.flat();
+  const deduped = Array.from(
+    new Map(flat.map(source => [source.skillName, source])).values()
+  );
+  return Object.freeze(
+    [...deduped].sort((a, b) => a.skillName.localeCompare(b.skillName))
+  );
+}
+
+/**
+ * List the plugin directory names under `plugins/`, base-first then the rest
+ * alphabetically, skipping the `src/` build-input tree.
+ *
+ * Base-first ordering is what gives the last-wins Map dedup its "stack
+ * overrides base" behavior.
+ * @param pluginsDir - Absolute path to `<lisaDir>/plugins`.
+ * @returns Ordered plugin directory names.
+ */
+async function orderedPluginNames(
+  pluginsDir: string
+): Promise<readonly string[]> {
+  const all = (await readdir(pluginsDir)).filter(name => name !== "src");
+  return [
+    ...all.filter(n => n === "lisa"),
+    ...all.filter(n => n !== "lisa").sort((a, b) => a.localeCompare(b)),
+  ];
+}
+
+/**
+ * Discover every skill directory under one plugin's `skills/` folder. Skips any
+ * non-directory entries (defensive against stray .DS_Store and similar).
+ * @param pluginsDir - Absolute path to `<lisaDir>/plugins`.
+ * @param pluginName - Plugin directory name (e.g. "lisa", "lisa-rails").
+ * @returns Bundled-skill sources discovered in this plugin (file order).
+ */
+async function discoverSkillsInPlugin(
+  pluginsDir: string,
+  pluginName: string
+): Promise<readonly BundledSkillSource[]> {
+  const skillsDir = path.join(pluginsDir, pluginName, "skills");
+  if (!(await fse.pathExists(skillsDir))) {
+    return [];
+  }
+  const skillNames = await readdir(skillsDir);
+  const candidates = await Promise.all(
+    skillNames.map(async skillName => {
+      const sourceDir = path.join(skillsDir, skillName);
+      const dirStat = await stat(sourceDir);
+      if (!dirStat.isDirectory()) {
+        return undefined;
+      }
+      const files = await listFilesRecursive(sourceDir);
+      return { skillName, sourceDir, files } satisfies BundledSkillSource;
+    })
+  );
+  return candidates.filter(
+    (entry): entry is BundledSkillSource => entry !== undefined
+  );
+}
+
+/**
+ * Discover every Markdown command file under one plugin's `commands/` folder,
+ * turning each into a LisaCommandSource. Returns [] if the plugin has no
+ * commands directory.
+ * @param pluginsDir - Absolute path to `<lisaDir>/plugins`.
+ * @param pluginName - Plugin directory name.
+ * @returns Command sources discovered in this plugin (file order).
+ */
+async function discoverCommandsInPlugin(
+  pluginsDir: string,
+  pluginName: string
+): Promise<readonly LisaCommandSource[]> {
+  const commandsRoot = path.join(pluginsDir, pluginName, "commands");
+  if (!(await fse.pathExists(commandsRoot))) {
+    return [];
+  }
+  const files = await listFilesRecursive(commandsRoot);
+  return files
+    .filter(relFile => relFile.endsWith(".md"))
+    .map(relFile => {
+      // commands/git/commit.md → ["git", "commit"]
+      const segments = relFile.replace(/\.md$/, "").split(path.sep);
+      const skillName = `${LISA_COMMAND_SKILL_PREFIX}${segments.join("-")}`;
+      return {
+        skillName,
+        sourcePath: path.join(commandsRoot, relFile),
+        displayName: `lisa:${segments.join(":")}`,
+      };
+    });
+}
+
+/**
+ * Recursively list all file paths under `root` as relative paths. Pure
+ * recursion (no mutable accumulator) so the result is referentially clean.
+ * @param root - Absolute path to the directory to walk.
+ * @returns Relative paths of every regular file under `root`.
+ */
+export async function listFilesRecursive(
+  root: string
+): Promise<readonly string[]> {
+  return walkDir(root, "");
+}
+
+/**
+ * Recursive helper for listFilesRecursive. The relative path is threaded down
+ * so nested files come back as `subdir/file.ext` etc.
+ * @param root - Absolute path to the directory to walk.
+ * @param rel - Path under `root` we're currently visiting (relative).
+ * @returns Relative paths of every regular file at or below `root/rel`.
+ */
+async function walkDir(root: string, rel: string): Promise<readonly string[]> {
+  const abs = path.join(root, rel);
+  const entries = await readdir(abs, { withFileTypes: true });
+  const childResults = await Promise.all(
+    entries.map(entry => {
+      const childRel = path.join(rel, entry.name);
+      if (entry.isDirectory()) {
+        return walkDir(root, childRel);
+      }
+      if (entry.isFile()) {
+        return Promise.resolve([childRel] as readonly string[]);
+      }
+      return Promise.resolve([] as readonly string[]);
+    })
+  );
+  return childResults.flat();
+}

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -23,6 +23,11 @@ import {
 } from "../agy/mcp-installer.js";
 import { installCopilotPlugin } from "../copilot/plugin-installer.js";
 import { installCopilotInstructions } from "../copilot/copilot-instructions-installer.js";
+import {
+  readManagedManifest as readOpencodeManifest,
+  writeManagedManifest as writeOpencodeManifest,
+} from "../opencode/manifest.js";
+import { installSkills as installOpencodeSkills } from "../opencode/skills-installer.js";
 import { installClaudeMd } from "../claude/claude-md-installer.js";
 import { DetectorRegistry } from "../detection/index.js";
 import {
@@ -678,6 +683,7 @@ export class Lisa {
       await this.processClaudeEmit();
       await this.processAgyEmit();
       await this.processCopilotEmit();
+      await this.processOpencodeEmit();
       await this.processInstructionFilesMigration();
       await this.registerPlugins();
       await this.finalize();
@@ -998,6 +1004,49 @@ export class Lisa {
         }, copilot-instructions ${
           instructionsResult.created ? "created" : HOST_OWNED_LABEL
         }`
+      )
+    );
+  }
+
+  /**
+   * Emit OpenCode-targeted artifacts when the harness includes OpenCode.
+   *
+   * OpenCode reads the open Agent Skills format and `AGENTS.md` natively
+   * (opencode.ai/docs/skills, /docs/rules), so Lisa needs no transformed plugin
+   * variant: it writes skills (bundled + command-derived) into the
+   * OpenCode-owned `.opencode/skills/lisa/` tree and ensures the canonical
+   * `AGENTS.md` exists. Ownership is tracked via `.opencode/.lisa-managed.json`
+   * so updates clean up stale skills without touching host customizations.
+   * Skipped in dry-run mode and on harness modes that don't include OpenCode.
+   */
+  private async processOpencodeEmit(): Promise<void> {
+    const { harness } = this.config;
+    if (!harnessIncludesAgent(harness, "opencode")) {
+      return;
+    }
+    if (this.config.dryRun) {
+      this.deps.logger.info(pc.gray("OpenCode emit: skipped (dry-run mode)"));
+      return;
+    }
+
+    const previous = await readOpencodeManifest(this.config.destDir);
+    const skillsResult = await installOpencodeSkills(
+      this.config.lisaDir,
+      this.config.destDir,
+      previous.files
+    );
+    // OpenCode reads AGENTS.md natively; ensure the canonical file exists. It is
+    // create-only and host-owned afterward, so it's not tracked in the manifest.
+    const agentsResult = await installAgentsMd(this.config.destDir);
+    await writeOpencodeManifest(this.config.destDir, skillsResult.managedFiles);
+
+    this.deps.logger.info(
+      pc.cyan(
+        `OpenCode emit: ${skillsResult.installed.length} skills${
+          skillsResult.deleted.length > 0
+            ? ` (${skillsResult.deleted.length} stale skills removed)`
+            : ""
+        }, AGENTS.md ${agentsResult.created ? "created" : HOST_OWNED_LABEL}`
       )
     );
   }

--- a/src/opencode/manifest.ts
+++ b/src/opencode/manifest.ts
@@ -1,0 +1,110 @@
+/**
+ * Tracking manifest for Lisa-managed OpenCode artifacts.
+ *
+ * When Lisa emits files into a host project's `.opencode/` directory, it needs
+ * a way to identify those files on the next run so:
+ *   1. Stale files (skills Lisa stopped shipping) can be cleaned up.
+ *   2. Host-authored files (custom skills/agents the user added) are never
+ *      accidentally overwritten or deleted.
+ *
+ * The manifest lives at `.opencode/.lisa-managed.json` in the destination
+ * project. It is checked into the host repo so the cleanup behavior is
+ * deterministic across machines. This mirrors `src/codex/manifest.ts`; the only
+ * difference is the config directory (`.opencode/` vs `.codex/`).
+ * @module opencode/manifest
+ */
+import * as fse from "fs-extra";
+import { readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+/** Config directory OpenCode reads project-scope artifacts from */
+export const OPENCODE_CONFIG_DIR = ".opencode";
+
+/** Filename of the Lisa-managed manifest, relative to `.opencode/` */
+export const LISA_MANAGED_MANIFEST_FILENAME = ".lisa-managed.json";
+
+/** Schema of `.opencode/.lisa-managed.json` */
+export interface LisaManagedManifest {
+  /**
+   * Paths of files Lisa wrote, relative to the `.opencode/` directory.
+   * Used to identify which files to delete when they stop being shipped.
+   */
+  readonly files: readonly string[];
+}
+
+/**
+ * Read the Lisa-managed manifest from `<destDir>/.opencode/.lisa-managed.json`.
+ * Returns an empty manifest if the file doesn't exist.
+ * @param destDir - Absolute path to the destination project root.
+ * @returns Parsed manifest (with empty file list if absent).
+ */
+export async function readManagedManifest(
+  destDir: string
+): Promise<LisaManagedManifest> {
+  const manifestPath = path.join(
+    destDir,
+    OPENCODE_CONFIG_DIR,
+    LISA_MANAGED_MANIFEST_FILENAME
+  );
+  if (!(await fse.pathExists(manifestPath))) {
+    return { files: [] };
+  }
+  const raw = await readFile(manifestPath, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  return validateManifest(parsed, manifestPath);
+}
+
+/**
+ * Write the Lisa-managed manifest to disk, replacing any existing content.
+ * @param destDir - Absolute path to the destination project root.
+ * @param files - List of relative-to-`.opencode/` file paths Lisa shipped.
+ */
+export async function writeManagedManifest(
+  destDir: string,
+  files: readonly string[]
+): Promise<void> {
+  const configDir = path.join(destDir, OPENCODE_CONFIG_DIR);
+  await fse.ensureDir(configDir);
+  const manifestPath = path.join(configDir, LISA_MANAGED_MANIFEST_FILENAME);
+  const manifest: LisaManagedManifest = {
+    files: [...files].sort((a, b) => a.localeCompare(b)),
+  };
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * Type-guard validator. Throws on shape errors so a corrupted manifest is
+ * surfaced rather than silently producing data loss.
+ * @param parsed - Untrusted JSON value.
+ * @param manifestPath - Path used in error messages.
+ * @returns Validated manifest.
+ */
+function validateManifest(
+  parsed: unknown,
+  manifestPath: string
+): LisaManagedManifest {
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(
+      `Invalid Lisa-managed manifest at ${manifestPath}: expected JSON object`
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.files)) {
+    throw new Error(
+      `Invalid Lisa-managed manifest at ${manifestPath}: expected "files" array`
+    );
+  }
+  const files = obj.files.filter(
+    (file): file is string => typeof file === "string"
+  );
+  if (files.length !== obj.files.length) {
+    throw new Error(
+      `Invalid Lisa-managed manifest at ${manifestPath}: "files" must contain only strings`
+    );
+  }
+  return { files: Object.freeze(files) };
+}

--- a/src/opencode/manifest.ts
+++ b/src/opencode/manifest.ts
@@ -98,13 +98,43 @@ function validateManifest(
       `Invalid Lisa-managed manifest at ${manifestPath}: expected "files" array`
     );
   }
-  const files = obj.files.filter(
-    (file): file is string => typeof file === "string"
+  const files = obj.files.map((file, index) =>
+    validateManifestPath(file, index, manifestPath)
   );
-  if (files.length !== obj.files.length) {
+  return { files: Object.freeze(files) };
+}
+
+/**
+ * Validate one manifest entry is a normalized, in-tree relative path.
+ *
+ * The manifest drives stale-file deletion, so a traversal or absolute entry
+ * (`../../etc`, `/abs`, mixed `\` separators) could expand the delete scope
+ * beyond the Lisa skill boundary. Reject those here so no consumer ever acts on
+ * an unsafe path.
+ * @param file - Untrusted entry from the parsed `files` array.
+ * @param index - Position in the array (for error messages).
+ * @param manifestPath - Path used in error messages.
+ * @returns The validated, forward-slash-normalized relative path.
+ */
+function validateManifestPath(
+  file: unknown,
+  index: number,
+  manifestPath: string
+): string {
+  if (typeof file !== "string") {
     throw new Error(
-      `Invalid Lisa-managed manifest at ${manifestPath}: "files" must contain only strings`
+      `Invalid Lisa-managed manifest at ${manifestPath}: "files[${index}]" must be a string`
     );
   }
-  return { files: Object.freeze(files) };
+  const normalized = file.replaceAll("\\", "/");
+  const segments = normalized.split("/");
+  if (
+    path.posix.isAbsolute(normalized) ||
+    segments.some(seg => seg === "" || seg === "." || seg === "..")
+  ) {
+    throw new Error(
+      `Invalid Lisa-managed manifest at ${manifestPath}: "files[${index}]" must be a normalized relative path`
+    );
+  }
+  return normalized;
 }

--- a/src/opencode/skills-installer.ts
+++ b/src/opencode/skills-installer.ts
@@ -1,26 +1,24 @@
 /**
- * Install Lisa-bundled skills into a host project's `.codex/skills/lisa/`.
+ * Install Lisa-bundled skills into a host project's `.opencode/skills/lisa/`.
  *
- * Skills are the open Agent Skills format (SKILL.md + optional siblings).
- * Codex discovers them from the project config folder (`<destDir>/.codex/`)
- * via the loader at `codex-rs/core-skills/src/loader.rs`.
+ * OpenCode discovers skills (the open Agent Skills format: SKILL.md + optional
+ * siblings) natively from `.opencode/skills/<name>/`, walking up from the cwd to
+ * the git worktree (see opencode.ai/docs/skills). It ALSO reads `.claude/skills`
+ * and `.agents/skills`, but Lisa writes into the OpenCode-owned `.opencode/`
+ * tree so its artifacts never collide with a Claude install on the same machine
+ * (OpenCode dedupes duplicate skill names with a warning — verified-by-run on
+ * opencode 1.16.2).
  *
  * What this installs:
- *   1. Lisa-bundled skill folders from `plugins/<p>/skills/<n>/` are copied
- *      verbatim to `.codex/skills/lisa/<n>/`.
- *   2. Lisa commands (e.g., `plugins/lisa/commands/fix.md`) are converted
- *      to skills since Codex has no first-class slash-command extension
- *      point. A command at `commands/jira/create.md` becomes a skill named
- *      `lisa-jira-create` invocable via `$lisa-jira-create`.
+ *   1. Lisa-bundled skill folders from `plugins/<p>/skills/<n>/` copied verbatim
+ *      to `.opencode/skills/lisa/<n>/` (OpenCode reads SKILL.md verbatim — no
+ *      transform needed, unlike the Codex TOML/openai.yaml path).
+ *   2. Lisa commands converted to skills with a `lisa-` prefix, since the safest
+ *      cross-runtime carrier for a Lisa command is a self-complete skill.
  *
- * The lisa-namespace prefix ensures Lisa's commands-as-skills don't collide
- * with same-named skills (e.g., Lisa's `fix.md` command + Lisa's existing
- * `fix` skill if one ever existed).
- *
- * Source discovery (walking the plugin tree, dedup, denylist) is shared with
- * the OpenCode overlay via `core/lisa-skill-sources`; only the copy/stale/
- * target-directory logic is Codex-specific and lives here.
- * @module codex/skills-installer
+ * Source discovery (walking the plugin tree, dedup, denylist) is shared with the
+ * Codex overlay via `core/lisa-skill-sources`.
+ * @module opencode/skills-installer
  */
 import * as fse from "fs-extra";
 import { mkdir, copyFile, readFile, rm, writeFile } from "node:fs/promises";
@@ -32,21 +30,22 @@ import {
   discoverLisaCommands,
   loadSkillDenylist,
 } from "../core/lisa-skill-sources.js";
-import { convertCommandToSkill } from "./command-skill-transformer.js";
+import { convertCommandToSkill } from "../codex/command-skill-transformer.js";
+import { OPENCODE_CONFIG_DIR } from "./manifest.js";
 
-export { convertCommandToSkill } from "./command-skill-transformer.js";
-export { LISA_COMMAND_SKILL_PREFIX } from "../core/lisa-skill-sources.js";
+/** Runtime label threaded into generated command-as-skill compatibility notes */
+const OPENCODE_RUNTIME_LABEL = "OpenCode";
 
-/** Subdirectory inside `.codex/skills/` where Lisa-owned skills live */
+/** Subdirectory inside `.opencode/skills/` where Lisa-owned skills live */
 export const LISA_SKILLS_SUBDIR = path.join("skills", "lisa");
 
 /** Filename of the skill manifest at the root of every skill folder */
 const SKILL_MD_FILENAME = "SKILL.md";
 
-/** Path to the Codex skill distribution policy, relative to the Lisa root */
-const INTERNAL_CODEX_SKILL_POLICY_RELATIVE_PATH = path.join(
+/** Path to the OpenCode skill distribution policy, relative to the Lisa root */
+const INTERNAL_OPENCODE_SKILL_POLICY_RELATIVE_PATH = path.join(
   "scripts",
-  "internal-codex-skill-policy.json"
+  "internal-opencode-skill-policy.json"
 );
 
 /** Result of one skill copy */
@@ -55,7 +54,7 @@ export interface InstalledSkill {
   readonly name: string;
   /** Source kind: bundled skill folder or generated from command */
   readonly source: "bundled" | "command";
-  /** Path written, relative to `.codex/` */
+  /** Path written, relative to `.opencode/` */
   readonly relativePath: string;
 }
 
@@ -68,27 +67,27 @@ export interface SkillsInstallResult {
 }
 
 /**
- * Install all Lisa-bundled skills + command-derived skills.
+ * Install all Lisa-bundled skills + command-derived skills into
+ * `.opencode/skills/lisa/`.
  *
- * Stale skills (in the previous manifest but no longer in Lisa's catalog)
- * are deleted from `.codex/skills/lisa/` so renames in the source tree
- * don't leave orphan directories behind.
- * @param lisaDir - Absolute path to the Lisa repo root
- * @param destDir - Absolute path to the host project root
+ * Stale skills (in the previous manifest but no longer in Lisa's catalog) are
+ * deleted so renames in the source tree don't leave orphan directories behind.
+ * @param lisaDir - Absolute path to the Lisa repo root.
+ * @param destDir - Absolute path to the host project root.
  * @param previousManagedFiles - Files Lisa managed on the previous run
- *   (relative to `.codex/`); used to detect stale skill directories
- * @returns Result describing installed skills + managed files + deletions
+ *   (relative to `.opencode/`); used to detect stale skill directories.
+ * @returns Result describing installed skills + managed files + deletions.
  */
 export async function installSkills(
   lisaDir: string,
   destDir: string,
   previousManagedFiles: readonly string[]
 ): Promise<SkillsInstallResult> {
-  const skillsDir = path.join(destDir, ".codex", LISA_SKILLS_SUBDIR);
+  const skillsDir = path.join(destDir, OPENCODE_CONFIG_DIR, LISA_SKILLS_SUBDIR);
   await fse.ensureDir(skillsDir);
   const denylistedSkills = await loadSkillDenylist(
     lisaDir,
-    INTERNAL_CODEX_SKILL_POLICY_RELATIVE_PATH
+    INTERNAL_OPENCODE_SKILL_POLICY_RELATIVE_PATH
   );
 
   // Step 1: bundled skills
@@ -131,18 +130,18 @@ export async function installSkills(
 }
 
 /**
- * Delete skill directories that were Lisa-managed last run but aren't
- * shipped this run. Identifies skill names from the previous manifest by
- * looking for paths inside `.codex/skills/lisa/<name>/...`.
+ * Delete skill directories that were Lisa-managed last run but aren't shipped
+ * this run. Identifies skill names from the previous manifest by looking for
+ * paths inside `.opencode/skills/lisa/<name>/...`.
  *
  * Whole directories are removed (not individual files) so siblings the host
- * accidentally added inside a Lisa skill folder also disappear — Lisa owns
- * the directory boundary, not just specific files.
+ * accidentally added inside a Lisa skill folder also disappear — Lisa owns the
+ * directory boundary, not just specific files.
  * @param previousManagedFiles - Files Lisa managed on the previous run
- *   (relative to `.codex/`)
- * @param currentSkillNames - Skill names Lisa is shipping this run
- * @param destDir - Absolute path to the host project root
- * @returns Sorted list of stale skill names that were deleted
+ *   (relative to `.opencode/`).
+ * @param currentSkillNames - Skill names Lisa is shipping this run.
+ * @param destDir - Absolute path to the host project root.
+ * @returns Sorted list of stale skill names that were deleted.
  */
 async function deleteStaleSkills(
   previousManagedFiles: readonly string[],
@@ -157,7 +156,12 @@ async function deleteStaleSkills(
   const stale = previousSkillNames.filter(name => !currentSkillNames.has(name));
   await Promise.all(
     stale.map(async name => {
-      const absPath = path.join(destDir, ".codex", LISA_SKILLS_SUBDIR, name);
+      const absPath = path.join(
+        destDir,
+        OPENCODE_CONFIG_DIR,
+        LISA_SKILLS_SUBDIR,
+        name
+      );
       if (await fse.pathExists(absPath)) {
         await rm(absPath, { recursive: true, force: true });
       }
@@ -167,12 +171,11 @@ async function deleteStaleSkills(
 }
 
 /**
- * Pick the unique skill-folder names out of the previous manifest's file
- * list — every path inside `.codex/skills/lisa/<name>/...` contributes
- * `<name>` to the result.
- * @param previousManagedFiles - Files Lisa managed on the previous run
- * @param lisaSkillsPrefix - The path prefix that identifies Lisa skill files
- * @returns Unique skill names extracted from those paths
+ * Pick the unique skill-folder names out of the previous manifest's file list —
+ * every path inside `.opencode/skills/lisa/<name>/...` contributes `<name>`.
+ * @param previousManagedFiles - Files Lisa managed on the previous run.
+ * @param lisaSkillsPrefix - The path prefix that identifies Lisa skill files.
+ * @returns Unique skill names extracted from those paths.
  */
 function extractPreviousSkillNames(
   previousManagedFiles: readonly string[],
@@ -186,10 +189,10 @@ function extractPreviousSkillNames(
 }
 
 /**
- * Copy one bundled skill folder verbatim into the host's `.codex/skills/lisa/`.
- * @param source - Bundled-skill source to copy
- * @param skillsDir - Absolute path to `<destDir>/.codex/skills/lisa/`
- * @returns Result describing the installed skill
+ * Copy one bundled skill folder verbatim into `.opencode/skills/lisa/`.
+ * @param source - Bundled-skill source to copy.
+ * @param skillsDir - Absolute path to `<destDir>/.opencode/skills/lisa/`.
+ * @returns Result describing the installed skill.
  */
 async function copyBundledSkill(
   source: BundledSkillSource,
@@ -213,14 +216,13 @@ async function copyBundledSkill(
 }
 
 /**
- * Convert a Lisa command Markdown file into a Codex skill.
+ * Convert a Lisa command Markdown file into an OpenCode skill.
  *
- * The command's frontmatter becomes skill metadata plus a compatibility note.
  * The command body becomes the skill body, with `$ARGUMENTS` replaced by an
  * explicit instruction to use the user's surrounding request as arguments.
- * @param cmd - Discovered command source
- * @param skillsDir - Absolute path to `<destDir>/.codex/skills/lisa/`
- * @returns Result describing the installed (command-derived) skill
+ * @param cmd - Discovered command source.
+ * @param skillsDir - Absolute path to `<destDir>/.opencode/skills/lisa/`.
+ * @returns Result describing the installed (command-derived) skill.
  */
 async function emitCommandAsSkill(
   cmd: LisaCommandSource,
@@ -230,7 +232,8 @@ async function emitCommandAsSkill(
   const skillContent = convertCommandToSkill(
     sourceContent,
     cmd.skillName,
-    cmd.displayName
+    cmd.displayName,
+    OPENCODE_RUNTIME_LABEL
   );
   const destSkillDir = path.join(skillsDir, cmd.skillName);
   await fse.ensureDir(destSkillDir);

--- a/src/opencode/skills-installer.ts
+++ b/src/opencode/skills-installer.ts
@@ -199,6 +199,10 @@ async function copyBundledSkill(
   skillsDir: string
 ): Promise<InstalledSkill> {
   const destSkillDir = path.join(skillsDir, source.skillName);
+  // Clean-replace the Lisa-owned skill folder before copying so files removed
+  // from the source between releases don't linger inside a surviving skill.
+  // Lisa owns this directory boundary (host customizations belong outside it).
+  await rm(destSkillDir, { recursive: true, force: true });
   await fse.ensureDir(destSkillDir);
   await Promise.all(
     source.files.map(async file => {

--- a/tests/unit/opencode/manifest.test.ts
+++ b/tests/unit/opencode/manifest.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the OpenCode Lisa-managed manifest.
+ *
+ * Covers round-trip read/write, the empty-when-absent default, deterministic
+ * sorting, and validation throwing on corrupt input.
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_MANAGED_MANIFEST_FILENAME,
+  OPENCODE_CONFIG_DIR,
+  readManagedManifest,
+  writeManagedManifest,
+} from "../../../src/opencode/manifest.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+describe("opencode/manifest", () => {
+  let destDir: string;
+
+  beforeEach(async () => {
+    destDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(destDir);
+  });
+
+  /**
+   * Absolute path of the manifest file under the test destination.
+   * @returns Path to `.opencode/.lisa-managed.json`.
+   */
+  function manifestPath(): string {
+    return path.join(
+      destDir,
+      OPENCODE_CONFIG_DIR,
+      LISA_MANAGED_MANIFEST_FILENAME
+    );
+  }
+
+  it("returns an empty manifest when none exists", async () => {
+    expect(await readManagedManifest(destDir)).toEqual({ files: [] });
+  });
+
+  it("writes and reads back a sorted file list", async () => {
+    await writeManagedManifest(destDir, [
+      "skills/lisa/zebra/SKILL.md",
+      "skills/lisa/alpha/SKILL.md",
+    ]);
+    const manifest = await readManagedManifest(destDir);
+    expect(manifest.files).toEqual([
+      "skills/lisa/alpha/SKILL.md",
+      "skills/lisa/zebra/SKILL.md",
+    ]);
+  });
+
+  it("writes JSON with a trailing newline", async () => {
+    await writeManagedManifest(destDir, ["skills/lisa/a/SKILL.md"]);
+    expect(await fs.readFile(manifestPath(), "utf8")).toMatch(/}\n$/);
+  });
+
+  it("throws on a corrupt manifest (missing files array)", async () => {
+    await fs.ensureDir(path.join(destDir, OPENCODE_CONFIG_DIR));
+    await fs.writeFile(manifestPath(), JSON.stringify({ nope: 1 }), "utf8");
+    await expect(readManagedManifest(destDir)).rejects.toThrow(
+      /expected "files" array/
+    );
+  });
+});

--- a/tests/unit/opencode/manifest.test.ts
+++ b/tests/unit/opencode/manifest.test.ts
@@ -66,4 +66,31 @@ describe("opencode/manifest", () => {
       /expected "files" array/
     );
   });
+
+  it("rejects traversal and absolute path entries", async () => {
+    await fs.ensureDir(path.join(destDir, OPENCODE_CONFIG_DIR));
+    const cases = [
+      "skills/lisa/../../etc/passwd",
+      "/abs/skills/lisa/x/SKILL.md",
+      "skills/./lisa/x/SKILL.md",
+    ];
+    for (const bad of cases) {
+      await fs.writeFile(
+        manifestPath(),
+        JSON.stringify({ files: [bad] }),
+        "utf8"
+      );
+      await expect(readManagedManifest(destDir)).rejects.toThrow(
+        /normalized relative path/
+      );
+    }
+  });
+
+  it("rejects non-string file entries", async () => {
+    await fs.ensureDir(path.join(destDir, OPENCODE_CONFIG_DIR));
+    await fs.writeFile(manifestPath(), JSON.stringify({ files: [42] }), "utf8");
+    await expect(readManagedManifest(destDir)).rejects.toThrow(
+      /must be a string/
+    );
+  });
 });

--- a/tests/unit/opencode/skills-installer.test.ts
+++ b/tests/unit/opencode/skills-installer.test.ts
@@ -303,4 +303,26 @@ describe("opencode/skills-installer", () => {
       cmdFirst
     );
   });
+
+  it("removes files dropped from source inside a surviving skill", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, {
+      [SKILL_MD]: SAMPLE_SKILL_MD,
+      "scripts/old.sh": "#!/bin/bash\necho old\n",
+    });
+    await installSkills(lisaDir, destDir, []);
+    expect(
+      await fs.pathExists(installedSkillPath(BUG_TRIAGE, "scripts/old.sh"))
+    ).toBe(true);
+
+    // Source no longer ships scripts/old.sh; the skill folder still exists.
+    await fs.remove(
+      path.join(lisaDir, "plugins", "lisa", "skills", BUG_TRIAGE, "scripts")
+    );
+    await installSkills(lisaDir, destDir, []);
+
+    expect(
+      await fs.pathExists(installedSkillPath(BUG_TRIAGE, "scripts/old.sh"))
+    ).toBe(false);
+    expect(await fs.pathExists(installedSkillPath(BUG_TRIAGE))).toBe(true);
+  });
 });

--- a/tests/unit/opencode/skills-installer.test.ts
+++ b/tests/unit/opencode/skills-installer.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for the OpenCode skills installer.
+ *
+ * Covers:
+ *   - Bundled skill directory copy (verbatim, including nested files)
+ *   - Command-to-skill conversion (preserve description, strip $ARGUMENTS,
+ *     OpenCode runtime label in the compatibility note)
+ *   - Skill name namespacing (`lisa-` prefix on commands, raw on skills)
+ *   - Maintainer-only denylist (harness-parity-council excluded)
+ *   - De-dup across plugins, stale cleanup, never deleting host skills
+ *   - Target directory is `.opencode/skills/lisa/` (not `.codex/`)
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_SKILLS_SUBDIR,
+  installSkills,
+} from "../../../src/opencode/skills-installer.js";
+import { LISA_COMMAND_SKILL_PREFIX } from "../../../src/core/lisa-skill-sources.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+/** Reusable bundled-skill name for happy-path tests */
+const BUG_TRIAGE = "bug-triage";
+/** SKILL.md filename — appears in many path joins */
+const SKILL_MD = "SKILL.md";
+/** Command-derived skill name reused across assertions */
+const LISA_FIX = "lisa-fix";
+/** Stale-skill folder name reused across cleanup assertions */
+const OLD_SKILL = "old-skill";
+/** Maintainer-only skill name used in denylist assertions */
+const PARITY_COUNCIL = "harness-parity-council";
+/** Host-owned skill folder name used in safety assertions */
+const HOST_SKILL = "host-skill";
+/** OpenCode config dir all artifacts land under */
+const OPENCODE_DIR = ".opencode";
+
+const SAMPLE_SKILL_MD = `---
+name: bug-triage
+description: Triage a bug
+---
+
+Body content here.
+`;
+
+const SAMPLE_COMMAND_MD = `---
+description: "Fix a bug. Reproduces, analyzes, fixes via TDD."
+argument-hint: "<description>"
+---
+
+Apply the intent-routing rule and execute the Implement flow.
+
+$ARGUMENTS
+`;
+
+describe("opencode/skills-installer", () => {
+  let tempDir: string;
+  let lisaDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a fake plugin tree under <lisaDir>/plugins/<plugin>/skills/<n>/.
+   * @param pluginName - Plugin directory name.
+   * @param skillName - Skill directory name (matches the `name` frontmatter).
+   * @param files - Map of relative-to-skill-dir filename → content.
+   */
+  async function seedSkill(
+    pluginName: string,
+    skillName: string,
+    files: Record<string, string>
+  ): Promise<void> {
+    const skillDir = path.join(
+      lisaDir,
+      "plugins",
+      pluginName,
+      "skills",
+      skillName
+    );
+    await fs.ensureDir(skillDir);
+    for (const [filename, content] of Object.entries(files)) {
+      const filePath = path.join(skillDir, filename);
+      await fs.ensureDir(path.dirname(filePath));
+      await fs.writeFile(filePath, content, "utf8");
+    }
+  }
+
+  /**
+   * Write a fake command file under plugins/<plugin>/commands/<...path>.md.
+   * @param pluginName - Plugin directory name.
+   * @param relPath - Path under commands/ (e.g. "fix.md", "git/commit.md").
+   * @param content - Markdown content of the command file.
+   */
+  async function seedCommand(
+    pluginName: string,
+    relPath: string,
+    content: string
+  ): Promise<void> {
+    const filePath = path.join(
+      lisaDir,
+      "plugins",
+      pluginName,
+      "commands",
+      relPath
+    );
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, content, "utf8");
+  }
+
+  /**
+   * Resolve the absolute path of an installed Lisa skill folder file.
+   * @param skillName - Installed skill folder name.
+   * @param file - File inside the skill folder (default SKILL.md).
+   * @returns Absolute path under `.opencode/skills/lisa/`.
+   */
+  function installedSkillPath(skillName: string, file = SKILL_MD): string {
+    return path.join(
+      destDir,
+      OPENCODE_DIR,
+      LISA_SKILLS_SUBDIR,
+      skillName,
+      file
+    );
+  }
+
+  it("copies a bundled skill folder verbatim into .opencode/skills/lisa", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, {
+      [SKILL_MD]: SAMPLE_SKILL_MD,
+      "scripts/helper.sh": "#!/bin/bash\necho hi\n",
+      "references/REFERENCE.md": "# Reference\n",
+    });
+    const result = await installSkills(lisaDir, destDir, []);
+
+    expect(await fs.readFile(installedSkillPath(BUG_TRIAGE), "utf8")).toBe(
+      SAMPLE_SKILL_MD
+    );
+    expect(
+      await fs.readFile(
+        installedSkillPath(BUG_TRIAGE, "scripts/helper.sh"),
+        "utf8"
+      )
+    ).toContain("echo hi");
+    expect(result.installed.find(s => s.name === BUG_TRIAGE)?.source).toBe(
+      "bundled"
+    );
+  });
+
+  it("converts a top-level command into a lisa- prefixed skill", async () => {
+    await seedCommand("lisa", "fix.md", SAMPLE_COMMAND_MD);
+    const result = await installSkills(lisaDir, destDir, []);
+
+    const skillPath = installedSkillPath(`${LISA_COMMAND_SKILL_PREFIX}fix`);
+    expect(await fs.pathExists(skillPath)).toBe(true);
+    const content = await fs.readFile(skillPath, "utf8");
+    expect(content).toMatch(/name: lisa-fix\n/);
+    expect(content).not.toContain("$ARGUMENTS");
+    expect(result.installed.find(s => s.name === LISA_FIX)?.source).toBe(
+      "command"
+    );
+  });
+
+  it("labels the command compatibility note for OpenCode (not Codex)", async () => {
+    await seedCommand("lisa", "fix.md", SAMPLE_COMMAND_MD);
+    await installSkills(lisaDir, destDir, []);
+    const content = await fs.readFile(
+      installedSkillPath(`${LISA_COMMAND_SKILL_PREFIX}fix`),
+      "utf8"
+    );
+    expect(content).toContain("OpenCode invocation: `$lisa-fix`");
+    expect(content).not.toContain("Codex invocation");
+  });
+
+  it("converts a nested command using dash-joined namespace", async () => {
+    await seedCommand("lisa", "git/commit.md", SAMPLE_COMMAND_MD);
+    const skillName = `${LISA_COMMAND_SKILL_PREFIX}git-commit`;
+    const result = await installSkills(lisaDir, destDir, []);
+
+    expect(await fs.pathExists(installedSkillPath(skillName))).toBe(true);
+    expect(result.installed.find(s => s.name === skillName)?.source).toBe(
+      "command"
+    );
+  });
+
+  it("excludes maintainer-only skills on the denylist", async () => {
+    await fs.ensureDir(path.join(lisaDir, "scripts"));
+    await fs.writeFile(
+      path.join(lisaDir, "scripts", "internal-opencode-skill-policy.json"),
+      JSON.stringify({ denylistedSkills: [PARITY_COUNCIL] }),
+      "utf8"
+    );
+    await seedSkill("lisa", PARITY_COUNCIL, {
+      [SKILL_MD]: SAMPLE_SKILL_MD.replace("bug-triage", PARITY_COUNCIL),
+    });
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
+    const result = await installSkills(lisaDir, destDir, []);
+
+    const names = result.installed.map(s => s.name);
+    expect(names).toContain(BUG_TRIAGE);
+    expect(names).not.toContain(PARITY_COUNCIL);
+    expect(await fs.pathExists(installedSkillPath(PARITY_COUNCIL))).toBe(false);
+  });
+
+  it("returns managedFiles including bundled and command-derived skills", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, {
+      [SKILL_MD]: SAMPLE_SKILL_MD,
+      "scripts/helper.sh": "#!/bin/bash\n",
+    });
+    await seedCommand("lisa", "fix.md", SAMPLE_COMMAND_MD);
+    const result = await installSkills(lisaDir, destDir, []);
+
+    expect(result.managedFiles).toContain(
+      path.join(LISA_SKILLS_SUBDIR, BUG_TRIAGE, SKILL_MD)
+    );
+    expect(result.managedFiles).toContain(
+      path.join(LISA_SKILLS_SUBDIR, BUG_TRIAGE, "scripts", "helper.sh")
+    );
+    expect(result.managedFiles).toContain(
+      path.join(LISA_SKILLS_SUBDIR, LISA_FIX, SKILL_MD)
+    );
+  });
+
+  it("de-duplicates skills by name across plugins (stack wins over base)", async () => {
+    const railsContent = SAMPLE_SKILL_MD.replace(
+      "Triage a bug",
+      "Rails version"
+    );
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
+    await seedSkill("lisa-rails", BUG_TRIAGE, { [SKILL_MD]: railsContent });
+    const result = await installSkills(lisaDir, destDir, []);
+
+    expect(result.installed.filter(s => s.name === BUG_TRIAGE)).toHaveLength(1);
+    expect(await fs.readFile(installedSkillPath(BUG_TRIAGE), "utf8")).toBe(
+      railsContent
+    );
+  });
+
+  it("deletes stale skills managed previously but not shipped now", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
+    const skillsDir = path.join(destDir, OPENCODE_DIR, LISA_SKILLS_SUBDIR);
+    await fs.ensureDir(path.join(skillsDir, OLD_SKILL));
+    await fs.writeFile(
+      path.join(skillsDir, OLD_SKILL, SKILL_MD),
+      "stale",
+      "utf8"
+    );
+    const previousManagedFiles = [
+      path.join(LISA_SKILLS_SUBDIR, BUG_TRIAGE, SKILL_MD),
+      path.join(LISA_SKILLS_SUBDIR, OLD_SKILL, SKILL_MD),
+    ];
+    const result = await installSkills(lisaDir, destDir, previousManagedFiles);
+
+    expect(result.deleted).toEqual([OLD_SKILL]);
+    expect(await fs.pathExists(path.join(skillsDir, OLD_SKILL))).toBe(false);
+    expect(await fs.pathExists(path.join(skillsDir, BUG_TRIAGE))).toBe(true);
+  });
+
+  it("never deletes skills outside .opencode/skills/lisa/", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
+    const hostSkillsDir = path.join(destDir, OPENCODE_DIR, "skills", "host");
+    await fs.ensureDir(path.join(hostSkillsDir, HOST_SKILL));
+    await fs.writeFile(
+      path.join(hostSkillsDir, HOST_SKILL, SKILL_MD),
+      "host-owned",
+      "utf8"
+    );
+    const result = await installSkills(lisaDir, destDir, [
+      path.join("skills", "host", HOST_SKILL, SKILL_MD),
+    ]);
+
+    expect(result.deleted).toEqual([]);
+    expect(await fs.pathExists(path.join(hostSkillsDir, HOST_SKILL))).toBe(
+      true
+    );
+  });
+
+  it("idempotent: running twice produces the same files", async () => {
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
+    await seedCommand("lisa", "fix.md", SAMPLE_COMMAND_MD);
+
+    await installSkills(lisaDir, destDir, []);
+    const skillFirst = await fs.readFile(
+      installedSkillPath(BUG_TRIAGE),
+      "utf8"
+    );
+    const cmdFirst = await fs.readFile(installedSkillPath(LISA_FIX), "utf8");
+
+    await installSkills(lisaDir, destDir, []);
+    expect(await fs.readFile(installedSkillPath(BUG_TRIAGE), "utf8")).toBe(
+      skillFirst
+    );
+    expect(await fs.readFile(installedSkillPath(LISA_FIX), "utf8")).toBe(
+      cmdFirst
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds **OpenCode** ([opencode.ai](https://opencode.ai)) as a new Lisa install target, joining Claude, Codex, Cursor, agy, and Copilot. `lisa apply --harness opencode` (and `--harness fleet`) now delivers Lisa's skills and rules to OpenCode projects.

## Why this is the lightest agent we've onboarded

OpenCode reads the open **Agent Skills** format (`SKILL.md`) and **`AGENTS.md`** natively (it also reads `.claude/skills` and `.agents/skills`). So it follows the **Codex per-project-overlay model** — no transformed plugin variant, no `PER_AGENT_VARIANTS` entry, no marketplace changes. Lisa writes skills into the OpenCode-owned `.opencode/skills/lisa/` tree and ensures the canonical `AGENTS.md` exists, tracking ownership via `.opencode/.lisa-managed.json` for clean stale-skill removal.

## Empirical verification (opencode 1.16.2, run locally)

- `lisa apply --harness opencode` in a scratch repo → **274 skills installed**, `AGENTS.md` created, manifest written.
- A real `opencode run` in that project then **discovers them**: reports **91 `lisa-` skills** and names real ones (`lisa-implement`, `lisa-verify`, `lisa-plan`).
- Also verified earlier: OpenCode project `.opencode/plugin/*.ts` hooks **fire headless** (unlike agy/Copilot), and duplicate skill names dedupe with a warning (benign).

## Changes

- **config**: add `"opencode"` to `Harness`, `HARNESS_VALUES`, `EmitAgent`. `fleet` includes it automatically; CLI + `.lisa.config.json` derive from `HARNESS_VALUES` (no extra wiring).
- **core/lisa-skill-sources** (new): extract the agent-agnostic skill/command discovery (plugin-tree walk, dedup, denylist) so the Codex and OpenCode overlays share one source of truth (DRY).
- **codex/skills-installer**: delegate discovery to the shared module; public API + byte output unchanged (**489 Codex tests still green**).
- **codex/command-skill-transformer**: parameterize the runtime label (defaults to `"Codex"`, OpenCode passes `"OpenCode"`).
- **opencode/{skills-installer,manifest}** (new): the per-project overlay.
- **lisa**: `processOpencodeEmit()` dispatch after `processCopilotEmit()`.
- **tests**: OpenCode skills-installer + manifest suites (14 tests).

## Test status

- `typecheck` ✅ · `lint` ✅ (0 errors) · full unit suite ✅ **2960 passing / 179 files** (incl. new OpenCode tests + unchanged Codex suite).

## Scope / follow-ups (separate PRs)

This PR delivers the core: **skills + commands-as-skills + rules (AGENTS.md) + harness wiring**, which is the bulk of Lisa's value. Deferred, tracked as follow-ups:
- Native `.opencode/agents/<name>.md` + `.opencode/commands/<name>.md` surfaces (commands already work as `lisa-` skills).
- `opencode.json` settings (`"share": "disabled"` for enterprise) + MCP wrap (`mcp` key).
- Runtime hooks as `.opencode/plugin/*.ts` (or mapped to permissions/formatter).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for emitting artifacts targeted to OpenCode.
  * OpenCode now receives Lisa-bundled and command-derived skills with automatic tracking and management.

* **Refactor**
  * Consolidated skill discovery logic for improved maintainability.

* **Chores**
  * Updated internal skill policy to block denylisted skill identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->