### PR TITLE
feat(wiki): add local wiki.source.path; unify local resolution

### DIFF
--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -171,9 +171,13 @@ fi
 
 ### Wiki source (`wiki`)
 
-Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. This pointer belongs in the **consumer** repo's `.lisa.config.json` — not in `wiki/lisa-wiki.config.json`, which describes a wiki from the inside and is unavailable until the remote wiki is mirrored (chicken-and-egg).
+Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. `wiki.source` has two shapes — **local** (`path`) and **remote** (`url`) — and the block belongs in the **consumer** repo's `.lisa.config.json`, not in `wiki/lisa-wiki.config.json` (which describes a wiki from the inside and is unavailable until a remote wiki is mirrored — chicken-and-egg). The whole `wiki` block is optional; omit it and the resolver falls back to the in-repo `wiki/` convention.
 
 ```json
+// local: an explicit path (optional — equivalent to the default convention)
+"wiki": { "source": { "path": "wiki" } }
+
+// remote: mirror a separate wiki repo
 "wiki": {
   "source": {
     "url": "git@github.com:org/wiki.git",
@@ -187,13 +191,14 @@ Declares **where this repo's LLM Wiki lives** so the query/ingest skills can res
 
 | Field | Required | Default | Notes |
 |-------|----------|---------|-------|
-| `wiki.source.url` | no | — | Clone URL of the canonical wiki repo. **Its presence selects REMOTE mode.** Omit the whole `wiki` block for a local in-repo wiki. |
-| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror. |
-| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized. `ensure-wiki` keeps this path gitignored automatically. |
-| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo. Auto-detected as `wiki/` if present, else the repo root. |
-| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this. |
+| `wiki.source.path` | no | `wiki` (via convention) | **Local** wiki root, relative to the repo. The explicit form of the in-repo default. Mutually exclusive with `url`. |
+| `wiki.source.url` | no | — | Clone URL of a separate wiki repo. **Its presence selects REMOTE mode.** Mutually exclusive with `path`. |
+| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror (remote only). |
+| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized (remote only). `ensure-wiki` keeps this path gitignored automatically. |
+| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo (remote only). Auto-detected as `wiki/` if present, else the repo root. |
+| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this (remote only). |
 
-`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). LOCAL mode is a no-op that returns the in-repo `wikiRoot`; REMOTE mode clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
+`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). **LOCAL** mode (no `url`) is a no-op that resolves the wiki root in precedence order `wiki.source.path` → `wikiRoot` in `wiki/lisa-wiki.config.json` → `wiki`; **REMOTE** mode (`url` set) clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
 
 ### Vendor sections
 

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -176,9 +176,13 @@ fi
 
 ### Wiki source (`wiki`)
 
-Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. This pointer belongs in the **consumer** repo's `.lisa.config.json` — not in `wiki/lisa-wiki.config.json`, which describes a wiki from the inside and is unavailable until the remote wiki is mirrored (chicken-and-egg).
+Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. `wiki.source` has two shapes — **local** (`path`) and **remote** (`url`) — and the block belongs in the **consumer** repo's `.lisa.config.json`, not in `wiki/lisa-wiki.config.json` (which describes a wiki from the inside and is unavailable until a remote wiki is mirrored — chicken-and-egg). The whole `wiki` block is optional; omit it and the resolver falls back to the in-repo `wiki/` convention.
 
 ```json
