### PR TITLE
feat: block Harper generated artifact edits

### DIFF
--- a/harper-fabric/copy-contents/.gitignore
+++ b/harper-fabric/copy-contents/.gitignore
@@ -1,8 +1,8 @@
 # BEGIN: AI GUARDRAILS HARPER-FABRIC
 harper-app/resources.js
 harper-app/resource-*.js
-harper-app/web/**/*.js
-harper-app/web/**/*.js.map
+harper-app/web/**
+harper-app/lib/**
 .lisabak/
 .lisabak
 # END: AI GUARDRAILS HARPER-FABRIC

--- a/harper-fabric/copy-contents/.prettierignore
+++ b/harper-fabric/copy-contents/.prettierignore
@@ -2,7 +2,10 @@
 
 # Harper/Fabric generated web output and scraped research captures are not
 # source formatting inputs.
-harper-app/web/
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**
 research/articles/
 
 # END: AI GUARDRAILS HARPER-FABRIC

--- a/harper-fabric/copy-overwrite/knip.json
+++ b/harper-fabric/copy-overwrite/knip.json
@@ -15,7 +15,8 @@
     "**/node_modules/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
-    "harper-app/web/**/*.js"
+    "harper-app/web/**",
+    "harper-app/lib/**"
   ],
   "ignoreIssues": {
     "src/types/harper-schema.ts": ["types"]

--- a/harper-fabric/copy-overwrite/tsconfig.eslint.json
+++ b/harper-fabric/copy-overwrite/tsconfig.eslint.json
@@ -22,6 +22,7 @@
     "coverage",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
-    "harper-app/web/**/*.js"
+    "harper-app/web/**",
+    "harper-app/lib/**"
   ]
 }

--- a/harper-fabric/merge/.oxlintrc.json
+++ b/harper-fabric/merge/.oxlintrc.json
@@ -12,6 +12,7 @@
     "**/generated/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
-    "harper-app/web/**/*.js"
+    "harper-app/web/**",
+    "harper-app/lib/**"
   ]
 }

--- a/oxlint/harper-fabric.json
+++ b/oxlint/harper-fabric.json
@@ -7,6 +7,7 @@
     "node_modules/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
-    "harper-app/web/**/*.js"
+    "harper-app/web/**",
+    "harper-app/lib/**"
   ]
 }

--- a/plugins/lisa-harper-fabric-agy/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-agy/generated-artifact-globs.txt
@@ -1,0 +1,4 @@
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**

--- a/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
@@ -9,6 +9,17 @@
     "lisa-typescript"
   ],
   "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh"
+          }
+        ]
+      }
+    ],
     "sessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric-copilot/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-copilot/generated-artifact-globs.txt
@@ -1,0 +1,4 @@
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**

--- a/plugins/lisa-harper-fabric-copilot/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric-copilot/hooks/block-generated-artifact-edits.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PreToolUse hook: block Write/Edit/MultiEdit on generated Harper deploy
+# artifacts. Harper/Fabric projects build these files from TypeScript under
+# src/, so direct edits are overwritten by the next build and usually ship as
+# no-op fixes.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+
+JSON_INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+GLOBS_FILE="$PLUGIN_ROOT/generated-artifact-globs.txt"
+[ -f "$GLOBS_FILE" ] || exit 0
+
+normalize_path() {
+  local path="$1"
+  path="${path#./}"
+  printf '%s' "$path"
+}
+
+matches_glob() {
+  local file="$1"
+  local glob="$2"
+
+  if [ "${glob: -3}" = "/**" ]; then
+    local dir="${glob%/**}"
+    case "$file" in
+      "$dir"/* | */"$dir"/*) return 0 ;;
+    esac
+    return 1
+  fi
+
+  case "$file" in
+    $glob | */$glob) return 0 ;;
+  esac
+
+  return 1
+}
+
+NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+while IFS= read -r glob || [ -n "$glob" ]; do
+  [ -n "$glob" ] || continue
+  case "$glob" in \#*) continue ;; esac
+
+  if matches_glob "$NORMALIZED_FILE" "$glob"; then
+    cat >&2 <<MSG
+Blocked: direct edit to generated Harper/Fabric artifact.
+
+File: $FILE_PATH
+Matched generated artifact pattern: $glob
+
+TypeScript under src/ is the source of truth for Harper resources, web assets,
+and shared libraries. Change the matching TypeScript source under src/ and run
+the project build to regenerate harper-app outputs.
+MSG
+    exit 2
+  fi
+done <"$GLOBS_FILE"
+
+exit 0

