### PR TITLE
feat: add Harper Fabric deploy workflows

### DIFF
--- a/harper-fabric/create-only/.github/workflows/deploy.yml
+++ b/harper-fabric/create-only/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+# This file is create-only from Lisa.
+# Customize it for your Harper Fabric target; Lisa will not overwrite it.
+
+name: Deploy Harper Fabric
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: harper-fabric-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build, deploy, and verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      HARPER_PROJECT: ${{ vars.HARPER_PROJECT || github.event.repository.name }}
+      HARPER_PACKAGE: ${{ vars.HARPER_PACKAGE || 'harper-app' }}
+      CLI_TARGET: ${{ secrets.CLI_TARGET || secrets.HARPER_FABRIC_TARGET }}
+      CLI_TARGET_USERNAME: ${{ secrets.CLI_TARGET_USERNAME }}
+      CLI_TARGET_PASSWORD: ${{ secrets.CLI_TARGET_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.21.1'
+          package-manager-cache: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Harper component
+        run: bun run build
+
+      - name: Verify Fabric secrets
+        run: |
+          test -n "${CLI_TARGET}" || { echo "Missing CLI_TARGET or HARPER_FABRIC_TARGET secret"; exit 1; }
+          test -n "${CLI_TARGET_USERNAME}" || { echo "Missing CLI_TARGET_USERNAME secret"; exit 1; }
+          test -n "${CLI_TARGET_PASSWORD}" || { echo "Missing CLI_TARGET_PASSWORD secret"; exit 1; }
+
+      - name: Deploy component to Harper Fabric
+        run: |
+          if command -v harper >/dev/null 2>&1; then
+            HARPER_BIN="harper"
+          elif [ -x node_modules/.bin/harper ]; then
+            HARPER_BIN="node_modules/.bin/harper"
+          elif [ -x node_modules/.bin/harperdb ]; then
+            HARPER_BIN="node_modules/.bin/harperdb"
+          else
+            echo "Missing Harper CLI. Add harper/harperdb to devDependencies or install it before deploy."
+            exit 1
+          fi
+
+          "$HARPER_BIN" deploy_component \
+            project="${HARPER_PROJECT}" \
+            package="${HARPER_PACKAGE}" \
+            target="${CLI_TARGET}" \
+            username="${CLI_TARGET_USERNAME}" \
+            password="${CLI_TARGET_PASSWORD}" \
+            restart=true \
+            replicated=true
+
+      - name: Smoke verify deployed component
+        run: |
+          if bun run | grep -qE '^[[:space:]]*verify[[:space:]]'; then
+            bun run verify
+          else
+            echo "No verify script defined; add one to smoke-test the deployed Harper endpoint."
+          fi

--- a/harper-fabric/create-only/.github/workflows/zap-baseline.yml
+++ b/harper-fabric/create-only/.github/workflows/zap-baseline.yml
@@ -1,0 +1,56 @@
+# This file is create-only from Lisa.
+# Customize the target URL and rules for your Harper Fabric app.
+
+name: ZAP Baseline
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: URL to scan. Defaults to ZAP_TARGET_URL variable or http://host.docker.internal:9926.
+        required: false
+        type: string
+
+concurrency:
+  group: harper-fabric-zap-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zap:
+    name: ZAP baseline scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ZAP_TARGET_URL: ${{ inputs.target_url || vars.ZAP_TARGET_URL || 'http://host.docker.internal:9926' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.21.1'
+          package-manager-cache: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run ZAP baseline
+        run: bash scripts/zap-baseline.sh
+
+      - name: Upload ZAP reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-baseline-report
+          path: |
+            zap-report.html
+            zap-report.json
+            zap-report.md
+          if-no-files-found: ignore

--- a/harper-fabric/create-only/.zap/baseline.conf
+++ b/harper-fabric/create-only/.zap/baseline.conf
@@ -1,0 +1,21 @@
+# OWASP ZAP Baseline Scan Configuration - Harper Fabric apps
+# Format: <rule_id> <action> <description>
+# Actions: IGNORE (skip rule), WARN (report but do not fail), FAIL (fail on finding)
+
+# Harper apps often sit behind Fabric/proxy infrastructure that owns transport headers.
+10035	WARN	(Strict-Transport-Security Header Not Set)
+10021	WARN	(X-Content-Type-Options Header Missing)
+10038	WARN	(Content Security Policy (CSP) Header Not Set)
+
+# Static/browser surfaces should not disclose implementation details.
+10036	WARN	(Server Leaks Version Information via "Server" HTTP Response Header Field)
+10023	FAIL	(Information Disclosure - Debug Error Messages)
+
+# Session cookies, when present, must carry browser-safe flags.
+10010	FAIL	(Cookie No HttpOnly Flag)
+10011	FAIL	(Cookie Without Secure Flag)
+10054	WARN	(Cookie without SameSite Attribute)
+
+# Harper REST/GraphQL endpoints may legitimately expose API-oriented responses.
+10020	WARN	(X-Frame-Options Header Not Set)
+10063	WARN	(Permissions Policy Header Not Set)

--- a/harper-fabric/create-only/scripts/zap-baseline.sh
+++ b/harper-fabric/create-only/scripts/zap-baseline.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# OWASP ZAP Baseline Scan - Harper Fabric app
+# Builds the Harper app, starts it locally when no deployed target is supplied,
+# and runs a ZAP baseline scan via Docker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_URL="${ZAP_TARGET_URL:-http://host.docker.internal:9926}"
+LOCAL_TARGETS=("http://localhost:9926" "http://host.docker.internal:9926")
+SCAN_TARGET_URL="$TARGET_URL"
+ZAP_RULES_FILE="${ZAP_RULES_FILE:-.zap/baseline.conf}"
+REPORT_FILE="zap-report.html"
+SERVER_PID=""
+
+cd "$PROJECT_ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: Docker is required but not installed."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: Docker daemon is not running."
+  exit 1
+fi
+
+echo "==> Building Harper Fabric project..."
+bun run build
+
+should_start_local=false
+for local_target in "${LOCAL_TARGETS[@]}"; do
+  if [ "$TARGET_URL" = "$local_target" ]; then
+    should_start_local=true
+    SCAN_TARGET_URL="http://host.docker.internal:9926"
+  fi
+done
+
+cleanup() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    echo "==> Stopping Harper app..."
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [ "$should_start_local" = true ]; then
+  if command -v harper >/dev/null 2>&1; then
+    HARPER_BIN="harper"
+  elif [ -x node_modules/.bin/harper ]; then
+    HARPER_BIN="node_modules/.bin/harper"
+  elif [ -x node_modules/.bin/harperdb ]; then
+    HARPER_BIN="node_modules/.bin/harperdb"
+  else
+    echo "Error: missing Harper CLI. Set ZAP_TARGET_URL to a deployed app or install the Harper CLI."
+    exit 1
+  fi
+
+  echo "==> Starting Harper app locally..."
+  "$HARPER_BIN" run harper-app &
+  SERVER_PID=$!
+
+  echo "==> Waiting for Harper app..."
+  retries=30
+  until curl -sf http://localhost:9926 >/dev/null 2>&1 || [ "$retries" -eq 0 ]; do
+    retries=$((retries - 1))
+    sleep 2
+  done
+
+  if [ "$retries" -eq 0 ]; then
+    echo "Error: Harper app did not become reachable at http://localhost:9926"
+    exit 1
+  fi
+fi
+
+echo "==> Running OWASP ZAP baseline scan against $SCAN_TARGET_URL..."
+zap_args="-t $SCAN_TARGET_URL"
+
+if [ -f "$ZAP_RULES_FILE" ]; then
+  echo "    Using rules file: $ZAP_RULES_FILE"
+  zap_args="$zap_args -c /zap/wrk/$(basename "$ZAP_RULES_FILE")"
+  mount_rules="-v $(dirname "$(realpath "$ZAP_RULES_FILE")"):/zap/wrk:ro"
+else
+  mount_rules=""
+fi
+
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$(pwd)":/zap/wrk/:rw \
+  $mount_rules \
+  ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py $zap_args \
+  -r "$REPORT_FILE" \
+  -J zap-report.json \
+  -w zap-report.md \
+  -l WARN || zap_exit=$?
+
+if [ -f "$REPORT_FILE" ]; then
+  echo "ZAP report saved to: $REPORT_FILE"
+fi
+
+if [ "${zap_exit:-0}" -ne 0 ]; then
+  echo "ZAP found medium+ severity findings (exit code: $zap_exit)."
+  exit "$zap_exit"
+fi
+
+echo "ZAP baseline scan passed."

--- a/plugins/lisa-harper-fabric-agy/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-build-and-deploy/SKILL.md
@@ -53,8 +53,25 @@ relevant deployed or smoke path agree.
 
 ## Deploying to Fabric
 
-Fabric is Harper's distributed deploy network. Deploy packages the component and
-sends it to a target instance:
+Fabric is Harper's distributed deploy network. Lisa ships a create-only GitHub
+Actions workflow at `.github/workflows/deploy.yml` for Harper/Fabric projects. Use
+that workflow as the canonical deployment path for repositories that have adopted
+the template: it builds the project, runs `harper deploy_component` against the
+configured Fabric target, and then runs the project's smoke verification script.
+
+Required GitHub secrets:
+
+- `CLI_TARGET` or `HARPER_FABRIC_TARGET` — Fabric target URL.
+- `CLI_TARGET_USERNAME` — deploy username.
+- `CLI_TARGET_PASSWORD` — deploy password.
+
+Optional GitHub variables:
+
+- `HARPER_PROJECT` — Fabric project name; defaults to the repository name.
+- `HARPER_PACKAGE` — package path; defaults to `harper-app`.
+
+For local debugging or one-off deploys, the equivalent CLI command packages the
+component and sends it to a target instance:
 
 ```bash
 harper deploy_component \
@@ -85,8 +102,11 @@ env var, which store) without recording their values.
 1. `bun run build` — produces fresh `resources.js` / `web/**`.
 2. `bun run typecheck`.
 3. The smallest relevant test command.
-4. For deploy-affecting changes, the project **smoke command** against the local or
-   deployed Harper endpoint.
+4. For deploy-affecting changes, run the create-only GitHub deploy workflow when
+   available, or manually run `harper deploy_component` plus the project **smoke
+   command** against the local or deployed Harper endpoint.
+5. For public HTTP surfaces, run the create-only ZAP baseline workflow or
+   `bash scripts/zap-baseline.sh` with `ZAP_TARGET_URL` set to the deployed app.
 
 If a verification command cannot run, report the exact command and the blocker —
 do not claim completion. When you hit a Harper/Fabric limitation or workaround,

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-build-and-deploy/SKILL.md
@@ -53,8 +53,25 @@ relevant deployed or smoke path agree.
 
 ## Deploying to Fabric
 
-Fabric is Harper's distributed deploy network. Deploy packages the component and
-sends it to a target instance:
+Fabric is Harper's distributed deploy network. Lisa ships a create-only GitHub
+Actions workflow at `.github/workflows/deploy.yml` for Harper/Fabric projects. Use
+that workflow as the canonical deployment path for repositories that have adopted
+the template: it builds the project, runs `harper deploy_component` against the
+configured Fabric target, and then runs the project's smoke verification script.
+
+Required GitHub secrets:
+
+- `CLI_TARGET` or `HARPER_FABRIC_TARGET` — Fabric target URL.
+- `CLI_TARGET_USERNAME` — deploy username.
+- `CLI_TARGET_PASSWORD` — deploy password.
+
+Optional GitHub variables:
+
+- `HARPER_PROJECT` — Fabric project name; defaults to the repository name.
+- `HARPER_PACKAGE` — package path; defaults to `harper-app`.
+
+For local debugging or one-off deploys, the equivalent CLI command packages the
+component and sends it to a target instance:
 
 ```bash
 harper deploy_component \
@@ -85,8 +102,11 @@ env var, which store) without recording their values.
 1. `bun run build` — produces fresh `resources.js` / `web/**`.
 2. `bun run typecheck`.
 3. The smallest relevant test command.
-4. For deploy-affecting changes, the project **smoke command** against the local or
-   deployed Harper endpoint.
+4. For deploy-affecting changes, run the create-only GitHub deploy workflow when
+   available, or manually run `harper deploy_component` plus the project **smoke
+   command** against the local or deployed Harper endpoint.
+5. For public HTTP surfaces, run the create-only ZAP baseline workflow or
+   `bash scripts/zap-baseline.sh` with `ZAP_TARGET_URL` set to the deployed app.
 
 If a verification command cannot run, report the exact command and the blocker —
 do not claim completion. When you hit a Harper/Fabric limitation or workaround,

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-build-and-deploy/SKILL.md
@@ -53,8 +53,25 @@ relevant deployed or smoke path agree.
 
 ## Deploying to Fabric
 
-Fabric is Harper's distributed deploy network. Deploy packages the component and
-sends it to a target instance:
+Fabric is Harper's distributed deploy network. Lisa ships a create-only GitHub
+Actions workflow at `.github/workflows/deploy.yml` for Harper/Fabric projects. Use
+that workflow as the canonical deployment path for repositories that have adopted
+the template: it builds the project, runs `harper deploy_component` against the
+configured Fabric target, and then runs the project's smoke verification script.
+
+Required GitHub secrets:
+
+- `CLI_TARGET` or `HARPER_FABRIC_TARGET` — Fabric target URL.
+- `CLI_TARGET_USERNAME` — deploy username.
+- `CLI_TARGET_PASSWORD` — deploy password.
+
+Optional GitHub variables:
+
+- `HARPER_PROJECT` — Fabric project name; defaults to the repository name.
+- `HARPER_PACKAGE` — package path; defaults to `harper-app`.
+
+For local debugging or one-off deploys, the equivalent CLI command packages the
+component and sends it to a target instance:
 
 ```bash
 harper deploy_component \
@@ -85,8 +102,11 @@ env var, which store) without recording their values.
 1. `bun run build` — produces fresh `resources.js` / `web/**`.
 2. `bun run typecheck`.
 3. The smallest relevant test command.
-4. For deploy-affecting changes, the project **smoke command** against the local or
-   deployed Harper endpoint.
+4. For deploy-affecting changes, run the create-only GitHub deploy workflow when
+   available, or manually run `harper deploy_component` plus the project **smoke
+   command** against the local or deployed Harper endpoint.
+5. For public HTTP surfaces, run the create-only ZAP baseline workflow or
+   `bash scripts/zap-baseline.sh` with `ZAP_TARGET_URL` set to the deployed app.
 
 If a verification command cannot run, report the exact command and the blocker —
 do not claim completion. When you hit a Harper/Fabric limitation or workaround,

--- a/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/SKILL.md
@@ -53,8 +53,25 @@ relevant deployed or smoke path agree.
 
 ## Deploying to Fabric
 
-Fabric is Harper's distributed deploy network. Deploy packages the component and
-sends it to a target instance:
+Fabric is Harper's distributed deploy network. Lisa ships a create-only GitHub
+Actions workflow at `.github/workflows/deploy.yml` for Harper/Fabric projects. Use
+that workflow as the canonical deployment path for repositories that have adopted
+the template: it builds the project, runs `harper deploy_component` against the
+configured Fabric target, and then runs the project's smoke verification script.
+
+Required GitHub secrets:
+
+- `CLI_TARGET` or `HARPER_FABRIC_TARGET` — Fabric target URL.
+- `CLI_TARGET_USERNAME` — deploy username.
+- `CLI_TARGET_PASSWORD` — deploy password.
+
+Optional GitHub variables:
+
+- `HARPER_PROJECT` — Fabric project name; defaults to the repository name.
+- `HARPER_PACKAGE` — package path; defaults to `harper-app`.
+
+For local debugging or one-off deploys, the equivalent CLI command packages the
+component and sends it to a target instance:
 
 ```bash
 harper deploy_component \
@@ -85,8 +102,11 @@ env var, which store) without recording their values.
 1. `bun run build` — produces fresh `resources.js` / `web/**`.
 2. `bun run typecheck`.
 3. The smallest relevant test command.
-4. For deploy-affecting changes, the project **smoke command** against the local or
-   deployed Harper endpoint.
+4. For deploy-affecting changes, run the create-only GitHub deploy workflow when
+   available, or manually run `harper deploy_component` plus the project **smoke
+   command** against the local or deployed Harper endpoint.
+5. For public HTTP surfaces, run the create-only ZAP baseline workflow or
+   `bash scripts/zap-baseline.sh` with `ZAP_TARGET_URL` set to the deployed app.
 
 If a verification command cannot run, report the exact command and the blocker —
 do not claim completion. When you hit a Harper/Fabric limitation or workaround,

--- a/plugins/src/harper-fabric/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-build-and-deploy/SKILL.md
@@ -53,8 +53,25 @@ relevant deployed or smoke path agree.
 
 ## Deploying to Fabric
 
-Fabric is Harper's distributed deploy network. Deploy packages the component and
-sends it to a target instance:
+Fabric is Harper's distributed deploy network. Lisa ships a create-only GitHub
+Actions workflow at `.github/workflows/deploy.yml` for Harper/Fabric projects. Use
+that workflow as the canonical deployment path for repositories that have adopted
+the template: it builds the project, runs `harper deploy_component` against the
+configured Fabric target, and then runs the project's smoke verification script.
+
+Required GitHub secrets:
+
+- `CLI_TARGET` or `HARPER_FABRIC_TARGET` — Fabric target URL.
+- `CLI_TARGET_USERNAME` — deploy username.
+- `CLI_TARGET_PASSWORD` — deploy password.
+
+Optional GitHub variables:
+
+- `HARPER_PROJECT` — Fabric project name; defaults to the repository name.
+- `HARPER_PACKAGE` — package path; defaults to `harper-app`.
+
+For local debugging or one-off deploys, the equivalent CLI command packages the
+component and sends it to a target instance:
 
 ```bash
 harper deploy_component \
@@ -85,8 +102,11 @@ env var, which store) without recording their values.
 1. `bun run build` — produces fresh `resources.js` / `web/**`.
 2. `bun run typecheck`.
 3. The smallest relevant test command.
-4. For deploy-affecting changes, the project **smoke command** against the local or
-   deployed Harper endpoint.
+4. For deploy-affecting changes, run the create-only GitHub deploy workflow when
+   available, or manually run `harper deploy_component` plus the project **smoke
+   command** against the local or deployed Harper endpoint.
+5. For public HTTP surfaces, run the create-only ZAP baseline workflow or
+   `bash scripts/zap-baseline.sh` with `ZAP_TARGET_URL` set to the deployed app.
 
 If a verification command cannot run, report the exact command and the blocker —
 do not claim completion. When you hit a Harper/Fabric limitation or workaround,

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -143,6 +143,49 @@ export async function createRailsProject(dir: string): Promise<void> {
 }
 
 /**
+ * Add representative Harper/Fabric templates to a mock Lisa directory.
+ * @param dir - Mock Lisa directory
+ */
+async function createMockHarperFabricTemplates(dir: string): Promise<void> {
+  const harperCreateOnly = path.join(dir, "harper-fabric", CREATE_ONLY);
+  await fs.ensureDir(path.join(harperCreateOnly, ".github", "workflows"));
+  await fs.ensureDir(path.join(harperCreateOnly, ".zap"));
+  await fs.ensureDir(path.join(harperCreateOnly, "scripts"));
+  await fs.writeFile(
+    path.join(harperCreateOnly, ".github", "workflows", "deploy.yml"),
+    [
+      "name: Deploy Harper Fabric",
+      "jobs:",
+      "  deploy:",
+      "    steps:",
+      "      - run: bun run build",
+      "      - run: harper deploy_component",
+      "      - run: bun run verify",
+      "",
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(harperCreateOnly, ".github", "workflows", "zap-baseline.yml"),
+    [
+      "name: ZAP Baseline",
+      "jobs:",
+      "  zap:",
+      "    steps:",
+      "      - run: bash scripts/zap-baseline.sh",
+      "",
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(harperCreateOnly, ".zap", "baseline.conf"),
+    "10023\tFAIL\t(Information Disclosure - Debug Error Messages)\n"
+  );
+  await fs.writeFile(
+    path.join(harperCreateOnly, "scripts", "zap-baseline.sh"),
+    "#!/usr/bin/env bash\nzap-baseline.py -t ${ZAP_TARGET_URL:-http://localhost:9926}\n"
+  );
+}
+
+/**
  * Create a mock Lisa config directory structure with all strategies
  * @param dir - Directory to create Lisa structure in
  */
@@ -182,6 +225,8 @@ export async function createMockLisaDir(dir: string): Promise<void> {
   await fs.writeJson(path.join(dir, "typescript", DELETIONS_JSON), {
     paths: ["legacy-workflow.yml"],
   });
+
+  await createMockHarperFabricTemplates(dir);
 
   // Create rails/ directory with Rails-specific files
   const railsCopyOverwrite = path.join(dir, "rails", COPY_OVERWRITE);

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -221,6 +221,61 @@ describe("Lisa Integration Tests", () => {
       );
     });
 
+    it("ships Harper/Fabric deploy and ZAP workflow templates as create-only files", async () => {
+      await createHarperFabricProject(destDir);
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      const deployPath = path.join(
+        destDir,
+        ".github",
+        "workflows",
+        "deploy.yml"
+      );
+      const zapWorkflowPath = path.join(
+        destDir,
+        ".github",
+        "workflows",
+        "zap-baseline.yml"
+      );
+      const zapScriptPath = path.join(destDir, "scripts", "zap-baseline.sh");
+      const zapConfigPath = path.join(destDir, ".zap", "baseline.conf");
+
+      expect(await fs.pathExists(deployPath)).toBe(true);
+      expect(await fs.pathExists(zapWorkflowPath)).toBe(true);
+      expect(await fs.pathExists(zapScriptPath)).toBe(true);
+      expect(await fs.pathExists(zapConfigPath)).toBe(true);
+
+      const deployContent = await fs.readFile(deployPath, "utf-8");
+      expect(deployContent).toContain("bun run build");
+      expect(deployContent).toContain("harper deploy_component");
+      expect(deployContent).toContain("bun run verify");
+
+      const zapWorkflowContent = await fs.readFile(zapWorkflowPath, "utf-8");
+      expect(zapWorkflowContent).toContain("scripts/zap-baseline.sh");
+    });
+
+    it("preserves existing Harper/Fabric deploy workflow customizations", async () => {
+      await createHarperFabricProject(destDir);
+      const deployPath = path.join(
+        destDir,
+        ".github",
+        "workflows",
+        "deploy.yml"
+      );
+      const customDeploy = "name: Custom Harper Deploy\n";
+      await fs.ensureDir(path.dirname(deployPath));
+      await fs.writeFile(deployPath, customDeploy);
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      await createLisa().apply();
+      const deployContent = await fs.readFile(deployPath, "utf-8");
+      expect(deployContent).toBe(customDeploy);
+    });
+
     it("removes an existing manifest file during apply", async () => {
       await createTypeScriptProject(destDir);
       const manifestPath = path.join(destDir, ".lisa-manifest");


### PR DESCRIPTION
## Summary
- Add create-only Harper Fabric deploy and ZAP baseline workflow templates
- Add ZAP rules/script assets and document the workflow as the canonical deploy path
- Cover fresh apply and create-only preservation in integration tests

## Verification
- bun test tests/integration/lisa.test.ts
- bun run format:check
- bun run typecheck
- bun run lint (passes with existing warnings)
- bun run check:plugins
- git push pre-push hook: bun audit, slow lint, knip, vitest coverage, integration tests

Closes #1255