### PR TITLE
fix(sync-down): no-op chain when all deploy.branches collapse to one branch

### DIFF
--- a/.github/workflows/reusable-claude-sync-down-branches.yml
+++ b/.github/workflows/reusable-claude-sync-down-branches.yml
@@ -62,6 +62,12 @@ jobs:
           # next-lower env's branch via `deploy.branches`. This is the inverse of
           # the promotion order: a hotfix landing on the production branch
           # back-syncs to staging, staging back-syncs to dev.
+          #
+          # If every environment maps to the SAME branch (e.g. dev/staging/
+          # production all -> main, a single-branch repo), there is nothing to
+          # back-sync: the chain is the empty no-op `{}` and `deploy.order` is
+          # not required. `deploy.order` is only needed when `deploy.branches`
+          # resolves to more than one DISTINCT branch.
           if [ ! -f .lisa.config.json ]; then
             echo "::error::No chain input and no .lisa.config.json found — cannot derive a sync chain. Pass the chain input explicitly or add deploy.order + deploy.branches to .lisa.config.json."
             exit 1
@@ -72,6 +78,7 @@ jobs:
             | ($b | keys | sort) as $bk
             | ($o | sort) as $ok
             | if ($b | length) <= 1 then "{}"
+              elif (($b | [.[]] | unique | length) <= 1) then "{}"
               elif ($o | length) == 0 then "ERR_NO_ORDER"
               elif ($bk != $ok) then "ERR_MISMATCH"
               else ($o | reverse) as $hl

--- a/plugins/lisa-agy/skills/doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/doctor/SKILL.md
@@ -104,8 +104,12 @@ this order:
 6. **Deploy env-order audit** (only when `deploy.branches` is present)
    - `PASS` (or skip) when `deploy.branches` defines a single environment — `deploy.order` is
      optional and the back-sync chain is empty.
-   - `WARN` when `deploy.branches` defines **more than one** environment but `deploy.order` is
-     absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
+   - `PASS` (or skip) when `deploy.branches` defines multiple environments that all map to the
+     **same** branch (e.g. `dev`/`staging`/`production` all → `main`). The branches resolve to a
+     single distinct branch, so there is nothing to back-sync, the chain is the empty no-op, and
+     `deploy.order` is not required. Do not WARN.
+   - `WARN` when `deploy.branches` resolves to **more than one distinct** branch but `deploy.order`
+     is absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
      source→target chain without the env ranking; the repo must either add `deploy.order`
      (low→high, e.g. `["dev","staging","production"]`) or pass an explicit `chain` in its
      `claude-sync-down-branches.yml` wrapper. WARN not FAIL because the explicit-chain override is

