### PR TITLE
fix: relax automation dirty tree preflight

### DIFF
--- a/plugins/lisa-agy/skills/setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/setup-automations/SKILL.md
@@ -45,11 +45,15 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
-Before running the Lisa command, each automation must sync its checkout: fetch the default remote
-branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
-If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
-the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
-the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
+Before running the Lisa command, each automation must attempt to sync its checkout.
+Fetch the default remote branch, then rebase onto `origin/main` or the resolved default branch. If
+the checkout is already on the default branch, fast-forward/rebase it to the remote default. A dirty
+working tree is not by itself a blocker: capture
+`git status --short --branch`,
+leave pre-existing changes untouched, and continue when the sync and selected Lisa command can run
+without overwriting those paths. Abort only when Git reports an actual sync conflict or the selected
+command would need to modify an already-dirty path; in that case leave queue state unchanged and
+report the exact conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-copilot/skills/setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/setup-automations/SKILL.md
@@ -45,11 +45,15 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
-Before running the Lisa command, each automation must sync its checkout: fetch the default remote
-branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
-If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
-the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
-the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
+Before running the Lisa command, each automation must attempt to sync its checkout.
+Fetch the default remote branch, then rebase onto `origin/main` or the resolved default branch. If
+the checkout is already on the default branch, fast-forward/rebase it to the remote default. A dirty
+working tree is not by itself a blocker: capture
+`git status --short --branch`,
+leave pre-existing changes untouched, and continue when the sync and selected Lisa command can run
+without overwriting those paths. Abort only when Git reports an actual sync conflict or the selected
+command would need to modify an already-dirty path; in that case leave queue state unchanged and
+report the exact conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-cursor/skills/setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/setup-automations/SKILL.md
@@ -45,11 +45,15 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
-Before running the Lisa command, each automation must sync its checkout: fetch the default remote
-branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
-If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
-the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
-the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
+Before running the Lisa command, each automation must attempt to sync its checkout.
+Fetch the default remote branch, then rebase onto `origin/main` or the resolved default branch. If
+the checkout is already on the default branch, fast-forward/rebase it to the remote default. A dirty
+working tree is not by itself a blocker: capture
+`git status --short --branch`,
+leave pre-existing changes untouched, and continue when the sync and selected Lisa command can run
+without overwriting those paths. Abort only when Git reports an actual sync conflict or the selected
+command would need to modify an already-dirty path; in that case leave queue state unchanged and
+report the exact conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-setup-automations/SKILL.md
@@ -43,11 +43,14 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
-Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
-rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
-checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
-rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
-rebase and report the blocker instead of ingesting from stale code.
+Before running the ingest, the automation must attempt to sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. A
+dirty working tree is not by itself a blocker: capture `git status --short --branch`, leave
+pre-existing changes untouched, and continue when sync and ingest can run without overwriting those
+paths. Abort only when Git reports an actual sync conflict or ingest would need to modify an
+already-dirty path; in that case leave existing queue/wiki state unchanged and report the exact
+conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-setup-automations/SKILL.md
@@ -43,11 +43,14 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
-Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
-rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
-checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
-rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
-rebase and report the blocker instead of ingesting from stale code.
+Before running the ingest, the automation must attempt to sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. A
+dirty working tree is not by itself a blocker: capture `git status --short --branch`, leave
+pre-existing changes untouched, and continue when sync and ingest can run without overwriting those
+paths. Abort only when Git reports an actual sync conflict or ingest would need to modify an
+already-dirty path; in that case leave existing queue/wiki state unchanged and report the exact
+conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-setup-automations/SKILL.md
@@ -43,11 +43,14 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
-Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
-rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
-checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
-rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
-rebase and report the blocker instead of ingesting from stale code.
+Before running the ingest, the automation must attempt to sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. A
+dirty working tree is not by itself a blocker: capture `git status --short --branch`, leave
+pre-existing changes untouched, and continue when sync and ingest can run without overwriting those
+paths. Abort only when Git reports an actual sync conflict or ingest would need to modify an
+already-dirty path; in that case leave existing queue/wiki state unchanged and report the exact
+conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -43,11 +43,14 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
-Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
-rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
-checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
-rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
-rebase and report the blocker instead of ingesting from stale code.
+Before running the ingest, the automation must attempt to sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. A
+dirty working tree is not by itself a blocker: capture `git status --short --branch`, leave
+pre-existing changes untouched, and continue when sync and ingest can run without overwriting those
+paths. Abort only when Git reports an actual sync conflict or ingest would need to modify an
+already-dirty path; in that case leave existing queue/wiki state unchanged and report the exact
+conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/lisa/skills/setup-automations/SKILL.md
+++ b/plugins/lisa/skills/setup-automations/SKILL.md
@@ -45,11 +45,15 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
-Before running the Lisa command, each automation must sync its checkout: fetch the default remote
-branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
-If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
-the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
-the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
+Before running the Lisa command, each automation must attempt to sync its checkout.
+Fetch the default remote branch, then rebase onto `origin/main` or the resolved default branch. If
+the checkout is already on the default branch, fast-forward/rebase it to the remote default. A dirty
+working tree is not by itself a blocker: capture
+`git status --short --branch`,
+leave pre-existing changes untouched, and continue when the sync and selected Lisa command can run
+without overwriting those paths. Abort only when Git reports an actual sync conflict or the selected
+command would need to modify an already-dirty path; in that case leave queue state unchanged and
+report the exact conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/src/base/skills/setup-automations/SKILL.md
+++ b/plugins/src/base/skills/setup-automations/SKILL.md
@@ -45,11 +45,15 @@ affect **only** the two exploratory automations.
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy
 (never ask before running; exit cleanly when the queue is idle; report the cycle summary).
