### PR TITLE
feat(opencode): port Lisa lifecycle hooks to OpenCode

### DIFF
--- a/eslint.config.local.ts
+++ b/eslint.config.local.ts
@@ -35,6 +35,11 @@ export default [
       "typescript/**",
       "plugins/**",
       "wiki/**",
+      // OpenCode plugin templates: copied verbatim into a host project's
+      // `.opencode/plugin/` and executed under OpenCode's Bun runtime, NOT this
+      // monorepo's runtime. They use Bun globals (`Bun`, `$`) and the OpenCode
+      // plugin shape, so this repo's functional/jsdoc rules don't apply.
+      "src/opencode/plugin-templates/**",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "bun run build:dist && bun run build:plugins",
-    "build:dist": "tsc && node scripts/copy-codex-scripts.mjs",
+    "build:dist": "tsc && node scripts/copy-codex-scripts.mjs && node scripts/copy-opencode-plugin-templates.mjs",
     "test:integration": "vitest run tests/integration",
     "postinstall": "bash ./scripts/install-claude-plugins.sh || true; [ -d dist/configs ] || tsc || true",
     "pretest": "[ -d dist/configs ] || bun run build",

--- a/scripts/copy-opencode-plugin-templates.mjs
+++ b/scripts/copy-opencode-plugin-templates.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Copy OpenCode plugin templates next to the compiled OpenCode hooks installer.
+ *
+ * `src/opencode/plugin-templates/*.ts` are NOT app source — they run under
+ * OpenCode's Bun runtime inside a host project's `.opencode/plugin/`, so they
+ * are excluded from this repo's tsconfig (tsc never emits them). The installer
+ * (`dist/opencode/hooks-installer.js`) copies them verbatim into a host project
+ * at install time, resolving them from `dist/opencode/plugin-templates/`. This
+ * step puts the source `.ts` files there. Mirrors `copy-codex-scripts.mjs`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const sourceDir = path.join(repoRoot, "src", "opencode", "plugin-templates");
+const destDir = path.join(repoRoot, "dist", "opencode", "plugin-templates");
+
+fs.rmSync(destDir, { recursive: true, force: true });
+fs.mkdirSync(destDir, { recursive: true });
+
+for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+  if (!entry.isFile() || !entry.name.endsWith(".ts")) {
+    continue;
+  }
+  const sourcePath = path.join(sourceDir, entry.name);
+  const destPath = path.join(destDir, entry.name);
+  fs.copyFileSync(sourcePath, destPath);
+}

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -28,6 +28,7 @@ import {
   writeManagedManifest as writeOpencodeManifest,
 } from "../opencode/manifest.js";
 import { installSkills as installOpencodeSkills } from "../opencode/skills-installer.js";
