### PR TITLE
fix(safety-net): portable line-continuation normalization in the push guard

### DIFF
--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -71,11 +71,13 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (backslash + newline → space) before
-# segmenting the command. Without this, "git push --force origin \<newline>main"
-# gets split by the grep into a segment that matches --force but not `main`,
-# letting a protected force-push slip past the guard.
-normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_str" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -71,11 +71,13 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (backslash + newline → space) before
-# segmenting the command. Without this, "git push --force origin \<newline>main"
-# gets split by the grep into a segment that matches --force but not `main`,
-# letting a protected force-push slip past the guard.
-normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_str" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -71,11 +71,13 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (backslash + newline → space) before
-# segmenting the command. Without this, "git push --force origin \<newline>main"
-# gets split by the grep into a segment that matches --force but not `main`,
-# letting a protected force-push slip past the guard.
-normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_str" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -71,11 +71,13 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (backslash + newline → space) before
-# segmenting the command. Without this, "git push --force origin \<newline>main"
-# gets split by the grep into a segment that matches --force but not `main`,
-# letting a protected force-push slip past the guard.
-normalized_command_str="$(printf '%s' "$command_str" | sed ':a;N;$!ba;s/\\\n/ /g')"
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_str" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \


### PR DESCRIPTION
## Problem
The line-continuation normalization in the push guard (added in the follow-up to #1224) uses GNU-only `sed ':a;N;$!ba;s/.../ /g'`. On **BSD sed (macOS)** that errors with `unused label` and silently no-ops, so the two backslash-continuation regression tests **fail on every Mac**. Because the pre-push hook runs the full coverage suite, this **blocked all local pushes** on macOS.

## Fix
Replace the GNU-`sed` normalization with **POSIX `awk`** that joins trailing-backslash lines — works identically on GNU and BSD:
```sh
awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }'
```

## Verification
All **16** `parity-safety-net.sh` hook tests pass on macOS (previously 2 failed), including the backslash-continuation cases. Generated plugin copies regenerated and in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
