### PR TITLE
feat(codex): nudge on shell writes

### DIFF
--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -17,6 +17,17 @@
         ]
       }
     ],
+    "postToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
+          }
+        ]
+      }
+    ],
     "preToolUse": [
       {
         "matcher": "Bash",

--- a/plugins/lisa-copilot/hooks/shell-write-nudge.sh
+++ b/plugins/lisa-copilot/hooks/shell-write-nudge.sh
@@ -33,6 +33,21 @@ is_tracked_file() {
   git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
 }
 
+# Returns 0 when an inline runtime command (python -c / node -e / bun -e) contains
+# explicit write-intent indicators.  Read-only operations such as open(f).read() or
+# readFileSync should not trigger the nudge.
+inline_runtime_intends_to_write() {
+  local cmd="$1"
+  # Python: open() with write/append mode as second positional argument
+  [[ "$cmd" == *", 'w'"* || "$cmd" == *", 'a'"* || "$cmd" == *", 'wb'"* || "$cmd" == *", 'ab'"* ]] && return 0
+  [[ "$cmd" == *', "w"'* || "$cmd" == *', "a"'* || "$cmd" == *', "wb"'* || "$cmd" == *', "ab"'* ]] && return 0
+  # Python / general: explicit .write( method call
+  [[ "$cmd" == *'.write('* ]] && return 0
+  # Node/Bun fs write functions
+  [[ "$cmd" == *'writeFile'* || "$cmd" == *'appendFile'* || "$cmd" == *'createWriteStream'* ]] && return 0
+  return 1
+}
+
 command_mentions_tracked_write() {
   local token
   local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
@@ -49,11 +64,11 @@ command_mentions_tracked_write() {
     is_tracked_file "$token" && return 0
   done < <(
     printf '%s\n' "$COMMAND" |
-      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
-      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+      grep -Eo '(^|[[:space:]])(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
   )
 
-  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+  if [[ "$COMMAND" =~ $inline_runtime_re ]] && inline_runtime_intends_to_write "$COMMAND"; then
     while IFS= read -r token; do
       is_tracked_file "$token" && return 0
     done < <(git ls-files | while IFS= read -r file; do

--- a/plugins/lisa-copilot/hooks/shell-write-nudge.sh
+++ b/plugins/lisa-copilot/hooks/shell-write-nudge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# Shell Write Nudge Hook (PostToolUse - Bash)
+# =============================================================================
+# Emits a one-line, non-blocking notice when a Bash command appears to mutate a
+# tracked repository file directly. This keeps shell escape hatches visible
+# without blocking legitimate scripts or codemods.
+# =============================================================================
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+COMMAND="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$COMMAND" ] || exit 0
+
+case "$COMMAND" in
+  bun\ run* | npm\ run* | pnpm\ run* | yarn\ run* | node\ scripts/* | bun\ scripts/* | bash\ scripts/* | sh\ scripts/*)
+    exit 0
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" 2>/dev/null || exit 0
+
+is_tracked_file() {
+  local candidate="$1"
+  [ -n "$candidate" ] || return 1
+  candidate="${candidate#./}"
+  git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+command_mentions_tracked_write() {
+  local token
+  local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
+  local inline_runtime_re='(^|[[:space:];&|])(python3?|node|bun)[[:space:]]+-[ce][[:space:]]'
+
+  if [[ "$COMMAND" =~ $sed_command_re && "$COMMAND" == *"-i"* ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(printf '%s\n' "$COMMAND" | tr ' ' '\n' | sed 's/^[\"'\'']//; s/[\"'\'',;|&)]$//')
+  fi
+
+  while IFS= read -r token; do
+    token="${token#./}"
+    is_tracked_file "$token" && return 0
+  done < <(
+    printf '%s\n' "$COMMAND" |
+      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+  )
+
+  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(git ls-files | while IFS= read -r file; do
+      [[ "$COMMAND" == *"$file"* ]] && printf '%s\n' "$file"
+    done)
+  fi
+
+  return 1
+}
+
+if command_mentions_tracked_write; then
+  echo "Lisa notice: prefer Edit/Write for tracked file edits so lint-on-edit can see the change." >&2
+fi
+
+exit 0

--- a/plugins/lisa-cursor/hooks/hooks.json
+++ b/plugins/lisa-cursor/hooks/hooks.json
@@ -6,6 +6,12 @@
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
       }
     ],
+    "postToolUse": [
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/shell-write-nudge.sh",
+        "matcher": "Bash"
+      }
+    ],
     "preToolUse": [
       {
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-no-verify.sh",

--- a/plugins/lisa-cursor/hooks/shell-write-nudge.sh
+++ b/plugins/lisa-cursor/hooks/shell-write-nudge.sh
@@ -33,6 +33,21 @@ is_tracked_file() {
   git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
 }
 
+# Returns 0 when an inline runtime command (python -c / node -e / bun -e) contains
+# explicit write-intent indicators.  Read-only operations such as open(f).read() or
+# readFileSync should not trigger the nudge.
+inline_runtime_intends_to_write() {
+  local cmd="$1"
+  # Python: open() with write/append mode as second positional argument
+  [[ "$cmd" == *", 'w'"* || "$cmd" == *", 'a'"* || "$cmd" == *", 'wb'"* || "$cmd" == *", 'ab'"* ]] && return 0
+  [[ "$cmd" == *', "w"'* || "$cmd" == *', "a"'* || "$cmd" == *', "wb"'* || "$cmd" == *', "ab"'* ]] && return 0
+  # Python / general: explicit .write( method call
+  [[ "$cmd" == *'.write('* ]] && return 0
+  # Node/Bun fs write functions
+  [[ "$cmd" == *'writeFile'* || "$cmd" == *'appendFile'* || "$cmd" == *'createWriteStream'* ]] && return 0
+  return 1
+}
+
 command_mentions_tracked_write() {
   local token
   local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
@@ -49,11 +64,11 @@ command_mentions_tracked_write() {
     is_tracked_file "$token" && return 0
   done < <(
     printf '%s\n' "$COMMAND" |
-      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
-      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+      grep -Eo '(^|[[:space:]])(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
   )
 
-  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+  if [[ "$COMMAND" =~ $inline_runtime_re ]] && inline_runtime_intends_to_write "$COMMAND"; then
     while IFS= read -r token; do
       is_tracked_file "$token" && return 0
     done < <(git ls-files | while IFS= read -r file; do

--- a/plugins/lisa-cursor/hooks/shell-write-nudge.sh
+++ b/plugins/lisa-cursor/hooks/shell-write-nudge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# Shell Write Nudge Hook (PostToolUse - Bash)
+# =============================================================================
+# Emits a one-line, non-blocking notice when a Bash command appears to mutate a
+# tracked repository file directly. This keeps shell escape hatches visible
+# without blocking legitimate scripts or codemods.
+# =============================================================================
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+COMMAND="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$COMMAND" ] || exit 0
+
+case "$COMMAND" in
+  bun\ run* | npm\ run* | pnpm\ run* | yarn\ run* | node\ scripts/* | bun\ scripts/* | bash\ scripts/* | sh\ scripts/*)
+    exit 0
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" 2>/dev/null || exit 0
+
+is_tracked_file() {
+  local candidate="$1"
+  [ -n "$candidate" ] || return 1
+  candidate="${candidate#./}"
+  git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+command_mentions_tracked_write() {
+  local token
+  local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
+  local inline_runtime_re='(^|[[:space:];&|])(python3?|node|bun)[[:space:]]+-[ce][[:space:]]'
+
+  if [[ "$COMMAND" =~ $sed_command_re && "$COMMAND" == *"-i"* ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(printf '%s\n' "$COMMAND" | tr ' ' '\n' | sed 's/^[\"'\'']//; s/[\"'\'',;|&)]$//')
+  fi
+
+  while IFS= read -r token; do
+    token="${token#./}"
+    is_tracked_file "$token" && return 0
+  done < <(
+    printf '%s\n' "$COMMAND" |
+      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+  )
+
+  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(git ls-files | while IFS= read -r file; do
+      [[ "$COMMAND" == *"$file"* ]] && printf '%s\n' "$file"
+    done)
+  fi
+
+  return 1
+}
+
+if command_mentions_tracked_write; then
+  echo "Lisa notice: prefer Edit/Write for tracked file edits so lint-on-edit can see the change." >&2
+fi
+
+exit 0

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -55,6 +55,15 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
+          }
+        ]
+      },
+      {
         "matcher": "TeamCreate",
         "hooks": [
           {

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/plugins/lisa/hooks/shell-write-nudge.sh
+++ b/plugins/lisa/hooks/shell-write-nudge.sh
@@ -33,6 +33,21 @@ is_tracked_file() {
   git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
 }
 
+# Returns 0 when an inline runtime command (python -c / node -e / bun -e) contains
+# explicit write-intent indicators.  Read-only operations such as open(f).read() or
+# readFileSync should not trigger the nudge.
+inline_runtime_intends_to_write() {
+  local cmd="$1"
+  # Python: open() with write/append mode as second positional argument
+  [[ "$cmd" == *", 'w'"* || "$cmd" == *", 'a'"* || "$cmd" == *", 'wb'"* || "$cmd" == *", 'ab'"* ]] && return 0
+  [[ "$cmd" == *', "w"'* || "$cmd" == *', "a"'* || "$cmd" == *', "wb"'* || "$cmd" == *', "ab"'* ]] && return 0
+  # Python / general: explicit .write( method call
+  [[ "$cmd" == *'.write('* ]] && return 0
+  # Node/Bun fs write functions
+  [[ "$cmd" == *'writeFile'* || "$cmd" == *'appendFile'* || "$cmd" == *'createWriteStream'* ]] && return 0
+  return 1
+}
+
 command_mentions_tracked_write() {
   local token
   local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
@@ -49,11 +64,11 @@ command_mentions_tracked_write() {
     is_tracked_file "$token" && return 0
   done < <(
     printf '%s\n' "$COMMAND" |
-      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
-      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+      grep -Eo '(^|[[:space:]])(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
   )
 
-  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+  if [[ "$COMMAND" =~ $inline_runtime_re ]] && inline_runtime_intends_to_write "$COMMAND"; then
     while IFS= read -r token; do
       is_tracked_file "$token" && return 0
     done < <(git ls-files | while IFS= read -r file; do

--- a/plugins/lisa/hooks/shell-write-nudge.sh
+++ b/plugins/lisa/hooks/shell-write-nudge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# Shell Write Nudge Hook (PostToolUse - Bash)
+# =============================================================================
+# Emits a one-line, non-blocking notice when a Bash command appears to mutate a
+# tracked repository file directly. This keeps shell escape hatches visible
+# without blocking legitimate scripts or codemods.
+# =============================================================================
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+COMMAND="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$COMMAND" ] || exit 0
+
+case "$COMMAND" in
+  bun\ run* | npm\ run* | pnpm\ run* | yarn\ run* | node\ scripts/* | bun\ scripts/* | bash\ scripts/* | sh\ scripts/*)
+    exit 0
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" 2>/dev/null || exit 0
+
+is_tracked_file() {
+  local candidate="$1"
+  [ -n "$candidate" ] || return 1
+  candidate="${candidate#./}"
+  git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+command_mentions_tracked_write() {
+  local token
+  local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
+  local inline_runtime_re='(^|[[:space:];&|])(python3?|node|bun)[[:space:]]+-[ce][[:space:]]'
+
+  if [[ "$COMMAND" =~ $sed_command_re && "$COMMAND" == *"-i"* ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(printf '%s\n' "$COMMAND" | tr ' ' '\n' | sed 's/^[\"'\'']//; s/[\"'\'',;|&)]$//')
+  fi
+
+  while IFS= read -r token; do
+    token="${token#./}"
+    is_tracked_file "$token" && return 0
+  done < <(
+    printf '%s\n' "$COMMAND" |
+      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+  )
+
+  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(git ls-files | while IFS= read -r file; do
+      [[ "$COMMAND" == *"$file"* ]] && printf '%s\n' "$file"
+    done)
+  fi
+
+  return 1
+}
+
+if command_mentions_tracked_write; then
+  echo "Lisa notice: prefer Edit/Write for tracked file edits so lint-on-edit can see the change." >&2
+fi
+
+exit 0

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -41,6 +41,12 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh" }
+        ]
+      },
+      {
         "matcher": "TeamCreate",
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }

--- a/plugins/src/base/hooks/shell-write-nudge.sh
+++ b/plugins/src/base/hooks/shell-write-nudge.sh
@@ -33,6 +33,21 @@ is_tracked_file() {
   git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
 }
 
+# Returns 0 when an inline runtime command (python -c / node -e / bun -e) contains
+# explicit write-intent indicators.  Read-only operations such as open(f).read() or
+# readFileSync should not trigger the nudge.
+inline_runtime_intends_to_write() {
+  local cmd="$1"
+  # Python: open() with write/append mode as second positional argument
+  [[ "$cmd" == *", 'w'"* || "$cmd" == *", 'a'"* || "$cmd" == *", 'wb'"* || "$cmd" == *", 'ab'"* ]] && return 0
+  [[ "$cmd" == *', "w"'* || "$cmd" == *', "a"'* || "$cmd" == *', "wb"'* || "$cmd" == *', "ab"'* ]] && return 0
+  # Python / general: explicit .write( method call
+  [[ "$cmd" == *'.write('* ]] && return 0
+  # Node/Bun fs write functions
+  [[ "$cmd" == *'writeFile'* || "$cmd" == *'appendFile'* || "$cmd" == *'createWriteStream'* ]] && return 0
+  return 1
+}
+
 command_mentions_tracked_write() {
   local token
   local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
@@ -49,11 +64,11 @@ command_mentions_tracked_write() {
     is_tracked_file "$token" && return 0
   done < <(
     printf '%s\n' "$COMMAND" |
-      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
-      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+      grep -Eo '(^|[[:space:]])(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
   )
 
-  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+  if [[ "$COMMAND" =~ $inline_runtime_re ]] && inline_runtime_intends_to_write "$COMMAND"; then
     while IFS= read -r token; do
       is_tracked_file "$token" && return 0
     done < <(git ls-files | while IFS= read -r file; do

--- a/plugins/src/base/hooks/shell-write-nudge.sh
+++ b/plugins/src/base/hooks/shell-write-nudge.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+# =============================================================================
+# Shell Write Nudge Hook (PostToolUse - Bash)
+# =============================================================================
+# Emits a one-line, non-blocking notice when a Bash command appears to mutate a
+# tracked repository file directly. This keeps shell escape hatches visible
+# without blocking legitimate scripts or codemods.
+# =============================================================================
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+COMMAND="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$COMMAND" ] || exit 0
+
+case "$COMMAND" in
+  bun\ run* | npm\ run* | pnpm\ run* | yarn\ run* | node\ scripts/* | bun\ scripts/* | bash\ scripts/* | sh\ scripts/*)
+    exit 0
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" 2>/dev/null || exit 0
+
+is_tracked_file() {
+  local candidate="$1"
+  [ -n "$candidate" ] || return 1
+  candidate="${candidate#./}"
+  git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+command_mentions_tracked_write() {
+  local token
+  local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
+  local inline_runtime_re='(^|[[:space:];&|])(python3?|node|bun)[[:space:]]+-[ce][[:space:]]'
+
+  if [[ "$COMMAND" =~ $sed_command_re && "$COMMAND" == *"-i"* ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(printf '%s\n' "$COMMAND" | tr ' ' '\n' | sed 's/^[\"'\'']//; s/[\"'\'',;|&)]$//')
+  fi
+
+  while IFS= read -r token; do
+    token="${token#./}"
+    is_tracked_file "$token" && return 0
+  done < <(
+    printf '%s\n' "$COMMAND" |
+      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+  )
+
+  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(git ls-files | while IFS= read -r file; do
+      [[ "$COMMAND" == *"$file"* ]] && printf '%s\n' "$file"
+    done)
+  fi
+
+  return 1
+}
+
+if command_mentions_tracked_write; then
+  echo "Lisa notice: prefer Edit/Write for tracked file edits so lint-on-edit can see the change." >&2
+fi
+
+exit 0

--- a/src/codex/hooks-installer.ts
+++ b/src/codex/hooks-installer.ts
@@ -144,6 +144,14 @@ const HOOK_CATALOG: readonly HookCatalogEntry[] = [
     statusMessage: "Checking shell command policy",
   },
   {
+    id: "shell-write-nudge",
+    event: "PostToolUse",
+    matcher: "Bash",
+    scriptFilename: "shell-write-nudge.sh",
+    forProjectTypes: ["*"],
+    statusMessage: "Checking shell write visibility",
+  },
+  {
     id: "format-on-edit",
     event: "PostToolUse",
     matcher: WRITE_MATCHER,

--- a/src/codex/scripts/shell-write-nudge.sh
+++ b/src/codex/scripts/shell-write-nudge.sh
@@ -28,6 +28,21 @@ is_tracked_file() {
   git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
 }
 
+# Returns 0 when an inline runtime command (python -c / node -e / bun -e) contains
+# explicit write-intent indicators.  Read-only operations such as open(f).read() or
+# readFileSync should not trigger the nudge.
+inline_runtime_intends_to_write() {
+  local cmd="$1"
+  # Python: open() with write/append mode as second positional argument
+  [[ "$cmd" == *", 'w'"* || "$cmd" == *", 'a'"* || "$cmd" == *", 'wb'"* || "$cmd" == *", 'ab'"* ]] && return 0
+  [[ "$cmd" == *', "w"'* || "$cmd" == *', "a"'* || "$cmd" == *', "wb"'* || "$cmd" == *', "ab"'* ]] && return 0
+  # Python / general: explicit .write( method call
+  [[ "$cmd" == *'.write('* ]] && return 0
+  # Node/Bun fs write functions
+  [[ "$cmd" == *'writeFile'* || "$cmd" == *'appendFile'* || "$cmd" == *'createWriteStream'* ]] && return 0
+  return 1
+}
+
 command_mentions_tracked_write() {
   local token
   local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
@@ -44,11 +59,11 @@ command_mentions_tracked_write() {
     is_tracked_file "$token" && return 0
   done < <(
     printf '%s\n' "$COMMAND" |
-      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
-      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+      grep -Eo '(^|[[:space:]])(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee([[:space:]]+-a)?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
   )
 
-  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+  if [[ "$COMMAND" =~ $inline_runtime_re ]] && inline_runtime_intends_to_write "$COMMAND"; then
     while IFS= read -r token; do
       is_tracked_file "$token" && return 0
     done < <(git ls-files | while IFS= read -r file; do

--- a/src/codex/scripts/shell-write-nudge.sh
+++ b/src/codex/scripts/shell-write-nudge.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Lisa-managed Codex hook script (PostToolUse Bash).
+# Emits a non-blocking nudge when a shell command appears to write directly to a
+# tracked repository file, bypassing Edit/Write hooks such as lint-on-edit.
+set -uo pipefail
+
+JSON_INPUT="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+COMMAND="$(printf '%s' "$JSON_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+[ -n "$COMMAND" ] || exit 0
+
+# Running committed scripts or package scripts is the supported shell path.
+case "$COMMAND" in
+  bun\ run* | npm\ run* | pnpm\ run* | yarn\ run* | node\ scripts/* | bun\ scripts/* | bash\ scripts/* | sh\ scripts/*)
+    exit 0
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" 2>/dev/null || exit 0
+
+is_tracked_file() {
+  local candidate="$1"
+  [ -n "$candidate" ] || return 1
+  candidate="${candidate#./}"
+  git ls-files --error-unmatch -- "$candidate" >/dev/null 2>&1
+}
+
+command_mentions_tracked_write() {
+  local token
+  local sed_command_re='(^|[[:space:];&|])sed[[:space:]]'
+  local inline_runtime_re='(^|[[:space:];&|])(python3?|node|bun)[[:space:]]+-[ce][[:space:]]'
+
+  if [[ "$COMMAND" =~ $sed_command_re && "$COMMAND" == *"-i"* ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(printf '%s\n' "$COMMAND" | tr ' ' '\n' | sed 's/^[\"'\'']//; s/[\"'\'',;|&)]$//')
+  fi
+
+  while IFS= read -r token; do
+    token="${token#./}"
+    is_tracked_file "$token" && return 0
+  done < <(
+    printf '%s\n' "$COMMAND" |
+      grep -Eo '(^|[[:space:]])(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*[^[:space:];|&]+' |
+      sed -E 's/^[[:space:]]*(>>?|tee[[:space:]]+-a?|cat[[:space:]]+<<[^[:space:]]+[[:space:]]*>)[[:space:]]*//; s/^[\"'\'']//; s/[\"'\'']$//'
+  )
+
+  if [[ "$COMMAND" =~ $inline_runtime_re ]]; then
+    while IFS= read -r token; do
+      is_tracked_file "$token" && return 0
+    done < <(git ls-files | while IFS= read -r file; do
+      [[ "$COMMAND" == *"$file"* ]] && printf '%s\n' "$file"
+    done)
+  fi
+
+  return 1
+}
+
+if command_mentions_tracked_write; then
+  echo "Lisa notice: prefer Edit/Write for tracked file edits so lint-on-edit can see the change." >&2
+fi
+
+exit 0

--- a/tests/unit/codex/codex-edit-hooks.test.ts
+++ b/tests/unit/codex/codex-edit-hooks.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 const SCRIPTS_DIR = path.resolve("src/codex/scripts");
 const LIB_PATH = path.join(SCRIPTS_DIR, "_extract-edit-paths.sh");
 const BLOCK_MIGRATION_PATH = path.join(SCRIPTS_DIR, "block-migration-edits.sh");
+const SHELL_WRITE_NUDGE_PATH = path.join(SCRIPTS_DIR, "shell-write-nudge.sh");
 const BASH_PATH = "/bin/bash";
 
 const EXIT_BLOCKED = 2;
@@ -34,6 +35,12 @@ const editEnvelope = (filePath: string): string =>
   JSON.stringify({
     tool_name: "Edit",
     tool_input: { file_path: filePath },
+  });
+
+const bashEnvelope = (command: string): string =>
+  JSON.stringify({
+    tool_name: "Bash",
+    tool_input: { command },
   });
 
 // Source the helper and run lisa_extract_edit_paths against an envelope.
@@ -54,6 +61,16 @@ const runBlockMigration = (
   envelope: string
 ): { status: number | null; stderr: string } => {
   const result = spawnSync(BASH_PATH, [BLOCK_MIGRATION_PATH], {
+    input: envelope,
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+const runShellWriteNudge = (
+  envelope: string
+): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [SHELL_WRITE_NUDGE_PATH], {
     input: envelope,
     encoding: "utf-8",
   });
@@ -133,5 +150,31 @@ describe("block-migration-edits.sh", () => {
       "*** Begin Patch\n*** Add File: src/users.entity.ts\n+x\n*** End Patch\n";
     const { status } = runBlockMigration(applyPatchEnvelope(patch));
     expect(status).toBe(EXIT_ALLOWED);
+  });
+});
+
+describe("shell-write-nudge.sh", () => {
+  it("emits a non-blocking nudge for sed -i on a tracked file", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("sed -i '' 's/foo/bar/' src/codex/hooks-installer.ts")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toContain("prefer Edit/Write");
+  });
+
+  it("emits a non-blocking nudge for redirection into a tracked file", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("printf '%s\\n' value >> package.json")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toContain("prefer Edit/Write");
+  });
+
+  it("does not nudge for committed script execution", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("node scripts/build-plugins.sh")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toBe("");
   });
 });

