### PR TITLE
feat(apply): exclude generated harness dirs from sonar.exclusions

### DIFF
--- a/src/migrations/ensure-sonar-excludes-lisa-harness.ts
+++ b/src/migrations/ensure-sonar-excludes-lisa-harness.ts
@@ -1,0 +1,142 @@
+import { readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const SONAR_FILE = "sonar-project.properties";
+const EXCLUSIONS_KEY = "sonar.exclusions";
+
+/**
+ * Glob patterns for the Lisa-generated multi-agent harness directories.
+ *
+ * `lisa apply` commits the full Codex/OpenCode/Copilot harness (hundreds of
+ * generated .md/.toml/.sh/.py/.ts files) so marketplace-less agents work
+ * in-repo. They are generated scaffolding, not project source, and must not be
+ * analyzed by SonarCloud — otherwise the quality gate trips on generated code.
+ */
+const HARNESS_GLOBS: readonly string[] = [
+  ".codex/**",
+  ".opencode/**",
+  ".agents/**",
+];
+
+/**
+ * Parsed view of the project's `sonar.exclusions` line.
+ */
+interface SonarExclusionsState {
+  /** Full file text, or null when sonar-project.properties does not exist. */
+  readonly text: string | null;
+  /** The exact `sonar.exclusions=...` line, or null when absent. */
+  readonly line: string | null;
+  /** Harness globs not yet present in the exclusions. */
+  readonly missing: readonly string[];
+}
+
+/**
+ * Migration: ensure the Lisa-generated harness directories are listed in
+ * `sonar.exclusions` of `sonar-project.properties`.
+ *
+ * Only runs when the project actually ships a `sonar-project.properties`
+ * (SonarCloud-using repos). Idempotent — appends only the harness globs that
+ * are missing, preserving every existing exclusion. Single-line exclusions are
+ * the supported (and Lisa-emitted) shape; a backslash-continued value is left
+ * untouched to avoid corrupting a multi-line property.
+ *
+ * Mirrors the host-config reconciliation pattern of the other `ensure-*`
+ * migrations. Uses node:fs/promises for the raw read/write because fs-extra's
+ * fs-passthrough methods are undefined in the bundled dist.
+ */
+export class EnsureSonarExcludesLisaHarnessMigration implements Migration {
+  readonly name = "ensure-sonar-excludes-lisa-harness";
+  readonly description =
+    "Add the Lisa-generated harness dirs (.codex/.opencode/.agents) to sonar.exclusions";
+
+  /**
+   * Read and parse the current sonar.exclusions state for the project.
+   * @param projectDir - The destination project directory
+   * @returns The file text, the matched exclusions line, and any missing globs
+   */
+  private async readState(projectDir: string): Promise<SonarExclusionsState> {
+    const file = path.join(projectDir, SONAR_FILE);
+    if (!(await fse.pathExists(file))) {
+      return { text: null, line: null, missing: [] };
+    }
+    const text = await readFile(file, "utf8");
+    const line =
+      text
+        .split("\n")
+        .find(l => l.replace(/\s/g, "").startsWith(`${EXCLUSIONS_KEY}=`)) ??
+      null;
+    // A backslash-continued value spans multiple physical lines; leave it be.
+    if (line !== null && line.trimEnd().endsWith("\\")) {
+      return { text, line, missing: [] };
+    }
+    const current = line
+      ? line
+          .slice(line.indexOf("=") + 1)
+          .split(",")
+          .map(g => g.trim())
+          .filter(Boolean)
+      : [];
+    const missing = HARNESS_GLOBS.filter(g => !current.includes(g));
+    return { text, line, missing };
+  }
+
+  /**
+   * Applies when a sonar-project.properties exists and is missing at least one
+   * harness glob.
+   * @param ctx - Migration context
+   * @returns True when there is work to do
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    const { text, missing } = await this.readState(ctx.projectDir);
+    return text !== null && missing.length > 0;
+  }
+
+  /**
+   * Append the missing harness globs to sonar.exclusions (creating the line if
+   * absent), preserving all existing exclusions.
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const file = path.join(ctx.projectDir, SONAR_FILE);
+    const { text, line, missing } = await this.readState(ctx.projectDir);
+    if (text === null || missing.length === 0) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const base = text === "" || text.endsWith("\n") ? text : `${text}\n`;
+    const updated =
+      line === null
+        ? `${base}${EXCLUSIONS_KEY}=${missing.join(",")}\n`
+        : text.replace(
+            line,
+            `${line.trimEnd()}${line.trimEnd().endsWith("=") ? "" : ","}${missing.join(",")}`
+          );
+
+    const message = `Added ${missing.length} harness glob(s) to ${EXCLUSIONS_KEY} (${missing.join(", ")})`;
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would update ${EXCLUSIONS_KEY}: ${missing.join(", ")}`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [SONAR_FILE],
+        message,
+      };
+    }
+
+    await writeFile(file, updated);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [SONAR_FILE],
+      message,
+    };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,6 +1,7 @@
 import { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 import { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-mock-accessibility-manager.js";
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+import { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 import { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
@@ -19,6 +20,7 @@ export type {
 export { EnsureAuditIgnoreLocalExclusionsMigration } from "./ensure-audit-ignore-local-exclusions.js";
 export { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-mock-accessibility-manager.js";
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+export { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 export { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
@@ -40,6 +42,7 @@ export class MigrationRegistry {
       new EnsureAuditIgnoreLocalExclusionsMigration(),
       new EnsureJestRnMockAccessibilityManagerMigration(),
       new EnsureLisaPostinstallMigration(),
+      new EnsureSonarExcludesLisaHarnessMigration(),
       new ReconcileClaudeStackPluginsMigration(),
     ];
   }

--- a/tests/unit/migrations/ensure-sonar-excludes-lisa-harness.test.ts
+++ b/tests/unit/migrations/ensure-sonar-excludes-lisa-harness.test.ts
@@ -1,0 +1,101 @@
+import os from "node:os";
+import path from "node:path";
+
+import fs from "fs-extra";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureSonarExcludesLisaHarnessMigration } from "../../../src/migrations/ensure-sonar-excludes-lisa-harness.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+
+const SONAR = "sonar-project.properties";
+const CODEX = ".codex/**";
+const OPENCODE = ".opencode/**";
+const AGENTS = ".agents/**";
+
+describe("EnsureSonarExcludesLisaHarnessMigration", () => {
+  const migration = new EnsureSonarExcludesLisaHarnessMigration();
+  let tempDir: string;
+  let projectDir: string;
+  let lisaDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-sonar-"));
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  const ctx = (dryRun = false): MigrationContext => ({
+    projectDir,
+    lisaDir,
+    detectedTypes: ["typescript"] as ProjectType[],
+    dryRun,
+    logger: new SilentLogger(),
+  });
+  const sonarPath = (): string => path.join(projectDir, SONAR);
+  const readSonar = (): Promise<string> => fs.readFile(sonarPath(), "utf8");
+
+  it("is a noop when no sonar-project.properties exists", async () => {
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+  });
+
+  it("appends missing harness globs, preserving existing exclusions and other keys", async () => {
+    await fs.writeFile(
+      sonarPath(),
+      "sonar.exclusions=node_modules/**/*,scripts/**\nsonar.host.url=https://sonarcloud.io\n"
+    );
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+    const out = await readSonar();
+    for (const g of [
+      "node_modules/**/*",
+      "scripts/**",
+      CODEX,
+      OPENCODE,
+      AGENTS,
+    ]) {
+      expect(out).toContain(g);
+    }
+    expect(out).toContain("sonar.host.url=https://sonarcloud.io");
+  });
+
+  it("is idempotent when the globs are already present", async () => {
+    await fs.writeFile(
+      sonarPath(),
+      `sonar.exclusions=a/**,${CODEX},${OPENCODE},${AGENTS}\n`
+    );
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+  });
+
+  it("creates the exclusions line when absent", async () => {
+    await fs.writeFile(sonarPath(), "sonar.projectKey=foo\n");
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+    const out = await readSonar();
+    expect(out).toMatch(/sonar\.exclusions=.*\.codex\/\*\*/);
+    expect(out).toContain("sonar.projectKey=foo");
+  });
+
+  it("leaves a backslash-continued exclusions value untouched", async () => {
+    const original = "sonar.exclusions=a/**,\\\n  b/**\n";
+    await fs.writeFile(sonarPath(), original);
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+    expect(await readSonar()).toBe(original);
+  });
+
+  it("dry-run reports applied without writing", async () => {
+    await fs.writeFile(sonarPath(), "sonar.exclusions=a/**\n");
+    expect((await migration.apply(ctx(true))).action).toBe("applied");
+    expect(await readSonar()).not.toContain(CODEX);
+  });
+});


### PR DESCRIPTION
## Why
`lisa apply` commits the full **Codex/OpenCode/Copilot** harness (hundreds of generated `.md/.toml/.sh/.py/.ts` files) so marketplace-less agents work in-repo. On SonarCloud-using repos, those generated files get analyzed and the **quality gate trips on generated code**, blocking PRs — observed on a real Expo bump PR (geminisportsai/frontend-v2).

## What
New `ensure-sonar-excludes-lisa-harness` migration: when `sonar-project.properties` exists, append `.codex/**`, `.opencode/**`, `.agents/**` to `sonar.exclusions`. Idempotent, preserves existing exclusions and other keys, skips backslash-continued values, only touches SonarCloud repos. Uses `node:fs/promises` (fs-extra fs-passthroughs are undefined in the bundled dist — see #1220).

## Verification
End-to-end against a real Expo project (globs added) + 6 unit tests; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated migration that ensures code generation artifacts (`.codex/**`, `.opencode/**`, `.agents/**`) are excluded from Sonar code quality analysis. This prevents generated code from impacting code quality metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->