### PR TITLE
feat(cross-pollinate): make local agent definitions available across the fleet

### DIFF
--- a/plugins/lisa-agy/commands/cross-pollinate.md
+++ b/plugins/lisa-agy/commands/cross-pollinate.md
@@ -1,0 +1,15 @@
+---
+description: "Detect locally-authored agent definitions and regenerate them in the formats of the other coding agents this project supports (per .lisa.config.json)."
+allowed-tools: ["Skill"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+Use the /lisa:cross-pollinate skill to detect this project's locally-authored
+coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and
+make each available in the formats of the other agents the project's
+`.lisa.config.json` harness includes. $ARGUMENTS
+
+Provenance is tracked in `.lisa/cross-pollination.lock.json`: the run is
+idempotent, garbage-collects orphaned translations, never overwrites a
+hand-edited target, and reports any conflict or unsupported translation rather
+than guessing.

--- a/plugins/lisa-agy/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-agy/scripts/cross-pollinate.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * Cross-pollinate a host project's locally-authored coding-agent definitions
+ * across every agent the project supports.
+ *
+ * A host project that installs Lisa may hand-author a skill, subagent, rule,
+ * command, hook, or MCP entry for ONE coding agent (e.g. a `.claude/skills/foo`
+ * that only Claude sees). This engine detects those locally-authored
+ * definitions, normalizes each to a canonical intermediate representation (IR),
+ * and fans it out to the formats of the OTHER agents declared in the project's
+ * `.lisa.config.json` `harness`.
+ *
+ * Architecture (see the cross-pollinate SKILL.md for the full spec):
+ *   any agent's format  ->  Claude-format IR  ->  every other configured agent
+ *
+ * Claude format is the IR because every existing Lisa generator already sources
+ * from it; emitting IR -> {cursor, codex, agy, copilot, opencode} reuses those
+ * battle-tested transforms instead of an N x N translator matrix.
+ *
+ * PROVENANCE is authoritative via a committed lockfile,
+ * `.lisa/cross-pollination.lock.json`. Path/location heuristics alone CANNOT
+ * distinguish a generated translation from a hand-authored original (both live
+ * in the same per-agent directory), so the lockfile is the only reliable way to:
+ *   1. prevent loops    — a recorded target is never treated as a source
+ *   2. garbage-collect  — an orphaned target (source deleted) is removed
+ *   3. protect edits    — a target whose on-disk hash drifts from the recorded
+ *                         generated hash was hand-edited; never clobber it
+ *   4. stay idempotent  — unchanged source + intact targets => no-op
+ *
+ * This engine is the deterministic core. It is invoked standalone
+ * (`node .../cross-pollinate.mjs <path> [--dry-run] [--json] [--write]`) and by
+ * the cross-pollinate skill, which layers in the judgment-heavy translations the
+ * engine reports as `pending`.
+ *
+ * @module cross-pollinate
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
+const LOCK_VERSION = 1;
+
+/**
+ * Canonical coding agents Lisa can fan out to. Mirrors `EmitAgent` in
+ * src/core/config.ts; kept inline because this engine ships inside the plugin
+ * and runs in host projects without the Lisa TypeScript build on the path.
+ */
+const ALL_AGENTS = ["claude", "codex", "cursor", "agy", "copilot", "opencode"];
+
+/**
+ * Resolve the agent set a `harness` value targets. Mirrors
+ * `harnessIncludesAgent` in src/core/config.ts (with the `all` -> `fleet`
+ * alias already normalized away on the config read path).
+ *
+ * @param {string} harness Canonical harness string from `.lisa.config.json`.
+ * @returns {string[]} Agents the harness includes.
+ */
+function agentsForHarness(harness) {
+  if (harness === "fleet") return [...ALL_AGENTS];
+  if (harness === "both") return ["claude", "codex"];
+  if (harness === "all") return [...ALL_AGENTS]; // defensive: pre-normalized alias
+  return ALL_AGENTS.includes(harness) ? [harness] : ["claude"];
+}
+
+/**
+ * Per-(agent, primitive) host-project location + format registry.
+ *
+ * Only entries we can place with confidence are marked `supported: true` and
+ * carry a `dir`/`ext`. Entries marked `supported: false` are intentionally NOT
+ * guessed — the engine reports detected definitions of that kind as `pending`
+ * so the skill (which reads the real on-disk layout) translates them with
+ * judgment rather than the engine writing a wrong path. This is deliberate:
+ * silently emitting to an unverified location is worse than reporting it.
+ *
+ * `kind` legend: skill | agent | rule | command | hook | mcp
+ */
+const HOST_LOCATIONS = {
+  skill: {
+    // Most agents consume the Claude SKILL.md format directly (OpenCode reads
+    // .claude/skills natively; agy/copilot ship SKILL.md verbatim). Codex is
+    // the one that needs a derived interface sidecar (agents/openai.yaml).
+    claude: { supported: true, dir: ".claude/skills", layout: "skill-dir" },
+    codex: { supported: true, dir: ".claude/skills", layout: "codex-sidecar" },
+    opencode: {
+      supported: true,
+      dir: ".claude/skills",
+      layout: "native-claude",
+    },
+    cursor: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+  },
+  mcp: {
+    claude: { supported: true, file: ".mcp.json", layout: "json" },
+    cursor: { supported: true, file: ".cursor/mcp.json", layout: "json" },
+    codex: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+    opencode: { supported: false },
+  },
+  rule: {
+    // Claude <-> Cursor is the clean, verified pair: a flat per-rule file in
+    // both, only the frontmatter + extension differ. codex/agy/opencode deliver
+    // project rules by merging into a shared AGENTS.md (section-marker management
+    // the engine does not fake) and copilot into .github/copilot-instructions.md
+    // — those stay `pending` for the skill to merge with judgment.
+    claude: {
+      supported: true,
+      dir: ".claude/rules",
+      ext: ".md",
+      layout: "rule-md",
+    },
+    cursor: {
+      supported: true,
+      dir: ".cursor/rules",
+      ext: ".mdc",
+      layout: "rule-mdc",
+    },
+  },
+  // Subagents, commands, hooks: detected by the scanner and reported as
+  // `pending` for the skill to translate. Their host locations differ per agent
+  // (and some are lossy/unsupported), so the engine does not hardcode them.
+  agent: {},
+  command: {},
+  hook: {},
+};
+
+/**
+ * Source-detection patterns: where a HUMAN authors each primitive, keyed by the
+ * agent whose format it is. The scanner walks these; the lockfile then filters
+ * out anything that is actually a generated target (loop prevention).
+ *
+ * @type {Array<{ kind: string, agent: string, glob: (root: string) => string[] }>}
+ */
+const SOURCE_SCANNERS = [
+  {
+    kind: "skill",
+    agent: "claude",
+    glob: root => listSkillDirs(path.join(root, ".claude/skills")),
+  },
+  {
+    kind: "agent",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/agents"), ".md"),
+  },
+  {
+    kind: "command",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/commands"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/rules"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "cursor",
+    glob: root => listFiles(path.join(root, ".cursor/rules"), ".mdc"),
+  },
+  {
+    kind: "mcp",
+    agent: "claude",
+    glob: root => existing(path.join(root, ".mcp.json")),
+  },
+  {
+    kind: "mcp",
+    agent: "cursor",
+    glob: root => existing(path.join(root, ".cursor/mcp.json")),
+  },
+];
+
+/** @returns {string[]} Absolute paths to skill directories (those holding SKILL.md). */
+function listSkillDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(
+      e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))
+    )
+    .map(e => path.join(dir, e.name));
+}
+
+/** @returns {string[]} Absolute file paths under `dir` with extension `ext`. */
+function listFiles(dir, ext, recursive = false) {
+  if (!isDir(dir)) return [];
+  const out = [];
+  const walk = current => {
+    for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory() && recursive) walk(p);
+      else if (e.isFile() && e.name.endsWith(ext)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** @returns {string[]} `[file]` if it exists, else `[]`. */
+function existing(file) {
+  return fs.existsSync(file) ? [file] : [];
+}
+
+/** @returns {boolean} */
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+/**
+ * Stable content hash for a definition. For a skill DIRECTORY we hash the
+ * sorted (relpath, content) pairs of every file so a change anywhere in the
+ * skill invalidates it; for a single file we hash its bytes.
+ *
+ * @param {string} target Absolute path to a file or skill directory.
+ * @returns {string} Hex sha256.
+ */
+function hashDefinition(target) {
+  const h = createHash("sha256");
+  if (isDir(target)) {
+    const files = listFiles(target, "", true).sort();
+    for (const f of files) {
+      h.update(path.relative(target, f));
+      h.update("\0");
+      h.update(fs.readFileSync(f));
+      h.update("\0");
+    }
+  } else {
+    h.update(fs.readFileSync(target));
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Logical identity of a definition, stable across agent formats. Two
+ * definitions sharing a logicalId are "the same thing" in different formats —
+ * the basis for both linking a source to its targets and detecting a
+ * human-authored collision.
+ *
+ * @param {string} kind
+ * @param {string} sourcePath Absolute path to the source definition.
+ * @returns {string} e.g. "skill:security-review"
+ */
+function logicalId(kind, sourcePath) {
+  // MCP config is a per-project singleton: `.mcp.json` (Claude) and
+  // `.cursor/mcp.json` (Cursor) are the SAME logical thing in different
+  // formats, so its identity must not derive from the (differing) filename —
+  // otherwise a genuine cross-agent collision reads as two unrelated configs.
+  if (kind === "mcp") return "mcp:project";
+  const base = isDir(sourcePath)
+    ? path.basename(sourcePath)
+    : path.basename(sourcePath).replace(/\.[^.]+$/, "");
+  return `${kind}:${base}`;
+}
+
+/** Read `.lisa.config.json` harness; default "claude". */
+function readHarness(root) {
+  const p = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(p)) return "claude";
+  try {
+    const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    return typeof cfg.harness === "string" ? cfg.harness : "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/** Read the provenance lockfile; returns an empty lock when absent. */
+function readLock(root) {
+  const p = path.join(root, LOCKFILE_REL);
+  if (!fs.existsSync(p)) return { version: LOCK_VERSION, entries: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.entries
+      ? parsed
+      : { version: LOCK_VERSION, entries: {} };
+  } catch {
+    return { version: LOCK_VERSION, entries: {} };
+  }
+}
+
+/** Persist the provenance lockfile (deterministic key ordering). */
+function writeLock(root, lock) {
+  const p = path.join(root, LOCKFILE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const ordered = { version: LOCK_VERSION, entries: {} };
+  for (const key of Object.keys(lock.entries).sort()) {
+    ordered.entries[key] = lock.entries[key];
+  }
+  fs.writeFileSync(p, JSON.stringify(ordered, null, 2) + "\n");
+}
+
+/**
+ * The set of absolute paths the lockfile records as GENERATED targets. A path
+ * in this set is never treated as a source (loop prevention).
+ *
+ * @param {object} lock
+ * @param {string} root
+ * @returns {Set<string>} Absolute target paths.
+ */
+function generatedTargetPaths(lock, root) {
+  const set = new Set();
+  for (const entry of Object.values(lock.entries)) {
+    for (const t of entry.targets ?? []) {
+      set.add(path.resolve(root, t.path));
+    }
+  }
+  return set;
+}
+
+/**
+ * Plan cross-pollination: scan sources, classify against the lockfile, and
+ * compute the actions needed. Pure with respect to the filesystem (reads only).
+ *
+ * @param {string} root Absolute host-project root.
+ * @returns {object} A structured plan (see fields below).
+ */
+export function plan(root) {
+  const harness = readHarness(root);
+  const targetAgents = agentsForHarness(harness);
+  const lock = readLock(root);
+  const generated = generatedTargetPaths(lock, root);
+
+  // Scan every source location, skipping anything the lock says is generated.
+  const sources = [];
+  const byLogicalId = new Map();
+  for (const scanner of SOURCE_SCANNERS) {
+    for (const abs of scanner.glob(root)) {
+      if (generated.has(path.resolve(abs))) continue; // loop prevention
+      const id = logicalId(scanner.kind, abs);
+      const src = {
+        logicalId: id,
+        kind: scanner.kind,
+        agent: scanner.agent,
+        path: path.relative(root, abs),
+        abs,
+        hash: hashDefinition(abs),
+      };
+      sources.push(src);
+      const bucket = byLogicalId.get(id) ?? [];
+      bucket.push(src);
+      byLogicalId.set(id, bucket);
+    }
+  }
+
+  // Conflicts: same logicalId authored independently in >1 agent (neither is a
+  // generated target). Never auto-translate over either — report for a human.
+  const conflicts = [];
+  for (const [id, bucket] of byLogicalId) {
+    if (bucket.length > 1) {
+      conflicts.push({
+        logicalId: id,
+        authoredIn: bucket.map(s => ({ agent: s.agent, path: s.path })),
+      });
+    }
+  }
+  const conflictIds = new Set(conflicts.map(c => c.logicalId));
+
+  // For each non-conflicting source, decide which target agents need an emit,
+  // and which kinds are pending (no confident host location).
+  const emits = [];
+  const pending = [];
+  for (const src of sources) {
+    if (conflictIds.has(src.logicalId)) continue;
+    const entry = lock.entries[src.logicalId];
+    const sourceChanged = !entry || entry.source?.hash !== src.hash;
+    for (const agent of targetAgents) {
+      if (agent === src.agent) continue;
+      const loc = HOST_LOCATIONS[src.kind]?.[agent];
+      if (!loc || !loc.supported) {
+        pending.push({
+          logicalId: src.logicalId,
+          kind: src.kind,
+          from: src.agent,
+          to: agent,
+        });
+        continue;
+      }
+      // The agent consumes the source format natively (e.g. OpenCode reads
+      // .claude/skills directly) — there is nothing to emit, and it must NOT be
+      // reported as a perpetual "missing" emit. It is inherently satisfied.
+      if (loc.layout === "native-claude") continue;
+      const recordedTarget = entry?.targets?.find(t => t.agent === agent);
+      const targetAbs = recordedTarget
+        ? path.resolve(root, recordedTarget.path)
+        : null;
+      const targetExists = targetAbs ? fs.existsSync(targetAbs) : false;
+      const targetDrifted =
+        targetExists &&
+        recordedTarget &&
+        hashDefinition(targetAbs) !== recordedTarget.generatedHash;
+      emits.push({
+        logicalId: src.logicalId,
+        kind: src.kind,
+        from: src.agent,
+        to: agent,
+        sourceAbs: src.abs,
+        reason: !targetExists
+          ? "missing"
+          : sourceChanged
+            ? "source-changed"
+            : targetDrifted
+              ? "drift"
+              : "up-to-date",
+        drifted: Boolean(targetDrifted),
+      });
+    }
+  }
+
+  // Orphans: lockfile entries whose source no longer exists -> GC their targets.
+  const liveIds = new Set(sources.map(s => s.logicalId));
+  const orphans = [];
+  for (const [id, entry] of Object.entries(lock.entries)) {
+    if (!liveIds.has(id)) {
+      orphans.push({
+        logicalId: id,
+        targets: (entry.targets ?? []).map(t => t.path),
+      });
+    }
+  }
+
+  return {
+    root,
+    harness,
+    targetAgents,
+    sources,
+    emits,
+    pending,
+    conflicts,
+    orphans,
+  };
+}
+
+/**
+ * Execute the deterministic emits a plan calls for (skills + mcp today),
+ * skipping `drift` emits (never clobber hand-edited targets), and update the
+ * lockfile. Judgment-heavy `pending` kinds are left for the skill.
+ *
+ * @param {object} p A plan from {@link plan}.
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{ written: object[], skippedDrift: object[], gc: string[] }}
+ */
+export function apply(p, opts = {}) {
+  const { root } = p;
+  const lock = readLock(root);
+  const written = [];
+  const skippedDrift = [];
+  const gc = [];
+
+  for (const emit of p.emits) {
+    if (emit.reason === "up-to-date") continue;
+    if (emit.drifted) {
+      skippedDrift.push(emit);
+      continue;
+    }
+    const result = emitOne(root, emit, opts);
+    if (!result) continue;
+    written.push({ ...emit, target: path.relative(root, result.abs) });
+    if (!opts.dryRun) recordTarget(lock, root, emit, result);
+  }
+
+  // GC orphaned targets.
+  for (const orphan of p.orphans) {
+    for (const rel of orphan.targets) {
+      const abs = path.resolve(root, rel);
+      if (fs.existsSync(abs)) {
+        gc.push(rel);
+        if (!opts.dryRun) fs.rmSync(abs, { recursive: true, force: true });
+      }
+    }
+    if (!opts.dryRun) delete lock.entries[orphan.logicalId];
+  }
+
+  if (!opts.dryRun) writeLock(root, lock);
+  return { written, skippedDrift, gc };
+}
+
+/**
+ * Emit a single target. Returns the written target's {abs} or null when the
+ * kind has no deterministic emitter (left to the skill).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitOne(root, emit, opts) {
+  const loc = HOST_LOCATIONS[emit.kind]?.[emit.to];
+  if (!loc || !loc.supported) return null;
+
+  if (emit.kind === "skill") return emitSkill(root, emit, loc, opts);
+  if (emit.kind === "mcp") return emitMcp(root, emit, loc, opts);
+  if (emit.kind === "rule") return emitRule(root, emit, loc, opts);
+  return null;
+}
+
+/**
+ * Emit a rule to a target agent, translating between the Claude `.md` and Cursor
+ * `.mdc` flat-file formats.
+ *
+ * Cursor requires YAML frontmatter (`description` from the first H1, `alwaysApply`)
+ * and discovers only `.mdc`; Claude reads plain `.md`. The transform mirrors
+ * scripts/generate-cursor-plugin-artifacts.mjs (reimplemented inline because that
+ * generator operates on the nested plugin layout and is not importable from the
+ * plugin at host runtime).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dir: string, ext: string, layout: string }} loc
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitRule(root, emit, loc, opts) {
+  const name = path.basename(emit.sourceAbs).replace(/\.(md|mdc)$/, "");
+  const outAbs = path.join(root, loc.dir, `${name}${loc.ext}`);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  const body = stripFrontmatter(raw);
+  let contents;
+  if (loc.layout === "rule-mdc") {
+    const fm = `---\ndescription: ${yamlQuote(deriveRuleDescription(body, name))}\nalwaysApply: true\n---\n\n`;
+    contents = fm + rewriteRuleLinks(body, ".mdc");
+  } else {
+    contents = rewriteRuleLinks(body, ".md");
+  }
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, contents);
+  }
+  return { abs: outAbs };
+}
+
+/**
+ * Emit a skill to a target agent. For native-Claude consumers (opencode) and
+ * the canonical Claude dir this is a no-op (they already read the source). For
+ * Codex, derive the `agents/openai.yaml` interface sidecar next to the SKILL.md.
+ */
+function emitSkill(_root, emit, loc, opts) {
+  if (loc.layout === "native-claude") return null; // agent reads source as-is
+
+  if (loc.layout === "codex-sidecar") {
+    const skillName = path.basename(emit.sourceAbs);
+    const skillMd = path.join(emit.sourceAbs, "SKILL.md");
+    if (!fs.existsSync(skillMd)) return null;
+    const fm = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    const outAbs = path.join(emit.sourceAbs, "agents", "openai.yaml");
+    const yaml = renderOpenAiInterface(
+      fm.name ?? skillName,
+      fm.description ?? ""
+    );
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+      fs.writeFileSync(outAbs, yaml);
+    }
+    return { abs: outAbs };
+  }
+
+  return null;
+}
+
+/** Emit an MCP config by re-shaping the source JSON to the target agent's file. */
+function emitMcp(root, emit, loc, opts) {
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed source; leave to the skill to surface
+  }
+  const outAbs = path.join(root, loc.file);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify(parsed, null, 2) + "\n");
+  }
+  return { abs: outAbs };
+}
+
+/** Record/refresh a target in the lockfile after a successful emit. */
+function recordTarget(lock, root, emit, result) {
+  const src = {
+    agent: emit.from,
+    path: path.relative(root, emit.sourceAbs),
+    hash: hashDefinition(emit.sourceAbs),
+  };
+  const entry = lock.entries[emit.logicalId] ?? { source: src, targets: [] };
+  entry.source = src;
+  const rel = path.relative(root, result.abs);
+  const generatedHash = hashDefinition(result.abs);
+  const existingIdx = entry.targets.findIndex(t => t.agent === emit.to);
+  const record = { agent: emit.to, path: rel, generatedHash };
+  if (existingIdx >= 0) entry.targets[existingIdx] = record;
+  else entry.targets.push(record);
+  entry.targets.sort((a, b) => a.agent.localeCompare(b.agent));
+  lock.entries[emit.logicalId] = entry;
+}
+
+/** Strip a leading `---`-fenced YAML frontmatter block, returning the body. */
+function stripFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, "");
+}
+
+/** YAML-quote a description value for `.mdc` frontmatter. */
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Derive a single-line rule description: the first H1, else a titleized slug.
+ * Mirrors generate-cursor-plugin-artifacts.mjs.
+ *
+ * @param {string} body Rule markdown body (frontmatter already stripped).
+ * @param {string} name Rule slug.
+ * @returns {string}
+ */
+function deriveRuleDescription(body, name) {
+  const withoutFences = body.replace(/^(```|~~~).*$[\s\S]*?^\1.*$/gm, "");
+  const h1 = /^#\s+(.+?)\s*$/m.exec(withoutFences);
+  const text = (h1 ? h1[1] : "").replace(/\s+/g, " ").trim();
+  if (text) return text;
+  return name
+    .split("-")
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Rewrite intra-rule markdown link extensions to the target rule format so links
+ * still resolve after translation (e.g. `](foo.md)` -> `](foo.mdc)`). Only the
+ * URL is touched; the link text is preserved. External/`http` links are left as-is.
+ *
+ * @param {string} body
+ * @param {".md"|".mdc"} targetExt
+ * @returns {string}
+ */
+function rewriteRuleLinks(body, targetExt) {
+  const otherExt = targetExt === ".mdc" ? ".md" : ".mdc";
+  const re = new RegExp(`\\]\\(([^)]+?)\\${otherExt}(#[^)]*)?\\)`, "g");
+  return body.replace(re, (match, base, fragment = "") =>
+    /^https?:/.test(base) ? match : `](${base}${targetExt}${fragment})`
+  );
+}
+
+/** Minimal YAML/Markdown frontmatter parser for `name`/`description`. */
+function parseFrontmatter(text) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  const out = {};
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+/** Render a Codex `openai.yaml` interface from a skill's name/description. */
+function renderOpenAiInterface(name, description) {
+  const display = name
+    .split("-")
+    .map(p => (p ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+  const short = description.split(/[.!?]/)[0].trim() || display;
+  const esc = s => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return (
+    `display_name: ${esc(display)}\n` +
+    `short_description: ${esc(short)}\n` +
+    `default_prompt:\n` +
+    `  - ${esc(`Use $${name}: ${short}.`)}\n`
+  );
+}
+
+/** Render a human-readable report of a plan + apply result. */
+export function renderReport(p, result) {
+  const lines = [];
+  lines.push(
+    `Cross-pollination — harness: ${p.harness} -> [${p.targetAgents.join(", ")}]`
+  );
+  lines.push(`  sources detected: ${p.sources.length}`);
+  if (result) {
+    lines.push(`  written:          ${result.written.length}`);
+    if (result.skippedDrift.length)
+      lines.push(`  skipped (edited): ${result.skippedDrift.length}`);
+    if (result.gc.length) lines.push(`  garbage-collected:${result.gc.length}`);
+  }
+  if (p.conflicts.length) {
+    lines.push(`  CONFLICTS (authored in >1 agent — not translated):`);
+    for (const c of p.conflicts)
+      lines.push(
+        `    - ${c.logicalId}: ${c.authoredIn.map(a => a.agent).join(" + ")}`
+      );
+  }
+  if (p.pending.length) {
+    const byKind = {};
+    for (const x of p.pending) byKind[x.kind] = (byKind[x.kind] ?? 0) + 1;
+    lines.push(
+      `  PENDING (need skill-driven translation): ${Object.entries(byKind)
+        .map(([k, n]) => `${k}×${n}`)
+        .join(", ")}`
+    );
+  }
+  return lines.join("\n");
+}
+
+// CLI entrypoint.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
+  const dryRun = args.includes("--dry-run") || !args.includes("--write");
+  const asJson = args.includes("--json");
+  const p = plan(root);
+  const result = apply(p, { dryRun });
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { plan: p, result, dryRun },
+        (k, v) => (k === "abs" ? undefined : v),
+        2
+      )
+    );
+  } else {
+    console.log(renderReport(p, result));
+    if (dryRun)
+      console.log("\n(dry-run — pass --write to apply; default is dry-run)");
+  }
+}