--- a/tests/unit/codex/codex-edit-hooks.test.ts
+++ b/tests/unit/codex/codex-edit-hooks.test.ts
@@ -153,13 +153,15 @@ describe("block-migration-edits.sh", () => {
   });
 });
 
+const NUDGE_MESSAGE = "prefer Edit/Write";
+
 describe("shell-write-nudge.sh", () => {
   it("emits a non-blocking nudge for sed -i on a tracked file", () => {
     const { status, stderr } = runShellWriteNudge(
       bashEnvelope("sed -i '' 's/foo/bar/' src/codex/hooks-installer.ts")
     );
     expect(status).toBe(EXIT_ALLOWED);
-    expect(stderr).toContain("prefer Edit/Write");
+    expect(stderr).toContain(NUDGE_MESSAGE);
   });
 
   it("emits a non-blocking nudge for redirection into a tracked file", () => {
@@ -167,7 +169,7 @@ describe("shell-write-nudge.sh", () => {
       bashEnvelope("printf '%s\\n' value >> package.json")
     );
     expect(status).toBe(EXIT_ALLOWED);
-    expect(stderr).toContain("prefer Edit/Write");
+    expect(stderr).toContain(NUDGE_MESSAGE);
   });
 
   it("does not nudge for committed script execution", () => {
@@ -176,5 +178,51 @@ describe("shell-write-nudge.sh", () => {
     );
     expect(status).toBe(EXIT_ALLOWED);
     expect(stderr).toBe("");
+  });
+
+  // Thread 2: plain tee (no -a flag) must also trigger the nudge
+  it("emits a non-blocking nudge for plain tee (no -a flag) into a tracked file", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("echo value | tee package.json")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toContain(NUDGE_MESSAGE);
+  });
+
+  // Thread 3: inline runtime read-only operations must NOT trigger the nudge
+  it("does not nudge for python -c reading a tracked file (read-only)", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("python3 -c \"print(open('package.json').read())\"")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toBe("");
+  });
+
+  it("emits a nudge for python -c with open() in write mode for a tracked file", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope("python3 -c \"open('package.json', 'w').write('x')\"")
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toContain(NUDGE_MESSAGE);
+  });
+
+  it("does not nudge for node -e reading a tracked file (read-only)", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope(
+        "node -e \"require('fs').readFileSync('package.json', 'utf8')\""
+      )
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toBe("");
+  });
+
+  it("emits a nudge for node -e with writeFileSync for a tracked file", () => {
+    const { status, stderr } = runShellWriteNudge(
+      bashEnvelope(
+        "node -e \"require('fs').writeFileSync('package.json', 'x')\""
+      )
+    );
+    expect(status).toBe(EXIT_ALLOWED);
+    expect(stderr).toContain(NUDGE_MESSAGE);
   });
 });