+// local: an explicit path (optional — equivalent to the default convention)
+"wiki": { "source": { "path": "wiki" } }
+
+// remote: mirror a separate wiki repo
 "wiki": {
   "source": {
     "url": "git@github.com:org/wiki.git",
@@ -192,13 +196,14 @@ Declares **where this repo's LLM Wiki lives** so the query/ingest skills can res
 
 | Field | Required | Default | Notes |
 |-------|----------|---------|-------|
-| `wiki.source.url` | no | — | Clone URL of the canonical wiki repo. **Its presence selects REMOTE mode.** Omit the whole `wiki` block for a local in-repo wiki. |
-| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror. |
-| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized. `ensure-wiki` keeps this path gitignored automatically. |
-| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo. Auto-detected as `wiki/` if present, else the repo root. |
-| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this. |
+| `wiki.source.path` | no | `wiki` (via convention) | **Local** wiki root, relative to the repo. The explicit form of the in-repo default. Mutually exclusive with `url`. |
+| `wiki.source.url` | no | — | Clone URL of a separate wiki repo. **Its presence selects REMOTE mode.** Mutually exclusive with `path`. |
+| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror (remote only). |
+| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized (remote only). `ensure-wiki` keeps this path gitignored automatically. |
+| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo (remote only). Auto-detected as `wiki/` if present, else the repo root. |
+| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this (remote only). |
 
-`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). LOCAL mode is a no-op that returns the in-repo `wikiRoot`; REMOTE mode clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
+`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). **LOCAL** mode (no `url`) is a no-op that resolves the wiki root in precedence order `wiki.source.path` → `wikiRoot` in `wiki/lisa-wiki.config.json` → `wiki`; **REMOTE** mode (`url` set) clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
 
 ### Vendor sections
 

--- a/plugins/lisa-wiki-agy/scripts/ensure-wiki.mjs
+++ b/plugins/lisa-wiki-agy/scripts/ensure-wiki.mjs
@@ -8,19 +8,27 @@
  * call as step 0 so they never hardcode `wiki/` and never have to know whether
  * the wiki is local or remote. The mode decision lives HERE, not in the skills:
  *
- *   - LOCAL  — the wiki lives in this repo (the common case). Resolve the wiki
- *              root from `wiki/lisa-wiki.config.json` (`wikiRoot`, default
- *              `wiki`) and return it. No network, effectively a no-op.
+ *   - LOCAL  — the wiki lives on the local filesystem (the common case). Resolve
+ *              the wiki root, in precedence order, from `wiki.source.path`, else
+ *              `wikiRoot` in `wiki/lisa-wiki.config.json`, else `wiki`. No
+ *              network, a no-op. `wiki.source.path` is just the explicit form of
+ *              what the convention resolves implicitly.
  *   - REMOTE — `.lisa.config.json` declares `wiki.source.url`. Maintain a
  *              gitignored mirror of that repo and return the wiki root inside
  *              it. Clone-if-missing, fetch+fast-forward when stale (TTL), and
  *              tolerate being offline (proceed with the existing mirror + warn).
+ *
+ * `url` (remote) and `path` (local) are the two shapes of `wiki.source`; `url`
+ * takes precedence if both are somehow present.
  *
  * Config (consumer repo `.lisa.config.json`, with `.lisa.config.local.json`
  * overriding per the config-resolution rule):
  *
  *   "wiki": {
  *     "source": {
+ *       // LOCAL shape — optional; defaults to the in-repo `wiki/` convention:
+ *       "path":       "wiki",            // local wiki root, relative to repo root
+ *       // REMOTE shape (instead of path):
  *       "url":        "git@github.com:org/wiki.git",  // present => REMOTE mode
  *       "ref":        "main",            // default: remote HEAD / "main"
  *       "mirrorPath": ".lisa/wiki",      // default; always gitignored
@@ -98,6 +106,9 @@ const ttlSeconds = Number(
 if (source.url !== undefined && typeof source.url !== "string") {
   fail("`wiki.source.url` in .lisa.config.json must be a string");
 }
+if (source.path !== undefined && typeof source.path !== "string") {
+  fail("`wiki.source.path` in .lisa.config.json must be a string");
+}
 
 function emit(result) {
   if (asJson) process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -105,15 +116,24 @@ function emit(result) {
   process.exit(0);
 }
 
-// ── LOCAL mode ────────────────────────────────────────────────────────────────
+// ── LOCAL mode (no remote clone) ───────────────────────────────────────────────
+// The wiki lives on the local filesystem. Its root is, in precedence order:
+//   1. `wiki.source.path` — explicit override in .lisa.config.json
+//   2. `wikiRoot` from wiki/lisa-wiki.config.json — the in-repo convention
+//   3. `wiki` — the default
+// No network, a no-op resolve. `wiki.source.path` is just the explicit form of
+// the same thing the convention resolves implicitly.
 if (!source.url) {
-  const localCfg = readJsonSafe(
-    path.join(projectDir, "wiki", "lisa-wiki.config.json")
+  const wikiRoot = path.resolve(
+    projectDir,
+    source.path ??
+      readJsonSafe(path.join(projectDir, "wiki", "lisa-wiki.config.json"))
+        ?.wikiRoot ??
+      "wiki"
   );
-  const wikiRoot = path.resolve(projectDir, localCfg?.wikiRoot ?? "wiki");
   if (!fs.existsSync(path.join(wikiRoot, "index.md"))) {
     log(
-      `⚠ no index.md under ${wikiRoot} — local wiki may not be scaffolded yet (run /lisa-wiki:setup)`
+      `⚠ no index.md under ${wikiRoot} — check wiki.source.path, or run /lisa-wiki:setup if the wiki is not scaffolded yet`
     );
   }
   log(`✓ local wiki: ${wikiRoot}`);

--- a/plugins/lisa-wiki-copilot/scripts/ensure-wiki.mjs
+++ b/plugins/lisa-wiki-copilot/scripts/ensure-wiki.mjs
@@ -8,19 +8,27 @@
  * call as step 0 so they never hardcode `wiki/` and never have to know whether
  * the wiki is local or remote. The mode decision lives HERE, not in the skills:
  *
- *   - LOCAL  — the wiki lives in this repo (the common case). Resolve the wiki
- *              root from `wiki/lisa-wiki.config.json` (`wikiRoot`, default
- *              `wiki`) and return it. No network, effectively a no-op.
+ *   - LOCAL  — the wiki lives on the local filesystem (the common case). Resolve
+ *              the wiki root, in precedence order, from `wiki.source.path`, else
+ *              `wikiRoot` in `wiki/lisa-wiki.config.json`, else `wiki`. No
+ *              network, a no-op. `wiki.source.path` is just the explicit form of
+ *              what the convention resolves implicitly.
  *   - REMOTE — `.lisa.config.json` declares `wiki.source.url`. Maintain a
  *              gitignored mirror of that repo and return the wiki root inside
  *              it. Clone-if-missing, fetch+fast-forward when stale (TTL), and
  *              tolerate being offline (proceed with the existing mirror + warn).
+ *
+ * `url` (remote) and `path` (local) are the two shapes of `wiki.source`; `url`
+ * takes precedence if both are somehow present.
  *
  * Config (consumer repo `.lisa.config.json`, with `.lisa.config.local.json`
  * overriding per the config-resolution rule):
  *
  *   "wiki": {
  *     "source": {
+ *       // LOCAL shape — optional; defaults to the in-repo `wiki/` convention:
+ *       "path":       "wiki",            // local wiki root, relative to repo root
+ *       // REMOTE shape (instead of path):
  *       "url":        "git@github.com:org/wiki.git",  // present => REMOTE mode
  *       "ref":        "main",            // default: remote HEAD / "main"
  *       "mirrorPath": ".lisa/wiki",      // default; always gitignored
@@ -98,6 +106,9 @@ const ttlSeconds = Number(
 if (source.url !== undefined && typeof source.url !== "string") {
   fail("`wiki.source.url` in .lisa.config.json must be a string");
 }
+if (source.path !== undefined && typeof source.path !== "string") {
+  fail("`wiki.source.path` in .lisa.config.json must be a string");
+}
 
 function emit(result) {
   if (asJson) process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -105,15 +116,24 @@ function emit(result) {
   process.exit(0);
 }
 
-// ── LOCAL mode ────────────────────────────────────────────────────────────────
+// ── LOCAL mode (no remote clone) ───────────────────────────────────────────────
+// The wiki lives on the local filesystem. Its root is, in precedence order:
+//   1. `wiki.source.path` — explicit override in .lisa.config.json
+//   2. `wikiRoot` from wiki/lisa-wiki.config.json — the in-repo convention
+//   3. `wiki` — the default
+// No network, a no-op resolve. `wiki.source.path` is just the explicit form of
+// the same thing the convention resolves implicitly.
 if (!source.url) {
-  const localCfg = readJsonSafe(
-    path.join(projectDir, "wiki", "lisa-wiki.config.json")
+  const wikiRoot = path.resolve(
+    projectDir,
+    source.path ??
+      readJsonSafe(path.join(projectDir, "wiki", "lisa-wiki.config.json"))
+        ?.wikiRoot ??
+      "wiki"
   );
-  const wikiRoot = path.resolve(projectDir, localCfg?.wikiRoot ?? "wiki");
   if (!fs.existsSync(path.join(wikiRoot, "index.md"))) {
     log(
-      `⚠ no index.md under ${wikiRoot} — local wiki may not be scaffolded yet (run /lisa-wiki:setup)`
+      `⚠ no index.md under ${wikiRoot} — check wiki.source.path, or run /lisa-wiki:setup if the wiki is not scaffolded yet`
     );
   }
   log(`✓ local wiki: ${wikiRoot}`);

--- a/plugins/lisa-wiki-cursor/scripts/ensure-wiki.mjs
+++ b/plugins/lisa-wiki-cursor/scripts/ensure-wiki.mjs
@@ -8,19 +8,27 @@
  * call as step 0 so they never hardcode `wiki/` and never have to know whether
  * the wiki is local or remote. The mode decision lives HERE, not in the skills:
  *
- *   - LOCAL  — the wiki lives in this repo (the common case). Resolve the wiki
- *              root from `wiki/lisa-wiki.config.json` (`wikiRoot`, default
- *              `wiki`) and return it. No network, effectively a no-op.
+ *   - LOCAL  — the wiki lives on the local filesystem (the common case). Resolve
+ *              the wiki root, in precedence order, from `wiki.source.path`, else
+ *              `wikiRoot` in `wiki/lisa-wiki.config.json`, else `wiki`. No
+ *              network, a no-op. `wiki.source.path` is just the explicit form of
+ *              what the convention resolves implicitly.
  *   - REMOTE — `.lisa.config.json` declares `wiki.source.url`. Maintain a
  *              gitignored mirror of that repo and return the wiki root inside
  *              it. Clone-if-missing, fetch+fast-forward when stale (TTL), and
  *              tolerate being offline (proceed with the existing mirror + warn).
+ *
+ * `url` (remote) and `path` (local) are the two shapes of `wiki.source`; `url`
+ * takes precedence if both are somehow present.
  *
  * Config (consumer repo `.lisa.config.json`, with `.lisa.config.local.json`
  * overriding per the config-resolution rule):
  *
  *   "wiki": {
  *     "source": {
+ *       // LOCAL shape — optional; defaults to the in-repo `wiki/` convention:
+ *       "path":       "wiki",            // local wiki root, relative to repo root
+ *       // REMOTE shape (instead of path):
  *       "url":        "git@github.com:org/wiki.git",  // present => REMOTE mode
  *       "ref":        "main",            // default: remote HEAD / "main"
  *       "mirrorPath": ".lisa/wiki",      // default; always gitignored
@@ -98,6 +106,9 @@ const ttlSeconds = Number(
 if (source.url !== undefined && typeof source.url !== "string") {
   fail("`wiki.source.url` in .lisa.config.json must be a string");
 }
+if (source.path !== undefined && typeof source.path !== "string") {
+  fail("`wiki.source.path` in .lisa.config.json must be a string");
+}
 
 function emit(result) {
   if (asJson) process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -105,15 +116,24 @@ function emit(result) {
   process.exit(0);
 }
 
-// ── LOCAL mode ────────────────────────────────────────────────────────────────
+// ── LOCAL mode (no remote clone) ───────────────────────────────────────────────
+// The wiki lives on the local filesystem. Its root is, in precedence order:
+//   1. `wiki.source.path` — explicit override in .lisa.config.json
+//   2. `wikiRoot` from wiki/lisa-wiki.config.json — the in-repo convention
+//   3. `wiki` — the default
+// No network, a no-op resolve. `wiki.source.path` is just the explicit form of
+// the same thing the convention resolves implicitly.
 if (!source.url) {
-  const localCfg = readJsonSafe(
-    path.join(projectDir, "wiki", "lisa-wiki.config.json")
+  const wikiRoot = path.resolve(
+    projectDir,
+    source.path ??
+      readJsonSafe(path.join(projectDir, "wiki", "lisa-wiki.config.json"))
+        ?.wikiRoot ??
+      "wiki"
   );
-  const wikiRoot = path.resolve(projectDir, localCfg?.wikiRoot ?? "wiki");
   if (!fs.existsSync(path.join(wikiRoot, "index.md"))) {
     log(
-      `⚠ no index.md under ${wikiRoot} — local wiki may not be scaffolded yet (run /lisa-wiki:setup)`
+      `⚠ no index.md under ${wikiRoot} — check wiki.source.path, or run /lisa-wiki:setup if the wiki is not scaffolded yet`
     );
   }
   log(`✓ local wiki: ${wikiRoot}`);

--- a/plugins/lisa-wiki/scripts/ensure-wiki.mjs
+++ b/plugins/lisa-wiki/scripts/ensure-wiki.mjs
@@ -8,19 +8,27 @@
  * call as step 0 so they never hardcode `wiki/` and never have to know whether
  * the wiki is local or remote. The mode decision lives HERE, not in the skills:
  *
- *   - LOCAL  — the wiki lives in this repo (the common case). Resolve the wiki
- *              root from `wiki/lisa-wiki.config.json` (`wikiRoot`, default
- *              `wiki`) and return it. No network, effectively a no-op.
+ *   - LOCAL  — the wiki lives on the local filesystem (the common case). Resolve
+ *              the wiki root, in precedence order, from `wiki.source.path`, else
+ *              `wikiRoot` in `wiki/lisa-wiki.config.json`, else `wiki`. No
+ *              network, a no-op. `wiki.source.path` is just the explicit form of
+ *              what the convention resolves implicitly.
  *   - REMOTE — `.lisa.config.json` declares `wiki.source.url`. Maintain a
  *              gitignored mirror of that repo and return the wiki root inside
  *              it. Clone-if-missing, fetch+fast-forward when stale (TTL), and
  *              tolerate being offline (proceed with the existing mirror + warn).
+ *
+ * `url` (remote) and `path` (local) are the two shapes of `wiki.source`; `url`
+ * takes precedence if both are somehow present.
  *
  * Config (consumer repo `.lisa.config.json`, with `.lisa.config.local.json`
  * overriding per the config-resolution rule):
  *
  *   "wiki": {
  *     "source": {
+ *       // LOCAL shape — optional; defaults to the in-repo `wiki/` convention:
+ *       "path":       "wiki",            // local wiki root, relative to repo root
+ *       // REMOTE shape (instead of path):
  *       "url":        "git@github.com:org/wiki.git",  // present => REMOTE mode
  *       "ref":        "main",            // default: remote HEAD / "main"
  *       "mirrorPath": ".lisa/wiki",      // default; always gitignored
@@ -98,6 +106,9 @@ const ttlSeconds = Number(
 if (source.url !== undefined && typeof source.url !== "string") {
   fail("`wiki.source.url` in .lisa.config.json must be a string");
 }
+if (source.path !== undefined && typeof source.path !== "string") {
+  fail("`wiki.source.path` in .lisa.config.json must be a string");
+}
 
 function emit(result) {
   if (asJson) process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -105,15 +116,24 @@ function emit(result) {
   process.exit(0);
 }
 
-// ── LOCAL mode ────────────────────────────────────────────────────────────────
+// ── LOCAL mode (no remote clone) ───────────────────────────────────────────────
+// The wiki lives on the local filesystem. Its root is, in precedence order:
+//   1. `wiki.source.path` — explicit override in .lisa.config.json
+//   2. `wikiRoot` from wiki/lisa-wiki.config.json — the in-repo convention
+//   3. `wiki` — the default
+// No network, a no-op resolve. `wiki.source.path` is just the explicit form of
+// the same thing the convention resolves implicitly.
 if (!source.url) {
-  const localCfg = readJsonSafe(
-    path.join(projectDir, "wiki", "lisa-wiki.config.json")
+  const wikiRoot = path.resolve(
+    projectDir,
+    source.path ??
+      readJsonSafe(path.join(projectDir, "wiki", "lisa-wiki.config.json"))
+        ?.wikiRoot ??
+      "wiki"
   );
-  const wikiRoot = path.resolve(projectDir, localCfg?.wikiRoot ?? "wiki");
   if (!fs.existsSync(path.join(wikiRoot, "index.md"))) {
     log(
-      `⚠ no index.md under ${wikiRoot} — local wiki may not be scaffolded yet (run /lisa-wiki:setup)`
+      `⚠ no index.md under ${wikiRoot} — check wiki.source.path, or run /lisa-wiki:setup if the wiki is not scaffolded yet`
     );
   }
   log(`✓ local wiki: ${wikiRoot}`);

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -171,9 +171,13 @@ fi
 
 ### Wiki source (`wiki`)
 
-Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. This pointer belongs in the **consumer** repo's `.lisa.config.json` — not in `wiki/lisa-wiki.config.json`, which describes a wiki from the inside and is unavailable until the remote wiki is mirrored (chicken-and-egg).
+Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. `wiki.source` has two shapes — **local** (`path`) and **remote** (`url`) — and the block belongs in the **consumer** repo's `.lisa.config.json`, not in `wiki/lisa-wiki.config.json` (which describes a wiki from the inside and is unavailable until a remote wiki is mirrored — chicken-and-egg). The whole `wiki` block is optional; omit it and the resolver falls back to the in-repo `wiki/` convention.
 
 ```json
+// local: an explicit path (optional — equivalent to the default convention)
+"wiki": { "source": { "path": "wiki" } }
+
+// remote: mirror a separate wiki repo
 "wiki": {
   "source": {
     "url": "git@github.com:org/wiki.git",
@@ -187,13 +191,14 @@ Declares **where this repo's LLM Wiki lives** so the query/ingest skills can res
 
 | Field | Required | Default | Notes |
 |-------|----------|---------|-------|
-| `wiki.source.url` | no | — | Clone URL of the canonical wiki repo. **Its presence selects REMOTE mode.** Omit the whole `wiki` block for a local in-repo wiki. |
-| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror. |
-| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized. `ensure-wiki` keeps this path gitignored automatically. |
-| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo. Auto-detected as `wiki/` if present, else the repo root. |
-| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this. |
+| `wiki.source.path` | no | `wiki` (via convention) | **Local** wiki root, relative to the repo. The explicit form of the in-repo default. Mutually exclusive with `url`. |
+| `wiki.source.url` | no | — | Clone URL of a separate wiki repo. **Its presence selects REMOTE mode.** Mutually exclusive with `path`. |
+| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror (remote only). |
+| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized (remote only). `ensure-wiki` keeps this path gitignored automatically. |
+| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo (remote only). Auto-detected as `wiki/` if present, else the repo root. |
+| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this (remote only). |
 
-`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). LOCAL mode is a no-op that returns the in-repo `wikiRoot`; REMOTE mode clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
+`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). **LOCAL** mode (no `url`) is a no-op that resolves the wiki root in precedence order `wiki.source.path` → `wikiRoot` in `wiki/lisa-wiki.config.json` → `wiki`; **REMOTE** mode (`url` set) clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
 
 ### Vendor sections
 

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -171,9 +171,13 @@ fi
 
 ### Wiki source (`wiki`)
 
-Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. This pointer belongs in the **consumer** repo's `.lisa.config.json` — not in `wiki/lisa-wiki.config.json`, which describes a wiki from the inside and is unavailable until the remote wiki is mirrored (chicken-and-egg).
+Declares **where this repo's LLM Wiki lives** so the query/ingest skills can resolve and (for a remote wiki) mirror it. `wiki.source` has two shapes — **local** (`path`) and **remote** (`url`) — and the block belongs in the **consumer** repo's `.lisa.config.json`, not in `wiki/lisa-wiki.config.json` (which describes a wiki from the inside and is unavailable until a remote wiki is mirrored — chicken-and-egg). The whole `wiki` block is optional; omit it and the resolver falls back to the in-repo `wiki/` convention.
 
 ```json
+// local: an explicit path (optional — equivalent to the default convention)
+"wiki": { "source": { "path": "wiki" } }
+
+// remote: mirror a separate wiki repo
 "wiki": {
   "source": {
     "url": "git@github.com:org/wiki.git",
@@ -187,13 +191,14 @@ Declares **where this repo's LLM Wiki lives** so the query/ingest skills can res
 
 | Field | Required | Default | Notes |
 |-------|----------|---------|-------|
-| `wiki.source.url` | no | — | Clone URL of the canonical wiki repo. **Its presence selects REMOTE mode.** Omit the whole `wiki` block for a local in-repo wiki. |
-| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror. |
-| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized. `ensure-wiki` keeps this path gitignored automatically. |
-| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo. Auto-detected as `wiki/` if present, else the repo root. |
-| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this. |
+| `wiki.source.path` | no | `wiki` (via convention) | **Local** wiki root, relative to the repo. The explicit form of the in-repo default. Mutually exclusive with `url`. |
+| `wiki.source.url` | no | — | Clone URL of a separate wiki repo. **Its presence selects REMOTE mode.** Mutually exclusive with `path`. |
+| `wiki.source.ref` | no | remote HEAD | Branch/ref to mirror (remote only). |
+| `wiki.source.mirrorPath` | no | `.lisa/wiki` | Where the gitignored mirror is materialized (remote only). `ensure-wiki` keeps this path gitignored automatically. |
+| `wiki.source.subdir` | no | auto | Wiki root within the cloned repo (remote only). Auto-detected as `wiki/` if present, else the repo root. |
+| `wiki.ttlSeconds` | no | `300` | Skip the refresh fetch if the mirror was synced more recently than this (remote only). |
 
-`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). LOCAL mode is a no-op that returns the in-repo `wikiRoot`; REMOTE mode clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
+`scripts/ensure-wiki.mjs` is the single resolver (`node scripts/ensure-wiki.mjs --json` → `{mode, wikiRoot, …}`). **LOCAL** mode (no `url`) is a no-op that resolves the wiki root in precedence order `wiki.source.path` → `wikiRoot` in `wiki/lisa-wiki.config.json` → `wiki`; **REMOTE** mode (`url` set) clones-if-missing, fast-forwards when stale, and is offline-tolerant (proceeds with the existing mirror and warns rather than blocking). Callers (`lisa-wiki-query`, `lisa-wiki-ingest`) invoke it as step 0 and never hardcode `wiki/`; the freshness guarantee is the tool's, not the caller's.
 
 ### Vendor sections
 

--- a/plugins/src/wiki/scripts/ensure-wiki.mjs
+++ b/plugins/src/wiki/scripts/ensure-wiki.mjs
@@ -8,19 +8,27 @@
  * call as step 0 so they never hardcode `wiki/` and never have to know whether
  * the wiki is local or remote. The mode decision lives HERE, not in the skills:
  *
- *   - LOCAL  — the wiki lives in this repo (the common case). Resolve the wiki
- *              root from `wiki/lisa-wiki.config.json` (`wikiRoot`, default
- *              `wiki`) and return it. No network, effectively a no-op.
+ *   - LOCAL  — the wiki lives on the local filesystem (the common case). Resolve
+ *              the wiki root, in precedence order, from `wiki.source.path`, else
+ *              `wikiRoot` in `wiki/lisa-wiki.config.json`, else `wiki`. No
+ *              network, a no-op. `wiki.source.path` is just the explicit form of
+ *              what the convention resolves implicitly.
  *   - REMOTE — `.lisa.config.json` declares `wiki.source.url`. Maintain a
  *              gitignored mirror of that repo and return the wiki root inside
  *              it. Clone-if-missing, fetch+fast-forward when stale (TTL), and
  *              tolerate being offline (proceed with the existing mirror + warn).
+ *
+ * `url` (remote) and `path` (local) are the two shapes of `wiki.source`; `url`
+ * takes precedence if both are somehow present.
  *
  * Config (consumer repo `.lisa.config.json`, with `.lisa.config.local.json`
  * overriding per the config-resolution rule):
  *
  *   "wiki": {
  *     "source": {
+ *       // LOCAL shape — optional; defaults to the in-repo `wiki/` convention:
+ *       "path":       "wiki",            // local wiki root, relative to repo root
+ *       // REMOTE shape (instead of path):
  *       "url":        "git@github.com:org/wiki.git",  // present => REMOTE mode
  *       "ref":        "main",            // default: remote HEAD / "main"
  *       "mirrorPath": ".lisa/wiki",      // default; always gitignored
@@ -98,6 +106,9 @@ const ttlSeconds = Number(
 if (source.url !== undefined && typeof source.url !== "string") {
   fail("`wiki.source.url` in .lisa.config.json must be a string");
 }
+if (source.path !== undefined && typeof source.path !== "string") {
+  fail("`wiki.source.path` in .lisa.config.json must be a string");
+}
 
 function emit(result) {
   if (asJson) process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -105,15 +116,24 @@ function emit(result) {
   process.exit(0);
 }
 
-// ── LOCAL mode ────────────────────────────────────────────────────────────────
+// ── LOCAL mode (no remote clone) ───────────────────────────────────────────────
+// The wiki lives on the local filesystem. Its root is, in precedence order:
+//   1. `wiki.source.path` — explicit override in .lisa.config.json
+//   2. `wikiRoot` from wiki/lisa-wiki.config.json — the in-repo convention
+//   3. `wiki` — the default
+// No network, a no-op resolve. `wiki.source.path` is just the explicit form of
+// the same thing the convention resolves implicitly.
 if (!source.url) {
-  const localCfg = readJsonSafe(
-    path.join(projectDir, "wiki", "lisa-wiki.config.json")
+  const wikiRoot = path.resolve(
+    projectDir,
+    source.path ??
+      readJsonSafe(path.join(projectDir, "wiki", "lisa-wiki.config.json"))
+        ?.wikiRoot ??
+      "wiki"
   );
-  const wikiRoot = path.resolve(projectDir, localCfg?.wikiRoot ?? "wiki");
   if (!fs.existsSync(path.join(wikiRoot, "index.md"))) {
     log(
-      `⚠ no index.md under ${wikiRoot} — local wiki may not be scaffolded yet (run /lisa-wiki:setup)`
+      `⚠ no index.md under ${wikiRoot} — check wiki.source.path, or run /lisa-wiki:setup if the wiki is not scaffolded yet`
     );
   }
   log(`✓ local wiki: ${wikiRoot}`);

--- a/tests/unit/strategies/wiki-ensure-wiki.test.ts
+++ b/tests/unit/strategies/wiki-ensure-wiki.test.ts
@@ -29,6 +29,10 @@ const MIRROR_MARKER = "# BEGIN: AI GUARDRAILS WIKI MIRROR";
 const INDEX_MD = "index.md";
 /** Body written into the fixture wiki's index page. */
 const REMOTE_WIKI_BODY = "# Remote Wiki\n";
+/** Non-default local wiki dir used by the explicit-path tests. */
+const CUSTOM_WIKI = "custom-wiki";
+/** Override dir used to prove wiki.source.path beats the convention. */
+const OVERRIDE = "override";
 /** Absolute path to the script under test. */
 const SCRIPT_PATH = path.resolve(
   __dirname,
@@ -143,6 +147,38 @@ describe("lisa-wiki ensure-wiki.mjs", () => {
     fs.writeFileSync(path.join(tmp, "wiki", "docs", INDEX_MD), "# Index\n");
     const res = run(tmp);
     expect(res.wikiRoot).toBe(path.join(tmp, "wiki", "docs"));
+  });
+
+  it("LOCAL: an explicit wiki.source.path resolves in place (still mode 'local', no mirror)", () => {
+    fs.mkdirSync(path.join(tmp, CUSTOM_WIKI), { recursive: true });
+    fs.writeFileSync(path.join(tmp, CUSTOM_WIKI, INDEX_MD), "# Index\n");
+    fs.writeFileSync(
+      path.join(tmp, LISA_CONFIG),
+      JSON.stringify({ wiki: { source: { path: CUSTOM_WIKI } } })
+    );
+    const res = run(tmp);
+    expect(res.mode).toBe("local");
+    expect(res.wikiRoot).toBe(path.join(tmp, CUSTOM_WIKI));
+    expect(res.fetched).toBe(false);
+    // Pure no-op: no gitignore churn, no mirror dir.
+    expect(fs.existsSync(path.join(tmp, ".gitignore"))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, ".lisa"))).toBe(false);
+  });
+
+  it("LOCAL: wiki.source.path wins over a lisa-wiki.config.json wikiRoot", () => {
+    fs.mkdirSync(path.join(tmp, "wiki"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "wiki", "lisa-wiki.config.json"),
+      JSON.stringify({ wikiRoot: "wiki" })
+    );
+    fs.writeFileSync(path.join(tmp, "wiki", INDEX_MD), "# convention\n");
+    fs.mkdirSync(path.join(tmp, OVERRIDE), { recursive: true });
+    fs.writeFileSync(path.join(tmp, OVERRIDE, INDEX_MD), "# override\n");
+    fs.writeFileSync(
+      path.join(tmp, LISA_CONFIG),
+      JSON.stringify({ wiki: { source: { path: OVERRIDE } } })
+    );
+    expect(run(tmp).wikiRoot).toBe(path.join(tmp, OVERRIDE));
   });
 
   it("REMOTE: clones the mirror, resolves its wiki/ root, and gitignores it", () => {


### PR DESCRIPTION
## What

Follow-up to the `ensure-wiki` resolver. Adds an explicit **local** shape to `wiki.source` and collapses the two local code paths into one.

- `wiki.source.path` — declares the local wiki root explicitly in `.lisa.config.json`. Mutually exclusive with `wiki.source.url` (remote).
- **One LOCAL mode.** The wiki root resolves in precedence order: `wiki.source.path` → `wikiRoot` in `wiki/lisa-wiki.config.json` → `wiki`. `path` is just the explicit, self-documenting form of what the convention already resolves implicitly — a no-op resolve, no clone, no gitignore churn.
- Remote mode (`url`) is unchanged and still takes precedence if both are present.

## Why

A prior iteration modeled the explicit path as a separate `local-path` mode, but for the common case (`path: "wiki"`) it's functionally identical to the convention. Two modes for one behavior is redundant — this unifies them so `path` is simply an optional override of the same `local` resolution.

## Tests

`tests/unit/strategies/wiki-ensure-wiki.test.ts` (8 cases): adds explicit-path resolves-in-place (mode `local`, no mirror/gitignore) and `wiki.source.path` beats a `lisa-wiki.config.json` `wikiRoot`. Existing local/remote cases unchanged. ESLint clean; plugins rebuilt and in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)