### PR TITLE
fix(package-lisa): rename knip script to knip:check and add remove section

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1121,7 +1121,15 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 🗑️ Run dead code detection (knip)
-        run: ${{ inputs.package_manager }} run knip
+        # The script was renamed knip -> knip:check (expo-doctor flags scripts
+        # that shadow node_modules/.bin entries); fall back to the legacy name
+        # for projects that haven't re-applied Lisa yet.
+        run: |
+          if jq -e '.scripts["knip:check"]' package.json >/dev/null 2>&1; then
+            ${{ inputs.package_manager }} run knip:check
+          else
+            ${{ inputs.package_manager }} run knip
+          fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
   sg_scan:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -183,10 +183,20 @@ else
   echo "ℹ️  Skipping slow lint rules (lint:slow not configured)"
 fi
 
-# Run dead code detection (knip) - only if script exists
-if jq -e '.scripts.knip' package.json >/dev/null 2>&1; then
+# Run dead code detection (knip) - only if script exists.
+# Prefer knip:check (the script was renamed because expo-doctor flags scripts
+# that shadow node_modules/.bin entries); fall back to the legacy knip name.
+if jq -e '.scripts["knip:check"]' package.json >/dev/null 2>&1; then
+  KNIP_SCRIPT="knip:check"
+elif jq -e '.scripts.knip' package.json >/dev/null 2>&1; then
+  KNIP_SCRIPT="knip"
+else
+  KNIP_SCRIPT=""
+fi
+
+if [ -n "$KNIP_SCRIPT" ]; then
   echo "🗑️ Running dead code detection (knip)..."
-  $RUNNER knip
+  $RUNNER "$KNIP_SCRIPT"
   if [ $? -ne 0 ]; then
     echo "❌ Dead code detected. Please remove unused exports/dependencies before pushing."
     echo ""
@@ -283,6 +293,20 @@ fi
 #     echo "✅ Lighthouse CI performance audit passed"
 #   fi
 # fi
+
+# Project-specific extension slot (see .husky/pre-push.local).
+# This hook sources pre-push.local if present so per-project checks
+# (e.g., app-boot verification, schema validation) survive Lisa template
+# updates without editing the governance block above.
+if [ -f .husky/pre-push.local ]; then
+  echo "🔌 Running project-specific pre-push checks (.husky/pre-push.local)..."
+  # shellcheck source=/dev/null
+  . .husky/pre-push.local
+  if [ $? -ne 0 ]; then
+    echo "❌ Project-specific pre-push checks failed."
+    exit 1
+  fi
+fi
 
 exit 0
 

--- a/harper-fabric/package-lisa/package.lisa.json
+++ b/harper-fabric/package-lisa/package.lisa.json
@@ -11,7 +11,7 @@
       "lint:slow": "eslint . --config eslint.slow.config.ts --quiet",
       "format:check": "prettier --check .",
       "format": "prettier --check . --write",
-      "knip": "knip",
+      "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "start": "harperdb start",
@@ -78,5 +78,10 @@
       "dev:server": "bun run build && node dist/scripts/dev_server.js",
       "deploy": "bun run build && node dist/scripts/deploy.js"
     }
