### PR TITLE
fix(typescript): ignore .opencode overlay in eslint/prettier gates

### DIFF
--- a/typescript/copy-overwrite/.prettierignore
+++ b/typescript/copy-overwrite/.prettierignore
@@ -36,3 +36,8 @@ amplify
 # scalars) and are not source formatting inputs. Keep them out of format gates.
 # No-op for projects without a Codex mirror.
 .codex
+
+# Lisa also regenerates the OpenCode distribution mirror (.opencode/) on every
+# run. Same generated-output rationale as .codex above.
+# No-op for projects without an OpenCode mirror.
+.opencode

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -49,6 +49,7 @@
 
     ".expo/**",
     ".codex/**",
+    ".opencode/**",
     ".github/**",
     "public/**",
     ".dead/**",


### PR DESCRIPTION
## Problem

Lisa now emits the `.opencode/` distribution mirror (agents, commands, skills, plugins) alongside `.codex/`. But the managed `typescript/copy-overwrite/eslint.ignore.config.json` and `.prettierignore` templates only excluded `.codex`.

As a result, **every host project that runs `lisa apply` after the OpenCode overlay landed** gets the generated `.opencode/**/*.ts` and `.mjs`/`.js` artifacts linted, which fails the pre-commit eslint gate on vendored output that isn't a source-formatting input. Example failures observed in a host repo on upgrade to 2.155.2:

```
.opencode/plugin/lisa-session-bootstrap.ts
  0:0  error  Parsing error: ... TSConfig does not include this file ...
.opencode/skills/lisa/.../scripts/*.mjs|*.js
  error  Unexpected let, use const instead          functional/no-let
  error  Missing JSDoc @returns declaration         jsdoc/require-returns
  ...
```

Because `eslint.ignore.config.json` is a `copy-overwrite` template, a host-side workaround is clobbered on the next `lisa apply` — so the fix has to live here.

## Fix

Add `.opencode` to both ignore templates, mirroring the existing `.codex` treatment. The overlay is generated output and should be excluded the same way it's generated.

## Verification

- `tsc --noEmit` ✅
- Host repo (advisory-rankings) confirmed pre-commit eslint/prettier gate passes once `.opencode/**` is ignored (CodySwannGT/advisory-rankings#1046 carries the equivalent local stopgap pending this release).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated formatting and linting configurations to exclude auto-regenerated distribution-mirror directories (e.g., generated output like .codex/.opencode) from Prettier and ESLint checks, ensuring generated files are not subject to style or lint gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->