### PR TITLE
feat: guard Harper config extension drops

### DIFF
--- a/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
@@ -20,6 +20,17 @@
         ]
       }
     ],
+    "postToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-config-extensions.sh"
+          }
+        ]
+      }
+    ],
     "sessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const BLOCKED = 2;
+const ALLOWED = 0;
+const CONFIG_PATH = "harper-app/config.yaml";
+const ALLOWLIST_PATH = ".lisa/harper-config-extension-allowlist.json";
+
+const readStdin = () => {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+};
+
+const parseHookInput = raw => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+};
+
+const normalizePath = filePath =>
+  filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+
+const isConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  return normalized === CONFIG_PATH || normalized.endsWith(`/${CONFIG_PATH}`);
+};
+
+const repoRelativeConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  const index = normalized.lastIndexOf(CONFIG_PATH);
+  return index === -1 ? normalized : normalized.slice(index);
+};
+
+const loadYaml = () => {
+  const require = createRequire(import.meta.url);
+  return require("js-yaml");
+};
+
+const topLevelExtensionKeys = yamlText => {
+  const yaml = loadYaml();
+  const parsed = yaml.load(yamlText);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  return Object.keys(parsed).sort();
+};
+
+const gitEnv = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const readGitBlob = repoRoot => {
+  const result = spawnSync(
+    "git",
+    ["-C", repoRoot, "show", `HEAD:${CONFIG_PATH}`],
+    {
+      encoding: "utf8",
+      env: gitEnv(),
+    }
+  );
+  return result.status === 0 ? result.stdout : null;
+};
+
+const readAllowlist = (repoRoot, configPath) => {
+  const allowlistFile = path.join(repoRoot, ALLOWLIST_PATH);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(allowlistFile, "utf8"));
+  } catch {
+    return new Set();
+  }
+
+  const entry = parsed?.[configPath] ?? parsed?.[CONFIG_PATH];
+  const values = Array.isArray(entry)
+    ? entry
+    : Array.isArray(entry?.allowedRemovedExtensions)
+      ? entry.allowedRemovedExtensions
+      : [];
+  return new Set(values.filter(value => typeof value === "string"));
+};
+
+const main = () => {
+  const input = parseHookInput(readStdin());
+  const filePath = input?.tool_input?.file_path;
+  if (typeof filePath !== "string" || !isConfigPath(filePath)) return ALLOWED;
+
+  const repoRoot = process.cwd();
+  const configPath = repoRelativeConfigPath(filePath);
+  let currentText;
+  try {
+    currentText = readFileSync(path.join(repoRoot, configPath), "utf8");
+  } catch {
+    return ALLOWED;
+  }
+
+  const previousText = readGitBlob(repoRoot);
+  if (previousText === null) return ALLOWED;
+
+  const previousExtensions = topLevelExtensionKeys(previousText);
+  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const allowedRemovals = readAllowlist(repoRoot, configPath);
+  const missing = previousExtensions.filter(
+    extension =>
+      !currentExtensions.has(extension) && !allowedRemovals.has(extension)
+  );
+
+  if (missing.length === 0) return ALLOWED;
+
+  process.stderr
+    .write(`Blocked: harper-app/config.yaml dropped required Harper extension(s).
+
+Missing extension(s): ${missing.join(", ")}
+
+Harper does not merge a custom config.yaml with defaults. Removing a top-level
+extension silently disables that runtime surface and may only fail after deploy.
+Re-add the missing extension(s), or document an intentional removal in
+${ALLOWLIST_PATH}:
+
+{
+  "${CONFIG_PATH}": {
+    "allowedRemovedExtensions": ["${missing[0]}"]
+  }
+}
+`);
+  return BLOCKED;
+};
+
+process.exitCode = main();