+  },
+  "remove": {
+    "scripts": [
+      "knip"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check .",
     "format": "prettier --check . --write",
-    "knip": "knip",
+    "knip:check": "knip",
     "knip:fix": "knip --fix",
     "sg:scan": "ast-grep scan",
     "build:plugins": "bash scripts/build-plugins.sh",

--- a/phaser/package-lisa/package.lisa.json
+++ b/phaser/package-lisa/package.lisa.json
@@ -10,7 +10,7 @@
       "lint:slow": "eslint . --config eslint.slow.config.ts --quiet",
       "format:check": "prettier --check .",
       "format": "prettier --write .",
-      "knip": "knip",
+      "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "prepare": "husky install || true"
@@ -55,7 +55,10 @@
     "private": true
   },
   "merge": {
-    "trustedDependencies": ["@ast-grep/cli", "@codyswann/lisa"]
+    "trustedDependencies": [
+      "@ast-grep/cli",
+      "@codyswann/lisa"
+    ]
   },
   "defaults": {
     "scripts": {
@@ -69,5 +72,10 @@
     "devDependencies": {
       "vite": "^6.3.1"
     }
+  },
+  "remove": {
+    "scripts": [
+      "knip"
+    ]
   }
 }

--- a/src/strategies/package-lisa-types.ts
+++ b/src/strategies/package-lisa-types.ts
@@ -36,11 +36,24 @@ export interface MergeSection {
 }
 
 /**
+ * Remove behavior: Keys Lisa deletes from the named package.json section.
+ * Used to retire keys Lisa previously forced (e.g. a renamed script) so they
+ * don't linger in downstream projects forever. Applied after force/defaults/
+ * merge, so a removed key cannot be reintroduced by an earlier phase in the
+ * same apply. Each entry maps a package.json section (e.g. "scripts") to the
+ * list of keys to delete from it.
+ */
+export interface RemoveSection {
+  [key: string]: string[];
+}
+
+/**
  * Template structure for package.lisa.json files
  * @remarks
  * - `force`: Sections where Lisa's values completely replace project's values
  * - `defaults`: Sections where project's values take precedence if they exist
  * - `merge`: Array sections that are concatenated and deduplicated
+ * - `remove`: Section keys Lisa deletes from the project (retired keys)
  *
  * When multiple package.lisa.json files are loaded from the inheritance chain (all → typescript → specific),
  * they are merged with child types overriding parent types in each section.
@@ -63,6 +76,9 @@ export interface MergeSection {
  *   },
  *   "merge": {
  *     "trustedDependencies": ["@ast-grep/cli"]
+ *   },
+ *   "remove": {
+ *     "scripts": ["knip"]
  *   }
  * }
  * ```
@@ -76,14 +92,18 @@ export interface PackageLisaTemplate {
 
   /** Array sections that are concatenated and deduplicated */
   merge?: Record<string, unknown[]>;
+
+  /** Section keys Lisa deletes from the project (retired keys) */
+  remove?: Record<string, string[]>;
 }
 
 /**
- * Merged template with resolved force/defaults/merge sections
+ * Merged template with resolved force/defaults/merge/remove sections
  * ready to be applied to a project's package.json
  */
 export interface ResolvedPackageLisaTemplate extends PackageLisaTemplate {
   force: Record<string, unknown>;
   defaults: Record<string, unknown>;
   merge: Record<string, unknown[]>;
+  remove: Record<string, string[]>;
 }

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -389,6 +389,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
       force: {},
       defaults: {},
       merge: {},
+      remove: {},
     };
 
     // Expand types to include parents (e.g., expo includes typescript)
