### PR TITLE
fix(husky): make pre-push bun audit gate filter exclusions reliably

### DIFF
--- a/.claude-pr/.husky/pre-push
+++ b/.claude-pr/.husky/pre-push
@@ -144,17 +144,29 @@ else
     echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
 
   elif [ "$PACKAGE_MANAGER" = "bun" ]; then
-    # Build --ignore flags dynamically from exclusion list
-    BUN_IGNORE_FLAGS=""
-    for _id in $AUDIT_EXCLUSIONS; do
-      BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore $_id"
-    done
-
-    if ! bun audit --audit-level=high $BUN_IGNORE_FLAGS; then
-      echo "⚠️ Security audit failed. Please fix high/critical vulnerabilities before pushing."
+    # NOTE: bun's `--ignore` flag is unreliable when many exclusions are passed
+    # (bun <=1.3.x silently stops applying ignores past a small count, leaking
+    # excluded high/critical advisories and failing the gate). So instead of
+    # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
+    # apply the exclusion list ourselves with jq — same approach as the npm/yarn
+    # paths above.
+    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
+      ($ids | split(" ") | map(select(length > 0))) as $ex
+      | [ .[]? | .[]?
+          | select(.severity == "high" or .severity == "critical")
+          | (.url | sub(".*/"; "")) as $g
+          | select(($ex | index($g)) | not)
+          | $g ]
+      | unique')
+    UNFIXED_COUNT=$(echo "$UNFIXED_HIGH" | jq -r 'length' 2>/dev/null || echo 0)
+    if [ "$UNFIXED_COUNT" -gt 0 ]; then
+      echo "⚠️ Security audit failed. Unresolved high/critical advisories in production dependencies:"
+      echo "$UNFIXED_HIGH" | jq -r '.[]'
+      echo "Fix them, or add the GHSA id to audit.ignore.local.json with a justification, before pushing."
       exit 1
     fi
-    echo "✅ No high or critical vulnerabilities found in production dependencies"
+    echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
   fi
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -144,17 +144,29 @@ else
     echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
 
   elif [ "$PACKAGE_MANAGER" = "bun" ]; then
-    # Build --ignore flags dynamically from exclusion list
-    BUN_IGNORE_FLAGS=""
-    for _id in $AUDIT_EXCLUSIONS; do
-      BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore $_id"
-    done
-
-    if ! bun audit --audit-level=high $BUN_IGNORE_FLAGS; then
-      echo "⚠️ Security audit failed. Please fix high/critical vulnerabilities before pushing."
+    # NOTE: bun's `--ignore` flag is unreliable when many exclusions are passed
+    # (bun <=1.3.x silently stops applying ignores past a small count, leaking
+    # excluded high/critical advisories and failing the gate). So instead of
+    # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
+    # apply the exclusion list ourselves with jq — same approach as the npm/yarn
+    # paths above.
+    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
+      ($ids | split(" ") | map(select(length > 0))) as $ex
+      | [ .[]? | .[]?
+          | select(.severity == "high" or .severity == "critical")
+          | (.url | sub(".*/"; "")) as $g
+          | select(($ex | index($g)) | not)
+          | $g ]
+      | unique')
+    UNFIXED_COUNT=$(echo "$UNFIXED_HIGH" | jq -r 'length' 2>/dev/null || echo 0)
+    if [ "$UNFIXED_COUNT" -gt 0 ]; then
+      echo "⚠️ Security audit failed. Unresolved high/critical advisories in production dependencies:"
+      echo "$UNFIXED_HIGH" | jq -r '.[]'
+      echo "Fix them, or add the GHSA id to audit.ignore.local.json with a justification, before pushing."
       exit 1
     fi
-    echo "✅ No high or critical vulnerabilities found in production dependencies"
+    echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
   fi
 fi
 

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -144,17 +144,29 @@ else
     echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
 
   elif [ "$PACKAGE_MANAGER" = "bun" ]; then
-    # Build --ignore flags dynamically from exclusion list
-    BUN_IGNORE_FLAGS=""
-    for _id in $AUDIT_EXCLUSIONS; do
-      BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore $_id"
-    done
-
-    if ! bun audit --audit-level=high $BUN_IGNORE_FLAGS; then
-      echo "⚠️ Security audit failed. Please fix high/critical vulnerabilities before pushing."
+    # NOTE: bun's `--ignore` flag is unreliable when many exclusions are passed
+    # (bun <=1.3.x silently stops applying ignores past a small count, leaking
+    # excluded high/critical advisories and failing the gate). So instead of
+    # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
+    # apply the exclusion list ourselves with jq — same approach as the npm/yarn
+    # paths above.
+    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
+      ($ids | split(" ") | map(select(length > 0))) as $ex
+      | [ .[]? | .[]?
+          | select(.severity == "high" or .severity == "critical")
+          | (.url | sub(".*/"; "")) as $g
+          | select(($ex | index($g)) | not)
+          | $g ]
+      | unique')
+    UNFIXED_COUNT=$(echo "$UNFIXED_HIGH" | jq -r 'length' 2>/dev/null || echo 0)
+    if [ "$UNFIXED_COUNT" -gt 0 ]; then
+      echo "⚠️ Security audit failed. Unresolved high/critical advisories in production dependencies:"
+      echo "$UNFIXED_HIGH" | jq -r '.[]'
+      echo "Fix them, or add the GHSA id to audit.ignore.local.json with a justification, before pushing."
       exit 1
     fi
-    echo "✅ No high or critical vulnerabilities found in production dependencies"
+    echo "✅ No high or critical vulnerabilities found in production dependencies (excluding known false positives)"
   fi
 fi
 


### PR DESCRIPTION
## Problem
The `.husky/pre-push` security-audit gate's **bun** branch builds one `--ignore <GHSA>` flag per exclusion and runs `bun audit --audit-level=high $BUN_IGNORE_FLAGS`. bun ≤1.3.x **silently stops applying `--ignore` flags past a small count**. A project with a large exclusion list (PropSwap's frontend has ~33 entries) therefore leaks already-excluded high/critical advisories — e.g. `shell-quote` GHSA-w7jw-789q-3m8p — and fails the gate on documented false positives. A single `--ignore` works; the full list does not. This forced contributors to bypass the hook to push.

## Fix
Parse `bun audit --json` and apply the exclusion list ourselves with `jq` — filter to high/critical and drop GHSA ids present in `AUDIT_EXCLUSIONS`. This mirrors the **npm/yarn** branches, which already do their own JSON filtering and never relied on bun's flag.

Applied to all three vendored copies so they stay in sync:
- `typescript/copy-contents/.husky/pre-push` (the template shipped into TS projects)
- `.husky/pre-push` (lisa's own hook)
- `.claude-pr/.husky/pre-push`

## Verification
- `sh -n` clean on all three; jq filter unit-tested (excluded critical dropped, moderate dropped, genuine high retained).
- This branch's own push passed lisa's pre-push gate using the new logic.
- Downstream: confirmed the fixed `typescript/copy-contents` template is byte-identical to the fix applied in PropSwap frontend (PropSwapLLC/frontend#740), so a future `lisa apply` is a no-op there rather than a revert.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-push security audit to more reliably detect unresolved high/critical security advisories and provide clearer error reporting during code push operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->