--- a/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.mjs
@@ -46,7 +46,12 @@ const loadYaml = () => {
 
 const topLevelExtensionKeys = yamlText => {
   const yaml = loadYaml();
-  const parsed = yaml.load(yamlText);
+  let parsed;
+  try {
+    parsed = yaml.load(yamlText);
+  } catch {
+    return null;
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
   return Object.keys(parsed).sort();
 };
@@ -104,7 +109,10 @@ const main = () => {
   if (previousText === null) return ALLOWED;
 
   const previousExtensions = topLevelExtensionKeys(previousText);
-  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const currentExtensionKeys = topLevelExtensionKeys(currentText);
+  if (previousExtensions === null || currentExtensionKeys === null)
+    return ALLOWED;
+  const currentExtensions = new Set(currentExtensionKeys);
   const allowedRemovals = readAllowlist(repoRoot, configPath);
   const missing = previousExtensions.filter(
     extension =>

--- a/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.sh
+++ b/plugins/lisa-harper-fabric-copilot/hooks/enforce-config-extensions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PostToolUse hook: after a harper-app/config.yaml edit, compare the edited
+# extension set against HEAD and block silent removals. Harper does not merge a
+# custom config.yaml with defaults, so removing a top-level extension can disable
+# runtime surfaces without a build-time failure.
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  exec bun "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"
+fi
+
+exec node "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"

--- a/plugins/lisa-harper-fabric-copilot/rules/harper-fabric.md
+++ b/plugins/lisa-harper-fabric-copilot/rules/harper-fabric.md
@@ -12,6 +12,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
+- `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
 - `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 

--- a/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const BLOCKED = 2;
+const ALLOWED = 0;
+const CONFIG_PATH = "harper-app/config.yaml";
+const ALLOWLIST_PATH = ".lisa/harper-config-extension-allowlist.json";
+
+const readStdin = () => {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+};
+
+const parseHookInput = raw => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+};
+
+const normalizePath = filePath =>
+  filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+
+const isConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  return normalized === CONFIG_PATH || normalized.endsWith(`/${CONFIG_PATH}`);
+};
+
+const repoRelativeConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  const index = normalized.lastIndexOf(CONFIG_PATH);
+  return index === -1 ? normalized : normalized.slice(index);
+};
+
+const loadYaml = () => {
+  const require = createRequire(import.meta.url);
+  return require("js-yaml");
+};
+
+const topLevelExtensionKeys = yamlText => {
+  const yaml = loadYaml();
+  const parsed = yaml.load(yamlText);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  return Object.keys(parsed).sort();
+};
+
+const gitEnv = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const readGitBlob = repoRoot => {
+  const result = spawnSync(
+    "git",
+    ["-C", repoRoot, "show", `HEAD:${CONFIG_PATH}`],
+    {
+      encoding: "utf8",
+      env: gitEnv(),
+    }
+  );
+  return result.status === 0 ? result.stdout : null;
+};
+
+const readAllowlist = (repoRoot, configPath) => {
+  const allowlistFile = path.join(repoRoot, ALLOWLIST_PATH);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(allowlistFile, "utf8"));
+  } catch {
+    return new Set();
+  }
+
+  const entry = parsed?.[configPath] ?? parsed?.[CONFIG_PATH];
+  const values = Array.isArray(entry)
+    ? entry
+    : Array.isArray(entry?.allowedRemovedExtensions)
+      ? entry.allowedRemovedExtensions
+      : [];
+  return new Set(values.filter(value => typeof value === "string"));
+};
+
+const main = () => {
+  const input = parseHookInput(readStdin());
+  const filePath = input?.tool_input?.file_path;
+  if (typeof filePath !== "string" || !isConfigPath(filePath)) return ALLOWED;
+
+  const repoRoot = process.cwd();
+  const configPath = repoRelativeConfigPath(filePath);
+  let currentText;
+  try {
+    currentText = readFileSync(path.join(repoRoot, configPath), "utf8");
+  } catch {
+    return ALLOWED;
+  }
+
+  const previousText = readGitBlob(repoRoot);
+  if (previousText === null) return ALLOWED;
+
+  const previousExtensions = topLevelExtensionKeys(previousText);
+  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const allowedRemovals = readAllowlist(repoRoot, configPath);
+  const missing = previousExtensions.filter(
+    extension =>
+      !currentExtensions.has(extension) && !allowedRemovals.has(extension)
+  );
+
+  if (missing.length === 0) return ALLOWED;
+
+  process.stderr
+    .write(`Blocked: harper-app/config.yaml dropped required Harper extension(s).
+
+Missing extension(s): ${missing.join(", ")}
+
+Harper does not merge a custom config.yaml with defaults. Removing a top-level
+extension silently disables that runtime surface and may only fail after deploy.
+Re-add the missing extension(s), or document an intentional removal in
+${ALLOWLIST_PATH}:
+
+{
+  "${CONFIG_PATH}": {
+    "allowedRemovedExtensions": ["${missing[0]}"]
+  }
+}
+`);
+  return BLOCKED;
+};
+
+process.exitCode = main();

