### PR TITLE
fix(expo): pin apollo-link-sentry to exactly 4.4.0 (Apollo v3 + Sentry v8)

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -56,7 +56,7 @@
     "dependencies": {
       "@apollo/client": "^3.10.8",
       "@hookform/resolvers": "^3.9.0",
-      "apollo-link-sentry": "^3.3.0",
+      "apollo-link-sentry": "4.4.0",
       "base-64": "^1.0.0",
       "date-fns": "^3.6.0",
       "date-fns-tz": "^3.1.3",

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -822,16 +822,20 @@ describe("PackageLisaStrategy", () => {
       const template = readExpoTemplate();
       // Pure JS tooling stays forced (governance-critical).
       expect(template.force.dependencies["@apollo/client"]).toBeDefined();
-      // The forced apollo-link-sentry range must stay on the 3.x line so its
-      // `@apollo/client` peer (`^3.2.3`) is satisfiable by the forced
-      // `@apollo/client` major (v3). apollo-link-sentry 4.5.0 bumped that peer
-      // to `@apollo/client@^4.0.10`, so a `^4.0.0` pin let a fresh, lockfile-less
-      // Expo install resolve an apollo pair where SentryLink fails to typecheck
-      // against @apollo/client v3 (blocked expostarter).
+      // apollo-link-sentry must be pinned to EXACTLY 4.4.0 — it is the only
+      // release that satisfies BOTH forced majors simultaneously:
+      //   - @apollo/client v3 (forced): 4.5.0 bumped its peer to
+      //     `@apollo/client@^4.0.10`, so any >=4.5.0 (incl. a `^4.0.0` range)
+      //     makes SentryLink fail to typecheck against v3 (blocked expostarter).
+      //   - @sentry/react-native ~7.x (Sentry v8 SDK): the 3.x line imports and
+      //     calls `Sentry.configureScope`, which Sentry v8 REMOVED — so 3.3.0
+      //     throws `(0, t.configureScope) is not a function` on EVERY GraphQL
+      //     request at runtime (broke geminisportsai/frontend-v2 in dev and the
+      //     prod path of expostarter/thumbwar where the Sentry DSN is set).
+      // 4.4.0 (Apollo v3 peer + Sentry v8 API) is the only compatible version,
+      // so it is pinned exactly — a range re-opens one failure mode or the other.
       expect(template.force.dependencies["@apollo/client"]).toMatch(/^\^?3\./);
-      expect(template.force.dependencies["apollo-link-sentry"]).toMatch(
-        /^\^?3\./
-      );
+      expect(template.force.dependencies["apollo-link-sentry"]).toBe("4.4.0");
       expect(template.force.dependencies["zod"]).toBeDefined();
       expect(template.force.dependencies["tailwindcss"]).toBeDefined();
       expect(template.force.devDependencies["jest"]).toBeDefined();


### PR DESCRIPTION
## Why
The Expo template forces `apollo-link-sentry: ^3.3.0`. That's **broken at runtime** under the template's Sentry v8 SDK (`@sentry/react-native ~7.x`): the 3.x line imports and calls `Sentry.configureScope`, which **Sentry v8 removed**, so `SentryLink` throws `(0, t.configureScope) is not a function` on **every GraphQL request** → the app renders no data.

This already shipped and broke:
- **geminisportsai/frontend-v2** (dev — unconditional `SentryLink`) — fixed in their #5068
- **expostarter** / **gunnertech/thumbwar-frontend** (prod/staging path — `SentryLink` is instantiated when `EXPO_PUBLIC_SENTRY_DSN` is set) — fixed in their PRs

But `^4.0.0` is **also** broken (the reason it was reverted to 3.x): **4.5.0** bumped its peer to `@apollo/client@^4.0.10`, which fails to typecheck against the template's forced `@apollo/client` v3.

## The fix
**4.4.0 is the only release compatible with both forced majors** (peerDeps: `@apollo/client ^3.2.3`, `@sentry/core ^8.33 || ^9 || ^10`). Pin it **exactly** — a range re-opens one failure mode or the other:
- `>= 4.5.0` (incl. `^4.0.0`) → Apollo v4 peer → typecheck break on v3
- `3.x` → calls removed `configureScope` → runtime GraphQL break on Sentry v8

Updates the `package-lisa.test.ts` governance assertion (was `/^\^?3\./` → now `toBe("4.4.0")`) with the full reasoning. `vitest run` passes (33/33).

## Impact
This stops the regression from recurring across every Expo repo on the template (the bootstrap re-applies this pin into each repo's `package.json`). Long-term, when consumers move to `@apollo/client` v4, this pin should move to `apollo-link-sentry` ^4.5.0+.

🤖 Generated with Claude Code