### PR TITLE
fix(hooks): tokenize no-verify guard input

### DIFF
--- a/plugins/lisa-agy/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa-agy/hooks/block-no-verify.agy.sh
@@ -3,8 +3,9 @@
 # git quality gates (exact parity with the Claude block-no-verify.sh): the
 # `--no-verify` long flag, `HUSKY=0`/`HUSKY_SKIP_HOOKS=` (disables husky hooks),
 # and `core.hooksPath` pointed at /dev/null or set empty (disables all git
-# hooks). The short `-n` form is intentionally NOT matched, to avoid false
-# positives (see the matching block below).
+# hooks). Shell-token matching avoids false positives from issue bodies,
+# heredocs, and commit-message prose while still catching quoted real argv
+# values such as `git -c "core.hooksPath=/dev/null"`.
 #
 # agy protocol (distinct from the Claude block-no-verify.sh exit-code protocol):
 #   - stdin  = JSON: { "toolCall": { "name": "run_command",
@@ -34,17 +35,65 @@ input="$(cat 2>/dev/null || true)"
 command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
 [ -z "$command_str" ] && allow
 
-# Each pattern is bounded so longer flags (--no-verify-ssl) and legit values
-# (core.hooksPath=.husky, HUSKY=1) don't match, while every syntactic position
-# is caught (incl. subshells). Exact parity with the Claude block-no-verify.sh.
-# The short `-n` form is intentionally NOT matched — `-n` appears in commit
-# message prose (`git commit -m "fix -n flag"`) and unrelated piped commands
-# (`sort -n x; git commit`), so guarding it false-positives on valid work.
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || allow
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   deny
 fi
 

--- a/plugins/lisa-copilot/hooks/block-no-verify.sh
+++ b/plugins/lisa-copilot/hooks/block-no-verify.sh
@@ -9,8 +9,9 @@
 #   2. HUSKY=0 / HUSKY_SKIP_HOOKS=... — disables husky-managed git hooks;
 #   3. core.hooksPath pointed at /dev/null or set empty — disables ALL git hooks.
 #
-# Word-boundary matching avoids false positives on longer flags (--no-verify-ssl,
-# --no-verify-host) and on a legit custom hooks path (core.hooksPath=.husky).
+# Shell-token matching avoids false positives from issue bodies, heredocs, and
+# commit-message prose while still catching quoted real argv values such as
+# `git -c "core.hooksPath=/dev/null"`.
 #
 # The short `-n` form is intentionally NOT matched (see block-no-verify.agy.sh):
 # grep cannot distinguish a real -n option from -n in commit-message prose or an
