### PR TITLE
fix(ci): ignore no-config Playwright aggregate abandonment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -951,11 +951,15 @@ jobs:
       #   skipped  → playwright_e2e was skipped (no config / skip_jobs)
       #   failure  → at least one shard failed
       #   cancelled → at least one shard was cancelled
+      #   abandoned → runner was lost before the shard completed
       #
       # Fail the aggregator on anything other than success/skipped so the
       # `🎭 Playwright E2E Tests` check accurately reflects shard health.
+      #
+      # Guard on has_config: when there is no Playwright config, no shard tests
+      # ran, so an abandoned/cancelled shard job is not a test failure signal.
       - name: 🚨 Fail if any Playwright shard failed
-        if: ${{ always() && needs.playwright_e2e.result != 'success' && needs.playwright_e2e.result != 'skipped' }}
+        if: ${{ always() && steps.check_playwright.outputs.has_config == 'true' && needs.playwright_e2e.result != 'success' && needs.playwright_e2e.result != 'skipped' }}
         run: |
           echo "::error::Playwright shard matrix result is '${{ needs.playwright_e2e.result }}' — at least one shard did not pass"
           exit 1


### PR DESCRIPTION
## Summary
- guard the Playwright aggregate failure step behind the detected Playwright config flag
- keep real shard failures failing when a Playwright config exists
- document the abandoned shard result that caused #1222

Fixes #1222

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/quality.yml"); puts "yaml ok"'\n- bunx prettier --check .github/workflows/quality.yml\n- git diff --check\n- commit hooks: gitleaks, tsc --noEmit, lint-staged/prettier, commitlint, co-author validation\n- pre-push hooks: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by refining test aggregation conditions to prevent false failures when no tests are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->