@@ -451,7 +452,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
   /**
    * Merge two template objects
    * Child template (override) values win in force and defaults.
-   * Merge arrays are concatenated without deduplication at merge time.
+   * Merge and remove arrays are concatenated without deduplication at merge time.
    * @param parent - Parent template (e.g., "all" or "typescript")
    * @param child - Child template (e.g., "expo") that overrides parent
    * @returns Merged template
@@ -465,6 +466,10 @@ export class PackageLisaStrategy implements ICopyStrategy {
       force: deepMerge(parent.force, child.force || {}),
       defaults: deepMerge(parent.defaults, child.defaults || {}),
       merge: this.mergeMergeSections(parent.merge, child.merge || {}),
+      remove: this.mergeMergeSections(
+        parent.remove,
+        child.remove || {}
+      ) as Record<string, string[]>,
     };
   }
 
@@ -496,12 +501,14 @@ export class PackageLisaStrategy implements ICopyStrategy {
   }
 
   /**
-   * Apply force/defaults/merge logic to project's package.json
+   * Apply force/defaults/merge/remove logic to project's package.json
    * @remarks
    * Processing order:
    * 1. Apply force: Deep merge with Lisa values winning (entire section replaced)
    * 2. Apply defaults: Deep merge with project values winning (only set if missing)
    * 3. Apply merge: Concatenate arrays and deduplicate
+   * 4. Apply remove: Delete retired keys from their sections (runs last so an
+   *    earlier phase cannot reintroduce a removed key)
    * @param projectJson - Current project's package.json
    * @param template - Merged package.lisa.json template
    * @returns Modified package.json
@@ -524,7 +531,46 @@ export class PackageLisaStrategy implements ICopyStrategy {
     );
 
     // Phase 3: Apply merge (concatenate and deduplicate arrays)
-    return this.applyMergeSections(afterDefaults, template.merge);
+    const afterMerge = this.applyMergeSections(afterDefaults, template.merge);
+
+    // Phase 4: Apply remove (delete retired keys from their sections)
+    return this.applyRemoveSections(afterMerge, template.remove);
+  }
+
+  /**
+   * Delete retired keys from their package.json sections
+   * @remarks
+   * Used to clean up keys Lisa previously forced and has since renamed or
+   * retired (e.g. the "knip" script renamed to "knip:check"). Runs after
+   * force/defaults/merge so a removed key cannot be reintroduced within the
+   * same apply. Sections that don't exist or aren't objects are left alone.
+   * @param packageJson - Current package.json after force/defaults/merge applied
+   * @param removeSections - Map of section name to keys to delete from it
+   * @returns Package.json with retired keys removed
+   * @private
+   */
+  private applyRemoveSections(
+    packageJson: Record<string, unknown>,
+    removeSections: Record<string, string[]>
+  ): Record<string, unknown> {
+    const result = { ...packageJson };
+
+    for (const [sectionName, keysToRemove] of Object.entries(removeSections)) {
+      const section = result[sectionName];
+      if (!section || typeof section !== "object" || Array.isArray(section)) {
+        // Section missing or not a plain object; nothing to remove
+        continue;
+      }
+
+      const cleaned = Object.fromEntries(
+        Object.entries(section as Record<string, unknown>).filter(
+          ([key]) => !keysToRemove.includes(key)
+        )
+      );
+      result[sectionName] = cleaned;
+    }
+
+    return result;
   }
 
   /**

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -541,6 +541,157 @@ describe("PackageLisaStrategy", () => {
     });
   });
 
+  describe("remove behavior", () => {
+    it("deletes retired keys from the named section", async () => {
+      await createPackageLisaTemplate("all", {
+        force: {
+          scripts: { "knip:check": "knip" },
+        },
+        remove: {
+          scripts: ["knip"],
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "all",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await fs.writeJson(destPath, {
+        name: "my-project",
+        scripts: { knip: "knip", start: "node index.js" },
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext()
+      );
+
+      expect(_result.action).toBe("merged");
+      const content = await fs.readJson(destPath);
+      expect(content.scripts.knip).toBeUndefined(); // Retired key removed
+      expect(content.scripts["knip:check"]).toBe("knip"); // Replacement forced
+      expect(content.scripts.start).toBe("node index.js"); // Preserved
+    });
+
+    it("runs after force so a removed key cannot be reintroduced", async () => {
+      await createPackageLisaTemplate("all", {
+        force: {
+          scripts: { retired: "should-not-survive" },
+        },
+        remove: {
+          scripts: ["retired"],
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "all",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await fs.writeJson(destPath, { name: "my-project" });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext()
+      );
+
+      expect(_result.action).toBe("merged");
+      const content = await fs.readJson(destPath);
+      expect(content.scripts.retired).toBeUndefined();
+    });
+
+    it("leaves missing or non-object sections alone", async () => {
+      await createPackageLisaTemplate("all", {
+        remove: {
+          scripts: ["knip"],
+          missingSection: ["whatever"],
+          arraySection: ["item"],
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "all",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await fs.writeJson(destPath, {
+        name: "my-project",
+        arraySection: ["item", "other"],
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext()
+      );
+
+      // Nothing to remove → output equals input → strategy reports skipped
+      expect(_result.action).toBe("skipped");
+      const content = await fs.readJson(destPath);
+      expect(content.name).toBe("my-project");
+      expect(content.scripts).toBeUndefined(); // Still absent, not created
+      expect(content.missingSection).toBeUndefined();
+      expect(content.arraySection).toEqual(["item", "other"]); // Untouched
+    });
+
+    it("concatenates remove lists across the inheritance chain", async () => {
+      await createPackageLisaTemplate("typescript", {
+        remove: {
+          scripts: ["knip"],
+        },
+      });
+
+      await createPackageLisaTemplate("expo", {
+        remove: {
+          scripts: ["legacy-expo-script"],
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "typescript",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await createExpoProject(projectDir);
+      await fs.writeJson(path.join(projectDir, "tsconfig.json"), {});
+      await fs.writeJson(destPath, {
+        name: "my-project",
+        scripts: {
+          knip: "knip",
+          "legacy-expo-script": "expo legacy",
+          start: "expo start",
+        },
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext()
+      );
+
+      expect(_result.action).toBe("merged");
+      const content = await fs.readJson(destPath);
+      expect(content.scripts.knip).toBeUndefined(); // Parent removal applied
+      expect(content.scripts["legacy-expo-script"]).toBeUndefined(); // Child removal applied
+      expect(content.scripts.start).toBe("expo start"); // Preserved
+    });
+  });
+
   describe("inheritance and type hierarchy", () => {
     it("merges templates from all types in inheritance chain", async () => {
       // Setup all → typescript → expo hierarchy

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -183,10 +183,20 @@ else
   echo "ℹ️  Skipping slow lint rules (lint:slow not configured)"
 fi
 
-# Run dead code detection (knip) - only if script exists
-if jq -e '.scripts.knip' package.json >/dev/null 2>&1; then
+# Run dead code detection (knip) - only if script exists.
+# Prefer knip:check (the script was renamed because expo-doctor flags scripts
+# that shadow node_modules/.bin entries); fall back to the legacy knip name.
+if jq -e '.scripts["knip:check"]' package.json >/dev/null 2>&1; then
+  KNIP_SCRIPT="knip:check"
+elif jq -e '.scripts.knip' package.json >/dev/null 2>&1; then
+  KNIP_SCRIPT="knip"
+else
+  KNIP_SCRIPT=""
+fi
+
+if [ -n "$KNIP_SCRIPT" ]; then
   echo "🗑️ Running dead code detection (knip)..."
-  $RUNNER knip
+  $RUNNER "$KNIP_SCRIPT"
   if [ $? -ne 0 ]; then
     echo "❌ Dead code detected. Please remove unused exports/dependencies before pushing."
     echo ""

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -12,7 +12,7 @@
       "lint:fix": "oxlint --fix && eslint . --fix",
       "lint:slow": "eslint . --config eslint.slow.config.ts --quiet",
       "typecheck": "tsc --noEmit",
-      "knip": "knip",
+      "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "prepare": "node -e \"if (process.env.INIT_CWD && process.env.INIT_CWD.includes('.serverless')) { process.exit(0); }\" && husky install || true"
@@ -55,6 +55,11 @@
       "@ast-grep/cli",
       "@codyswann/lisa",
       "@sentry/cli"
+    ]
+  },
+  "remove": {
+    "scripts": [
+      "knip"
     ]
   }
 }

--- a/wiki/documentation/specs/package-lisa-json.md
+++ b/wiki/documentation/specs/package-lisa-json.md
@@ -13,6 +13,8 @@ Replace inline `//lisa-*` tags with separate `package.lisa.json` template files 
 - **force**: Keys Lisa always overwrites (project changes are discarded)
 - **defaults**: Keys Lisa sets only if missing (project can override)
 - **merge**: Arrays where Lisa's items are combined with project's items
+- **remove**: Keys Lisa deletes from a section (retired/renamed keys, e.g. the
+  `knip` script renamed to `knip:check`)
 
 The project's `package.json` remains 100% clean - no Lisa artifacts.
 
@@ -39,6 +41,9 @@ The project's `package.json` remains 100% clean - no Lisa artifacts.
   },
   "merge": {
     "trustedDependencies": ["@ast-grep/cli"]
+  },
+  "remove": {
+    "scripts": ["knip"]
   }
 }
 ```
@@ -60,18 +65,21 @@ all/package-lisa/package.lisa.json
 - `force`: Child values override parent values (deep merge, child wins)
 - `defaults`: Child values override parent values (deep merge, child wins)
 - `merge`: Arrays are concatenated and deduplicated
+- `remove`: Key lists are concatenated across the chain
 
 ### Application Logic
 
 When Lisa applies `package.lisa.json` to a project:
 
 1. **Collect templates** - Gather all `package.lisa.json` files from detected types (e.g., `all` + `typescript` + `expo`)
-2. **Merge templates** - Combine into single force/defaults/merge structure
+2. **Merge templates** - Combine into single force/defaults/merge/remove structure
 3. **Read project's package.json** - Parse current state
 4. **Apply force** - Deep merge, Lisa's values win
 5. **Apply defaults** - Deep merge, project's values win (only set if missing)
 6. **Apply merge** - Concatenate arrays, deduplicate
-7. **Write package.json** - Output clean JSON with no Lisa metadata
+7. **Apply remove** - Delete retired keys from their sections (runs last so an
+   earlier phase cannot reintroduce a removed key)
+8. **Write package.json** - Output clean JSON with no Lisa metadata
 
 ## Implementation Tasks
 


### PR DESCRIPTION
## Problem

expo-doctor's `PackageJsonCheck` fails any project whose npm script name shadows a `node_modules/.bin` entry. The forced `"knip": "knip"` script in the typescript/phaser/harper-fabric `package.lisa.json` templates does exactly that, so every Lisa-managed Expo project fails the check — and re-acquires the offending script on each Lisa apply, so projects can't fix it locally.

## Changes

- **Rename the forced script** to `"knip:check"` in the `typescript`, `phaser`, and `harper-fabric` `package.lisa.json` templates (`knip:fix` is unaffected — only exact `.bin` name matches are flagged).
- **New `remove` section** in the `package.lisa.json` format: keys Lisa deletes from a named package.json section. Applied after force/defaults/merge so an earlier phase can't reintroduce a removed key; remove lists concatenate across the type inheritance chain. Used here to retire the old `knip` key from downstream projects instead of letting it linger.
- **Transition-safe CI/hooks**: the `quality.yml` dead_code job and the pre-push hook now prefer `knip:check` and fall back to the legacy `knip` name, so downstream projects keep passing CI in both directions of the transition (renamed project + old workflow, or old project + new workflow).
- Rename Lisa's own `knip` script and sync its own pre-push hook.
- Document the `remove` section in `wiki/documentation/specs/package-lisa-json.md`.

## Verification

- `bunx vitest run tests/unit` — 3187 passed / 0 failed (includes 4 new tests covering remove semantics: basic removal, remove-after-force ordering, missing/non-object sections, inheritance-chain concatenation)
- `bun run typecheck` — clean
- `bun run lint` + eslint on changed files — clean

🤖 Generated with Claude Code