--- a/plugins/lisa-harper-fabric-cursor/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-cursor/generated-artifact-globs.txt
@@ -1,0 +1,4 @@
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**

--- a/plugins/lisa-harper-fabric-cursor/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric-cursor/hooks/block-generated-artifact-edits.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PreToolUse hook: block Write/Edit/MultiEdit on generated Harper deploy
+# artifacts. Harper/Fabric projects build these files from TypeScript under
+# src/, so direct edits are overwritten by the next build and usually ship as
+# no-op fixes.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+
+JSON_INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+GLOBS_FILE="$PLUGIN_ROOT/generated-artifact-globs.txt"
+[ -f "$GLOBS_FILE" ] || exit 0
+
+normalize_path() {
+  local path="$1"
+  path="${path#./}"
+  printf '%s' "$path"
+}
+
+matches_glob() {
+  local file="$1"
+  local glob="$2"
+
+  if [ "${glob: -3}" = "/**" ]; then
+    local dir="${glob%/**}"
+    case "$file" in
+      "$dir"/* | */"$dir"/*) return 0 ;;
+    esac
+    return 1
+  fi
+
+  case "$file" in
+    $glob | */$glob) return 0 ;;
+  esac
+
+  return 1
+}
+
+NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+while IFS= read -r glob || [ -n "$glob" ]; do
+  [ -n "$glob" ] || continue
+  case "$glob" in \#*) continue ;; esac
+
+  if matches_glob "$NORMALIZED_FILE" "$glob"; then
+    cat >&2 <<MSG
+Blocked: direct edit to generated Harper/Fabric artifact.
+
+File: $FILE_PATH
+Matched generated artifact pattern: $glob
+
+TypeScript under src/ is the source of truth for Harper resources, web assets,
+and shared libraries. Change the matching TypeScript source under src/ and run
+the project build to regenerate harper-app outputs.
+MSG
+    exit 2
+  fi
+done <"$GLOBS_FILE"
+
+exit 0

--- a/plugins/lisa-harper-fabric-cursor/hooks/hooks.json
+++ b/plugins/lisa-harper-fabric-cursor/hooks/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh",
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ]
+  }
+}

--- a/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
@@ -9,6 +9,17 @@
     "lisa-typescript"
   ],
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric/generated-artifact-globs.txt
@@ -1,0 +1,4 @@
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**

--- a/plugins/lisa-harper-fabric/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric/hooks/block-generated-artifact-edits.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PreToolUse hook: block Write/Edit/MultiEdit on generated Harper deploy
+# artifacts. Harper/Fabric projects build these files from TypeScript under
+# src/, so direct edits are overwritten by the next build and usually ship as
+# no-op fixes.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+
+JSON_INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+GLOBS_FILE="$PLUGIN_ROOT/generated-artifact-globs.txt"
+[ -f "$GLOBS_FILE" ] || exit 0
+
+normalize_path() {
+  local path="$1"
+  path="${path#./}"
+  printf '%s' "$path"
+}
+
+matches_glob() {
+  local file="$1"
+  local glob="$2"
+
+  if [ "${glob: -3}" = "/**" ]; then
+    local dir="${glob%/**}"
+    case "$file" in
+      "$dir"/* | */"$dir"/*) return 0 ;;
+    esac
+    return 1
+  fi
+
+  case "$file" in
+    $glob | */$glob) return 0 ;;
+  esac
+
+  return 1
+}
+
+NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+while IFS= read -r glob || [ -n "$glob" ]; do
+  [ -n "$glob" ] || continue
+  case "$glob" in \#*) continue ;; esac
+
+  if matches_glob "$NORMALIZED_FILE" "$glob"; then
+    cat >&2 <<MSG
+Blocked: direct edit to generated Harper/Fabric artifact.
+
+File: $FILE_PATH
+Matched generated artifact pattern: $glob
+
+TypeScript under src/ is the source of truth for Harper resources, web assets,
+and shared libraries. Change the matching TypeScript source under src/ and run
+the project build to regenerate harper-app outputs.
+MSG
+    exit 2
+  fi
+done <"$GLOBS_FILE"
+
+exit 0