--- a/tests/unit/codex/hooks-installer.test.ts
+++ b/tests/unit/codex/hooks-installer.test.ts
@@ -37,6 +37,8 @@ const BLOCK_MIGRATION_EDITS_ID = "block-migration-edits";
 const BLOCK_SUPPRESS_DIRECTIVES_ID = "block-suppress-directives";
 /** Universal Bash policy hook id */
 const BLOCK_NO_VERIFY_ID = "block-no-verify";
+/** Universal non-blocking shell write visibility hook id */
+const SHELL_WRITE_NUDGE_ID = "shell-write-nudge";
 /** Universal dependency bootstrap hook id */
 const INSTALL_PKGS_ID = "install-pkgs";
 /** Universal Jira configuration hook id */
@@ -159,7 +161,7 @@ describe("codex/hooks-installer", () => {
     const parsed = parseHooksFile(
       await fs.readFile(path.join(codexDir, HOOKS_FILENAME), "utf8")
     );
-    expect(parsed.hooks?.PostToolUse).toHaveLength(1);
+    expect(parsed.hooks?.PostToolUse).toHaveLength(2);
     expect(parsed.hooks?.PostToolUse?.[0]?.hooks[0]?.command).toBe(
       "./scripts/host-edit-hook.sh"
     );
@@ -184,13 +186,16 @@ describe("codex/hooks-installer", () => {
   it("returns managedFiles list including script + rules + hooks.json", async () => {
     const result = await installHooks(lisaDir, destDir, []);
     // Universal hooks: inject-rules + install-pkgs + setup-jira-cli +
-    // block-no-verify = 4 entries
-    expect(result.hookEntries).toBe(4);
+    // block-no-verify + shell-write-nudge = 5 entries
+    expect(result.hookEntries).toBe(5);
     const sortedFiles = [...result.managedFiles].sort((a, b) =>
       a.localeCompare(b)
     );
     expect(sortedFiles).toContain(
       path.join(LISA_HOOKS_SUBDIR, INJECT_RULES_SH)
+    );
+    expect(sortedFiles).toContain(
+      path.join(LISA_HOOKS_SUBDIR, "shell-write-nudge.sh")
     );
     expect(sortedFiles).toContain(
       path.join(LISA_RULES_SUBDIR, "eager", BASE_RULES_MD)
@@ -223,11 +228,12 @@ describe("codex/hooks-installer", () => {
       expect(ids).toContain(INSTALL_PKGS_ID);
       expect(ids).toContain(SETUP_JIRA_CLI_ID);
       expect(ids).toContain(BLOCK_NO_VERIFY_ID);
+      expect(ids).toContain(SHELL_WRITE_NUDGE_ID);
       expect(ids).not.toContain(FORMAT_ON_EDIT_ID);
       expect(ids).not.toContain(RUBOCOP_ON_EDIT_ID);
       expect(ids).not.toContain(BLOCK_MIGRATION_EDITS_ID);
       expect(ids).not.toContain(BLOCK_SUPPRESS_DIRECTIVES_ID);
-      expect(result.hookEntries).toBe(4);
+      expect(result.hookEntries).toBe(5);
     });
 
     it("ships TypeScript hooks when typescript is detected", async () => {
@@ -242,7 +248,7 @@ describe("codex/hooks-installer", () => {
       // NOT rails or nestjs
       expect(ids).not.toContain(RUBOCOP_ON_EDIT_ID);
       expect(ids).not.toContain(BLOCK_MIGRATION_EDITS_ID);
-      expect(result.hookEntries).toBe(8);
+      expect(result.hookEntries).toBe(9);
     });
 
     it("ships Rails hooks when rails is detected", async () => {
@@ -252,8 +258,8 @@ describe("codex/hooks-installer", () => {
       // ast-grep scanning applies to Rails too (Ruby files)
       expect(ids).toContain("sg-scan-on-edit");
       expect(ids).not.toContain(FORMAT_ON_EDIT_ID);
-      // rubocop + sg-scan + 4 universal
-      expect(result.hookEntries).toBe(6);
+      // rubocop + sg-scan + 5 universal
+      expect(result.hookEntries).toBe(7);
     });
 
     it("ships NestJS migration block when nestjs is detected", async () => {
@@ -268,7 +274,7 @@ describe("codex/hooks-installer", () => {
       expect(ids).toContain(FORMAT_ON_EDIT_ID);
       // typescript also brings the suppression-directive block
       expect(ids).toContain(BLOCK_SUPPRESS_DIRECTIVES_ID);
-      expect(result.hookEntries).toBe(9);
+      expect(result.hookEntries).toBe(10);
     });
 
     it("copies only the script files for applicable hooks", async () => {
@@ -286,6 +292,7 @@ describe("codex/hooks-installer", () => {
         "install-pkgs.sh",
         RUBOCOP_ON_EDIT_SH,
         "setup-jira-cli.sh",
+        "shell-write-nudge.sh",
         "sg-scan-on-edit.sh",
       ].sort((a, b) => a.localeCompare(b));
       expect(scriptFiles).toEqual(expected);


### PR DESCRIPTION
## Summary
- Add a non-blocking PostToolUse(Bash) shell-write nudge for tracked-file mutations.
- Wire the hook into Codex per-project installs and generated base plugin variants.
- Cover sed/redirection nudges, script exemptions, and installer hook counts.

Closes #1266

## Verification
- bunx vitest run tests/unit/codex/codex-edit-hooks.test.ts tests/unit/codex/hooks-installer.test.ts tests/unit/scripts/per-agent-hook-filter.test.ts tests/unit/scripts/build-cursor-hooks-json.test.ts tests/unit/scripts/codex-hook-filter.test.ts
- bun run build
- bun run check:plugins
- pre-push hook: slow lint, knip, unit tests with coverage, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shell-command hook that monitors Bash tool usage, detects when commands modify tracked repository files, and displays a notification to users.

* **Tests**
  * Added test coverage for the new shell-write-nudge hook to verify proper detection of tracked file modifications and user notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->