### PR TITLE
feat(harness): add "all" alias for fleet and remove legacy "both"

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { LisaConfig } from "../core/config.js";
-import { HARNESS_VALUES } from "../core/config.js";
+import { ACCEPTED_HARNESS_INPUTS } from "../core/config.js";
 import { Lisa } from "../core/lisa.js";
 import {
   projectConfigExists,
@@ -48,7 +48,7 @@ function printUsageAndExit(): never {
   );
   console.log("  --no-update-check Skip the npm latest-version check");
   console.log(
-    `  --harness <h>     Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (persisted in .lisa.config.json)`
+    `  --harness <h>     Target harness for emitted artifacts: ${ACCEPTED_HARNESS_INPUTS.join(" | ")} (persisted in .lisa.config.json)`
   );
   console.log("  -h, --help        Show this help message");
   console.log("");
@@ -61,7 +61,7 @@ function printUsageAndExit(): never {
   );
   console.log("  lisa --harness=codex .               # Emit Codex artifacts");
   console.log(
-    "  lisa --harness=both .                # Emit both Claude and Codex artifacts"
+    "  lisa --harness=all .                 # Emit for every agent (alias for fleet)"
   );
   process.exit(1);
 }

--- a/src/cli/shared-options.ts
+++ b/src/cli/shared-options.ts
@@ -1,12 +1,12 @@
 import { type Command, InvalidArgumentError } from "commander";
 import type { Harness } from "../core/config.js";
-import { HARNESS_VALUES } from "../core/config.js";
+import { ACCEPTED_HARNESS_INPUTS } from "../core/config.js";
 import { GitService } from "../core/git-service.js";
 import type { LisaDependencies } from "../core/lisa.js";
 import { DetectorRegistry } from "../detection/index.js";
 import type { ConsoleLogger } from "../logging/index.js";
 import { MigrationRegistry } from "../migrations/index.js";
-import { isHarness } from "../core/project-config.js";
+import { normalizeHarness } from "../core/project-config.js";
 import { StrategyRegistry } from "../strategies/index.js";
 import { BackupService, DryRunBackupService } from "../transaction/index.js";
 import { createPrompter } from "./prompts.js";