--- a/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.mjs
@@ -46,7 +46,12 @@ const loadYaml = () => {
 
 const topLevelExtensionKeys = yamlText => {
   const yaml = loadYaml();
-  const parsed = yaml.load(yamlText);
+  let parsed;
+  try {
+    parsed = yaml.load(yamlText);
+  } catch {
+    return null;
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
   return Object.keys(parsed).sort();
 };
@@ -104,7 +109,10 @@ const main = () => {
   if (previousText === null) return ALLOWED;
 
   const previousExtensions = topLevelExtensionKeys(previousText);
-  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const currentExtensionKeys = topLevelExtensionKeys(currentText);
+  if (previousExtensions === null || currentExtensionKeys === null)
+    return ALLOWED;
+  const currentExtensions = new Set(currentExtensionKeys);
   const allowedRemovals = readAllowlist(repoRoot, configPath);
   const missing = previousExtensions.filter(
     extension =>

--- a/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.sh
+++ b/plugins/lisa-harper-fabric-cursor/hooks/enforce-config-extensions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PostToolUse hook: after a harper-app/config.yaml edit, compare the edited
+# extension set against HEAD and block silent removals. Harper does not merge a
+# custom config.yaml with defaults, so removing a top-level extension can disable
+# runtime surfaces without a build-time failure.
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  exec bun "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"
+fi
+
+exec node "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"

--- a/plugins/lisa-harper-fabric-cursor/hooks/hooks.json
+++ b/plugins/lisa-harper-fabric-cursor/hooks/hooks.json
@@ -6,6 +6,12 @@
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-generated-artifact-edits.sh",
         "matcher": "Write|Edit|MultiEdit"
       }
+    ],
+    "postToolUse": [
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/enforce-config-extensions.sh",
+        "matcher": "Write|Edit|MultiEdit"
+      }
     ]
   }
 }

--- a/plugins/lisa-harper-fabric-cursor/rules/harper-fabric.mdc
+++ b/plugins/lisa-harper-fabric-cursor/rules/harper-fabric.mdc
@@ -17,6 +17,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
+- `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
 - `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 

