### PR TITLE
fix: guard bootstrapper in build contexts

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { LisaConfig } from "../core/config.js";
+import { getBootstrapApplySkipNotice } from "../core/bootstrap-environment.js";
 import { ACCEPTED_HARNESS_INPUTS } from "../core/config.js";
 import { Lisa } from "../core/lisa.js";
 import {
@@ -16,6 +17,22 @@ import { nudgeCrossPollinate } from "./cross-pollinate-nudge.js";
 import { type CLIOptions, createDependencies } from "./shared-options.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Inputs used to decide whether `.lisa.config.json` should be persisted.
+ */
+interface ProjectConfigPersistenceInput {
+  /** Whether the destination already has `.lisa.config.json`. */
+  readonly fileExists: boolean;
+  /** Harness value supplied by the caller, if any. */
+  readonly flagHarness: CLIOptions["harness"];
+  /** Harness already persisted in `.lisa.config.json`, if any. */
+  readonly existingHarness: Awaited<
+    ReturnType<typeof readProjectConfig>
+  >["harness"];
+  /** Harness resolved for this invocation. */
+  readonly resolvedHarness: LisaConfig["harness"];
+}
 
 /**
  * Get Lisa directory (where configs are stored)
@@ -68,6 +85,32 @@ function printUsageAndExit(): never {
 }
 
 /**
+ * Resolve the required destination argument or print the legacy usage error.
+ * @param destination - Destination argument from the CLI
+ * @returns Absolute destination path
+ */
+function resolveDestinationOrExit(destination: string | undefined): string {
+  if (!destination) {
+    printUsageAndExit();
+  }
+  return toAbsolutePath(destination);
+}
+
+/**
+ * Persist the resolved harness when a real apply needs to backfill or update
+ * `.lisa.config.json`.
+ * @param destDir - Destination project directory
+ * @param input - Existing config state and resolved harness values
+ */
+async function persistProjectConfigIfNeeded(
+  destDir: string,
+  input: ProjectConfigPersistenceInput
+): Promise<void> {
+  if (!shouldPersistProjectConfig(input)) return;
+  await writeProjectConfig(destDir, { harness: input.resolvedHarness });
+}
+
+/**
  * Apply Lisa to the given destination with the given options.
  *
  * This is the relocated action that previously lived inline in
@@ -82,13 +125,17 @@ export async function runApply(
   destination: string | undefined,
   options: CLIOptions
 ): Promise<void> {
-  if (!destination) {
-    printUsageAndExit();
-  }
-
   const dryRun = options.dryRun ?? options.validate ?? false;
   const yesMode = options.yes ?? false;
-  const destDir = toAbsolutePath(destination);
+  const validateOnly = options.validate ?? false;
+  const destDir = resolveDestinationOrExit(destination);
+  const logger = new ConsoleLogger();
+
+  const skipNotice = getBootstrapApplySkipNotice({ validateOnly });
+  if (skipNotice !== undefined) {
+    console.log(skipNotice);
+    return;
+  }
 
   // Resolve harness with precedence: CLI flag > .lisa.config.json > default
   const projectConfig = await readProjectConfig(destDir);
@@ -100,12 +147,11 @@ export async function runApply(
     destDir,
     dryRun,
     yesMode,
-    validateOnly: options.validate ?? false,
+    validateOnly,
     skipGitCheck: options.skipGitCheck ?? false,
     harness,
   };
 
-  const logger = new ConsoleLogger();
   const deps = createDependencies(dryRun, yesMode, logger);
   const lisa = new Lisa(config, deps);
 
@@ -124,17 +170,13 @@ export async function runApply(
     // resolved harness (the default when no --harness was passed) so no
     // project is left config-less; an existing file is only rewritten when
     // --harness actually changes the persisted value, avoiding churn.
-    if (
-      !options.validate &&
-      !dryRun &&
-      shouldPersistProjectConfig({
+    if (!options.validate && !dryRun) {
+      await persistProjectConfigIfNeeded(destDir, {
         fileExists: configFileExists,
         flagHarness: options.harness,
         existingHarness: projectConfig.harness,
         resolvedHarness: harness,
-      })
-    ) {
-      await writeProjectConfig(destDir, { harness });
+      });
     }
 
     // After a real apply, surface (read-only) whether any locally-authored

--- a/src/core/bootstrap-environment.ts
+++ b/src/core/bootstrap-environment.ts
@@ -1,0 +1,80 @@
+export const LISA_BOOTSTRAP_ENV = "LISA_BOOTSTRAP";
+
+export const BUILD_ENV_FINGERPRINTS: readonly string[] = [
+  "CI",
+  "CODEBUILD_BUILD_ID",
+  "GITHUB_ACTIONS",
+  "EAS_BUILD",
+  "VERCEL",
+  "BUILDKITE",
+  "JENKINS_URL",
+  "AMPLIFY_APP_ID",
+  "AWS_BRANCH",
+];
+
+export const BOOTSTRAP_SKIP_NOTICE =
+  "lisa: skipped (non-interactive environment; set LISA_BOOTSTRAP=1 to force)";
+
+/**
+ * Runtime state used by the bootstrap guard.
+ */
+export interface BootstrapEnvironment {
+  /** Environment variables visible to the current process. */
+  readonly env: NodeJS.ProcessEnv;
+  /** Whether stdin is attached to an interactive TTY. */
+  readonly stdinIsTTY: boolean;
+}
+
+/**
+ * Options for deciding whether the apply entry point should be skipped.
+ */
+export interface BootstrapGuardOptions {
+  /** Whether the caller requested validate-only mode. */
+  readonly validateOnly: boolean;
+  /** Injectable runtime state for tests. Defaults to the current process. */
+  readonly environment?: BootstrapEnvironment;
+}
+
+/**
+ * Read process.env through one explicit, reviewable exception to the app-template
+ * config access ban. Lisa's CLI bootstrap guard must inspect externally supplied
+ * build-system fingerprints before any project config is available.
+ * @returns The current process environment
+ */
+function readProcessEnv(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line no-restricted-syntax -- CLI bootstrap guard must read externally supplied build env vars once
+  return process.env;
+}
+
+/**
+ * Decide whether the Lisa apply entry point should refuse to run.
+ *
+ * Validate mode is intentionally exempt because it never writes project files.
+ * Real apply must be explicitly opted in when running without a TTY or under a
+ * known build-system fingerprint.
+ * @param options - Guard options and injectable runtime state
+ * @returns The skip notice when apply should be skipped, otherwise undefined
+ */
+export function getBootstrapApplySkipNotice(
+  options: BootstrapGuardOptions
+): string | undefined {
+  if (options.validateOnly) return undefined;
+
+  const environment = options.environment ?? {
+    env: readProcessEnv(),
+    stdinIsTTY: process.stdin.isTTY === true,
+  };
+
+  if (environment.env[LISA_BOOTSTRAP_ENV] === "1") return undefined;
+
+  const hasBuildEnvFingerprint = BUILD_ENV_FINGERPRINTS.some(name => {
+    const value = environment.env[name];
+    return value !== undefined && value !== "";
+  });
+
+  if (!environment.stdinIsTTY || hasBuildEnvFingerprint) {
+    return BOOTSTRAP_SKIP_NOTICE;
+  }
+
+  return undefined;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,3 @@
 export * from "./config.js";
+export * from "./bootstrap-environment.js";
 export { Lisa, type LisaDependencies } from "./lisa.js";

--- a/tests/unit/cli/apply.test.ts
+++ b/tests/unit/cli/apply.test.ts
@@ -6,23 +6,17 @@ import { BOOTSTRAP_SKIP_NOTICE } from "../../../src/core/bootstrap-environment.j
 import { runApply } from "../../../src/cli/apply.js";
 
 describe("runApply bootstrap guard", () => {
-  const originalCi = process.env.CI;
-
   afterEach(() => {
-    if (originalCi === undefined) {
-      delete process.env.CI;
-    } else {
-      process.env.CI = originalCi;
-    }
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("exits successfully without writing in a build context", async () => {
+    vi.stubEnv("CI", "1");
     const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
     const packageJson = join(projectDir, "package.json");
     await writeFile(packageJson, '{"name":"guard-fixture"}\n', "utf8");
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    process.env.CI = "true";
 
     await runApply(projectDir, { yes: true, skipGitCheck: true });
 
@@ -36,11 +30,11 @@ describe("runApply bootstrap guard", () => {
   });
 
   it("skips before parsing project config in a build context", async () => {
+    vi.stubEnv("CI", "1");
     const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
     const configPath = join(projectDir, ".lisa.config.json");
     await writeFile(configPath, "{not-json", "utf8");
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    process.env.CI = "true";
 
     await expect(
       runApply(projectDir, { yes: true, skipGitCheck: true })

--- a/tests/unit/cli/apply.test.ts
+++ b/tests/unit/cli/apply.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BOOTSTRAP_SKIP_NOTICE } from "../../../src/core/bootstrap-environment.js";
+import { runApply } from "../../../src/cli/apply.js";
+
+describe("runApply bootstrap guard", () => {
+  const originalCi = process.env.CI;
+
+  afterEach(() => {
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("exits successfully without writing in a build context", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
+    const packageJson = join(projectDir, "package.json");
+    await writeFile(packageJson, '{"name":"guard-fixture"}\n', "utf8");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    process.env.CI = "true";
+
+    await runApply(projectDir, { yes: true, skipGitCheck: true });
+
+    expect(log).toHaveBeenCalledWith(BOOTSTRAP_SKIP_NOTICE);
+    await expect(readFile(packageJson, "utf8")).resolves.toBe(
+      '{"name":"guard-fixture"}\n'
+    );
+    await expect(
+      readFile(join(projectDir, ".lisa.config.json"), "utf8")
+    ).rejects.toThrow();
+  });
+
+  it("skips before parsing project config in a build context", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
+    const configPath = join(projectDir, ".lisa.config.json");
+    await writeFile(configPath, "{not-json", "utf8");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    process.env.CI = "true";
+
+    await expect(
+      runApply(projectDir, { yes: true, skipGitCheck: true })
+    ).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith(BOOTSTRAP_SKIP_NOTICE);
+    await expect(readFile(configPath, "utf8")).resolves.toBe("{not-json");
+  });
+});

--- a/tests/unit/core/bootstrap-environment.test.ts
+++ b/tests/unit/core/bootstrap-environment.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOOTSTRAP_SKIP_NOTICE,
+  BUILD_ENV_FINGERPRINTS,
+  getBootstrapApplySkipNotice,
+} from "../../../src/core/bootstrap-environment.js";
+
+const interactive = {
+  env: {},
+  stdinIsTTY: true,
+};
+
+describe("getBootstrapApplySkipNotice", () => {
+  it("refuses to run apply without a TTY unless explicitly opted in", () => {
+    expect(
+      getBootstrapApplySkipNotice({
+        validateOnly: false,
+        environment: { env: {}, stdinIsTTY: false },
+      })
+    ).toBe(BOOTSTRAP_SKIP_NOTICE);
+  });
+
+  it.each(BUILD_ENV_FINGERPRINTS)(
+    "refuses to run apply when %s is present",
+    fingerprint => {
+      expect(
+        getBootstrapApplySkipNotice({
+          validateOnly: false,
+          environment: {
+            env: { [fingerprint]: "1" },
+            stdinIsTTY: true,
+          },
+        })
+      ).toBe(BOOTSTRAP_SKIP_NOTICE);
+    }
+  );
+
+  it("allows explicit bootstrap opt-in in non-interactive contexts", () => {
+    expect(
+      getBootstrapApplySkipNotice({
+        validateOnly: false,
+        environment: {
+          env: { LISA_BOOTSTRAP: "1", CI: "true" },
+          stdinIsTTY: false,
+        },
+      })
+    ).toBeUndefined();
+  });
+
+  it("keeps interactive apply behavior unchanged", () => {
+    expect(
+      getBootstrapApplySkipNotice({
+        validateOnly: false,
+        environment: interactive,
+      })
+    ).toBeUndefined();
+  });
+
+  it("keeps validate mode available in build contexts", () => {
+    expect(
+      getBootstrapApplySkipNotice({
+        validateOnly: true,
+        environment: {
+          env: { CI: "true" },
+          stdinIsTTY: false,
+        },
+      })
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a bootstrap apply guard that skips non-interactive/build environments unless `LISA_BOOTSTRAP=1` is set
- keep validate mode available in build contexts
- cover the guard helper and CLI no-write skip path

Fixes #1269

## Verification
- `bun test tests/unit/core/bootstrap-environment.test.ts tests/unit/cli/apply.test.ts tests/unit/cli/index.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun test tests/integration/cli-smoke.test.ts`
- real CLI smoke: no-TTY `bun src/index.ts apply <tmp> --yes --skip-git-check --no-update-check` exited 0, printed the skip notice, and left files unchanged
- pre-push hook: `bun audit`, slow lint, `knip`, `vitest run --coverage` (204 files / 3255 tests), and `vitest run tests/integration` (3 files / 54 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bootstrap guard that prevents accidental apply runs in non-interactive/build environments; a skip notice is logged when apply is skipped.

* **Improvements**
  * More reliable destination resolution and safer project configuration persistence/backfill during apply; invalid configs are left unchanged when apply is skipped.

* **Tests**
  * New unit tests covering the bootstrap guard and its behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->