--- a/plugins/lisa-agy/skills/sync-down/SKILL.md
+++ b/plugins/lisa-agy/skills/sync-down/SKILL.md
@@ -44,6 +44,7 @@ CHAIN=$(jq -e -r '
   | ($b | keys | sort) as $bk
   | ($o | sort) as $ok
   | if ($b | length) <= 1 then "{}"
+    elif (($b | [.[]] | unique | length) <= 1) then "{}"
     elif ($o | length) == 0 then "ERR_NO_ORDER"
     elif ($bk != $ok) then "ERR_MISMATCH"
     else ($o | reverse) as $hl
@@ -53,12 +54,16 @@ CHAIN=$(jq -e -r '
 ' .lisa.config.json)
 ```
 
-- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments but
-  `deploy.order` is missing. Tell the user to add `deploy.order` (low→high, e.g.
-  `["dev","staging","production"]`). Do not guess the ranking.
+- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments mapped to
+  more than one distinct branch but `deploy.order` is missing. Tell the user to
+  add `deploy.order` (low→high, e.g. `["dev","staging","production"]`). Do not
+  guess the ranking.
 - `ERR_MISMATCH` → stop: `deploy.order` and `deploy.branches` name different
   environments. They must match exactly.
-- `{}` (single-environment project) → nothing to sync; report and exit cleanly.
+- `{}` → nothing to sync; report and exit cleanly. This covers both a
+  single-environment project and a multi-environment project whose branches all
+  resolve to the **same** branch (e.g. dev/staging/production all → `main`), where
+  `deploy.order` is not required.
 
 ### 2. Resolve the source branch
 

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -404,9 +404,15 @@ Rules:
 
 - **Single-environment projects** (one entry in `deploy.branches`) may omit
   `deploy.order`; the derived chain is empty and the back-sync no-ops.
-- **Multi-environment projects MUST set `deploy.order`** for config-driven
-  back-sync. If it is absent, the Action fails rather than guessing the rank
-  (or the workflow wrapper must pass an explicit `chain`, which always wins).
+- **Projects whose environments all map to the same branch** (e.g.
+  `dev`/`staging`/`production` all → `main`) may also omit `deploy.order`: the
+  branches resolve to a single distinct branch, so there is nothing to back-sync
+  and the derived chain is the empty no-op. `deploy.order` is only required when
+  `deploy.branches` resolves to **more than one distinct branch**.
+- **Multi-branch projects MUST set `deploy.order`** for config-driven back-sync.
+  If `deploy.branches` resolves to more than one distinct branch and `deploy.order`
+  is absent, the Action fails rather than guessing the rank (or the workflow
+  wrapper must pass an explicit `chain`, which always wins).
 - The env-name set of `deploy.order` and `deploy.branches` **must match exactly**
   — every env in one appears in the other. A mismatch is a config error.
 
@@ -475,9 +481,12 @@ Doctor must validate config in three layers:
      and `deploy.branches`.
 
 4. **Deploy env-order correctness**
-   - When `deploy.branches` defines more than one environment but `deploy.order` is absent, `WARN`:
-     config-driven back-sync cannot derive a chain without the ranking (the wrapper must add
-     `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` resolves to more than one **distinct** branch but `deploy.order` is
+     absent, `WARN`: config-driven back-sync cannot derive a chain without the ranking (the wrapper
+     must add `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` defines multiple environments that all map to the **same** branch (e.g.
+     `dev`/`staging`/`production` all → `main`), `deploy.order` is **not** required — the chain is the
+     empty no-op. Do not `WARN` in this case.
    - When `deploy.order` is present but its env names do not exactly match the `deploy.branches`
      keys, `FAIL` — the derived sync-down chain would be wrong or empty.
 

--- a/plugins/lisa-copilot/skills/doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/doctor/SKILL.md
@@ -104,8 +104,12 @@ this order:
 6. **Deploy env-order audit** (only when `deploy.branches` is present)
    - `PASS` (or skip) when `deploy.branches` defines a single environment — `deploy.order` is
      optional and the back-sync chain is empty.
-   - `WARN` when `deploy.branches` defines **more than one** environment but `deploy.order` is
-     absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
+   - `PASS` (or skip) when `deploy.branches` defines multiple environments that all map to the
+     **same** branch (e.g. `dev`/`staging`/`production` all → `main`). The branches resolve to a
+     single distinct branch, so there is nothing to back-sync, the chain is the empty no-op, and
+     `deploy.order` is not required. Do not WARN.
+   - `WARN` when `deploy.branches` resolves to **more than one distinct** branch but `deploy.order`
+     is absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
      source→target chain without the env ranking; the repo must either add `deploy.order`
      (low→high, e.g. `["dev","staging","production"]`) or pass an explicit `chain` in its
      `claude-sync-down-branches.yml` wrapper. WARN not FAIL because the explicit-chain override is

--- a/plugins/lisa-copilot/skills/sync-down/SKILL.md
+++ b/plugins/lisa-copilot/skills/sync-down/SKILL.md
@@ -44,6 +44,7 @@ CHAIN=$(jq -e -r '
   | ($b | keys | sort) as $bk
   | ($o | sort) as $ok
   | if ($b | length) <= 1 then "{}"
+    elif (($b | [.[]] | unique | length) <= 1) then "{}"
     elif ($o | length) == 0 then "ERR_NO_ORDER"
     elif ($bk != $ok) then "ERR_MISMATCH"
     else ($o | reverse) as $hl
@@ -53,12 +54,16 @@ CHAIN=$(jq -e -r '
 ' .lisa.config.json)
 ```
 
-- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments but
-  `deploy.order` is missing. Tell the user to add `deploy.order` (low→high, e.g.
-  `["dev","staging","production"]`). Do not guess the ranking.
+- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments mapped to
+  more than one distinct branch but `deploy.order` is missing. Tell the user to
+  add `deploy.order` (low→high, e.g. `["dev","staging","production"]`). Do not
+  guess the ranking.
 - `ERR_MISMATCH` → stop: `deploy.order` and `deploy.branches` name different
   environments. They must match exactly.
-- `{}` (single-environment project) → nothing to sync; report and exit cleanly.
+- `{}` → nothing to sync; report and exit cleanly. This covers both a
+  single-environment project and a multi-environment project whose branches all
+  resolve to the **same** branch (e.g. dev/staging/production all → `main`), where
+  `deploy.order` is not required.
 
 ### 2. Resolve the source branch
 

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -409,9 +409,15 @@ Rules:
 
 - **Single-environment projects** (one entry in `deploy.branches`) may omit
   `deploy.order`; the derived chain is empty and the back-sync no-ops.
-- **Multi-environment projects MUST set `deploy.order`** for config-driven
-  back-sync. If it is absent, the Action fails rather than guessing the rank
-  (or the workflow wrapper must pass an explicit `chain`, which always wins).
+- **Projects whose environments all map to the same branch** (e.g.
+  `dev`/`staging`/`production` all → `main`) may also omit `deploy.order`: the
+  branches resolve to a single distinct branch, so there is nothing to back-sync
+  and the derived chain is the empty no-op. `deploy.order` is only required when
+  `deploy.branches` resolves to **more than one distinct branch**.
+- **Multi-branch projects MUST set `deploy.order`** for config-driven back-sync.
+  If `deploy.branches` resolves to more than one distinct branch and `deploy.order`
+  is absent, the Action fails rather than guessing the rank (or the workflow
+  wrapper must pass an explicit `chain`, which always wins).
 - The env-name set of `deploy.order` and `deploy.branches` **must match exactly**
   — every env in one appears in the other. A mismatch is a config error.
 
@@ -480,9 +486,12 @@ Doctor must validate config in three layers:
      and `deploy.branches`.
 
 4. **Deploy env-order correctness**
-   - When `deploy.branches` defines more than one environment but `deploy.order` is absent, `WARN`:
-     config-driven back-sync cannot derive a chain without the ranking (the wrapper must add
-     `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` resolves to more than one **distinct** branch but `deploy.order` is
+     absent, `WARN`: config-driven back-sync cannot derive a chain without the ranking (the wrapper
+     must add `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` defines multiple environments that all map to the **same** branch (e.g.
+     `dev`/`staging`/`production` all → `main`), `deploy.order` is **not** required — the chain is the
+     empty no-op. Do not `WARN` in this case.
    - When `deploy.order` is present but its env names do not exactly match the `deploy.branches`
      keys, `FAIL` — the derived sync-down chain would be wrong or empty.
 

--- a/plugins/lisa-cursor/skills/doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/doctor/SKILL.md
@@ -104,8 +104,12 @@ this order:
 6. **Deploy env-order audit** (only when `deploy.branches` is present)
    - `PASS` (or skip) when `deploy.branches` defines a single environment — `deploy.order` is
      optional and the back-sync chain is empty.
-   - `WARN` when `deploy.branches` defines **more than one** environment but `deploy.order` is
-     absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
+   - `PASS` (or skip) when `deploy.branches` defines multiple environments that all map to the
+     **same** branch (e.g. `dev`/`staging`/`production` all → `main`). The branches resolve to a
+     single distinct branch, so there is nothing to back-sync, the chain is the empty no-op, and
+     `deploy.order` is not required. Do not WARN.
+   - `WARN` when `deploy.branches` resolves to **more than one distinct** branch but `deploy.order`
+     is absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
      source→target chain without the env ranking; the repo must either add `deploy.order`
      (low→high, e.g. `["dev","staging","production"]`) or pass an explicit `chain` in its
      `claude-sync-down-branches.yml` wrapper. WARN not FAIL because the explicit-chain override is

--- a/plugins/lisa-cursor/skills/sync-down/SKILL.md
+++ b/plugins/lisa-cursor/skills/sync-down/SKILL.md
@@ -44,6 +44,7 @@ CHAIN=$(jq -e -r '
   | ($b | keys | sort) as $bk
   | ($o | sort) as $ok
   | if ($b | length) <= 1 then "{}"
+    elif (($b | [.[]] | unique | length) <= 1) then "{}"
     elif ($o | length) == 0 then "ERR_NO_ORDER"
     elif ($bk != $ok) then "ERR_MISMATCH"
     else ($o | reverse) as $hl
@@ -53,12 +54,16 @@ CHAIN=$(jq -e -r '
 ' .lisa.config.json)
 ```
 
-- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments but
-  `deploy.order` is missing. Tell the user to add `deploy.order` (low→high, e.g.
-  `["dev","staging","production"]`). Do not guess the ranking.
+- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments mapped to
+  more than one distinct branch but `deploy.order` is missing. Tell the user to
+  add `deploy.order` (low→high, e.g. `["dev","staging","production"]`). Do not
+  guess the ranking.
 - `ERR_MISMATCH` → stop: `deploy.order` and `deploy.branches` name different
   environments. They must match exactly.
-- `{}` (single-environment project) → nothing to sync; report and exit cleanly.
+- `{}` → nothing to sync; report and exit cleanly. This covers both a
+  single-environment project and a multi-environment project whose branches all
+  resolve to the **same** branch (e.g. dev/staging/production all → `main`), where
+  `deploy.order` is not required.
 
 ### 2. Resolve the source branch
 

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -404,9 +404,15 @@ Rules:
 
 - **Single-environment projects** (one entry in `deploy.branches`) may omit
   `deploy.order`; the derived chain is empty and the back-sync no-ops.
-- **Multi-environment projects MUST set `deploy.order`** for config-driven
-  back-sync. If it is absent, the Action fails rather than guessing the rank
-  (or the workflow wrapper must pass an explicit `chain`, which always wins).
+- **Projects whose environments all map to the same branch** (e.g.
+  `dev`/`staging`/`production` all → `main`) may also omit `deploy.order`: the
+  branches resolve to a single distinct branch, so there is nothing to back-sync
+  and the derived chain is the empty no-op. `deploy.order` is only required when
+  `deploy.branches` resolves to **more than one distinct branch**.
+- **Multi-branch projects MUST set `deploy.order`** for config-driven back-sync.
+  If `deploy.branches` resolves to more than one distinct branch and `deploy.order`
+  is absent, the Action fails rather than guessing the rank (or the workflow
+  wrapper must pass an explicit `chain`, which always wins).
 - The env-name set of `deploy.order` and `deploy.branches` **must match exactly**
   — every env in one appears in the other. A mismatch is a config error.
 
@@ -475,9 +481,12 @@ Doctor must validate config in three layers:
      and `deploy.branches`.
 
 4. **Deploy env-order correctness**
-   - When `deploy.branches` defines more than one environment but `deploy.order` is absent, `WARN`:
-     config-driven back-sync cannot derive a chain without the ranking (the wrapper must add
-     `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` resolves to more than one **distinct** branch but `deploy.order` is
+     absent, `WARN`: config-driven back-sync cannot derive a chain without the ranking (the wrapper
+     must add `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` defines multiple environments that all map to the **same** branch (e.g.
+     `dev`/`staging`/`production` all → `main`), `deploy.order` is **not** required — the chain is the
+     empty no-op. Do not `WARN` in this case.
    - When `deploy.order` is present but its env names do not exactly match the `deploy.branches`
      keys, `FAIL` — the derived sync-down chain would be wrong or empty.
 

--- a/plugins/lisa/skills/doctor/SKILL.md
+++ b/plugins/lisa/skills/doctor/SKILL.md
@@ -104,8 +104,12 @@ this order:
 6. **Deploy env-order audit** (only when `deploy.branches` is present)
    - `PASS` (or skip) when `deploy.branches` defines a single environment — `deploy.order` is
      optional and the back-sync chain is empty.
-   - `WARN` when `deploy.branches` defines **more than one** environment but `deploy.order` is
-     absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
+   - `PASS` (or skip) when `deploy.branches` defines multiple environments that all map to the
+     **same** branch (e.g. `dev`/`staging`/`production` all → `main`). The branches resolve to a
+     single distinct branch, so there is nothing to back-sync, the chain is the empty no-op, and
+     `deploy.order` is not required. Do not WARN.
+   - `WARN` when `deploy.branches` resolves to **more than one distinct** branch but `deploy.order`
+     is absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
      source→target chain without the env ranking; the repo must either add `deploy.order`
      (low→high, e.g. `["dev","staging","production"]`) or pass an explicit `chain` in its
      `claude-sync-down-branches.yml` wrapper. WARN not FAIL because the explicit-chain override is

--- a/plugins/lisa/skills/sync-down/SKILL.md
+++ b/plugins/lisa/skills/sync-down/SKILL.md
@@ -44,6 +44,7 @@ CHAIN=$(jq -e -r '
   | ($b | keys | sort) as $bk
   | ($o | sort) as $ok
   | if ($b | length) <= 1 then "{}"
+    elif (($b | [.[]] | unique | length) <= 1) then "{}"
     elif ($o | length) == 0 then "ERR_NO_ORDER"
     elif ($bk != $ok) then "ERR_MISMATCH"
     else ($o | reverse) as $hl
@@ -53,12 +54,16 @@ CHAIN=$(jq -e -r '
 ' .lisa.config.json)
 ```
 
-- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments but
-  `deploy.order` is missing. Tell the user to add `deploy.order` (low→high, e.g.
-  `["dev","staging","production"]`). Do not guess the ranking.
+- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments mapped to
+  more than one distinct branch but `deploy.order` is missing. Tell the user to
+  add `deploy.order` (low→high, e.g. `["dev","staging","production"]`). Do not
+  guess the ranking.
 - `ERR_MISMATCH` → stop: `deploy.order` and `deploy.branches` name different
   environments. They must match exactly.
-- `{}` (single-environment project) → nothing to sync; report and exit cleanly.
+- `{}` → nothing to sync; report and exit cleanly. This covers both a
+  single-environment project and a multi-environment project whose branches all
+  resolve to the **same** branch (e.g. dev/staging/production all → `main`), where
+  `deploy.order` is not required.
 
 ### 2. Resolve the source branch
 

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -404,9 +404,15 @@ Rules:
 
 - **Single-environment projects** (one entry in `deploy.branches`) may omit
   `deploy.order`; the derived chain is empty and the back-sync no-ops.
-- **Multi-environment projects MUST set `deploy.order`** for config-driven
-  back-sync. If it is absent, the Action fails rather than guessing the rank
-  (or the workflow wrapper must pass an explicit `chain`, which always wins).
+- **Projects whose environments all map to the same branch** (e.g.
+  `dev`/`staging`/`production` all → `main`) may also omit `deploy.order`: the
+  branches resolve to a single distinct branch, so there is nothing to back-sync
+  and the derived chain is the empty no-op. `deploy.order` is only required when
+  `deploy.branches` resolves to **more than one distinct branch**.
+- **Multi-branch projects MUST set `deploy.order`** for config-driven back-sync.
+  If `deploy.branches` resolves to more than one distinct branch and `deploy.order`
+  is absent, the Action fails rather than guessing the rank (or the workflow
+  wrapper must pass an explicit `chain`, which always wins).
 - The env-name set of `deploy.order` and `deploy.branches` **must match exactly**
   — every env in one appears in the other. A mismatch is a config error.
 
@@ -475,9 +481,12 @@ Doctor must validate config in three layers:
      and `deploy.branches`.
 
 4. **Deploy env-order correctness**
-   - When `deploy.branches` defines more than one environment but `deploy.order` is absent, `WARN`:
-     config-driven back-sync cannot derive a chain without the ranking (the wrapper must add
-     `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` resolves to more than one **distinct** branch but `deploy.order` is
+     absent, `WARN`: config-driven back-sync cannot derive a chain without the ranking (the wrapper
+     must add `deploy.order` or pass an explicit `chain`).
+   - When `deploy.branches` defines multiple environments that all map to the **same** branch (e.g.
+     `dev`/`staging`/`production` all → `main`), `deploy.order` is **not** required — the chain is the
+     empty no-op. Do not `WARN` in this case.
    - When `deploy.order` is present but its env names do not exactly match the `deploy.branches`
      keys, `FAIL` — the derived sync-down chain would be wrong or empty.
 

--- a/plugins/src/base/skills/doctor/SKILL.md
+++ b/plugins/src/base/skills/doctor/SKILL.md
@@ -104,8 +104,12 @@ this order:
 6. **Deploy env-order audit** (only when `deploy.branches` is present)
    - `PASS` (or skip) when `deploy.branches` defines a single environment — `deploy.order` is
      optional and the back-sync chain is empty.
-   - `WARN` when `deploy.branches` defines **more than one** environment but `deploy.order` is
-     absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
+   - `PASS` (or skip) when `deploy.branches` defines multiple environments that all map to the
+     **same** branch (e.g. `dev`/`staging`/`production` all → `main`). The branches resolve to a
+     single distinct branch, so there is nothing to back-sync, the chain is the empty no-op, and
+     `deploy.order` is not required. Do not WARN.
+   - `WARN` when `deploy.branches` resolves to **more than one distinct** branch but `deploy.order`
+     is absent. Config-driven back-sync (`reusable-claude-sync-down-branches.yml`) cannot derive a
      source→target chain without the env ranking; the repo must either add `deploy.order`
      (low→high, e.g. `["dev","staging","production"]`) or pass an explicit `chain` in its
      `claude-sync-down-branches.yml` wrapper. WARN not FAIL because the explicit-chain override is

--- a/plugins/src/base/skills/sync-down/SKILL.md
+++ b/plugins/src/base/skills/sync-down/SKILL.md
@@ -44,6 +44,7 @@ CHAIN=$(jq -e -r '
   | ($b | keys | sort) as $bk
   | ($o | sort) as $ok
   | if ($b | length) <= 1 then "{}"
+    elif (($b | [.[]] | unique | length) <= 1) then "{}"
     elif ($o | length) == 0 then "ERR_NO_ORDER"
     elif ($bk != $ok) then "ERR_MISMATCH"
     else ($o | reverse) as $hl
@@ -53,12 +54,16 @@ CHAIN=$(jq -e -r '
 ' .lisa.config.json)
 ```
 
-- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments but
-  `deploy.order` is missing. Tell the user to add `deploy.order` (low→high, e.g.
-  `["dev","staging","production"]`). Do not guess the ranking.
+- `ERR_NO_ORDER` → stop: `deploy.branches` has multiple environments mapped to
+  more than one distinct branch but `deploy.order` is missing. Tell the user to
+  add `deploy.order` (low→high, e.g. `["dev","staging","production"]`). Do not
+  guess the ranking.
 - `ERR_MISMATCH` → stop: `deploy.order` and `deploy.branches` name different
   environments. They must match exactly.
-- `{}` (single-environment project) → nothing to sync; report and exit cleanly.
+- `{}` → nothing to sync; report and exit cleanly. This covers both a
+  single-environment project and a multi-environment project whose branches all
+  resolve to the **same** branch (e.g. dev/staging/production all → `main`), where
+  `deploy.order` is not required.
 
 ### 2. Resolve the source branch
 

--- a/scripts/migrate-deploy-order.sh
+++ b/scripts/migrate-deploy-order.sh
@@ -76,7 +76,9 @@ derive_chain() {
   jq -e -r '
     (.deploy.branches // {}) as $b | (.deploy.order // []) as $o
     | ($b|keys|sort) as $bk | ($o|sort) as $ok
-    | if ($b|length)<=1 then "{}" elif ($o|length)==0 then "ERR_NO_ORDER"
+    | if ($b|length)<=1 then "{}"
+      elif (($b|[.[]]|unique|length)<=1) then "{}"
+      elif ($o|length)==0 then "ERR_NO_ORDER"
       elif ($bk!=$ok) then "ERR_MISMATCH"
       else ($o|reverse) as $hl
         | [ range(0;($hl|length)-1) | {($b[$hl[.]]):$b[$hl[.+1]]} ] | add | tojson end


### PR DESCRIPTION
## Problem

The reusable **Claude Sync Down Branches** workflow derives its back-sync `source → target` chain from `.lisa.config.json` `deploy.order` + `deploy.branches`. Previously, **any** config with more than one `deploy.branches` entry but no `deploy.order` failed hard with `ERR_NO_ORDER`:

> `deploy.branches defines multiple environments but deploy.order is missing.`

This fired even when every environment mapped to the **same** branch (e.g. `dev`/`staging`/`production` all → `main`) — a single-branch repo where there is genuinely **nothing to back-sync**. It broke the sync job on every merged PR for such repos. This is common when `jira.workflow.done` needs per-env statuses but all deploys ship from `main`.

Observed in `geminisportsai/infrastructure-v2` ([failing run](https://github.com/geminisportsai/infrastructure-v2/actions/runs/27140038785)). That repo was unblocked per-project by adding `deploy.order`; this PR fixes the **root cause** so no single-branch repo hits it again.

## Fix

Treat "`deploy.branches` resolves to a single **distinct** branch" as the empty no-op chain `{}` **before** requiring `deploy.order`. `deploy.order` is now only required when branches resolve to more than one distinct branch.

```diff
  | if ($b | length) <= 1 then "{}"
+   elif (($b | [.[]] | unique | length) <= 1) then "{}"
    elif ($o | length) == 0 then "ERR_NO_ORDER"
    elif ($bk != $ok) then "ERR_MISMATCH"
```

Applied consistently to every copy of the derivation contract:
- `.github/workflows/reusable-claude-sync-down-branches.yml` (the workflow)
- `scripts/migrate-deploy-order.sh` (`derive_chain`)
- `sync-down` skill, `doctor` skill, `config-resolution` rule (+ regenerated plugin artifacts via `bun run build:plugins`)

## Verification

Validated the jq across all cases:

| Config | Before | After |
|---|---|---|
| branches collapse to `main`, no order | `ERR_NO_ORDER` ❌ | `{}` ✅ |
| genuine multi-branch + order | real chain | real chain (unchanged) |
| genuine multi-branch, no order | `ERR_NO_ORDER` | `ERR_NO_ORDER` (still correct) |
| single env | `{}` | `{}` (unchanged) |

- `bun run check:plugins` → ✓ artifacts in sync, marketplace complete.
- `bun run build:plugins` is idempotent after the change.

🤖 Generated with Claude Code