--- a/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
@@ -20,6 +20,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-config-extensions.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/enforce-config-extensions.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const BLOCKED = 2;
+const ALLOWED = 0;
+const CONFIG_PATH = "harper-app/config.yaml";
+const ALLOWLIST_PATH = ".lisa/harper-config-extension-allowlist.json";
+
+const readStdin = () => {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+};
+
+const parseHookInput = raw => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+};
+
+const normalizePath = filePath =>
+  filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+
+const isConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  return normalized === CONFIG_PATH || normalized.endsWith(`/${CONFIG_PATH}`);
+};
+
+const repoRelativeConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  const index = normalized.lastIndexOf(CONFIG_PATH);
+  return index === -1 ? normalized : normalized.slice(index);
+};
+
+const loadYaml = () => {
+  const require = createRequire(import.meta.url);
+  return require("js-yaml");
+};
+
+const topLevelExtensionKeys = yamlText => {
+  const yaml = loadYaml();
+  const parsed = yaml.load(yamlText);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  return Object.keys(parsed).sort();
+};
+
+const gitEnv = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const readGitBlob = repoRoot => {
+  const result = spawnSync(
+    "git",
+    ["-C", repoRoot, "show", `HEAD:${CONFIG_PATH}`],
+    {
+      encoding: "utf8",
+      env: gitEnv(),
+    }
+  );
+  return result.status === 0 ? result.stdout : null;
+};
+
+const readAllowlist = (repoRoot, configPath) => {
+  const allowlistFile = path.join(repoRoot, ALLOWLIST_PATH);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(allowlistFile, "utf8"));
+  } catch {
+    return new Set();
+  }
+
+  const entry = parsed?.[configPath] ?? parsed?.[CONFIG_PATH];
+  const values = Array.isArray(entry)
+    ? entry
+    : Array.isArray(entry?.allowedRemovedExtensions)
+      ? entry.allowedRemovedExtensions
+      : [];
+  return new Set(values.filter(value => typeof value === "string"));
+};
+
+const main = () => {
+  const input = parseHookInput(readStdin());
+  const filePath = input?.tool_input?.file_path;
+  if (typeof filePath !== "string" || !isConfigPath(filePath)) return ALLOWED;
+
+  const repoRoot = process.cwd();
+  const configPath = repoRelativeConfigPath(filePath);
+  let currentText;
+  try {
+    currentText = readFileSync(path.join(repoRoot, configPath), "utf8");
+  } catch {
+    return ALLOWED;
+  }
+
+  const previousText = readGitBlob(repoRoot);
+  if (previousText === null) return ALLOWED;
+
+  const previousExtensions = topLevelExtensionKeys(previousText);
+  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const allowedRemovals = readAllowlist(repoRoot, configPath);
+  const missing = previousExtensions.filter(
+    extension =>
+      !currentExtensions.has(extension) && !allowedRemovals.has(extension)
+  );
+
+  if (missing.length === 0) return ALLOWED;
+
+  process.stderr
+    .write(`Blocked: harper-app/config.yaml dropped required Harper extension(s).
+
+Missing extension(s): ${missing.join(", ")}
+
+Harper does not merge a custom config.yaml with defaults. Removing a top-level
+extension silently disables that runtime surface and may only fail after deploy.
+Re-add the missing extension(s), or document an intentional removal in
+${ALLOWLIST_PATH}:
+
+{
+  "${CONFIG_PATH}": {
+    "allowedRemovedExtensions": ["${missing[0]}"]
+  }
+}
+`);
+  return BLOCKED;
+};
+
+process.exitCode = main();

--- a/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.mjs
+++ b/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.mjs
@@ -46,7 +46,12 @@ const loadYaml = () => {
 
 const topLevelExtensionKeys = yamlText => {
   const yaml = loadYaml();
-  const parsed = yaml.load(yamlText);
+  let parsed;
+  try {
+    parsed = yaml.load(yamlText);
+  } catch {
+    return null;
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
   return Object.keys(parsed).sort();
 };
@@ -104,7 +109,10 @@ const main = () => {
   if (previousText === null) return ALLOWED;
 
   const previousExtensions = topLevelExtensionKeys(previousText);
-  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const currentExtensionKeys = topLevelExtensionKeys(currentText);
+  if (previousExtensions === null || currentExtensionKeys === null)
+    return ALLOWED;
+  const currentExtensions = new Set(currentExtensionKeys);
   const allowedRemovals = readAllowlist(repoRoot, configPath);
   const missing = previousExtensions.filter(
     extension =>

--- a/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.sh
+++ b/plugins/lisa-harper-fabric/hooks/enforce-config-extensions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PostToolUse hook: after a harper-app/config.yaml edit, compare the edited
+# extension set against HEAD and block silent removals. Harper does not merge a
+# custom config.yaml with defaults, so removing a top-level extension can disable
+# runtime surfaces without a build-time failure.
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  exec bun "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"
+fi
+
+exec node "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"

--- a/plugins/lisa-harper-fabric/rules/harper-fabric.md
+++ b/plugins/lisa-harper-fabric/rules/harper-fabric.md
@@ -12,6 +12,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
+- `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
 - `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 

--- a/plugins/src/harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/src/harper-fabric/.claude-plugin/plugin.json
@@ -13,6 +13,14 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-config-extensions.sh" }
+        ]
+      }
+    ],
     "SessionStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] }
     ],

