### PR TITLE
fix(safety-net): correlate force-push guard to a single push statement

### DIFF
--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -61,14 +61,26 @@ fi
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+push\b'; then
-  if printf '%s' "$command_str" | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
-    && ! printf '%s' "$command_str" | grep -Eiq -- '--force-with-lease'; then
-    if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
-      block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
-    fi
+#
+#    The force flag AND the protected-branch name must appear in the SAME
+#    `git push` statement. Checking them independently over the whole command is
+#    a false-positive magnet: an unrelated `-f` (a `[ -f file ]` test, `rm -f`,
+#    `grep -f`, `tail -f`) plus an unrelated protected name (`--base main`,
+#    `origin/main`, `git fetch origin main`) alongside any feature-branch
+#    `git push` would wrongly block. So split the command into statements
+#    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
+#    inspect each in isolation — a real `git push --force origin main` still
+#    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+while IFS= read -r push_stmt; do
+  if printf '%s' "$push_stmt" \
+    | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
+    && ! printf '%s' "$push_stmt" | grep -Eiq -- '--force-with-lease' \
+    && printf '%s' "$push_stmt" \
+    | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
+    block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-fi
+done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -71,6 +71,12 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+# Normalize bash line-continuations (backslash + newline → space) before
+# segmenting the command. Without this, "git push --force origin \<newline>main"
+# gets split by the grep into a segment that matches --force but not `main`,
+# letting a protected force-push slip past the guard.
+normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -79,7 +85,7 @@ while IFS= read -r push_stmt; do
     | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
   | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -61,14 +61,26 @@ fi
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+push\b'; then
-  if printf '%s' "$command_str" | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
-    && ! printf '%s' "$command_str" | grep -Eiq -- '--force-with-lease'; then
-    if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
-      block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
-    fi
+#
+#    The force flag AND the protected-branch name must appear in the SAME
+#    `git push` statement. Checking them independently over the whole command is
+#    a false-positive magnet: an unrelated `-f` (a `[ -f file ]` test, `rm -f`,
+#    `grep -f`, `tail -f`) plus an unrelated protected name (`--base main`,
+#    `origin/main`, `git fetch origin main`) alongside any feature-branch
+#    `git push` would wrongly block. So split the command into statements
+#    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
+#    inspect each in isolation — a real `git push --force origin main` still
+#    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+while IFS= read -r push_stmt; do
+  if printf '%s' "$push_stmt" \
+    | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
+    && ! printf '%s' "$push_stmt" | grep -Eiq -- '--force-with-lease' \
+    && printf '%s' "$push_stmt" \
+    | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
+    block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-fi
+done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -71,6 +71,12 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+# Normalize bash line-continuations (backslash + newline → space) before
+# segmenting the command. Without this, "git push --force origin \<newline>main"
+# gets split by the grep into a segment that matches --force but not `main`,
+# letting a protected force-push slip past the guard.
+normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -79,7 +85,7 @@ while IFS= read -r push_stmt; do
     | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
   | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -61,14 +61,26 @@ fi
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+push\b'; then
-  if printf '%s' "$command_str" | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
-    && ! printf '%s' "$command_str" | grep -Eiq -- '--force-with-lease'; then
-    if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
-      block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
-    fi
+#
+#    The force flag AND the protected-branch name must appear in the SAME
+#    `git push` statement. Checking them independently over the whole command is
+#    a false-positive magnet: an unrelated `-f` (a `[ -f file ]` test, `rm -f`,
+#    `grep -f`, `tail -f`) plus an unrelated protected name (`--base main`,
+#    `origin/main`, `git fetch origin main`) alongside any feature-branch
+#    `git push` would wrongly block. So split the command into statements
+#    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
+#    inspect each in isolation — a real `git push --force origin main` still
+#    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+while IFS= read -r push_stmt; do
+  if printf '%s' "$push_stmt" \
+    | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
+    && ! printf '%s' "$push_stmt" | grep -Eiq -- '--force-with-lease' \
+    && printf '%s' "$push_stmt" \
+    | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
+    block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-fi
+done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -71,6 +71,12 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+# Normalize bash line-continuations (backslash + newline → space) before
+# segmenting the command. Without this, "git push --force origin \<newline>main"
+# gets split by the grep into a segment that matches --force but not `main`,
+# letting a protected force-push slip past the guard.
+normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -79,7 +85,7 @@ while IFS= read -r push_stmt; do
     | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
   | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -61,14 +61,26 @@ fi
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+push\b'; then
-  if printf '%s' "$command_str" | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
-    && ! printf '%s' "$command_str" | grep -Eiq -- '--force-with-lease'; then
-    if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
-      block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
-    fi
+#
+#    The force flag AND the protected-branch name must appear in the SAME
+#    `git push` statement. Checking them independently over the whole command is
+#    a false-positive magnet: an unrelated `-f` (a `[ -f file ]` test, `rm -f`,
+#    `grep -f`, `tail -f`) plus an unrelated protected name (`--base main`,
+#    `origin/main`, `git fetch origin main`) alongside any feature-branch
+#    `git push` would wrongly block. So split the command into statements
+#    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
+#    inspect each in isolation — a real `git push --force origin main` still
+#    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+while IFS= read -r push_stmt; do
+  if printf '%s' "$push_stmt" \
+    | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
+    && ! printf '%s' "$push_stmt" | grep -Eiq -- '--force-with-lease' \
+    && printf '%s' "$push_stmt" \
+    | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
+    block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-fi
+done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -71,6 +71,12 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
+# Normalize bash line-continuations (backslash + newline → space) before
+# segmenting the command. Without this, "git push --force origin \<newline>main"
+# gets split by the grep into a segment that matches --force but not `main`,
+# letting a protected force-push slip past the guard.
+normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -79,7 +85,7 @@ while IFS= read -r push_stmt; do
     | grep -Eiq '(^|[^[:alnum:]_/-])(main|master|production|prod|release)([^[:alnum:]_/-]|$)'; then
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
-done < <(printf '%s' "$command_str" | tr '&|;' '\n' \
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
   | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
 
 # 3. `git reset --hard` while the working tree has uncommitted changes — this

--- a/tests/unit/hooks/parity-safety-net.test.ts
+++ b/tests/unit/hooks/parity-safety-net.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the force-push guard in parity-safety-net.sh.
+ *
+ * The guard blocks force-pushing a protected branch (main/master/production/
+ * prod/release) while allowing the safe `--force-with-lease`. The force flag and
+ * the protected-branch name must appear in the SAME `git push` statement —
+ * checking them independently across the whole command false-positives on an
+ * unrelated `-f` (a `[ -f file ]` test, `rm -f`, `grep -f`) plus an unrelated
+ * protected name (`--base main`, `origin/main`) sitting next to a feature-branch
+ * push. These tests lock in that correlation.
+ * @module tests/unit/hooks/parity-safety-net
+ */
+import { spawnSync } from "child_process";
+import path from "path";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const runHook = (
+  toolName: string,
+  command: string
+): { status: number | null; stderr: string } => {
+  const input = JSON.stringify({
+    tool_name: toolName,
+    tool_input: { command },
+  });
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    input,
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+describe("parity-safety-net.sh — force-push guard", () => {
+  describe("blocks force-pushing a protected branch", () => {
+    it("blocks git push --force origin main", () => {
+      expect(runHook("Bash", "git push --force origin main").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+
+    it("blocks git push -f origin master", () => {
+      expect(runHook("Bash", "git push -f origin master").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+
+    it("blocks force-push to production", () => {
+      expect(runHook("Bash", "git push --force origin production").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+
+    it("blocks force-push to release", () => {
+      expect(runHook("Bash", "git push --force origin release").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+
+    it("blocks a force-push to main inside a subshell / chain", () => {
+      expect(
+        runHook("Bash", "cd /repo && git push --force origin main").status
+      ).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks force-push to main via the HEAD:main refspec", () => {
+      expect(runHook("Bash", "git push --force origin HEAD:main").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+  });
+
+  describe("allows safe pushes (no cross-statement false positives)", () => {
+    it("allows a feature-branch push alongside a [ -f ] test and --base main", () => {
+      // The exact false positive: feature push + `-f` from a file test + `main`
+      // from `--base main`, none of which is a force-push to a protected branch.
+      const cmd =
+        "git push -u origin chore/foo; [ -f package-lock.json ] && echo hi; " +
+        "gh pr create --base main --head chore/foo";
+      expect(runHook("Bash", cmd).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows a subshell feature-branch push piped to tail", () => {
+      expect(
+        runHook("Bash", '( cd /x && git push -u origin "$BR" 2>&1 | tail -3 )')
+          .status
+      ).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows --force-with-lease to main", () => {
+      expect(
+        runHook("Bash", "git push --force-with-lease origin main").status
+      ).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows a non-force push to main", () => {
+      expect(runHook("Bash", "git push origin main").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows force-pushing a feature branch whose name contains main", () => {
+      expect(
+        runHook("Bash", "git push --force origin feature/main-thing").status
+      ).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows rm -f next to a feature-branch push", () => {
+      expect(
+        runHook("Bash", "rm -f stale.txt && git push -u origin feature/x")
+          .status
+      ).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows git fetch origin main next to a [ -f ] test (no push at all)", () => {
+      expect(
+        runHook("Bash", "git fetch origin main; [ -f x ] && echo y").status
+      ).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("ignores non-Bash tools", () => {
+    it("allows a non-Bash tool even with force-push text in input", () => {
+      expect(runHook("Read", "git push --force origin main").status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+  });
+});

--- a/tests/unit/hooks/parity-safety-net.test.ts
+++ b/tests/unit/hooks/parity-safety-net.test.ts
@@ -71,6 +71,21 @@ describe("parity-safety-net.sh — force-push guard", () => {
         EXIT_BLOCKED
       );
     });
+
+    it("blocks force-push to main when command uses backslash-newline continuation", () => {
+      // "git push --force origin \\\nmain" has a bash line continuation
+      // (backslash + newline) that could split the command across two segments
+      // before the branch name is evaluated, bypassing the protection.
+      expect(runHook("Bash", "git push --force origin \\\nmain").status).toBe(
+        EXIT_BLOCKED
+      );
+    });
+
+    it("blocks force-push to main via HEAD:main with backslash-newline continuation", () => {
+      expect(
+        runHook("Bash", "git push --force origin \\\nHEAD:main").status
+      ).toBe(EXIT_BLOCKED);
+    });
   });
 
   describe("allows safe pushes (no cross-statement false positives)", () => {


### PR DESCRIPTION
## Problem
The protected-branch force-push guard checked three conditions **independently across the whole command**, never tied to the same push:
1. command contains a push invocation
2. command contains a force flag (`--force` / `-f`)
3. command contains a protected name (`main` / `master` / `production` / `prod` / `release`)

It blocked when all three matched **anywhere**. So a perfectly safe feature-branch push was blocked whenever the command *also* contained:
- an unrelated force-looking flag — a `[ -f file ]` test, `rm -f`, `grep -f`, `tail -f`; and
- an unrelated protected name — `--base main` (gh pr create), `origin/main`, `fetch origin main`.

That false-positives constantly on real workflow scripts (e.g. `git push -u origin chore/x; [ -f lockfile ] && …; gh pr create --base main`). The block message even claimed "staging" — which isn't in the list; it was `main` from a base-branch reference.

## Fix
Split the command into statements (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and require the force flag **and** a protected branch **in the same segment**. Real force-pushes to protected branches still block; safe feature-branch pushes pass.

## Tests
`tests/unit/hooks/parity-safety-net.test.ts` — 14 cases. Blocks: `--force`/`-f` to main/master/production/release, subshell chains, `HEAD:main` refspec. Allows: the exact false positive (feature push + `[ -f ]` + `--base main`), subshell feature push, `--force-with-lease` to main, non-force push to main, force-push of a branch named `…/main-thing`, `rm -f` next to a feature push, and `fetch origin main` next to a `[ -f ]` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of force-pushing protected branches by evaluating each push statement separately, reducing false positives in complex/continued commands while preserving exemptions for safe flags.

* **Tests**
  * Added comprehensive tests covering blocked and allowed force-push scenarios, command chaining, line continuations, and non-Bash/tool bypass cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->