--- a/plugins/lisa-agy/skills/cross-pollinate/SKILL.md
+++ b/plugins/lisa-agy/skills/cross-pollinate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cross-pollinate
+description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available in the formats of the OTHER agents the project supports, as declared in .lisa.config.json. Any-to-any, provenance-tracked, idempotent, never clobbers hand-edited output."
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+# Cross-Pollinate: $ARGUMENTS
+
+A host project that installs Lisa may hand-author a definition for **one** coding
+agent — a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server only
+Claude sees. `/lisa:cross-pollinate` detects those locally-authored definitions
+and regenerates each in the formats of the **other** agents the project supports,
+so the whole fleet stays in parity with what a developer wrote for any single one.
+
+## The model
+
+```
+any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
+```
+
+Claude format is the canonical intermediate representation (IR) because every
+Lisa generator already sources from it. So translation is always: **normalize
+the detected definition up to Claude-format IR, then fan that IR out** to each
+target agent using the documented mappings below. Never translate format A → B
+directly — that multiplies error and loses fidelity on every hop.
+
+The agents a project supports come from `.lisa.config.json` `harness`
+(`claude` | `codex` | `cursor` | `agy` | `copilot` | `opencode` | `both` | `fleet`;
+`all` is an alias for `fleet`). Only emit to agents that harness includes.
+
+## Provenance is authoritative — the lockfile, not file paths
+
+`.lisa/cross-pollination.lock.json` (committed) is the source of truth for what
+this skill generated. Location heuristics **cannot** work: a generated Cursor
+rule sits in the same `.cursor/rules/` directory as a hand-authored one. The
+lockfile is the only reliable way to enforce the four invariants:
+
+1. **No loops** — a path recorded as a `target` is NEVER treated as a source on
+   the next run. Without this, today's output becomes tomorrow's input and
+   translations ping-pong forever.
+2. **Garbage collection** — when a source is deleted/renamed, its now-orphaned
+   targets are removed.
+3. **Never clobber edits (Chesterton's fence)** — if a target's on-disk hash
+   differs from the recorded `generatedHash`, a human edited it. Stop and report;
+   do not overwrite. They may have intentionally diverged, or want to adopt the
+   edit as a new source.
+4. **Idempotent** — unchanged source + intact targets => no-op. (This is why it
+   is safe to also run during `lisa apply`.)
+
+Lockfile shape:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "skill:security-review": {
+      "source":  { "agent": "claude", "path": ".claude/skills/security-review", "hash": "…" },
+      "targets": [ { "agent": "codex", "path": ".claude/skills/security-review/agents/openai.yaml", "generatedHash": "…" } ]
+    }
+  }
+}
+```
+
+The `logicalId` is `<kind>:<name>` — stable across formats. It links a source to
+its targets and detects **collisions**: the same `logicalId` authored
+independently in two agents (neither generated). On a collision, NEVER
+auto-translate over either side — report it and let the human pick the source of
+truth.
+
+## How to run
+
+The deterministic core (scan, provenance, loop/GC/drift/conflict detection, and
+the skill + MCP emitters) is a bundled engine. **Always run it first** — it does
+the safe, mechanical work and tells you exactly what is left for you to translate
+by hand.
+
+```bash
+# dry-run (default): report only, writes nothing
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --json
+# apply the deterministic emits + update the lockfile
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --write
+```
+
+In the Lisa source repo itself the path is
+`node plugins/lisa/scripts/cross-pollinate.mjs` (built) or
+`node plugins/src/base/scripts/cross-pollinate.mjs` (source).
+
+The JSON report has four lists you act on:
+
+- `emits` — already handled by `--write` (skills, MCP). Verify, don't redo.
+- `conflicts` — STOP. Report each to the user; do not translate.
+- `orphans` — GC'd by `--write`. Confirm the removals look right.
+- `pending` — **your job.** Definitions whose target format the engine does not
+  emit deterministically. Translate each per the mappings below, then record
+  provenance (see "Recording provenance").
+
+## Per-agent format mappings (for `pending` translation)
+
+Normalize the source to Claude-format IR first, then emit per target:
+
+### Rules
+- **Claude ↔ Cursor**: handled deterministically by the engine. Claude reads
+  `.claude/rules/<name>.md`; Cursor reads `.cursor/rules/<name>.mdc` with YAML
+  frontmatter (`description` from the first H1, `alwaysApply: true`) and intra-rule
+  link extensions rewritten. You do not translate these — verify the engine's
+  emits.
+- **Codex / OpenCode / agy** (`pending`): project rules are delivered via
+  `AGENTS.md`, not a per-rule file. MERGE the rule content into `AGENTS.md` under a
+  stable marked section rather than writing a separate file (so re-runs replace,
+  not append). agy never gets a duplicate rule file (rules-once).
+- **Copilot** (`pending`): `.github/copilot-instructions.md` (inline). Merge into a
+  marked section, don't scatter.
+
+### Subagents
+- **Claude / agy / Cursor / OpenCode**: `agents/<name>.md` (or `.claude/agents/`).
+- **Copilot**: `agents/<name>.agent.md` (note the `.agent.md` suffix).
+- **Codex**: does not consume agent files. Report as **dropped — unsupported**,
+  do not invent a target.
+
+### Commands
+- **Claude / Cursor / Copilot**: markdown command files (`.claude/commands/…`).
+- **Codex / agy**: auto-derive commands from skills; no separate command file.
+  Report as **dropped — derived-from-skill**.
+
+### Hooks (lossy — drop-and-report, never fake support)
+- Event-name casing differs per agent (`PreToolUse`→`preToolUse`/`beforeSubmitPrompt`,
+  `UserPromptSubmit`→`userPromptSubmitted`, `Stop`→`agentStop`/`stop`, …).
+- **agy** lacks `SessionStart`/`SubagentStart` — only `PreToolUse` (e.g.
+  block-no-verify) is portable. Everything else: dropped — unsupported.
+- **Codex** plugin hooks do not fire in `codex exec` — install into
+  `~/.codex/hooks.json`, not a bundled file.
+- **Copilot** rejects the entire hooks config if a `SubagentStart`/empty-matcher
+  entry is present — drop that event wholesale.
+- For every hook you cannot faithfully translate to a target, REPORT it with the
+  reason. Do not silently omit (no silent caps).
+
+### MCP (handled by the engine for Claude↔Cursor; report others)
+- **Claude**: `.mcp.json`. **Cursor**: `.cursor/mcp.json` (same JSON shape).
+- **Copilot**: inline `mcpServers` object in the plugin manifest (bundled
+  `.mcp.json` is ignored). **Codex**: TOML / `.codex-plugin` pointer.
+  **agy/OpenCode**: user-global installer / `.opencode`. The engine reports these
+  as pending; translate per the target's documented shape or report dropped.
+
+## Recording provenance for hand-translated `pending` items
+
+After you write a target by hand, it MUST be recorded in
+`.lisa/cross-pollination.lock.json` or the next run will treat it as a source
+(loop) or fail to GC it. Re-run the engine after staging your translated files —
+on its next pass it adopts and hashes any target already referenced — OR add the
+entry yourself following the lockfile shape above (compute `generatedHash` as the
+sha256 of the written file/dir). Prefer the engine; only hand-edit the lock if
+the engine cannot infer the mapping.
+
+## Output
+
+Report, concisely:
+- harness + resolved target agents
+- counts: detected sources, written, skipped-drift, GC'd
+- every conflict (with the agents involved)
+- every pending item you translated, and every hook/agent/command you **dropped**
+  with its reason
+- confirm `.lisa/cross-pollination.lock.json` was updated and the working tree
+  otherwise contains only intended changes
+
+## Rules
+
+- Treat the lockfile as authoritative; never infer "mine vs theirs" from paths.
+- Never overwrite a drifted (hand-edited) target — report it.
+- Never auto-resolve a collision — report it.
+- Only emit to agents the project's `harness` includes.
+- Drop-and-report any translation a target genuinely cannot support; never fake
+  a location you are unsure of.
+- This skill is additive — it does not delete a human's source definitions, only
+  its own orphaned generated targets.

--- a/plugins/lisa-copilot/commands/cross-pollinate.md
+++ b/plugins/lisa-copilot/commands/cross-pollinate.md
@@ -1,0 +1,15 @@
+---
+description: "Detect locally-authored agent definitions and regenerate them in the formats of the other coding agents this project supports (per .lisa.config.json)."
+allowed-tools: ["Skill"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+Use the /lisa:cross-pollinate skill to detect this project's locally-authored
+coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and
+make each available in the formats of the other agents the project's
+`.lisa.config.json` harness includes. $ARGUMENTS
+
+Provenance is tracked in `.lisa/cross-pollination.lock.json`: the run is
+idempotent, garbage-collects orphaned translations, never overwrites a
+hand-edited target, and reports any conflict or unsupported translation rather
+than guessing.

--- a/plugins/lisa-copilot/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-copilot/scripts/cross-pollinate.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * Cross-pollinate a host project's locally-authored coding-agent definitions
+ * across every agent the project supports.
+ *
+ * A host project that installs Lisa may hand-author a skill, subagent, rule,
+ * command, hook, or MCP entry for ONE coding agent (e.g. a `.claude/skills/foo`
+ * that only Claude sees). This engine detects those locally-authored
+ * definitions, normalizes each to a canonical intermediate representation (IR),
+ * and fans it out to the formats of the OTHER agents declared in the project's
+ * `.lisa.config.json` `harness`.
+ *
+ * Architecture (see the cross-pollinate SKILL.md for the full spec):
+ *   any agent's format  ->  Claude-format IR  ->  every other configured agent
+ *
+ * Claude format is the IR because every existing Lisa generator already sources
+ * from it; emitting IR -> {cursor, codex, agy, copilot, opencode} reuses those
+ * battle-tested transforms instead of an N x N translator matrix.
+ *
+ * PROVENANCE is authoritative via a committed lockfile,
+ * `.lisa/cross-pollination.lock.json`. Path/location heuristics alone CANNOT
+ * distinguish a generated translation from a hand-authored original (both live
+ * in the same per-agent directory), so the lockfile is the only reliable way to:
+ *   1. prevent loops    — a recorded target is never treated as a source
+ *   2. garbage-collect  — an orphaned target (source deleted) is removed
+ *   3. protect edits    — a target whose on-disk hash drifts from the recorded
+ *                         generated hash was hand-edited; never clobber it
+ *   4. stay idempotent  — unchanged source + intact targets => no-op
+ *
+ * This engine is the deterministic core. It is invoked standalone
+ * (`node .../cross-pollinate.mjs <path> [--dry-run] [--json] [--write]`) and by
+ * the cross-pollinate skill, which layers in the judgment-heavy translations the
+ * engine reports as `pending`.
+ *
+ * @module cross-pollinate
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
+const LOCK_VERSION = 1;
+
+/**
+ * Canonical coding agents Lisa can fan out to. Mirrors `EmitAgent` in
+ * src/core/config.ts; kept inline because this engine ships inside the plugin
+ * and runs in host projects without the Lisa TypeScript build on the path.
+ */
+const ALL_AGENTS = ["claude", "codex", "cursor", "agy", "copilot", "opencode"];
+
+/**
+ * Resolve the agent set a `harness` value targets. Mirrors
+ * `harnessIncludesAgent` in src/core/config.ts (with the `all` -> `fleet`
+ * alias already normalized away on the config read path).
+ *
+ * @param {string} harness Canonical harness string from `.lisa.config.json`.
+ * @returns {string[]} Agents the harness includes.
+ */
+function agentsForHarness(harness) {
+  if (harness === "fleet") return [...ALL_AGENTS];
+  if (harness === "both") return ["claude", "codex"];
+  if (harness === "all") return [...ALL_AGENTS]; // defensive: pre-normalized alias
+  return ALL_AGENTS.includes(harness) ? [harness] : ["claude"];
+}
+
+/**
+ * Per-(agent, primitive) host-project location + format registry.
+ *
+ * Only entries we can place with confidence are marked `supported: true` and
+ * carry a `dir`/`ext`. Entries marked `supported: false` are intentionally NOT
+ * guessed — the engine reports detected definitions of that kind as `pending`
+ * so the skill (which reads the real on-disk layout) translates them with
+ * judgment rather than the engine writing a wrong path. This is deliberate:
+ * silently emitting to an unverified location is worse than reporting it.
+ *
+ * `kind` legend: skill | agent | rule | command | hook | mcp
+ */
+const HOST_LOCATIONS = {
+  skill: {
+    // Most agents consume the Claude SKILL.md format directly (OpenCode reads
+    // .claude/skills natively; agy/copilot ship SKILL.md verbatim). Codex is
+    // the one that needs a derived interface sidecar (agents/openai.yaml).
+    claude: { supported: true, dir: ".claude/skills", layout: "skill-dir" },
+    codex: { supported: true, dir: ".claude/skills", layout: "codex-sidecar" },
+    opencode: {
+      supported: true,
+      dir: ".claude/skills",
+      layout: "native-claude",
+    },
+    cursor: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+  },
+  mcp: {
+    claude: { supported: true, file: ".mcp.json", layout: "json" },
+    cursor: { supported: true, file: ".cursor/mcp.json", layout: "json" },
+    codex: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+    opencode: { supported: false },
+  },
+  rule: {
+    // Claude <-> Cursor is the clean, verified pair: a flat per-rule file in
+    // both, only the frontmatter + extension differ. codex/agy/opencode deliver
+    // project rules by merging into a shared AGENTS.md (section-marker management
+    // the engine does not fake) and copilot into .github/copilot-instructions.md
+    // — those stay `pending` for the skill to merge with judgment.
+    claude: {
+      supported: true,
+      dir: ".claude/rules",
+      ext: ".md",
+      layout: "rule-md",
+    },
+    cursor: {
+      supported: true,
+      dir: ".cursor/rules",
+      ext: ".mdc",
+      layout: "rule-mdc",
+    },
+  },
+  // Subagents, commands, hooks: detected by the scanner and reported as
+  // `pending` for the skill to translate. Their host locations differ per agent
+  // (and some are lossy/unsupported), so the engine does not hardcode them.
+  agent: {},
+  command: {},
+  hook: {},
+};
+
+/**
+ * Source-detection patterns: where a HUMAN authors each primitive, keyed by the
+ * agent whose format it is. The scanner walks these; the lockfile then filters
+ * out anything that is actually a generated target (loop prevention).
+ *
+ * @type {Array<{ kind: string, agent: string, glob: (root: string) => string[] }>}
+ */
+const SOURCE_SCANNERS = [
+  {
+    kind: "skill",
+    agent: "claude",
+    glob: root => listSkillDirs(path.join(root, ".claude/skills")),
+  },
+  {
+    kind: "agent",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/agents"), ".md"),
+  },
+  {
+    kind: "command",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/commands"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/rules"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "cursor",
+    glob: root => listFiles(path.join(root, ".cursor/rules"), ".mdc"),
+  },
+  {
+    kind: "mcp",
+    agent: "claude",
+    glob: root => existing(path.join(root, ".mcp.json")),
+  },
+  {
+    kind: "mcp",
+    agent: "cursor",
+    glob: root => existing(path.join(root, ".cursor/mcp.json")),
+  },
+];
+
+/** @returns {string[]} Absolute paths to skill directories (those holding SKILL.md). */
+function listSkillDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(
+      e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))
+    )
+    .map(e => path.join(dir, e.name));
+}
+
+/** @returns {string[]} Absolute file paths under `dir` with extension `ext`. */
+function listFiles(dir, ext, recursive = false) {
+  if (!isDir(dir)) return [];
+  const out = [];
+  const walk = current => {
+    for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory() && recursive) walk(p);
+      else if (e.isFile() && e.name.endsWith(ext)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** @returns {string[]} `[file]` if it exists, else `[]`. */
+function existing(file) {
+  return fs.existsSync(file) ? [file] : [];
+}
+
+/** @returns {boolean} */
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+/**
+ * Stable content hash for a definition. For a skill DIRECTORY we hash the
+ * sorted (relpath, content) pairs of every file so a change anywhere in the
+ * skill invalidates it; for a single file we hash its bytes.
+ *
+ * @param {string} target Absolute path to a file or skill directory.
+ * @returns {string} Hex sha256.
+ */
+function hashDefinition(target) {
+  const h = createHash("sha256");
+  if (isDir(target)) {
+    const files = listFiles(target, "", true).sort();
+    for (const f of files) {
+      h.update(path.relative(target, f));
+      h.update("\0");
+      h.update(fs.readFileSync(f));
+      h.update("\0");
+    }
+  } else {
+    h.update(fs.readFileSync(target));
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Logical identity of a definition, stable across agent formats. Two
+ * definitions sharing a logicalId are "the same thing" in different formats —
+ * the basis for both linking a source to its targets and detecting a
+ * human-authored collision.
+ *
+ * @param {string} kind
+ * @param {string} sourcePath Absolute path to the source definition.
+ * @returns {string} e.g. "skill:security-review"
+ */
+function logicalId(kind, sourcePath) {
+  // MCP config is a per-project singleton: `.mcp.json` (Claude) and
+  // `.cursor/mcp.json` (Cursor) are the SAME logical thing in different
+  // formats, so its identity must not derive from the (differing) filename —
+  // otherwise a genuine cross-agent collision reads as two unrelated configs.
+  if (kind === "mcp") return "mcp:project";
+  const base = isDir(sourcePath)
+    ? path.basename(sourcePath)
+    : path.basename(sourcePath).replace(/\.[^.]+$/, "");
+  return `${kind}:${base}`;
+}
+
+/** Read `.lisa.config.json` harness; default "claude". */
+function readHarness(root) {
+  const p = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(p)) return "claude";
+  try {
+    const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    return typeof cfg.harness === "string" ? cfg.harness : "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/** Read the provenance lockfile; returns an empty lock when absent. */
+function readLock(root) {
+  const p = path.join(root, LOCKFILE_REL);
+  if (!fs.existsSync(p)) return { version: LOCK_VERSION, entries: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.entries
+      ? parsed
+      : { version: LOCK_VERSION, entries: {} };
+  } catch {
+    return { version: LOCK_VERSION, entries: {} };
+  }
+}
+
+/** Persist the provenance lockfile (deterministic key ordering). */
+function writeLock(root, lock) {
+  const p = path.join(root, LOCKFILE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const ordered = { version: LOCK_VERSION, entries: {} };
+  for (const key of Object.keys(lock.entries).sort()) {
+    ordered.entries[key] = lock.entries[key];
+  }
+  fs.writeFileSync(p, JSON.stringify(ordered, null, 2) + "\n");
+}
+
+/**
+ * The set of absolute paths the lockfile records as GENERATED targets. A path
+ * in this set is never treated as a source (loop prevention).
+ *
+ * @param {object} lock
+ * @param {string} root
+ * @returns {Set<string>} Absolute target paths.
+ */
+function generatedTargetPaths(lock, root) {
+  const set = new Set();
+  for (const entry of Object.values(lock.entries)) {
+    for (const t of entry.targets ?? []) {
+      set.add(path.resolve(root, t.path));
+    }
+  }
+  return set;
+}
+
+/**
+ * Plan cross-pollination: scan sources, classify against the lockfile, and
+ * compute the actions needed. Pure with respect to the filesystem (reads only).
+ *
+ * @param {string} root Absolute host-project root.
+ * @returns {object} A structured plan (see fields below).
+ */
+export function plan(root) {
+  const harness = readHarness(root);
+  const targetAgents = agentsForHarness(harness);
+  const lock = readLock(root);
+  const generated = generatedTargetPaths(lock, root);
+
+  // Scan every source location, skipping anything the lock says is generated.
+  const sources = [];
+  const byLogicalId = new Map();
+  for (const scanner of SOURCE_SCANNERS) {
+    for (const abs of scanner.glob(root)) {
+      if (generated.has(path.resolve(abs))) continue; // loop prevention
+      const id = logicalId(scanner.kind, abs);
+      const src = {
+        logicalId: id,
+        kind: scanner.kind,
+        agent: scanner.agent,
+        path: path.relative(root, abs),
+        abs,
+        hash: hashDefinition(abs),
+      };
+      sources.push(src);
+      const bucket = byLogicalId.get(id) ?? [];
+      bucket.push(src);
+      byLogicalId.set(id, bucket);
+    }
+  }
+
+  // Conflicts: same logicalId authored independently in >1 agent (neither is a
+  // generated target). Never auto-translate over either — report for a human.
+  const conflicts = [];
+  for (const [id, bucket] of byLogicalId) {
+    if (bucket.length > 1) {
+      conflicts.push({
+        logicalId: id,
+        authoredIn: bucket.map(s => ({ agent: s.agent, path: s.path })),
+      });
+    }
+  }
+  const conflictIds = new Set(conflicts.map(c => c.logicalId));
+
+  // For each non-conflicting source, decide which target agents need an emit,
+  // and which kinds are pending (no confident host location).
+  const emits = [];
+  const pending = [];
+  for (const src of sources) {
+    if (conflictIds.has(src.logicalId)) continue;
+    const entry = lock.entries[src.logicalId];
+    const sourceChanged = !entry || entry.source?.hash !== src.hash;
+    for (const agent of targetAgents) {
+      if (agent === src.agent) continue;
+      const loc = HOST_LOCATIONS[src.kind]?.[agent];
+      if (!loc || !loc.supported) {
+        pending.push({
+          logicalId: src.logicalId,
+          kind: src.kind,
+          from: src.agent,
+          to: agent,
+        });
+        continue;
+      }
+      // The agent consumes the source format natively (e.g. OpenCode reads
+      // .claude/skills directly) — there is nothing to emit, and it must NOT be
+      // reported as a perpetual "missing" emit. It is inherently satisfied.
+      if (loc.layout === "native-claude") continue;
+      const recordedTarget = entry?.targets?.find(t => t.agent === agent);
+      const targetAbs = recordedTarget
+        ? path.resolve(root, recordedTarget.path)
+        : null;
+      const targetExists = targetAbs ? fs.existsSync(targetAbs) : false;
+      const targetDrifted =
+        targetExists &&
+        recordedTarget &&
+        hashDefinition(targetAbs) !== recordedTarget.generatedHash;
+      emits.push({
+        logicalId: src.logicalId,
+        kind: src.kind,
+        from: src.agent,
+        to: agent,
+        sourceAbs: src.abs,
+        reason: !targetExists
+          ? "missing"
+          : sourceChanged
+            ? "source-changed"
+            : targetDrifted
+              ? "drift"
+              : "up-to-date",
+        drifted: Boolean(targetDrifted),
+      });
+    }
+  }
+
+  // Orphans: lockfile entries whose source no longer exists -> GC their targets.
+  const liveIds = new Set(sources.map(s => s.logicalId));
+  const orphans = [];
+  for (const [id, entry] of Object.entries(lock.entries)) {
+    if (!liveIds.has(id)) {
+      orphans.push({
+        logicalId: id,
+        targets: (entry.targets ?? []).map(t => t.path),
+      });
+    }
+  }
+
+  return {
+    root,
+    harness,
+    targetAgents,
+    sources,
+    emits,
+    pending,
+    conflicts,
+    orphans,
+  };
+}
+
+/**
+ * Execute the deterministic emits a plan calls for (skills + mcp today),
+ * skipping `drift` emits (never clobber hand-edited targets), and update the
+ * lockfile. Judgment-heavy `pending` kinds are left for the skill.
+ *
+ * @param {object} p A plan from {@link plan}.
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{ written: object[], skippedDrift: object[], gc: string[] }}
+ */
+export function apply(p, opts = {}) {
+  const { root } = p;
+  const lock = readLock(root);
+  const written = [];
+  const skippedDrift = [];
+  const gc = [];
+
+  for (const emit of p.emits) {
+    if (emit.reason === "up-to-date") continue;
+    if (emit.drifted) {
+      skippedDrift.push(emit);
+      continue;
+    }
+    const result = emitOne(root, emit, opts);
+    if (!result) continue;
+    written.push({ ...emit, target: path.relative(root, result.abs) });
+    if (!opts.dryRun) recordTarget(lock, root, emit, result);
+  }
+
+  // GC orphaned targets.
+  for (const orphan of p.orphans) {
+    for (const rel of orphan.targets) {
+      const abs = path.resolve(root, rel);
+      if (fs.existsSync(abs)) {
+        gc.push(rel);
+        if (!opts.dryRun) fs.rmSync(abs, { recursive: true, force: true });
+      }
+    }
+    if (!opts.dryRun) delete lock.entries[orphan.logicalId];
+  }
+
+  if (!opts.dryRun) writeLock(root, lock);
+  return { written, skippedDrift, gc };
+}
+
+/**
+ * Emit a single target. Returns the written target's {abs} or null when the
+ * kind has no deterministic emitter (left to the skill).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitOne(root, emit, opts) {
+  const loc = HOST_LOCATIONS[emit.kind]?.[emit.to];
+  if (!loc || !loc.supported) return null;
+
+  if (emit.kind === "skill") return emitSkill(root, emit, loc, opts);
+  if (emit.kind === "mcp") return emitMcp(root, emit, loc, opts);
+  if (emit.kind === "rule") return emitRule(root, emit, loc, opts);
+  return null;
+}
+
+/**
+ * Emit a rule to a target agent, translating between the Claude `.md` and Cursor
+ * `.mdc` flat-file formats.
+ *
+ * Cursor requires YAML frontmatter (`description` from the first H1, `alwaysApply`)
+ * and discovers only `.mdc`; Claude reads plain `.md`. The transform mirrors
+ * scripts/generate-cursor-plugin-artifacts.mjs (reimplemented inline because that
+ * generator operates on the nested plugin layout and is not importable from the
+ * plugin at host runtime).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dir: string, ext: string, layout: string }} loc
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitRule(root, emit, loc, opts) {
+  const name = path.basename(emit.sourceAbs).replace(/\.(md|mdc)$/, "");
+  const outAbs = path.join(root, loc.dir, `${name}${loc.ext}`);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  const body = stripFrontmatter(raw);
+  let contents;
+  if (loc.layout === "rule-mdc") {
+    const fm = `---\ndescription: ${yamlQuote(deriveRuleDescription(body, name))}\nalwaysApply: true\n---\n\n`;
+    contents = fm + rewriteRuleLinks(body, ".mdc");
+  } else {
+    contents = rewriteRuleLinks(body, ".md");
+  }
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, contents);
+  }
+  return { abs: outAbs };
+}
+
+/**
+ * Emit a skill to a target agent. For native-Claude consumers (opencode) and
+ * the canonical Claude dir this is a no-op (they already read the source). For
+ * Codex, derive the `agents/openai.yaml` interface sidecar next to the SKILL.md.
+ */
+function emitSkill(_root, emit, loc, opts) {
+  if (loc.layout === "native-claude") return null; // agent reads source as-is
+
+  if (loc.layout === "codex-sidecar") {
+    const skillName = path.basename(emit.sourceAbs);
+    const skillMd = path.join(emit.sourceAbs, "SKILL.md");
+    if (!fs.existsSync(skillMd)) return null;
+    const fm = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    const outAbs = path.join(emit.sourceAbs, "agents", "openai.yaml");
+    const yaml = renderOpenAiInterface(
+      fm.name ?? skillName,
+      fm.description ?? ""
+    );
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+      fs.writeFileSync(outAbs, yaml);
+    }
+    return { abs: outAbs };
+  }
+
+  return null;
+}
+
+/** Emit an MCP config by re-shaping the source JSON to the target agent's file. */
+function emitMcp(root, emit, loc, opts) {
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed source; leave to the skill to surface
+  }
+  const outAbs = path.join(root, loc.file);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify(parsed, null, 2) + "\n");
+  }
+  return { abs: outAbs };
+}
+
+/** Record/refresh a target in the lockfile after a successful emit. */
+function recordTarget(lock, root, emit, result) {
+  const src = {
+    agent: emit.from,
+    path: path.relative(root, emit.sourceAbs),
+    hash: hashDefinition(emit.sourceAbs),
+  };
+  const entry = lock.entries[emit.logicalId] ?? { source: src, targets: [] };
+  entry.source = src;
+  const rel = path.relative(root, result.abs);
+  const generatedHash = hashDefinition(result.abs);
+  const existingIdx = entry.targets.findIndex(t => t.agent === emit.to);
+  const record = { agent: emit.to, path: rel, generatedHash };
+  if (existingIdx >= 0) entry.targets[existingIdx] = record;
+  else entry.targets.push(record);
+  entry.targets.sort((a, b) => a.agent.localeCompare(b.agent));
+  lock.entries[emit.logicalId] = entry;
+}
+
+/** Strip a leading `---`-fenced YAML frontmatter block, returning the body. */
+function stripFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, "");
+}
+
+/** YAML-quote a description value for `.mdc` frontmatter. */
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Derive a single-line rule description: the first H1, else a titleized slug.
+ * Mirrors generate-cursor-plugin-artifacts.mjs.
+ *
+ * @param {string} body Rule markdown body (frontmatter already stripped).
+ * @param {string} name Rule slug.
+ * @returns {string}
+ */
+function deriveRuleDescription(body, name) {
+  const withoutFences = body.replace(/^(```|~~~).*$[\s\S]*?^\1.*$/gm, "");
+  const h1 = /^#\s+(.+?)\s*$/m.exec(withoutFences);
+  const text = (h1 ? h1[1] : "").replace(/\s+/g, " ").trim();
+  if (text) return text;
+  return name
+    .split("-")
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Rewrite intra-rule markdown link extensions to the target rule format so links
+ * still resolve after translation (e.g. `](foo.md)` -> `](foo.mdc)`). Only the
+ * URL is touched; the link text is preserved. External/`http` links are left as-is.
+ *
+ * @param {string} body
+ * @param {".md"|".mdc"} targetExt
+ * @returns {string}
+ */
+function rewriteRuleLinks(body, targetExt) {
+  const otherExt = targetExt === ".mdc" ? ".md" : ".mdc";
+  const re = new RegExp(`\\]\\(([^)]+?)\\${otherExt}(#[^)]*)?\\)`, "g");
+  return body.replace(re, (match, base, fragment = "") =>
+    /^https?:/.test(base) ? match : `](${base}${targetExt}${fragment})`
+  );
+}
+
+/** Minimal YAML/Markdown frontmatter parser for `name`/`description`. */
+function parseFrontmatter(text) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  const out = {};
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+/** Render a Codex `openai.yaml` interface from a skill's name/description. */
+function renderOpenAiInterface(name, description) {
+  const display = name
+    .split("-")
+    .map(p => (p ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+  const short = description.split(/[.!?]/)[0].trim() || display;
+  const esc = s => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return (
+    `display_name: ${esc(display)}\n` +
+    `short_description: ${esc(short)}\n` +
+    `default_prompt:\n` +
+    `  - ${esc(`Use $${name}: ${short}.`)}\n`
+  );
+}
+
+/** Render a human-readable report of a plan + apply result. */
+export function renderReport(p, result) {
+  const lines = [];
+  lines.push(
+    `Cross-pollination — harness: ${p.harness} -> [${p.targetAgents.join(", ")}]`
+  );
+  lines.push(`  sources detected: ${p.sources.length}`);
+  if (result) {
+    lines.push(`  written:          ${result.written.length}`);
+    if (result.skippedDrift.length)
+      lines.push(`  skipped (edited): ${result.skippedDrift.length}`);
+    if (result.gc.length) lines.push(`  garbage-collected:${result.gc.length}`);
+  }
+  if (p.conflicts.length) {
+    lines.push(`  CONFLICTS (authored in >1 agent — not translated):`);
+    for (const c of p.conflicts)
+      lines.push(
+        `    - ${c.logicalId}: ${c.authoredIn.map(a => a.agent).join(" + ")}`
+      );
+  }
+  if (p.pending.length) {
+    const byKind = {};
+    for (const x of p.pending) byKind[x.kind] = (byKind[x.kind] ?? 0) + 1;
+    lines.push(
+      `  PENDING (need skill-driven translation): ${Object.entries(byKind)
+        .map(([k, n]) => `${k}×${n}`)
+        .join(", ")}`
+    );
+  }
+  return lines.join("\n");
+}
+
+// CLI entrypoint.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
+  const dryRun = args.includes("--dry-run") || !args.includes("--write");
+  const asJson = args.includes("--json");
+  const p = plan(root);
+  const result = apply(p, { dryRun });
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { plan: p, result, dryRun },
+        (k, v) => (k === "abs" ? undefined : v),
+        2
+      )
+    );
+  } else {
+    console.log(renderReport(p, result));
+    if (dryRun)
+      console.log("\n(dry-run — pass --write to apply; default is dry-run)");
+  }
+}

