### PR TITLE
fix(hooks): use oxlint for edit-time lint

### DIFF
--- a/plugins/lisa-typescript-copilot/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript-copilot/hooks/lint-on-edit.sh
@@ -4,17 +4,15 @@
 # =============================================================================
 # Lint-on-Edit Hook (PostToolUse - Write|Edit)
 # =============================================================================
-# Runs oxlint --fix, then ESLint --fix --quiet --cache on each edited
-# TypeScript file. Part of the inline self-correction pipeline:
-#   prettier → ast-grep → oxlint --fix → eslint --fix
+# Runs oxlint on each edited TypeScript file. Full ESLint remains enforced at
+# the commit/CI chokepoint via the project lint scripts.
 #
-# oxlint runs first because it's a Rust-native linter (~1000x faster) that
-# covers the majority of rules, leaving only the slow / type-aware / plugin
-# rules for ESLint to handle.
+# oxlint is Rust-native and covers the fast-feedback rule tier in milliseconds;
+# ESLint stays out of the edit-time path.
 #
 # Behavior:
-#   - Exit 0: lint passes or auto-fix resolved all errors
-#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 0: lint passes
+#   - Exit 2: oxlint errors remain - blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
@@ -49,7 +47,7 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Resolve oxlint and ESLint binaries — prefer local node_modules/.bin
+# Resolve oxlint binary - prefer local node_modules/.bin
 if [ -x "./node_modules/.bin/oxlint" ]; then
     OXLINT_CMD="./node_modules/.bin/oxlint"
 elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
@@ -62,19 +60,7 @@ else
     OXLINT_CMD="npx oxlint"
 fi
 
-if [ -x "./node_modules/.bin/eslint" ]; then
-    ESLINT_CMD="./node_modules/.bin/eslint"
-elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    ESLINT_CMD="bunx eslint"
-elif [ -f "pnpm-lock.yaml" ]; then
-    ESLINT_CMD="pnpm exec eslint"
-elif [ -f "yarn.lock" ]; then
-    ESLINT_CMD="yarn exec eslint"
-else
-    ESLINT_CMD="npx eslint"
-fi
-
-# 1) oxlint --fix (REQUIRED in the Phase 2 hybrid pipeline)
+# oxlint (REQUIRED in the Phase 2 hybrid pipeline)
 # If oxlint is missing the project is out of sync with the current Lisa
 # governance — fail loudly rather than silently skipping. ESLint alone is
 # no longer a complete lint pass.
