### PR TITLE
fix: preserve host config during postinstall apply

### DIFF
--- a/src/strategies/copy-overwrite.ts
+++ b/src/strategies/copy-overwrite.ts
@@ -13,6 +13,11 @@ import { filesIdentical, ensureParentDir } from "../utils/file-operations.js";
  */
 export class CopyOverwriteStrategy implements ICopyStrategy {
   readonly name = "copy-overwrite" as const;
+  private readonly postinstallHostOwnedPaths = new Set([
+    ".lintstagedrc.json",
+    ".safety-net.json",
+    "knip.json",
+  ]);
 
   /**
    * Apply copy-overwrite strategy: Create, skip, or prompt to overwrite file
@@ -40,6 +45,13 @@ export class CopyOverwriteStrategy implements ICopyStrategy {
     }
 
     if (await filesIdentical(sourcePath, destPath)) {
+      return { relativePath, strategy: this.name, action: "skipped" };
+    }
+
+    if (
+      config.skipGitCheck &&
+      this.postinstallHostOwnedPaths.has(relativePath)
+    ) {
       return { relativePath, strategy: this.name, action: "skipped" };
     }
 

--- a/src/strategies/merge.ts
+++ b/src/strategies/merge.ts
@@ -40,6 +40,10 @@ export class MergeStrategy implements ICopyStrategy {
       return { relativePath, strategy: this.name, action: "copied" };
     }
 
+    if (config.skipGitCheck && relativePath === "package.json") {
+      return { relativePath, strategy: this.name, action: "skipped" };
+    }
+
     const sourceJson = await readJson<object>(sourcePath).catch(() => {
       throw new JsonMergeError(
         relativePath,

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -92,6 +92,14 @@ export class PackageLisaStrategy implements ICopyStrategy {
 
     const destExists = await fse.pathExists(actualDestPath);
 
+    if (context.config.skipGitCheck && destExists) {
+      return {
+        relativePath: actualRelativePath,
+        strategy: this.name,
+        action: "skipped",
+      };
+    }
+
     try {
       // Load templates and apply to package.json
       const merged = await this.mergePackageJson(actualDestPath, context);

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -34,6 +34,9 @@ const LISAIGNORE = ".lisaignore";
 const LEGACY_WORKFLOW = "legacy-workflow.yml";
 const CREATE_ONLY = "create-only";
 const COPY_OVERWRITE = "copy-overwrite";
+const KNIP_JSON = "knip.json";
+const LINT_STAGED_JSON = ".lintstagedrc.json";
+const SAFETY_NET_JSON = ".safety-net.json";
 const HARPER_FABRIC_TYPE = "harper-fabric";
 const HARPER_FABRIC_TXT = "harper-fabric.txt";
 const JEST_CONFIG_LOCAL = "jest.config.local.ts";
@@ -114,6 +117,61 @@ describe("Lisa Integration Tests", () => {
       // Check that files were copied
       expect(await fs.pathExists(path.join(destDir, TEST_TXT))).toBe(true);
       expect(await fs.pathExists(path.join(destDir, TSCONFIG_BASE))).toBe(true);
+    });
+
+    it("preserves host-owned config during postinstall-safe apply", async () => {
+      await createTypeScriptProject(destDir);
+      const guardedPostinstall =
+        '[ -n "$CI" ] || node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true';
+      const hostPackageJson = {
+        name: "host-project",
+        dependencies: { typescript: "^5.0.0" },
+        scripts: { postinstall: guardedPostinstall, test: "host test" },
+        devDependencies: { oxlint: "^0.1.0" },
+      };
+      const hostKnip = { ignoreDependencies: ["shell-quote"] };
+      const hostLintStaged = { "*.ts": "host-lint" };
+      const hostSafetyNet = { rules: [] };
+
+      await fs.writeJson(path.join(destDir, PACKAGE_JSON), hostPackageJson);
+      await fs.writeJson(path.join(destDir, KNIP_JSON), hostKnip);
+      await fs.writeJson(path.join(destDir, LINT_STAGED_JSON), hostLintStaged);
+      await fs.writeJson(path.join(destDir, SAFETY_NET_JSON), hostSafetyNet);
+
+      const tsCopyOverwrite = path.join(lisaDir, "typescript", COPY_OVERWRITE);
+      await fs.writeJson(path.join(tsCopyOverwrite, KNIP_JSON), {
+        ignoreDependencies: ["from-lisa"],
+      });
+      await fs.writeJson(path.join(tsCopyOverwrite, LINT_STAGED_JSON), {
+        "*.ts": "lisa-lint",
+      });
+      await fs.writeJson(path.join(tsCopyOverwrite, SAFETY_NET_JSON), {
+        rules: [{ match: "no-verify" }],
+      });
+      const packageLisaDir = path.join(lisaDir, "typescript", "package-lisa");
+      await fs.ensureDir(packageLisaDir);
+      await fs.writeJson(path.join(packageLisaDir, "package.lisa.json"), {
+        force: {
+          scripts: { test: "vitest run" },
+          devDependencies: { oxlint: "^1.0.0" },
+        },
+      });
+
+      const result = await createLisa({ skipGitCheck: true }).apply();
+
+      expect(result.success).toBe(true);
+      expect(await fs.readJson(path.join(destDir, PACKAGE_JSON))).toEqual(
+        hostPackageJson
+      );
+      expect(await fs.readJson(path.join(destDir, KNIP_JSON))).toEqual(
+        hostKnip
+      );
+      expect(await fs.readJson(path.join(destDir, LINT_STAGED_JSON))).toEqual(
+        hostLintStaged
+      );
+      expect(await fs.readJson(path.join(destDir, SAFETY_NET_JSON))).toEqual(
+        hostSafetyNet
+      );
     });
 
     it("applies configurations to Expo project", async () => {

--- a/tests/unit/strategies/copy-overwrite.test.ts
+++ b/tests/unit/strategies/copy-overwrite.test.ts
@@ -8,6 +8,8 @@ import { createTempDir, cleanupTempDir } from "../../helpers/test-utils.js";
 const TEST_FILE = "TEST_FILE";
 const NEW_CONTENT = "new content";
 const OLD_CONTENT = "old content";
+const KNIP_JSON = "knip.json";
+const TSCONFIG_JSON = "tsconfig.json";
 
 describe("CopyOverwriteStrategy", () => {
   let strategy: CopyOverwriteStrategy;
@@ -146,6 +148,44 @@ describe("CopyOverwriteStrategy", () => {
 
     expect(result.action).toBe("skipped");
     expect(await fs.readFile(destFile, "utf-8")).toBe(OLD_CONTENT);
+  });
+
+  it("preserves host-owned config during skip-git-check applies", async () => {
+    const srcFile = path.join(srcDir, KNIP_JSON);
+    const destFile = path.join(destDir, KNIP_JSON);
+    await fs.writeJson(srcFile, { ignoreDependencies: ["from-lisa"] });
+    await fs.writeJson(destFile, { ignoreDependencies: ["shell-quote"] });
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      KNIP_JSON,
+      createContext({ skipGitCheck: true })
+    );
+
+    expect(result.action).toBe("skipped");
+    expect(await fs.readJson(destFile)).toEqual({
+      ignoreDependencies: ["shell-quote"],
+    });
+  });
+
+  it("still overwrites other Lisa-managed files during skip-git-check applies", async () => {
+    const srcFile = path.join(srcDir, TSCONFIG_JSON);
+    const destFile = path.join(destDir, TSCONFIG_JSON);
+    await fs.writeJson(srcFile, { extends: "./tsconfig.base.json" });
+    await fs.writeJson(destFile, {});
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      TSCONFIG_JSON,
+      createContext({ skipGitCheck: true })
+    );
+
+    expect(result.action).toBe("overwritten");
+    expect(await fs.readJson(destFile)).toEqual({
+      extends: "./tsconfig.base.json",
+    });
   });
 
   it("creates parent directories when needed", async () => {

--- a/tests/unit/strategies/merge.test.ts
+++ b/tests/unit/strategies/merge.test.ts
@@ -129,6 +129,30 @@ describe("MergeStrategy", () => {
     expect(result.action).toBe("skipped");
   });
 
+  it("preserves existing package.json during skip-git-check applies", async () => {
+    const srcFile = path.join(srcDir, PACKAGE_JSON);
+    const destFile = path.join(destDir, PACKAGE_JSON);
+
+    await fs.writeJson(srcFile, { scripts: { test: "echo test" } });
+    await fs.writeJson(destFile, {
+      name: "host-project",
+      scripts: { test: "host test" },
+    });
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      PACKAGE_JSON,
+      createContext({ skipGitCheck: true })
+    );
+
+    expect(result.action).toBe("skipped");
+    expect(await fs.readJson(destFile)).toEqual({
+      name: "host-project",
+      scripts: { test: "host test" },
+    });
+  });
+
   it("backs up file before merging", async () => {
     const srcFile = path.join(srcDir, PACKAGE_JSON);
     const destFile = path.join(destDir, PACKAGE_JSON);

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -200,6 +200,43 @@ describe("PackageLisaStrategy", () => {
       expect(content.devDependencies).toEqual({ eslint: "^9.0.0" });
     });
 
+    it("preserves existing package.json during skip-git-check applies", async () => {
+      await createPackageLisaTemplate("all", {
+        force: {
+          scripts: { test: "vitest run" },
+          devDependencies: { oxlint: "^1.0.0" },
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "all",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.lisa.json");
+      const actualPackageJson = path.join(projectDir, "package.json");
+      await fs.writeJson(actualPackageJson, {
+        name: "host-project",
+        scripts: { test: "host test" },
+        devDependencies: { oxlint: "^0.1.0" },
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.lisa.json",
+        createContext({ skipGitCheck: true })
+      );
+
+      expect(_result.action).toBe("skipped");
+      expect(await fs.readJson(actualPackageJson)).toEqual({
+        name: "host-project",
+        scripts: { test: "host test" },
+        devDependencies: { oxlint: "^0.1.0" },
+      });
+    });
+
     // Regression: force.resolutions and force.overrides must replace project-side
     // values for package-level dep pinning (e.g. axios). This is the write that
     // was silently lost when `bun add -d @codyswann/lisa@latest` clobbered


### PR DESCRIPTION
## Summary
- Preserve existing host-owned config files during postinstall-safe Lisa applies (--skip-git-check).
- Skip existing package.json mutations from generic merge and package-lisa strategies in that install-time path.
- Add unit and integration regression coverage for knip.json, .lintstagedrc.json, .safety-net.json, and package.json.

## Verification
- bun run typecheck
- bun run lint
- bun test tests/unit/strategies/copy-overwrite.test.ts tests/unit/strategies/merge.test.ts tests/unit/strategies/package-lisa.test.ts tests/integration/lisa.test.ts
- pre-push hook: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration

Fixes #1239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation now preserves host-owned configuration files (package.json and tool configs) when skipGitCheck is enabled, preventing unintended overwrites.

* **Tests**
  * Added comprehensive test coverage for skipGitCheck behavior across strategy implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->