--- a/plugins/lisa-copilot/skills/cross-pollinate/SKILL.md
+++ b/plugins/lisa-copilot/skills/cross-pollinate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cross-pollinate
+description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available in the formats of the OTHER agents the project supports, as declared in .lisa.config.json. Any-to-any, provenance-tracked, idempotent, never clobbers hand-edited output."
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+# Cross-Pollinate: $ARGUMENTS
+
+A host project that installs Lisa may hand-author a definition for **one** coding
+agent — a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server only
+Claude sees. `/lisa:cross-pollinate` detects those locally-authored definitions
+and regenerates each in the formats of the **other** agents the project supports,
+so the whole fleet stays in parity with what a developer wrote for any single one.
+
+## The model
+
+```
+any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
+```
+
+Claude format is the canonical intermediate representation (IR) because every
+Lisa generator already sources from it. So translation is always: **normalize
+the detected definition up to Claude-format IR, then fan that IR out** to each
+target agent using the documented mappings below. Never translate format A → B
+directly — that multiplies error and loses fidelity on every hop.
+
+The agents a project supports come from `.lisa.config.json` `harness`
+(`claude` | `codex` | `cursor` | `agy` | `copilot` | `opencode` | `both` | `fleet`;
+`all` is an alias for `fleet`). Only emit to agents that harness includes.
+
+## Provenance is authoritative — the lockfile, not file paths
+
+`.lisa/cross-pollination.lock.json` (committed) is the source of truth for what
+this skill generated. Location heuristics **cannot** work: a generated Cursor
+rule sits in the same `.cursor/rules/` directory as a hand-authored one. The
+lockfile is the only reliable way to enforce the four invariants:
+
+1. **No loops** — a path recorded as a `target` is NEVER treated as a source on
+   the next run. Without this, today's output becomes tomorrow's input and
+   translations ping-pong forever.
+2. **Garbage collection** — when a source is deleted/renamed, its now-orphaned
+   targets are removed.
+3. **Never clobber edits (Chesterton's fence)** — if a target's on-disk hash
+   differs from the recorded `generatedHash`, a human edited it. Stop and report;
+   do not overwrite. They may have intentionally diverged, or want to adopt the
+   edit as a new source.
+4. **Idempotent** — unchanged source + intact targets => no-op. (This is why it
+   is safe to also run during `lisa apply`.)
+
+Lockfile shape:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "skill:security-review": {
+      "source":  { "agent": "claude", "path": ".claude/skills/security-review", "hash": "…" },
+      "targets": [ { "agent": "codex", "path": ".claude/skills/security-review/agents/openai.yaml", "generatedHash": "…" } ]
+    }
+  }
+}
+```
+
+The `logicalId` is `<kind>:<name>` — stable across formats. It links a source to
+its targets and detects **collisions**: the same `logicalId` authored
+independently in two agents (neither generated). On a collision, NEVER
+auto-translate over either side — report it and let the human pick the source of
+truth.
+
+## How to run
+
+The deterministic core (scan, provenance, loop/GC/drift/conflict detection, and
+the skill + MCP emitters) is a bundled engine. **Always run it first** — it does
+the safe, mechanical work and tells you exactly what is left for you to translate
+by hand.
+
+```bash
+# dry-run (default): report only, writes nothing
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --json
+# apply the deterministic emits + update the lockfile
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --write
+```
+
+In the Lisa source repo itself the path is
+`node plugins/lisa/scripts/cross-pollinate.mjs` (built) or
+`node plugins/src/base/scripts/cross-pollinate.mjs` (source).
+
+The JSON report has four lists you act on:
+
+- `emits` — already handled by `--write` (skills, MCP). Verify, don't redo.
+- `conflicts` — STOP. Report each to the user; do not translate.
+- `orphans` — GC'd by `--write`. Confirm the removals look right.
+- `pending` — **your job.** Definitions whose target format the engine does not
+  emit deterministically. Translate each per the mappings below, then record
+  provenance (see "Recording provenance").
+
+## Per-agent format mappings (for `pending` translation)
+
+Normalize the source to Claude-format IR first, then emit per target:
+
+### Rules
+- **Claude ↔ Cursor**: handled deterministically by the engine. Claude reads
+  `.claude/rules/<name>.md`; Cursor reads `.cursor/rules/<name>.mdc` with YAML
+  frontmatter (`description` from the first H1, `alwaysApply: true`) and intra-rule
+  link extensions rewritten. You do not translate these — verify the engine's
+  emits.
+- **Codex / OpenCode / agy** (`pending`): project rules are delivered via
+  `AGENTS.md`, not a per-rule file. MERGE the rule content into `AGENTS.md` under a
+  stable marked section rather than writing a separate file (so re-runs replace,
+  not append). agy never gets a duplicate rule file (rules-once).
+- **Copilot** (`pending`): `.github/copilot-instructions.md` (inline). Merge into a
+  marked section, don't scatter.
+
+### Subagents
+- **Claude / agy / Cursor / OpenCode**: `agents/<name>.md` (or `.claude/agents/`).
+- **Copilot**: `agents/<name>.agent.md` (note the `.agent.md` suffix).
+- **Codex**: does not consume agent files. Report as **dropped — unsupported**,
+  do not invent a target.
+
+### Commands
+- **Claude / Cursor / Copilot**: markdown command files (`.claude/commands/…`).
+- **Codex / agy**: auto-derive commands from skills; no separate command file.
+  Report as **dropped — derived-from-skill**.
+
+### Hooks (lossy — drop-and-report, never fake support)
+- Event-name casing differs per agent (`PreToolUse`→`preToolUse`/`beforeSubmitPrompt`,
+  `UserPromptSubmit`→`userPromptSubmitted`, `Stop`→`agentStop`/`stop`, …).
+- **agy** lacks `SessionStart`/`SubagentStart` — only `PreToolUse` (e.g.
+  block-no-verify) is portable. Everything else: dropped — unsupported.
+- **Codex** plugin hooks do not fire in `codex exec` — install into
+  `~/.codex/hooks.json`, not a bundled file.
+- **Copilot** rejects the entire hooks config if a `SubagentStart`/empty-matcher
+  entry is present — drop that event wholesale.
+- For every hook you cannot faithfully translate to a target, REPORT it with the
+  reason. Do not silently omit (no silent caps).
+
+### MCP (handled by the engine for Claude↔Cursor; report others)
+- **Claude**: `.mcp.json`. **Cursor**: `.cursor/mcp.json` (same JSON shape).
+- **Copilot**: inline `mcpServers` object in the plugin manifest (bundled
+  `.mcp.json` is ignored). **Codex**: TOML / `.codex-plugin` pointer.
+  **agy/OpenCode**: user-global installer / `.opencode`. The engine reports these
+  as pending; translate per the target's documented shape or report dropped.
+
+## Recording provenance for hand-translated `pending` items
+
+After you write a target by hand, it MUST be recorded in
+`.lisa/cross-pollination.lock.json` or the next run will treat it as a source
+(loop) or fail to GC it. Re-run the engine after staging your translated files —
+on its next pass it adopts and hashes any target already referenced — OR add the
+entry yourself following the lockfile shape above (compute `generatedHash` as the
+sha256 of the written file/dir). Prefer the engine; only hand-edit the lock if
+the engine cannot infer the mapping.
+
+## Output
+
+Report, concisely:
+- harness + resolved target agents
+- counts: detected sources, written, skipped-drift, GC'd
+- every conflict (with the agents involved)
+- every pending item you translated, and every hook/agent/command you **dropped**
+  with its reason
+- confirm `.lisa/cross-pollination.lock.json` was updated and the working tree
+  otherwise contains only intended changes
+
+## Rules
+
+- Treat the lockfile as authoritative; never infer "mine vs theirs" from paths.
+- Never overwrite a drifted (hand-edited) target — report it.
+- Never auto-resolve a collision — report it.
+- Only emit to agents the project's `harness` includes.
+- Drop-and-report any translation a target genuinely cannot support; never fake
+  a location you are unsure of.
+- This skill is additive — it does not delete a human's source definitions, only
+  its own orphaned generated targets.

--- a/plugins/lisa-cursor/commands/cross-pollinate.md
+++ b/plugins/lisa-cursor/commands/cross-pollinate.md
@@ -1,0 +1,15 @@
+---
+description: "Detect locally-authored agent definitions and regenerate them in the formats of the other coding agents this project supports (per .lisa.config.json)."
+allowed-tools: ["Skill"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+Use the /lisa:cross-pollinate skill to detect this project's locally-authored
+coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and
+make each available in the formats of the other agents the project's
+`.lisa.config.json` harness includes. $ARGUMENTS
+
+Provenance is tracked in `.lisa/cross-pollination.lock.json`: the run is
+idempotent, garbage-collects orphaned translations, never overwrites a
+hand-edited target, and reports any conflict or unsupported translation rather
+than guessing.

--- a/plugins/lisa-cursor/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-cursor/scripts/cross-pollinate.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * Cross-pollinate a host project's locally-authored coding-agent definitions
+ * across every agent the project supports.
+ *
+ * A host project that installs Lisa may hand-author a skill, subagent, rule,
+ * command, hook, or MCP entry for ONE coding agent (e.g. a `.claude/skills/foo`
+ * that only Claude sees). This engine detects those locally-authored
+ * definitions, normalizes each to a canonical intermediate representation (IR),
+ * and fans it out to the formats of the OTHER agents declared in the project's
+ * `.lisa.config.json` `harness`.
+ *
+ * Architecture (see the cross-pollinate SKILL.md for the full spec):
+ *   any agent's format  ->  Claude-format IR  ->  every other configured agent
+ *
+ * Claude format is the IR because every existing Lisa generator already sources
+ * from it; emitting IR -> {cursor, codex, agy, copilot, opencode} reuses those
+ * battle-tested transforms instead of an N x N translator matrix.
+ *
+ * PROVENANCE is authoritative via a committed lockfile,
+ * `.lisa/cross-pollination.lock.json`. Path/location heuristics alone CANNOT
+ * distinguish a generated translation from a hand-authored original (both live
+ * in the same per-agent directory), so the lockfile is the only reliable way to:
+ *   1. prevent loops    — a recorded target is never treated as a source
+ *   2. garbage-collect  — an orphaned target (source deleted) is removed
+ *   3. protect edits    — a target whose on-disk hash drifts from the recorded
+ *                         generated hash was hand-edited; never clobber it
+ *   4. stay idempotent  — unchanged source + intact targets => no-op
+ *
+ * This engine is the deterministic core. It is invoked standalone
+ * (`node .../cross-pollinate.mjs <path> [--dry-run] [--json] [--write]`) and by
+ * the cross-pollinate skill, which layers in the judgment-heavy translations the
+ * engine reports as `pending`.
+ *
+ * @module cross-pollinate
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
+const LOCK_VERSION = 1;
+
+/**
+ * Canonical coding agents Lisa can fan out to. Mirrors `EmitAgent` in
+ * src/core/config.ts; kept inline because this engine ships inside the plugin
+ * and runs in host projects without the Lisa TypeScript build on the path.
+ */
+const ALL_AGENTS = ["claude", "codex", "cursor", "agy", "copilot", "opencode"];
+
+/**
+ * Resolve the agent set a `harness` value targets. Mirrors
+ * `harnessIncludesAgent` in src/core/config.ts (with the `all` -> `fleet`
+ * alias already normalized away on the config read path).
+ *
+ * @param {string} harness Canonical harness string from `.lisa.config.json`.
+ * @returns {string[]} Agents the harness includes.
+ */
+function agentsForHarness(harness) {
+  if (harness === "fleet") return [...ALL_AGENTS];
+  if (harness === "both") return ["claude", "codex"];
+  if (harness === "all") return [...ALL_AGENTS]; // defensive: pre-normalized alias
+  return ALL_AGENTS.includes(harness) ? [harness] : ["claude"];
+}
+
+/**
+ * Per-(agent, primitive) host-project location + format registry.
+ *
+ * Only entries we can place with confidence are marked `supported: true` and
+ * carry a `dir`/`ext`. Entries marked `supported: false` are intentionally NOT
+ * guessed — the engine reports detected definitions of that kind as `pending`
+ * so the skill (which reads the real on-disk layout) translates them with
+ * judgment rather than the engine writing a wrong path. This is deliberate:
+ * silently emitting to an unverified location is worse than reporting it.
+ *
+ * `kind` legend: skill | agent | rule | command | hook | mcp
+ */
+const HOST_LOCATIONS = {
+  skill: {
+    // Most agents consume the Claude SKILL.md format directly (OpenCode reads
+    // .claude/skills natively; agy/copilot ship SKILL.md verbatim). Codex is
+    // the one that needs a derived interface sidecar (agents/openai.yaml).
+    claude: { supported: true, dir: ".claude/skills", layout: "skill-dir" },
+    codex: { supported: true, dir: ".claude/skills", layout: "codex-sidecar" },
+    opencode: {
+      supported: true,
+      dir: ".claude/skills",
+      layout: "native-claude",
+    },
+    cursor: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+  },
+  mcp: {
+    claude: { supported: true, file: ".mcp.json", layout: "json" },
+    cursor: { supported: true, file: ".cursor/mcp.json", layout: "json" },
+    codex: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+    opencode: { supported: false },
+  },
+  rule: {
+    // Claude <-> Cursor is the clean, verified pair: a flat per-rule file in
+    // both, only the frontmatter + extension differ. codex/agy/opencode deliver
+    // project rules by merging into a shared AGENTS.md (section-marker management
+    // the engine does not fake) and copilot into .github/copilot-instructions.md
+    // — those stay `pending` for the skill to merge with judgment.
+    claude: {
+      supported: true,
+      dir: ".claude/rules",
+      ext: ".md",
+      layout: "rule-md",
+    },
+    cursor: {
+      supported: true,
+      dir: ".cursor/rules",
+      ext: ".mdc",
+      layout: "rule-mdc",
+    },
+  },
+  // Subagents, commands, hooks: detected by the scanner and reported as
+  // `pending` for the skill to translate. Their host locations differ per agent
+  // (and some are lossy/unsupported), so the engine does not hardcode them.
+  agent: {},
+  command: {},
+  hook: {},
+};
+
+/**
+ * Source-detection patterns: where a HUMAN authors each primitive, keyed by the
+ * agent whose format it is. The scanner walks these; the lockfile then filters
+ * out anything that is actually a generated target (loop prevention).
+ *
+ * @type {Array<{ kind: string, agent: string, glob: (root: string) => string[] }>}
+ */
+const SOURCE_SCANNERS = [
+  {
+    kind: "skill",
+    agent: "claude",
+    glob: root => listSkillDirs(path.join(root, ".claude/skills")),
+  },
+  {
+    kind: "agent",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/agents"), ".md"),
+  },
+  {
+    kind: "command",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/commands"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/rules"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "cursor",
+    glob: root => listFiles(path.join(root, ".cursor/rules"), ".mdc"),
+  },
+  {
+    kind: "mcp",
+    agent: "claude",
+    glob: root => existing(path.join(root, ".mcp.json")),
+  },
+  {
+    kind: "mcp",
+    agent: "cursor",
+    glob: root => existing(path.join(root, ".cursor/mcp.json")),
+  },
+];
+
+/** @returns {string[]} Absolute paths to skill directories (those holding SKILL.md). */
+function listSkillDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(
+      e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))
+    )
+    .map(e => path.join(dir, e.name));
+}
+
+/** @returns {string[]} Absolute file paths under `dir` with extension `ext`. */
+function listFiles(dir, ext, recursive = false) {
+  if (!isDir(dir)) return [];
+  const out = [];
+  const walk = current => {
+    for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory() && recursive) walk(p);
+      else if (e.isFile() && e.name.endsWith(ext)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** @returns {string[]} `[file]` if it exists, else `[]`. */
+function existing(file) {
+  return fs.existsSync(file) ? [file] : [];
+}
+
+/** @returns {boolean} */
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+/**
+ * Stable content hash for a definition. For a skill DIRECTORY we hash the
+ * sorted (relpath, content) pairs of every file so a change anywhere in the
+ * skill invalidates it; for a single file we hash its bytes.
+ *
+ * @param {string} target Absolute path to a file or skill directory.
+ * @returns {string} Hex sha256.
+ */
+function hashDefinition(target) {
+  const h = createHash("sha256");
+  if (isDir(target)) {
+    const files = listFiles(target, "", true).sort();
+    for (const f of files) {
+      h.update(path.relative(target, f));
+      h.update("\0");
+      h.update(fs.readFileSync(f));
+      h.update("\0");
+    }
+  } else {
+    h.update(fs.readFileSync(target));
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Logical identity of a definition, stable across agent formats. Two
+ * definitions sharing a logicalId are "the same thing" in different formats —
+ * the basis for both linking a source to its targets and detecting a
+ * human-authored collision.
+ *
+ * @param {string} kind
+ * @param {string} sourcePath Absolute path to the source definition.
+ * @returns {string} e.g. "skill:security-review"
+ */
+function logicalId(kind, sourcePath) {
+  // MCP config is a per-project singleton: `.mcp.json` (Claude) and
+  // `.cursor/mcp.json` (Cursor) are the SAME logical thing in different
+  // formats, so its identity must not derive from the (differing) filename —
+  // otherwise a genuine cross-agent collision reads as two unrelated configs.
+  if (kind === "mcp") return "mcp:project";
+  const base = isDir(sourcePath)
+    ? path.basename(sourcePath)
+    : path.basename(sourcePath).replace(/\.[^.]+$/, "");
+  return `${kind}:${base}`;
+}
+
+/** Read `.lisa.config.json` harness; default "claude". */
+function readHarness(root) {
+  const p = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(p)) return "claude";
+  try {
+    const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    return typeof cfg.harness === "string" ? cfg.harness : "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/** Read the provenance lockfile; returns an empty lock when absent. */
+function readLock(root) {
+  const p = path.join(root, LOCKFILE_REL);
+  if (!fs.existsSync(p)) return { version: LOCK_VERSION, entries: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.entries
+      ? parsed
+      : { version: LOCK_VERSION, entries: {} };
+  } catch {
+    return { version: LOCK_VERSION, entries: {} };
+  }
+}
+
+/** Persist the provenance lockfile (deterministic key ordering). */
+function writeLock(root, lock) {
+  const p = path.join(root, LOCKFILE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const ordered = { version: LOCK_VERSION, entries: {} };
+  for (const key of Object.keys(lock.entries).sort()) {
+    ordered.entries[key] = lock.entries[key];
+  }
+  fs.writeFileSync(p, JSON.stringify(ordered, null, 2) + "\n");
+}
+
+/**
+ * The set of absolute paths the lockfile records as GENERATED targets. A path
+ * in this set is never treated as a source (loop prevention).
+ *
+ * @param {object} lock
+ * @param {string} root
+ * @returns {Set<string>} Absolute target paths.
+ */
+function generatedTargetPaths(lock, root) {
+  const set = new Set();
+  for (const entry of Object.values(lock.entries)) {
+    for (const t of entry.targets ?? []) {
+      set.add(path.resolve(root, t.path));
+    }
+  }
+  return set;
+}
+
+/**
+ * Plan cross-pollination: scan sources, classify against the lockfile, and
+ * compute the actions needed. Pure with respect to the filesystem (reads only).
+ *
+ * @param {string} root Absolute host-project root.
+ * @returns {object} A structured plan (see fields below).
+ */
+export function plan(root) {
+  const harness = readHarness(root);
+  const targetAgents = agentsForHarness(harness);
+  const lock = readLock(root);
+  const generated = generatedTargetPaths(lock, root);
+
+  // Scan every source location, skipping anything the lock says is generated.
+  const sources = [];
+  const byLogicalId = new Map();
+  for (const scanner of SOURCE_SCANNERS) {
+    for (const abs of scanner.glob(root)) {
+      if (generated.has(path.resolve(abs))) continue; // loop prevention
+      const id = logicalId(scanner.kind, abs);
+      const src = {
+        logicalId: id,
+        kind: scanner.kind,
+        agent: scanner.agent,
+        path: path.relative(root, abs),
+        abs,
+        hash: hashDefinition(abs),
+      };
+      sources.push(src);
+      const bucket = byLogicalId.get(id) ?? [];
+      bucket.push(src);
+      byLogicalId.set(id, bucket);
+    }
+  }
+
+  // Conflicts: same logicalId authored independently in >1 agent (neither is a
+  // generated target). Never auto-translate over either — report for a human.
+  const conflicts = [];
+  for (const [id, bucket] of byLogicalId) {
+    if (bucket.length > 1) {
+      conflicts.push({
+        logicalId: id,
+        authoredIn: bucket.map(s => ({ agent: s.agent, path: s.path })),
+      });
+    }
+  }
+  const conflictIds = new Set(conflicts.map(c => c.logicalId));
+
+  // For each non-conflicting source, decide which target agents need an emit,
+  // and which kinds are pending (no confident host location).
+  const emits = [];
+  const pending = [];
+  for (const src of sources) {
+    if (conflictIds.has(src.logicalId)) continue;
+    const entry = lock.entries[src.logicalId];
+    const sourceChanged = !entry || entry.source?.hash !== src.hash;
+    for (const agent of targetAgents) {
+      if (agent === src.agent) continue;
+      const loc = HOST_LOCATIONS[src.kind]?.[agent];
+      if (!loc || !loc.supported) {
+        pending.push({
+          logicalId: src.logicalId,
+          kind: src.kind,
+          from: src.agent,
+          to: agent,
+        });
+        continue;
+      }
+      // The agent consumes the source format natively (e.g. OpenCode reads
+      // .claude/skills directly) — there is nothing to emit, and it must NOT be
+      // reported as a perpetual "missing" emit. It is inherently satisfied.
+      if (loc.layout === "native-claude") continue;
+      const recordedTarget = entry?.targets?.find(t => t.agent === agent);
+      const targetAbs = recordedTarget
+        ? path.resolve(root, recordedTarget.path)
+        : null;
+      const targetExists = targetAbs ? fs.existsSync(targetAbs) : false;
+      const targetDrifted =
+        targetExists &&
+        recordedTarget &&
+        hashDefinition(targetAbs) !== recordedTarget.generatedHash;
+      emits.push({
+        logicalId: src.logicalId,
+        kind: src.kind,
+        from: src.agent,
+        to: agent,
+        sourceAbs: src.abs,
+        reason: !targetExists
+          ? "missing"
+          : sourceChanged
+            ? "source-changed"
+            : targetDrifted
+              ? "drift"
+              : "up-to-date",
+        drifted: Boolean(targetDrifted),
+      });
+    }
+  }
+
+  // Orphans: lockfile entries whose source no longer exists -> GC their targets.
+  const liveIds = new Set(sources.map(s => s.logicalId));
+  const orphans = [];
+  for (const [id, entry] of Object.entries(lock.entries)) {
+    if (!liveIds.has(id)) {
+      orphans.push({
+        logicalId: id,
+        targets: (entry.targets ?? []).map(t => t.path),
+      });
+    }
+  }
+
+  return {
+    root,
+    harness,
+    targetAgents,
+    sources,
+    emits,
+    pending,
+    conflicts,
+    orphans,
+  };
+}
+
+/**
+ * Execute the deterministic emits a plan calls for (skills + mcp today),
+ * skipping `drift` emits (never clobber hand-edited targets), and update the
+ * lockfile. Judgment-heavy `pending` kinds are left for the skill.
+ *
+ * @param {object} p A plan from {@link plan}.
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{ written: object[], skippedDrift: object[], gc: string[] }}
+ */
+export function apply(p, opts = {}) {
+  const { root } = p;
+  const lock = readLock(root);
+  const written = [];
+  const skippedDrift = [];
+  const gc = [];
+
+  for (const emit of p.emits) {
+    if (emit.reason === "up-to-date") continue;
+    if (emit.drifted) {
+      skippedDrift.push(emit);
+      continue;
+    }
+    const result = emitOne(root, emit, opts);
+    if (!result) continue;
+    written.push({ ...emit, target: path.relative(root, result.abs) });
+    if (!opts.dryRun) recordTarget(lock, root, emit, result);
+  }
+
+  // GC orphaned targets.
+  for (const orphan of p.orphans) {
+    for (const rel of orphan.targets) {
+      const abs = path.resolve(root, rel);
+      if (fs.existsSync(abs)) {
+        gc.push(rel);
+        if (!opts.dryRun) fs.rmSync(abs, { recursive: true, force: true });
+      }
+    }
+    if (!opts.dryRun) delete lock.entries[orphan.logicalId];
+  }
+
+  if (!opts.dryRun) writeLock(root, lock);
+  return { written, skippedDrift, gc };
+}
+
+/**
+ * Emit a single target. Returns the written target's {abs} or null when the
+ * kind has no deterministic emitter (left to the skill).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitOne(root, emit, opts) {
+  const loc = HOST_LOCATIONS[emit.kind]?.[emit.to];
+  if (!loc || !loc.supported) return null;
+
+  if (emit.kind === "skill") return emitSkill(root, emit, loc, opts);
+  if (emit.kind === "mcp") return emitMcp(root, emit, loc, opts);
+  if (emit.kind === "rule") return emitRule(root, emit, loc, opts);
+  return null;
+}
+
+/**
+ * Emit a rule to a target agent, translating between the Claude `.md` and Cursor
+ * `.mdc` flat-file formats.
+ *
+ * Cursor requires YAML frontmatter (`description` from the first H1, `alwaysApply`)
+ * and discovers only `.mdc`; Claude reads plain `.md`. The transform mirrors
+ * scripts/generate-cursor-plugin-artifacts.mjs (reimplemented inline because that
+ * generator operates on the nested plugin layout and is not importable from the
+ * plugin at host runtime).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dir: string, ext: string, layout: string }} loc
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitRule(root, emit, loc, opts) {
+  const name = path.basename(emit.sourceAbs).replace(/\.(md|mdc)$/, "");
+  const outAbs = path.join(root, loc.dir, `${name}${loc.ext}`);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  const body = stripFrontmatter(raw);
+  let contents;
+  if (loc.layout === "rule-mdc") {
+    const fm = `---\ndescription: ${yamlQuote(deriveRuleDescription(body, name))}\nalwaysApply: true\n---\n\n`;
+    contents = fm + rewriteRuleLinks(body, ".mdc");
+  } else {
+    contents = rewriteRuleLinks(body, ".md");
+  }
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, contents);
+  }
+  return { abs: outAbs };
+}
+
+/**
+ * Emit a skill to a target agent. For native-Claude consumers (opencode) and
+ * the canonical Claude dir this is a no-op (they already read the source). For
+ * Codex, derive the `agents/openai.yaml` interface sidecar next to the SKILL.md.
+ */
+function emitSkill(_root, emit, loc, opts) {
+  if (loc.layout === "native-claude") return null; // agent reads source as-is
+
+  if (loc.layout === "codex-sidecar") {
+    const skillName = path.basename(emit.sourceAbs);
+    const skillMd = path.join(emit.sourceAbs, "SKILL.md");
+    if (!fs.existsSync(skillMd)) return null;
+    const fm = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    const outAbs = path.join(emit.sourceAbs, "agents", "openai.yaml");
+    const yaml = renderOpenAiInterface(
+      fm.name ?? skillName,
+      fm.description ?? ""
+    );
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+      fs.writeFileSync(outAbs, yaml);
+    }
+    return { abs: outAbs };
+  }
+
+  return null;
+}
+
+/** Emit an MCP config by re-shaping the source JSON to the target agent's file. */
+function emitMcp(root, emit, loc, opts) {
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed source; leave to the skill to surface
+  }
+  const outAbs = path.join(root, loc.file);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify(parsed, null, 2) + "\n");
+  }
+  return { abs: outAbs };
+}
+
+/** Record/refresh a target in the lockfile after a successful emit. */
+function recordTarget(lock, root, emit, result) {
+  const src = {
+    agent: emit.from,
+    path: path.relative(root, emit.sourceAbs),
+    hash: hashDefinition(emit.sourceAbs),
+  };
+  const entry = lock.entries[emit.logicalId] ?? { source: src, targets: [] };
+  entry.source = src;
+  const rel = path.relative(root, result.abs);
+  const generatedHash = hashDefinition(result.abs);
+  const existingIdx = entry.targets.findIndex(t => t.agent === emit.to);
+  const record = { agent: emit.to, path: rel, generatedHash };
+  if (existingIdx >= 0) entry.targets[existingIdx] = record;
+  else entry.targets.push(record);
+  entry.targets.sort((a, b) => a.agent.localeCompare(b.agent));
+  lock.entries[emit.logicalId] = entry;
+}
+
+/** Strip a leading `---`-fenced YAML frontmatter block, returning the body. */
+function stripFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, "");
+}
+
+/** YAML-quote a description value for `.mdc` frontmatter. */
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Derive a single-line rule description: the first H1, else a titleized slug.
+ * Mirrors generate-cursor-plugin-artifacts.mjs.
+ *
+ * @param {string} body Rule markdown body (frontmatter already stripped).
+ * @param {string} name Rule slug.
+ * @returns {string}
+ */
+function deriveRuleDescription(body, name) {
+  const withoutFences = body.replace(/^(```|~~~).*$[\s\S]*?^\1.*$/gm, "");
+  const h1 = /^#\s+(.+?)\s*$/m.exec(withoutFences);
+  const text = (h1 ? h1[1] : "").replace(/\s+/g, " ").trim();
+  if (text) return text;
+  return name
+    .split("-")
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Rewrite intra-rule markdown link extensions to the target rule format so links
+ * still resolve after translation (e.g. `](foo.md)` -> `](foo.mdc)`). Only the
+ * URL is touched; the link text is preserved. External/`http` links are left as-is.
+ *
+ * @param {string} body
+ * @param {".md"|".mdc"} targetExt
+ * @returns {string}
+ */
+function rewriteRuleLinks(body, targetExt) {
+  const otherExt = targetExt === ".mdc" ? ".md" : ".mdc";
+  const re = new RegExp(`\\]\\(([^)]+?)\\${otherExt}(#[^)]*)?\\)`, "g");
+  return body.replace(re, (match, base, fragment = "") =>
+    /^https?:/.test(base) ? match : `](${base}${targetExt}${fragment})`
+  );
+}
+
+/** Minimal YAML/Markdown frontmatter parser for `name`/`description`. */
+function parseFrontmatter(text) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  const out = {};
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+/** Render a Codex `openai.yaml` interface from a skill's name/description. */
+function renderOpenAiInterface(name, description) {
+  const display = name
+    .split("-")
+    .map(p => (p ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+  const short = description.split(/[.!?]/)[0].trim() || display;
+  const esc = s => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return (
+    `display_name: ${esc(display)}\n` +
+    `short_description: ${esc(short)}\n` +
+    `default_prompt:\n` +
+    `  - ${esc(`Use $${name}: ${short}.`)}\n`
+  );
+}
+
+/** Render a human-readable report of a plan + apply result. */
+export function renderReport(p, result) {
+  const lines = [];
+  lines.push(
+    `Cross-pollination — harness: ${p.harness} -> [${p.targetAgents.join(", ")}]`
+  );
+  lines.push(`  sources detected: ${p.sources.length}`);
+  if (result) {
+    lines.push(`  written:          ${result.written.length}`);
+    if (result.skippedDrift.length)
+      lines.push(`  skipped (edited): ${result.skippedDrift.length}`);
+    if (result.gc.length) lines.push(`  garbage-collected:${result.gc.length}`);
+  }
+  if (p.conflicts.length) {
+    lines.push(`  CONFLICTS (authored in >1 agent — not translated):`);
+    for (const c of p.conflicts)
+      lines.push(
+        `    - ${c.logicalId}: ${c.authoredIn.map(a => a.agent).join(" + ")}`
+      );
+  }
+  if (p.pending.length) {
+    const byKind = {};
+    for (const x of p.pending) byKind[x.kind] = (byKind[x.kind] ?? 0) + 1;
+    lines.push(
+      `  PENDING (need skill-driven translation): ${Object.entries(byKind)
+        .map(([k, n]) => `${k}×${n}`)
+        .join(", ")}`
+    );
+  }
+  return lines.join("\n");
+}
+
+// CLI entrypoint.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
+  const dryRun = args.includes("--dry-run") || !args.includes("--write");
+  const asJson = args.includes("--json");
+  const p = plan(root);
+  const result = apply(p, { dryRun });
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { plan: p, result, dryRun },
+        (k, v) => (k === "abs" ? undefined : v),
+        2
+      )
+    );
+  } else {
+    console.log(renderReport(p, result));
+    if (dryRun)
+      console.log("\n(dry-run — pass --write to apply; default is dry-run)");
+  }
+}