@@ -29,14 +30,65 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
-# Each pattern is bounded by non-token characters so longer flags
-# (--no-verify-ssl) and legit values (core.hooksPath=.husky, HUSKY=1) don't match,
-# while every syntactic position is caught (incl. subshells, e.g. `(git commit --no-verify)`).
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
 or core.hooksPath disabling). Fix the underlying issue (lint error, failing

--- a/plugins/lisa-cursor/hooks/block-no-verify.sh
+++ b/plugins/lisa-cursor/hooks/block-no-verify.sh
@@ -9,8 +9,9 @@
 #   2. HUSKY=0 / HUSKY_SKIP_HOOKS=... — disables husky-managed git hooks;
 #   3. core.hooksPath pointed at /dev/null or set empty — disables ALL git hooks.
 #
-# Word-boundary matching avoids false positives on longer flags (--no-verify-ssl,
-# --no-verify-host) and on a legit custom hooks path (core.hooksPath=.husky).
+# Shell-token matching avoids false positives from issue bodies, heredocs, and
+# commit-message prose while still catching quoted real argv values such as
+# `git -c "core.hooksPath=/dev/null"`.
 #
 # The short `-n` form is intentionally NOT matched (see block-no-verify.agy.sh):
 # grep cannot distinguish a real -n option from -n in commit-message prose or an
@@ -29,14 +30,65 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
-# Each pattern is bounded by non-token characters so longer flags
-# (--no-verify-ssl) and legit values (core.hooksPath=.husky, HUSKY=1) don't match,
-# while every syntactic position is caught (incl. subshells, e.g. `(git commit --no-verify)`).
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
 or core.hooksPath disabling). Fix the underlying issue (lint error, failing

--- a/plugins/lisa/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa/hooks/block-no-verify.agy.sh
@@ -3,8 +3,9 @@
 # git quality gates (exact parity with the Claude block-no-verify.sh): the
 # `--no-verify` long flag, `HUSKY=0`/`HUSKY_SKIP_HOOKS=` (disables husky hooks),
 # and `core.hooksPath` pointed at /dev/null or set empty (disables all git
-# hooks). The short `-n` form is intentionally NOT matched, to avoid false
-# positives (see the matching block below).
+# hooks). Shell-token matching avoids false positives from issue bodies,
+# heredocs, and commit-message prose while still catching quoted real argv
+# values such as `git -c "core.hooksPath=/dev/null"`.
 #
 # agy protocol (distinct from the Claude block-no-verify.sh exit-code protocol):
 #   - stdin  = JSON: { "toolCall": { "name": "run_command",
@@ -34,17 +35,65 @@ input="$(cat 2>/dev/null || true)"
 command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
 [ -z "$command_str" ] && allow
 
-# Each pattern is bounded so longer flags (--no-verify-ssl) and legit values
-# (core.hooksPath=.husky, HUSKY=1) don't match, while every syntactic position
-# is caught (incl. subshells). Exact parity with the Claude block-no-verify.sh.
-# The short `-n` form is intentionally NOT matched — `-n` appears in commit
-# message prose (`git commit -m "fix -n flag"`) and unrelated piped commands
-# (`sort -n x; git commit`), so guarding it false-positives on valid work.
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || allow
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   deny
 fi
 

--- a/plugins/lisa/hooks/block-no-verify.sh
+++ b/plugins/lisa/hooks/block-no-verify.sh
@@ -9,8 +9,9 @@
 #   2. HUSKY=0 / HUSKY_SKIP_HOOKS=... — disables husky-managed git hooks;
 #   3. core.hooksPath pointed at /dev/null or set empty — disables ALL git hooks.
 #
-# Word-boundary matching avoids false positives on longer flags (--no-verify-ssl,
-# --no-verify-host) and on a legit custom hooks path (core.hooksPath=.husky).
+# Shell-token matching avoids false positives from issue bodies, heredocs, and
+# commit-message prose while still catching quoted real argv values such as
+# `git -c "core.hooksPath=/dev/null"`.
 #
 # The short `-n` form is intentionally NOT matched (see block-no-verify.agy.sh):
 # grep cannot distinguish a real -n option from -n in commit-message prose or an
@@ -29,14 +30,65 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
-# Each pattern is bounded by non-token characters so longer flags
-# (--no-verify-ssl) and legit values (core.hooksPath=.husky, HUSKY=1) don't match,
-# while every syntactic position is caught (incl. subshells, e.g. `(git commit --no-verify)`).
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
 or core.hooksPath disabling). Fix the underlying issue (lint error, failing

--- a/plugins/src/base/hooks/block-no-verify.agy.sh
+++ b/plugins/src/base/hooks/block-no-verify.agy.sh
@@ -3,8 +3,9 @@
 # git quality gates (exact parity with the Claude block-no-verify.sh): the
 # `--no-verify` long flag, `HUSKY=0`/`HUSKY_SKIP_HOOKS=` (disables husky hooks),
 # and `core.hooksPath` pointed at /dev/null or set empty (disables all git
-# hooks). The short `-n` form is intentionally NOT matched, to avoid false
-# positives (see the matching block below).
+# hooks). Shell-token matching avoids false positives from issue bodies,
+# heredocs, and commit-message prose while still catching quoted real argv
+# values such as `git -c "core.hooksPath=/dev/null"`.
 #
 # agy protocol (distinct from the Claude block-no-verify.sh exit-code protocol):
 #   - stdin  = JSON: { "toolCall": { "name": "run_command",
@@ -34,17 +35,65 @@ input="$(cat 2>/dev/null || true)"
 command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
 [ -z "$command_str" ] && allow
 
-# Each pattern is bounded so longer flags (--no-verify-ssl) and legit values
-# (core.hooksPath=.husky, HUSKY=1) don't match, while every syntactic position
-# is caught (incl. subshells). Exact parity with the Claude block-no-verify.sh.
-# The short `-n` form is intentionally NOT matched — `-n` appears in commit
-# message prose (`git commit -m "fix -n flag"`) and unrelated piped commands
-# (`sort -n x; git commit`), so guarding it false-positives on valid work.
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || allow
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   deny
 fi
 

--- a/plugins/src/base/hooks/block-no-verify.sh
+++ b/plugins/src/base/hooks/block-no-verify.sh
@@ -9,8 +9,9 @@
 #   2. HUSKY=0 / HUSKY_SKIP_HOOKS=... — disables husky-managed git hooks;
 #   3. core.hooksPath pointed at /dev/null or set empty — disables ALL git hooks.
 #
-# Word-boundary matching avoids false positives on longer flags (--no-verify-ssl,
-# --no-verify-host) and on a legit custom hooks path (core.hooksPath=.husky).
+# Shell-token matching avoids false positives from issue bodies, heredocs, and
+# commit-message prose while still catching quoted real argv values such as
+# `git -c "core.hooksPath=/dev/null"`.
 #
 # The short `-n` form is intentionally NOT matched (see block-no-verify.agy.sh):
 # grep cannot distinguish a real -n option from -n in commit-message prose or an
@@ -29,14 +30,65 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
-# Each pattern is bounded by non-token characters so longer flags
-# (--no-verify-ssl) and legit values (core.hooksPath=.husky, HUSKY=1) don't match,
-# while every syntactic position is caught (incl. subshells, e.g. `(git commit --no-verify)`).
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
 or core.hooksPath disabling). Fix the underlying issue (lint error, failing

--- a/src/codex/scripts/block-no-verify.sh
+++ b/src/codex/scripts/block-no-verify.sh
@@ -2,10 +2,10 @@
 # Lisa-managed Codex hook script (PreToolUse Bash).
 # Blocks git commands that bypass verification hooks: the --no-verify long flag,
 # HUSKY=0 / HUSKY_SKIP_HOOKS= (disables husky hooks), and core.hooksPath pointed
-# at /dev/null or set empty (disables all git hooks). The short `-n` form is
-# intentionally NOT matched (parity with block-no-verify.sh / .agy.sh): grep
-# cannot distinguish it from -n in commit-message prose or an unrelated piped
-# command, and -n is far more common than --no-verify.
+# at /dev/null or set empty (disables all git hooks). Shell-token matching
+# avoids false positives from issue bodies, heredocs, and commit-message prose
+# while still catching quoted real argv values such as
+# `git -c "core.hooksPath=/dev/null"`.
 set -euo pipefail
 
 input="$(cat 2>/dev/null || true)"
@@ -18,11 +18,65 @@ tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || t
 command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 [ -n "$command_str" ] || exit 0
 
-if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])--no-verify($|[^[:alnum:]_-])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY=0($|[^[:alnum:]])' \
-  || printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])HUSKY_SKIP_HOOKS=' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath([[:space:]]*=)?[[:space:]]*/dev/null' \
-  || printf '%s' "$command_str" | grep -Eq 'core\.hooksPath[[:space:]]*=[[:space:]]*($|[[:space:];&|"'\''])'; then
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_NO_VERIFY_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+try:
+    tokens = shlex.split(strip_heredocs(command), posix=True)
+except ValueError:
+    sys.exit(0)
+
+normalized_tokens = [token.strip("();|&") for token in tokens]
+
+for i, token in enumerate(normalized_tokens):
+    if token == "--no-verify":
+        sys.exit(1)
+    if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
+        sys.exit(1)
+    if token.startswith("core.hooksPath="):
+        value = token.split("=", 1)[1]
+        if value in ("", "/dev/null"):
+            sys.exit(1)
+    if token == "core.hooksPath" and i + 1 < len(normalized_tokens) and normalized_tokens[i + 1] in ("", "/dev/null"):
+        sys.exit(1)
+
+sys.exit(0)
+PY
+then
   jq -n '{
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",

--- a/tests/unit/agy/block-no-verify-agy.test.ts
+++ b/tests/unit/agy/block-no-verify-agy.test.ts
@@ -74,6 +74,22 @@ describe("block-no-verify.agy.sh", () => {
     expect(decide(payload("git commit -n -m wip"))).toBe("allow");
   });
 
+  it("allows --no-verify when it only appears in heredoc payload text", () => {
+    expect(
+      decide(
+        payload(
+          "gh issue create --body-file - <<'EOF'\nMention --no-verify in prose.\nEOF"
+        )
+      )
+    ).toBe("allow");
+  });
+
+  it("allows --no-verify when it only appears in a message argument", () => {
+    expect(
+      decide(payload('gh issue comment 1 --body "Mention --no-verify."'))
+    ).toBe("allow");
+  });
+
   it("allows -n appearing in a commit message (no false positive)", () => {
     expect(decide(payload('git commit -m "fix the -n flag handling"'))).toBe(
       "allow"
@@ -111,6 +127,12 @@ describe("block-no-verify.agy.sh", () => {
   it("denies core.hooksPath pointed at /dev/null", () => {
     expect(
       decide(payload("git -c core.hooksPath=/dev/null commit -m wip"))
+    ).toBe("deny");
+  });
+
+  it("denies quoted core.hooksPath pointed at /dev/null", () => {
+    expect(
+      decide(payload('git -c "core.hooksPath=/dev/null" commit -m wip'))
     ).toBe("deny");
   });
 

--- a/tests/unit/hooks/block-no-verify.test.ts
+++ b/tests/unit/hooks/block-no-verify.test.ts
@@ -79,6 +79,22 @@ describe("block-no-verify.sh", () => {
       const { status } = runHook("Bash", "git push --no-verify");
       expect(status).toBe(EXIT_BLOCKED);
     });
+
+    it("allows --no-verify when it only appears in heredoc payload text", () => {
+      const { status } = runHook(
+        "Bash",
+        "gh issue create --body-file - <<'EOF'\nMention --no-verify in the issue body.\nEOF"
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows --no-verify when it only appears in a message argument", () => {
+      const { status } = runHook(
+        "Bash",
+        'gh issue comment 1 --body "Mention --no-verify in prose."'
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
   });
 
   describe("blocks husky-disabling env bypasses", () => {
@@ -117,6 +133,14 @@ describe("block-no-verify.sh", () => {
       );
       expect(status).toBe(EXIT_BLOCKED);
     });
+
+    it("blocks quoted core.hooksPath set to /dev/null", () => {
+      const { status } = runHook(
+        "Bash",
+        'git -c "core.hooksPath=/dev/null" commit -m bypass'
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
   });
 
   describe("allows commands without --no-verify", () => {
@@ -134,6 +158,14 @@ describe("block-no-verify.sh", () => {
 
     it("allows HUSKY=1 (enabling husky)", () => {
       const { status } = runHook("Bash", 'HUSKY=1 git commit -m "normal"');
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows HUSKY=0 when it only appears in heredoc payload text", () => {
+      const { status } = runHook(
+        "Bash",
+        "gh issue create --body-file - <<EOF\nMention HUSKY=0 in the issue body.\nEOF"
+      );
       expect(status).toBe(EXIT_ALLOWED);
     });
 


### PR DESCRIPTION
## Summary
- Tokenize block-no-verify shell commands after stripping heredoc bodies, so issue/comment payload text no longer trips the bypass guard.
- Preserve blocking for real argv bypasses including --no-verify, HUSKY=0, HUSKY_SKIP_HOOKS, and quoted core.hooksPath=/dev/null.
- Regenerate Lisa plugin variants and add regression coverage for Claude/Copilot-style and agy hooks.

Fixes #1268

## Verification
- bun test tests/unit/hooks/block-no-verify.test.ts tests/unit/agy/block-no-verify-agy.test.ts
- bun run typecheck
- bun run check:plugins
- pre-push hook: slow lint, knip, vitest run --coverage, vitest run tests/integration