--- a/plugins/src/harper-fabric/hooks/enforce-config-extensions.mjs
+++ b/plugins/src/harper-fabric/hooks/enforce-config-extensions.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const BLOCKED = 2;
+const ALLOWED = 0;
+const CONFIG_PATH = "harper-app/config.yaml";
+const ALLOWLIST_PATH = ".lisa/harper-config-extension-allowlist.json";
+
+const readStdin = () => {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+};
+
+const parseHookInput = raw => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+};
+
+const normalizePath = filePath =>
+  filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+
+const isConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  return normalized === CONFIG_PATH || normalized.endsWith(`/${CONFIG_PATH}`);
+};
+
+const repoRelativeConfigPath = filePath => {
+  const normalized = normalizePath(filePath);
+  const index = normalized.lastIndexOf(CONFIG_PATH);
+  return index === -1 ? normalized : normalized.slice(index);
+};
+
+const loadYaml = () => {
+  const require = createRequire(import.meta.url);
+  return require("js-yaml");
+};
+
+const topLevelExtensionKeys = yamlText => {
+  const yaml = loadYaml();
+  const parsed = yaml.load(yamlText);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  return Object.keys(parsed).sort();
+};
+
+const gitEnv = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const readGitBlob = repoRoot => {
+  const result = spawnSync(
+    "git",
+    ["-C", repoRoot, "show", `HEAD:${CONFIG_PATH}`],
+    {
+      encoding: "utf8",
+      env: gitEnv(),
+    }
+  );
+  return result.status === 0 ? result.stdout : null;
+};
+
+const readAllowlist = (repoRoot, configPath) => {
+  const allowlistFile = path.join(repoRoot, ALLOWLIST_PATH);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(allowlistFile, "utf8"));
+  } catch {
+    return new Set();
+  }
+
+  const entry = parsed?.[configPath] ?? parsed?.[CONFIG_PATH];
+  const values = Array.isArray(entry)
+    ? entry
+    : Array.isArray(entry?.allowedRemovedExtensions)
+      ? entry.allowedRemovedExtensions
+      : [];
+  return new Set(values.filter(value => typeof value === "string"));
+};
+
+const main = () => {
+  const input = parseHookInput(readStdin());
+  const filePath = input?.tool_input?.file_path;
+  if (typeof filePath !== "string" || !isConfigPath(filePath)) return ALLOWED;
+
+  const repoRoot = process.cwd();
+  const configPath = repoRelativeConfigPath(filePath);
+  let currentText;
+  try {
+    currentText = readFileSync(path.join(repoRoot, configPath), "utf8");
+  } catch {
+    return ALLOWED;
+  }
+
+  const previousText = readGitBlob(repoRoot);
+  if (previousText === null) return ALLOWED;
+
+  const previousExtensions = topLevelExtensionKeys(previousText);
+  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const allowedRemovals = readAllowlist(repoRoot, configPath);
+  const missing = previousExtensions.filter(
+    extension =>
+      !currentExtensions.has(extension) && !allowedRemovals.has(extension)
+  );
+
+  if (missing.length === 0) return ALLOWED;
+
+  process.stderr
+    .write(`Blocked: harper-app/config.yaml dropped required Harper extension(s).
+
+Missing extension(s): ${missing.join(", ")}
+
+Harper does not merge a custom config.yaml with defaults. Removing a top-level
+extension silently disables that runtime surface and may only fail after deploy.
+Re-add the missing extension(s), or document an intentional removal in
+${ALLOWLIST_PATH}:
+
+{
+  "${CONFIG_PATH}": {
+    "allowedRemovedExtensions": ["${missing[0]}"]
+  }
+}
+`);
+  return BLOCKED;
+};
+
+process.exitCode = main();

