### PR TITLE
fix(apply): use node:fs/promises for fs reads/writes (Expo apply crash)

### DIFF
--- a/src/migrations/ensure-jest-rn-mock-accessibility-manager.ts
+++ b/src/migrations/ensure-jest-rn-mock-accessibility-manager.ts
@@ -1,3 +1,4 @@
+import { readFile, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as fse from "fs-extra";
 import type {
@@ -79,7 +80,7 @@ export class EnsureJestRnMockAccessibilityManagerMigration implements Migration 
     if (!(await fse.pathExists(mockPath))) {
       return false;
     }
-    const content = await fse.readFile(mockPath, "utf8");
+    const content = await readFile(mockPath, "utf8");
     return content.includes(ANCHOR) && !content.includes(MARKER);
   }
 
@@ -97,7 +98,7 @@ export class EnsureJestRnMockAccessibilityManagerMigration implements Migration 
       return { name: this.name, action: "noop" };
     }
 
-    const content = await fse.readFile(mockPath, "utf8");
+    const content = await readFile(mockPath, "utf8");
     if (content.includes(MARKER) || !content.includes(ANCHOR)) {
       return { name: this.name, action: "noop" };
     }
@@ -118,7 +119,7 @@ export class EnsureJestRnMockAccessibilityManagerMigration implements Migration 
       };
     }
 
-    await fse.writeFile(mockPath, updated);
+    await writeFile(mockPath, updated);
     ctx.logger.success(message);
     return {
       name: this.name,

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- Package merge strategy is intentionally comprehensive */
+import { readFile } from "node:fs/promises";
 import * as fse from "fs-extra";
 import path from "node:path";
 import type { FileOperationResult, ProjectType } from "../core/config.js";
@@ -277,7 +278,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
     projectDir: string
   ): Promise<boolean> {
     try {
-      const content = await fse.readFile(
+      const content = await readFile(
         path.join(projectDir, this.HARPER_APP_CONFIG),
         "utf8"
       );


### PR DESCRIPTION
## Problem
`lisa apply` crashes with **`fse.readFile is not a function`** and rolls back on **every Expo project**, leaving the Codex/OpenCode/Copilot harness ungenerated. CDK/NestJS/TypeScript projects are unaffected.

## Root cause
fs-extra's **fs-passthrough** methods (`readFile`/`writeFile`) are `undefined` on the `import * as fse from "fs-extra"` namespace **in the bundled dist** (fs-extra's own methods like `pathExists`/`copy` work fine). The Expo-only RN-mock migration `ensure-jest-rn-mock-accessibility-manager` calls `fse.readFile`/`writeFile`, so it throws → apply rolls back. Other stacks never run that migration.

## Fix
Switch the 4 fs-passthrough call sites to **`node:fs/promises`** (3 in the RN migration, 1 in `package-lisa` Harper check). fs-extra native methods untouched.

## Verification
Built dist + ran apply against a real Expo project (geminisportsai/frontend-v2): completes cleanly, generates the full harness (`.codex` 436, `.opencode` 470), **0** `fse.readFile` errors. Existing migration unit test still passes (8/8); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal file I/O handling to use Node's native promises-based API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->