### PR TITLE
feat(opencode): emit native agents and commands

### DIFF
--- a/src/codex/agent-installer.ts
+++ b/src/codex/agent-installer.ts
@@ -66,10 +66,15 @@ export interface AgentInstallResult {
  * order, so any stack-specific plugin (e.g. `lisa-rails`) or third-party
  * plugin overrides the base regardless of how the name sorts.
  * @param lisaDir - Absolute path to the Lisa repo root
+ * @param pluginFilter - Optional predicate to restrict which plugin directories
+ *   are walked (e.g. canonical-only for the OpenCode native agent surface, which
+ *   must skip the `*-copilot` variants whose `.agent.md` naming would otherwise
+ *   ship duplicate agents). Defaults to including every plugin.
  * @returns De-duplicated agent sources, sorted by id
  */
 export async function discoverLisaAgents(
-  lisaDir: string
+  lisaDir: string,
+  pluginFilter?: (pluginName: string) => boolean
 ): Promise<readonly AgentSource[]> {
   const pluginsDir = path.join(lisaDir, "plugins");
   if (!(await fse.pathExists(pluginsDir))) {
@@ -78,7 +83,10 @@ export async function discoverLisaAgents(
   // Put the base "lisa" plugin first so it is always overridable by any
   // other plugin via last-wins Map dedup below.  Remaining plugins are
   // sorted for deterministic ordering across machines.
-  const all = (await readdir(pluginsDir)).filter(name => name !== "src");
+  const include = pluginFilter ?? (() => true);
+  const all = (await readdir(pluginsDir)).filter(
+    name => name !== "src" && include(name)
+  );
   const plugins = [
     ...all.filter(n => n === "lisa"),
     ...all.filter(n => n !== "lisa").sort((a, b) => a.localeCompare(b)),

--- a/src/core/lisa-skill-sources.ts
+++ b/src/core/lisa-skill-sources.ts
@@ -23,6 +23,40 @@ import * as path from "node:path";
 /** Prefix applied to Lisa command-as-skill names (e.g. `lisa-git-commit`). */
 export const LISA_COMMAND_SKILL_PREFIX = "lisa-";
 
+/**
+ * Suffixes that mark a plugin directory as a per-harness fanout VARIANT rather
+ * than a canonical source. Lisa generates `<plugin>-agy`, `<plugin>-copilot`,
+ * and `<plugin>-cursor` variants from the canonical `<plugin>` for those
+ * harnesses (see the stack-per-agent fanout). They are reformatted copies — the
+ * copilot variant even renames agents to `*.agent.md` — so an overlay that reads
+ * the canonical Markdown format (Codex, OpenCode) must ingest the canonical
+ * plugins, not these variants, or it ships duplicates / harness-specific copies.
+ */
+export const HARNESS_VARIANT_PLUGIN_SUFFIXES = [
+  "-agy",
+  "-copilot",
+  "-cursor",
+] as const;
+
+/**
+ * Predicate: is `pluginName` a per-harness fanout variant (agy/copilot/cursor)?
+ * Canonical plugins (`lisa`, `lisa-typescript`, `lisa-wiki`, …) return false.
+ * @param pluginName - Plugin directory name under `plugins/`.
+ * @returns True when the plugin is a harness-specific variant, not a source.
+ */
+export function isHarnessVariantPlugin(pluginName: string): boolean {
+  return HARNESS_VARIANT_PLUGIN_SUFFIXES.some(suffix =>
+    pluginName.endsWith(suffix)
+  );
+}
+
+/**
+ * A plugin-name filter: given a plugin directory name, return true to include
+ * it in discovery. Used to restrict an overlay to canonical (non-variant)
+ * plugins.
+ */
+export type PluginFilter = (pluginName: string) => boolean;
+
 /** A single discovered bundled-skill folder source. */
 export interface BundledSkillSource {
   /** Skill name (matches the SKILL.md `name` frontmatter and folder name). */
@@ -122,16 +156,20 @@ export async function discoverBundledSkills(
  * first, then remaining plugins alphabetically) so stack-specific plugins
  * override the base regardless of name sort order.
  * @param lisaDir - Absolute path to the Lisa repo / installed package.
+ * @param pluginFilter - Optional predicate to restrict which plugin directories
+ *   are walked (e.g. canonical-only for the OpenCode native command surface).
+ *   Defaults to including every plugin.
  * @returns De-duplicated command-derived skill sources, sorted by skill name.
  */
 export async function discoverLisaCommands(
-  lisaDir: string
+  lisaDir: string,
+  pluginFilter?: PluginFilter
 ): Promise<readonly LisaCommandSource[]> {
   const pluginsDir = path.join(lisaDir, "plugins");
   if (!(await fse.pathExists(pluginsDir))) {
     return [];
   }
-  const plugins = await orderedPluginNames(pluginsDir);
+  const plugins = await orderedPluginNames(pluginsDir, pluginFilter);
   const candidatesByPlugin = await Promise.all(
     plugins.map(pluginName => discoverCommandsInPlugin(pluginsDir, pluginName))
   );
@@ -151,12 +189,18 @@ export async function discoverLisaCommands(
  * Base-first ordering is what gives the last-wins Map dedup its "stack
  * overrides base" behavior.
  * @param pluginsDir - Absolute path to `<lisaDir>/plugins`.
+ * @param pluginFilter - Optional predicate to drop plugin directories before
+ *   ordering (e.g. exclude per-harness variants). Defaults to including all.
  * @returns Ordered plugin directory names.
  */
 async function orderedPluginNames(
-  pluginsDir: string
+  pluginsDir: string,
+  pluginFilter?: PluginFilter
 ): Promise<readonly string[]> {
-  const all = (await readdir(pluginsDir)).filter(name => name !== "src");
+  const include = pluginFilter ?? (() => true);
+  const all = (await readdir(pluginsDir)).filter(
+    name => name !== "src" && include(name)
+  );
   return [
     ...all.filter(n => n === "lisa"),
     ...all.filter(n => n !== "lisa").sort((a, b) => a.localeCompare(b)),

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -33,6 +33,8 @@ import {
   installOpencodeMcpConfig,
   resolveOpencodeConfigPath,
 } from "../opencode/mcp-installer.js";
+import { discoverAndInstallAgents as installOpencodeAgents } from "../opencode/agent-installer.js";
+import { discoverAndInstallCommands as installOpencodeCommands } from "../opencode/command-installer.js";
 import { installClaudeMd } from "../claude/claude-md-installer.js";
 import { DetectorRegistry } from "../detection/index.js";
 import {
@@ -1016,13 +1018,17 @@ export class Lisa {
   /**
    * Emit OpenCode-targeted artifacts when the harness includes OpenCode.
    *
-   * OpenCode reads the open Agent Skills format and `AGENTS.md` natively
-   * (opencode.ai/docs/skills, /docs/rules), so Lisa needs no transformed plugin
-   * variant: it writes skills (bundled + command-derived) into the
-   * OpenCode-owned `.opencode/skills/lisa/` tree and ensures the canonical
-   * `AGENTS.md` exists. Ownership is tracked via `.opencode/.lisa-managed.json`
-   * so updates clean up stale skills without touching host customizations.
-   * Skipped in dry-run mode and on harness modes that don't include OpenCode.
+   * OpenCode reads the open Agent Skills format, native agents
+   * (`.opencode/agents/`), native commands (`.opencode/commands/`), and
+   * `AGENTS.md` natively (opencode.ai/docs/skills, /docs/agents, /docs/commands,
+   * /docs/rules), so Lisa needs no transformed plugin variant. It writes:
+   *   - skills (bundled + command-derived) into `.opencode/skills/lisa/`,
+   *   - agents (Markdown, `lisa-` prefixed) into `.opencode/agents/`,
+   *   - commands (Markdown, `lisa-` prefixed) into `.opencode/commands/`,
+   * and ensures the canonical `AGENTS.md` exists. Ownership of skills/agents/
+   * commands is tracked via `.opencode/.lisa-managed.json` so updates clean up
+   * stale artifacts without touching host customizations. Skipped in dry-run
+   * mode and on harness modes that don't include OpenCode.
    */
   private async processOpencodeEmit(): Promise<void> {
     const { harness } = this.config;
@@ -1040,10 +1046,28 @@ export class Lisa {
       this.config.destDir,
       previous.files
     );
+    // OpenCode reads agents (`.opencode/agents/`) and commands
+    // (`.opencode/commands/`) natively. Emit both from Lisa's plugin sources.
+    // Each installer scopes its own stale cleanup to its `lisa-` namespace, so
+    // passing the full previous manifest to all three is safe.
+    const opencodeAgentsResult = await installOpencodeAgents(
+      this.config.lisaDir,
+      this.config.destDir,
+      previous.files
+    );
+    const commandsResult = await installOpencodeCommands(
+      this.config.lisaDir,
+      this.config.destDir,
+      previous.files
+    );
     // OpenCode reads AGENTS.md natively; ensure the canonical file exists. It is
     // create-only and host-owned afterward, so it's not tracked in the manifest.
-    const agentsResult = await installAgentsMd(this.config.destDir);
-    await writeOpencodeManifest(this.config.destDir, skillsResult.managedFiles);
+    const agentsMdResult = await installAgentsMd(this.config.destDir);
+    await writeOpencodeManifest(this.config.destDir, [
+      ...skillsResult.managedFiles,
+      ...opencodeAgentsResult.managedFiles,
+      ...commandsResult.managedFiles,
+    ]);
 
     // Config-level delivery (host-preserving merges into the project
     // `opencode.json`, NOT tracked in the manifest — deleting a merged host file
@@ -1077,8 +1101,16 @@ export class Lisa {
           skillsResult.deleted.length > 0
             ? ` (${skillsResult.deleted.length} stale skills removed)`
             : ""
+        }, ${opencodeAgentsResult.installed.length} agents${
+          opencodeAgentsResult.deleted.length > 0
+            ? ` (${opencodeAgentsResult.deleted.length} stale agents removed)`
+            : ""
+        }, ${commandsResult.installed.length} commands${
+          commandsResult.deleted.length > 0
+            ? ` (${commandsResult.deleted.length} stale commands removed)`
+            : ""
         }, AGENTS.md ${
-          agentsResult.created ? "created" : HOST_OWNED_LABEL
+          agentsMdResult.created ? "created" : HOST_OWNED_LABEL
         }, opencode.json ${
           settingsResult.created ? "created" : "merged"
         }${mcpMessage}`

--- a/src/opencode/agent-installer.ts
+++ b/src/opencode/agent-installer.ts
@@ -1,0 +1,182 @@
+/**
+ * Install Lisa-bundled agents into a host project's `.opencode/agents/`.
+ *
+ * Pipeline per agent:
+ *   1. Read the source `.md` from the Lisa plugin (discovered via the shared
+ *      `discoverLisaAgents` walker, identical to the Codex overlay).
+ *   2. Transform Markdown + YAML frontmatter → OpenCode subagent Markdown
+ *      (frontmatter `description` + `mode: subagent`; body is the prompt). This
+ *      is a near-passthrough — OpenCode agents are Markdown like Claude's, so it
+ *      is simpler than the Codex TOML transform.
+ *   3. Write the result to `.opencode/agents/lisa-<id>.md`.
+ *
+ * The `lisa-` filename prefix is the ownership boundary: OpenCode derives an
+ * agent's name from its filename and reads `.opencode/agents/` flat (verified on
+ * opencode 1.16.2 — `opencode agent list` surfaces files placed there), so a
+ * prefix — rather than a `lisa/` subdir as used for skills — is what keeps Lisa
+ * agents from colliding with host-authored agents and gives stale cleanup a safe
+ * scope. Host agents (any file NOT starting with `lisa-`) are never touched.
+ *
+ * Stale agents (in the previous manifest but no longer shipped by Lisa) are
+ * deleted so renames in the source tree don't leave orphans behind.
+ * @module opencode/agent-installer
+ */
+import * as fse from "fs-extra";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import {
+  type AgentSource,
+  discoverLisaAgents,
+} from "../codex/agent-installer.js";
+import { isHarnessVariantPlugin } from "../core/lisa-skill-sources.js";
+import { transformAgentMarkdownToOpencode } from "./agent-transformer.js";
+import { OPENCODE_CONFIG_DIR } from "./manifest.js";
+
+export {
+  type AgentSource,
+  discoverLisaAgents,
+} from "../codex/agent-installer.js";
+
+/** Subdirectory inside `.opencode/` where Lisa-owned agents live */
+export const LISA_AGENTS_SUBDIR = "agents";
+
+/**
+ * Filename prefix marking an agent file as Lisa-owned. OpenCode reads
+ * `.opencode/agents/` flat, so the prefix (not a subdirectory) is the ownership
+ * boundary used for collision avoidance and stale cleanup.
+ */
+export const LISA_AGENT_FILE_PREFIX = "lisa-";
+
+/** Result of installing one agent */
+export interface InstalledAgent {
+  /** Agent id (source filename basename, without the `lisa-` prefix) */
+  readonly id: string;
+  /** Path written, relative to the destination project's `.opencode/` directory */
+  readonly relativePath: string;
+}
+
+/** Aggregated result of an install pass */
+export interface AgentInstallResult {
+  readonly installed: readonly InstalledAgent[];
+  /** Stale agent files deleted from `.opencode/agents/` (relative to `.opencode/`) */
+  readonly deleted: readonly string[];
+  /** Files written, relative to `.opencode/`. Used to update the manifest. */
+  readonly managedFiles: readonly string[];
+}
+
+/**
+ * Install all discovered agents into `<destDir>/.opencode/agents/`.
+ *
+ * Returns a result describing what was written and what stale files were
+ * deleted, so the caller can update the Lisa-managed manifest.
+ * @param sources - Agent sources from discoverLisaAgents
+ * @param destDir - Absolute path to the destination project root
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ *   (relative to `.opencode/`); used to detect stale agents to delete
+ * @returns Result describing installed/deleted/managedFiles
+ */
+export async function installAgents(
+  sources: readonly AgentSource[],
+  destDir: string,
+  previousManagedFiles: readonly string[]
+): Promise<AgentInstallResult> {
+  const agentsDir = path.join(destDir, OPENCODE_CONFIG_DIR, LISA_AGENTS_SUBDIR);
+  await fse.ensureDir(agentsDir);
+
+  const installed: readonly InstalledAgent[] = await Promise.all(
+    sources.map(source => installSingleAgent(source, agentsDir))
+  );
+  const managedFiles: readonly string[] = installed.map(
+    agent => agent.relativePath
+  );
+
+  const deleted = await deleteStaleAgents(
+    previousManagedFiles,
+    managedFiles,
+    destDir
+  );
+
+  return {
+    installed: Object.freeze(installed),
+    deleted: Object.freeze(deleted),
+    managedFiles: Object.freeze(managedFiles),
+  };
+}
+
+/**
+ * Transform + write a single agent file.
+ * @param source - Discovered agent source (id, plugin, source path)
+ * @param agentsDir - Absolute path to `.opencode/agents/` in the host project
+ * @returns Result describing the installed file
+ */
+async function installSingleAgent(
+  source: AgentSource,
+  agentsDir: string
+): Promise<InstalledAgent> {
+  const sourceContent = await readFile(source.sourcePath, "utf8");
+  const markdown = transformAgentMarkdownToOpencode(sourceContent);
+  const filename = `${LISA_AGENT_FILE_PREFIX}${source.id}.md`;
+  await writeFile(path.join(agentsDir, filename), markdown, "utf8");
+  return {
+    id: source.id,
+    relativePath: path.join(LISA_AGENTS_SUBDIR, filename),
+  };
+}
+
+/**
+ * Delete files that were Lisa-managed last run but aren't shipped this run.
+ * Only deletes files inside `.opencode/agents/` whose basename carries the
+ * `lisa-` prefix, so host-authored agents are never removed even if the
+ * previous manifest somehow references them.
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ *   (relative to `.opencode/`)
+ * @param currentManagedFiles - Files Lisa is shipping this run (relative
+ *   to `.opencode/`)
+ * @param destDir - Absolute path to the host project root
+ * @returns The list of relative paths that were deleted
+ */
+async function deleteStaleAgents(
+  previousManagedFiles: readonly string[],
+  currentManagedFiles: readonly string[],
+  destDir: string
+): Promise<readonly string[]> {
+  const currentSet = new Set(currentManagedFiles);
+  const lisaAgentPrefix = `${LISA_AGENTS_SUBDIR}${path.sep}${LISA_AGENT_FILE_PREFIX}`;
+  const stale = previousManagedFiles.filter(
+    file => !currentSet.has(file) && file.startsWith(lisaAgentPrefix)
+  );
+  await Promise.all(
+    stale.map(async file => {
+      const absPath = path.join(destDir, OPENCODE_CONFIG_DIR, file);
+      if (await fse.pathExists(absPath)) {
+        await unlink(absPath);
+      }
+    })
+  );
+  return Object.freeze(stale);
+}
+
+/**
+ * Convenience one-shot: discover Lisa agents from `lisaDir` and install them.
+ *
+ * Discovery is restricted to canonical plugins — the per-harness fanout variants
+ * (`*-agy`, `*-copilot`, `*-cursor`) are skipped. The copilot variants rename
+ * agents to `*.agent.md`, which would otherwise slip past id-dedup and ship a
+ * duplicate `lisa-<name>.agent` for every agent; the cursor/agy variants are
+ * just reformatted copies of the base agents.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package
+ * @param destDir - Absolute path to the destination project root
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ * @returns Result describing installed/deleted/managedFiles
+ */
+export async function discoverAndInstallAgents(
+  lisaDir: string,
+  destDir: string,
+  previousManagedFiles: readonly string[]
+): Promise<AgentInstallResult> {
+  const sources = await discoverLisaAgents(
+    lisaDir,
+    name => !isHarnessVariantPlugin(name)
+  );
+  return installAgents(sources, destDir, previousManagedFiles);
+}

--- a/src/opencode/agent-transformer.ts
+++ b/src/opencode/agent-transformer.ts
@@ -1,0 +1,143 @@
+/**
+ * Transform a Claude Code-style agent definition (Markdown with YAML
+ * frontmatter) into an OpenCode subagent Markdown file.
+ *
+ * Claude Code agent shape:
+ * ```
+ * ---
+ * name: bug-fixer
+ * description: ...
+ * tools: Read, Bash             # optional; preserved as compatibility context
+ * model: sonnet                 # optional; preserved as compatibility context
+ * skills: [skill-a, skill-b]    # optional; preserved as context
+ * ---
+ * # Body becomes the agent prompt
+ * ```
+ *
+ * OpenCode agent shape (per https://opencode.ai/docs/agents):
+ * ```
+ * ---
+ * description: ...
+ * mode: subagent
+ * ---
+ * # Body is the agent prompt
+ * ```
+ *
+ * OpenCode agents are Markdown like Claude's, so — unlike the Codex TOML
+ * transform — this is a near-passthrough: the body is preserved verbatim and
+ * the only required reshape is the frontmatter. The agent NAME is derived by
+ * OpenCode from the destination filename (not a frontmatter field), so the
+ * installer owns naming; this transformer only owns the file contents.
+ *
+ * Claude-only metadata (`tools`, `model`, `skills`) is NOT emitted as OpenCode
+ * frontmatter — `model` expects a `provider/model` string that a Claude alias
+ * (`sonnet`) would violate, and `tools`/`skills` have no 1:1 frontmatter slot.
+ * Instead that metadata is preserved as a context block in the body so nothing
+ * is silently dropped, mirroring the Codex transformer's compatibility blocks.
+ * @module opencode/agent-transformer
+ */
+import {
+  type ParsedAgent,
+  parseAgentMarkdown,
+} from "../codex/agent-transformer.js";
+
+/**
+ * Transform a parsed Lisa agent into OpenCode subagent Markdown.
+ * @param parsed - Output of parseAgentMarkdown (frontmatter + body)
+ * @returns OpenCode agent Markdown (frontmatter + prompt body)
+ */
+export function transformAgentToOpencodeMarkdown(parsed: ParsedAgent): string {
+  const frontmatter = [
+    "---",
+    `description: ${jsonScalar(parsed.frontmatter.description)}`,
+    "mode: subagent",
+    "---",
+    "",
+  ].join("\n");
+  const body = composeAgentBody(parsed);
+  return `${frontmatter}${body}\n`;
+}
+
+/**
+ * One-shot helper: parse + transform.
+ * @param source - Raw contents of an agent .md file
+ * @returns OpenCode agent Markdown
+ */
+export function transformAgentMarkdownToOpencode(source: string): string {
+  return transformAgentToOpencodeMarkdown(parseAgentMarkdown(source));
+}
+
+/**
+ * Build the OpenCode agent body. The original Claude body is preserved
+ * verbatim; any Claude-only metadata that has no OpenCode frontmatter slot is
+ * prepended as a context block so the information survives the transform.
+ * @param parsed - Output of parseAgentMarkdown for the source agent file
+ * @returns The composed Markdown body
+ */
+function composeAgentBody(parsed: ParsedAgent): string {
+  const compatibilityBlock = formatCompatibilityBlock(parsed);
+  const skillsBlock = formatSkillsBlock(parsed);
+  return [compatibilityBlock, skillsBlock, parsed.body.trimEnd()]
+    .filter(block => block.length > 0)
+    .join("\n\n");
+}
+
+/**
+ * Preserve Claude-only `model`/`tools` metadata as an OpenCode context block.
+ * OpenCode governs model and tool access through its own runtime/config, so
+ * these are advisory notes rather than enforced settings.
+ * @param parsed - Parsed source agent
+ * @returns Markdown compatibility block, or an empty string when unnecessary
+ */
+function formatCompatibilityBlock(parsed: ParsedAgent): string {
+  const { model, tools } = parsed.frontmatter;
+  const modelLines =
+    model === undefined
+      ? []
+      : [
+          `- Claude requested model: \`${model}\`. OpenCode uses the active session model unless the host sets \`model\` on this agent.`,
+        ];
+  const toolLines =
+    tools === undefined
+      ? []
+      : [
+          `- Claude allowed tools: \`${tools}\`. OpenCode tool access is governed by the active OpenCode runtime, \`permission\` settings, and project policy.`,
+        ];
+  const lines = [...modelLines, ...toolLines];
+  if (lines.length === 0) {
+    return "";
+  }
+  return ["## Claude Agent Compatibility", "", ...lines].join("\n");
+}
+
+/**
+ * Preserve the source agent's `skills:` list as a context block. OpenCode
+ * discovers these skills natively from `.opencode/skills/lisa/`, so this block
+ * just documents which ones the agent is expected to use.
+ * @param parsed - Parsed source agent
+ * @returns Markdown skills block, or an empty string when no skills are listed
+ */
+function formatSkillsBlock(parsed: ParsedAgent): string {
+  const skills = parsed.frontmatter.skills;
+  if (skills === undefined || skills.length === 0) {
+    return "";
+  }
+  return [
+    "## Available Lisa Skills",
+    "",
+    "This agent operates in a Lisa-managed OpenCode environment with access to the following skills:",
+    "",
+    ...skills.map(skill => `- ${skill}`),
+  ].join("\n");
+}
+
+/**
+ * Encode a string as a YAML-safe flow scalar. A JSON-encoded string is always a
+ * valid YAML double-quoted scalar, so this safely handles descriptions that
+ * contain colons, quotes, or other YAML-significant characters.
+ * @param value - The raw string to encode
+ * @returns A double-quoted YAML scalar
+ */
+function jsonScalar(value: string): string {
+  return JSON.stringify(value);
+}

--- a/src/opencode/command-installer.ts
+++ b/src/opencode/command-installer.ts
@@ -1,0 +1,182 @@
+/**
+ * Install Lisa commands as native OpenCode custom commands in
+ * `.opencode/commands/`.
+ *
+ * Pipeline per command:
+ *   1. Discover `plugins/<plugin>/commands/**\/*.md` via the shared
+ *      `discoverLisaCommands` walker (identical discovery to the skills path).
+ *   2. Transform the command Markdown → OpenCode command Markdown (frontmatter
+ *      `description`; body preserves `$ARGUMENTS` for native substitution).
+ *   3. Write the result to `.opencode/commands/<lisa-name>.md`, where the
+ *      filename is the shared dash-joined `lisa-` prefixed name (e.g.
+ *      `lisa-git-commit`), so the command surfaces as `/lisa-git-commit`.
+ *
+ * This is ADDITIVE and native-fidelity: Lisa commands already work on OpenCode
+ * as `lisa-` prefixed skills, so the lower-priority value here is exposing them
+ * through OpenCode's first-class command surface with native argument handling.
+ *
+ * The `lisa-` filename prefix (already baked into the shared command skill name)
+ * is the ownership boundary — host-authored commands (any file NOT starting with
+ * `lisa-`) are never touched, and stale cleanup is scoped to `lisa-` files only.
+ * @module opencode/command-installer
+ */
+import * as fse from "fs-extra";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import {
+  type LisaCommandSource,
+  discoverLisaCommands,
+  isHarnessVariantPlugin,
+} from "../core/lisa-skill-sources.js";
+import { transformCommandToOpencode } from "./command-transformer.js";
+import { OPENCODE_CONFIG_DIR } from "./manifest.js";
+
+export {
+  type LisaCommandSource,
+  discoverLisaCommands,
+} from "../core/lisa-skill-sources.js";
+
+/** Subdirectory inside `.opencode/` where Lisa-owned commands live */
+export const LISA_COMMANDS_SUBDIR = "commands";
+
+/**
+ * Filename prefix marking a command file as Lisa-owned. The shared command
+ * discovery already names every command `lisa-<...>`, so this matches the
+ * basename of every file Lisa writes and scopes stale cleanup safely.
+ */
+export const LISA_COMMAND_FILE_PREFIX = "lisa-";
+
+/** Result of installing one command */
+export interface InstalledCommand {
+  /** Command name (the `lisa-` prefixed, dash-joined skill name) */
+  readonly name: string;
+  /** Path written, relative to the destination project's `.opencode/` directory */
+  readonly relativePath: string;
+}
+
+/** Aggregated result of an install pass */
+export interface CommandInstallResult {
+  readonly installed: readonly InstalledCommand[];
+  /** Stale command files deleted from `.opencode/commands/` (relative to `.opencode/`) */
+  readonly deleted: readonly string[];
+  /** Files written, relative to `.opencode/`. Used to update the manifest. */
+  readonly managedFiles: readonly string[];
+}
+
+/**
+ * Install all discovered commands into `<destDir>/.opencode/commands/`.
+ * @param sources - Command sources from discoverLisaCommands
+ * @param destDir - Absolute path to the destination project root
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ *   (relative to `.opencode/`); used to detect stale commands to delete
+ * @returns Result describing installed/deleted/managedFiles
+ */
+export async function installCommands(
+  sources: readonly LisaCommandSource[],
+  destDir: string,
+  previousManagedFiles: readonly string[]
+): Promise<CommandInstallResult> {
+  const commandsDir = path.join(
+    destDir,
+    OPENCODE_CONFIG_DIR,
+    LISA_COMMANDS_SUBDIR
+  );
+  await fse.ensureDir(commandsDir);
+
+  const installed: readonly InstalledCommand[] = await Promise.all(
+    sources.map(source => installSingleCommand(source, commandsDir))
+  );
+  const managedFiles: readonly string[] = installed.map(
+    command => command.relativePath
+  );
+
+  const deleted = await deleteStaleCommands(
+    previousManagedFiles,
+    managedFiles,
+    destDir
+  );
+
+  return {
+    installed: Object.freeze(installed),
+    deleted: Object.freeze(deleted),
+    managedFiles: Object.freeze(managedFiles),
+  };
+}
+
+/**
+ * Transform + write a single command file.
+ * @param source - Discovered command source (skill name, display name, path)
+ * @param commandsDir - Absolute path to `.opencode/commands/` in the host
+ * @returns Result describing the installed file
+ */
+async function installSingleCommand(
+  source: LisaCommandSource,
+  commandsDir: string
+): Promise<InstalledCommand> {
+  const sourceContent = await readFile(source.sourcePath, "utf8");
+  const markdown = transformCommandToOpencode(
+    sourceContent,
+    source.displayName
+  );
+  const filename = `${source.skillName}.md`;
+  await writeFile(path.join(commandsDir, filename), markdown, "utf8");
+  return {
+    name: source.skillName,
+    relativePath: path.join(LISA_COMMANDS_SUBDIR, filename),
+  };
+}
+
+/**
+ * Delete files that were Lisa-managed last run but aren't shipped this run.
+ * Only deletes files inside `.opencode/commands/` whose basename carries the
+ * `lisa-` prefix, so host-authored commands are never removed.
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ *   (relative to `.opencode/`)
+ * @param currentManagedFiles - Files Lisa is shipping this run (relative
+ *   to `.opencode/`)
+ * @param destDir - Absolute path to the host project root
+ * @returns The list of relative paths that were deleted
+ */
+async function deleteStaleCommands(
+  previousManagedFiles: readonly string[],
+  currentManagedFiles: readonly string[],
+  destDir: string
+): Promise<readonly string[]> {
+  const currentSet = new Set(currentManagedFiles);
+  const lisaCommandPrefix = `${LISA_COMMANDS_SUBDIR}${path.sep}${LISA_COMMAND_FILE_PREFIX}`;
+  const stale = previousManagedFiles.filter(
+    file => !currentSet.has(file) && file.startsWith(lisaCommandPrefix)
+  );
+  await Promise.all(
+    stale.map(async file => {
+      const absPath = path.join(destDir, OPENCODE_CONFIG_DIR, file);
+      if (await fse.pathExists(absPath)) {
+        await unlink(absPath);
+      }
+    })
+  );
+  return Object.freeze(stale);
+}
+
+/**
+ * Convenience one-shot: discover Lisa commands from `lisaDir` and install them.
+ *
+ * Discovery is restricted to canonical plugins — the per-harness fanout variants
+ * (`*-agy`, `*-copilot`, `*-cursor`) are skipped so a reformatted variant copy
+ * of a command body never wins the last-wins dedup over the canonical source.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package
+ * @param destDir - Absolute path to the destination project root
+ * @param previousManagedFiles - Files Lisa managed on the previous run
+ * @returns Result describing installed/deleted/managedFiles
+ */
+export async function discoverAndInstallCommands(
+  lisaDir: string,
+  destDir: string,
+  previousManagedFiles: readonly string[]
+): Promise<CommandInstallResult> {
+  const sources = await discoverLisaCommands(
+    lisaDir,
+    name => !isHarnessVariantPlugin(name)
+  );
+  return installCommands(sources, destDir, previousManagedFiles);
+}

--- a/src/opencode/command-transformer.ts
+++ b/src/opencode/command-transformer.ts
@@ -1,0 +1,84 @@
+/**
+ * Convert a Lisa command Markdown file into an OpenCode custom command.
+ *
+ * Lisa commands already work today on OpenCode as `lisa-` prefixed skills (see
+ * `opencode/skills-installer.ts`). This transformer is the additive, native
+ * path: OpenCode has a first-class command format
+ * (https://opencode.ai/docs/commands) with its own frontmatter and native
+ * `$ARGUMENTS` / `$1` / `@file` substitution.
+ *
+ * Claude command shape:
+ * ```
+ * ---
+ * description: ...
+ * argument-hint: "<x>"          # optional
+ * ---
+ * Body with $ARGUMENTS
+ * ```
+ *
+ * OpenCode command shape:
+ * ```
+ * ---
+ * description: ...
+ * ---
+ * Body with $ARGUMENTS
+ * ```
+ *
+ * Unlike the command-to-SKILL conversion (which strips `$ARGUMENTS` because a
+ * skill has no argument channel), this PRESERVES `$ARGUMENTS` verbatim because
+ * OpenCode substitutes it natively (verified on opencode 1.16.2 — the resolved
+ * config keeps `$ARGUMENTS` in the command template). The body is otherwise
+ * passed through unchanged.
+ * @module opencode/command-transformer
+ */
+import yaml from "js-yaml";
+
+/**
+ * Pure transform: convert a Lisa command Markdown into an OpenCode command
+ * Markdown.
+ * @param commandSource - Raw contents of the command .md file
+ * @param displayName - Human-readable name used as a fallback description
+ *   (e.g. "lisa:git:commit")
+ * @returns The OpenCode command Markdown content as a string
+ */
+export function transformCommandToOpencode(
+  commandSource: string,
+  displayName: string
+): string {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(
+    commandSource
+  );
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    throw new Error(
+      `Command source is missing YAML frontmatter for ${displayName}`
+    );
+  }
+  const description = parseDescription(yaml.load(match[1]), displayName);
+  const body = match[2].trimStart().trimEnd();
+
+  const frontmatter = [
+    "---",
+    `description: ${JSON.stringify(description)}`,
+    "---",
+    "",
+  ].join("\n");
+
+  return `${frontmatter}${body}\n`;
+}
+
+/**
+ * Extract the command description from parsed frontmatter, falling back to the
+ * display name when none is present.
+ * @param parsed - Output of `yaml.load(rawFrontmatter)` (untrusted shape)
+ * @param displayName - Fallback used when no description is available
+ * @returns The description string
+ */
+function parseDescription(parsed: unknown, displayName: string): string {
+  if (parsed === null || typeof parsed !== "object") {
+    return displayName;
+  }
+  const obj = parsed as Record<string, unknown>;
+  return typeof obj.description === "string" && obj.description.length > 0
+    ? obj.description
+    : displayName;
+}

--- a/tests/unit/core/lisa-skill-sources.test.ts
+++ b/tests/unit/core/lisa-skill-sources.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for the agent-agnostic Lisa source discovery helpers.
+ *
+ * Focused on `isHarnessVariantPlugin`, the canonical-vs-variant classifier used
+ * by the OpenCode (and any canonical-Markdown) overlay to skip per-harness
+ * fanout plugins (`*-agy`, `*-copilot`, `*-cursor`).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  HARNESS_VARIANT_PLUGIN_SUFFIXES,
+  isHarnessVariantPlugin,
+} from "../../../src/core/lisa-skill-sources.js";
+
+describe("core/lisa-skill-sources isHarnessVariantPlugin", () => {
+  it("treats the base and stack plugins as canonical", () => {
+    for (const name of [
+      "lisa",
+      "lisa-typescript",
+      "lisa-expo",
+      "lisa-cdk",
+      "lisa-nestjs",
+      "lisa-rails",
+      "lisa-harper-fabric",
+      "lisa-openclaw",
+      "lisa-wiki",
+    ]) {
+      expect(isHarnessVariantPlugin(name)).toBe(false);
+    }
+  });
+
+  it("flags every per-harness fanout variant", () => {
+    for (const name of [
+      "lisa-agy",
+      "lisa-copilot",
+      "lisa-cursor",
+      "lisa-cdk-copilot",
+      "lisa-expo-cursor",
+      "lisa-wiki-agy",
+    ]) {
+      expect(isHarnessVariantPlugin(name)).toBe(true);
+    }
+  });
+
+  it("matches each documented suffix", () => {
+    for (const suffix of HARNESS_VARIANT_PLUGIN_SUFFIXES) {
+      expect(isHarnessVariantPlugin(`lisa-stack${suffix}`)).toBe(true);
+    }
+  });
+});

--- a/tests/unit/opencode/agent-installer.test.ts
+++ b/tests/unit/opencode/agent-installer.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the OpenCode agent installer (discovery reuse + transform +
+ * stale cleanup).
+ *
+ * Covers:
+ *   - Writes agents to `.opencode/agents/lisa-<id>.md` (flat, `lisa-` prefixed)
+ *   - Frontmatter is OpenCode-shaped (description + mode: subagent)
+ *   - De-dup across plugins (stack wins over base) via shared discovery
+ *   - Stale cleanup scoped to `agents/lisa-*` — never touches host agents
+ *   - managedFiles list for manifest persistence; idempotence
+ */
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_AGENTS_SUBDIR,
+  LISA_AGENT_FILE_PREFIX,
+  discoverAndInstallAgents,
+  discoverLisaAgents,
+  installAgents,
+} from "../../../src/opencode/agent-installer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const BUG_FIXER = "bug-fixer";
+const BUG_FIXER_MD = `${BUG_FIXER}.md`;
+const BUG_FIXER_OUT = `${LISA_AGENT_FILE_PREFIX}${BUG_FIXER}.md`;
+const PLUGIN_LISA = "lisa";
+const PLUGIN_LISA_RAILS = "lisa-rails";
+const OPENCODE_DIR = ".opencode";
+const HOST_AGENT_MD = "host-agent.md";
+const OLD_AGENT_OUT = `${LISA_AGENT_FILE_PREFIX}old-agent.md`;
+
+const SAMPLE_AGENT = `---
+name: bug-fixer
+description: Bug fix agent
+---
+
+Body content.
+`;
+
+const SAMPLE_AGENT_2 = `---
+name: bug-fixer
+description: Rails bug fix agent
+---
+
+Rails body.
+`;
+
+describe("opencode/agent-installer", () => {
+  let tempDir: string;
+  let lisaDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a fake plugin tree under <lisaDir>/plugins/<plugin>/agents/.
+   * @param pluginName - Plugin directory name (e.g. "lisa", "lisa-rails").
+   * @param files - Map of agent filename → markdown content.
+   */
+  async function seedPlugin(
+    pluginName: string,
+    files: Record<string, string>
+  ): Promise<void> {
+    const agentsDir = path.join(lisaDir, "plugins", pluginName, "agents");
+    await fs.ensureDir(agentsDir);
+    for (const [filename, content] of Object.entries(files)) {
+      await fs.writeFile(path.join(agentsDir, filename), content, "utf8");
+    }
+  }
+
+  /**
+   * Resolve the absolute path of an installed Lisa agent file.
+   * @param filename - Emitted filename (e.g. "lisa-bug-fixer.md").
+   * @returns Absolute path under `.opencode/agents/`.
+   */
+  function installedAgentPath(filename: string): string {
+    return path.join(destDir, OPENCODE_DIR, LISA_AGENTS_SUBDIR, filename);
+  }
+
+  it("writes agents to .opencode/agents/ with a lisa- prefix", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    const result = await discoverAndInstallAgents(lisaDir, destDir, []);
+
+    expect(result.installed).toHaveLength(1);
+    expect(result.installed[0]?.id).toBe(BUG_FIXER);
+    expect(result.installed[0]?.relativePath).toBe(
+      path.join(LISA_AGENTS_SUBDIR, BUG_FIXER_OUT)
+    );
+    expect(await fs.pathExists(installedAgentPath(BUG_FIXER_OUT))).toBe(true);
+  });
+
+  it("emits OpenCode-shaped frontmatter (description + mode: subagent)", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    await discoverAndInstallAgents(lisaDir, destDir, []);
+    const content = await fs.readFile(
+      installedAgentPath(BUG_FIXER_OUT),
+      "utf8"
+    );
+    const fm = yaml.load(
+      /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)?.[1] ?? ""
+    ) as Record<string, unknown>;
+    expect(fm.description).toBe("Bug fix agent");
+    expect(fm.mode).toBe("subagent");
+    expect(content).toContain("Body content.");
+  });
+
+  it("excludes per-harness variant plugins (copilot .agent.md duplicates)", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    // The copilot fanout renames agents to *.agent.md; without canonical
+    // filtering this would ship a duplicate lisa-bug-fixer.agent.md.
+    await seedPlugin("lisa-copilot", { "bug-fixer.agent.md": SAMPLE_AGENT });
+    // The cursor/agy fanout are reformatted copies that must not override base.
+    await seedPlugin("lisa-cursor", { [BUG_FIXER_MD]: SAMPLE_AGENT_2 });
+    const result = await discoverAndInstallAgents(lisaDir, destDir, []);
+
+    expect(result.installed.map(a => a.id)).toEqual([BUG_FIXER]);
+    expect(
+      await fs.pathExists(
+        installedAgentPath(`${LISA_AGENT_FILE_PREFIX}bug-fixer.agent.md`)
+      )
+    ).toBe(false);
+    // Base content wins (cursor variant excluded), not the Rails-labelled copy.
+    const content = await fs.readFile(
+      installedAgentPath(BUG_FIXER_OUT),
+      "utf8"
+    );
+    expect(content).toContain("Bug fix agent");
+    expect(content).not.toContain("Rails bug fix agent");
+  });
+
+  it("de-duplicates by id with stack winning over base", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    await seedPlugin(PLUGIN_LISA_RAILS, { [BUG_FIXER_MD]: SAMPLE_AGENT_2 });
+    const result = await discoverAndInstallAgents(lisaDir, destDir, []);
+
+    expect(result.installed).toHaveLength(1);
+    const content = await fs.readFile(
+      installedAgentPath(BUG_FIXER_OUT),
+      "utf8"
+    );
+    expect(content).toContain("Rails bug fix agent");
+    expect(content).toContain("Rails body.");
+  });
+
+  it("returns managedFiles for manifest persistence", async () => {
+    await seedPlugin(PLUGIN_LISA, {
+      [BUG_FIXER_MD]: SAMPLE_AGENT,
+      "builder.md": SAMPLE_AGENT.replace("bug-fixer", "builder"),
+    });
+    const result = await discoverAndInstallAgents(lisaDir, destDir, []);
+    expect([...result.managedFiles].sort((a, b) => a.localeCompare(b))).toEqual(
+      [
+        path.join(LISA_AGENTS_SUBDIR, BUG_FIXER_OUT),
+        path.join(LISA_AGENTS_SUBDIR, `${LISA_AGENT_FILE_PREFIX}builder.md`),
+      ]
+    );
+  });
+
+  it("deletes stale lisa- agents managed previously but not shipped now", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    const agentsDir = path.join(destDir, OPENCODE_DIR, LISA_AGENTS_SUBDIR);
+    await fs.ensureDir(agentsDir);
+    await fs.writeFile(path.join(agentsDir, OLD_AGENT_OUT), "stale", "utf8");
+    const previousManagedFiles = [
+      path.join(LISA_AGENTS_SUBDIR, BUG_FIXER_OUT),
+      path.join(LISA_AGENTS_SUBDIR, OLD_AGENT_OUT),
+    ];
+    const result = await discoverAndInstallAgents(
+      lisaDir,
+      destDir,
+      previousManagedFiles
+    );
+
+    expect(result.deleted).toEqual([
+      path.join(LISA_AGENTS_SUBDIR, OLD_AGENT_OUT),
+    ]);
+    expect(await fs.pathExists(path.join(agentsDir, OLD_AGENT_OUT))).toBe(
+      false
+    );
+    expect(await fs.pathExists(installedAgentPath(BUG_FIXER_OUT))).toBe(true);
+  });
+
+  it("never deletes host agents (files without the lisa- prefix)", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    const agentsDir = path.join(destDir, OPENCODE_DIR, LISA_AGENTS_SUBDIR);
+    await fs.ensureDir(agentsDir);
+    await fs.writeFile(
+      path.join(agentsDir, HOST_AGENT_MD),
+      "host-owned",
+      "utf8"
+    );
+    // Even if the previous manifest somehow references the host file, the
+    // prefix guard must protect it.
+    const result = await discoverAndInstallAgents(lisaDir, destDir, [
+      path.join(LISA_AGENTS_SUBDIR, HOST_AGENT_MD),
+    ]);
+
+    expect(result.deleted).toEqual([]);
+    expect(await fs.pathExists(path.join(agentsDir, HOST_AGENT_MD))).toBe(true);
+  });
+
+  it("idempotent: running twice produces identical output", async () => {
+    await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+    const sources = await discoverLisaAgents(lisaDir);
+    await installAgents(sources, destDir, []);
+    const first = await fs.readFile(installedAgentPath(BUG_FIXER_OUT), "utf8");
+    await installAgents(sources, destDir, []);
+    const second = await fs.readFile(installedAgentPath(BUG_FIXER_OUT), "utf8");
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/opencode/agent-transformer.test.ts
+++ b/tests/unit/opencode/agent-transformer.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the OpenCode agent transformer (Claude agent Markdown →
+ * OpenCode subagent Markdown).
+ *
+ * Covers:
+ *   - Frontmatter reshape (description + mode: subagent), body passthrough
+ *   - skills/model/tools metadata preserved as body context blocks
+ *   - YAML-safe description encoding (colons, quotes)
+ *   - Malformed frontmatter throws
+ */
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import {
+  transformAgentMarkdownToOpencode,
+  transformAgentToOpencodeMarkdown,
+} from "../../../src/opencode/agent-transformer.js";
+import { parseAgentMarkdown } from "../../../src/codex/agent-transformer.js";
+
+const SIMPLE_AGENT = `---
+name: bug-fixer
+description: Bug fix agent
+---
+
+Body content here.
+`;
+
+describe("opencode/agent-transformer", () => {
+  it("emits description + mode: subagent frontmatter and preserves the body", () => {
+    const out = transformAgentMarkdownToOpencode(SIMPLE_AGENT);
+    const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/.exec(out);
+    expect(match).not.toBeNull();
+    const fm = yaml.load(match?.[1] ?? "") as Record<string, unknown>;
+    expect(fm.description).toBe("Bug fix agent");
+    expect(fm.mode).toBe("subagent");
+    // No name field — OpenCode derives the name from the filename
+    expect(fm.name).toBeUndefined();
+    expect(match?.[2]).toContain("Body content here.");
+  });
+
+  it("does not emit a Claude name field into OpenCode frontmatter", () => {
+    const out = transformAgentMarkdownToOpencode(SIMPLE_AGENT);
+    expect(out).not.toMatch(/^name:/m);
+  });
+
+  it("preserves a skills: list as an in-body context block", () => {
+    const agent = `---
+name: architect
+description: Architecture agent
+skills:
+  - codebase-research
+  - task-decomposition
+---
+
+Design the approach.
+`;
+    const out = transformAgentMarkdownToOpencode(agent);
+    expect(out).toContain("## Available Lisa Skills");
+    expect(out).toContain("- codebase-research");
+    expect(out).toContain("- task-decomposition");
+    expect(out).toContain("Design the approach.");
+  });
+
+  it("preserves model/tools metadata as a compatibility block, not frontmatter", () => {
+    const agent = `---
+name: runner
+description: Runner agent
+tools: Read, Bash
+model: sonnet
+---
+
+Do the thing.
+`;
+    const out = transformAgentMarkdownToOpencode(agent);
+    const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)?.[1] ?? "";
+    // model/tools must NOT leak into frontmatter (a Claude alias would be an
+    // invalid OpenCode model id)
+    expect(fm).not.toMatch(/^model:/m);
+    expect(fm).not.toMatch(/^tools:/m);
+    // ...but the information is preserved in the body
+    expect(out).toContain("## Claude Agent Compatibility");
+    expect(out).toContain("`sonnet`");
+    expect(out).toContain("Read, Bash");
+  });
+
+  it("encodes descriptions containing colons and quotes as YAML-safe scalars", () => {
+    const agent = `---
+name: tricky
+description: 'Does X: "quoted" and more'
+---
+
+Body.
+`;
+    const out = transformAgentMarkdownToOpencode(agent);
+    const fm = yaml.load(
+      /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)?.[1] ?? ""
+    ) as Record<string, unknown>;
+    expect(fm.description).toBe('Does X: "quoted" and more');
+  });
+
+  it("transformAgentToOpencodeMarkdown accepts a pre-parsed agent", () => {
+    const parsed = parseAgentMarkdown(SIMPLE_AGENT);
+    const out = transformAgentToOpencodeMarkdown(parsed);
+    expect(out).toContain("mode: subagent");
+    expect(out).toContain("Body content here.");
+  });
+
+  it("throws on markdown missing YAML frontmatter", () => {
+    expect(() =>
+      transformAgentMarkdownToOpencode("no frontmatter here")
+    ).toThrow(/frontmatter/i);
+  });
+});

--- a/tests/unit/opencode/command-installer.test.ts
+++ b/tests/unit/opencode/command-installer.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the OpenCode command installer (discovery reuse + transform +
+ * stale cleanup).
+ *
+ * Covers:
+ *   - Writes commands to `.opencode/commands/lisa-<name>.md`
+ *   - Nested commands use the dash-joined `lisa-` name
+ *   - $ARGUMENTS preserved in the emitted command
+ *   - Stale cleanup scoped to `commands/lisa-*` — never touches host commands
+ *   - managedFiles for manifest persistence; idempotence
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_COMMANDS_SUBDIR,
+  discoverAndInstallCommands,
+} from "../../../src/opencode/command-installer.js";
+import { LISA_COMMAND_SKILL_PREFIX } from "../../../src/core/lisa-skill-sources.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const PLUGIN_LISA = "lisa";
+const OPENCODE_DIR = ".opencode";
+const HOST_COMMAND_MD = "host-command.md";
+const OLD_COMMAND_OUT = `${LISA_COMMAND_SKILL_PREFIX}old.md`;
+
+const SAMPLE_COMMAND = `---
+description: "Fix a bug via TDD."
+argument-hint: "<description>"
+---
+
+Execute the Implement flow.
+
+$ARGUMENTS
+`;
+
+describe("opencode/command-installer", () => {
+  let tempDir: string;
+  let lisaDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a fake command file under plugins/<plugin>/commands/<relPath>.
+   * @param pluginName - Plugin directory name.
+   * @param relPath - Path under commands/ (e.g. "fix.md", "git/commit.md").
+   * @param content - Markdown content of the command file.
+   */
+  async function seedCommand(
+    pluginName: string,
+    relPath: string,
+    content: string
+  ): Promise<void> {
+    const filePath = path.join(
+      lisaDir,
+      "plugins",
+      pluginName,
+      "commands",
+      relPath
+    );
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, content, "utf8");
+  }
+
+  /**
+   * Resolve the absolute path of an installed Lisa command file.
+   * @param filename - Emitted filename (e.g. "lisa-fix.md").
+   * @returns Absolute path under `.opencode/commands/`.
+   */
+  function installedCommandPath(filename: string): string {
+    return path.join(destDir, OPENCODE_DIR, LISA_COMMANDS_SUBDIR, filename);
+  }
+
+  it("writes a top-level command to .opencode/commands/lisa-<name>.md", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    const result = await discoverAndInstallCommands(lisaDir, destDir, []);
+
+    const filename = `${LISA_COMMAND_SKILL_PREFIX}fix.md`;
+    expect(result.installed.map(c => c.name)).toContain(
+      `${LISA_COMMAND_SKILL_PREFIX}fix`
+    );
+    expect(await fs.pathExists(installedCommandPath(filename))).toBe(true);
+    const content = await fs.readFile(installedCommandPath(filename), "utf8");
+    expect(content).toContain('description: "Fix a bug via TDD."');
+    expect(content).toContain("$ARGUMENTS");
+  });
+
+  it("names nested commands with the dash-joined lisa- prefix", async () => {
+    await seedCommand(PLUGIN_LISA, "git/commit.md", SAMPLE_COMMAND);
+    const result = await discoverAndInstallCommands(lisaDir, destDir, []);
+
+    const filename = `${LISA_COMMAND_SKILL_PREFIX}git-commit.md`;
+    expect(await fs.pathExists(installedCommandPath(filename))).toBe(true);
+    expect(result.installed.map(c => c.name)).toContain(
+      `${LISA_COMMAND_SKILL_PREFIX}git-commit`
+    );
+  });
+
+  it("excludes per-harness variant plugins so the canonical body wins", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    // A cursor fanout copy with a reformatted body must not win the dedup.
+    const variantCommand = SAMPLE_COMMAND.replace(
+      "Execute the Implement flow.",
+      "CURSOR REFORMATTED BODY"
+    );
+    await seedCommand("lisa-cursor", "fix.md", variantCommand);
+    const result = await discoverAndInstallCommands(lisaDir, destDir, []);
+
+    expect(result.installed.map(c => c.name)).toEqual([
+      `${LISA_COMMAND_SKILL_PREFIX}fix`,
+    ]);
+    const content = await fs.readFile(
+      installedCommandPath(`${LISA_COMMAND_SKILL_PREFIX}fix.md`),
+      "utf8"
+    );
+    expect(content).toContain("Execute the Implement flow.");
+    expect(content).not.toContain("CURSOR REFORMATTED BODY");
+  });
+
+  it("returns managedFiles for manifest persistence", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    const result = await discoverAndInstallCommands(lisaDir, destDir, []);
+    expect(result.managedFiles).toContain(
+      path.join(LISA_COMMANDS_SUBDIR, `${LISA_COMMAND_SKILL_PREFIX}fix.md`)
+    );
+  });
+
+  it("deletes stale lisa- commands managed previously but not shipped now", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    const commandsDir = path.join(destDir, OPENCODE_DIR, LISA_COMMANDS_SUBDIR);
+    await fs.ensureDir(commandsDir);
+    await fs.writeFile(
+      path.join(commandsDir, OLD_COMMAND_OUT),
+      "stale",
+      "utf8"
+    );
+    const previousManagedFiles = [
+      path.join(LISA_COMMANDS_SUBDIR, `${LISA_COMMAND_SKILL_PREFIX}fix.md`),
+      path.join(LISA_COMMANDS_SUBDIR, OLD_COMMAND_OUT),
+    ];
+    const result = await discoverAndInstallCommands(
+      lisaDir,
+      destDir,
+      previousManagedFiles
+    );
+
+    expect(result.deleted).toEqual([
+      path.join(LISA_COMMANDS_SUBDIR, OLD_COMMAND_OUT),
+    ]);
+    expect(await fs.pathExists(path.join(commandsDir, OLD_COMMAND_OUT))).toBe(
+      false
+    );
+  });
+
+  it("never deletes host commands (files without the lisa- prefix)", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    const commandsDir = path.join(destDir, OPENCODE_DIR, LISA_COMMANDS_SUBDIR);
+    await fs.ensureDir(commandsDir);
+    await fs.writeFile(
+      path.join(commandsDir, HOST_COMMAND_MD),
+      "host-owned",
+      "utf8"
+    );
+    const result = await discoverAndInstallCommands(lisaDir, destDir, [
+      path.join(LISA_COMMANDS_SUBDIR, HOST_COMMAND_MD),
+    ]);
+
+    expect(result.deleted).toEqual([]);
+    expect(await fs.pathExists(path.join(commandsDir, HOST_COMMAND_MD))).toBe(
+      true
+    );
+  });
+
+  it("idempotent: running twice produces identical output", async () => {
+    await seedCommand(PLUGIN_LISA, "fix.md", SAMPLE_COMMAND);
+    const filename = `${LISA_COMMAND_SKILL_PREFIX}fix.md`;
+    await discoverAndInstallCommands(lisaDir, destDir, []);
+    const first = await fs.readFile(installedCommandPath(filename), "utf8");
+    await discoverAndInstallCommands(lisaDir, destDir, []);
+    const second = await fs.readFile(installedCommandPath(filename), "utf8");
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/opencode/command-transformer.test.ts
+++ b/tests/unit/opencode/command-transformer.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the OpenCode command transformer (Lisa command Markdown →
+ * OpenCode command Markdown).
+ *
+ * Covers:
+ *   - description frontmatter preserved (fallback to display name)
+ *   - $ARGUMENTS preserved verbatim (native OpenCode substitution)
+ *   - body passthrough; malformed frontmatter throws
+ */
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { transformCommandToOpencode } from "../../../src/opencode/command-transformer.js";
+
+const SAMPLE_COMMAND = `---
+description: "Fix a bug. Reproduces, analyzes, fixes via TDD."
+argument-hint: "<description>"
+---
+
+Apply the intent-routing rule and execute the Implement flow.
+
+$ARGUMENTS
+`;
+
+describe("opencode/command-transformer", () => {
+  it("preserves the description in frontmatter", () => {
+    const out = transformCommandToOpencode(SAMPLE_COMMAND, "lisa:fix");
+    const fm = yaml.load(
+      /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)?.[1] ?? ""
+    ) as Record<string, unknown>;
+    expect(fm.description).toBe(
+      "Fix a bug. Reproduces, analyzes, fixes via TDD."
+    );
+  });
+
+  it("preserves $ARGUMENTS verbatim (unlike the skill conversion)", () => {
+    const out = transformCommandToOpencode(SAMPLE_COMMAND, "lisa:fix");
+    expect(out).toContain("$ARGUMENTS");
+    expect(out).toContain("execute the Implement flow.");
+  });
+
+  it("does not carry argument-hint into OpenCode frontmatter", () => {
+    const out = transformCommandToOpencode(SAMPLE_COMMAND, "lisa:fix");
+    const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)?.[1] ?? "";
+    expect(fm).not.toMatch(/argument-hint/);
+  });
+
+  it("falls back to the display name when no description is present", () => {
+    const command = `---
+argument-hint: "<x>"
+---
+
+Body $ARGUMENTS
+`;
+    const out = transformCommandToOpencode(command, "lisa:git:commit");
+    const fm = yaml.load(
+      /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)?.[1] ?? ""
+    ) as Record<string, unknown>;
+    expect(fm.description).toBe("lisa:git:commit");
+  });
+
+  it("throws on a command missing YAML frontmatter", () => {
+    expect(() =>
+      transformCommandToOpencode("no frontmatter", "lisa:x")
+    ).toThrow(/frontmatter/i);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1197 (OpenCode added to Lisa's fleet as a Codex-style per-project overlay). Phase 1 shipped skills + command-as-skills + AGENTS.md for `--harness opencode`. This PR adds OpenCode's **native authoring surfaces**:

- **Agents** → `.opencode/agents/lisa-<id>.md` (Markdown + YAML frontmatter, `mode: subagent`). A near-passthrough vs the Codex TOML transform — OpenCode agents are Markdown like Claude's. Claude-only `model`/`tools`/`skills` metadata is preserved as in-body context blocks (a Claude model alias like `sonnet` is not a valid OpenCode `provider/model`, so it must not leak into frontmatter).
- **Commands** → `.opencode/commands/lisa-<name>.md` (native command format). `$ARGUMENTS` is preserved verbatim for OpenCode's native substitution (unlike the command-to-skill path, which strips it). Additive/native-fidelity — commands already worked as `lisa-` prefixed skills.

Both reuse the shared discovery (`discoverLisaAgents` / `discoverLisaCommands`) and the manifest/stale-cleanup model, scoped to a `lisa-` filename prefix so host-authored agents/commands are never touched. Wired into `processOpencodeEmit()` with a combined `.opencode/.lisa-managed.json` tracking skills + agents + commands.

### Canonical-plugin filtering

Discovery is now restricted to canonical plugins via a new `isHarnessVariantPlugin` classifier — the per-harness fanout variants (`*-agy` / `*-copilot` / `*-cursor`) are skipped. Without this the copilot variants' `.agent.md` naming slips past id-dedup and ships a duplicate `lisa-<name>.agent` for every agent (and cursor/agy reformatted copies could win the last-wins dedup over the canonical source). The shared `discoverLisaAgents`/`discoverLisaCommands` gained an optional, backward-compatible plugin filter; the Codex call is unchanged.

## Verification

- **Unit:** 3053 tests pass; new tests for the agent/command transformers + installers (incl. variant-exclusion + host-safety) and the `isHarnessVariantPlugin` helper. Typecheck + lint clean.
- **Real `lisa apply --harness opencode`:** `28 agents (0 .agent.md dupes), 65 commands, AGENTS.md created`; manifest tracks all three surfaces.
- **Real `opencode run`** (free `opencode/deepseek-v4-flash-free`, no auth): the `lisa-bug-fixer` subagent was invoked end-to-end and responded from its body; a native slash-command template was confirmed expanded (recorded session contained the expanded template, not the literal slash text).

🤖 Generated with Claude Code