--- a/plugins/lisa-cursor/skills/cross-pollinate/SKILL.md
+++ b/plugins/lisa-cursor/skills/cross-pollinate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cross-pollinate
+description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available in the formats of the OTHER agents the project supports, as declared in .lisa.config.json. Any-to-any, provenance-tracked, idempotent, never clobbers hand-edited output."
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+# Cross-Pollinate: $ARGUMENTS
+
+A host project that installs Lisa may hand-author a definition for **one** coding
+agent — a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server only
+Claude sees. `/lisa:cross-pollinate` detects those locally-authored definitions
+and regenerates each in the formats of the **other** agents the project supports,
+so the whole fleet stays in parity with what a developer wrote for any single one.
+
+## The model
+
+```
+any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
+```
+
+Claude format is the canonical intermediate representation (IR) because every
+Lisa generator already sources from it. So translation is always: **normalize
+the detected definition up to Claude-format IR, then fan that IR out** to each
+target agent using the documented mappings below. Never translate format A → B
+directly — that multiplies error and loses fidelity on every hop.
+
+The agents a project supports come from `.lisa.config.json` `harness`
+(`claude` | `codex` | `cursor` | `agy` | `copilot` | `opencode` | `both` | `fleet`;
+`all` is an alias for `fleet`). Only emit to agents that harness includes.
+
+## Provenance is authoritative — the lockfile, not file paths
+
+`.lisa/cross-pollination.lock.json` (committed) is the source of truth for what
+this skill generated. Location heuristics **cannot** work: a generated Cursor
+rule sits in the same `.cursor/rules/` directory as a hand-authored one. The
+lockfile is the only reliable way to enforce the four invariants:
+
+1. **No loops** — a path recorded as a `target` is NEVER treated as a source on
+   the next run. Without this, today's output becomes tomorrow's input and
+   translations ping-pong forever.
+2. **Garbage collection** — when a source is deleted/renamed, its now-orphaned
+   targets are removed.
+3. **Never clobber edits (Chesterton's fence)** — if a target's on-disk hash
+   differs from the recorded `generatedHash`, a human edited it. Stop and report;
+   do not overwrite. They may have intentionally diverged, or want to adopt the
+   edit as a new source.
+4. **Idempotent** — unchanged source + intact targets => no-op. (This is why it
+   is safe to also run during `lisa apply`.)
+
+Lockfile shape:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "skill:security-review": {
+      "source":  { "agent": "claude", "path": ".claude/skills/security-review", "hash": "…" },
+      "targets": [ { "agent": "codex", "path": ".claude/skills/security-review/agents/openai.yaml", "generatedHash": "…" } ]
+    }
+  }
+}
+```
+
+The `logicalId` is `<kind>:<name>` — stable across formats. It links a source to
+its targets and detects **collisions**: the same `logicalId` authored
+independently in two agents (neither generated). On a collision, NEVER
+auto-translate over either side — report it and let the human pick the source of
+truth.
+
+## How to run
+
+The deterministic core (scan, provenance, loop/GC/drift/conflict detection, and
+the skill + MCP emitters) is a bundled engine. **Always run it first** — it does
+the safe, mechanical work and tells you exactly what is left for you to translate
+by hand.
+
+```bash
+# dry-run (default): report only, writes nothing
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --json
+# apply the deterministic emits + update the lockfile
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --write
+```
+
+In the Lisa source repo itself the path is
+`node plugins/lisa/scripts/cross-pollinate.mjs` (built) or
+`node plugins/src/base/scripts/cross-pollinate.mjs` (source).
+
+The JSON report has four lists you act on:
+
+- `emits` — already handled by `--write` (skills, MCP). Verify, don't redo.
+- `conflicts` — STOP. Report each to the user; do not translate.
+- `orphans` — GC'd by `--write`. Confirm the removals look right.
+- `pending` — **your job.** Definitions whose target format the engine does not
+  emit deterministically. Translate each per the mappings below, then record
+  provenance (see "Recording provenance").
+
+## Per-agent format mappings (for `pending` translation)
+
+Normalize the source to Claude-format IR first, then emit per target:
+
+### Rules
+- **Claude ↔ Cursor**: handled deterministically by the engine. Claude reads
+  `.claude/rules/<name>.md`; Cursor reads `.cursor/rules/<name>.mdc` with YAML
+  frontmatter (`description` from the first H1, `alwaysApply: true`) and intra-rule
+  link extensions rewritten. You do not translate these — verify the engine's
+  emits.
+- **Codex / OpenCode / agy** (`pending`): project rules are delivered via
+  `AGENTS.md`, not a per-rule file. MERGE the rule content into `AGENTS.md` under a
+  stable marked section rather than writing a separate file (so re-runs replace,
+  not append). agy never gets a duplicate rule file (rules-once).
+- **Copilot** (`pending`): `.github/copilot-instructions.md` (inline). Merge into a
+  marked section, don't scatter.
+
+### Subagents
+- **Claude / agy / Cursor / OpenCode**: `agents/<name>.md` (or `.claude/agents/`).
+- **Copilot**: `agents/<name>.agent.md` (note the `.agent.md` suffix).
+- **Codex**: does not consume agent files. Report as **dropped — unsupported**,
+  do not invent a target.
+
+### Commands
+- **Claude / Cursor / Copilot**: markdown command files (`.claude/commands/…`).
+- **Codex / agy**: auto-derive commands from skills; no separate command file.
+  Report as **dropped — derived-from-skill**.
+
+### Hooks (lossy — drop-and-report, never fake support)
+- Event-name casing differs per agent (`PreToolUse`→`preToolUse`/`beforeSubmitPrompt`,
+  `UserPromptSubmit`→`userPromptSubmitted`, `Stop`→`agentStop`/`stop`, …).
+- **agy** lacks `SessionStart`/`SubagentStart` — only `PreToolUse` (e.g.
+  block-no-verify) is portable. Everything else: dropped — unsupported.
+- **Codex** plugin hooks do not fire in `codex exec` — install into
+  `~/.codex/hooks.json`, not a bundled file.
+- **Copilot** rejects the entire hooks config if a `SubagentStart`/empty-matcher
+  entry is present — drop that event wholesale.
+- For every hook you cannot faithfully translate to a target, REPORT it with the
+  reason. Do not silently omit (no silent caps).
+
+### MCP (handled by the engine for Claude↔Cursor; report others)
+- **Claude**: `.mcp.json`. **Cursor**: `.cursor/mcp.json` (same JSON shape).
+- **Copilot**: inline `mcpServers` object in the plugin manifest (bundled
+  `.mcp.json` is ignored). **Codex**: TOML / `.codex-plugin` pointer.
+  **agy/OpenCode**: user-global installer / `.opencode`. The engine reports these
+  as pending; translate per the target's documented shape or report dropped.
+
+## Recording provenance for hand-translated `pending` items
+
+After you write a target by hand, it MUST be recorded in
+`.lisa/cross-pollination.lock.json` or the next run will treat it as a source
+(loop) or fail to GC it. Re-run the engine after staging your translated files —
+on its next pass it adopts and hashes any target already referenced — OR add the
+entry yourself following the lockfile shape above (compute `generatedHash` as the
+sha256 of the written file/dir). Prefer the engine; only hand-edit the lock if
+the engine cannot infer the mapping.
+
+## Output
+
+Report, concisely:
+- harness + resolved target agents
+- counts: detected sources, written, skipped-drift, GC'd
+- every conflict (with the agents involved)
+- every pending item you translated, and every hook/agent/command you **dropped**
+  with its reason
+- confirm `.lisa/cross-pollination.lock.json` was updated and the working tree
+  otherwise contains only intended changes
+
+## Rules
+
+- Treat the lockfile as authoritative; never infer "mine vs theirs" from paths.
+- Never overwrite a drifted (hand-edited) target — report it.
+- Never auto-resolve a collision — report it.
+- Only emit to agents the project's `harness` includes.
+- Drop-and-report any translation a target genuinely cannot support; never fake
+  a location you are unsure of.
+- This skill is additive — it does not delete a human's source definitions, only
+  its own orphaned generated targets.

--- a/plugins/lisa/commands/cross-pollinate.md
+++ b/plugins/lisa/commands/cross-pollinate.md
@@ -1,0 +1,15 @@
+---
+description: "Detect locally-authored agent definitions and regenerate them in the formats of the other coding agents this project supports (per .lisa.config.json)."
+allowed-tools: ["Skill"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+Use the /lisa:cross-pollinate skill to detect this project's locally-authored
+coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and
+make each available in the formats of the other agents the project's
+`.lisa.config.json` harness includes. $ARGUMENTS
+
+Provenance is tracked in `.lisa/cross-pollination.lock.json`: the run is
+idempotent, garbage-collects orphaned translations, never overwrites a
+hand-edited target, and reports any conflict or unsupported translation rather
+than guessing.

--- a/plugins/lisa/scripts/cross-pollinate.mjs
+++ b/plugins/lisa/scripts/cross-pollinate.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * Cross-pollinate a host project's locally-authored coding-agent definitions
+ * across every agent the project supports.
+ *
+ * A host project that installs Lisa may hand-author a skill, subagent, rule,
+ * command, hook, or MCP entry for ONE coding agent (e.g. a `.claude/skills/foo`
+ * that only Claude sees). This engine detects those locally-authored
+ * definitions, normalizes each to a canonical intermediate representation (IR),
+ * and fans it out to the formats of the OTHER agents declared in the project's
+ * `.lisa.config.json` `harness`.
+ *
+ * Architecture (see the cross-pollinate SKILL.md for the full spec):
+ *   any agent's format  ->  Claude-format IR  ->  every other configured agent
+ *
+ * Claude format is the IR because every existing Lisa generator already sources
+ * from it; emitting IR -> {cursor, codex, agy, copilot, opencode} reuses those
+ * battle-tested transforms instead of an N x N translator matrix.
+ *
+ * PROVENANCE is authoritative via a committed lockfile,
+ * `.lisa/cross-pollination.lock.json`. Path/location heuristics alone CANNOT
+ * distinguish a generated translation from a hand-authored original (both live
+ * in the same per-agent directory), so the lockfile is the only reliable way to:
+ *   1. prevent loops    — a recorded target is never treated as a source
+ *   2. garbage-collect  — an orphaned target (source deleted) is removed
+ *   3. protect edits    — a target whose on-disk hash drifts from the recorded
+ *                         generated hash was hand-edited; never clobber it
+ *   4. stay idempotent  — unchanged source + intact targets => no-op
+ *
+ * This engine is the deterministic core. It is invoked standalone
+ * (`node .../cross-pollinate.mjs <path> [--dry-run] [--json] [--write]`) and by
+ * the cross-pollinate skill, which layers in the judgment-heavy translations the
+ * engine reports as `pending`.
+ *
+ * @module cross-pollinate
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
+const LOCK_VERSION = 1;
+
+/**
+ * Canonical coding agents Lisa can fan out to. Mirrors `EmitAgent` in
+ * src/core/config.ts; kept inline because this engine ships inside the plugin
+ * and runs in host projects without the Lisa TypeScript build on the path.
+ */
+const ALL_AGENTS = ["claude", "codex", "cursor", "agy", "copilot", "opencode"];
+
+/**
+ * Resolve the agent set a `harness` value targets. Mirrors
+ * `harnessIncludesAgent` in src/core/config.ts (with the `all` -> `fleet`
+ * alias already normalized away on the config read path).
+ *
+ * @param {string} harness Canonical harness string from `.lisa.config.json`.
+ * @returns {string[]} Agents the harness includes.
+ */
+function agentsForHarness(harness) {
+  if (harness === "fleet") return [...ALL_AGENTS];
+  if (harness === "both") return ["claude", "codex"];
+  if (harness === "all") return [...ALL_AGENTS]; // defensive: pre-normalized alias
+  return ALL_AGENTS.includes(harness) ? [harness] : ["claude"];
+}
+
+/**
+ * Per-(agent, primitive) host-project location + format registry.
+ *
+ * Only entries we can place with confidence are marked `supported: true` and
+ * carry a `dir`/`ext`. Entries marked `supported: false` are intentionally NOT
+ * guessed — the engine reports detected definitions of that kind as `pending`
+ * so the skill (which reads the real on-disk layout) translates them with
+ * judgment rather than the engine writing a wrong path. This is deliberate:
+ * silently emitting to an unverified location is worse than reporting it.
+ *
+ * `kind` legend: skill | agent | rule | command | hook | mcp
+ */
+const HOST_LOCATIONS = {
+  skill: {
+    // Most agents consume the Claude SKILL.md format directly (OpenCode reads
+    // .claude/skills natively; agy/copilot ship SKILL.md verbatim). Codex is
+    // the one that needs a derived interface sidecar (agents/openai.yaml).
+    claude: { supported: true, dir: ".claude/skills", layout: "skill-dir" },
+    codex: { supported: true, dir: ".claude/skills", layout: "codex-sidecar" },
+    opencode: {
+      supported: true,
+      dir: ".claude/skills",
+      layout: "native-claude",
+    },
+    cursor: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+  },
+  mcp: {
+    claude: { supported: true, file: ".mcp.json", layout: "json" },
+    cursor: { supported: true, file: ".cursor/mcp.json", layout: "json" },
+    codex: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+    opencode: { supported: false },
+  },
+  rule: {
+    // Claude <-> Cursor is the clean, verified pair: a flat per-rule file in
+    // both, only the frontmatter + extension differ. codex/agy/opencode deliver
+    // project rules by merging into a shared AGENTS.md (section-marker management
+    // the engine does not fake) and copilot into .github/copilot-instructions.md
+    // — those stay `pending` for the skill to merge with judgment.
+    claude: {
+      supported: true,
+      dir: ".claude/rules",
+      ext: ".md",
+      layout: "rule-md",
+    },
+    cursor: {
+      supported: true,
+      dir: ".cursor/rules",
+      ext: ".mdc",
+      layout: "rule-mdc",
+    },
+  },
+  // Subagents, commands, hooks: detected by the scanner and reported as
+  // `pending` for the skill to translate. Their host locations differ per agent
+  // (and some are lossy/unsupported), so the engine does not hardcode them.
+  agent: {},
+  command: {},
+  hook: {},
+};
+
+/**
+ * Source-detection patterns: where a HUMAN authors each primitive, keyed by the
+ * agent whose format it is. The scanner walks these; the lockfile then filters
+ * out anything that is actually a generated target (loop prevention).
+ *
+ * @type {Array<{ kind: string, agent: string, glob: (root: string) => string[] }>}
+ */
+const SOURCE_SCANNERS = [
+  {
+    kind: "skill",
+    agent: "claude",
+    glob: root => listSkillDirs(path.join(root, ".claude/skills")),
+  },
+  {
+    kind: "agent",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/agents"), ".md"),
+  },
+  {
+    kind: "command",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/commands"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/rules"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "cursor",
+    glob: root => listFiles(path.join(root, ".cursor/rules"), ".mdc"),
+  },
+  {
+    kind: "mcp",
+    agent: "claude",
+    glob: root => existing(path.join(root, ".mcp.json")),
+  },
+  {
+    kind: "mcp",
+    agent: "cursor",
+    glob: root => existing(path.join(root, ".cursor/mcp.json")),
+  },
+];
+
+/** @returns {string[]} Absolute paths to skill directories (those holding SKILL.md). */
+function listSkillDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(
+      e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))
+    )
+    .map(e => path.join(dir, e.name));
+}
+
+/** @returns {string[]} Absolute file paths under `dir` with extension `ext`. */
+function listFiles(dir, ext, recursive = false) {
+  if (!isDir(dir)) return [];
+  const out = [];
+  const walk = current => {
+    for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory() && recursive) walk(p);
+      else if (e.isFile() && e.name.endsWith(ext)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** @returns {string[]} `[file]` if it exists, else `[]`. */
+function existing(file) {
+  return fs.existsSync(file) ? [file] : [];
+}
+
+/** @returns {boolean} */
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+/**
+ * Stable content hash for a definition. For a skill DIRECTORY we hash the
+ * sorted (relpath, content) pairs of every file so a change anywhere in the
+ * skill invalidates it; for a single file we hash its bytes.
+ *
+ * @param {string} target Absolute path to a file or skill directory.
+ * @returns {string} Hex sha256.
+ */
+function hashDefinition(target) {
+  const h = createHash("sha256");
+  if (isDir(target)) {
+    const files = listFiles(target, "", true).sort();
+    for (const f of files) {
+      h.update(path.relative(target, f));
+      h.update("\0");
+      h.update(fs.readFileSync(f));
+      h.update("\0");
+    }
+  } else {
+    h.update(fs.readFileSync(target));
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Logical identity of a definition, stable across agent formats. Two
+ * definitions sharing a logicalId are "the same thing" in different formats —
+ * the basis for both linking a source to its targets and detecting a
+ * human-authored collision.
+ *
+ * @param {string} kind
+ * @param {string} sourcePath Absolute path to the source definition.
+ * @returns {string} e.g. "skill:security-review"
+ */
+function logicalId(kind, sourcePath) {
+  // MCP config is a per-project singleton: `.mcp.json` (Claude) and
+  // `.cursor/mcp.json` (Cursor) are the SAME logical thing in different
+  // formats, so its identity must not derive from the (differing) filename —
+  // otherwise a genuine cross-agent collision reads as two unrelated configs.
+  if (kind === "mcp") return "mcp:project";
+  const base = isDir(sourcePath)
+    ? path.basename(sourcePath)
+    : path.basename(sourcePath).replace(/\.[^.]+$/, "");
+  return `${kind}:${base}`;
+}
+
+/** Read `.lisa.config.json` harness; default "claude". */
+function readHarness(root) {
+  const p = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(p)) return "claude";
+  try {
+    const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    return typeof cfg.harness === "string" ? cfg.harness : "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/** Read the provenance lockfile; returns an empty lock when absent. */
+function readLock(root) {
+  const p = path.join(root, LOCKFILE_REL);
+  if (!fs.existsSync(p)) return { version: LOCK_VERSION, entries: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.entries
+      ? parsed
+      : { version: LOCK_VERSION, entries: {} };
+  } catch {
+    return { version: LOCK_VERSION, entries: {} };
+  }
+}
+
+/** Persist the provenance lockfile (deterministic key ordering). */
+function writeLock(root, lock) {
+  const p = path.join(root, LOCKFILE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const ordered = { version: LOCK_VERSION, entries: {} };
+  for (const key of Object.keys(lock.entries).sort()) {
+    ordered.entries[key] = lock.entries[key];
+  }
+  fs.writeFileSync(p, JSON.stringify(ordered, null, 2) + "\n");
+}
+
+/**
+ * The set of absolute paths the lockfile records as GENERATED targets. A path
+ * in this set is never treated as a source (loop prevention).
+ *
+ * @param {object} lock
+ * @param {string} root
+ * @returns {Set<string>} Absolute target paths.
+ */
+function generatedTargetPaths(lock, root) {
+  const set = new Set();
+  for (const entry of Object.values(lock.entries)) {
+    for (const t of entry.targets ?? []) {
+      set.add(path.resolve(root, t.path));
+    }
+  }
+  return set;
+}
+
+/**
+ * Plan cross-pollination: scan sources, classify against the lockfile, and
+ * compute the actions needed. Pure with respect to the filesystem (reads only).
+ *
+ * @param {string} root Absolute host-project root.
+ * @returns {object} A structured plan (see fields below).
+ */
+export function plan(root) {
+  const harness = readHarness(root);
+  const targetAgents = agentsForHarness(harness);
+  const lock = readLock(root);
+  const generated = generatedTargetPaths(lock, root);
+
+  // Scan every source location, skipping anything the lock says is generated.
+  const sources = [];
+  const byLogicalId = new Map();
+  for (const scanner of SOURCE_SCANNERS) {
+    for (const abs of scanner.glob(root)) {
+      if (generated.has(path.resolve(abs))) continue; // loop prevention
+      const id = logicalId(scanner.kind, abs);
+      const src = {
+        logicalId: id,
+        kind: scanner.kind,
+        agent: scanner.agent,
+        path: path.relative(root, abs),
+        abs,
+        hash: hashDefinition(abs),
+      };
+      sources.push(src);
+      const bucket = byLogicalId.get(id) ?? [];
+      bucket.push(src);
+      byLogicalId.set(id, bucket);
+    }
+  }
+
+  // Conflicts: same logicalId authored independently in >1 agent (neither is a
+  // generated target). Never auto-translate over either — report for a human.
+  const conflicts = [];
+  for (const [id, bucket] of byLogicalId) {
+    if (bucket.length > 1) {
+      conflicts.push({
+        logicalId: id,
+        authoredIn: bucket.map(s => ({ agent: s.agent, path: s.path })),
+      });
+    }
+  }
+  const conflictIds = new Set(conflicts.map(c => c.logicalId));
+
+  // For each non-conflicting source, decide which target agents need an emit,
+  // and which kinds are pending (no confident host location).
+  const emits = [];
+  const pending = [];
+  for (const src of sources) {
+    if (conflictIds.has(src.logicalId)) continue;
+    const entry = lock.entries[src.logicalId];
+    const sourceChanged = !entry || entry.source?.hash !== src.hash;
+    for (const agent of targetAgents) {
+      if (agent === src.agent) continue;
+      const loc = HOST_LOCATIONS[src.kind]?.[agent];
+      if (!loc || !loc.supported) {
+        pending.push({
+          logicalId: src.logicalId,
+          kind: src.kind,
+          from: src.agent,
+          to: agent,
+        });
+        continue;
+      }
+      // The agent consumes the source format natively (e.g. OpenCode reads
+      // .claude/skills directly) — there is nothing to emit, and it must NOT be
+      // reported as a perpetual "missing" emit. It is inherently satisfied.
+      if (loc.layout === "native-claude") continue;
+      const recordedTarget = entry?.targets?.find(t => t.agent === agent);
+      const targetAbs = recordedTarget
+        ? path.resolve(root, recordedTarget.path)
+        : null;
+      const targetExists = targetAbs ? fs.existsSync(targetAbs) : false;
+      const targetDrifted =
+        targetExists &&
+        recordedTarget &&
+        hashDefinition(targetAbs) !== recordedTarget.generatedHash;
+      emits.push({
+        logicalId: src.logicalId,
+        kind: src.kind,
+        from: src.agent,
+        to: agent,
+        sourceAbs: src.abs,
+        reason: !targetExists
+          ? "missing"
+          : sourceChanged
+            ? "source-changed"
+            : targetDrifted
+              ? "drift"
+              : "up-to-date",
+        drifted: Boolean(targetDrifted),
+      });
+    }
+  }
+
+  // Orphans: lockfile entries whose source no longer exists -> GC their targets.
+  const liveIds = new Set(sources.map(s => s.logicalId));
+  const orphans = [];
+  for (const [id, entry] of Object.entries(lock.entries)) {
+    if (!liveIds.has(id)) {
+      orphans.push({
+        logicalId: id,
+        targets: (entry.targets ?? []).map(t => t.path),
+      });
+    }
+  }
+
+  return {
+    root,
+    harness,
+    targetAgents,
+    sources,
+    emits,
+    pending,
+    conflicts,
+    orphans,
+  };
+}
+
+/**
+ * Execute the deterministic emits a plan calls for (skills + mcp today),
+ * skipping `drift` emits (never clobber hand-edited targets), and update the
+ * lockfile. Judgment-heavy `pending` kinds are left for the skill.
+ *
+ * @param {object} p A plan from {@link plan}.
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{ written: object[], skippedDrift: object[], gc: string[] }}
+ */
+export function apply(p, opts = {}) {
+  const { root } = p;
+  const lock = readLock(root);
+  const written = [];
+  const skippedDrift = [];
+  const gc = [];
+
+  for (const emit of p.emits) {
+    if (emit.reason === "up-to-date") continue;
+    if (emit.drifted) {
+      skippedDrift.push(emit);
+      continue;
+    }
+    const result = emitOne(root, emit, opts);
+    if (!result) continue;
+    written.push({ ...emit, target: path.relative(root, result.abs) });
+    if (!opts.dryRun) recordTarget(lock, root, emit, result);
+  }
+
+  // GC orphaned targets.
+  for (const orphan of p.orphans) {
+    for (const rel of orphan.targets) {
+      const abs = path.resolve(root, rel);
+      if (fs.existsSync(abs)) {
+        gc.push(rel);
+        if (!opts.dryRun) fs.rmSync(abs, { recursive: true, force: true });
+      }
+    }
+    if (!opts.dryRun) delete lock.entries[orphan.logicalId];
+  }
+
+  if (!opts.dryRun) writeLock(root, lock);
+  return { written, skippedDrift, gc };
+}
+
+/**
+ * Emit a single target. Returns the written target's {abs} or null when the
+ * kind has no deterministic emitter (left to the skill).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitOne(root, emit, opts) {
+  const loc = HOST_LOCATIONS[emit.kind]?.[emit.to];
+  if (!loc || !loc.supported) return null;
+
+  if (emit.kind === "skill") return emitSkill(root, emit, loc, opts);
+  if (emit.kind === "mcp") return emitMcp(root, emit, loc, opts);
+  if (emit.kind === "rule") return emitRule(root, emit, loc, opts);
+  return null;
+}
+
+/**
+ * Emit a rule to a target agent, translating between the Claude `.md` and Cursor
+ * `.mdc` flat-file formats.
+ *
+ * Cursor requires YAML frontmatter (`description` from the first H1, `alwaysApply`)
+ * and discovers only `.mdc`; Claude reads plain `.md`. The transform mirrors
+ * scripts/generate-cursor-plugin-artifacts.mjs (reimplemented inline because that
+ * generator operates on the nested plugin layout and is not importable from the
+ * plugin at host runtime).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dir: string, ext: string, layout: string }} loc
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitRule(root, emit, loc, opts) {
+  const name = path.basename(emit.sourceAbs).replace(/\.(md|mdc)$/, "");
+  const outAbs = path.join(root, loc.dir, `${name}${loc.ext}`);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  const body = stripFrontmatter(raw);
+  let contents;
+  if (loc.layout === "rule-mdc") {
+    const fm = `---\ndescription: ${yamlQuote(deriveRuleDescription(body, name))}\nalwaysApply: true\n---\n\n`;
+    contents = fm + rewriteRuleLinks(body, ".mdc");
+  } else {
+    contents = rewriteRuleLinks(body, ".md");
+  }
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, contents);
+  }
+  return { abs: outAbs };
+}
+
+/**
+ * Emit a skill to a target agent. For native-Claude consumers (opencode) and
+ * the canonical Claude dir this is a no-op (they already read the source). For
+ * Codex, derive the `agents/openai.yaml` interface sidecar next to the SKILL.md.
+ */
+function emitSkill(_root, emit, loc, opts) {
+  if (loc.layout === "native-claude") return null; // agent reads source as-is
+
+  if (loc.layout === "codex-sidecar") {
+    const skillName = path.basename(emit.sourceAbs);
+    const skillMd = path.join(emit.sourceAbs, "SKILL.md");
+    if (!fs.existsSync(skillMd)) return null;
+    const fm = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    const outAbs = path.join(emit.sourceAbs, "agents", "openai.yaml");
+    const yaml = renderOpenAiInterface(
+      fm.name ?? skillName,
+      fm.description ?? ""
+    );
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+      fs.writeFileSync(outAbs, yaml);
+    }
+    return { abs: outAbs };
+  }
+
+  return null;
+}
+
+/** Emit an MCP config by re-shaping the source JSON to the target agent's file. */
+function emitMcp(root, emit, loc, opts) {
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed source; leave to the skill to surface
+  }
+  const outAbs = path.join(root, loc.file);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify(parsed, null, 2) + "\n");
+  }
+  return { abs: outAbs };
+}
+
+/** Record/refresh a target in the lockfile after a successful emit. */
+function recordTarget(lock, root, emit, result) {
+  const src = {
+    agent: emit.from,
+    path: path.relative(root, emit.sourceAbs),
+    hash: hashDefinition(emit.sourceAbs),
+  };
+  const entry = lock.entries[emit.logicalId] ?? { source: src, targets: [] };
+  entry.source = src;
+  const rel = path.relative(root, result.abs);
+  const generatedHash = hashDefinition(result.abs);
+  const existingIdx = entry.targets.findIndex(t => t.agent === emit.to);
+  const record = { agent: emit.to, path: rel, generatedHash };
+  if (existingIdx >= 0) entry.targets[existingIdx] = record;
+  else entry.targets.push(record);
+  entry.targets.sort((a, b) => a.agent.localeCompare(b.agent));
+  lock.entries[emit.logicalId] = entry;
+}
+
+/** Strip a leading `---`-fenced YAML frontmatter block, returning the body. */
+function stripFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, "");
+}
+
+/** YAML-quote a description value for `.mdc` frontmatter. */
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Derive a single-line rule description: the first H1, else a titleized slug.
+ * Mirrors generate-cursor-plugin-artifacts.mjs.
+ *
+ * @param {string} body Rule markdown body (frontmatter already stripped).
+ * @param {string} name Rule slug.
+ * @returns {string}
+ */
+function deriveRuleDescription(body, name) {
+  const withoutFences = body.replace(/^(```|~~~).*$[\s\S]*?^\1.*$/gm, "");
+  const h1 = /^#\s+(.+?)\s*$/m.exec(withoutFences);
+  const text = (h1 ? h1[1] : "").replace(/\s+/g, " ").trim();
+  if (text) return text;
+  return name
+    .split("-")
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Rewrite intra-rule markdown link extensions to the target rule format so links
+ * still resolve after translation (e.g. `](foo.md)` -> `](foo.mdc)`). Only the
+ * URL is touched; the link text is preserved. External/`http` links are left as-is.
+ *
+ * @param {string} body
+ * @param {".md"|".mdc"} targetExt
+ * @returns {string}
+ */
+function rewriteRuleLinks(body, targetExt) {
+  const otherExt = targetExt === ".mdc" ? ".md" : ".mdc";
+  const re = new RegExp(`\\]\\(([^)]+?)\\${otherExt}(#[^)]*)?\\)`, "g");
+  return body.replace(re, (match, base, fragment = "") =>
+    /^https?:/.test(base) ? match : `](${base}${targetExt}${fragment})`
+  );
+}
+
+/** Minimal YAML/Markdown frontmatter parser for `name`/`description`. */
+function parseFrontmatter(text) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  const out = {};
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+/** Render a Codex `openai.yaml` interface from a skill's name/description. */
+function renderOpenAiInterface(name, description) {
+  const display = name
+    .split("-")
+    .map(p => (p ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+  const short = description.split(/[.!?]/)[0].trim() || display;
+  const esc = s => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return (
+    `display_name: ${esc(display)}\n` +
+    `short_description: ${esc(short)}\n` +
+    `default_prompt:\n` +
+    `  - ${esc(`Use $${name}: ${short}.`)}\n`
+  );
+}
+
+/** Render a human-readable report of a plan + apply result. */
+export function renderReport(p, result) {
+  const lines = [];
+  lines.push(
+    `Cross-pollination — harness: ${p.harness} -> [${p.targetAgents.join(", ")}]`
+  );
+  lines.push(`  sources detected: ${p.sources.length}`);
+  if (result) {
+    lines.push(`  written:          ${result.written.length}`);
+    if (result.skippedDrift.length)
+      lines.push(`  skipped (edited): ${result.skippedDrift.length}`);
+    if (result.gc.length) lines.push(`  garbage-collected:${result.gc.length}`);
+  }
+  if (p.conflicts.length) {
+    lines.push(`  CONFLICTS (authored in >1 agent — not translated):`);
+    for (const c of p.conflicts)
+      lines.push(
+        `    - ${c.logicalId}: ${c.authoredIn.map(a => a.agent).join(" + ")}`
+      );
+  }
+  if (p.pending.length) {
+    const byKind = {};
+    for (const x of p.pending) byKind[x.kind] = (byKind[x.kind] ?? 0) + 1;
+    lines.push(
+      `  PENDING (need skill-driven translation): ${Object.entries(byKind)
+        .map(([k, n]) => `${k}×${n}`)
+        .join(", ")}`
+    );
+  }
+  return lines.join("\n");
+}
+
+// CLI entrypoint.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
+  const dryRun = args.includes("--dry-run") || !args.includes("--write");
+  const asJson = args.includes("--json");
+  const p = plan(root);
+  const result = apply(p, { dryRun });
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { plan: p, result, dryRun },
+        (k, v) => (k === "abs" ? undefined : v),
+        2
+      )
+    );
+  } else {
+    console.log(renderReport(p, result));
+    if (dryRun)
+      console.log("\n(dry-run — pass --write to apply; default is dry-run)");
+  }
+}

