### PR TITLE
fix(apply): prune stale Lisa stack plugins from settings.json

### DIFF
--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -3,6 +3,7 @@ import { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
+import { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
 import type {
   Migration,
   MigrationContext,
@@ -20,6 +21,7 @@ export { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
+export { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
 
 /**
  * Registry that runs applicable migrations against a destination project
@@ -38,6 +40,7 @@ export class MigrationRegistry {
       new EnsureAuditIgnoreLocalExclusionsMigration(),
       new EnsureJestRnMockAccessibilityManagerMigration(),
       new EnsureLisaPostinstallMigration(),
+      new ReconcileClaudeStackPluginsMigration(),
     ];
   }
 

--- a/src/migrations/reconcile-claude-stack-plugins.ts
+++ b/src/migrations/reconcile-claude-stack-plugins.ts
@@ -1,0 +1,205 @@
+import * as path from "node:path";
+import type { ProjectType } from "../core/config.js";
+import { readJsonOrNull, writeJson } from "../utils/json-utils.js";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const SETTINGS_REL_PATH = path.join(".claude", "settings.json");
+
+/**
+ * Project types that ship their own `lisa-<type>@lisa` stack plugin.
+ *
+ * `npm-package` is intentionally excluded: it has no dedicated plugin and is
+ * represented by its `typescript` parent (see PROJECT_TYPE_HIERARCHY). Every
+ * other detectable type ships a stack plugin whose enablement Lisa owns.
+ */
+const STACK_PLUGIN_TYPES: readonly ProjectType[] = [
+  "typescript",
+  "expo",
+  "nestjs",
+  "cdk",
+  "harper-fabric",
+  "rails",
+];
+
+/**
+ * The full set of `lisa-<type>@lisa` plugin keys that this migration manages.
+ * Any key outside this set (e.g. `lisa@lisa`, `lisa-wiki@lisa`, third-party
+ * marketplace plugins like `typescript-lsp@claude-plugins-official`) is left
+ * untouched.
+ */
+const MANAGED_STACK_PLUGIN_KEYS: ReadonlySet<string> = new Set(
+  STACK_PLUGIN_TYPES.map(type => stackPluginKey(type))
+);
+
+/**
+ * Build the canonical enabledPlugins key for a stack plugin type.
+ * @param type - Project type that ships a stack plugin
+ * @returns The `lisa-<type>@lisa` enabledPlugins key
+ */
+function stackPluginKey(type: ProjectType): string {
+  return `lisa-${type}@lisa`;
+}
+
+/**
+ * Minimal shape of a Claude `.claude/settings.json` for plugin reconciliation.
+ */
+interface ClaudeSettings {
+  readonly enabledPlugins?: Readonly<Record<string, boolean>>;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Outcome of reconciling the managed stack plugins against detected types.
+ */
+interface ReconcileResult {
+  readonly enabledPlugins: Record<string, boolean>;
+  readonly removed: readonly string[];
+  readonly added: readonly string[];
+}
+
+/**
+ * Compute the reconciled enabledPlugins map for the managed stack plugin keys.
+ *
+ * Rules (only the managed `lisa-<type>@lisa` keys are considered):
+ * - A stack plugin whose type is detected stays; if it is missing entirely it
+ *   is added (`true`). An explicit existing value (including `false`, a
+ *   deliberate opt-out) is preserved.
+ * - A stack plugin whose type is NOT detected is removed entirely — it does not
+ *   apply to this project.
+ *
+ * All non-managed keys pass through unchanged.
+ * @param enabledPlugins - Current enabledPlugins map
+ * @param detectedTypes - Detected project types (already parent-expanded)
+ * @returns The reconciled map plus the lists of removed and added keys
+ */
+function reconcileStackPlugins(
+  enabledPlugins: Readonly<Record<string, boolean>>,
+  detectedTypes: readonly ProjectType[]
+): ReconcileResult {
+  const desiredKeys = new Set(
+    detectedTypes
+      .filter(type => STACK_PLUGIN_TYPES.includes(type))
+      .map(type => stackPluginKey(type))
+  );
+
+  const entries = Object.entries(enabledPlugins);
+  const isStale = (key: string): boolean =>
+    MANAGED_STACK_PLUGIN_KEYS.has(key) && !desiredKeys.has(key);
+
+  const removed = entries.map(([key]) => key).filter(isStale);
+  const kept = entries.filter(([key]) => !isStale(key));
+  const keptKeys = new Set(kept.map(([key]) => key));
+  const added = [...desiredKeys].filter(key => !keptKeys.has(key));
+
+  const enabledPluginsNext = Object.fromEntries([
+    ...kept,
+    ...added.map(key => [key, true] as const),
+  ]);
+
+  return { enabledPlugins: enabledPluginsNext, removed, added };
+}
+
+/**
+ * Read the project's `.claude/settings.json`, returning null when absent.
+ * @param projectDir - Destination project directory
+ * @returns Parsed settings or null when missing/invalid
+ */
+async function readClaudeSettings(
+  projectDir: string
+): Promise<ClaudeSettings | null> {
+  return readJsonOrNull<ClaudeSettings>(
+    path.join(projectDir, SETTINGS_REL_PATH)
+  );
+}
+
+/**
+ * Migration: reconcile Lisa stack plugins in `.claude/settings.json` against
+ * the project's currently detected types.
+ *
+ * Lisa enables `lisa-<type>@lisa` stack plugins by deep-merging each detected
+ * stack's `merge/.claude/settings.json` template. Because the merge only ever
+ * adds keys, a stack plugin enabled by a past apply persists forever even after
+ * the project's nature changes — e.g. a project that once detected as TypeScript
+ * but is now Rails keeps a stale `lisa-typescript@lisa`, and a TS backend that
+ * briefly looked like Nest keeps a stale `lisa-nestjs@lisa`. This migration runs
+ * after the merge strategies and prunes any managed stack plugin whose type is
+ * no longer detected, while ensuring the detected stacks' plugins are present.
+ * Non-stack plugins (`lisa@lisa`, `lisa-wiki@lisa`) and third-party marketplace
+ * plugins are never touched.
+ */
+export class ReconcileClaudeStackPluginsMigration implements Migration {
+  readonly name = "reconcile-claude-stack-plugins";
+  readonly description =
+    "Prune stale Lisa stack plugins from .claude/settings.json that no longer match detected types";
+
+  /**
+   * Whether reconciliation would change any managed stack plugin key.
+   * @param ctx - Migration context
+   * @returns True when a managed stack plugin would be added or removed
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    const settings = await readClaudeSettings(ctx.projectDir);
+    if (!settings?.enabledPlugins) {
+      return false;
+    }
+    const { removed, added } = reconcileStackPlugins(
+      settings.enabledPlugins,
+      ctx.detectedTypes
+    );
+    return removed.length > 0 || added.length > 0;
+  }
+
+  /**
+   * Reconcile the managed stack plugins and write the result back.
+   * @param ctx - Migration context
+   * @returns Result describing the keys removed and added
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const settings = await readClaudeSettings(ctx.projectDir);
+    if (!settings?.enabledPlugins) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const { enabledPlugins, removed, added } = reconcileStackPlugins(
+      settings.enabledPlugins,
+      ctx.detectedTypes
+    );
+
+    if (removed.length === 0 && added.length === 0) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const parts: string[] = [];
+    if (removed.length > 0) {
+      parts.push(`removed stale ${removed.join(", ")}`);
+    }
+    if (added.length > 0) {
+      parts.push(`added ${added.join(", ")}`);
+    }
+    const message = `Reconciled stack plugins: ${parts.join("; ")}`;
+
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would update ${SETTINGS_REL_PATH}: ${message}`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [SETTINGS_REL_PATH],
+        message,
+      };
+    }
+
+    const nextSettings: ClaudeSettings = { ...settings, enabledPlugins };
+    await writeJson(path.join(ctx.projectDir, SETTINGS_REL_PATH), nextSettings);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [SETTINGS_REL_PATH],
+      message,
+    };
+  }
+}

--- a/tests/unit/migrations/reconcile-claude-stack-plugins.test.ts
+++ b/tests/unit/migrations/reconcile-claude-stack-plugins.test.ts
@@ -1,0 +1,287 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { ReconcileClaudeStackPluginsMigration } from "../../../src/migrations/reconcile-claude-stack-plugins.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const SETTINGS_REL_PATH = path.join(".claude", "settings.json");
+
+describe("ReconcileClaudeStackPluginsMigration", () => {
+  let migration: ReconcileClaudeStackPluginsMigration;
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    migration = new ReconcileClaudeStackPluginsMigration();
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Build a migration context for testing
+   * @param detectedTypes - Detected project types
+   * @param dryRun - Whether to run in dry-run mode
+   * @returns A migration context suitable for tests
+   */
+  function createContext(
+    detectedTypes: readonly ProjectType[],
+    dryRun = false
+  ): MigrationContext {
+    return {
+      projectDir,
+      lisaDir: tempDir,
+      detectedTypes,
+      dryRun,
+      logger: new SilentLogger(),
+    };
+  }
+
+  /**
+   * Write a `.claude/settings.json` into the project directory
+   * @param settings - Settings content to serialize
+   */
+  async function writeSettings(settings: unknown): Promise<void> {
+    await fs.outputJson(path.join(projectDir, SETTINGS_REL_PATH), settings);
+  }
+
+  /**
+   * Read the project's `.claude/settings.json`
+   * @returns Parsed settings object
+   */
+  async function readSettings(): Promise<Record<string, unknown>> {
+    return fs.readJson(path.join(projectDir, SETTINGS_REL_PATH));
+  }
+
+  describe("basic properties", () => {
+    it("has correct name and description", () => {
+      expect(migration.name).toBe("reconcile-claude-stack-plugins");
+      expect(migration.description).toContain("stack plugins");
+    });
+  });
+
+  describe("applies()", () => {
+    it("returns false when settings.json is absent", async () => {
+      expect(await migration.applies(createContext(["typescript"]))).toBe(
+        false
+      );
+    });
+
+    it("returns false when enabledPlugins is absent", async () => {
+      await writeSettings({ permissions: {} });
+      expect(await migration.applies(createContext(["typescript"]))).toBe(
+        false
+      );
+    });
+
+    it("returns false when stack plugins already match detection", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "lisa-typescript@lisa": true,
+          "lisa-wiki@lisa": true,
+        },
+      });
+      expect(await migration.applies(createContext(["typescript"]))).toBe(
+        false
+      );
+    });
+
+    it("returns true when a stale stack plugin is present", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa-typescript@lisa": true,
+          "lisa-nestjs@lisa": true,
+        },
+      });
+      expect(await migration.applies(createContext(["typescript"]))).toBe(true);
+    });
+
+    it("returns true when a detected stack plugin is missing", async () => {
+      await writeSettings({
+        enabledPlugins: { "lisa-wiki@lisa": true },
+      });
+      expect(await migration.applies(createContext(["typescript"]))).toBe(true);
+    });
+  });
+
+  describe("apply()", () => {
+    it("removes a stale typescript plugin from a rails project", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "lisa-typescript@lisa": true,
+          "lisa-rails@lisa": true,
+          "lisa-wiki@lisa": true,
+        },
+      });
+
+      const result = await migration.apply(createContext(["rails"]));
+
+      expect(result.action).toBe("applied");
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa@lisa": true,
+        "lisa-rails@lisa": true,
+        "lisa-wiki@lisa": true,
+      });
+    });
+
+    it("removes a stale nestjs plugin from a typescript-only backend", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "lisa-typescript@lisa": true,
+          "lisa-nestjs@lisa": true,
+          "lisa-wiki@lisa": true,
+        },
+      });
+
+      const result = await migration.apply(createContext(["typescript"]));
+
+      expect(result.action).toBe("applied");
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa@lisa": true,
+        "lisa-typescript@lisa": true,
+        "lisa-wiki@lisa": true,
+      });
+    });
+
+    it("removes all stack plugins when nothing is detected (wiki shell)", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "lisa-typescript@lisa": true,
+          "lisa-wiki@lisa": true,
+        },
+      });
+
+      const result = await migration.apply(createContext([]));
+
+      expect(result.action).toBe("applied");
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa@lisa": true,
+        "lisa-wiki@lisa": true,
+      });
+    });
+
+    it("adds a missing detected stack plugin", async () => {
+      await writeSettings({
+        enabledPlugins: { "lisa-wiki@lisa": true },
+      });
+
+      const result = await migration.apply(
+        createContext(["npm-package", "typescript"])
+      );
+
+      expect(result.action).toBe("applied");
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa-wiki@lisa": true,
+        "lisa-typescript@lisa": true,
+      });
+    });
+
+    it("keeps both parent and child stack plugins for a child stack", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa-typescript@lisa": true,
+          "lisa-expo@lisa": true,
+          "lisa-cdk@lisa": true,
+        },
+      });
+
+      const result = await migration.apply(
+        createContext(["typescript", "expo"])
+      );
+
+      expect(result.action).toBe("applied");
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa-typescript@lisa": true,
+        "lisa-expo@lisa": true,
+      });
+    });
+
+    it("never touches non-stack and third-party plugins", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "lisa-wiki@lisa": true,
+          "typescript-lsp@claude-plugins-official": true,
+          "coderabbit@claude-plugins-official": true,
+          "lisa-cdk@lisa": true,
+        },
+      });
+
+      await migration.apply(createContext(["typescript"]));
+
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa@lisa": true,
+        "lisa-wiki@lisa": true,
+        "typescript-lsp@claude-plugins-official": true,
+        "coderabbit@claude-plugins-official": true,
+        "lisa-typescript@lisa": true,
+      });
+    });
+
+    it("preserves an explicit disabled (false) value for a detected stack", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa-typescript@lisa": false,
+          "lisa-nestjs@lisa": true,
+        },
+      });
+
+      await migration.apply(createContext(["typescript"]));
+
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa-typescript@lisa": false,
+      });
+    });
+
+    it("does not write in dry-run mode but reports applied", async () => {
+      await writeSettings({
+        enabledPlugins: {
+          "lisa-typescript@lisa": true,
+          "lisa-nestjs@lisa": true,
+        },
+      });
+
+      const result = await migration.apply(createContext(["typescript"], true));
+
+      expect(result.action).toBe("applied");
+      expect(result.changedFiles).toEqual([SETTINGS_REL_PATH]);
+      const settings = await readSettings();
+      expect(settings.enabledPlugins).toEqual({
+        "lisa-typescript@lisa": true,
+        "lisa-nestjs@lisa": true,
+      });
+    });
+
+    it("preserves other top-level settings keys", async () => {
+      await writeSettings({
+        permissions: { allow: ["Bash"] },
+        enabledPlugins: {
+          "lisa-typescript@lisa": true,
+          "lisa-cdk@lisa": true,
+        },
+      });
+
+      await migration.apply(createContext(["typescript"]));
+
+      const settings = await readSettings();
+      expect(settings.permissions).toEqual({ allow: ["Bash"] });
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`lisa apply` enables `lisa-<stack>@lisa` plugins by deep-merging each detected stack's `merge/.claude/settings.json` template. The merge only ever **adds** keys, so a stack plugin enabled by a past apply persists forever after a project's nature changes.

Audit across the workspace fleet found four drifted repos:

| Repo | Detected | Drift |
|---|---|---|
| qualis/app | rails | stale `lisa-typescript@lisa` |
| propswap/projects/backend | typescript | stale `lisa-nestjs@lisa` (serverless TS, not Nest) |
| workstation-setup | (none) | stale `lisa-typescript@lisa` |
| aws-soc2-setup | npm-package → typescript | missing `lisa-typescript@lisa` |

## Fix

New `reconcile-claude-stack-plugins` migration runs after the settings merge and before plugin registration. For the managed `lisa-<type>@lisa` stack keys it:

- removes any whose type is **not** in `detectedTypes`
- adds any detected stack that is missing

`lisa@lisa`, `lisa-wiki@lisa`, and all third-party plugins are never touched; an explicit `false` opt-out is preserved.

## Verification

- `typecheck` clean, lint clean
- 135 unit tests pass (12 new for the migration)
- Real `lisa apply --dry-run` confirmed correct prune/add on all four drifted repos

🤖 Generated with Claude Code