-Before running the Lisa command, each automation must sync its checkout: fetch the default remote
-branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
-If the checkout is already on the default branch, fast-forward/rebase it to the remote default. If
-the rebase has conflicts or the working tree is dirty in a way the automation did not create, abort
-the rebase, leave queue state unchanged, and report the blocker instead of running on stale code.
+Before running the Lisa command, each automation must attempt to sync its checkout.
+Fetch the default remote branch, then rebase onto `origin/main` or the resolved default branch. If
+the checkout is already on the default branch, fast-forward/rebase it to the remote default. A dirty
+working tree is not by itself a blocker: capture
+`git status --short --branch`,
+leave pre-existing changes untouched, and continue when the sync and selected Lisa command can run
+without overwriting those paths. Abort only when Git reports an actual sync conflict or the selected
+command would need to modify an already-dirty path; in that case leave queue state unchanged and
+report the exact conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|

--- a/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-setup-automations/SKILL.md
@@ -43,11 +43,14 @@ independent and use disjoint name prefixes, so running both is safe.
 The automation runs **one cycle** of the full wiki ingest and respects that command's own confirmation
 and commit/PR policy (never ask before running; run a full ingest across every enabled
 non-external-write source; commit/PR per the ingest skill's bookends; report the cycle summary).
-Before running the ingest, the automation must sync its checkout: fetch the default remote branch and
-rebase the current automation branch onto it (for the common GitHub case, `origin/main`). If the
-checkout is already on the default branch, fast-forward/rebase it to the remote default. If the
-rebase has conflicts or the working tree is dirty in a way the automation did not create, abort the
-rebase and report the blocker instead of ingesting from stale code.
+Before running the ingest, the automation must attempt to sync its checkout: fetch the default remote
+branch and rebase the current automation branch onto it (for the common GitHub case, `origin/main`).
+If the checkout is already on the default branch, fast-forward/rebase it to the remote default. A
+dirty working tree is not by itself a blocker: capture `git status --short --branch`, leave
+pre-existing changes untouched, and continue when sync and ingest can run without overwriting those
+paths. Abort only when Git reports an actual sync conflict or ingest would need to modify an
+already-dirty path; in that case leave existing queue/wiki state unchanged and report the exact
+conflicting path(s).
 
 | Automation | Command it runs | Cadence |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Clarifies Lisa setup-automations so dirty working-tree state alone does not block intake/repair automations
- Keeps pre-existing changes protected and only stops for actual sync conflicts or selected-command path conflicts
- Applies the same guidance to wiki automation setup and regenerates plugin variants

## Reviewer replay
1. Open `plugins/src/base/skills/setup-automations/SKILL.md`.
2. Confirm the automation preflight says to record dirty state and continue when sync/command execution will not overwrite those paths.
3. Confirm it only stops for actual sync conflicts or when the selected command needs an already-dirty path.
4. Run `bun run check:plugins` to verify generated plugin outputs stay in sync.

## Verification
- `bun run build:plugins`
- `bun vitest run tests/unit/strategies/automations-skills.test.ts`
- `bun run check:plugins`
- Pre-push hook: `bun audit`, slow lint, `knip`, `vitest run --coverage`, and integration tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated automation Git synchronization behavior across all Lisa plugins to be more tolerant of existing local changes. Automations now preserve pre-existing modifications and continue running when safe, aborting only on genuine sync conflicts or when the automation would overwrite already-modified paths. Improved clarity on conflict reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->