--- a/plugins/lisa/skills/cross-pollinate/SKILL.md
+++ b/plugins/lisa/skills/cross-pollinate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cross-pollinate
+description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available in the formats of the OTHER agents the project supports, as declared in .lisa.config.json. Any-to-any, provenance-tracked, idempotent, never clobbers hand-edited output."
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+# Cross-Pollinate: $ARGUMENTS
+
+A host project that installs Lisa may hand-author a definition for **one** coding
+agent — a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server only
+Claude sees. `/lisa:cross-pollinate` detects those locally-authored definitions
+and regenerates each in the formats of the **other** agents the project supports,
+so the whole fleet stays in parity with what a developer wrote for any single one.
+
+## The model
+
+```
+any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
+```
+
+Claude format is the canonical intermediate representation (IR) because every
+Lisa generator already sources from it. So translation is always: **normalize
+the detected definition up to Claude-format IR, then fan that IR out** to each
+target agent using the documented mappings below. Never translate format A → B
+directly — that multiplies error and loses fidelity on every hop.
+
+The agents a project supports come from `.lisa.config.json` `harness`
+(`claude` | `codex` | `cursor` | `agy` | `copilot` | `opencode` | `both` | `fleet`;
+`all` is an alias for `fleet`). Only emit to agents that harness includes.
+
+## Provenance is authoritative — the lockfile, not file paths
+
+`.lisa/cross-pollination.lock.json` (committed) is the source of truth for what
+this skill generated. Location heuristics **cannot** work: a generated Cursor
+rule sits in the same `.cursor/rules/` directory as a hand-authored one. The
+lockfile is the only reliable way to enforce the four invariants:
+
+1. **No loops** — a path recorded as a `target` is NEVER treated as a source on
+   the next run. Without this, today's output becomes tomorrow's input and
+   translations ping-pong forever.
+2. **Garbage collection** — when a source is deleted/renamed, its now-orphaned
+   targets are removed.
+3. **Never clobber edits (Chesterton's fence)** — if a target's on-disk hash
+   differs from the recorded `generatedHash`, a human edited it. Stop and report;
+   do not overwrite. They may have intentionally diverged, or want to adopt the
+   edit as a new source.
+4. **Idempotent** — unchanged source + intact targets => no-op. (This is why it
+   is safe to also run during `lisa apply`.)
+
+Lockfile shape:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "skill:security-review": {
+      "source":  { "agent": "claude", "path": ".claude/skills/security-review", "hash": "…" },
+      "targets": [ { "agent": "codex", "path": ".claude/skills/security-review/agents/openai.yaml", "generatedHash": "…" } ]
+    }
+  }
+}
+```
+
+The `logicalId` is `<kind>:<name>` — stable across formats. It links a source to
+its targets and detects **collisions**: the same `logicalId` authored
+independently in two agents (neither generated). On a collision, NEVER
+auto-translate over either side — report it and let the human pick the source of
+truth.
+
+## How to run
+
+The deterministic core (scan, provenance, loop/GC/drift/conflict detection, and
+the skill + MCP emitters) is a bundled engine. **Always run it first** — it does
+the safe, mechanical work and tells you exactly what is left for you to translate
+by hand.
+
+```bash
+# dry-run (default): report only, writes nothing
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --json
+# apply the deterministic emits + update the lockfile
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --write
+```
+
+In the Lisa source repo itself the path is
+`node plugins/lisa/scripts/cross-pollinate.mjs` (built) or
+`node plugins/src/base/scripts/cross-pollinate.mjs` (source).
+
+The JSON report has four lists you act on:
+
+- `emits` — already handled by `--write` (skills, MCP). Verify, don't redo.
+- `conflicts` — STOP. Report each to the user; do not translate.
+- `orphans` — GC'd by `--write`. Confirm the removals look right.
+- `pending` — **your job.** Definitions whose target format the engine does not
+  emit deterministically. Translate each per the mappings below, then record
+  provenance (see "Recording provenance").
+
+## Per-agent format mappings (for `pending` translation)
+
+Normalize the source to Claude-format IR first, then emit per target:
+
+### Rules
+- **Claude ↔ Cursor**: handled deterministically by the engine. Claude reads
+  `.claude/rules/<name>.md`; Cursor reads `.cursor/rules/<name>.mdc` with YAML
+  frontmatter (`description` from the first H1, `alwaysApply: true`) and intra-rule
+  link extensions rewritten. You do not translate these — verify the engine's
+  emits.
+- **Codex / OpenCode / agy** (`pending`): project rules are delivered via
+  `AGENTS.md`, not a per-rule file. MERGE the rule content into `AGENTS.md` under a
+  stable marked section rather than writing a separate file (so re-runs replace,
+  not append). agy never gets a duplicate rule file (rules-once).
+- **Copilot** (`pending`): `.github/copilot-instructions.md` (inline). Merge into a
+  marked section, don't scatter.
+
+### Subagents
+- **Claude / agy / Cursor / OpenCode**: `agents/<name>.md` (or `.claude/agents/`).
+- **Copilot**: `agents/<name>.agent.md` (note the `.agent.md` suffix).
+- **Codex**: does not consume agent files. Report as **dropped — unsupported**,
+  do not invent a target.
+
+### Commands
+- **Claude / Cursor / Copilot**: markdown command files (`.claude/commands/…`).
+- **Codex / agy**: auto-derive commands from skills; no separate command file.
+  Report as **dropped — derived-from-skill**.
+
+### Hooks (lossy — drop-and-report, never fake support)
+- Event-name casing differs per agent (`PreToolUse`→`preToolUse`/`beforeSubmitPrompt`,
+  `UserPromptSubmit`→`userPromptSubmitted`, `Stop`→`agentStop`/`stop`, …).
+- **agy** lacks `SessionStart`/`SubagentStart` — only `PreToolUse` (e.g.
+  block-no-verify) is portable. Everything else: dropped — unsupported.
+- **Codex** plugin hooks do not fire in `codex exec` — install into
+  `~/.codex/hooks.json`, not a bundled file.
+- **Copilot** rejects the entire hooks config if a `SubagentStart`/empty-matcher
+  entry is present — drop that event wholesale.
+- For every hook you cannot faithfully translate to a target, REPORT it with the
+  reason. Do not silently omit (no silent caps).
+
+### MCP (handled by the engine for Claude↔Cursor; report others)
+- **Claude**: `.mcp.json`. **Cursor**: `.cursor/mcp.json` (same JSON shape).
+- **Copilot**: inline `mcpServers` object in the plugin manifest (bundled
+  `.mcp.json` is ignored). **Codex**: TOML / `.codex-plugin` pointer.
+  **agy/OpenCode**: user-global installer / `.opencode`. The engine reports these
+  as pending; translate per the target's documented shape or report dropped.
+
+## Recording provenance for hand-translated `pending` items
+
+After you write a target by hand, it MUST be recorded in
+`.lisa/cross-pollination.lock.json` or the next run will treat it as a source
+(loop) or fail to GC it. Re-run the engine after staging your translated files —
+on its next pass it adopts and hashes any target already referenced — OR add the
+entry yourself following the lockfile shape above (compute `generatedHash` as the
+sha256 of the written file/dir). Prefer the engine; only hand-edit the lock if
+the engine cannot infer the mapping.
+
+## Output
+
+Report, concisely:
+- harness + resolved target agents
+- counts: detected sources, written, skipped-drift, GC'd
+- every conflict (with the agents involved)
+- every pending item you translated, and every hook/agent/command you **dropped**
+  with its reason
+- confirm `.lisa/cross-pollination.lock.json` was updated and the working tree
+  otherwise contains only intended changes
+
+## Rules
+
+- Treat the lockfile as authoritative; never infer "mine vs theirs" from paths.
+- Never overwrite a drifted (hand-edited) target — report it.
+- Never auto-resolve a collision — report it.
+- Only emit to agents the project's `harness` includes.
+- Drop-and-report any translation a target genuinely cannot support; never fake
+  a location you are unsure of.
+- This skill is additive — it does not delete a human's source definitions, only
+  its own orphaned generated targets.

--- a/plugins/lisa/skills/cross-pollinate/agents/openai.yaml
+++ b/plugins/lisa/skills/cross-pollinate/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Cross Pollinate"
+short_description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available…"
+default_prompt:
+  - "Use $cross-pollinate: Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available…."

--- a/plugins/src/base/commands/cross-pollinate.md
+++ b/plugins/src/base/commands/cross-pollinate.md
@@ -1,0 +1,15 @@
+---
+description: "Detect locally-authored agent definitions and regenerate them in the formats of the other coding agents this project supports (per .lisa.config.json)."
+allowed-tools: ["Skill"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+Use the /lisa:cross-pollinate skill to detect this project's locally-authored
+coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and
+make each available in the formats of the other agents the project's
+`.lisa.config.json` harness includes. $ARGUMENTS
+
+Provenance is tracked in `.lisa/cross-pollination.lock.json`: the run is
+idempotent, garbage-collects orphaned translations, never overwrites a
+hand-edited target, and reports any conflict or unsupported translation rather
+than guessing.

--- a/plugins/src/base/scripts/cross-pollinate.mjs
+++ b/plugins/src/base/scripts/cross-pollinate.mjs
@@ -1,0 +1,727 @@
+#!/usr/bin/env node
+/**
+ * Cross-pollinate a host project's locally-authored coding-agent definitions
+ * across every agent the project supports.
+ *
+ * A host project that installs Lisa may hand-author a skill, subagent, rule,
+ * command, hook, or MCP entry for ONE coding agent (e.g. a `.claude/skills/foo`
+ * that only Claude sees). This engine detects those locally-authored
+ * definitions, normalizes each to a canonical intermediate representation (IR),
+ * and fans it out to the formats of the OTHER agents declared in the project's
+ * `.lisa.config.json` `harness`.
+ *
+ * Architecture (see the cross-pollinate SKILL.md for the full spec):
+ *   any agent's format  ->  Claude-format IR  ->  every other configured agent
+ *
+ * Claude format is the IR because every existing Lisa generator already sources
+ * from it; emitting IR -> {cursor, codex, agy, copilot, opencode} reuses those
+ * battle-tested transforms instead of an N x N translator matrix.
+ *
+ * PROVENANCE is authoritative via a committed lockfile,
+ * `.lisa/cross-pollination.lock.json`. Path/location heuristics alone CANNOT
+ * distinguish a generated translation from a hand-authored original (both live
+ * in the same per-agent directory), so the lockfile is the only reliable way to:
+ *   1. prevent loops    — a recorded target is never treated as a source
+ *   2. garbage-collect  — an orphaned target (source deleted) is removed
+ *   3. protect edits    — a target whose on-disk hash drifts from the recorded
+ *                         generated hash was hand-edited; never clobber it
+ *   4. stay idempotent  — unchanged source + intact targets => no-op
+ *
+ * This engine is the deterministic core. It is invoked standalone
+ * (`node .../cross-pollinate.mjs <path> [--dry-run] [--json] [--write]`) and by
+ * the cross-pollinate skill, which layers in the judgment-heavy translations the
+ * engine reports as `pending`.
+ *
+ * @module cross-pollinate
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
+const LOCK_VERSION = 1;
+
+/**
+ * Canonical coding agents Lisa can fan out to. Mirrors `EmitAgent` in
+ * src/core/config.ts; kept inline because this engine ships inside the plugin
+ * and runs in host projects without the Lisa TypeScript build on the path.
+ */
+const ALL_AGENTS = ["claude", "codex", "cursor", "agy", "copilot", "opencode"];
+
+/**
+ * Resolve the agent set a `harness` value targets. Mirrors
+ * `harnessIncludesAgent` in src/core/config.ts (with the `all` -> `fleet`
+ * alias already normalized away on the config read path).
+ *
+ * @param {string} harness Canonical harness string from `.lisa.config.json`.
+ * @returns {string[]} Agents the harness includes.
+ */
+function agentsForHarness(harness) {
+  if (harness === "fleet") return [...ALL_AGENTS];
+  if (harness === "both") return ["claude", "codex"];
+  if (harness === "all") return [...ALL_AGENTS]; // defensive: pre-normalized alias
+  return ALL_AGENTS.includes(harness) ? [harness] : ["claude"];
+}
+
+/**
+ * Per-(agent, primitive) host-project location + format registry.
+ *
+ * Only entries we can place with confidence are marked `supported: true` and
+ * carry a `dir`/`ext`. Entries marked `supported: false` are intentionally NOT
+ * guessed — the engine reports detected definitions of that kind as `pending`
+ * so the skill (which reads the real on-disk layout) translates them with
+ * judgment rather than the engine writing a wrong path. This is deliberate:
+ * silently emitting to an unverified location is worse than reporting it.
+ *
+ * `kind` legend: skill | agent | rule | command | hook | mcp
+ */
+const HOST_LOCATIONS = {
+  skill: {
+    // Most agents consume the Claude SKILL.md format directly (OpenCode reads
+    // .claude/skills natively; agy/copilot ship SKILL.md verbatim). Codex is
+    // the one that needs a derived interface sidecar (agents/openai.yaml).
+    claude: { supported: true, dir: ".claude/skills", layout: "skill-dir" },
+    codex: { supported: true, dir: ".claude/skills", layout: "codex-sidecar" },
+    opencode: {
+      supported: true,
+      dir: ".claude/skills",
+      layout: "native-claude",
+    },
+    cursor: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+  },
+  mcp: {
+    claude: { supported: true, file: ".mcp.json", layout: "json" },
+    cursor: { supported: true, file: ".cursor/mcp.json", layout: "json" },
+    codex: { supported: false },
+    agy: { supported: false },
+    copilot: { supported: false },
+    opencode: { supported: false },
+  },
+  rule: {
+    // Claude <-> Cursor is the clean, verified pair: a flat per-rule file in
+    // both, only the frontmatter + extension differ. codex/agy/opencode deliver
+    // project rules by merging into a shared AGENTS.md (section-marker management
+    // the engine does not fake) and copilot into .github/copilot-instructions.md
+    // — those stay `pending` for the skill to merge with judgment.
+    claude: {
+      supported: true,
+      dir: ".claude/rules",
+      ext: ".md",
+      layout: "rule-md",
+    },
+    cursor: {
+      supported: true,
+      dir: ".cursor/rules",
+      ext: ".mdc",
+      layout: "rule-mdc",
+    },
+  },
+  // Subagents, commands, hooks: detected by the scanner and reported as
+  // `pending` for the skill to translate. Their host locations differ per agent
+  // (and some are lossy/unsupported), so the engine does not hardcode them.
+  agent: {},
+  command: {},
+  hook: {},
+};
+
+/**
+ * Source-detection patterns: where a HUMAN authors each primitive, keyed by the
+ * agent whose format it is. The scanner walks these; the lockfile then filters
+ * out anything that is actually a generated target (loop prevention).
+ *
+ * @type {Array<{ kind: string, agent: string, glob: (root: string) => string[] }>}
+ */
+const SOURCE_SCANNERS = [
+  {
+    kind: "skill",
+    agent: "claude",
+    glob: root => listSkillDirs(path.join(root, ".claude/skills")),
+  },
+  {
+    kind: "agent",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/agents"), ".md"),
+  },
+  {
+    kind: "command",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/commands"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "claude",
+    glob: root => listFiles(path.join(root, ".claude/rules"), ".md", true),
+  },
+  {
+    kind: "rule",
+    agent: "cursor",
+    glob: root => listFiles(path.join(root, ".cursor/rules"), ".mdc"),
+  },
+  {
+    kind: "mcp",
+    agent: "claude",
+    glob: root => existing(path.join(root, ".mcp.json")),
+  },
+  {
+    kind: "mcp",
+    agent: "cursor",
+    glob: root => existing(path.join(root, ".cursor/mcp.json")),
+  },
+];
+
+/** @returns {string[]} Absolute paths to skill directories (those holding SKILL.md). */
+function listSkillDirs(dir) {
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter(
+      e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))
+    )
+    .map(e => path.join(dir, e.name));
+}
+
+/** @returns {string[]} Absolute file paths under `dir` with extension `ext`. */
+function listFiles(dir, ext, recursive = false) {
+  if (!isDir(dir)) return [];
+  const out = [];
+  const walk = current => {
+    for (const e of fs.readdirSync(current, { withFileTypes: true })) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory() && recursive) walk(p);
+      else if (e.isFile() && e.name.endsWith(ext)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** @returns {string[]} `[file]` if it exists, else `[]`. */
+function existing(file) {
+  return fs.existsSync(file) ? [file] : [];
+}
+
+/** @returns {boolean} */
+function isDir(p) {
+  return fs.existsSync(p) && fs.statSync(p).isDirectory();
+}
+
+/**
+ * Stable content hash for a definition. For a skill DIRECTORY we hash the
+ * sorted (relpath, content) pairs of every file so a change anywhere in the
+ * skill invalidates it; for a single file we hash its bytes.
+ *
+ * @param {string} target Absolute path to a file or skill directory.
+ * @returns {string} Hex sha256.
+ */
+function hashDefinition(target) {
+  const h = createHash("sha256");
+  if (isDir(target)) {
+    const files = listFiles(target, "", true).sort();
+    for (const f of files) {
+      h.update(path.relative(target, f));
+      h.update("\0");
+      h.update(fs.readFileSync(f));
+      h.update("\0");
+    }
+  } else {
+    h.update(fs.readFileSync(target));
+  }
+  return h.digest("hex");
+}
+
+/**
+ * Logical identity of a definition, stable across agent formats. Two
+ * definitions sharing a logicalId are "the same thing" in different formats —
+ * the basis for both linking a source to its targets and detecting a
+ * human-authored collision.
+ *
+ * @param {string} kind
+ * @param {string} sourcePath Absolute path to the source definition.
+ * @returns {string} e.g. "skill:security-review"
+ */
+function logicalId(kind, sourcePath) {
+  // MCP config is a per-project singleton: `.mcp.json` (Claude) and
+  // `.cursor/mcp.json` (Cursor) are the SAME logical thing in different
+  // formats, so its identity must not derive from the (differing) filename —
+  // otherwise a genuine cross-agent collision reads as two unrelated configs.
+  if (kind === "mcp") return "mcp:project";
+  const base = isDir(sourcePath)
+    ? path.basename(sourcePath)
+    : path.basename(sourcePath).replace(/\.[^.]+$/, "");
+  return `${kind}:${base}`;
+}
+
+/** Read `.lisa.config.json` harness; default "claude". */
+function readHarness(root) {
+  const p = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(p)) return "claude";
+  try {
+    const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+    return typeof cfg.harness === "string" ? cfg.harness : "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/** Read the provenance lockfile; returns an empty lock when absent. */
+function readLock(root) {
+  const p = path.join(root, LOCKFILE_REL);
+  if (!fs.existsSync(p)) return { version: LOCK_VERSION, entries: {} };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.entries
+      ? parsed
+      : { version: LOCK_VERSION, entries: {} };
+  } catch {
+    return { version: LOCK_VERSION, entries: {} };
+  }
+}
+
+/** Persist the provenance lockfile (deterministic key ordering). */
+function writeLock(root, lock) {
+  const p = path.join(root, LOCKFILE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const ordered = { version: LOCK_VERSION, entries: {} };
+  for (const key of Object.keys(lock.entries).sort()) {
+    ordered.entries[key] = lock.entries[key];
+  }
+  fs.writeFileSync(p, JSON.stringify(ordered, null, 2) + "\n");
+}
+
+/**
+ * The set of absolute paths the lockfile records as GENERATED targets. A path
+ * in this set is never treated as a source (loop prevention).
+ *
+ * @param {object} lock
+ * @param {string} root
+ * @returns {Set<string>} Absolute target paths.
+ */
+function generatedTargetPaths(lock, root) {
+  const set = new Set();
+  for (const entry of Object.values(lock.entries)) {
+    for (const t of entry.targets ?? []) {
+      set.add(path.resolve(root, t.path));
+    }
+  }
+  return set;
+}
+
+/**
+ * Plan cross-pollination: scan sources, classify against the lockfile, and
+ * compute the actions needed. Pure with respect to the filesystem (reads only).
+ *
+ * @param {string} root Absolute host-project root.
+ * @returns {object} A structured plan (see fields below).
+ */
+export function plan(root) {
+  const harness = readHarness(root);
+  const targetAgents = agentsForHarness(harness);
+  const lock = readLock(root);
+  const generated = generatedTargetPaths(lock, root);
+
+  // Scan every source location, skipping anything the lock says is generated.
+  const sources = [];
+  const byLogicalId = new Map();
+  for (const scanner of SOURCE_SCANNERS) {
+    for (const abs of scanner.glob(root)) {
+      if (generated.has(path.resolve(abs))) continue; // loop prevention
+      const id = logicalId(scanner.kind, abs);
+      const src = {
+        logicalId: id,
+        kind: scanner.kind,
+        agent: scanner.agent,
+        path: path.relative(root, abs),
+        abs,
+        hash: hashDefinition(abs),
+      };
+      sources.push(src);
+      const bucket = byLogicalId.get(id) ?? [];
+      bucket.push(src);
+      byLogicalId.set(id, bucket);
+    }
+  }
+
+  // Conflicts: same logicalId authored independently in >1 agent (neither is a
+  // generated target). Never auto-translate over either — report for a human.
+  const conflicts = [];
+  for (const [id, bucket] of byLogicalId) {
+    if (bucket.length > 1) {
+      conflicts.push({
+        logicalId: id,
+        authoredIn: bucket.map(s => ({ agent: s.agent, path: s.path })),
+      });
+    }
+  }
+  const conflictIds = new Set(conflicts.map(c => c.logicalId));
+
+  // For each non-conflicting source, decide which target agents need an emit,
+  // and which kinds are pending (no confident host location).
+  const emits = [];
+  const pending = [];
+  for (const src of sources) {
+    if (conflictIds.has(src.logicalId)) continue;
+    const entry = lock.entries[src.logicalId];
+    const sourceChanged = !entry || entry.source?.hash !== src.hash;
+    for (const agent of targetAgents) {
+      if (agent === src.agent) continue;
+      const loc = HOST_LOCATIONS[src.kind]?.[agent];
+      if (!loc || !loc.supported) {
+        pending.push({
+          logicalId: src.logicalId,
+          kind: src.kind,
+          from: src.agent,
+          to: agent,
+        });
+        continue;
+      }
+      // The agent consumes the source format natively (e.g. OpenCode reads
+      // .claude/skills directly) — there is nothing to emit, and it must NOT be
+      // reported as a perpetual "missing" emit. It is inherently satisfied.
+      if (loc.layout === "native-claude") continue;
+      const recordedTarget = entry?.targets?.find(t => t.agent === agent);
+      const targetAbs = recordedTarget
+        ? path.resolve(root, recordedTarget.path)
+        : null;
+      const targetExists = targetAbs ? fs.existsSync(targetAbs) : false;
+      const targetDrifted =
+        targetExists &&
+        recordedTarget &&
+        hashDefinition(targetAbs) !== recordedTarget.generatedHash;
+      emits.push({
+        logicalId: src.logicalId,
+        kind: src.kind,
+        from: src.agent,
+        to: agent,
+        sourceAbs: src.abs,
+        reason: !targetExists
+          ? "missing"
+          : sourceChanged
+            ? "source-changed"
+            : targetDrifted
+              ? "drift"
+              : "up-to-date",
+        drifted: Boolean(targetDrifted),
+      });
+    }
+  }
+
+  // Orphans: lockfile entries whose source no longer exists -> GC their targets.
+  const liveIds = new Set(sources.map(s => s.logicalId));
+  const orphans = [];
+  for (const [id, entry] of Object.entries(lock.entries)) {
+    if (!liveIds.has(id)) {
+      orphans.push({
+        logicalId: id,
+        targets: (entry.targets ?? []).map(t => t.path),
+      });
+    }
+  }
+
+  return {
+    root,
+    harness,
+    targetAgents,
+    sources,
+    emits,
+    pending,
+    conflicts,
+    orphans,
+  };
+}
+
+/**
+ * Execute the deterministic emits a plan calls for (skills + mcp today),
+ * skipping `drift` emits (never clobber hand-edited targets), and update the
+ * lockfile. Judgment-heavy `pending` kinds are left for the skill.
+ *
+ * @param {object} p A plan from {@link plan}.
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{ written: object[], skippedDrift: object[], gc: string[] }}
+ */
+export function apply(p, opts = {}) {
+  const { root } = p;
+  const lock = readLock(root);
+  const written = [];
+  const skippedDrift = [];
+  const gc = [];
+
+  for (const emit of p.emits) {
+    if (emit.reason === "up-to-date") continue;
+    if (emit.drifted) {
+      skippedDrift.push(emit);
+      continue;
+    }
+    const result = emitOne(root, emit, opts);
+    if (!result) continue;
+    written.push({ ...emit, target: path.relative(root, result.abs) });
+    if (!opts.dryRun) recordTarget(lock, root, emit, result);
+  }
+
+  // GC orphaned targets.
+  for (const orphan of p.orphans) {
+    for (const rel of orphan.targets) {
+      const abs = path.resolve(root, rel);
+      if (fs.existsSync(abs)) {
+        gc.push(rel);
+        if (!opts.dryRun) fs.rmSync(abs, { recursive: true, force: true });
+      }
+    }
+    if (!opts.dryRun) delete lock.entries[orphan.logicalId];
+  }
+
+  if (!opts.dryRun) writeLock(root, lock);
+  return { written, skippedDrift, gc };
+}
+
+/**
+ * Emit a single target. Returns the written target's {abs} or null when the
+ * kind has no deterministic emitter (left to the skill).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitOne(root, emit, opts) {
+  const loc = HOST_LOCATIONS[emit.kind]?.[emit.to];
+  if (!loc || !loc.supported) return null;
+
+  if (emit.kind === "skill") return emitSkill(root, emit, loc, opts);
+  if (emit.kind === "mcp") return emitMcp(root, emit, loc, opts);
+  if (emit.kind === "rule") return emitRule(root, emit, loc, opts);
+  return null;
+}
+
+/**
+ * Emit a rule to a target agent, translating between the Claude `.md` and Cursor
+ * `.mdc` flat-file formats.
+ *
+ * Cursor requires YAML frontmatter (`description` from the first H1, `alwaysApply`)
+ * and discovers only `.mdc`; Claude reads plain `.md`. The transform mirrors
+ * scripts/generate-cursor-plugin-artifacts.mjs (reimplemented inline because that
+ * generator operates on the nested plugin layout and is not importable from the
+ * plugin at host runtime).
+ *
+ * @param {string} root
+ * @param {object} emit
+ * @param {{ dir: string, ext: string, layout: string }} loc
+ * @param {{ dryRun?: boolean }} opts
+ * @returns {{ abs: string } | null}
+ */
+function emitRule(root, emit, loc, opts) {
+  const name = path.basename(emit.sourceAbs).replace(/\.(md|mdc)$/, "");
+  const outAbs = path.join(root, loc.dir, `${name}${loc.ext}`);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  const body = stripFrontmatter(raw);
+  let contents;
+  if (loc.layout === "rule-mdc") {
+    const fm = `---\ndescription: ${yamlQuote(deriveRuleDescription(body, name))}\nalwaysApply: true\n---\n\n`;
+    contents = fm + rewriteRuleLinks(body, ".mdc");
+  } else {
+    contents = rewriteRuleLinks(body, ".md");
+  }
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, contents);
+  }
+  return { abs: outAbs };
+}
+
+/**
+ * Emit a skill to a target agent. For native-Claude consumers (opencode) and
+ * the canonical Claude dir this is a no-op (they already read the source). For
+ * Codex, derive the `agents/openai.yaml` interface sidecar next to the SKILL.md.
+ */
+function emitSkill(_root, emit, loc, opts) {
+  if (loc.layout === "native-claude") return null; // agent reads source as-is
+
+  if (loc.layout === "codex-sidecar") {
+    const skillName = path.basename(emit.sourceAbs);
+    const skillMd = path.join(emit.sourceAbs, "SKILL.md");
+    if (!fs.existsSync(skillMd)) return null;
+    const fm = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    const outAbs = path.join(emit.sourceAbs, "agents", "openai.yaml");
+    const yaml = renderOpenAiInterface(
+      fm.name ?? skillName,
+      fm.description ?? ""
+    );
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+      fs.writeFileSync(outAbs, yaml);
+    }
+    return { abs: outAbs };
+  }
+
+  return null;
+}
+
+/** Emit an MCP config by re-shaping the source JSON to the target agent's file. */
+function emitMcp(root, emit, loc, opts) {
+  const raw = fs.readFileSync(emit.sourceAbs, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // malformed source; leave to the skill to surface
+  }
+  const outAbs = path.join(root, loc.file);
+  if (path.resolve(outAbs) === path.resolve(emit.sourceAbs)) return null;
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(outAbs), { recursive: true });
+    fs.writeFileSync(outAbs, JSON.stringify(parsed, null, 2) + "\n");
+  }
+  return { abs: outAbs };
+}
+
+/** Record/refresh a target in the lockfile after a successful emit. */
+function recordTarget(lock, root, emit, result) {
+  const src = {
+    agent: emit.from,
+    path: path.relative(root, emit.sourceAbs),
+    hash: hashDefinition(emit.sourceAbs),
+  };
+  const entry = lock.entries[emit.logicalId] ?? { source: src, targets: [] };
+  entry.source = src;
+  const rel = path.relative(root, result.abs);
+  const generatedHash = hashDefinition(result.abs);
+  const existingIdx = entry.targets.findIndex(t => t.agent === emit.to);
+  const record = { agent: emit.to, path: rel, generatedHash };
+  if (existingIdx >= 0) entry.targets[existingIdx] = record;
+  else entry.targets.push(record);
+  entry.targets.sort((a, b) => a.agent.localeCompare(b.agent));
+  lock.entries[emit.logicalId] = entry;
+}
+
+/** Strip a leading `---`-fenced YAML frontmatter block, returning the body. */
+function stripFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, "");
+}
+
+/** YAML-quote a description value for `.mdc` frontmatter. */
+function yamlQuote(value) {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Derive a single-line rule description: the first H1, else a titleized slug.
+ * Mirrors generate-cursor-plugin-artifacts.mjs.
+ *
+ * @param {string} body Rule markdown body (frontmatter already stripped).
+ * @param {string} name Rule slug.
+ * @returns {string}
+ */
+function deriveRuleDescription(body, name) {
+  const withoutFences = body.replace(/^(```|~~~).*$[\s\S]*?^\1.*$/gm, "");
+  const h1 = /^#\s+(.+?)\s*$/m.exec(withoutFences);
+  const text = (h1 ? h1[1] : "").replace(/\s+/g, " ").trim();
+  if (text) return text;
+  return name
+    .split("-")
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Rewrite intra-rule markdown link extensions to the target rule format so links
+ * still resolve after translation (e.g. `](foo.md)` -> `](foo.mdc)`). Only the
+ * URL is touched; the link text is preserved. External/`http` links are left as-is.
+ *
+ * @param {string} body
+ * @param {".md"|".mdc"} targetExt
+ * @returns {string}
+ */
+function rewriteRuleLinks(body, targetExt) {
+  const otherExt = targetExt === ".mdc" ? ".md" : ".mdc";
+  const re = new RegExp(`\\]\\(([^)]+?)\\${otherExt}(#[^)]*)?\\)`, "g");
+  return body.replace(re, (match, base, fragment = "") =>
+    /^https?:/.test(base) ? match : `](${base}${targetExt}${fragment})`
+  );
+}
+
+/** Minimal YAML/Markdown frontmatter parser for `name`/`description`. */
+function parseFrontmatter(text) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(text);
+  const out = {};
+  if (!m) return out;
+  for (const line of m[1].split("\n")) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+/** Render a Codex `openai.yaml` interface from a skill's name/description. */
+function renderOpenAiInterface(name, description) {
+  const display = name
+    .split("-")
+    .map(p => (p ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+  const short = description.split(/[.!?]/)[0].trim() || display;
+  const esc = s => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return (
+    `display_name: ${esc(display)}\n` +
+    `short_description: ${esc(short)}\n` +
+    `default_prompt:\n` +
+    `  - ${esc(`Use $${name}: ${short}.`)}\n`
+  );
+}
+
+/** Render a human-readable report of a plan + apply result. */
+export function renderReport(p, result) {
+  const lines = [];
+  lines.push(
+    `Cross-pollination — harness: ${p.harness} -> [${p.targetAgents.join(", ")}]`
+  );
+  lines.push(`  sources detected: ${p.sources.length}`);
+  if (result) {
+    lines.push(`  written:          ${result.written.length}`);
+    if (result.skippedDrift.length)
+      lines.push(`  skipped (edited): ${result.skippedDrift.length}`);
+    if (result.gc.length) lines.push(`  garbage-collected:${result.gc.length}`);
+  }
+  if (p.conflicts.length) {
+    lines.push(`  CONFLICTS (authored in >1 agent — not translated):`);
+    for (const c of p.conflicts)
+      lines.push(
+        `    - ${c.logicalId}: ${c.authoredIn.map(a => a.agent).join(" + ")}`
+      );
+  }
+  if (p.pending.length) {
+    const byKind = {};
+    for (const x of p.pending) byKind[x.kind] = (byKind[x.kind] ?? 0) + 1;
+    lines.push(
+      `  PENDING (need skill-driven translation): ${Object.entries(byKind)
+        .map(([k, n]) => `${k}×${n}`)
+        .join(", ")}`
+    );
+  }
+  return lines.join("\n");
+}
+
+// CLI entrypoint.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
+  const dryRun = args.includes("--dry-run") || !args.includes("--write");
+  const asJson = args.includes("--json");
+  const p = plan(root);
+  const result = apply(p, { dryRun });
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { plan: p, result, dryRun },
+        (k, v) => (k === "abs" ? undefined : v),
+        2
+      )
+    );
+  } else {
+    console.log(renderReport(p, result));
+    if (dryRun)
+      console.log("\n(dry-run — pass --write to apply; default is dry-run)");
+  }
+}