--- a/plugins/src/harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/src/harper-fabric/.claude-plugin/plugin.json
@@ -5,6 +5,14 @@
   "author": { "name": "Cody Swann" },
   "dependencies": ["lisa-typescript"],
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh" }
+        ]
+      }
+    ],
     "SessionStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] }
     ],

--- a/plugins/src/harper-fabric/generated-artifact-globs.txt
+++ b/plugins/src/harper-fabric/generated-artifact-globs.txt
@@ -1,0 +1,4 @@
+harper-app/resources.js
+harper-app/resource-*.js
+harper-app/web/**
+harper-app/lib/**

--- a/plugins/src/harper-fabric/hooks/block-generated-artifact-edits.sh
+++ b/plugins/src/harper-fabric/hooks/block-generated-artifact-edits.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PreToolUse hook: block Write/Edit/MultiEdit on generated Harper deploy
+# artifacts. Harper/Fabric projects build these files from TypeScript under
+# src/, so direct edits are overwritten by the next build and usually ship as
+# no-op fixes.
+# Reference: https://docs.claude.com/en/docs/claude-code/hooks
+# Exit code 2 blocks the tool call and surfaces stderr to Claude.
+
+JSON_INPUT=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILE_PATH=$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.file_path // empty')
+[ -n "$FILE_PATH" ] || exit 0
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+GLOBS_FILE="$PLUGIN_ROOT/generated-artifact-globs.txt"
+[ -f "$GLOBS_FILE" ] || exit 0
+
+normalize_path() {
+  local path="$1"
+  path="${path#./}"
+  printf '%s' "$path"
+}
+
+matches_glob() {
+  local file="$1"
+  local glob="$2"
+
+  if [ "${glob: -3}" = "/**" ]; then
+    local dir="${glob%/**}"
+    case "$file" in
+      "$dir"/* | */"$dir"/*) return 0 ;;
+    esac
+    return 1
+  fi
+
+  case "$file" in
+    $glob | */$glob) return 0 ;;
+  esac
+
+  return 1
+}
+
+NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+while IFS= read -r glob || [ -n "$glob" ]; do
+  [ -n "$glob" ] || continue
+  case "$glob" in \#*) continue ;; esac
+
+  if matches_glob "$NORMALIZED_FILE" "$glob"; then
+    cat >&2 <<MSG
+Blocked: direct edit to generated Harper/Fabric artifact.
+
+File: $FILE_PATH
+Matched generated artifact pattern: $glob
+
+TypeScript under src/ is the source of truth for Harper resources, web assets,
+and shared libraries. Change the matching TypeScript source under src/ and run
+the project build to regenerate harper-app outputs.
+MSG
+    exit 2
+  fi
+done <"$GLOBS_FILE"
+
+exit 0