@@ -31,13 +31,14 @@ export interface CLIOptions {
  * @returns The validated harness
  */
 export function parseHarnessArg(value: string): Harness {
-  if (!isHarness(value)) {
-    const allowed = HARNESS_VALUES.join(" | ");
+  const normalized = normalizeHarness(value);
+  if (normalized === undefined) {
+    const allowed = ACCEPTED_HARNESS_INPUTS.join(" | ");
     throw new InvalidArgumentError(
       `expected ${allowed}, got ${JSON.stringify(value)}`
     );
   }
-  return value;
+  return normalized;
 }
 
 /**
@@ -63,7 +64,7 @@ export function addSharedOptions(command: Command): Command {
     )
     .option(
       "--harness <harness>",
-      `Target harness for emitted artifacts: ${HARNESS_VALUES.join(" | ")} (default: claude, or value from .lisa.config.json)`,
+      `Target harness for emitted artifacts: ${ACCEPTED_HARNESS_INPUTS.join(" | ")} (default: claude, or value from .lisa.config.json)`,
       parseHarnessArg
     );
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -70,8 +70,10 @@ export const COPY_STRATEGIES: readonly CopyStrategy[] = [
  * - "agy":     emit Antigravity artifacts (~/.gemini/config/mcp_config.json + AGENTS.md with baked rules)
  * - "copilot": emit GitHub Copilot artifacts (.github/copilot-instructions.md + plugin install)
  * - "opencode": emit OpenCode artifacts (.opencode/skills/lisa/ + AGENTS.md, read natively)
- * - "both":    emit both Claude and Codex (back-compat — predates the per-agent expansion)
  * - "fleet":   emit for every supported agent (Claude + Codex + Cursor + agy + Copilot + OpenCode)
+ *
+ * The input alias `all` is accepted on the CLI and in `.lisa.config.json` and
+ * normalized to `fleet` (see {@link HARNESS_ALIASES} / `normalizeHarness`).
  */
 export type Harness =
   | "claude"
@@ -80,7 +82,6 @@ export type Harness =
   | "agy"
   | "copilot"
   | "opencode"
-  | "both"
   | "fleet";
 
 /**
@@ -93,9 +94,26 @@ export const HARNESS_VALUES: readonly Harness[] = [
   "agy",
   "copilot",
   "opencode",
-  "both",
   "fleet",
 ] as const;
+
+/**
+ * Input aliases accepted on the CLI and in `.lisa.config.json`, each mapping to
+ * a canonical {@link Harness}. `all` is a friendly synonym for `fleet`.
+ */
+export const HARNESS_ALIASES: Readonly<Record<string, Harness>> = {
+  all: "fleet",
+};
+
+/**
+ * Every string a user may supply for a harness: the canonical values plus the
+ * accepted aliases. Used to build help text and validation error messages so
+ * `all` is advertised alongside `fleet`.
+ */
+export const ACCEPTED_HARNESS_INPUTS: readonly string[] = [
+  ...HARNESS_VALUES,
+  ...Object.keys(HARNESS_ALIASES),
+];
 
 /**
  * Per-project emit agents that have a dispatch path in `lisa apply`.
@@ -108,11 +126,10 @@ export type EmitAgent = "claude" | "codex" | "agy" | "copilot" | "opencode";
  * Whether a configured harness should emit artifacts for a given agent.
  *
  * Centralizes the dispatch-inclusion rule so the four `process<Agent>Emit`
- * guards stay consistent: a `"fleet"` harness includes every agent, `"both"`
- * is the Claude+Codex back-compat pair, and any single-agent harness matches
- * only itself. (A prior copy-paste left `"fleet"` out of the Codex guard, so
- * fleet installs silently skipped Codex — this predicate prevents that class
- * of bug.)
+ * guards stay consistent: a `"fleet"` harness includes every agent, and any
+ * single-agent harness matches only itself. (A prior copy-paste left `"fleet"`
+ * out of the Codex guard, so fleet installs silently skipped Codex — this
+ * predicate prevents that class of bug.)
  * @param harness - The configured/CLI-resolved harness value.
  * @param agent - The emit agent whose dispatch is being gated.
  * @returns True when the harness should run that agent's emit path.
@@ -122,7 +139,6 @@ export function harnessIncludesAgent(
   agent: EmitAgent
 ): boolean {
   if (harness === "fleet") return true;
-  if (harness === "both") return agent === "claude" || agent === "codex";
   return harness === agent;
 }
 
@@ -154,7 +170,7 @@ export interface LisaConfig {
   /** If true, skip the dirty git working directory check (for postinstall use) */
   readonly skipGitCheck: boolean;
 
-  /** Target harness(es) for emitted artifacts (claude | codex | both) */
+  /** Target harness(es) for emitted artifacts (e.g. claude | codex | fleet) */
   readonly harness: Harness;
 }
 

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -749,7 +749,8 @@ export class Lisa {
 
   /**
    * Emit Codex-targeted artifacts (agents, hooks, settings) when the host
-   * project's harness is `codex` or `both`. No-op for `claude` (default).
+   * project's harness includes Codex (`codex` or `fleet`). No-op for `claude`
+   * (default).
    *
    * Codex can now ship skills, MCP servers, apps, and hooks via plugins, so
    * Lisa emits a repo-local marketplace as the durable plugin-native path.

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -10,7 +10,13 @@
 import * as fse from "fs-extra";
 import { readFile, writeFile } from "node:fs/promises";
 import * as path from "node:path";
-import { DEFAULT_HARNESS, HARNESS_VALUES, type Harness } from "./config.js";
+import {
+  ACCEPTED_HARNESS_INPUTS,
+  DEFAULT_HARNESS,
+  HARNESS_ALIASES,
+  HARNESS_VALUES,
+  type Harness,
+} from "./config.js";
 
 /** Filename of the per-project config, relative to the destination root */
 export const PROJECT_CONFIG_FILENAME = ".lisa.config.json";
@@ -177,13 +183,15 @@ function validateProjectConfig(
   if (obj.harness === undefined) {
     return {};
   }
-  if (!isHarness(obj.harness)) {
-    const allowed = HARNESS_VALUES.join(" | ");
+  const normalized =
+    typeof obj.harness === "string" ? normalizeHarness(obj.harness) : undefined;
+  if (normalized === undefined) {
+    const allowed = ACCEPTED_HARNESS_INPUTS.join(" | ");
     throw new Error(
       `Invalid harness in ${configPath}: expected ${allowed}, got ${JSON.stringify(obj.harness)}`
     );
   }
-  return { harness: obj.harness };
+  return { harness: normalized };
 }
 
 /**
@@ -196,4 +204,17 @@ export function isHarness(value: unknown): value is Harness {
     typeof value === "string" &&
     (HARNESS_VALUES as readonly string[]).includes(value)
   );
+}
+
+/**
+ * Normalize a raw user-supplied harness string to its canonical Harness,
+ * resolving input aliases (e.g. `all` → `fleet`). Returns undefined when the
+ * value is neither a canonical harness nor a known alias, so callers can raise
+ * a single consistent validation error.
+ * @param value - Raw harness string from the CLI flag or `.lisa.config.json`
+ * @returns The canonical Harness, or undefined if unrecognized
+ */
+export function normalizeHarness(value: string): Harness | undefined {
+  const canonical = HARNESS_ALIASES[value] ?? value;
+  return isHarness(canonical) ? canonical : undefined;
 }

--- a/tests/unit/cli/shared-options.test.ts
+++ b/tests/unit/cli/shared-options.test.ts
@@ -13,14 +13,23 @@ describe("parseHarnessArg", () => {
     }
   });
 
+  it("normalizes the 'all' alias to 'fleet'", () => {
+    expect(parseHarnessArg("all")).toBe("fleet");
+  });
+
   it("throws InvalidArgumentError listing the allowed values for an unknown harness", () => {
     expect(() => parseHarnessArg("nonsense")).toThrow(InvalidArgumentError);
     try {
       parseHarnessArg("nonsense");
     } catch (error) {
       expect((error as Error).message).toContain(HARNESS_VALUES.join(" | "));
+      expect((error as Error).message).toContain("all");
       expect((error as Error).message).toContain('"nonsense"');
     }
+  });
+
+  it("rejects the removed 'both' harness value", () => {
+    expect(() => parseHarnessArg("both")).toThrow(InvalidArgumentError);
   });
 });
 

