### PR TITLE
feat(harper-fabric): add realtime skill

### DIFF
--- a/plugins/lisa-harper-fabric-agy/skills/harper-config-yaml/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-config-yaml/SKILL.md
@@ -52,7 +52,7 @@ unmentioned extensions stay on.
 
 | Key | Purpose | Common options |
 | --- | --- | --- |
-| `rest` | Auto REST endpoints for exported resources/tables | `true`, or an object with options |
+| `rest` | Auto REST endpoints and resource WebSocket subscriptions | `true`, or an object with options such as `webSocket` |
 | `graphqlSchema` | Define tables/types from GraphQL files | `files: '*.graphql'` — see [[harper-schema-graphql]] |
 | `jsResource` | Load custom JS resources | `files: 'resources.js'` — see [[harper-resources]] |
 | `static` | Serve static files over HTTP | `files: 'web/**'`, `urlPath` |
@@ -60,6 +60,11 @@ unmentioned extensions stay on.
 | `loadEnv` | Load env vars from `.env` | `files` |
 | `dataLoader` | Seed tables from JSON/YAML | `files` |
 | `fastifyRoutes` | Custom Fastify routes | `files: 'routes/*.js'`, `urlPath` |
+
+For real-time work, component `config.yaml` keeps `rest`, `graphqlSchema`, and
+`jsResource` enabled so exported resources can be addressed by HTTP/WebSocket and
+MQTT topic paths. Broker ports and MQTT authentication live in the root
+`harper-config.yaml`, not the component file. See [[harper-realtime]].
 
 ## External components and custom plugins
 