+import { installHooks as installOpencodeHooks } from "../opencode/hooks-installer.js";
 import { installClaudeMd } from "../claude/claude-md-installer.js";
 import { DetectorRegistry } from "../detection/index.js";
 import {
@@ -1035,17 +1036,28 @@ export class Lisa {
       this.config.destDir,
       previous.files
     );
+    // Hooks: block-no-verify maps to opencode.json `permission.bash`; the
+    // runtime-behavior hooks ship as `.opencode/plugin/lisa-*.ts` modules.
+    const hooksResult = await installOpencodeHooks(
+      this.config.destDir,
+      this.detectedTypes,
+      previous.files
+    );
     // OpenCode reads AGENTS.md natively; ensure the canonical file exists. It is
     // create-only and host-owned afterward, so it's not tracked in the manifest.
     const agentsResult = await installAgentsMd(this.config.destDir);
-    await writeOpencodeManifest(this.config.destDir, skillsResult.managedFiles);
+    await writeOpencodeManifest(this.config.destDir, [
+      ...skillsResult.managedFiles,
+      ...hooksResult.managedFiles,
+    ]);
 
+    const staleCount = skillsResult.deleted.length + hooksResult.deleted.length;
     this.deps.logger.info(
       pc.cyan(
-        `OpenCode emit: ${skillsResult.installed.length} skills${
-          skillsResult.deleted.length > 0
-            ? ` (${skillsResult.deleted.length} stale skills removed)`
-            : ""
+        `OpenCode emit: ${skillsResult.installed.length} skills, ${hooksResult.pluginCount} plugin hooks, opencode.json ${
+          hooksResult.configCreated ? "created" : "merged"
+        }${
+          staleCount > 0 ? ` (${staleCount} stale removed)` : ""
         }, AGENTS.md ${agentsResult.created ? "created" : HOST_OWNED_LABEL}`
       )
     );

--- a/src/opencode/hooks-installer.ts
+++ b/src/opencode/hooks-installer.ts
@@ -1,0 +1,346 @@
+/**
+ * Install Lisa-managed OpenCode hooks into a host project.
+ *
+ * Unlike Codex (which drives every hook through shell scripts wired into
+ * `.codex/hooks.json`), OpenCode is mapped to its NATIVE surfaces first, then
+ * falls back to runtime plugins only where genuine behavior is required:
+ *
+ *   - block-no-verify → `permission.bash` deny rules in `opencode.json`. Cheaper
+ *     and more robust than a hook: OpenCode evaluates the parsed command against
+ *     glob patterns and rejects matches before they run (verified-by-run on
+ *     opencode 1.16.2: `git commit … --no-verify` and `HUSKY=0 …` are denied).
+ *   - format-on-edit → OpenCode's BUILT-IN prettier formatter already formats on
+ *     edit, so Lisa emits no formatter config (overriding it would be worse than
+ *     the default). This is why there is no format plugin below.
+ *   - inject-rules → not needed; rules ship via the canonical `AGENTS.md`, which
+ *     OpenCode reads natively (handled by the skills/AGENTS.md emit).
+ *   - everything that needs runtime behavior (blocking suppression directives /
+ *     migration edits, linting / scanning just-edited files, session bootstrap)
+ *     → a `.opencode/plugin/lisa-*.ts` module. OpenCode loads project plugins
+ *     and fires their `tool.execute.before` / `tool.execute.after` hooks under
+ *     `opencode run` headless (verified-by-run; unlike agy / Copilot).
+ *
+ * The plugin templates live in `src/opencode/plugin-templates/` and are copied
+ * verbatim into the host's `.opencode/plugin/`. Stack-specific plugins are gated
+ * by `forProjectTypes` so they ship only when the relevant project type is
+ * detected, exactly like the Codex hook catalog.
+ * @module opencode/hooks-installer
+ */
+import * as fse from "fs-extra";
+import { copyFile, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ProjectType } from "../core/config.js";
+import { OPENCODE_CONFIG_DIR } from "./manifest.js";
+
+/** Subdirectory inside `.opencode/` where OpenCode discovers project plugins */
+export const OPENCODE_PLUGIN_SUBDIR = "plugin";
+
+/** Filename of the OpenCode project config merged at the host root */
+export const OPENCODE_CONFIG_FILENAME = "opencode.json";
+
+/** JSON Schema URL stamped into a freshly created `opencode.json` */
+const OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json";
+
+/** Prefix every Lisa-managed plugin filename carries (used for stale cleanup) */
+const LISA_PLUGIN_PREFIX = "lisa-";
+
+/**
+ * `permission.bash` deny patterns that replace Lisa's `block-no-verify` hook.
+ * Each glob is matched against the parsed shell command; `*` matches any run of
+ * characters. Deny-only (no catch-all allow) so non-matching commands fall
+ * through to the host's / OpenCode's default posture.
+ */
+const NO_VERIFY_DENY_PATTERNS: Readonly<Record<string, "deny">> = {
+  "*--no-verify*": "deny",
+  "*HUSKY=0*": "deny",
+  "*HUSKY_SKIP_HOOKS=*": "deny",
+  "*core.hooksPath*/dev/null*": "deny",
+};
+
+/** One Lisa-shipped OpenCode plugin template. */
+interface PluginCatalogEntry {
+  /** Stable identifier (also the basename without the `lisa-`/`.ts`) */
+  readonly id: string;
+  /** Template filename in `plugin-templates/` and the dest filename verbatim */
+  readonly templateFilename: string;
+  /** Project types this plugin ships for. `["*"]` ships for every stack. */
+  readonly forProjectTypes: readonly (ProjectType | "*")[];
+}
+
+/**
+ * Plugin catalog — the OpenCode counterpart of the Codex HOOK_CATALOG. Adding a
+ * plugin? Drop a template in `plugin-templates/`, add an entry here, add tests.
+ */
+const PLUGIN_CATALOG: readonly PluginCatalogEntry[] = [
+  {
+    id: "session-bootstrap",
+    templateFilename: "lisa-session-bootstrap.ts",
+    forProjectTypes: ["*"],
+  },
+  {
+    id: "block-suppress-directives",
+    templateFilename: "lisa-block-suppress-directives.ts",
+    forProjectTypes: ["typescript"],
+  },
+  {
+    id: "lint-on-edit",
+    templateFilename: "lisa-lint-on-edit.ts",
+    forProjectTypes: ["typescript"],
+  },
+  {
+    id: "sg-scan-on-edit",
+    templateFilename: "lisa-sg-scan-on-edit.ts",
+    forProjectTypes: ["typescript", "rails"],
+  },
+  {
+    id: "block-migration-edits",
+    templateFilename: "lisa-block-migration-edits.ts",
+    forProjectTypes: ["nestjs"],
+  },
+  {
+    id: "rubocop-on-edit",
+    templateFilename: "lisa-rubocop-on-edit.ts",
+    forProjectTypes: ["rails"],
+  },
+];
+
+/** Result of the OpenCode hooks install pass */
+export interface OpencodeHooksInstallResult {
+  /** Files written, relative to `.opencode/` (added to the manifest). */
+  readonly managedFiles: readonly string[];
+  /** Number of plugin templates emitted into `.opencode/plugin/`. */
+  readonly pluginCount: number;
+  /** Whether `opencode.json` was created (vs merged into an existing file). */
+  readonly configCreated: boolean;
+  /** Stale Lisa plugin files removed because they're no longer shipped. */
+  readonly deleted: readonly string[];
+}
+
+/**
+ * Install Lisa's OpenCode hooks: merge `permission.bash` deny rules into
+ * `opencode.json` and emit the applicable `.opencode/plugin/lisa-*.ts` modules.
+ *
+ * `opencode.json` lives at the host ROOT (outside `.opencode/`), is a shared
+ * merged file, and is intentionally NOT returned in `managedFiles` — the
+ * `.opencode/`-relative manifest never deletes it. Plugin files under
+ * `.opencode/plugin/` ARE tracked so renames clean up stale modules.
+ * @param destDir - Absolute path to the host project root.
+ * @param detectedTypes - Project types Lisa detected; gates stack-specific
+ *   plugins. Universal plugins/config install regardless.
+ * @param previousManagedFiles - Files Lisa managed last run (relative to
+ *   `.opencode/`); used to detect stale plugin modules.
+ * @returns Result describing what was written + removed.
+ */
+export async function installHooks(
+  destDir: string,
+  detectedTypes: readonly ProjectType[],
+  previousManagedFiles: readonly string[]
+): Promise<OpencodeHooksInstallResult> {
+  const configCreated = await mergeOpencodeConfig(destDir);
+
+  const pluginDir = path.join(
+    destDir,
+    OPENCODE_CONFIG_DIR,
+    OPENCODE_PLUGIN_SUBDIR
+  );
+  await fse.ensureDir(pluginDir);
+
+  const applicable = filterCatalogByTypes(detectedTypes);
+  const managedFiles = await Promise.all(
+    applicable.map(async entry => {
+      const source = resolveTemplate(entry.templateFilename);
+      const dest = path.join(pluginDir, entry.templateFilename);
+      await copyFile(source, dest);
+      return path.join(OPENCODE_PLUGIN_SUBDIR, entry.templateFilename);
+    })
+  );
+
+  const currentFilenames = new Set(
+    applicable.map(entry => entry.templateFilename)
+  );
+  const deleted = await deleteStalePlugins(
+    previousManagedFiles,
+    currentFilenames,
+    destDir
+  );
+
+  return {
+    managedFiles: Object.freeze(managedFiles),
+    pluginCount: applicable.length,
+    configCreated,
+    deleted,
+  };
+}
+
+/**
+ * Filter the catalog by detected project types. Universal plugins (`"*"`)
+ * always pass; stack-specific plugins pass only if their type is detected.
+ * @param detectedTypes - Project types Lisa detected for the host.
+ * @returns The catalog entries that apply to this host.
+ */
+function filterCatalogByTypes(
+  detectedTypes: readonly ProjectType[]
+): readonly PluginCatalogEntry[] {
+  const detectedSet = new Set<string>(detectedTypes);
+  return PLUGIN_CATALOG.filter(entry =>
+    entry.forProjectTypes.some(t => t === "*" || detectedSet.has(t))
+  );
+}
+
+/**
+ * Resolve a bundled plugin template path. Templates ship alongside the compiled
+ * installer at `dist/opencode/plugin-templates/<name>` (copied there by
+ * `scripts/copy-opencode-plugin-templates.mjs`).
+ * @param filename - Template filename (e.g. "lisa-lint-on-edit.ts").
+ * @returns Absolute path to the bundled template.
+ */
+function resolveTemplate(filename: string): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(moduleDir, "plugin-templates", filename);
+}
+
+/**
+ * Delete Lisa plugin modules that were managed last run but aren't shipped this
+ * run (e.g. a project type stopped being detected, or a template was renamed).
+ * Only files under `.opencode/plugin/` with the `lisa-` prefix are eligible, so
+ * host-authored plugins are never touched.
+ * @param previousManagedFiles - Files Lisa managed last run (relative to
+ *   `.opencode/`).
+ * @param currentFilenames - Plugin filenames Lisa is shipping this run.
+ * @param destDir - Absolute path to the host project root.
+ * @returns Sorted list of stale plugin filenames that were deleted.
+ */
+async function deleteStalePlugins(
+  previousManagedFiles: readonly string[],
+  currentFilenames: ReadonlySet<string>,
+  destDir: string
+): Promise<readonly string[]> {
+  const prefix = `${OPENCODE_PLUGIN_SUBDIR}${path.sep}`;
+  const stale = previousManagedFiles
+    .filter(file => file.startsWith(prefix))
+    .map(file => file.slice(prefix.length))
+    .filter(
+      name =>
+        name.startsWith(LISA_PLUGIN_PREFIX) &&
+        !name.includes(path.sep) &&
+        !currentFilenames.has(name)
+    );
+  await Promise.all(
+    stale.map(async name => {
+      const absPath = path.join(
+        destDir,
+        OPENCODE_CONFIG_DIR,
+        OPENCODE_PLUGIN_SUBDIR,
+        name
+      );
+      if (await fse.pathExists(absPath)) {
+        await rm(absPath, { force: true });
+      }
+    })
+  );
+  return Object.freeze([...new Set(stale)].sort((a, b) => a.localeCompare(b)));
+}
+
+/**
+ * Merge Lisa's `permission.bash` deny rules into the host's `opencode.json`,
+ * preserving every other key. Creates the file (with `$schema`) when absent.
+ *
+ * A host `permission.bash` set to a bare string (e.g. `"allow"`) is preserved by
+ * re-seeding it as a `{ "*": <string> }` catch-all before adding the deny
+ * patterns, so the host's posture survives. The deny patterns are spread LAST so
+ * they win OpenCode's most-specific/last-match evaluation.
+ * @param destDir - Absolute path to the host project root.
+ * @returns Whether the config file was created (vs merged into an existing one).
+ */
+async function mergeOpencodeConfig(destDir: string): Promise<boolean> {
+  const configPath = path.join(destDir, OPENCODE_CONFIG_FILENAME);
+  const existingRaw = (await fse.pathExists(configPath))
+    ? await readFile(configPath, "utf8")
+    : null;
+  const created = existingRaw === null;
+  const config = parseConfigObject(existingRaw, configPath);
+
+  const permission = isPlainObject(config["permission"])
+    ? config["permission"]
+    : {};
+  const existingBash = permission["bash"];
+  const bashBase =
+    typeof existingBash === "string"
+      ? { "*": existingBash }
+      : isPlainObject(existingBash)
+        ? existingBash
+        : {};
+
+  // Build the merged config immutably (functional/immutable-data): a leading
+  // `$schema` provides the default, the `...config` spread overrides it with the
+  // host's own value when present, and `permission` is overridden last so the
+  // deny patterns survive.
+  const merged: Record<string, unknown> = {
+    $schema: OPENCODE_CONFIG_SCHEMA,
+    ...config,
+    permission: {
+      ...permission,
+      bash: { ...bashBase, ...NO_VERIFY_DENY_PATTERNS },
+    },
+  };
+
+  await writeFile(configPath, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+  return created;
+}
+
+/**
+ * Parse an existing `opencode.json` body into a mutable object. Throws on
+ * malformed JSON (so a corrupt config is surfaced, not silently overwritten);
+ * returns a fresh object when the file is absent.
+ * @param raw - File contents, or null when the file doesn't exist.
+ * @param configPath - Path used in error messages.
+ * @returns A shallow-mutable record to merge into.
+ */
+function parseConfigObject(
+  raw: string | null,
+  configPath: string
+): Record<string, unknown> {
+  if (raw === null || raw.trim() === "") {
+    return {};
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `Invalid ${OPENCODE_CONFIG_FILENAME} at ${configPath}: expected a JSON object`
+    );
+  }
+  return { ...parsed };
+}
+
+/**
+ * Narrow an unknown value to a plain (non-array, non-null) object record.
+ * @param value - The value to test.
+ * @returns Whether `value` is a plain object.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Enumerate the Lisa plugin filenames currently present in a host's
+ * `.opencode/plugin/` directory. Exposed for tests/diagnostics.
+ * @param destDir - Absolute path to the host project root.
+ * @returns Sorted list of `lisa-*.ts` filenames (empty if the dir is absent).
+ */
+export async function listInstalledPluginFiles(
+  destDir: string
+): Promise<readonly string[]> {
+  const pluginDir = path.join(
+    destDir,
+    OPENCODE_CONFIG_DIR,
+    OPENCODE_PLUGIN_SUBDIR
+  );
+  if (!(await fse.pathExists(pluginDir))) {
+    return [];
+  }
+  const entries = await readdir(pluginDir);
+  return entries
+    .filter(name => name.startsWith(LISA_PLUGIN_PREFIX) && name.endsWith(".ts"))
+    .sort((a, b) => a.localeCompare(b));
+}

--- a/src/opencode/plugin-templates/lisa-block-migration-edits.ts
+++ b/src/opencode/plugin-templates/lisa-block-migration-edits.ts
@@ -1,0 +1,44 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.before).
+ *
+ * Blocks edits to TypeORM migration files. Use `bun run migration:generate`
+ * to regenerate from entity diffs instead — hand-written migrations drift from
+ * entity metadata and break the schema/migration contract.
+ *
+ * Port of Lisa's Codex hook `block-migration-edits.sh`. OpenCode exposes only
+ * `edit` / `write` filesystem tools (no `apply_patch`), so the file path comes
+ * straight from `output.args.filePath`. Throwing in `tool.execute.before`
+ * cancels the tool call and surfaces the message to the agent (verified-by-run
+ * on opencode 1.16.2).
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export /**
+ *
+ */
+const LisaBlockMigrationEdits = async () => {
+  const MIGRATION_RE = /\/migrations\/[^/]*\d[^/]*-[^/]*\.ts$/;
+  return {
+    "tool.execute.before": async (
+      input: { tool: string },
+      output: { args?: { filePath?: string } }
+    ) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(output.args?.filePath ?? "");
+      if (!filePath || !MIGRATION_RE.test(filePath)) return;
+      throw new Error(
+        [
+          `block-migration-edits: refusing to modify ${filePath}.`,
+          "",
+          "TypeORM migrations must be regenerated from entity diffs:",
+          "  bun run migration:generate -- src/database/migrations/<descriptive-name>",
+          "",
+          "Hand-written migrations drift from entity metadata and break the",
+          "schema contract. Modify the entity, run the generator, then commit.",
+        ].join("\n")
+      );
+    },
+  };
+};

--- a/src/opencode/plugin-templates/lisa-block-suppress-directives.ts
+++ b/src/opencode/plugin-templates/lisa-block-suppress-directives.ts
@@ -1,0 +1,57 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.before).
+ *
+ * Blocks adding error-suppression directives (@ts-ignore, @ts-nocheck,
+ * eslint-disable, biome-ignore, prettier-ignore) to JS/TS source. Suppressing
+ * the type checker, linter, or formatter hides real defects — fix the
+ * underlying error. @ts-expect-error is intentionally NOT matched (it is the
+ * safer alternative).
+ *
+ * Port of Lisa's Codex hook `block-suppress-directives.sh`. OpenCode exposes
+ * `edit` (oldString/newString) and `write` (content) tools — there is no
+ * multi-file apply_patch — so the new text comes straight from the tool args.
+ * Throwing in `tool.execute.before` cancels the call and surfaces the message
+ * to the agent (verified-by-run on opencode 1.16.2).
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export const LisaBlockSuppressDirectives = async () => {
+  // Comment-syntax-only match: // or /* opener, optional whitespace, directive.
+  const DIRECTIVE_RE =
+    /(\/\/|\/\*)\s*(@ts-(ignore|nocheck)|eslint-disable|biome-ignore|prettier-ignore)/;
+  const JS_TS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+  const extOf = (p: string) => p.split(".").pop()?.toLowerCase() ?? "";
+  return {
+    "tool.execute.before": async (
+      input: { tool: string },
+      output: {
+        args?: { filePath?: string; content?: string; newString?: string };
+      }
+    ) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(output.args?.filePath ?? "");
+      if (!filePath || !JS_TS.has(extOf(filePath))) return;
+      const newText =
+        input.tool === "write"
+          ? String(output.args?.content ?? "")
+          : String(output.args?.newString ?? "");
+      if (!DIRECTIVE_RE.test(newText)) return;
+      throw new Error(
+        [
+          `block-suppress-directives: refusing to add an error-suppression directive to ${filePath}.`,
+          "",
+          "@ts-ignore / @ts-nocheck / eslint-disable / biome-ignore / prettier-ignore",
+          "silence the type checker, linter, or formatter instead of fixing the problem.",
+          "Fix the underlying type/lint error — add the missing annotation, narrow the",
+          "type, or restructure the code so the rule passes.",
+          "",
+          "Suppression is a last resort. If there is genuinely no other way, STOP and get",
+          "the user's approval first, prefer @ts-expect-error over @ts-ignore, scope the",
+          'disable to one line and one rule, and add a "-- <reason>" description.',
+        ].join("\n")
+      );
+    },
+  };
+};

--- a/src/opencode/plugin-templates/lisa-lint-on-edit.ts
+++ b/src/opencode/plugin-templates/lisa-lint-on-edit.ts
@@ -1,0 +1,53 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.after).
+ *
+ * Runs ESLint --fix on every just-edited JS/TS file, then re-checks. If
+ * unfixable problems remain, throws so OpenCode marks the tool call failed and
+ * the agent self-corrects (the equivalent of the Codex hook's non-zero exit).
+ * Fails open when ESLint isn't installed.
+ *
+ * Port of Lisa's Codex hook `lint-on-edit.sh`. OpenCode passes the edited file
+ * via `input.args.filePath`; `tool.execute.after` runs after a successful
+ * edit/write (verified-by-run on opencode 1.16.2: a throw here surfaces the
+ * message to the agent).
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export const LisaLintOnEdit = async ({
+  $,
+  directory,
+}: {
+  $: (strings: TemplateStringsArray, ...exprs: unknown[]) => any;
+  directory: string;
+}) => {
+  const EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+  const extOf = (p: string) => p.split(".").pop()?.toLowerCase() ?? "";
+  const { existsSync } = await import("node:fs");
+  const resolveBin = (name: string): string | null => {
+    const local = `${directory}/node_modules/.bin/${name}`;
+    if (existsSync(local)) return local;
+    return Bun.which(name);
+  };
+  return {
+    "tool.execute.after": async (input: {
+      tool: string;
+      args?: { filePath?: string };
+    }) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(input.args?.filePath ?? "");
+      if (!filePath || !EXTS.has(extOf(filePath))) return;
+      const eslint = resolveBin("eslint");
+      if (!eslint) return; // fail open — no ESLint installed
+      await $`${eslint} --fix ${filePath}`.quiet().nothrow();
+      const res = await $`${eslint} --quiet ${filePath}`.quiet().nothrow();
+      if (res.exitCode === 0) return;
+      const out =
+        `${res.stdout?.toString() ?? ""}${res.stderr?.toString() ?? ""}`.trim();
+      throw new Error(
+        `lint-on-edit: ESLint reported unfixable problems in ${filePath}:\n${out}`
+      );
+    },
+  };
+};

--- a/src/opencode/plugin-templates/lisa-rubocop-on-edit.ts
+++ b/src/opencode/plugin-templates/lisa-rubocop-on-edit.ts
@@ -1,0 +1,54 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.after).
+ *
+ * Runs RuboCop -a (safe autocorrect) on every just-edited Ruby file, then
+ * re-checks for remaining unfixable offenses. If any remain, throws so OpenCode
+ * marks the tool call failed and the agent fixes them. Prefers `bundle exec
+ * rubocop` when a Gemfile is present. Fails open when RuboCop isn't installed.
+ *
+ * Port of Lisa's Codex hook `rubocop-on-edit.sh`.
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export const LisaRubocopOnEdit = async ({
+  $,
+  directory,
+}: {
+  $: (strings: TemplateStringsArray, ...exprs: unknown[]) => any;
+  directory: string;
+}) => {
+  const EXTS = new Set(["rb", "rake"]);
+  const extOf = (p: string) => p.split(".").pop()?.toLowerCase() ?? "";
+  const { existsSync } = await import("node:fs");
+  const resolveRunner = (): string[] | null => {
+    const bundle = Bun.which("bundle");
+    if (bundle && existsSync(`${directory}/Gemfile`)) {
+      return [bundle, "exec", "rubocop"];
+    }
+    const rubocop = Bun.which("rubocop");
+    return rubocop ? [rubocop] : null;
+  };
+  return {
+    "tool.execute.after": async (input: {
+      tool: string;
+      args?: { filePath?: string };
+    }) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(input.args?.filePath ?? "");
+      if (!filePath || !EXTS.has(extOf(filePath))) return;
+      const runner = resolveRunner();
+      if (!runner) return; // fail open — no RuboCop installed
+      const [bin, ...rest] = runner;
+      await $`${bin} ${rest} -a ${filePath}`.quiet().nothrow();
+      const res = await $`${bin} ${rest} ${filePath}`.quiet().nothrow();
+      if (res.exitCode === 0) return;
+      const out =
+        `${res.stdout?.toString() ?? ""}${res.stderr?.toString() ?? ""}`.trim();
+      throw new Error(
+        `rubocop-on-edit: RuboCop reported unfixable offenses in ${filePath}:\n${out}`
+      );
+    },
+  };
+};

--- a/src/opencode/plugin-templates/lisa-session-bootstrap.ts
+++ b/src/opencode/plugin-templates/lisa-session-bootstrap.ts
@@ -1,0 +1,76 @@
+/**
+ * Lisa-managed OpenCode plugin (session bootstrap).
+ *
+ * OpenCode runs a plugin's factory function once when it loads the plugin at
+ * session start, which is the natural home for Lisa's Codex SessionStart hooks:
+ *   - install-pkgs.sh   → install dependencies when node_modules is missing
+ *   - setup-jira-cli.sh → write jira-cli config from environment variables
+ *
+ * Both are fully fail-open (wrapped in try/catch) so a package-manager or
+ * filesystem hiccup never bricks OpenCode startup, mirroring the Codex scripts.
+ * install only runs on the first session of a fresh checkout (node_modules
+ * absent), so the common case is a cheap no-op.
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export const LisaSessionBootstrap = async ({
+  $,
+  worktree,
+}: {
+  $: (strings: TemplateStringsArray, ...exprs: unknown[]) => any;
+  worktree: string;
+}) => {
+  const root = worktree;
+  const { existsSync, mkdirSync, writeFileSync } = await import("node:fs");
+
+  // install-pkgs: bootstrap dependencies when they're missing.
+  try {
+    if (
+      existsSync(`${root}/package.json`) &&
+      !existsSync(`${root}/node_modules`)
+    ) {
+      const has = (f: string) => existsSync(`${root}/${f}`);
+      const install = async (cmd: string) => {
+        if (Bun.which(cmd)) {
+          await $`${cmd} install`.cwd(root).quiet().nothrow();
+        }
+      };
+      if (has("bun.lockb") || has("bun.lock")) await install("bun");
+      else if (has("pnpm-lock.yaml")) await install("pnpm");
+      else if (has("yarn.lock")) await install("yarn");
+      else await install("npm");
+    }
+  } catch {
+    // fail open — never block startup on a dependency-install error
+  }
+
+  // setup-jira-cli: write jira-cli config from environment variables.
+  try {
+    const server = process.env.JIRA_SERVER;
+    const login = process.env.JIRA_LOGIN;
+    const home = process.env.HOME;
+    if (server && login && home) {
+      const dir = `${home}/.config/.jira`;
+      mkdirSync(dir, { recursive: true });
+      const config = [
+        `installation: ${process.env.JIRA_INSTALLATION ?? "cloud"}`,
+        `server: ${server}`,
+        `login: ${login}`,
+        `project: ${process.env.JIRA_PROJECT ?? ""}`,
+        `board: "${process.env.JIRA_BOARD ?? ""}"`,
+        "auth_type: basic",
+        "epic:",
+        "  name: Epic Name",
+        "  link: Epic Link",
+        "",
+      ].join("\n");
+      writeFileSync(`${dir}/.config.yml`, config);
+    }
+  } catch {
+    // fail open — never block startup on a jira-cli config error
+  }
+
+  return {};
+};

--- a/src/opencode/plugin-templates/lisa-sg-scan-on-edit.ts
+++ b/src/opencode/plugin-templates/lisa-sg-scan-on-edit.ts
@@ -1,0 +1,50 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.after).
+ *
+ * Runs `ast-grep scan` on every just-edited source file (TypeScript/JS or
+ * Ruby) when the project ships an `sgconfig.yml`. If ast-grep reports findings,
+ * throws so OpenCode marks the tool call failed and the agent fixes them.
+ * Fails open when ast-grep or sgconfig.yml is absent.
+ *
+ * Port of Lisa's Codex hook `sg-scan-on-edit.sh`.
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export const LisaSgScanOnEdit = async ({
+  $,
+  directory,
+}: {
+  $: (strings: TemplateStringsArray, ...exprs: unknown[]) => any;
+  directory: string;
+}) => {
+  const EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "rb", "rake"]);
+  const extOf = (p: string) => p.split(".").pop()?.toLowerCase() ?? "";
+  const { existsSync } = await import("node:fs");
+  const resolveBin = (): string | null => {
+    const local = `${directory}/node_modules/.bin/ast-grep`;
+    if (existsSync(local)) return local;
+    return Bun.which("ast-grep") ?? Bun.which("sg");
+  };
+  return {
+    "tool.execute.after": async (input: {
+      tool: string;
+      args?: { filePath?: string };
+    }) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(input.args?.filePath ?? "");
+      if (!filePath || !EXTS.has(extOf(filePath))) return;
+      if (!existsSync(`${directory}/sgconfig.yml`)) return; // fail open
+      const astGrep = resolveBin();
+      if (!astGrep) return; // fail open — no ast-grep installed
+      const res = await $`${astGrep} scan ${filePath}`.quiet().nothrow();
+      if (res.exitCode === 0) return;
+      const out =
+        `${res.stdout?.toString() ?? ""}${res.stderr?.toString() ?? ""}`.trim();
+      throw new Error(
+        `sg-scan-on-edit: ast-grep reported findings in ${filePath}:\n${out}`
+      );
+    },
+  };
+};

--- a/tests/unit/opencode/hooks-installer.test.ts
+++ b/tests/unit/opencode/hooks-installer.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the OpenCode hooks installer.
+ *
+ * Covers the two delivery surfaces: `opencode.json` `permission.bash` deny rules
+ * (the block-no-verify port) and the `.opencode/plugin/lisa-*.ts` modules (the
+ * runtime-behavior hooks), including project-type gating, stale cleanup, and the
+ * non-destructive config merge.
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  OPENCODE_CONFIG_FILENAME,
+  OPENCODE_PLUGIN_SUBDIR,
+  installHooks,
+  listInstalledPluginFiles,
+} from "../../../src/opencode/hooks-installer.js";
+import { OPENCODE_CONFIG_DIR } from "../../../src/opencode/manifest.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+/** Plugin template basenames (de-duplicated for sonarjs/no-duplicate-string). */
+const SESSION = "lisa-session-bootstrap.ts";
+const LINT = "lisa-lint-on-edit.ts";
+const SUPPRESS = "lisa-block-suppress-directives.ts";
+const SGSCAN = "lisa-sg-scan-on-edit.ts";
+const MIGRATION = "lisa-block-migration-edits.ts";
+const RUBOCOP = "lisa-rubocop-on-edit.ts";
+
+describe("opencode/hooks-installer", () => {
+  let destDir: string;
+
+  beforeEach(async () => {
+    destDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(destDir);
+  });
+
+  /**
+   * Read and parse the host `opencode.json`.
+   * @returns The parsed config object.
+   */
+  async function readConfig(): Promise<Record<string, unknown>> {
+    const raw = await fs.readFile(
+      path.join(destDir, OPENCODE_CONFIG_FILENAME),
+      "utf8"
+    );
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  /**
+   * Read the bash permission map from the host `opencode.json`.
+   * @returns The `permission.bash` object.
+   */
+  async function readBash(): Promise<Record<string, string>> {
+    const config = await readConfig();
+    const permission = config["permission"] as Record<string, unknown>;
+    return permission["bash"] as Record<string, string>;
+  }
+
+  describe("opencode.json permission.bash (block-no-verify)", () => {
+    it("creates opencode.json with deny rules when absent", async () => {
+      const result = await installHooks(destDir, ["typescript"], []);
+      expect(result.configCreated).toBe(true);
+      const bash = await readBash();
+      expect(bash["*--no-verify*"]).toBe("deny");
+      expect(bash["*HUSKY=0*"]).toBe("deny");
+      expect(bash["*HUSKY_SKIP_HOOKS=*"]).toBe("deny");
+      expect(bash["*core.hooksPath*/dev/null*"]).toBe("deny");
+    });
+
+    it("stamps the $schema on a freshly created config", async () => {
+      await installHooks(destDir, [], []);
+      const config = await readConfig();
+      expect(config["$schema"]).toBe("https://opencode.ai/config.json");
+    });
+
+    it("writes the config with a trailing newline", async () => {
+      await installHooks(destDir, [], []);
+      const raw = await fs.readFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        "utf8"
+      );
+      expect(raw).toMatch(/}\n$/);
+    });
+
+    it("merges into an existing config, preserving host keys", async () => {
+      await fs.writeFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "tokyonight",
+          permission: { edit: "allow", bash: { "rm *": "deny" } },
+        }),
+        "utf8"
+      );
+      const result = await installHooks(destDir, [], []);
+      expect(result.configCreated).toBe(false);
+      const config = await readConfig();
+      expect(config["theme"]).toBe("tokyonight");
+      const permission = config["permission"] as Record<string, unknown>;
+      expect(permission["edit"]).toBe("allow");
+      const bash = permission["bash"] as Record<string, string>;
+      // Host rule preserved, Lisa deny rules added.
+      expect(bash["rm *"]).toBe("deny");
+      expect(bash["*--no-verify*"]).toBe("deny");
+    });
+
+    it("preserves a host bash string posture as a catch-all", async () => {
+      await fs.writeFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        JSON.stringify({ permission: { bash: "allow" } }),
+        "utf8"
+      );
+      await installHooks(destDir, [], []);
+      const bash = await readBash();
+      expect(bash["*"]).toBe("allow");
+      expect(bash["*--no-verify*"]).toBe("deny");
+    });
+
+    it("is idempotent across repeated installs", async () => {
+      await installHooks(destDir, [], []);
+      const first = await fs.readFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        "utf8"
+      );
+      await installHooks(destDir, [], []);
+      const second = await fs.readFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        "utf8"
+      );
+      expect(second).toBe(first);
+    });
+
+    it("throws on a corrupt existing opencode.json", async () => {
+      await fs.writeFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        "{ not json",
+        "utf8"
+      );
+      await expect(installHooks(destDir, [], [])).rejects.toThrow();
+    });
+
+    it("does not list opencode.json in managedFiles", async () => {
+      const result = await installHooks(destDir, ["typescript"], []);
+      expect(result.managedFiles).not.toContain(OPENCODE_CONFIG_FILENAME);
+      expect(
+        result.managedFiles.every(f =>
+          f.startsWith(`${OPENCODE_PLUGIN_SUBDIR}/`)
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("plugin emission + project-type gating", () => {
+    it("always ships the universal session-bootstrap plugin", async () => {
+      await installHooks(destDir, [], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).toContain(SESSION);
+    });
+
+    it("ships the typescript guards for a typescript project", async () => {
+      await installHooks(destDir, ["typescript"], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).toEqual([SUPPRESS, LINT, SESSION, SGSCAN]);
+    });
+
+    it("adds the migration guard for a nestjs project", async () => {
+      // detectedTypes arrive already expanded (nestjs implies typescript).
+      await installHooks(destDir, ["typescript", "nestjs"], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).toContain(MIGRATION);
+      expect(files).toContain(LINT);
+    });
+
+    it("ships the rails guards for a rails project", async () => {
+      await installHooks(destDir, ["rails"], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).toEqual([RUBOCOP, SESSION, SGSCAN]);
+    });
+
+    it("does not ship typescript guards to a rails-only project", async () => {
+      await installHooks(destDir, ["rails"], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).not.toContain(LINT);
+      expect(files).not.toContain(SUPPRESS);
+    });
+
+    it("copies real plugin source (not an empty stub)", async () => {
+      await installHooks(destDir, [], []);
+      const body = await fs.readFile(
+        path.join(
+          destDir,
+          OPENCODE_CONFIG_DIR,
+          OPENCODE_PLUGIN_SUBDIR,
+          SESSION
+        ),
+        "utf8"
+      );
+      expect(body).toContain("export const LisaSessionBootstrap");
+    });
+
+    it("reports pluginCount equal to the emitted file count", async () => {
+      const result = await installHooks(destDir, ["typescript"], []);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(result.pluginCount).toBe(files.length);
+      expect(result.managedFiles).toHaveLength(files.length);
+    });
+  });
+
+  describe("stale plugin cleanup", () => {
+    it("deletes a Lisa plugin no longer shipped this run", async () => {
+      // First install as a nestjs project (ships the migration guard).
+      await installHooks(destDir, ["typescript", "nestjs"], []);
+      const previous = (await listInstalledPluginFiles(destDir)).map(name =>
+        path.join(OPENCODE_PLUGIN_SUBDIR, name)
+      );
+      expect(previous.some(f => f.endsWith(MIGRATION))).toBe(true);
+
+      // Re-install as a plain typescript project — migration guard goes stale.
+      const result = await installHooks(destDir, ["typescript"], previous);
+      expect(result.deleted).toContain(MIGRATION);
+      const files = await listInstalledPluginFiles(destDir);
+      expect(files).not.toContain(MIGRATION);
+    });
+
+    it("never deletes a host-authored plugin", async () => {
+      const hostPlugin = "my-plugin.ts";
+      const pluginDir = path.join(
+        destDir,
+        OPENCODE_CONFIG_DIR,
+        OPENCODE_PLUGIN_SUBDIR
+      );
+      await fs.ensureDir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, hostPlugin),
+        "export const Mine = async () => ({})",
+        "utf8"
+      );
+      // Even if a stale-looking host entry is in the manifest, only `lisa-`
+      // files are eligible for deletion.
+      await installHooks(
+        destDir,
+        ["typescript"],
+        [path.join(OPENCODE_PLUGIN_SUBDIR, hostPlugin)]
+      );
+      expect(await fs.pathExists(path.join(pluginDir, hostPlugin))).toBe(true);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/typescript", "./tsconfig.local.json"],
   "include": ["src/**/*"],
-  "exclude": ["node_modules", ".build", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": [
+    "node_modules",
+    ".build",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/opencode/plugin-templates"
+  ]
 }

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -13,7 +13,8 @@
     "node_modules",
     "dist",
     "tests",
-    "configs"
+    "configs",
+    "src/opencode/plugin-templates"
   ],
   "files": []
 }

--- a/wiki/architecture/lisa-hook-per-agent-ship-list.md
+++ b/wiki/architecture/lisa-hook-per-agent-ship-list.md
@@ -215,3 +215,34 @@ the `reference_codex_plugin_hooks_shape_and_firing` session memory.
   "cursor auto-loads `rules/`" claim, which was false for the nested `.md` tree),
   copilot/codex/claude inject once via hooks, agy baked once. _(Post-2026-06-06:
   agy no longer bakes or injects eager rules at all — see PR #1150.)_
+
+## OpenCode hook delivery (follow-up to PR #1197)
+
+OpenCode does **not** consume the Pattern B per-agent filter above. Like Codex,
+it uses a per-project overlay (`src/opencode/hooks-installer.ts`), so its hooks
+are mapped to OpenCode-native surfaces first and to runtime plugins only where
+genuine behavior is required. Verified-by-run on opencode 1.16.2 (free model,
+`opencode run` headless):
+
+| Lisa hook | OpenCode delivery |
+| --- | --- |
+| `block-no-verify` | `opencode.json` → `permission.bash` deny globs (`*--no-verify*`, `*HUSKY=0*`, `*HUSKY_SKIP_HOOKS=*`, `*core.hooksPath*/dev/null*`). Cheaper + more robust than a hook; OpenCode rejects matches before they run. |
+| `format-on-edit` | OpenCode's **built-in prettier formatter** already formats on edit — Lisa emits no formatter config (overriding it would be worse than the default). |
+| `inject-rules` | Not needed — rules ship via the canonical `AGENTS.md`, which OpenCode reads natively. |
+| `install-pkgs`, `setup-jira-cli` | `.opencode/plugin/lisa-session-bootstrap.ts` (universal) — the plugin factory runs once at session start, the SessionStart equivalent. Fully fail-open. |
+| `block-suppress-directives` (ts) | `.opencode/plugin/lisa-block-suppress-directives.ts` — `tool.execute.before` throws to block the edit/write. |
+| `block-migration-edits` (nestjs) | `.opencode/plugin/lisa-block-migration-edits.ts` — `tool.execute.before` throws. |
+| `lint-on-edit` (ts) | `.opencode/plugin/lisa-lint-on-edit.ts` — `tool.execute.after` runs ESLint `--fix`, throws on remaining problems. |
+| `sg-scan-on-edit` (ts/rails) | `.opencode/plugin/lisa-sg-scan-on-edit.ts` — `tool.execute.after` runs `ast-grep scan`. |
+| `rubocop-on-edit` (rails) | `.opencode/plugin/lisa-rubocop-on-edit.ts` — `tool.execute.after` runs RuboCop `-a`. |
+| `enforce-team-first`, `inject-flow-context` | Not ported (Claude-team-specific / no equivalent), matching Codex. |
+
+OpenCode exposes only `edit`/`write` filesystem tools (no `apply_patch`), so file
+paths come straight from the tool args. Plugin templates live in
+`src/opencode/plugin-templates/` (excluded from this repo's tsconfig/eslint — they
+run under OpenCode's Bun runtime) and are copied verbatim into the host's
+`.opencode/plugin/`, gated by detected project type exactly like the Codex hook
+catalog. `opencode.json` is a shared merged root file (not tracked in the
+`.opencode/`-relative manifest); plugin files are manifest-tracked for stale
+cleanup. Note: OpenCode's first `opencode run` pays a Bun cold-start (~30s) to
+transpile project plugins.


### PR DESCRIPTION
## What

Follow-up to #1197 (OpenCode added to Lisa's fleet). Ports Lisa's lifecycle hooks to OpenCode, mapping each to OpenCode's **native surfaces first** and to **runtime plugins** only where genuine behavior is required.

## Mapping

| Lisa Codex hook | OpenCode delivery |
| --- | --- |
| `block-no-verify` | `opencode.json` → `permission.bash` deny globs (`*--no-verify*`, husky-skip env vars, `core.hooksPath` → /dev/null). Cheaper + more robust than a hook — OpenCode rejects matches before they run. |
| `format-on-edit` | OpenCode's **built-in prettier formatter** already formats on edit — no config emitted (overriding it would be worse than the default). |
| `inject-rules` | Not needed — rules ship via the canonical `AGENTS.md`, read natively (Phase 1 / #1197). |
| `install-pkgs`, `setup-jira-cli` | `.opencode/plugin/lisa-session-bootstrap.ts` (universal) — the plugin factory runs once at session start. Fully fail-open. |
| `block-suppress-directives` (ts) | `lisa-block-suppress-directives.ts` — `tool.execute.before` throws. |
| `block-migration-edits` (nestjs) | `lisa-block-migration-edits.ts` — `tool.execute.before` throws. |
| `lint-on-edit` (ts) | `lisa-lint-on-edit.ts` — `tool.execute.after` ESLint `--fix`, throws on remaining problems. |
| `sg-scan-on-edit` (ts/rails) | `lisa-sg-scan-on-edit.ts` — `tool.execute.after` `ast-grep scan`. |
| `rubocop-on-edit` (rails) | `lisa-rubocop-on-edit.ts` — `tool.execute.after` RuboCop `-a`. |

Plugins are gated by detected project type exactly like the Codex hook catalog. OpenCode exposes only `edit`/`write` tools (no `apply_patch`), so file paths come straight from the tool args.

## Architecture

- **`src/opencode/hooks-installer.ts`** (new): merges `permission.bash` into the host `opencode.json` (preserving host keys; a host `bash` string posture is re-seeded as a `*` catch-all) and emits the applicable `.opencode/plugin/lisa-*.ts` modules, with stale-plugin cleanup.
- **`src/opencode/plugin-templates/*.ts`** (new): the six plugin modules. Excluded from this repo's tsconfig/eslint — they run under OpenCode's **Bun** runtime, not here — and copied into `dist/` by **`scripts/copy-opencode-plugin-templates.mjs`** (mirrors `copy-codex-scripts.mjs`), wired into `build:dist`.
- **`src/core/lisa.ts`**: `processOpencodeEmit()` now also installs hooks and records plugin files in `.opencode/.lisa-managed.json`. `opencode.json` is a shared merged root file, intentionally **not** manifest-tracked.
- OpenCode uses the Codex per-project-overlay model (not the Pattern B per-agent variant filter), so **`scripts/lib/per-agent-hook-filter.mjs`** and **`scripts/plugin-routing-validate.mjs`** are deliberately untouched.
- Doc: added an OpenCode section to `wiki/architecture/lisa-hook-per-agent-ship-list.md`.

## Verification

**Verified-by-run** on opencode 1.16.2 (free model, `opencode run` headless):

- `permission.bash` deny: `git commit … --no-verify` and `HUSKY=0 git commit` denied; `echo` allowed.
- `tool.execute.before` throw blocks an `edit`/`write` (migration + suppress-directive cases); file not written, agent sees the error.
- `tool.execute.after` fires with `input.args.filePath`; both a throw (blocks) and an `output.output` append (feedback) reach the agent.
- Plugins load from `.opencode/plugin/*.ts` headless.
- **End-to-end**: real `lisa apply --harness opencode` on a TypeScript project emits `opencode.json` (deny rules) + the 4 type-gated plugins; a subsequent `opencode run` **fires `block-suppress-directives`** (write of an `eslint-disable` file blocked) and lets a normal `.ts` write through (lint fails open without ESLint installed).

**Tests**: `tests/unit/opencode/hooks-installer.test.ts` (20 new) covering config create/merge/idempotency/corruption, project-type gating, stale cleanup, and host-plugin preservation. `2990` unit tests pass; `typecheck` ✅ · `lint` ✅ (0 errors).

> Note: OpenCode's first `opencode run` pays a Bun cold-start (~30s) to transpile project plugins.

🤖 Generated with Claude Code