--- a/tests/unit/core/project-config.test.ts
+++ b/tests/unit/core/project-config.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   PROJECT_CONFIG_FILENAME,
   isHarness,
+  normalizeHarness,
   projectConfigExists,
   readProjectConfig,
   resolveHarness,
@@ -80,16 +81,29 @@ describe("project-config", () => {
       expect(result).toEqual({});
     });
 
-    it("throws on invalid harness value", async () => {
+    it("normalizes the 'all' alias to 'fleet'", async () => {
       await fs.writeFile(
         path.join(tempDir, PROJECT_CONFIG_FILENAME),
-        JSON.stringify({ harness: "windsurf" }),
+        JSON.stringify({ harness: "all" }),
         "utf8"
       );
-      await expect(readProjectConfig(tempDir)).rejects.toThrow(
-        /Invalid harness/
-      );
+      const result = await readProjectConfig(tempDir);
+      expect(result).toEqual({ harness: "fleet" });
     });
+
+    it.each(["windsurf", "both"])(
+      "throws on an invalid or removed harness value (%p)",
+      async harness => {
+        await fs.writeFile(
+          path.join(tempDir, PROJECT_CONFIG_FILENAME),
+          JSON.stringify({ harness }),
+          "utf8"
+        );
+        await expect(readProjectConfig(tempDir)).rejects.toThrow(
+          /Invalid harness/
+        );
+      }
+    );
 
     it("throws on non-string harness value", async () => {
       await fs.writeFile(
@@ -160,11 +174,11 @@ describe("project-config", () => {
 
     it("merges into existing config without dropping other fields", async () => {
       await writeProjectConfig(tempDir, { harness: "claude" });
-      await writeProjectConfig(tempDir, { harness: "both" });
+      await writeProjectConfig(tempDir, { harness: "fleet" });
       const written = JSON.parse(
         await fs.readFile(path.join(tempDir, PROJECT_CONFIG_FILENAME), "utf8")
       );
-      expect(written).toEqual({ harness: "both" });
+      expect(written).toEqual({ harness: "fleet" });
     });
   });
 
@@ -215,9 +229,9 @@ describe("project-config", () => {
       expect(
         shouldPersistProjectConfig({
           fileExists: true,
-          flagHarness: "both",
-          existingHarness: "both",
-          resolvedHarness: "both",
+          flagHarness: "fleet",
+          existingHarness: "fleet",
+          resolvedHarness: "fleet",
         })
       ).toBe(false);
     });
@@ -259,13 +273,13 @@ describe("project-config", () => {
       expect(resolveHarness(undefined, {})).toBe("claude");
     });
 
-    it("respects flag value 'both'", () => {
-      expect(resolveHarness("both", {})).toBe("both");
+    it("respects flag value 'fleet'", () => {
+      expect(resolveHarness("fleet", {})).toBe("fleet");
     });
   });
 
   describe("isHarness", () => {
-    it.each(["claude", "codex", "both"] as const)(
+    it.each(["claude", "codex", "fleet"] as const)(
       "accepts %s as a valid harness",
       value => {
         expect(isHarness(value)).toBe(true);
@@ -275,6 +289,8 @@ describe("project-config", () => {
     it.each([
       ["windsurf"],
       ["Claude"],
+      ["all"],
+      ["both"],
       [""],
       [42],
       [null],
@@ -286,18 +302,23 @@ describe("project-config", () => {
     });
   });
 
+  describe("normalizeHarness", () => {
+    it("passes canonical values through, maps 'all' to 'fleet', rejects the rest", () => {
+      for (const value of HARNESS_VALUES) {
+        expect(normalizeHarness(value)).toBe(value);
+      }
+      expect(normalizeHarness("all")).toBe("fleet");
+      expect(normalizeHarness("both")).toBeUndefined();
+      expect(normalizeHarness("windsurf")).toBeUndefined();
+      expect(normalizeHarness("")).toBeUndefined();
+    });
+  });
+
   describe("harnessIncludesAgent", () => {
     it("fleet includes every emit agent (regression: Codex was once excluded)", () => {
       for (const agent of ["claude", "codex", "agy", "copilot"] as const) {
         expect(harnessIncludesAgent("fleet", agent)).toBe(true);
       }
-    });
-
-    it("both includes only Claude and Codex", () => {
-      expect(harnessIncludesAgent("both", "claude")).toBe(true);
-      expect(harnessIncludesAgent("both", "codex")).toBe(true);
-      expect(harnessIncludesAgent("both", "agy")).toBe(false);
-      expect(harnessIncludesAgent("both", "copilot")).toBe(false);
     });
 
     it("a single-agent harness matches only itself", () => {


### PR DESCRIPTION
## What

- Add **`all`** as an input alias that normalizes to `fleet` (every supported agent), accepted on the CLI (`--harness=all`) and in `.lisa.config.json`.
- **Remove the legacy `both`** harness value entirely (it predated the per-agent expansion and confusingly meant only Claude+Codex).

## How

- `all` is resolved at the input boundary via a new `normalizeHarness()` so the rest of the code only ever sees canonical `Harness` values (`fleet` is persisted, not `all`).
- Removed `both` from the `Harness` type, `HARNESS_VALUES`, and the `harnessIncludesAgent` dispatch guard; CLI help/error text and apply examples now advertise the accepted inputs incl. `all`.

## Breaking change

Any project whose `.lisa.config.json` declares `harness: "both"` will now be rejected as invalid. All projects in `.lisa.workspaces.json` were migrated off `both` (to `fleet`) prior to this.

## Tests

Updated `project-config` and `shared-options` unit tests for the alias + removal; typecheck, eslint, and the affected suites pass.

🤖 Generated with Claude Code