@@ -89,46 +75,14 @@ if [ ! -f ".oxlintrc.json" ] && [ ! -f ".oxlintrc.jsonc" ] && [ ! -f "oxlint.con
     exit 2
 fi
 
-echo "Running oxlint --fix on: $FILE_PATH"
-OX_OUTPUT=$($OXLINT_CMD --fix --quiet "$FILE_PATH" 2>&1)
+echo "Running oxlint on: $FILE_PATH"
+OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
-    # Re-run without --fix to capture remaining errors
-    OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
-    OX_EXIT=$?
-    if [ $OX_EXIT -ne 0 ]; then
-        echo "oxlint found unfixable errors in: $FILE_PATH" >&2
-        echo "$OX_OUTPUT" >&2
-        exit 2
-    fi
+    echo "oxlint found errors in: $FILE_PATH" >&2
+    echo "$OX_OUTPUT" >&2
+    exit 2
 fi
 
-# 2) ESLint --fix --quiet --cache
-# --quiet: suppress warnings, only show errors
-# --cache: use ESLint cache for performance
-# --rule: disable no-unused-vars auto-fix to prevent removing imports that Claude
-#         plans to use in a subsequent edit (pre-commit hook still catches them)
-echo "Running ESLint --fix on: $FILE_PATH"
-
-# First pass: attempt auto-fix
-OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
-FIX_EXIT=$?
-
-if [ $FIX_EXIT -eq 0 ]; then
-    echo "ESLint: No errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
-LINT_EXIT=$?
-
-if [ $LINT_EXIT -eq 0 ]; then
-    echo "ESLint: Auto-fixed all errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Unfixable errors remain — block with feedback
-echo "ESLint found unfixable errors in: $FILE_PATH" >&2
-echo "$OUTPUT" >&2
-exit 2
+echo "oxlint: No errors in $(basename "$FILE_PATH")"
+exit 0

--- a/plugins/lisa-typescript-cursor/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript-cursor/hooks/lint-on-edit.sh
@@ -4,17 +4,15 @@
 # =============================================================================
 # Lint-on-Edit Hook (PostToolUse - Write|Edit)
 # =============================================================================
-# Runs oxlint --fix, then ESLint --fix --quiet --cache on each edited
-# TypeScript file. Part of the inline self-correction pipeline:
-#   prettier → ast-grep → oxlint --fix → eslint --fix
+# Runs oxlint on each edited TypeScript file. Full ESLint remains enforced at
+# the commit/CI chokepoint via the project lint scripts.
 #
-# oxlint runs first because it's a Rust-native linter (~1000x faster) that
-# covers the majority of rules, leaving only the slow / type-aware / plugin
-# rules for ESLint to handle.
+# oxlint is Rust-native and covers the fast-feedback rule tier in milliseconds;
+# ESLint stays out of the edit-time path.
 #
 # Behavior:
-#   - Exit 0: lint passes or auto-fix resolved all errors
-#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 0: lint passes
+#   - Exit 2: oxlint errors remain - blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
@@ -49,7 +47,7 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Resolve oxlint and ESLint binaries — prefer local node_modules/.bin
+# Resolve oxlint binary - prefer local node_modules/.bin
 if [ -x "./node_modules/.bin/oxlint" ]; then
     OXLINT_CMD="./node_modules/.bin/oxlint"
 elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
@@ -62,19 +60,7 @@ else
     OXLINT_CMD="npx oxlint"
 fi
 
-if [ -x "./node_modules/.bin/eslint" ]; then
-    ESLINT_CMD="./node_modules/.bin/eslint"
-elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    ESLINT_CMD="bunx eslint"
-elif [ -f "pnpm-lock.yaml" ]; then
-    ESLINT_CMD="pnpm exec eslint"
-elif [ -f "yarn.lock" ]; then
-    ESLINT_CMD="yarn exec eslint"
-else
-    ESLINT_CMD="npx eslint"
-fi
-
-# 1) oxlint --fix (REQUIRED in the Phase 2 hybrid pipeline)
+# oxlint (REQUIRED in the Phase 2 hybrid pipeline)
 # If oxlint is missing the project is out of sync with the current Lisa
 # governance — fail loudly rather than silently skipping. ESLint alone is
 # no longer a complete lint pass.
@@ -89,46 +75,14 @@ if [ ! -f ".oxlintrc.json" ] && [ ! -f ".oxlintrc.jsonc" ] && [ ! -f "oxlint.con
     exit 2
 fi
 
-echo "Running oxlint --fix on: $FILE_PATH"
-OX_OUTPUT=$($OXLINT_CMD --fix --quiet "$FILE_PATH" 2>&1)
+echo "Running oxlint on: $FILE_PATH"
+OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
-    # Re-run without --fix to capture remaining errors
-    OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
-    OX_EXIT=$?
-    if [ $OX_EXIT -ne 0 ]; then
-        echo "oxlint found unfixable errors in: $FILE_PATH" >&2
-        echo "$OX_OUTPUT" >&2
-        exit 2
-    fi
+    echo "oxlint found errors in: $FILE_PATH" >&2
+    echo "$OX_OUTPUT" >&2
+    exit 2
 fi
 
-# 2) ESLint --fix --quiet --cache
-# --quiet: suppress warnings, only show errors
-# --cache: use ESLint cache for performance
-# --rule: disable no-unused-vars auto-fix to prevent removing imports that Claude
-#         plans to use in a subsequent edit (pre-commit hook still catches them)
-echo "Running ESLint --fix on: $FILE_PATH"
-
-# First pass: attempt auto-fix
-OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
-FIX_EXIT=$?
-
-if [ $FIX_EXIT -eq 0 ]; then
-    echo "ESLint: No errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
-LINT_EXIT=$?
-
-if [ $LINT_EXIT -eq 0 ]; then
-    echo "ESLint: Auto-fixed all errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Unfixable errors remain — block with feedback
-echo "ESLint found unfixable errors in: $FILE_PATH" >&2
-echo "$OUTPUT" >&2
-exit 2
+echo "oxlint: No errors in $(basename "$FILE_PATH")"
+exit 0

--- a/plugins/lisa-typescript/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/lint-on-edit.sh
@@ -4,17 +4,15 @@
 # =============================================================================
 # Lint-on-Edit Hook (PostToolUse - Write|Edit)
 # =============================================================================
-# Runs oxlint --fix, then ESLint --fix --quiet --cache on each edited
-# TypeScript file. Part of the inline self-correction pipeline:
-#   prettier → ast-grep → oxlint --fix → eslint --fix
+# Runs oxlint on each edited TypeScript file. Full ESLint remains enforced at
+# the commit/CI chokepoint via the project lint scripts.
 #
-# oxlint runs first because it's a Rust-native linter (~1000x faster) that
-# covers the majority of rules, leaving only the slow / type-aware / plugin
-# rules for ESLint to handle.
+# oxlint is Rust-native and covers the fast-feedback rule tier in milliseconds;
+# ESLint stays out of the edit-time path.
 #
 # Behavior:
-#   - Exit 0: lint passes or auto-fix resolved all errors
-#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 0: lint passes
+#   - Exit 2: oxlint errors remain - blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
@@ -49,7 +47,7 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Resolve oxlint and ESLint binaries — prefer local node_modules/.bin
+# Resolve oxlint binary - prefer local node_modules/.bin
 if [ -x "./node_modules/.bin/oxlint" ]; then
     OXLINT_CMD="./node_modules/.bin/oxlint"
 elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
@@ -62,19 +60,7 @@ else
     OXLINT_CMD="npx oxlint"
 fi
 
-if [ -x "./node_modules/.bin/eslint" ]; then
-    ESLINT_CMD="./node_modules/.bin/eslint"
-elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    ESLINT_CMD="bunx eslint"
-elif [ -f "pnpm-lock.yaml" ]; then
-    ESLINT_CMD="pnpm exec eslint"
-elif [ -f "yarn.lock" ]; then
-    ESLINT_CMD="yarn exec eslint"
-else
-    ESLINT_CMD="npx eslint"
-fi
-
-# 1) oxlint --fix (REQUIRED in the Phase 2 hybrid pipeline)
+# oxlint (REQUIRED in the Phase 2 hybrid pipeline)
 # If oxlint is missing the project is out of sync with the current Lisa
 # governance — fail loudly rather than silently skipping. ESLint alone is
 # no longer a complete lint pass.
@@ -89,46 +75,14 @@ if [ ! -f ".oxlintrc.json" ] && [ ! -f ".oxlintrc.jsonc" ] && [ ! -f "oxlint.con
     exit 2
 fi
 
-echo "Running oxlint --fix on: $FILE_PATH"
-OX_OUTPUT=$($OXLINT_CMD --fix --quiet "$FILE_PATH" 2>&1)
+echo "Running oxlint on: $FILE_PATH"
+OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
-    # Re-run without --fix to capture remaining errors
-    OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
-    OX_EXIT=$?
-    if [ $OX_EXIT -ne 0 ]; then
-        echo "oxlint found unfixable errors in: $FILE_PATH" >&2
-        echo "$OX_OUTPUT" >&2
-        exit 2
-    fi
+    echo "oxlint found errors in: $FILE_PATH" >&2
+    echo "$OX_OUTPUT" >&2
+    exit 2
 fi
 
-# 2) ESLint --fix --quiet --cache
-# --quiet: suppress warnings, only show errors
-# --cache: use ESLint cache for performance
-# --rule: disable no-unused-vars auto-fix to prevent removing imports that Claude
-#         plans to use in a subsequent edit (pre-commit hook still catches them)
-echo "Running ESLint --fix on: $FILE_PATH"
-
-# First pass: attempt auto-fix
-OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
-FIX_EXIT=$?
-
-if [ $FIX_EXIT -eq 0 ]; then
-    echo "ESLint: No errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
-LINT_EXIT=$?
-
-if [ $LINT_EXIT -eq 0 ]; then
-    echo "ESLint: Auto-fixed all errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Unfixable errors remain — block with feedback
-echo "ESLint found unfixable errors in: $FILE_PATH" >&2
-echo "$OUTPUT" >&2
-exit 2
+echo "oxlint: No errors in $(basename "$FILE_PATH")"
+exit 0

--- a/plugins/src/typescript/hooks/lint-on-edit.sh
+++ b/plugins/src/typescript/hooks/lint-on-edit.sh
@@ -4,17 +4,15 @@
 # =============================================================================
 # Lint-on-Edit Hook (PostToolUse - Write|Edit)
 # =============================================================================
-# Runs oxlint --fix, then ESLint --fix --quiet --cache on each edited
-# TypeScript file. Part of the inline self-correction pipeline:
-#   prettier → ast-grep → oxlint --fix → eslint --fix
+# Runs oxlint on each edited TypeScript file. Full ESLint remains enforced at
+# the commit/CI chokepoint via the project lint scripts.
 #
-# oxlint runs first because it's a Rust-native linter (~1000x faster) that
-# covers the majority of rules, leaving only the slow / type-aware / plugin
-# rules for ESLint to handle.
+# oxlint is Rust-native and covers the fast-feedback rule tier in milliseconds;
+# ESLint stays out of the edit-time path.
 #
 # Behavior:
-#   - Exit 0: lint passes or auto-fix resolved all errors
-#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 0: lint passes
+#   - Exit 2: oxlint errors remain - blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verfication.md "Self-Correction Loop" section
 # =============================================================================
@@ -49,7 +47,7 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Resolve oxlint and ESLint binaries — prefer local node_modules/.bin
+# Resolve oxlint binary - prefer local node_modules/.bin
 if [ -x "./node_modules/.bin/oxlint" ]; then
     OXLINT_CMD="./node_modules/.bin/oxlint"
 elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
@@ -62,19 +60,7 @@ else
     OXLINT_CMD="npx oxlint"
 fi
 
-if [ -x "./node_modules/.bin/eslint" ]; then
-    ESLINT_CMD="./node_modules/.bin/eslint"
-elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-    ESLINT_CMD="bunx eslint"
-elif [ -f "pnpm-lock.yaml" ]; then
-    ESLINT_CMD="pnpm exec eslint"
-elif [ -f "yarn.lock" ]; then
-    ESLINT_CMD="yarn exec eslint"
-else
-    ESLINT_CMD="npx eslint"
-fi
-
-# 1) oxlint --fix (REQUIRED in the Phase 2 hybrid pipeline)
+# oxlint (REQUIRED in the Phase 2 hybrid pipeline)
 # If oxlint is missing the project is out of sync with the current Lisa
 # governance — fail loudly rather than silently skipping. ESLint alone is
 # no longer a complete lint pass.
@@ -89,46 +75,14 @@ if [ ! -f ".oxlintrc.json" ] && [ ! -f ".oxlintrc.jsonc" ] && [ ! -f "oxlint.con
     exit 2
 fi
 
-echo "Running oxlint --fix on: $FILE_PATH"
-OX_OUTPUT=$($OXLINT_CMD --fix --quiet "$FILE_PATH" 2>&1)
+echo "Running oxlint on: $FILE_PATH"
+OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
-    # Re-run without --fix to capture remaining errors
-    OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
-    OX_EXIT=$?
-    if [ $OX_EXIT -ne 0 ]; then
-        echo "oxlint found unfixable errors in: $FILE_PATH" >&2
-        echo "$OX_OUTPUT" >&2
-        exit 2
-    fi
+    echo "oxlint found errors in: $FILE_PATH" >&2
+    echo "$OX_OUTPUT" >&2
+    exit 2
 fi
 
-# 2) ESLint --fix --quiet --cache
-# --quiet: suppress warnings, only show errors
-# --cache: use ESLint cache for performance
-# --rule: disable no-unused-vars auto-fix to prevent removing imports that Claude
-#         plans to use in a subsequent edit (pre-commit hook still catches them)
-echo "Running ESLint --fix on: $FILE_PATH"
-
-# First pass: attempt auto-fix
-OUTPUT=$($ESLINT_CMD --fix --quiet --cache --rule '@typescript-eslint/no-unused-vars: off' "$FILE_PATH" 2>&1)
-FIX_EXIT=$?
-
-if [ $FIX_EXIT -eq 0 ]; then
-    echo "ESLint: No errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Auto-fix resolved some issues but errors remain — re-run to get remaining errors
-OUTPUT=$($ESLINT_CMD --quiet --cache "$FILE_PATH" 2>&1)
-LINT_EXIT=$?
-
-if [ $LINT_EXIT -eq 0 ]; then
-    echo "ESLint: Auto-fixed all errors in $(basename "$FILE_PATH")"
-    exit 0
-fi
-
-# Unfixable errors remain — block with feedback
-echo "ESLint found unfixable errors in: $FILE_PATH" >&2
-echo "$OUTPUT" >&2
-exit 2
+echo "oxlint: No errors in $(basename "$FILE_PATH")"
+exit 0

--- a/src/codex/scripts/lint-on-edit.sh
+++ b/src/codex/scripts/lint-on-edit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Lisa-managed Codex hook script (PostToolUse Edit|Write|apply_patch).
-# Runs ESLint --fix on every just-edited file. If unfixable errors remain on
-# any file, exits non-zero so Codex sees the failure and the agent self-corrects.
+# Runs oxlint on every just-edited JS/TS file. Full ESLint remains enforced at
+# the commit/CI chokepoint via the project lint scripts.
 # Resolves target file(s) via the shared extractor (Edit/Write + apply_patch).
 set -uo pipefail
 
@@ -15,10 +15,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "${SCRIPT_DIR}/_extract-edit-paths.sh"
 
-if [ -x "./node_modules/.bin/eslint" ]; then
-  ESLINT="./node_modules/.bin/eslint"
-elif command -v eslint >/dev/null 2>&1; then
-  ESLINT="eslint"
+if [ -x "./node_modules/.bin/oxlint" ]; then
+  OXLINT="./node_modules/.bin/oxlint"
+elif command -v oxlint >/dev/null 2>&1; then
+  OXLINT="oxlint"
 else
   exit 0
 fi
@@ -31,9 +31,7 @@ while IFS= read -r FILE_PATH; do
     ts | tsx | js | jsx | mjs | cjs) ;;
     *) continue ;;
   esac
-  # Auto-fix what we can; surface anything left so the agent fixes it itself.
-  "$ESLINT" --fix "${FILE_PATH}" >/dev/null 2>&1 || true
-  "$ESLINT" --quiet "${FILE_PATH}" || STATUS=1
+  "$OXLINT" --quiet "${FILE_PATH}" || STATUS=1
 done <<EOF
 $(lisa_extract_edit_paths "$JSON_INPUT")
 EOF

--- a/src/opencode/plugin-templates/lisa-lint-on-edit.ts
+++ b/src/opencode/plugin-templates/lisa-lint-on-edit.ts
@@ -1,10 +1,10 @@
 /**
  * Lisa-managed OpenCode plugin (tool.execute.after).
  *
- * Runs ESLint --fix on every just-edited JS/TS file, then re-checks. If
- * unfixable problems remain, throws so OpenCode marks the tool call failed and
- * the agent self-corrects (the equivalent of the Codex hook's non-zero exit).
- * Fails open when ESLint isn't installed.
+ * Runs oxlint on every just-edited JS/TS file. If problems remain, throws so
+ * OpenCode marks the tool call failed and the agent self-corrects (the
+ * equivalent of the Codex hook's non-zero exit). Fails open when oxlint isn't
+ * installed. Full ESLint remains enforced at the commit/CI chokepoint.
  *
  * Port of Lisa's Codex hook `lint-on-edit.sh`. OpenCode passes the edited file
  * via `input.args.filePath`; `tool.execute.after` runs after a successful
@@ -38,15 +38,14 @@ export const LisaLintOnEdit = async ({
       if (input.tool !== "edit" && input.tool !== "write") return;
       const filePath = String(input.args?.filePath ?? "");
       if (!filePath || !EXTS.has(extOf(filePath))) return;
-      const eslint = resolveBin("eslint");
-      if (!eslint) return; // fail open — no ESLint installed
-      await $`${eslint} --fix ${filePath}`.quiet().nothrow();
-      const res = await $`${eslint} --quiet ${filePath}`.quiet().nothrow();
+      const oxlint = resolveBin("oxlint");
+      if (!oxlint) return; // fail open - no oxlint installed
+      const res = await $`${oxlint} --quiet ${filePath}`.quiet().nothrow();
       if (res.exitCode === 0) return;
       const out =
         `${res.stdout?.toString() ?? ""}${res.stderr?.toString() ?? ""}`.trim();
       throw new Error(
-        `lint-on-edit: ESLint reported unfixable problems in ${filePath}:\n${out}`
+        `lint-on-edit: oxlint reported problems in ${filePath}:\n${out}`
       );
     },
   };

--- a/tests/unit/hooks/lint-on-edit.test.ts
+++ b/tests/unit/hooks/lint-on-edit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for edit-time lint hooks.
+ *
+ * The edit tier must stay fast: oxlint runs on each edit, while full ESLint is
+ * reserved for pre-commit and CI chokepoints.
+ * @module tests/unit/hooks/lint-on-edit
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const CODEX_HOOK_PATH = path.resolve("src/codex/scripts/lint-on-edit.sh");
+const TYPESCRIPT_HOOK_PATH = path.resolve(
+  "plugins/src/typescript/hooks/lint-on-edit.sh"
+);
+const BASH_PATH = "/bin/bash";
+const EXAMPLE_SOURCE_RELATIVE_PATH = path.join("src", "example.ts");
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  tempDirs = [];
+});
+
+describe("lint-on-edit hooks", () => {
+  it("runs oxlint, not ESLint, for Codex edit hooks", () => {
+    const project = createProject();
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const result = spawnSync(BASH_PATH, [CODEX_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      input: JSON.stringify({
+        tool_name: "Edit",
+        tool_input: { file_path: sourcePath },
+      }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(readLog(project)).toContain(`oxlint --quiet ${sourcePath}`);
+    expect(readLog(project)).not.toContain("eslint");
+  });
+
+  it("runs oxlint, not ESLint, for TypeScript-stack edit hooks", () => {
+    const project = createProject();
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const result = spawnSync(BASH_PATH, [TYPESCRIPT_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+      input: JSON.stringify({ tool_input: { file_path: sourcePath } }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(readLog(project)).toContain(`oxlint --quiet ${sourcePath}`);
+    expect(readLog(project)).not.toContain("eslint");
+  });
+});
+
+/**
+ * Create a temp project with fake local linter binaries.
+ * @returns The temp project root.
+ */
+function createProject(): string {
+  const project = mkdtempSync(path.join(tmpdir(), "lisa-lint-on-edit-"));
+  tempDirs.push(project);
+  mkdirSync(path.join(project, "src"), { recursive: true });
+  mkdirSync(path.join(project, "node_modules", ".bin"), { recursive: true });
+  writeFileSync(
+    path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH),
+    "export const x = 1;\n"
+  );
+  writeFileSync(path.join(project, ".oxlintrc.json"), "{}\n");
+  writeBin(
+    project,
+    "oxlint",
+    'printf \'oxlint %s\\n\' "$*" >> "$PWD/lint.log"\n'
+  );
+  writeBin(
+    project,
+    "eslint",
+    'printf \'eslint %s\\n\' "$*" >> "$PWD/lint.log"\nexit 42\n'
+  );
+  return project;
+}
+
+/**
+ * Write an executable fake binary into node_modules/.bin.
+ * @param project - Temp project root.
+ * @param name - Binary name.
+ * @param body - Shell body to run after the shebang.
+ */
+function writeBin(project: string, name: string, body: string): void {
+  const binPath = path.join(project, "node_modules", ".bin", name);
+  writeFileSync(binPath, `#!/usr/bin/env bash\n${body}`);
+  chmodSync(binPath, 0o755);
+}
+
+/**
+ * Read the fake linter invocation log.
+ * @param project - Temp project root.
+ * @returns The log content.
+ */
+function readLog(project: string): string {
+  return readFileSync(path.join(project, "lint.log"), "utf8");
+}


### PR DESCRIPTION
## Summary
- switch Codex, Claude TypeScript-stack, and OpenCode lint-on-edit hooks to run oxlint only at edit time
- preserve full ESLint enforcement at package lint / pre-commit / CI chokepoints
- regenerate TypeScript plugin hook artifacts and add regression coverage that fails if edit-time hooks call ESLint

## Verification
- bun test tests/unit/hooks/lint-on-edit.test.ts
- bun test tests/unit/hooks/lint-on-edit.test.ts tests/unit/opencode/hooks-installer.test.ts tests/unit/codex/hooks-installer.test.ts
- bun run build
- bun run check:plugins
- pre-push hook: eslint slow rules, knip, vitest run --coverage, vitest run tests/integration

Closes #1265