--- a/plugins/src/harper-fabric/hooks/enforce-config-extensions.mjs
+++ b/plugins/src/harper-fabric/hooks/enforce-config-extensions.mjs
@@ -46,7 +46,12 @@ const loadYaml = () => {
 
 const topLevelExtensionKeys = yamlText => {
   const yaml = loadYaml();
-  const parsed = yaml.load(yamlText);
+  let parsed;
+  try {
+    parsed = yaml.load(yamlText);
+  } catch {
+    return null;
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
   return Object.keys(parsed).sort();
 };
@@ -104,7 +109,10 @@ const main = () => {
   if (previousText === null) return ALLOWED;
 
   const previousExtensions = topLevelExtensionKeys(previousText);
-  const currentExtensions = new Set(topLevelExtensionKeys(currentText));
+  const currentExtensionKeys = topLevelExtensionKeys(currentText);
+  if (previousExtensions === null || currentExtensionKeys === null)
+    return ALLOWED;
+  const currentExtensions = new Set(currentExtensionKeys);
   const allowedRemovals = readAllowlist(repoRoot, configPath);
   const missing = previousExtensions.filter(
     extension =>

--- a/plugins/src/harper-fabric/hooks/enforce-config-extensions.sh
+++ b/plugins/src/harper-fabric/hooks/enforce-config-extensions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly - changes will be overwritten on the next `lisa` run.
+
+# PostToolUse hook: after a harper-app/config.yaml edit, compare the edited
+# extension set against HEAD and block silent removals. Harper does not merge a
+# custom config.yaml with defaults, so removing a top-level extension can disable
+# runtime surfaces without a build-time failure.
+
+PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if command -v bun >/dev/null 2>&1; then
+  exec bun "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"
+fi
+
+exec node "$PLUGIN_ROOT/hooks/enforce-config-extensions.mjs"

--- a/plugins/src/harper-fabric/rules/harper-fabric.md
+++ b/plugins/src/harper-fabric/rules/harper-fabric.md
@@ -12,6 +12,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
+- `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
 - `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 

--- a/tests/unit/hooks/enforce-config-extensions.test.ts
+++ b/tests/unit/hooks/enforce-config-extensions.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for enforce-config-extensions.sh - the Harper/Fabric PostToolUse hook
+ * that blocks accidental top-level config.yaml extension removal.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const PLUGIN_ROOT = path.resolve("plugins/src/harper-fabric");
+const SCRIPT_PATH = path.join(
+  PLUGIN_ROOT,
+  "hooks/enforce-config-extensions.sh"
+);
+const BASH_PATH = "/bin/bash";
+const CONFIG_PATH = "harper-app/config.yaml";
+const GIT_PATH = "/usr/bin/git";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const BASE_CONFIG = `rest: true
+graphqlSchema:
+  files: '*.graphql'
+roles:
+  files: 'roles.yaml'
+jsResource:
+  files: 'resources.js'
+static:
+  files: 'web/**'
+`;
+
+const WITHOUT_GRAPHQL = `rest: true
+roles:
+  files: 'roles.yaml'
+jsResource:
+  files: 'resources.js'
+static:
+  files: 'web/**'
+`;
+
+const envelope = (filePath: string): string =>
+  JSON.stringify({
+    tool_name: "Edit",
+    tool_input: { file_path: filePath },
+  });
+
+const run = (cwd: string, filePath = CONFIG_PATH) =>
+  spawnSync(BASH_PATH, [SCRIPT_PATH], {
+    cwd,
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    input: envelope(filePath),
+    encoding: "utf-8",
+  });
+
+const gitEnv = (): NodeJS.ProcessEnv =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const git = (cwd: string, args: readonly string[]) => {
+  const result = spawnSync(GIT_PATH, args, {
+    cwd,
+    encoding: "utf-8",
+    env: gitEnv(),
+  });
+  expect(result.status).toBe(0);
+};
+
+describe("enforce-config-extensions.sh", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "harper-config-hook-"));
+    fs.mkdirSync(path.join(tempDir, "harper-app"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, CONFIG_PATH), BASE_CONFIG);
+    git(tempDir, ["init"]);
+    git(tempDir, ["config", "user.email", "test@example.com"]);
+    git(tempDir, ["config", "user.name", "Test User"]);
+    git(tempDir, ["add", CONFIG_PATH]);
+    git(tempDir, ["commit", "-m", "seed config"]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it("blocks silent extension drops", () => {
+    fs.writeFileSync(path.join(tempDir, CONFIG_PATH), WITHOUT_GRAPHQL);
+
+    const result = run(tempDir);
+
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain("graphqlSchema");
+    expect(result.stderr).toContain("does not merge");
+  });
+
+  it("allows an intentional removal documented in the allowlist", () => {
+    fs.mkdirSync(path.join(tempDir, ".lisa"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".lisa/harper-config-extension-allowlist.json"),
+      JSON.stringify({
+        [CONFIG_PATH]: {
+          allowedRemovedExtensions: ["graphqlSchema"],
+        },
+      })
+    );
+    fs.writeFileSync(path.join(tempDir, CONFIG_PATH), WITHOUT_GRAPHQL);
+
+    const result = run(tempDir);
+
+    expect(result.status).toBe(EXIT_ALLOWED);
+    expect(result.stderr).toBe("");
+  });
+
+  it("allows non-config edits", () => {
+    const result = run(tempDir, "src/harper/resources.ts");
+
+    expect(result.status).toBe(EXIT_ALLOWED);
+    expect(result.stderr).toBe("");
+  });
+});

--- a/tests/unit/hooks/enforce-config-extensions.test.ts
+++ b/tests/unit/hooks/enforce-config-extensions.test.ts
@@ -120,4 +120,29 @@ describe("enforce-config-extensions.sh", () => {
     expect(result.status).toBe(EXIT_ALLOWED);
     expect(result.stderr).toBe("");
   });
+
+  it("allows edits when the current config.yaml contains malformed YAML", () => {
+    fs.writeFileSync(
+      path.join(tempDir, CONFIG_PATH),
+      "!! invalid yaml: {{{ unclosed"
+    );
+
+    const result = run(tempDir);
+
+    expect(result.status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows edits when the HEAD config.yaml contains malformed YAML", () => {
+    fs.writeFileSync(
+      path.join(tempDir, CONFIG_PATH),
+      "!! invalid yaml: {{{ unclosed"
+    );
+    git(tempDir, ["add", CONFIG_PATH]);
+    git(tempDir, ["commit", "-m", "commit malformed yaml"]);
+    fs.writeFileSync(path.join(tempDir, CONFIG_PATH), BASE_CONFIG);
+
+    const result = run(tempDir);
+
+    expect(result.status).toBe(EXIT_ALLOWED);
+  });
 });


### PR DESCRIPTION
## Summary

- Add a Harper Fabric PostToolUse hook that blocks accidental top-level `harper-app/config.yaml` extension removals by comparing against `HEAD` with `js-yaml`.
- Document the no-merge guard and intentional removal allowlist path.
- Rebuild Harper Fabric plugin artifacts for Claude, Codex, Cursor, and Copilot variants.

Closes #1253.

## Verification

- `bun install --frozen-lockfile`
- `bun test tests/unit/hooks/enforce-config-extensions.test.ts tests/unit/hooks/block-generated-artifact-edits.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint` (passes with 6 pre-existing warnings outside this change)
- `bun run check:plugins`
- pre-push hook: `bun audit`, slow lint, `knip`, `vitest run --coverage` (202 files / 3234 tests), `vitest run tests/integration` (3 files / 53 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced retention of required top-level extensions when editing app config files via post-edit hooks; intentional removals can be recorded in an allowlist.

* **Documentation**
  * Clarified Harper/Fabric guidance that the app config does not merge with defaults and requires explicit extension declarations.

* **Tests**
  * Added/expanded tests covering enforcement behavior, including cases with malformed current or base configs and allowlist handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->