### PR TITLE
fix(codex): exclude per-harness variant plugins from agent discovery

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import pc from "picocolors";
 import type { IPrompter } from "../cli/prompts.js";
 import { discoverLisaAgents, installAgents } from "../codex/agent-installer.js";
+import { isHarnessVariantPlugin } from "./lisa-skill-sources.js";
 import { installHooks } from "../codex/hooks-installer.js";
 import {
   readManagedManifest,
@@ -772,7 +773,14 @@ export class Lisa {
       this.config.destDir
     );
 
-    const agentSources = await discoverLisaAgents(this.config.lisaDir);
+    // Restrict to canonical plugins — the per-harness fanout variants
+    // (`*-agy`/`*-copilot`/`*-cursor`) are reformatted copies, and the copilot
+    // variants rename agents to `*.agent.md`, which slips past id-dedup and would
+    // otherwise ship a duplicate `lisa-<name>.agent.toml` for every agent.
+    const agentSources = await discoverLisaAgents(
+      this.config.lisaDir,
+      name => !isHarnessVariantPlugin(name)
+    );
     const agentResult = await installAgents(
       agentSources,
       this.config.destDir,

--- a/tests/unit/codex/agent-installer.test.ts
+++ b/tests/unit/codex/agent-installer.test.ts
@@ -177,6 +177,25 @@ describe("codex/agent-installer", () => {
       const result = await discoverLisaAgents(lisaDir);
       expect(result.map(r => r.id)).toEqual(["alpha", "mu", "zeta"]);
     });
+
+    it("applies an optional plugin filter (excludes copilot .agent.md dupes)", async () => {
+      // Without filtering, the copilot variant's `bug-fixer.agent.md` becomes a
+      // distinct id (`bug-fixer.agent`) and ships a duplicate agent.
+      await seedPlugin(PLUGIN_LISA, { [BUG_FIXER_MD]: SAMPLE_AGENT });
+      await seedPlugin("lisa-copilot", {
+        "bug-fixer.agent.md": SAMPLE_AGENT,
+      });
+      const unfiltered = await discoverLisaAgents(lisaDir);
+      expect(
+        unfiltered.map(r => r.id).sort((a, b) => a.localeCompare(b))
+      ).toEqual(["bug-fixer", "bug-fixer.agent"]);
+
+      const filtered = await discoverLisaAgents(
+        lisaDir,
+        name => !name.endsWith("-copilot")
+      );
+      expect(filtered.map(r => r.id)).toEqual([BUG_FIXER]);
+    });
   });
 
   describe("installAgents", () => {


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1203. While wiring the canonical-plugin filter for the new OpenCode agent emit, I found Codex had the **same latent bug** and confirmed it with a real apply.

`processCodexEmit()` called `discoverLisaAgents()` **unfiltered**, so the per-harness fanout plugins were ingested as agent sources. The copilot variants rename agents to `*.agent.md`, which becomes a distinct id (`bug-fixer.agent`) that slips past id-dedup — shipping a duplicate `lisa-<name>.agent.toml` for **every** agent.

**Before:** `lisa apply --harness codex` → `56 agents` (28 of them `.agent.toml` duplicates).
**After:** `28 agents`, `0` duplicates.

## Fix

One-line wire-up: pass the same `isHarnessVariantPlugin` filter the OpenCode emit uses (added to `discoverLisaAgents` in #1203) so Codex ingests only canonical plugins.

Skills and command bodies are **byte-identical** across the base and `-agy`/`-copilot`/`-cursor` variants (verified), so only agents — the `.agent.md` rename — were affected. No change needed for Codex skills/commands.

## Verification

- **Real `lisa apply --harness codex`:** `56 → 28 agents, 0 .agent.toml dupes`.
- **Unit:** 3076 pass; new regression test in `tests/unit/codex/agent-installer.test.ts` asserting the filter drops the copilot `.agent` duplicate. Typecheck + lint clean.

🤖 Generated with Claude Code