### PR TITLE
feat(apply): declare wiki.source.path when a project has a local wiki

### DIFF
--- a/src/migrations/ensure-wiki-source-declared.ts
+++ b/src/migrations/ensure-wiki-source-declared.ts
@@ -1,0 +1,115 @@
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import { readJsonOrNull, writeJson } from "../utils/json-utils.js";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const LISA_CONFIG = ".lisa.config.json";
+const WIKI_CONFIG = path.join("wiki", "lisa-wiki.config.json");
+const DEFAULT_WIKI_ROOT = "wiki";
+
+/**
+ * Minimal shape of `.lisa.config.json` for this migration.
+ */
+interface LisaConfig {
+  readonly wiki?: { readonly source?: unknown; readonly [k: string]: unknown };
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Resolved state needed to decide and perform the declaration.
+ */
+interface WikiSourceState {
+  readonly configPath: string;
+  readonly config: LisaConfig | null;
+  readonly wikiRoot: string;
+}
+
+/**
+ * Migration: when a project carries a local LLM Wiki (`wiki/lisa-wiki.config.json`
+ * exists) but its `.lisa.config.json` does not declare `wiki.source`, write the
+ * explicit default pointer `wiki.source.path = <wikiRoot>` (the path the wiki's
+ * own config reports, default `wiki`).
+ *
+ * Resolving the wiki is implicit local mode without this — the declaration just
+ * makes "this project has a wiki here" self-documenting in the project config,
+ * and is the consumer-side hook the remote-wiki story builds on. Idempotent:
+ * skips when `wiki.source` already exists, preserves all other config keys and
+ * any sibling `wiki` keys. Creates `.lisa.config.json` if absent (the project is
+ * already Lisa-managed by virtue of carrying a lisa-wiki).
+ */
+export class EnsureWikiSourceDeclaredMigration implements Migration {
+  readonly name = "ensure-wiki-source-declared";
+  readonly description =
+    "Declare wiki.source.path in .lisa.config.json when the project has a local wiki";
+
+  /**
+   * Gather the config + wiki root, or null when the project has no local wiki.
+   * @param projectDir - Destination project directory
+   * @returns Resolved state, or null when there is no local lisa-wiki
+   */
+  private async readState(projectDir: string): Promise<WikiSourceState | null> {
+    const wikiCfgPath = path.join(projectDir, WIKI_CONFIG);
+    if (!(await fse.pathExists(wikiCfgPath))) {
+      return null;
+    }
+    const wikiCfg = await readJsonOrNull<{ wikiRoot?: string }>(wikiCfgPath);
+    const configPath = path.join(projectDir, LISA_CONFIG);
+    const config = await readJsonOrNull<LisaConfig>(configPath);
+    return {
+      configPath,
+      config,
+      wikiRoot: wikiCfg?.wikiRoot ?? DEFAULT_WIKI_ROOT,
+    };
+  }
+
+  /**
+   * Applies when a local wiki exists and `wiki.source` is not yet declared.
+   * @param ctx - Migration context
+   * @returns True when there is work to do
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    const state = await this.readState(ctx.projectDir);
+    return state !== null && state.config?.wiki?.source === undefined;
+  }
+
+  /**
+   * Write `wiki.source.path` into `.lisa.config.json`, preserving existing keys.
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const state = await this.readState(ctx.projectDir);
+    if (state === null || state.config?.wiki?.source !== undefined) {
+      return { name: this.name, action: "noop" };
+    }
+    const { configPath, config, wikiRoot } = state;
+    const merged = {
+      ...(config ?? {}),
+      wiki: { ...(config?.wiki ?? {}), source: { path: wikiRoot } },
+    };
+
+    const message = `Declared wiki.source.path="${wikiRoot}" in ${LISA_CONFIG}`;
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would declare wiki.source.path="${wikiRoot}"`);
+      return {
+        name: this.name,
+        action: "applied",
+        changedFiles: [LISA_CONFIG],
+        message,
+      };
+    }
+
+    await writeJson(configPath, merged);
+    ctx.logger.success(message);
+    return {
+      name: this.name,
+      action: "applied",
+      changedFiles: [LISA_CONFIG],
+      message,
+    };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -3,6 +3,7 @@ import { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 import { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
+import { EnsureWikiSourceDeclaredMigration } from "./ensure-wiki-source-declared.js";
 import { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 import { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
 import type {
@@ -22,6 +23,7 @@ export { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
 export { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
+export { EnsureWikiSourceDeclaredMigration } from "./ensure-wiki-source-declared.js";
 export { EnsureTsconfigLocalIncludesMigration } from "./ensure-tsconfig-local-includes.js";
 export { ReconcileClaudeStackPluginsMigration } from "./reconcile-claude-stack-plugins.js";
 
@@ -43,6 +45,7 @@ export class MigrationRegistry {
       new EnsureJestRnMockAccessibilityManagerMigration(),
       new EnsureLisaPostinstallMigration(),
       new EnsureSonarExcludesLisaHarnessMigration(),
+      new EnsureWikiSourceDeclaredMigration(),
       new ReconcileClaudeStackPluginsMigration(),
     ];
   }

--- a/tests/unit/migrations/ensure-wiki-source-declared.test.ts
+++ b/tests/unit/migrations/ensure-wiki-source-declared.test.ts
@@ -1,0 +1,111 @@
+import os from "node:os";
+import path from "node:path";
+
+import fs from "fs-extra";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureWikiSourceDeclaredMigration } from "../../../src/migrations/ensure-wiki-source-declared.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+
+const LISA_CONFIG = ".lisa.config.json";
+const WIKI_CONFIG = path.join("wiki", "lisa-wiki.config.json");
+
+describe("EnsureWikiSourceDeclaredMigration", () => {
+  const migration = new EnsureWikiSourceDeclaredMigration();
+  let tempDir: string;
+  let projectDir: string;
+  let lisaDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-wikisrc-"));
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  const ctx = (dryRun = false): MigrationContext => ({
+    projectDir,
+    lisaDir,
+    detectedTypes: ["typescript"] as ProjectType[],
+    dryRun,
+    logger: new SilentLogger(),
+  });
+  const writeWiki = (wikiRoot?: string): Promise<void> =>
+    fs.outputJson(
+      path.join(projectDir, WIKI_CONFIG),
+      wikiRoot ? { wikiRoot } : { org: "x" }
+    );
+  const readConfig = (): Promise<Record<string, unknown>> =>
+    fs.readJson(path.join(projectDir, LISA_CONFIG));
+
+  it("is a noop when the project has no local wiki", async () => {
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), { tracker: "jira" });
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+  });
+
+  it("declares wiki.source.path when a wiki exists and config lacks it", async () => {
+    await writeWiki();
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+      tracker: "jira",
+      source: "notion",
+    });
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+    const c = await readConfig();
+    expect(c.wiki).toEqual({ source: { path: "wiki" } });
+    expect(c.tracker).toBe("jira"); // existing keys preserved
+    expect(c.source).toBe("notion");
+  });
+
+  it("honors a non-default wikiRoot from lisa-wiki.config.json", async () => {
+    await writeWiki("docs/wiki");
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {});
+    await migration.apply(ctx());
+    expect((await readConfig()).wiki).toEqual({
+      source: { path: "docs/wiki" },
+    });
+  });
+
+  it("creates .lisa.config.json when absent", async () => {
+    await writeWiki();
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+    expect((await readConfig()).wiki).toEqual({ source: { path: "wiki" } });
+  });
+
+  it("is idempotent when wiki.source already declared", async () => {
+    await writeWiki();
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+      wiki: { source: { url: "git@github.com:org/wiki.git" } },
+    });
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+  });
+
+  it("preserves sibling wiki keys (e.g. ttlSeconds) while adding source", async () => {
+    await writeWiki();
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+      wiki: { ttlSeconds: 600 },
+    });
+    await migration.apply(ctx());
+    expect((await readConfig()).wiki).toEqual({
+      ttlSeconds: 600,
+      source: { path: "wiki" },
+    });
+  });
+
+  it("dry-run reports applied without writing", async () => {
+    await writeWiki();
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), { tracker: "jira" });
+    expect((await migration.apply(ctx(true))).action).toBe("applied");
+    expect((await readConfig()).wiki).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds an `ensure-wiki-source-declared` migration: when a project has a local wiki (`wiki/lisa-wiki.config.json`) but `.lisa.config.json` doesn't declare `wiki.source`, it writes the default `wiki.source.path=<wikiRoot>`. Self-documenting, idempotent, preserves other keys, creates the config if absent. 7 unit tests.

This is the upstream of the downstream rollout already underway across the workspace (declaring the in-repo wiki so the ensure-wiki resolver runs in LOCAL mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)