### PR TITLE
fix(expo): add shell-quote to knip ignoreDependencies template

### DIFF
--- a/expo/copy-overwrite/knip.json
+++ b/expo/copy-overwrite/knip.json
@@ -119,6 +119,7 @@
     "react-native-element-dropdown",
     "react-native-keyboard-controller",
     "react-native-worklets",
+    "shell-quote",
     "tailwind-variants",
     "tar",
     "text-encoding-polyfill",


### PR DESCRIPTION
## Summary

- Adds `shell-quote` to the expo `copy-overwrite/knip.json` `ignoreDependencies` template, next to the existing `tar` entry that follows the same pattern.
- Host repos pin `shell-quote >=1.8.4` as a direct dependency (plus overrides/resolutions) to clear the critical advisory GHSA-w7jw-789q-3m8p. Nothing imports it, so knip only passes with the ignore entry.
- Because `knip.json` is copy-overwrite, every session-start bootstrap clobbers the host's local ignore entry, and the next `git push` fails the pre-push dead-code gate with `Unused dependencies: shell-quote`.

Surfaced in geminisportsai/frontend-v2#5256, where the bootstrap reverted frontend-v2's local fix from its commit 847d7f2f3.

## Test plan

- Template-only change; after release, re-bootstrap an expo host repo (e.g. frontend-v2) and confirm `bun run knip` passes with `shell-quote` pinned in dependencies and the bootstrap no longer strips the ignore entry.

🤖 Generated with Claude Code