--- a/src/configs/eslint/harper-fabric.ts
+++ b/src/configs/eslint/harper-fabric.ts
@@ -25,8 +25,8 @@ export const defaultHarperFabricIgnores = [
   "*.config.local.ts",
   "harper-app/resources.js",
   "harper-app/resource-*.js",
-  "harper-app/web/**/*.js",
-  "harper-app/web/**/*.js.map",
+  "harper-app/web/**",
+  "harper-app/lib/**",
 ];
 
 /**

--- a/tests/unit/config/harper-fabric-template.test.ts
+++ b/tests/unit/config/harper-fabric-template.test.ts
@@ -7,6 +7,12 @@ import * as path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const HARPER_FABRIC_KNIP_TEMPLATE = "harper-fabric/copy-overwrite/knip.json";
+const HARPER_FABRIC_TSCONFIG_ESLINT_TEMPLATE =
+  "harper-fabric/copy-overwrite/tsconfig.eslint.json";
+const HARPER_FABRIC_PRETTIERIGNORE_TEMPLATE =
+  "harper-fabric/copy-contents/.prettierignore";
+const GENERATED_ARTIFACT_GLOBS_TEMPLATE =
+  "plugins/src/harper-fabric/generated-artifact-globs.txt";
 
 /**
  * Read a JSON template from the Lisa repository.
@@ -26,6 +32,33 @@ function readJson(relativePath: string): unknown {
  */
 function readText(relativePath: string): string {
   return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+/**
+ * Read the source-of-truth generated Harper artifact glob list.
+ * @returns Non-empty generated artifact glob entries
+ */
+function readGeneratedArtifactGlobs(): readonly string[] {
+  return readText(GENERATED_ARTIFACT_GLOBS_TEMPLATE)
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith("#"));
+}
+
+/**
+ * Assert that one ignore surface contains every generated artifact glob.
+ * @param surfaceName - Human-readable surface name for assertion messages
+ * @param values - Ignore values from the surface
+ * @param expectedGlobs - Required generated artifact glob values
+ */
+function expectContainsAllGlobs(
+  surfaceName: string,
+  values: readonly string[],
+  expectedGlobs: readonly string[]
+): void {
+  for (const glob of expectedGlobs) {
+    expect(values, `${surfaceName} is missing ${glob}`).toContain(glob);
+  }
 }
 
 describe("Harper/Fabric templates", () => {
@@ -58,9 +91,7 @@ describe("Harper/Fabric templates", () => {
   });
 
   it("includes slow lint config but not Jest config in the ESLint project", () => {
-    const tsconfig = readJson(
-      "harper-fabric/copy-overwrite/tsconfig.eslint.json"
-    ) as {
+    const tsconfig = readJson(HARPER_FABRIC_TSCONFIG_ESLINT_TEMPLATE) as {
       readonly include?: readonly string[];
     };
 
@@ -69,18 +100,14 @@ describe("Harper/Fabric templates", () => {
   });
 
   it("keeps generated web and scraped research captures out of Prettier", () => {
-    const prettierIgnore = readText(
-      "harper-fabric/copy-contents/.prettierignore"
-    );
+    const prettierIgnore = readText(HARPER_FABRIC_PRETTIERIGNORE_TEMPLATE);
 
-    expect(prettierIgnore).toContain("harper-app/web/");
+    expect(prettierIgnore).toContain("harper-app/web/**");
     expect(prettierIgnore).toContain("research/articles/");
   });
 
-  it("ignores per-resource generated Harper deploy artifacts everywhere", () => {
-    // The Harper build emits one `harper-app/resource-<name>.js` per resource
-    // alongside the `harper-app/resources.js` barrel. Every ignore surface must
-    // cover the per-resource glob or lint/knip/oxlint break after a Lisa update.
+  it("keeps generated Harper deploy artifacts ignored across every surface", () => {
+    const generatedArtifactGlobs = readGeneratedArtifactGlobs();
     const oxlint = readJson("oxlint/harper-fabric.json") as {
       readonly ignorePatterns?: readonly string[];
     };
@@ -90,19 +117,54 @@ describe("Harper/Fabric templates", () => {
     const knip = readJson(HARPER_FABRIC_KNIP_TEMPLATE) as {
       readonly ignore?: readonly string[];
     };
-    const tsconfigEslint = readJson(
-      "harper-fabric/copy-overwrite/tsconfig.eslint.json"
-    ) as { readonly exclude?: readonly string[] };
-    const gitignore = readText("harper-fabric/copy-contents/.gitignore");
+    const tsconfigEslint = readJson(HARPER_FABRIC_TSCONFIG_ESLINT_TEMPLATE) as {
+      readonly exclude?: readonly string[];
+    };
+    const gitignore = readText("harper-fabric/copy-contents/.gitignore")
+      .split(/\r?\n/)
+      .map(line => line.trim());
+    const prettierIgnore = readText(HARPER_FABRIC_PRETTIERIGNORE_TEMPLATE)
+      .split(/\r?\n/)
+      .map(line => line.trim());
     const eslintConfigSource = readText("src/configs/eslint/harper-fabric.ts");
-    const perResourceGlob = "harper-app/resource-*.js";
 
-    expect(oxlint.ignorePatterns).toContain(perResourceGlob);
-    expect(oxlintMerge.ignorePatterns).toContain(perResourceGlob);
-    expect(knip.ignore).toContain(perResourceGlob);
-    expect(tsconfigEslint.exclude).toContain(perResourceGlob);
-    expect(gitignore).toContain(perResourceGlob);
-    expect(eslintConfigSource).toContain(`"${perResourceGlob}"`);
+    expectContainsAllGlobs(
+      "oxlint/harper-fabric.json",
+      oxlint.ignorePatterns ?? [],
+      generatedArtifactGlobs
+    );
+    expectContainsAllGlobs(
+      "harper-fabric/merge/.oxlintrc.json",
+      oxlintMerge.ignorePatterns ?? [],
+      generatedArtifactGlobs
+    );
+    expectContainsAllGlobs(
+      HARPER_FABRIC_KNIP_TEMPLATE,
+      knip.ignore ?? [],
+      generatedArtifactGlobs
+    );
+    expectContainsAllGlobs(
+      HARPER_FABRIC_TSCONFIG_ESLINT_TEMPLATE,
+      tsconfigEslint.exclude ?? [],
+      generatedArtifactGlobs
+    );
+    expectContainsAllGlobs(
+      "harper-fabric/copy-contents/.gitignore",
+      gitignore,
+      generatedArtifactGlobs
+    );
+    expectContainsAllGlobs(
+      HARPER_FABRIC_PRETTIERIGNORE_TEMPLATE,
+      prettierIgnore,
+      generatedArtifactGlobs
+    );
+
+    for (const glob of generatedArtifactGlobs) {
+      expect(
+        eslintConfigSource,
+        `src/configs/eslint/harper-fabric.ts is missing ${glob}`
+      ).toContain(`"${glob}"`);
+    }
   });
 
   it("keeps the generated Codex distribution mirror out of Prettier", () => {

--- a/tests/unit/hooks/block-generated-artifact-edits.test.ts
+++ b/tests/unit/hooks/block-generated-artifact-edits.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for block-generated-artifact-edits.sh - the Harper/Fabric PreToolUse
+ * hook that refuses direct edits to generated deploy artifacts.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOT = path.resolve("plugins/src/harper-fabric");
+const SCRIPT_PATH = path.join(
+  PLUGIN_ROOT,
+  "hooks/block-generated-artifact-edits.sh"
+);
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const envelope = (toolName: string, filePath: string): string =>
+  JSON.stringify({
+    tool_name: toolName,
+    tool_input: { file_path: filePath },
+  });
+
+const runHook = (
+  toolName: string,
+  filePath: string
+): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [SCRIPT_PATH], {
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    input: envelope(toolName, filePath),
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+describe("block-generated-artifact-edits.sh", () => {
+  it("blocks edits to harper-app/resources.js", () => {
+    const { status, stderr } = runHook("Edit", "harper-app/resources.js");
+
+    expect(status).toBe(EXIT_BLOCKED);
+    expect(stderr).toContain("TypeScript under src/");
+  });
+
+  it("blocks writes to generated web output", () => {
+    const { status, stderr } = runHook("Write", "harper-app/web/app.js");
+
+    expect(status).toBe(EXIT_BLOCKED);
+    expect(stderr).toContain("harper-app/web/**");
+  });
+
+  it("blocks nested generated library output", () => {
+    const { status } = runHook(
+      "MultiEdit",
+      "/repo/harper-app/lib/shared/util.js"
+    );
+
+    expect(status).toBe(EXIT_BLOCKED);
+  });
+
+  it("allows source edits", () => {
+    const { status } = runHook("Edit", "src/harper/resources.ts");
+
+    expect(status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows unrelated Harper deploy source files", () => {
+    const { status } = runHook("Edit", "harper-app/config.yaml");
+
+    expect(status).toBe(EXIT_ALLOWED);
+  });
+});

--- a/tsconfig/harper-fabric.json
+++ b/tsconfig/harper-fabric.json
@@ -15,6 +15,8 @@
     "coverage",
     "node_modules",
     "harper-app/resources.js",
-    "harper-app/web/**/*.js"
+    "harper-app/resource-*.js",
+    "harper-app/web/**",
+    "harper-app/lib/**"
   ]
 }


### PR DESCRIPTION
## Summary
- add a Harper/Fabric PreToolUse hook that blocks direct edits to generated harper-app resources, web, and lib artifacts
- define generated artifact globs once and assert ignore-surface parity across gitignore, prettier, knip, tsconfig, eslint, and oxlint surfaces
- regenerate Harper Fabric plugin artifacts for Claude, Codex, Cursor, agy, and Copilot variants

## Verification
- bun run format:check
- bun run typecheck
- bun run lint (passes with 6 pre-existing warnings)
- bun test tests/unit/config/harper-fabric-template.test.ts tests/unit/hooks/block-generated-artifact-edits.test.ts
- bun run check:plugins
- pre-push hook: bun audit, slow lint, knip, vitest run --coverage, vitest run tests/integration

Closes #1254