--- a/plugins/lisa-harper-fabric-agy/skills/harper-realtime/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-realtime/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: harper-realtime
+description: This skill should be used when adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource publish/subscribe handlers, SSE-style streaming routes, and local subscriber verification. Pairs with harper-resources, harper-config-yaml, harper-schema-graphql, and harper-build-and-deploy.
+---
+
+# Harper Realtime
+
+## Overview
+
+Harper exposes live data through the same Resource model used for REST and
+GraphQL. Exported tables/resources can be addressed as MQTT topics and WebSocket
+paths, while custom resources can override the messaging handlers when the default
+table behavior is not enough.
+
+Use real-time primitives when the product needs pushed state: live feeds, activity
+streams, collaborative views, device telemetry, or status updates. Do not replace
+these with client polling unless the issue explicitly asks for polling.
+
+## Resource and topic model
+
+- A GraphQL type marked `@table @export` creates a default exported table resource.
+- An exported JavaScript Resource class from `resources.js` creates a resource
+  endpoint with the class name as the path/topic root.
+- Resource paths map naturally to subscription targets: collection-level
+  subscriptions use the resource name, and record-level subscriptions append the
+  record id or path segment.
+- MQTT supports multi-level topics and wildcards. Use `resource/#` for a resource
+  subtree and `resource/+/status` for one path segment.
+- WebSocket subscriptions target the REST resource URL. For example,
+  `ws://localhost:9926/Activity/123` subscribes to the `Activity` resource record
+  with id `123`.
+
+Keep the URL/topic names stable. If a UI depends on `Activity/123`, changing the
+resource export name is an API break.
+
+## Resource methods
+
+The MQTT plugin routes broker messages through Resource methods:
+
+| Method | Use |
+| --- | --- |
+| `subscribe(target, context)` | Authorize and shape subscription reads for a resource or record. |
+| `publish(target, message, context)` | Accept or transform messages written to a topic/resource. |
+| `connect(incomingMessages)` | Customize WebSocket connection behavior for a resource. |
+
+For table-backed resources, prefer default behavior until the product needs a
+custom message shape, authorization check, fan-out, or derived event. When
+overriding, preserve built-in table behavior with `super.subscribe(...)` or
+`super.publish(...)` where that behavior is still wanted.
+
+```javascript
+export class Activity extends tables.Activity {
+  static async publish(target, message, context) {
+    const payload = await message;
+    await super.publish(target, payload, context);
+    return { ...payload, acceptedAt: Date.now() };
+  }
+}
+```
+
+For WebSocket-only behavior, implement `connect(incomingMessages)` and return an
+async iterable. Use the default `super.connect()` stream when you only need to
+push extra server messages or clean up on disconnect.
+
+## Transport choices
+
+| Transport | Best fit | Notes |
+| --- | --- | --- |
+| MQTT | Device streams, backend subscribers, wildcard topics, durable clients. | Plain MQTT defaults to port `1883`; MQTTS defaults to `8883`. |
+| MQTT over WebSocket | Browser or edge clients using MQTT semantics. | Uses the HTTP port, default `9926`, with the `mqtt` WebSocket subprotocol. |
+| Resource WebSocket | Browser live views tied to one REST resource path. | Enabled with the `rest` plugin unless `rest.webSocket: false` is set. |
+| SSE/custom streaming route | One-way browser updates when WebSocket is not appropriate. | Implement as a project route; do not assume SSE automatically subscribes to Resource changes. |
+
+Authentication is usually required for MQTT. When `mqtt.requireAuthentication` is
+`false`, authorization still applies at the resource/table level, so public
+connections must be explicitly allowed by roles or resource logic.
+
+## config.yaml wiring
+
+Component-level `config.yaml` enables the app surface:
+
+```yaml
+rest: true
+graphqlSchema:
+  files: schema.graphql
+jsResource:
+  files: resources.js
+```
+
+The root Harper `harper-config.yaml`, not the component `config.yaml`, owns broker
+ports and MQTT authentication:
+
+```yaml
+mqtt:
+  network:
+    port: 1883
+    securePort: 8883
+  webSocket: true
+  requireAuthentication: true
+```
+
+Keep the `rest`, `graphqlSchema`, and `jsResource` declarations together when a
+project has a custom component `config.yaml`. Harper does not merge custom
+component config with defaults. See [[harper-config-yaml]].
+
+## Filtering and message shape
+
+- Prefer record-level subscriptions (`Resource/<id>`) when the UI watches one
+  entity; use collection or wildcard subscriptions only when the product needs a
+  feed.
+- Keep published messages typed and small. Send the changed record or a compact
+  event envelope, not a full page payload.
+- Include stable identifiers in custom events: resource name, id, operation, and
+  timestamp are usually enough.
+- Treat inaccessible or unauthenticated subscribe attempts as authorization
+  failures, not empty streams.
+- Do not disable the audit log for tables that need real-time messages or
+  replication; Harper uses it for live subscriptions.
+
+## Fabric and replication
+
+For clustered/Fabric deployments, real-time behavior must match the deploy target:
+
+- Verify against the same environment that users connect to, not only a local
+  single-node process.
+- Use `replicated=true` when deploying a component that needs to run across Fabric
+  nodes. See [[harper-build-and-deploy]].
+- Keep event handlers idempotent. A subscriber may reconnect and replay from the
+  latest known state.
+- If a bug appears only across nodes, capture the target URL, topic/path, node
+  count when known, and the exact publish/subscribe commands in the evidence.
+
+## Local verification
+
+1. Build generated Harper assets from source:
+
+   ```bash
+   bun run build
+   ```
+
+2. Start the component:
+
+   ```bash
+   harper dev harper-app
+   ```
+
+3. In another shell, subscribe to a topic or WebSocket path:
+
+   ```bash
+   npx mqtt sub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/#' -v
+   ```
+
+   ```bash
+   npx wscat -c ws://localhost:9926/Activity/123
+   ```
+
+4. Publish or mutate the watched record:
+
+   ```bash
+   npx mqtt pub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/123' -m '{"status":"live"}'
+   ```
+
+5. Confirm the subscriber receives the expected message shape and that a normal
+   REST/GraphQL read returns the same resulting state.
+
+Record the command, topic/path, payload, and observed message in PR evidence. If a
+local Harper binary or credentials are unavailable, report that blocker instead of
+claiming the subscription was verified.
+
+## Project conventions
+
+- Write resource code in TypeScript under `src/`; `harper-app/resources.js` is a
+  generated artifact. See [[harper-resources]].
+- If real-time work changes `config.yaml`, update the project Fabric runbook and
+  re-run the smoke path. See [[harper-config-yaml]].
+- Prefer a pushed update over a polling workaround when the issue asks for live
+  behavior.
+- For Lisa plugin edits, change `plugins/src/harper-fabric`, run
+  `bun run build:plugins`, and commit both source and generated plugin copies.
+
+## Sources
+
+- [Resources overview](https://docs.harperdb.io/reference/v5/resources/overview)
+- [Resource API](https://docs.harperdb.io/reference/v5/resources/resource-api)
+- [WebSockets](https://docs.harperdb.io/reference/v5/rest/websockets)
+- [MQTT configuration](https://docs.harperdb.io/reference/v4/mqtt/configuration)
+- [Transaction logging](https://docs.harperdb.io/reference/v5/database/transaction)

--- a/plugins/lisa-harper-fabric-agy/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-resources/SKILL.md
@@ -70,8 +70,9 @@ jsResource:
 ```
 
 Resources can also be registered programmatically with `server.resources.set()`.
-See [[harper-config-yaml]] for the extension wiring and [[harper-schema-graphql]]
-for how the schema defines the tables resources extend.
+See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] for
+how the schema defines the tables resources extend, and [[harper-realtime]] when
+`subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
 ## Project conventions (TS is source)
 

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-config-yaml/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-config-yaml/SKILL.md
@@ -52,7 +52,7 @@ unmentioned extensions stay on.
 
 | Key | Purpose | Common options |
 | --- | --- | --- |
-| `rest` | Auto REST endpoints for exported resources/tables | `true`, or an object with options |
+| `rest` | Auto REST endpoints and resource WebSocket subscriptions | `true`, or an object with options such as `webSocket` |
 | `graphqlSchema` | Define tables/types from GraphQL files | `files: '*.graphql'` — see [[harper-schema-graphql]] |
 | `jsResource` | Load custom JS resources | `files: 'resources.js'` — see [[harper-resources]] |
 | `static` | Serve static files over HTTP | `files: 'web/**'`, `urlPath` |
@@ -60,6 +60,11 @@ unmentioned extensions stay on.
 | `loadEnv` | Load env vars from `.env` | `files` |
 | `dataLoader` | Seed tables from JSON/YAML | `files` |
 | `fastifyRoutes` | Custom Fastify routes | `files: 'routes/*.js'`, `urlPath` |
+
+For real-time work, component `config.yaml` keeps `rest`, `graphqlSchema`, and
+`jsResource` enabled so exported resources can be addressed by HTTP/WebSocket and
+MQTT topic paths. Broker ports and MQTT authentication live in the root
+`harper-config.yaml`, not the component file. See [[harper-realtime]].
 
 ## External components and custom plugins
 

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-realtime/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-realtime/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: harper-realtime
+description: This skill should be used when adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource publish/subscribe handlers, SSE-style streaming routes, and local subscriber verification. Pairs with harper-resources, harper-config-yaml, harper-schema-graphql, and harper-build-and-deploy.
+---
+
+# Harper Realtime
+
+## Overview
+
+Harper exposes live data through the same Resource model used for REST and
+GraphQL. Exported tables/resources can be addressed as MQTT topics and WebSocket
+paths, while custom resources can override the messaging handlers when the default
+table behavior is not enough.
+
+Use real-time primitives when the product needs pushed state: live feeds, activity
+streams, collaborative views, device telemetry, or status updates. Do not replace
+these with client polling unless the issue explicitly asks for polling.
+
+## Resource and topic model
+
+- A GraphQL type marked `@table @export` creates a default exported table resource.
+- An exported JavaScript Resource class from `resources.js` creates a resource
+  endpoint with the class name as the path/topic root.
+- Resource paths map naturally to subscription targets: collection-level
+  subscriptions use the resource name, and record-level subscriptions append the
+  record id or path segment.
+- MQTT supports multi-level topics and wildcards. Use `resource/#` for a resource
+  subtree and `resource/+/status` for one path segment.
+- WebSocket subscriptions target the REST resource URL. For example,
+  `ws://localhost:9926/Activity/123` subscribes to the `Activity` resource record
+  with id `123`.
+
+Keep the URL/topic names stable. If a UI depends on `Activity/123`, changing the
+resource export name is an API break.
+
+## Resource methods
+
+The MQTT plugin routes broker messages through Resource methods:
+
+| Method | Use |
+| --- | --- |
+| `subscribe(target, context)` | Authorize and shape subscription reads for a resource or record. |
+| `publish(target, message, context)` | Accept or transform messages written to a topic/resource. |
+| `connect(incomingMessages)` | Customize WebSocket connection behavior for a resource. |
+
+For table-backed resources, prefer default behavior until the product needs a
+custom message shape, authorization check, fan-out, or derived event. When
+overriding, preserve built-in table behavior with `super.subscribe(...)` or
+`super.publish(...)` where that behavior is still wanted.
+
+```javascript
+export class Activity extends tables.Activity {
+  static async publish(target, message, context) {
+    const payload = await message;
+    await super.publish(target, payload, context);
+    return { ...payload, acceptedAt: Date.now() };
+  }
+}
+```
+
+For WebSocket-only behavior, implement `connect(incomingMessages)` and return an
+async iterable. Use the default `super.connect()` stream when you only need to
+push extra server messages or clean up on disconnect.
+
+## Transport choices
+
+| Transport | Best fit | Notes |
+| --- | --- | --- |
+| MQTT | Device streams, backend subscribers, wildcard topics, durable clients. | Plain MQTT defaults to port `1883`; MQTTS defaults to `8883`. |
+| MQTT over WebSocket | Browser or edge clients using MQTT semantics. | Uses the HTTP port, default `9926`, with the `mqtt` WebSocket subprotocol. |
+| Resource WebSocket | Browser live views tied to one REST resource path. | Enabled with the `rest` plugin unless `rest.webSocket: false` is set. |
+| SSE/custom streaming route | One-way browser updates when WebSocket is not appropriate. | Implement as a project route; do not assume SSE automatically subscribes to Resource changes. |
+
+Authentication is usually required for MQTT. When `mqtt.requireAuthentication` is
+`false`, authorization still applies at the resource/table level, so public
+connections must be explicitly allowed by roles or resource logic.
+
+## config.yaml wiring
+
+Component-level `config.yaml` enables the app surface:
+
+```yaml
+rest: true
+graphqlSchema:
+  files: schema.graphql
+jsResource:
+  files: resources.js
+```
+
+The root Harper `harper-config.yaml`, not the component `config.yaml`, owns broker
+ports and MQTT authentication:
+
+```yaml
+mqtt:
+  network:
+    port: 1883
+    securePort: 8883
+  webSocket: true
+  requireAuthentication: true
+```
+
+Keep the `rest`, `graphqlSchema`, and `jsResource` declarations together when a
+project has a custom component `config.yaml`. Harper does not merge custom
+component config with defaults. See [[harper-config-yaml]].
+
+## Filtering and message shape
+
+- Prefer record-level subscriptions (`Resource/<id>`) when the UI watches one
+  entity; use collection or wildcard subscriptions only when the product needs a
+  feed.
+- Keep published messages typed and small. Send the changed record or a compact
+  event envelope, not a full page payload.
+- Include stable identifiers in custom events: resource name, id, operation, and
+  timestamp are usually enough.
+- Treat inaccessible or unauthenticated subscribe attempts as authorization
+  failures, not empty streams.
+- Do not disable the audit log for tables that need real-time messages or
+  replication; Harper uses it for live subscriptions.
+
+## Fabric and replication
+
+For clustered/Fabric deployments, real-time behavior must match the deploy target:
+
+- Verify against the same environment that users connect to, not only a local
+  single-node process.
+- Use `replicated=true` when deploying a component that needs to run across Fabric
+  nodes. See [[harper-build-and-deploy]].
+- Keep event handlers idempotent. A subscriber may reconnect and replay from the
+  latest known state.
+- If a bug appears only across nodes, capture the target URL, topic/path, node
+  count when known, and the exact publish/subscribe commands in the evidence.
+
+## Local verification
+
+1. Build generated Harper assets from source:
+
+   ```bash
+   bun run build
+   ```
+
+2. Start the component:
+
+   ```bash
+   harper dev harper-app
+   ```
+
+3. In another shell, subscribe to a topic or WebSocket path:
+
+   ```bash
+   npx mqtt sub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/#' -v
+   ```
+
+   ```bash
+   npx wscat -c ws://localhost:9926/Activity/123
+   ```
+
+4. Publish or mutate the watched record:
+
+   ```bash
+   npx mqtt pub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/123' -m '{"status":"live"}'
+   ```
+
+5. Confirm the subscriber receives the expected message shape and that a normal
+   REST/GraphQL read returns the same resulting state.
+
+Record the command, topic/path, payload, and observed message in PR evidence. If a
+local Harper binary or credentials are unavailable, report that blocker instead of
+claiming the subscription was verified.
+
+## Project conventions
+
+- Write resource code in TypeScript under `src/`; `harper-app/resources.js` is a
+  generated artifact. See [[harper-resources]].
+- If real-time work changes `config.yaml`, update the project Fabric runbook and
+  re-run the smoke path. See [[harper-config-yaml]].
+- Prefer a pushed update over a polling workaround when the issue asks for live
+  behavior.
+- For Lisa plugin edits, change `plugins/src/harper-fabric`, run
+  `bun run build:plugins`, and commit both source and generated plugin copies.
+
+## Sources
+
+- [Resources overview](https://docs.harperdb.io/reference/v5/resources/overview)
+- [Resource API](https://docs.harperdb.io/reference/v5/resources/resource-api)
+- [WebSockets](https://docs.harperdb.io/reference/v5/rest/websockets)
+- [MQTT configuration](https://docs.harperdb.io/reference/v4/mqtt/configuration)
+- [Transaction logging](https://docs.harperdb.io/reference/v5/database/transaction)

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-resources/SKILL.md
@@ -70,8 +70,9 @@ jsResource:
 ```
 
 Resources can also be registered programmatically with `server.resources.set()`.
-See [[harper-config-yaml]] for the extension wiring and [[harper-schema-graphql]]
-for how the schema defines the tables resources extend.
+See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] for
+how the schema defines the tables resources extend, and [[harper-realtime]] when
+`subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
 ## Project conventions (TS is source)
 

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-config-yaml/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-config-yaml/SKILL.md
@@ -52,7 +52,7 @@ unmentioned extensions stay on.
 
 | Key | Purpose | Common options |
 | --- | --- | --- |
-| `rest` | Auto REST endpoints for exported resources/tables | `true`, or an object with options |
+| `rest` | Auto REST endpoints and resource WebSocket subscriptions | `true`, or an object with options such as `webSocket` |
 | `graphqlSchema` | Define tables/types from GraphQL files | `files: '*.graphql'` — see [[harper-schema-graphql]] |
 | `jsResource` | Load custom JS resources | `files: 'resources.js'` — see [[harper-resources]] |
 | `static` | Serve static files over HTTP | `files: 'web/**'`, `urlPath` |
@@ -60,6 +60,11 @@ unmentioned extensions stay on.
 | `loadEnv` | Load env vars from `.env` | `files` |
 | `dataLoader` | Seed tables from JSON/YAML | `files` |
 | `fastifyRoutes` | Custom Fastify routes | `files: 'routes/*.js'`, `urlPath` |
+
+For real-time work, component `config.yaml` keeps `rest`, `graphqlSchema`, and
+`jsResource` enabled so exported resources can be addressed by HTTP/WebSocket and
+MQTT topic paths. Broker ports and MQTT authentication live in the root
+`harper-config.yaml`, not the component file. See [[harper-realtime]].
 
 ## External components and custom plugins
 

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-realtime/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-realtime/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: harper-realtime
+description: This skill should be used when adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource publish/subscribe handlers, SSE-style streaming routes, and local subscriber verification. Pairs with harper-resources, harper-config-yaml, harper-schema-graphql, and harper-build-and-deploy.
+---
+
+# Harper Realtime
+
+## Overview
+
+Harper exposes live data through the same Resource model used for REST and
+GraphQL. Exported tables/resources can be addressed as MQTT topics and WebSocket
+paths, while custom resources can override the messaging handlers when the default
+table behavior is not enough.
+
+Use real-time primitives when the product needs pushed state: live feeds, activity
+streams, collaborative views, device telemetry, or status updates. Do not replace
+these with client polling unless the issue explicitly asks for polling.
+
+## Resource and topic model
+
+- A GraphQL type marked `@table @export` creates a default exported table resource.
+- An exported JavaScript Resource class from `resources.js` creates a resource
+  endpoint with the class name as the path/topic root.
+- Resource paths map naturally to subscription targets: collection-level
+  subscriptions use the resource name, and record-level subscriptions append the
+  record id or path segment.
+- MQTT supports multi-level topics and wildcards. Use `resource/#` for a resource
+  subtree and `resource/+/status` for one path segment.
+- WebSocket subscriptions target the REST resource URL. For example,
+  `ws://localhost:9926/Activity/123` subscribes to the `Activity` resource record
+  with id `123`.
+
+Keep the URL/topic names stable. If a UI depends on `Activity/123`, changing the
+resource export name is an API break.
+
+## Resource methods
+
+The MQTT plugin routes broker messages through Resource methods:
+
+| Method | Use |
+| --- | --- |
+| `subscribe(target, context)` | Authorize and shape subscription reads for a resource or record. |
+| `publish(target, message, context)` | Accept or transform messages written to a topic/resource. |
+| `connect(incomingMessages)` | Customize WebSocket connection behavior for a resource. |
+
+For table-backed resources, prefer default behavior until the product needs a
+custom message shape, authorization check, fan-out, or derived event. When
+overriding, preserve built-in table behavior with `super.subscribe(...)` or
+`super.publish(...)` where that behavior is still wanted.
+
+```javascript
+export class Activity extends tables.Activity {
+  static async publish(target, message, context) {
+    const payload = await message;
+    await super.publish(target, payload, context);
+    return { ...payload, acceptedAt: Date.now() };
+  }
+}
+```
+
+For WebSocket-only behavior, implement `connect(incomingMessages)` and return an
+async iterable. Use the default `super.connect()` stream when you only need to
+push extra server messages or clean up on disconnect.
+
+## Transport choices
+
+| Transport | Best fit | Notes |
+| --- | --- | --- |
+| MQTT | Device streams, backend subscribers, wildcard topics, durable clients. | Plain MQTT defaults to port `1883`; MQTTS defaults to `8883`. |
+| MQTT over WebSocket | Browser or edge clients using MQTT semantics. | Uses the HTTP port, default `9926`, with the `mqtt` WebSocket subprotocol. |
+| Resource WebSocket | Browser live views tied to one REST resource path. | Enabled with the `rest` plugin unless `rest.webSocket: false` is set. |
+| SSE/custom streaming route | One-way browser updates when WebSocket is not appropriate. | Implement as a project route; do not assume SSE automatically subscribes to Resource changes. |
+
+Authentication is usually required for MQTT. When `mqtt.requireAuthentication` is
+`false`, authorization still applies at the resource/table level, so public
+connections must be explicitly allowed by roles or resource logic.
+
+## config.yaml wiring
+
+Component-level `config.yaml` enables the app surface:
+
+```yaml
+rest: true
+graphqlSchema:
+  files: schema.graphql
+jsResource:
+  files: resources.js
+```
+
+The root Harper `harper-config.yaml`, not the component `config.yaml`, owns broker
+ports and MQTT authentication:
+
+```yaml
+mqtt:
+  network:
+    port: 1883
+    securePort: 8883
+  webSocket: true
+  requireAuthentication: true
+```
+
+Keep the `rest`, `graphqlSchema`, and `jsResource` declarations together when a
+project has a custom component `config.yaml`. Harper does not merge custom
+component config with defaults. See [[harper-config-yaml]].
+
+## Filtering and message shape
+
+- Prefer record-level subscriptions (`Resource/<id>`) when the UI watches one
+  entity; use collection or wildcard subscriptions only when the product needs a
+  feed.
+- Keep published messages typed and small. Send the changed record or a compact
+  event envelope, not a full page payload.
+- Include stable identifiers in custom events: resource name, id, operation, and
+  timestamp are usually enough.
+- Treat inaccessible or unauthenticated subscribe attempts as authorization
+  failures, not empty streams.
+- Do not disable the audit log for tables that need real-time messages or
+  replication; Harper uses it for live subscriptions.
+
+## Fabric and replication
+
+For clustered/Fabric deployments, real-time behavior must match the deploy target:
+
+- Verify against the same environment that users connect to, not only a local
+  single-node process.
+- Use `replicated=true` when deploying a component that needs to run across Fabric
+  nodes. See [[harper-build-and-deploy]].
+- Keep event handlers idempotent. A subscriber may reconnect and replay from the
+  latest known state.
+- If a bug appears only across nodes, capture the target URL, topic/path, node
+  count when known, and the exact publish/subscribe commands in the evidence.
+
+## Local verification
+
+1. Build generated Harper assets from source:
+
+   ```bash
+   bun run build
+   ```
+
+2. Start the component:
+
+   ```bash
+   harper dev harper-app
+   ```
+
+3. In another shell, subscribe to a topic or WebSocket path:
+
+   ```bash
+   npx mqtt sub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/#' -v
+   ```
+
+   ```bash
+   npx wscat -c ws://localhost:9926/Activity/123
+   ```
+
+4. Publish or mutate the watched record:
+
+   ```bash
+   npx mqtt pub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/123' -m '{"status":"live"}'
+   ```
+
+5. Confirm the subscriber receives the expected message shape and that a normal
+   REST/GraphQL read returns the same resulting state.
+
+Record the command, topic/path, payload, and observed message in PR evidence. If a
+local Harper binary or credentials are unavailable, report that blocker instead of
+claiming the subscription was verified.
+
+## Project conventions
+
+- Write resource code in TypeScript under `src/`; `harper-app/resources.js` is a
+  generated artifact. See [[harper-resources]].
+- If real-time work changes `config.yaml`, update the project Fabric runbook and
+  re-run the smoke path. See [[harper-config-yaml]].
+- Prefer a pushed update over a polling workaround when the issue asks for live
+  behavior.
+- For Lisa plugin edits, change `plugins/src/harper-fabric`, run
+  `bun run build:plugins`, and commit both source and generated plugin copies.
+
+## Sources
+
+- [Resources overview](https://docs.harperdb.io/reference/v5/resources/overview)
+- [Resource API](https://docs.harperdb.io/reference/v5/resources/resource-api)
+- [WebSockets](https://docs.harperdb.io/reference/v5/rest/websockets)
+- [MQTT configuration](https://docs.harperdb.io/reference/v4/mqtt/configuration)
+- [Transaction logging](https://docs.harperdb.io/reference/v5/database/transaction)

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-resources/SKILL.md
@@ -70,8 +70,9 @@ jsResource:
 ```
 
 Resources can also be registered programmatically with `server.resources.set()`.
-See [[harper-config-yaml]] for the extension wiring and [[harper-schema-graphql]]
-for how the schema defines the tables resources extend.
+See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] for
+how the schema defines the tables resources extend, and [[harper-realtime]] when
+`subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
 ## Project conventions (TS is source)
 

--- a/plugins/lisa-harper-fabric/skills/harper-config-yaml/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-config-yaml/SKILL.md
@@ -52,7 +52,7 @@ unmentioned extensions stay on.
 
 | Key | Purpose | Common options |
 | --- | --- | --- |
-| `rest` | Auto REST endpoints for exported resources/tables | `true`, or an object with options |
+| `rest` | Auto REST endpoints and resource WebSocket subscriptions | `true`, or an object with options such as `webSocket` |
 | `graphqlSchema` | Define tables/types from GraphQL files | `files: '*.graphql'` — see [[harper-schema-graphql]] |
 | `jsResource` | Load custom JS resources | `files: 'resources.js'` — see [[harper-resources]] |
 | `static` | Serve static files over HTTP | `files: 'web/**'`, `urlPath` |
@@ -60,6 +60,11 @@ unmentioned extensions stay on.
 | `loadEnv` | Load env vars from `.env` | `files` |
 | `dataLoader` | Seed tables from JSON/YAML | `files` |
 | `fastifyRoutes` | Custom Fastify routes | `files: 'routes/*.js'`, `urlPath` |
+
+For real-time work, component `config.yaml` keeps `rest`, `graphqlSchema`, and
+`jsResource` enabled so exported resources can be addressed by HTTP/WebSocket and
+MQTT topic paths. Broker ports and MQTT authentication live in the root
+`harper-config.yaml`, not the component file. See [[harper-realtime]].
 
 ## External components and custom plugins
 

--- a/plugins/lisa-harper-fabric/skills/harper-realtime/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-realtime/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: harper-realtime
+description: This skill should be used when adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource publish/subscribe handlers, SSE-style streaming routes, and local subscriber verification. Pairs with harper-resources, harper-config-yaml, harper-schema-graphql, and harper-build-and-deploy.
+---
+
+# Harper Realtime
+
+## Overview
+
+Harper exposes live data through the same Resource model used for REST and
+GraphQL. Exported tables/resources can be addressed as MQTT topics and WebSocket
+paths, while custom resources can override the messaging handlers when the default
+table behavior is not enough.
+
+Use real-time primitives when the product needs pushed state: live feeds, activity
+streams, collaborative views, device telemetry, or status updates. Do not replace
+these with client polling unless the issue explicitly asks for polling.
+
+## Resource and topic model
+
+- A GraphQL type marked `@table @export` creates a default exported table resource.
+- An exported JavaScript Resource class from `resources.js` creates a resource
+  endpoint with the class name as the path/topic root.
+- Resource paths map naturally to subscription targets: collection-level
+  subscriptions use the resource name, and record-level subscriptions append the
+  record id or path segment.
+- MQTT supports multi-level topics and wildcards. Use `resource/#` for a resource
+  subtree and `resource/+/status` for one path segment.
+- WebSocket subscriptions target the REST resource URL. For example,
+  `ws://localhost:9926/Activity/123` subscribes to the `Activity` resource record
+  with id `123`.
+
+Keep the URL/topic names stable. If a UI depends on `Activity/123`, changing the
+resource export name is an API break.
+
+## Resource methods
+
+The MQTT plugin routes broker messages through Resource methods:
+
+| Method | Use |
+| --- | --- |
+| `subscribe(target, context)` | Authorize and shape subscription reads for a resource or record. |
+| `publish(target, message, context)` | Accept or transform messages written to a topic/resource. |
+| `connect(incomingMessages)` | Customize WebSocket connection behavior for a resource. |
+
+For table-backed resources, prefer default behavior until the product needs a
+custom message shape, authorization check, fan-out, or derived event. When
+overriding, preserve built-in table behavior with `super.subscribe(...)` or
+`super.publish(...)` where that behavior is still wanted.
+
+```javascript
+export class Activity extends tables.Activity {
+  static async publish(target, message, context) {
+    const payload = await message;
+    await super.publish(target, payload, context);
+    return { ...payload, acceptedAt: Date.now() };
+  }
+}
+```
+
+For WebSocket-only behavior, implement `connect(incomingMessages)` and return an
+async iterable. Use the default `super.connect()` stream when you only need to
+push extra server messages or clean up on disconnect.
+
+## Transport choices
+
+| Transport | Best fit | Notes |
+| --- | --- | --- |
+| MQTT | Device streams, backend subscribers, wildcard topics, durable clients. | Plain MQTT defaults to port `1883`; MQTTS defaults to `8883`. |
+| MQTT over WebSocket | Browser or edge clients using MQTT semantics. | Uses the HTTP port, default `9926`, with the `mqtt` WebSocket subprotocol. |
+| Resource WebSocket | Browser live views tied to one REST resource path. | Enabled with the `rest` plugin unless `rest.webSocket: false` is set. |
+| SSE/custom streaming route | One-way browser updates when WebSocket is not appropriate. | Implement as a project route; do not assume SSE automatically subscribes to Resource changes. |
+
+Authentication is usually required for MQTT. When `mqtt.requireAuthentication` is
+`false`, authorization still applies at the resource/table level, so public
+connections must be explicitly allowed by roles or resource logic.
+
+## config.yaml wiring
+
+Component-level `config.yaml` enables the app surface:
+
+```yaml
+rest: true
+graphqlSchema:
+  files: schema.graphql
+jsResource:
+  files: resources.js
+```
+
+The root Harper `harper-config.yaml`, not the component `config.yaml`, owns broker
+ports and MQTT authentication:
+
+```yaml
+mqtt:
+  network:
+    port: 1883
+    securePort: 8883
+  webSocket: true
+  requireAuthentication: true
+```
+
+Keep the `rest`, `graphqlSchema`, and `jsResource` declarations together when a
+project has a custom component `config.yaml`. Harper does not merge custom
+component config with defaults. See [[harper-config-yaml]].
+
+## Filtering and message shape
+
+- Prefer record-level subscriptions (`Resource/<id>`) when the UI watches one
+  entity; use collection or wildcard subscriptions only when the product needs a
+  feed.
+- Keep published messages typed and small. Send the changed record or a compact
+  event envelope, not a full page payload.
+- Include stable identifiers in custom events: resource name, id, operation, and
+  timestamp are usually enough.
+- Treat inaccessible or unauthenticated subscribe attempts as authorization
+  failures, not empty streams.
+- Do not disable the audit log for tables that need real-time messages or
+  replication; Harper uses it for live subscriptions.
+
+## Fabric and replication
+
+For clustered/Fabric deployments, real-time behavior must match the deploy target:
+
+- Verify against the same environment that users connect to, not only a local
+  single-node process.
+- Use `replicated=true` when deploying a component that needs to run across Fabric
+  nodes. See [[harper-build-and-deploy]].
+- Keep event handlers idempotent. A subscriber may reconnect and replay from the
+  latest known state.
+- If a bug appears only across nodes, capture the target URL, topic/path, node
+  count when known, and the exact publish/subscribe commands in the evidence.
+
+## Local verification
+
+1. Build generated Harper assets from source:
+
+   ```bash
+   bun run build
+   ```
+
+2. Start the component:
+
+   ```bash
+   harper dev harper-app
+   ```
+
+3. In another shell, subscribe to a topic or WebSocket path:
+
+   ```bash
+   npx mqtt sub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/#' -v
+   ```
+
+   ```bash
+   npx wscat -c ws://localhost:9926/Activity/123
+   ```
+
+4. Publish or mutate the watched record:
+
+   ```bash
+   npx mqtt pub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/123' -m '{"status":"live"}'
+   ```
+
+5. Confirm the subscriber receives the expected message shape and that a normal
+   REST/GraphQL read returns the same resulting state.
+
+Record the command, topic/path, payload, and observed message in PR evidence. If a
+local Harper binary or credentials are unavailable, report that blocker instead of
+claiming the subscription was verified.
+
+## Project conventions
+
+- Write resource code in TypeScript under `src/`; `harper-app/resources.js` is a
+  generated artifact. See [[harper-resources]].
+- If real-time work changes `config.yaml`, update the project Fabric runbook and
+  re-run the smoke path. See [[harper-config-yaml]].
+- Prefer a pushed update over a polling workaround when the issue asks for live
+  behavior.
+- For Lisa plugin edits, change `plugins/src/harper-fabric`, run
+  `bun run build:plugins`, and commit both source and generated plugin copies.
+
+## Sources
+
+- [Resources overview](https://docs.harperdb.io/reference/v5/resources/overview)
+- [Resource API](https://docs.harperdb.io/reference/v5/resources/resource-api)
+- [WebSockets](https://docs.harperdb.io/reference/v5/rest/websockets)
+- [MQTT configuration](https://docs.harperdb.io/reference/v4/mqtt/configuration)
+- [Transaction logging](https://docs.harperdb.io/reference/v5/database/transaction)

--- a/plugins/lisa-harper-fabric/skills/harper-realtime/agents/openai.yaml
+++ b/plugins/lisa-harper-fabric/skills/harper-realtime/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Harper Realtime"
+short_description: "adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource…"
+default_prompt:
+  - "Use $harper-realtime: adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource…."

--- a/plugins/lisa-harper-fabric/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-resources/SKILL.md
@@ -70,8 +70,9 @@ jsResource:
 ```
 
 Resources can also be registered programmatically with `server.resources.set()`.
-See [[harper-config-yaml]] for the extension wiring and [[harper-schema-graphql]]
-for how the schema defines the tables resources extend.
+See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] for
+how the schema defines the tables resources extend, and [[harper-realtime]] when
+`subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
 ## Project conventions (TS is source)
 

--- a/plugins/src/harper-fabric/skills/harper-config-yaml/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-config-yaml/SKILL.md
@@ -52,7 +52,7 @@ unmentioned extensions stay on.
 
 | Key | Purpose | Common options |
 | --- | --- | --- |
-| `rest` | Auto REST endpoints for exported resources/tables | `true`, or an object with options |
+| `rest` | Auto REST endpoints and resource WebSocket subscriptions | `true`, or an object with options such as `webSocket` |
 | `graphqlSchema` | Define tables/types from GraphQL files | `files: '*.graphql'` — see [[harper-schema-graphql]] |
 | `jsResource` | Load custom JS resources | `files: 'resources.js'` — see [[harper-resources]] |
 | `static` | Serve static files over HTTP | `files: 'web/**'`, `urlPath` |
@@ -60,6 +60,11 @@ unmentioned extensions stay on.
 | `loadEnv` | Load env vars from `.env` | `files` |
 | `dataLoader` | Seed tables from JSON/YAML | `files` |
 | `fastifyRoutes` | Custom Fastify routes | `files: 'routes/*.js'`, `urlPath` |
+
+For real-time work, component `config.yaml` keeps `rest`, `graphqlSchema`, and
+`jsResource` enabled so exported resources can be addressed by HTTP/WebSocket and
+MQTT topic paths. Broker ports and MQTT authentication live in the root
+`harper-config.yaml`, not the component file. See [[harper-realtime]].
 
 ## External components and custom plugins
 

--- a/plugins/src/harper-fabric/skills/harper-realtime/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-realtime/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: harper-realtime
+description: This skill should be used when adding or troubleshooting Harper (HarperDB/Fabric) real-time behavior: MQTT topics, WebSocket resource subscriptions, resource publish/subscribe handlers, SSE-style streaming routes, and local subscriber verification. Pairs with harper-resources, harper-config-yaml, harper-schema-graphql, and harper-build-and-deploy.
+---
+
+# Harper Realtime
+
+## Overview
+
+Harper exposes live data through the same Resource model used for REST and
+GraphQL. Exported tables/resources can be addressed as MQTT topics and WebSocket
+paths, while custom resources can override the messaging handlers when the default
+table behavior is not enough.
+
+Use real-time primitives when the product needs pushed state: live feeds, activity
+streams, collaborative views, device telemetry, or status updates. Do not replace
+these with client polling unless the issue explicitly asks for polling.
+
+## Resource and topic model
+
+- A GraphQL type marked `@table @export` creates a default exported table resource.
+- An exported JavaScript Resource class from `resources.js` creates a resource
+  endpoint with the class name as the path/topic root.
+- Resource paths map naturally to subscription targets: collection-level
+  subscriptions use the resource name, and record-level subscriptions append the
+  record id or path segment.
+- MQTT supports multi-level topics and wildcards. Use `resource/#` for a resource
+  subtree and `resource/+/status` for one path segment.
+- WebSocket subscriptions target the REST resource URL. For example,
+  `ws://localhost:9926/Activity/123` subscribes to the `Activity` resource record
+  with id `123`.
+
+Keep the URL/topic names stable. If a UI depends on `Activity/123`, changing the
+resource export name is an API break.
+
+## Resource methods
+
+The MQTT plugin routes broker messages through Resource methods:
+
+| Method | Use |
+| --- | --- |
+| `subscribe(target, context)` | Authorize and shape subscription reads for a resource or record. |
+| `publish(target, message, context)` | Accept or transform messages written to a topic/resource. |
+| `connect(incomingMessages)` | Customize WebSocket connection behavior for a resource. |
+
+For table-backed resources, prefer default behavior until the product needs a
+custom message shape, authorization check, fan-out, or derived event. When
+overriding, preserve built-in table behavior with `super.subscribe(...)` or
+`super.publish(...)` where that behavior is still wanted.
+
+```javascript
+export class Activity extends tables.Activity {
+  static async publish(target, message, context) {
+    const payload = await message;
+    await super.publish(target, payload, context);
+    return { ...payload, acceptedAt: Date.now() };
+  }
+}
+```
+
+For WebSocket-only behavior, implement `connect(incomingMessages)` and return an
+async iterable. Use the default `super.connect()` stream when you only need to
+push extra server messages or clean up on disconnect.
+
+## Transport choices
+
+| Transport | Best fit | Notes |
+| --- | --- | --- |
+| MQTT | Device streams, backend subscribers, wildcard topics, durable clients. | Plain MQTT defaults to port `1883`; MQTTS defaults to `8883`. |
+| MQTT over WebSocket | Browser or edge clients using MQTT semantics. | Uses the HTTP port, default `9926`, with the `mqtt` WebSocket subprotocol. |
+| Resource WebSocket | Browser live views tied to one REST resource path. | Enabled with the `rest` plugin unless `rest.webSocket: false` is set. |
+| SSE/custom streaming route | One-way browser updates when WebSocket is not appropriate. | Implement as a project route; do not assume SSE automatically subscribes to Resource changes. |
+
+Authentication is usually required for MQTT. When `mqtt.requireAuthentication` is
+`false`, authorization still applies at the resource/table level, so public
+connections must be explicitly allowed by roles or resource logic.
+
+## config.yaml wiring
+
+Component-level `config.yaml` enables the app surface:
+
+```yaml
+rest: true
+graphqlSchema:
+  files: schema.graphql
+jsResource:
+  files: resources.js
+```
+
+The root Harper `harper-config.yaml`, not the component `config.yaml`, owns broker
+ports and MQTT authentication:
+
+```yaml
+mqtt:
+  network:
+    port: 1883
+    securePort: 8883
+  webSocket: true
+  requireAuthentication: true
+```
+
+Keep the `rest`, `graphqlSchema`, and `jsResource` declarations together when a
+project has a custom component `config.yaml`. Harper does not merge custom
+component config with defaults. See [[harper-config-yaml]].
+
+## Filtering and message shape
+
+- Prefer record-level subscriptions (`Resource/<id>`) when the UI watches one
+  entity; use collection or wildcard subscriptions only when the product needs a
+  feed.
+- Keep published messages typed and small. Send the changed record or a compact
+  event envelope, not a full page payload.
+- Include stable identifiers in custom events: resource name, id, operation, and
+  timestamp are usually enough.
+- Treat inaccessible or unauthenticated subscribe attempts as authorization
+  failures, not empty streams.
+- Do not disable the audit log for tables that need real-time messages or
+  replication; Harper uses it for live subscriptions.
+
+## Fabric and replication
+
+For clustered/Fabric deployments, real-time behavior must match the deploy target:
+
+- Verify against the same environment that users connect to, not only a local
+  single-node process.
+- Use `replicated=true` when deploying a component that needs to run across Fabric
+  nodes. See [[harper-build-and-deploy]].
+- Keep event handlers idempotent. A subscriber may reconnect and replay from the
+  latest known state.
+- If a bug appears only across nodes, capture the target URL, topic/path, node
+  count when known, and the exact publish/subscribe commands in the evidence.
+
+## Local verification
+
+1. Build generated Harper assets from source:
+
+   ```bash
+   bun run build
+   ```
+
+2. Start the component:
+
+   ```bash
+   harper dev harper-app
+   ```
+
+3. In another shell, subscribe to a topic or WebSocket path:
+
+   ```bash
+   npx mqtt sub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/#' -v
+   ```
+
+   ```bash
+   npx wscat -c ws://localhost:9926/Activity/123
+   ```
+
+4. Publish or mutate the watched record:
+
+   ```bash
+   npx mqtt pub -h localhost -p 1883 -u HDB_ADMIN -P "$HARPER_PASSWORD" -t 'Activity/123' -m '{"status":"live"}'
+   ```
+
+5. Confirm the subscriber receives the expected message shape and that a normal
+   REST/GraphQL read returns the same resulting state.
+
+Record the command, topic/path, payload, and observed message in PR evidence. If a
+local Harper binary or credentials are unavailable, report that blocker instead of
+claiming the subscription was verified.
+
+## Project conventions
+
+- Write resource code in TypeScript under `src/`; `harper-app/resources.js` is a
+  generated artifact. See [[harper-resources]].
+- If real-time work changes `config.yaml`, update the project Fabric runbook and
+  re-run the smoke path. See [[harper-config-yaml]].
+- Prefer a pushed update over a polling workaround when the issue asks for live
+  behavior.
+- For Lisa plugin edits, change `plugins/src/harper-fabric`, run
+  `bun run build:plugins`, and commit both source and generated plugin copies.
+
+## Sources
+
+- [Resources overview](https://docs.harperdb.io/reference/v5/resources/overview)
+- [Resource API](https://docs.harperdb.io/reference/v5/resources/resource-api)
+- [WebSockets](https://docs.harperdb.io/reference/v5/rest/websockets)
+- [MQTT configuration](https://docs.harperdb.io/reference/v4/mqtt/configuration)
+- [Transaction logging](https://docs.harperdb.io/reference/v5/database/transaction)

--- a/plugins/src/harper-fabric/skills/harper-resources/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-resources/SKILL.md
@@ -70,8 +70,9 @@ jsResource:
 ```
 
 Resources can also be registered programmatically with `server.resources.set()`.
-See [[harper-config-yaml]] for the extension wiring and [[harper-schema-graphql]]
-for how the schema defines the tables resources extend.
+See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] for
+how the schema defines the tables resources extend, and [[harper-realtime]] when
+`subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
 ## Project conventions (TS is source)
 


### PR DESCRIPTION
## Summary
- Add `harper-realtime` to the Harper Fabric skill pack, covering MQTT topics, resource WebSocket subscriptions, publish/subscribe handlers, config wiring, Fabric notes, and local verification commands.
- Cross-link real-time guidance from `harper-resources` and `harper-config-yaml`.
- Rebuild Harper Fabric plugin variants from `plugins/src`.

Closes #1244

## Verification
- `bun run build:plugins`
- `bun run check:plugins`
- pre-commit hook: `tsc --noEmit`, `prettier --write` via lint-staged, gitleaks
- pre-push hook: slow lint, `knip`, `vitest run --coverage`, `vitest run tests/integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified REST endpoint capabilities to include WebSocket subscriptions.
  * Added comprehensive real-time behavior guide covering MQTT topics, WebSocket subscriptions, and transport selection.
  * Enhanced configuration guidance for enabling real-time features in components.
  * Added cross-references to real-time documentation across resource guides.
* **New Features**
  * Added OpenAI agent support for real-time troubleshooting assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->