--- a/plugins/src/base/skills/cross-pollinate/SKILL.md
+++ b/plugins/src/base/skills/cross-pollinate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cross-pollinate
+description: "Detect a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and make each available in the formats of the OTHER agents the project supports, as declared in .lisa.config.json. Any-to-any, provenance-tracked, idempotent, never clobbers hand-edited output."
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+argument-hint: "[path] [--dry-run] [--write]"
+---
+
+# Cross-Pollinate: $ARGUMENTS
+
+A host project that installs Lisa may hand-author a definition for **one** coding
+agent — a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server only
+Claude sees. `/lisa:cross-pollinate` detects those locally-authored definitions
+and regenerates each in the formats of the **other** agents the project supports,
+so the whole fleet stays in parity with what a developer wrote for any single one.
+
+## The model
+
+```
+any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
+```
+
+Claude format is the canonical intermediate representation (IR) because every
+Lisa generator already sources from it. So translation is always: **normalize
+the detected definition up to Claude-format IR, then fan that IR out** to each
+target agent using the documented mappings below. Never translate format A → B
+directly — that multiplies error and loses fidelity on every hop.
+
+The agents a project supports come from `.lisa.config.json` `harness`
+(`claude` | `codex` | `cursor` | `agy` | `copilot` | `opencode` | `both` | `fleet`;
+`all` is an alias for `fleet`). Only emit to agents that harness includes.
+
+## Provenance is authoritative — the lockfile, not file paths
+
+`.lisa/cross-pollination.lock.json` (committed) is the source of truth for what
+this skill generated. Location heuristics **cannot** work: a generated Cursor
+rule sits in the same `.cursor/rules/` directory as a hand-authored one. The
+lockfile is the only reliable way to enforce the four invariants:
+
+1. **No loops** — a path recorded as a `target` is NEVER treated as a source on
+   the next run. Without this, today's output becomes tomorrow's input and
+   translations ping-pong forever.
+2. **Garbage collection** — when a source is deleted/renamed, its now-orphaned
+   targets are removed.
+3. **Never clobber edits (Chesterton's fence)** — if a target's on-disk hash
+   differs from the recorded `generatedHash`, a human edited it. Stop and report;
+   do not overwrite. They may have intentionally diverged, or want to adopt the
+   edit as a new source.
+4. **Idempotent** — unchanged source + intact targets => no-op. (This is why it
+   is safe to also run during `lisa apply`.)
+
+Lockfile shape:
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "skill:security-review": {
+      "source":  { "agent": "claude", "path": ".claude/skills/security-review", "hash": "…" },
+      "targets": [ { "agent": "codex", "path": ".claude/skills/security-review/agents/openai.yaml", "generatedHash": "…" } ]
+    }
+  }
+}
+```
+
+The `logicalId` is `<kind>:<name>` — stable across formats. It links a source to
+its targets and detects **collisions**: the same `logicalId` authored
+independently in two agents (neither generated). On a collision, NEVER
+auto-translate over either side — report it and let the human pick the source of
+truth.
+
+## How to run
+
+The deterministic core (scan, provenance, loop/GC/drift/conflict detection, and
+the skill + MCP emitters) is a bundled engine. **Always run it first** — it does
+the safe, mechanical work and tells you exactly what is left for you to translate
+by hand.
+
+```bash
+# dry-run (default): report only, writes nothing
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --json
+# apply the deterministic emits + update the lockfile
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cross-pollinate.mjs" "$PROJECT_ROOT" --write
+```
+
+In the Lisa source repo itself the path is
+`node plugins/lisa/scripts/cross-pollinate.mjs` (built) or
+`node plugins/src/base/scripts/cross-pollinate.mjs` (source).
+
+The JSON report has four lists you act on:
+
+- `emits` — already handled by `--write` (skills, MCP). Verify, don't redo.
+- `conflicts` — STOP. Report each to the user; do not translate.
+- `orphans` — GC'd by `--write`. Confirm the removals look right.
+- `pending` — **your job.** Definitions whose target format the engine does not
+  emit deterministically. Translate each per the mappings below, then record
+  provenance (see "Recording provenance").
+
+## Per-agent format mappings (for `pending` translation)
+
+Normalize the source to Claude-format IR first, then emit per target:
+
+### Rules
+- **Claude ↔ Cursor**: handled deterministically by the engine. Claude reads
+  `.claude/rules/<name>.md`; Cursor reads `.cursor/rules/<name>.mdc` with YAML
+  frontmatter (`description` from the first H1, `alwaysApply: true`) and intra-rule
+  link extensions rewritten. You do not translate these — verify the engine's
+  emits.
+- **Codex / OpenCode / agy** (`pending`): project rules are delivered via
+  `AGENTS.md`, not a per-rule file. MERGE the rule content into `AGENTS.md` under a
+  stable marked section rather than writing a separate file (so re-runs replace,
+  not append). agy never gets a duplicate rule file (rules-once).
+- **Copilot** (`pending`): `.github/copilot-instructions.md` (inline). Merge into a
+  marked section, don't scatter.
+
+### Subagents
+- **Claude / agy / Cursor / OpenCode**: `agents/<name>.md` (or `.claude/agents/`).
+- **Copilot**: `agents/<name>.agent.md` (note the `.agent.md` suffix).
+- **Codex**: does not consume agent files. Report as **dropped — unsupported**,
+  do not invent a target.
+
+### Commands
+- **Claude / Cursor / Copilot**: markdown command files (`.claude/commands/…`).
+- **Codex / agy**: auto-derive commands from skills; no separate command file.
+  Report as **dropped — derived-from-skill**.
+
+### Hooks (lossy — drop-and-report, never fake support)
+- Event-name casing differs per agent (`PreToolUse`→`preToolUse`/`beforeSubmitPrompt`,
+  `UserPromptSubmit`→`userPromptSubmitted`, `Stop`→`agentStop`/`stop`, …).
+- **agy** lacks `SessionStart`/`SubagentStart` — only `PreToolUse` (e.g.
+  block-no-verify) is portable. Everything else: dropped — unsupported.
+- **Codex** plugin hooks do not fire in `codex exec` — install into
+  `~/.codex/hooks.json`, not a bundled file.
+- **Copilot** rejects the entire hooks config if a `SubagentStart`/empty-matcher
+  entry is present — drop that event wholesale.
+- For every hook you cannot faithfully translate to a target, REPORT it with the
+  reason. Do not silently omit (no silent caps).
+
+### MCP (handled by the engine for Claude↔Cursor; report others)
+- **Claude**: `.mcp.json`. **Cursor**: `.cursor/mcp.json` (same JSON shape).
+- **Copilot**: inline `mcpServers` object in the plugin manifest (bundled
+  `.mcp.json` is ignored). **Codex**: TOML / `.codex-plugin` pointer.
+  **agy/OpenCode**: user-global installer / `.opencode`. The engine reports these
+  as pending; translate per the target's documented shape or report dropped.
+
+## Recording provenance for hand-translated `pending` items
+
+After you write a target by hand, it MUST be recorded in
+`.lisa/cross-pollination.lock.json` or the next run will treat it as a source
+(loop) or fail to GC it. Re-run the engine after staging your translated files —
+on its next pass it adopts and hashes any target already referenced — OR add the
+entry yourself following the lockfile shape above (compute `generatedHash` as the
+sha256 of the written file/dir). Prefer the engine; only hand-edit the lock if
+the engine cannot infer the mapping.
+
+## Output
+
+Report, concisely:
+- harness + resolved target agents
+- counts: detected sources, written, skipped-drift, GC'd
+- every conflict (with the agents involved)
+- every pending item you translated, and every hook/agent/command you **dropped**
+  with its reason
+- confirm `.lisa/cross-pollination.lock.json` was updated and the working tree
+  otherwise contains only intended changes
+
+## Rules
+
+- Treat the lockfile as authoritative; never infer "mine vs theirs" from paths.
+- Never overwrite a drifted (hand-edited) target — report it.
+- Never auto-resolve a collision — report it.
+- Only emit to agents the project's `harness` includes.
+- Drop-and-report any translation a target genuinely cannot support; never fake
+  a location you are unsure of.
+- This skill is additive — it does not delete a human's source definitions, only
+  its own orphaned generated targets.

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -12,6 +12,7 @@ import {
 } from "../core/project-config.js";
 import { ConsoleLogger } from "../logging/index.js";
 import { toAbsolutePath } from "../utils/path-utils.js";
+import { nudgeCrossPollinate } from "./cross-pollinate-nudge.js";
 import { type CLIOptions, createDependencies } from "./shared-options.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -134,6 +135,13 @@ export async function runApply(
       })
     ) {
       await writeProjectConfig(destDir, { harness });
+    }
+
+    // After a real apply, surface (read-only) whether any locally-authored
+    // agent definitions need cross-pollinating to the project's other agents.
+    // Never writes here — the emit stays behind the explicit skill/command.
+    if (!options.validate && !dryRun) {
+      await nudgeCrossPollinate(destDir, getLisaDir(), logger);
     }
   } catch (error) {
     logger.error(error instanceof Error ? error.message : String(error));

--- a/src/cli/cross-pollinate-cmd.ts
+++ b/src/cli/cross-pollinate-cmd.ts
@@ -1,0 +1,74 @@
+/**
+ * `lisa cross-pollinate [path]` — run the deterministic cross-pollination engine
+ * over a host project, making its locally-authored agent definitions available
+ * in the formats of the other agents the project's harness includes.
+ *
+ * This is the CLI surface for the engine bundled at
+ * `plugins/lisa/scripts/cross-pollinate.mjs`; the `/lisa:cross-pollinate` skill
+ * layers in the judgment-heavy translations the engine reports as `pending`.
+ * Default is dry-run; pass `--write` to apply and update the provenance lockfile.
+ * @module cli/cross-pollinate-cmd
+ */
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { ConsoleLogger } from "../logging/index.js";
+import { toAbsolutePath } from "../utils/path-utils.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Options for {@link runCrossPollinate}. */
+export interface CrossPollinateOptions {
+  /** When true, write emits and update the lockfile; otherwise report only. */
+  readonly write?: boolean;
+}
+
+/** Minimal shape of the bundled engine module. */
+interface Engine {
+  readonly plan: (root: string) => unknown;
+  readonly apply: (p: unknown, opts: { dryRun: boolean }) => unknown;
+  readonly renderReport: (p: unknown, result: unknown) => string;
+}
+
+/**
+ * Resolve and dynamically import the bundled cross-pollinate engine.
+ * @returns The engine module.
+ */
+async function loadEngine(): Promise<Engine> {
+  const enginePath = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "plugins",
+    "lisa",
+    "scripts",
+    "cross-pollinate.mjs"
+  );
+  return (await import(pathToFileURL(enginePath).href)) as unknown as Engine;
+}
+
+/**
+ * Run cross-pollination against a destination project.
+ * @param destination - Project path (defaults to the current directory)
+ * @param options - CLI options
+ */
+export async function runCrossPollinate(
+  destination: string | undefined,
+  options: CrossPollinateOptions
+): Promise<void> {
+  const destDir = toAbsolutePath(destination ?? ".");
+  const logger = new ConsoleLogger();
+  const dryRun = options.write !== true;
+
+  try {
+    const engine = await loadEngine();
+    const plan = engine.plan(destDir);
+    const result = engine.apply(plan, { dryRun });
+    logger.info(engine.renderReport(plan, result));
+    if (dryRun) {
+      logger.info("\n(dry-run — pass --write to apply; default is dry-run)");
+    }
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/cli/cross-pollinate-nudge.ts
+++ b/src/cli/cross-pollinate-nudge.ts
@@ -1,0 +1,81 @@
+/**
+ * Read-only cross-pollination nudge for `lisa apply`.
+ *
+ * The cross-pollinate engine (`plugins/lisa/scripts/cross-pollinate.mjs`) keeps
+ * a host project's locally-authored agent definitions in sync across every
+ * agent the project's harness includes. `apply` runs here in PLAN mode only —
+ * it never writes — and prints a one-line suggestion to run
+ * `/lisa:cross-pollinate` (or `lisa cross-pollinate --write`) when it detects
+ * work to do. Writing agent files from `apply` would be a silent, outward-facing
+ * mutation (apply also runs during `postinstall`), so the actual emit stays
+ * behind explicit user intent.
+ *
+ * Every failure here is non-fatal: a missing engine, an unreadable project, or a
+ * malformed plan must never break an otherwise-successful apply.
+ * @module cli/cross-pollinate-nudge
+ */
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { ILogger } from "../logging/index.js";
+
+/** Shape of the plan object returned by the bundled engine's `plan()`. */
+interface CrossPollinationPlan {
+  readonly targetAgents: readonly string[];
+  readonly emits: ReadonlyArray<{ readonly reason: string }>;
+  readonly pending: readonly unknown[];
+  readonly conflicts: readonly unknown[];
+  readonly orphans: readonly unknown[];
+}
+
+/**
+ * Run the cross-pollinate engine in read-only plan mode and log a nudge when it
+ * finds actionable work. Never throws.
+ * @param destDir - Absolute path to the applied project root
+ * @param lisaDir - Absolute path to the Lisa package/repo root (holds plugins/)
+ * @param logger - Logger for the suggestion line
+ */
+export async function nudgeCrossPollinate(
+  destDir: string,
+  lisaDir: string,
+  logger: ILogger
+): Promise<void> {
+  try {
+    const enginePath = path.join(
+      lisaDir,
+      "plugins",
+      "lisa",
+      "scripts",
+      "cross-pollinate.mjs"
+    );
+    const engine = (await import(pathToFileURL(enginePath).href)) as {
+      plan?: (root: string) => CrossPollinationPlan;
+    };
+    if (typeof engine.plan !== "function") {
+      return;
+    }
+    const plan = engine.plan(destDir);
+    const pendingEmits = plan.emits.filter(
+      e => e.reason !== "up-to-date"
+    ).length;
+    const actionable =
+      pendingEmits +
+      plan.pending.length +
+      plan.conflicts.length +
+      plan.orphans.length;
+    if (actionable === 0) {
+      return;
+    }
+    const bits = [
+      pendingEmits ? `${pendingEmits} to sync` : "",
+      plan.pending.length ? `${plan.pending.length} need translation` : "",
+      plan.conflicts.length ? `${plan.conflicts.length} conflicts` : "",
+      plan.orphans.length ? `${plan.orphans.length} orphaned` : "",
+    ].filter(Boolean);
+    logger.info(
+      `Cross-pollination: ${bits.join(", ")} across [${plan.targetAgents.join(", ")}]. ` +
+        `Run /lisa:cross-pollinate (or: lisa cross-pollinate . --write) to update.`
+    );
+  } catch {
+    // Non-fatal: never let a nudge break apply.
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,9 @@
 import { Command } from "commander";
 import { runApply } from "./apply.js";
+import {
+  type CrossPollinateOptions,
+  runCrossPollinate,
+} from "./cross-pollinate-cmd.js";
 import { runDoctor } from "./doctor.js";
 import { printUpdateWarning } from "./print-update-warning.js";
 import { runSetupProject } from "./setup-project.js";
@@ -29,6 +33,8 @@ export interface ProgramDependencies {
   runUpdate: typeof runUpdate;
   /** Diagnoses Lisa project health. */
   runDoctor: typeof runDoctor;
+  /** Cross-pollinates locally-authored agent definitions across the fleet. */
+  runCrossPollinate: typeof runCrossPollinate;
   /** Runs the non-fatal npm update check (defaults to {@link runUpdateCheck}). */
   runUpdateCheck: typeof runUpdateCheck;
   /** Prints the update warning (defaults to {@link printUpdateWarning}). */
@@ -42,6 +48,7 @@ const DEFAULT_DEPENDENCIES: ProgramDependencies = {
   runVersion,
   runUpdate,
   runDoctor,
+  runCrossPollinate,
   runUpdateCheck,
   printUpdateWarning,
 };
@@ -85,6 +92,22 @@ function addMaintenanceCommands(
     .action(async (targetPath: string | undefined, options) => {
       await deps.runDoctor(targetPath, options);
     });
+
+  program
+    .command("cross-pollinate")
+    .description(
+      "Make locally-authored agent definitions available to the other agents this project supports"
+    )
+    .argument("[path]", "Project path (default: current directory)")
+    .option("--write", "Apply emits and update the lockfile (default: dry-run)")
+    .action(
+      async (
+        targetPath: string | undefined,
+        options: CrossPollinateOptions
+      ) => {
+        await deps.runCrossPollinate(targetPath, options);
+      }
+    );
 
   return program;
 }

--- a/tests/unit/scripts/cross-pollinate.test.ts
+++ b/tests/unit/scripts/cross-pollinate.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for plugins/src/base/scripts/cross-pollinate.mjs.
+ *
+ * Exercises the provenance core that makes any-to-any cross-pollination safe:
+ * detection, deterministic emit, idempotency, loop prevention, garbage
+ * collection, drift protection (never clobber a hand-edited target), and
+ * human-authored collision detection.
+ * @module tests/unit/scripts/cross-pollinate
+ */
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  apply,
+  plan,
+} from "../../../plugins/src/base/scripts/cross-pollinate.mjs";
+
+// The engine is plain JS (JSDoc-typed); describe the shapes we assert against.
+/**
+ *
+ */
+interface Emit {
+  readonly logicalId: string;
+  readonly kind: string;
+  readonly to: string;
+  readonly reason?: string;
+}
+/**
+ *
+ */
+interface Plan {
+  readonly targetAgents: readonly string[];
+  readonly sources: ReadonlyArray<{ readonly path: string }>;
+  readonly emits: readonly Emit[];
+  readonly pending: ReadonlyArray<{
+    readonly kind: string;
+    readonly to: string;
+  }>;
+  readonly conflicts: ReadonlyArray<{ readonly logicalId: string }>;
+}
+/**
+ *
+ */
+interface ApplyResult {
+  readonly written: readonly Emit[];
+  readonly skippedDrift: readonly Emit[];
+  readonly gc: readonly string[];
+}
+const planOf = (dir: string): Plan => plan(dir) as Plan;
+const applyOf = (p: Plan, dryRun: boolean): ApplyResult =>
+  apply(p, { dryRun }) as ApplyResult;
+
+const MCP_JSON = ".mcp.json";
+const CURSOR_MCP = ".cursor/mcp.json";
+const LOCKFILE = ".lisa/cross-pollination.lock.json";
+const SKILL_MD_PATH = ".claude/skills/my-skill/SKILL.md";
+const URL = "https://e.x";
+const CODEX = "codex";
+const LISA_CONFIG = ".lisa.config.json";
+const MCP_ID = "mcp:project";
+const SKILL_MD = [
+  "---",
+  "name: my-skill",
+  'description: "Do a thing. Detail."',
+  "---",
+  "# My Skill",
+  "Body.",
+].join("\n");
+const mcp = (servers: Record<string, unknown>): string =>
+  JSON.stringify({ mcpServers: servers });
+
+let root: string;
+
+// Write a file under the project root, creating parent dirs.
+const put = (rel: string, contents: string): void => {
+  const abs = path.join(root, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+};
+
+// Read a file relative to the project root.
+const read = (rel: string): string =>
+  readFileSync(path.join(root, rel), "utf8");
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "xpollinate-"));
+  put(LISA_CONFIG, JSON.stringify({ harness: "fleet" }));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("cross-pollinate detection + emit", () => {
+  it("derives the Codex openai.yaml sidecar from a Claude skill", () => {
+    put(SKILL_MD_PATH, SKILL_MD);
+
+    const result = applyOf(planOf(root), false);
+
+    expect(result.written.some(w => w.to === CODEX)).toBe(true);
+    const yaml = read(".claude/skills/my-skill/agents/openai.yaml");
+    expect(yaml).toContain('display_name: "My Skill"');
+    expect(yaml).toContain("$my-skill");
+  });
+
+  it("translates a Claude rule into a Cursor .mdc with frontmatter", () => {
+    put(
+      ".claude/rules/style.md",
+      "# Style Guide\n\nUse tabs. See [api](api.md)."
+    );
+
+    apply(plan(root), { dryRun: false });
+
+    const mdc = read(".cursor/rules/style.mdc");
+    expect(mdc).toContain('description: "Style Guide"');
+    expect(mdc).toContain("alwaysApply: true");
+    // Intra-rule link extension rewritten to the Cursor format.
+    expect(mdc).toContain("(api.mdc)");
+  });
+
+  it("translates a Cursor .mdc rule into a plain Claude .md", () => {
+    put(
+      ".cursor/rules/x.mdc",
+      '---\ndescription: "X"\nalwaysApply: true\n---\n\n# X\n\nBody [y](y.mdc).'
+    );
+
+    apply(plan(root), { dryRun: false });
+
+    const md = read(".claude/rules/x.md");
+    expect(md).not.toContain("alwaysApply"); // frontmatter stripped
+    expect(md).toContain("# X");
+    expect(md).toContain("(y.md)");
+  });
+
+  it("reshapes a Claude .mcp.json into the Cursor mcp.json location", () => {
+    put(MCP_JSON, mcp({ x: { type: "http", url: URL } }));
+
+    applyOf(planOf(root), false);
+
+    const cursor = JSON.parse(read(CURSOR_MCP));
+    expect(cursor.mcpServers.x.url).toBe(URL);
+  });
+
+  it("records every emit in the committed lockfile", () => {
+    put(SKILL_MD_PATH, SKILL_MD);
+
+    applyOf(planOf(root), false);
+
+    const lock = JSON.parse(read(LOCKFILE));
+    expect(lock.version).toBe(1);
+    expect(lock.entries["skill:my-skill"].targets[0].agent).toBe("codex");
+    expect(lock.entries["skill:my-skill"].targets[0].generatedHash).toMatch(
+      /^[a-f0-9]{64}$/
+    );
+  });
+
+  it("writes nothing in dry-run mode", () => {
+    put(MCP_JSON, mcp({}));
+
+    const result = applyOf(planOf(root), true);
+
+    expect(result.written.length).toBeGreaterThan(0);
+    expect(() => read(CURSOR_MCP)).toThrow();
+    expect(() => read(LOCKFILE)).toThrow();
+  });
+});
+
+describe("cross-pollinate invariants", () => {
+  it("is idempotent — a second run writes nothing", () => {
+    put(SKILL_MD_PATH, SKILL_MD);
+    put(MCP_JSON, mcp({ x: { url: URL } }));
+
+    applyOf(planOf(root), false);
+    const replan = planOf(root);
+    const second = applyOf(replan, false);
+
+    expect(second.written.length).toBe(0);
+    // The plan itself must converge — no emit left in a non-up-to-date state.
+    // (A natively-consuming agent like OpenCode must not perpetually re-flag.)
+    expect(replan.emits.every(e => e.reason === "up-to-date")).toBe(true);
+  });
+
+  it("prevents loops — a generated target is never treated as a source", () => {
+    put(MCP_JSON, mcp({ x: { url: URL } }));
+    applyOf(planOf(root), false);
+
+    // The generated .cursor/mcp.json must not appear as a fresh source.
+    const replan = planOf(root);
+    expect(replan.sources.find(s => s.path === CURSOR_MCP)).toBeUndefined();
+  });
+
+  it("garbage-collects targets when the source is removed", () => {
+    put(MCP_JSON, mcp({ x: { url: URL } }));
+    applyOf(planOf(root), false);
+    expect(read(CURSOR_MCP)).toContain(URL);
+
+    rmSync(path.join(root, MCP_JSON));
+    const result = applyOf(planOf(root), false);
+
+    expect(result.gc).toContain(CURSOR_MCP);
+    expect(() => read(CURSOR_MCP)).toThrow();
+    const lock = JSON.parse(read(LOCKFILE));
+    expect(lock.entries[MCP_ID]).toBeUndefined();
+  });
+
+  it("never clobbers a hand-edited (drifted) target", () => {
+    put(MCP_JSON, mcp({ x: { url: URL } }));
+    applyOf(planOf(root), false);
+
+    // Human edits the generated Cursor file, and the source also changes.
+    put(CURSOR_MCP, mcp({ x: { url: "https://EDITED" } }));
+    put(MCP_JSON, mcp({ x: { url: URL, note: "changed" } }));
+
+    const result = applyOf(planOf(root), false);
+
+    expect(result.skippedDrift.some(s => s.to === "cursor")).toBe(true);
+    expect(read(CURSOR_MCP)).toContain("EDITED");
+  });
+
+  it("reports a human-authored collision instead of translating over it", () => {
+    // Same logicalId authored independently in two agents (neither generated).
+    put(MCP_JSON, mcp({ a: {} }));
+    put(CURSOR_MCP, mcp({ b: {} }));
+
+    const p = planOf(root);
+
+    expect(p.conflicts.some(c => c.logicalId === MCP_ID)).toBe(true);
+    expect(p.emits.some(e => e.logicalId === MCP_ID)).toBe(false);
+  });
+});
+
+describe("cross-pollinate harness scoping", () => {
+  it("only targets agents the harness includes", () => {
+    rmSync(path.join(root, LISA_CONFIG));
+    put(LISA_CONFIG, JSON.stringify({ harness: "both" }));
+    put(SKILL_MD_PATH, SKILL_MD);
+
+    const p = planOf(root);
+
+    expect(p.targetAgents).toEqual(["claude", "codex"]);
+    expect(p.pending.every(x => ["claude", "codex"].includes(x.to))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a distributable **/lisa:cross-pollinate** skill + **lisa cross-pollinate** CLI that detects a host project's locally-authored coding-agent definitions (skills, subagents, rules, commands, hooks, MCP) and regenerates each in the formats of the **other** agents the project supports, as declared in `.lisa.config.json` `harness`.

A host project that installs Lisa may hand-author a definition for one agent (a `.claude/skills/foo`, a `.cursor/rules/bar.mdc`, an MCP server). This keeps the whole fleet in parity with whatever a developer wrote for any single agent.

## Architecture

```
any agent's format  ->  Claude-format IR  ->  every OTHER configured agent
```

Claude format is the IR because every existing Lisa generator already sources from it, so fan-out reuses those transforms instead of an N×N translator matrix.

## Provenance (the load-bearing design)

A committed lockfile `.lisa/cross-pollination.lock.json` is authoritative — path heuristics can't tell a generated translation from a hand-authored original (both live in the same per-agent dir). It enforces four invariants:

1. **No loops** — a recorded target is never re-ingested as a source.
2. **GC** — source deleted/renamed → orphaned targets removed.
3. **Never clobbers edits** — a target whose hash drifts from the recorded one was hand-edited; skipped + reported, not overwritten.
4. **Idempotent** — converges to zero writes.

It also detects **conflicts** (same logical definition authored independently in two agents) and reports rather than auto-resolving.

## Scope

- **Deterministic emitters:** skills (Codex `openai.yaml` sidecar), MCP (Claude↔Cursor), rules (Claude `.md` ↔ Cursor `.mdc`).
- **Reported `pending`** (skill translates with judgment): subagents, commands, hooks, and the `AGENTS.md`/Copilot rule targets — deliberately not written to unverified paths.

## Triggers

- Standalone: `lisa cross-pollinate [path] [--write]` (default dry-run) + the `/lisa:cross-pollinate` skill.
- `lisa apply`: **read-only** nudge that flags work but never writes (apply also runs during `postinstall`).

## Tests

12 provenance-invariant tests (loops, GC, drift protection, conflict detection, idempotency, harness scoping, rule + skill + MCP translation). Full suite green; `check:plugins` in sync.

🤖 Generated with Claude Code