### PR TITLE
docs(wiki): ingest Lisa wiki state

### DIFF
--- a/wiki/architecture/template-governance.md
+++ b/wiki/architecture/template-governance.md
@@ -15,6 +15,8 @@ Lisa distributes standards to downstream projects through template families and 
 
 Template families observed in the monorepo include all, TypeScript, Expo, NestJS, CDK, Rails, tsconfig, oxlint, and plugin-related assets.
 
+Recent additions extend the template surface to Phaser 4 and Harper Fabric. Phaser now has a stack pack with plugin metadata, templates, detection, and lint enforcement. Harper Fabric templates now include deploy workflow parity, generated-artifact edit guards, config-extension drop guards, and realtime skill support.
+
 ## Practical Rule
 
 When updating Lisa templates, preserve the strategy contract. A downstream project may rely on Lisa overwriting one file while preserving another.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by connector ingest on 2026-06-11 for Lisa `2.159.7` and current monorepo provenance through PR `#1241`.
+Last updated by connector ingest on 2026-06-12 for Lisa `2.165.0` and current monorepo provenance through PR `#1280`.
 
 ## Orientation
 
@@ -12,7 +12,7 @@ Last updated by connector ingest on 2026-06-11 for Lisa `2.159.7` and current mo
 
 - [Project Registry](projects/registry.md)
 - [Lisa Monorepo Snapshot](projects/lisa-monorepo.md)
-  - Current package version: `2.159.7`; latest captured merged PR: `#1241`.
+  - Current package version: `2.165.0`; latest captured merged PR: `#1280`.
 
 ## Documentation
 
@@ -30,6 +30,7 @@ Last updated by connector ingest on 2026-06-11 for Lisa `2.159.7` and current mo
 
 - [Lisa Architecture](architecture/lisa-architecture.md)
 - [Template Governance](architecture/template-governance.md)
+  - Current template surface includes Phaser 4 and Harper Fabric workflow/realtime guard additions.
 - [Coding-Agent Parity Architecture](architecture/coding-agent-parity.md)
 - [Lisa Hook Per-Agent Ship List](architecture/lisa-hook-per-agent-ship-list.md)
 - [Pattern B Per-Agent Plugin Fan-Out Specification](architecture/pattern-b-fan-out-spec.md)
@@ -46,6 +47,7 @@ Last updated by connector ingest on 2026-06-11 for Lisa `2.159.7` and current mo
 ## Playbooks
 
 - [Lisa Workflow Playbook](playbooks/lisa-workflow-playbook.md)
+  - Codex repair-intake defaults, hook-write nudges, oxlint edit-time lint, and bootstrapper build-context guards are captured here.
 - [Coding-Agent Parity Research Playbook](playbooks/coding-agent-parity-research.md)
 
 ## Concepts

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,14 @@
 # Lisa Wiki Log
 
+## 2026-06-12 - Incremental connector ingest
+
+- Synced the automation worktree with `origin/main` by fetching `origin` and created `wiki/ingest-20260612T000000Z` from current `origin/main` because the run started on a detached HEAD.
+- Ran the enabled non-external-write connector set in `wiki/lisa-wiki.config.json`: `git` and `roles`; `memory` was checked and skipped because no project-scoped Claude memory directory exists for `/Users/codysai/.codex/worktrees/9faa/lisa`, while global Codex memory remains out of scope.
+- No same-day git or roles source notes existed for `2026-06-12`, so no prior source provenance copy was needed before writing current connector notes.
+- Refreshed the `git` source note with 63 new commits through `f4278cbd2b796440fc943970c2c79cfedce3ca14`, advanced the merged-PR cursor to `#1280`, and captured the release line through Lisa `2.165.0`.
+- Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
+- Updated the monorepo snapshot, template governance, workflow playbook, and index for Codex repair-intake exposure, Harper Fabric deploy/realtime and generated-artifact guards, Phaser 4 stack support, bootstrapper and hook hardening, Expo knip ignore metadata, and release-history changes through `2.165.0`.
+
 ## 2026-06-10 - Incremental connector ingest
 
 - Synced the automation worktree with `origin/main` by fetching `origin` and created `wiki/ingest-20260610T000000Z` from current `origin/main` because the run started on a detached HEAD.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -64,6 +64,12 @@ Repair intake treats work as stuck after a two-hour threshold and records PR or 
 
 Build intake distinguishes container issues from leaf issues by both type and child state. Epics and parent Stories remain rollup containers when they have child work, but a childless Story or Spike can be treated as a buildable leaf when it is otherwise ready for a single-repository implementation lane.
 
+Codex has a local Lisa repair-intake skill surface. A bare `$lisa-repair-intake` trigger should use the current repo configuration and established defaults, including `github intake_mode=both` where that is the configured queue lane, instead of asking the operator to restate the queue.
+
+## Hook And Bootstrapper Guards
+
+Lisa hook defenses now tokenize no-verify guard input, detect shell writes including plain `tee`, nudge Codex away from shell-based file writes, and use `oxlint` for edit-time lint where applicable. Bootstrapper behavior is guarded in noninteractive build contexts and covered for second-apply convergence so generated installs do not hang or diverge during CI/package workflows.
+
 ## Quality Gate Habit
 
 Before shipping Lisa changes, expect local hooks and CI to run typecheck, formatting, linting, slow lint, dead-code detection, tests, coverage, security audit, and integration checks depending on the action.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -26,7 +26,7 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 - Total commits on HEAD: 3146
 - Latest merged PR captured in the incremental git snapshot: `#1280`
 - New commits since the previous incremental git cursor: `63`
-- Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists for `/Users/codysai/.codex/worktrees/9faa/lisa`; global Codex memory remains out of scope.
+- Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,16 +20,33 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-20260611T000000Z` created from detached `origin/main` HEAD
-- HEAD at 2026-06-11 incremental ingest: `f09469adb26fe433abedd62ede613b395e25ec4f`
-- Current package version: `2.159.7`
-- Total commits on HEAD: 3083
-- Latest merged PR captured in the incremental git snapshot: `#1241`
-- New commits since the previous incremental git cursor: `12`
-- Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists for `/Users/codysai/.codex/worktrees/058c/lisa`; global Codex memory remains out of scope.
+- Ingest branch: `wiki/ingest-20260612T000000Z` created from detached `origin/main` HEAD
+- HEAD at 2026-06-12 incremental ingest: `f4278cbd2b796440fc943970c2c79cfedce3ca14`
+- Current package version: `2.165.0`
+- Total commits on HEAD: 3146
+- Latest merged PR captured in the incremental git snapshot: `#1280`
+- New commits since the previous incremental git cursor: `63`
+- Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists for `/Users/codysai/.codex/worktrees/9faa/lisa`; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
+- Release automation advanced the monorepo through `2.165.0`.
+- PR `#1280` added a Harper Fabric realtime skill.
+- PR `#1279` moved edit-time hook linting to `oxlint`.
+- PR `#1278` added Codex shell-write nudges and broadened hook detection for plain `tee` writes while suppressing read-only inline-runtime false positives.
+- PR `#1277` added `shell-quote` to the Expo knip ignore-dependencies template.
+- PR `#1276` clarified sync-down conflict patterns.
+- PR `#1275` tokenizes the no-verify guard input before detecting bypass attempts.
+- PR `#1274` guards the bootstrapper in noninteractive build contexts and made the build-context test deterministic.
+- PR `#1273` renamed the package metadata knip script to `knip:check` and added a remove section.
+- PR `#1272` added regression coverage for bootstrapper second-apply convergence.
+- PR `#1271` made the pre-push bun audit gate filter exclusions reliably.
+- PR `#1260` guards Harper config extension drops and handles malformed YAML in that enforcement hook.
+- PR `#1258` blocks Harper generated artifact edits.
+- PR `#1257` added a Phaser 4 stack pack with plugin metadata, templates, detection, and lint enforcement.
+- PR `#1256` added Harper Fabric deploy workflow parity.
+- PR `#1242` merged the prior wiki ingestion through Lisa `2.159.7`.
+- PR `#1240` exposed the Lisa repair-intake skill to Codex and clarified bare-trigger defaults.
 - Release automation advanced the monorepo through `2.159.7`.
 - PR `#1241` preserves host-owned Lisa config fields during postinstall apply by keeping configured wiki and tracker values intact across copy-overwrite, JSON merge, and package metadata strategies.
 - PR `#1238` requires executed end-to-end regression proof for user-facing workflow changes in TDD and verification lifecycle skills, with scoped exceptions documented when an E2E run is not applicable.

--- a/wiki/sources/git/2026-06-12-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-06-12-lisa-monorepo-git.md
@@ -1,0 +1,109 @@
+---
+type: source
+created: 2026-06-12
+updated: 2026-06-12
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history — lisa-monorepo (2026-06-12)
+
+- Repo: `/Users/codysai/.codex/worktrees/9faa/lisa`
+- HEAD: `f4278cbd2b796440fc943970c2c79cfedce3ca14`
+- Total commits on HEAD: 3146
+- New commits since last ingest (`f09469adb26fe433abedd62ede613b395e25ec4f`): 63
+- Merged PRs since last cursor: `#1240`, `#1242`, `#1256`, `#1257`, `#1258`, `#1260`, `#1271`, `#1272`, `#1273`, `#1274`, `#1275`, `#1276`, `#1277`, `#1278`, `#1279`, `#1280`; latest #1280 "feat(harper-fabric): add realtime skill"
+
+## New commits
+- f4278cbd · 2026-06-12 · chore(release): 2.165.0 [skip ci]
+- 8d917520 · 2026-06-12 · Merge pull request #1280 from CodySwannGT/codex/issue-1244-harper-realtime-skill
+- 0b8e607b · 2026-06-12 · feat(harper-fabric): add realtime skill
+- 4b83b3f9 · 2026-06-12 · chore(release): 2.164.1 [skip ci]
+- 868a95ad · 2026-06-11 · Merge pull request #1279 from CodySwannGT/codex/issue-1265-lint-on-edit-oxlint
+- 589a1d28 · 2026-06-11 · fix(hooks): use oxlint for edit-time lint
+- b0b48ac9 · 2026-06-12 · chore(release): 2.164.0 [skip ci]
+- 677f1a44 · 2026-06-11 · Merge pull request #1278 from CodySwannGT/codex/1266-shell-write-nudge
+- 6b8814da · 2026-06-12 · fix(hooks): catch plain tee writes and suppress read-only inline-runtime false positives
+- a9249246 · 2026-06-12 · Merge branch 'main' into codex/1266-shell-write-nudge
+- 831b2e14 · 2026-06-11 · feat(codex): nudge on shell writes
+- 460a7a47 · 2026-06-12 · chore(release): 2.163.7 [skip ci]
+- 5403de2c · 2026-06-11 · Merge pull request #1277 from CodySwannGT/fix/expo-knip-ignore-shell-quote
+- 43acf3a7 · 2026-06-11 · fix(expo): add shell-quote to knip ignoreDependencies template
+- 83d6525e · 2026-06-12 · chore(release): 2.163.6 [skip ci]
+- 66deef23 · 2026-06-11 · Merge pull request #1276 from CodySwannGT/codex/1267-sync-down-conflict-patterns
+- 603a392b · 2026-06-11 · docs: clarify sync-down conflict patterns
+- 62d3bfd0 · 2026-06-11 · chore(release): 2.163.5 [skip ci]
+- 89e5b46d · 2026-06-11 · Merge pull request #1275 from CodySwannGT/fix/1268-tokenize-block-no-verify
+- ef62ea0c · 2026-06-11 · Merge branch 'main' into fix/1268-tokenize-block-no-verify
+- 37a79045 · 2026-06-11 · fix(hooks): tokenize no-verify guard input
+- bc117322 · 2026-06-11 · chore(release): 2.163.4 [skip ci]
+- fe366a96 · 2026-06-11 · Merge pull request #1274 from CodySwannGT/codex/1269-bootstrapper-noninteractive-guard
+- cdb73417 · 2026-06-11 · test: make bootstrap guard test deterministic via env stub
+- 65be62b7 · 2026-06-11 · fix: guard bootstrapper in build contexts
+- 263dd361 · 2026-06-11 · chore(release): 2.163.3 [skip ci]
+- 496bc8fa · 2026-06-11 · Merge pull request #1273 from CodySwannGT/fix/knip-script-shadow-bin
+- d72e351b · 2026-06-11 · fix(package-lisa): rename knip script to knip:check and add remove section
+- 1d0c5265 · 2026-06-11 · chore(release): 2.163.2 [skip ci]
+- 5cc13e16 · 2026-06-11 · Merge pull request #1272 from CodySwannGT/codex/1270-bootstrapper-idempotency
+- cf567e23 · 2026-06-11 · test: guard bootstrapper second apply convergence
+- 2bdcdcec · 2026-06-11 · chore(release): 2.163.1 [skip ci]
+- e90ac8b3 · 2026-06-11 · Merge pull request #1271 from CodySwannGT/fix/pre-push-bun-audit-ignore
+- a8888713 · 2026-06-11 · fix(husky): make pre-push bun audit gate filter exclusions reliably
+- a5d05bbe · 2026-06-11 · chore(release): 2.163.0 [skip ci]
+- 15f4991d · 2026-06-11 · Merge pull request #1260 from CodySwannGT/codex/1253-harper-config-extension-guard
+- e19be494 · 2026-06-11 · fix: handle malformed YAML in enforce-config-extensions hook
+- 5969713b · 2026-06-11 · feat: guard harper config extension drops
+- 1ed58a50 · 2026-06-11 · chore(release): 2.162.0 [skip ci]
+- 0bbd57c5 · 2026-06-11 · Merge pull request #1257 from CodySwannGT/claude/pedantic-bell-c4b3b8
+- be11926e · 2026-06-11 · Merge remote-tracking branch 'origin/claude/pedantic-bell-c4b3b8' into claude/pedantic-bell-c4b3b8
+- 57e43b0a · 2026-06-11 · chore(release): 2.161.0 [skip ci]
+- d7a754a6 · 2026-06-11 · Merge branch 'main' into claude/pedantic-bell-c4b3b8
+- 1bf2b3fc · 2026-06-11 · Merge pull request #1258 from CodySwannGT/codex/1254-harper-generated-artifact-guard
+- 101bbdb4 · 2026-06-11 · Merge branch 'claude/pedantic-bell-c4b3b8' of https://github.com/CodySwannGT/lisa into claude/pedantic-bell-c4b3b8
+- 149d4027 · 2026-06-11 · fix(phaser): remove conflicting --check flag from format script
+- 28c5e591 · 2026-06-11 · fix(phaser): re-stamp plugin artifacts at v2.160.0 after main merge + clarify skill provenance
+- a0f0a18a · 2026-06-11 · feat: block harper generated artifact edits
+- e50370b7 · 2026-06-11 · Merge remote-tracking branch 'origin/main' into claude/pedantic-bell-c4b3b8
+- 83adbf0a · 2026-06-11 · Merge branch 'main' into claude/pedantic-bell-c4b3b8
+- d9f8f683 · 2026-06-11 · feat(phaser): add Phaser 4 stack pack (plugin, templates, detection, lint enforcement)
+- a79d29af · 2026-06-11 · chore(release): 2.160.0 [skip ci]
+- 87ffcf53 · 2026-06-11 · Merge pull request #1256 from CodySwannGT/codex/1255-harper-fabric-ci-parity
+- e6533735 · 2026-06-11 · feat: add harper fabric deploy workflows
+- 012894b6 · 2026-06-11 · chore(release): 2.159.9 [skip ci]
+- 7852db1d · 2026-06-11 · Merge pull request #1240 from codysai001/codex/add-lisa-repair-intake-skill
+- ef5f0cc5 · 2026-06-11 · fix(codex): clarify repair intake default invocation
+- 8ae1ee77 · 2026-06-11 · chore(release): 2.159.8 [skip ci]
+- b860e3d9 · 2026-06-11 · Merge branch 'main' into codex/add-lisa-repair-intake-skill
+- d5dadbd1 · 2026-06-11 · Merge pull request #1242 from codysai001/wiki/ingest-20260611T000000Z
+- e518def1 · 2026-06-11 · docs(wiki): ingest Lisa wiki state
+- 513d4aff · 2026-06-11 · Merge branch 'main' into codex/add-lisa-repair-intake-skill
+- 84f8c633 · 2026-06-10 · fix(codex): expose lisa repair intake skill
+
+## Merged PRs captured
+
+- #1280 · 2026-06-12T04:15:11Z · `codex/issue-1244-harper-realtime-skill` · feat(harper-fabric): add realtime skill
+- #1279 · 2026-06-12T03:09:34Z · `codex/issue-1265-lint-on-edit-oxlint` · fix(hooks): use oxlint for edit-time lint
+- #1278 · 2026-06-12T01:31:42Z · `codex/1266-shell-write-nudge` · feat(codex): nudge on shell writes
+- #1277 · 2026-06-12T01:00:29Z · `fix/expo-knip-ignore-shell-quote` · fix(expo): add shell-quote to knip ignoreDependencies template
+- #1276 · 2026-06-12T00:05:33Z · `codex/1267-sync-down-conflict-patterns` · docs: clarify sync-down conflict patterns
+- #1275 · 2026-06-11T23:10:07Z · `fix/1268-tokenize-block-no-verify` · fix(hooks): tokenize no-verify guard input
+- #1274 · 2026-06-11T22:22:40Z · `codex/1269-bootstrapper-noninteractive-guard` · fix: guard bootstrapper in build contexts
+- #1273 · 2026-06-11T21:34:48Z · `fix/knip-script-shadow-bin` · fix(package-lisa): rename knip script to knip:check and add remove section
+- #1272 · 2026-06-11T21:13:27Z · `codex/1270-bootstrapper-idempotency` · test: guard bootstrapper second apply convergence
+- #1271 · 2026-06-11T20:43:36Z · `fix/pre-push-bun-audit-ignore` · fix(husky): make pre-push bun audit gate filter exclusions reliably
+- #1260 · 2026-06-11T13:37:56Z · `codex/1253-harper-config-extension-guard` · feat: guard Harper config extension drops
+- #1258 · 2026-06-11T12:12:31Z · `codex/1254-harper-generated-artifact-guard` · feat: block Harper generated artifact edits
+- #1257 · 2026-06-11T12:17:41Z · `claude/pedantic-bell-c4b3b8` · feat(phaser): add Phaser 4 stack pack (plugin, templates, detection, lint enforcement)
+- #1256 · 2026-06-11T11:09:48Z · `codex/1255-harper-fabric-ci-parity` · feat: add Harper Fabric deploy workflows
+- #1242 · 2026-06-11T06:55:33Z · `wiki/ingest-20260611T000000Z` · docs(wiki): ingest Lisa wiki state
+- #1240 · 2026-06-11T07:07:24Z · `codex/add-lisa-repair-intake-skill` · [codex] expose Lisa repair intake skill
+
+## Changed surface
+
+- Lisa advanced from `2.159.7` through `2.165.0`.
+- Codex now exposes the Lisa repair-intake skill with clearer bare-trigger defaults.
+- Harper Fabric gained deploy workflow parity, generated-artifact and config-extension guards, and a realtime skill.
+- Phaser 4 support now ships as a stack pack with plugin metadata, templates, detection, lint enforcement, and corrected format-script behavior.
+- Bootstrapper, package metadata, hook, and audit gates were hardened around noninteractive build contexts, idempotent second apply, knip script naming, bun audit exclusions, no-verify parsing, shell-write nudges, and oxlint edit-time linting.

--- a/wiki/sources/roles/2026-06-12-roles.md
+++ b/wiki/sources/roles/2026-06-12-roles.md
@@ -1,0 +1,18 @@
+---
+type: source
+created: 2026-06-12
+updated: 2026-06-12
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-06-12)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+_(no roles declared in config.staff[])_
+
+## Staff pages
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-06-11T06:47:11Z",
+  "ingested_at": "2026-06-12T06:46:50.949Z",
   "cursor": {
-    "lastCommit": "f09469adb26fe433abedd62ede613b395e25ec4f",
-    "lastPr": 1241
+    "lastCommit": "f4278cbd2b796440fc943970c2c79cfedce3ca14",
+    "lastPr": 1280
   },
   "source_notes": [
-    "wiki/sources/git/2026-06-11-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-06-12-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-06-11T06:47:11Z",
+  "ingested_at": "2026-06-12T06:46:50.441Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-06-11"
+    "lastIngest": "2026-06-12"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-06-11-roles.md"
+    "wiki/sources/roles/2026-06-12-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- ingest Lisa git history through 2.165.0 / PR #1280
- refresh git and roles source notes plus state cursors
- update wiki synthesis for Codex repair-intake, Harper Fabric, Phaser 4, and hook/bootstrapper guardrails

## Verification
- git diff --check
- node plugins/lisa-wiki-cursor/scripts/verify-wiki-safety.mjs --wiki wiki
- node plugins/lisa-wiki-cursor/scripts/lint-wiki.mjs --wiki wiki --config wiki/lisa-wiki.config.json (existing warnings only)
- commit hook: tsc --noEmit, lint-staged prettier
- pre-push hook: bun audit gate, eslint slow config, knip, vitest run --coverage, vitest run tests/integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Template governance updated to cover Phaser 4 and Harper Fabric template surface and capabilities.
  * Workflow playbook enhanced with repair-intake guidance, hook/bootstrapper guards, and edit-time lint/guard behavior.
  * Project metadata bumped to release 2.165.0 and repository snapshot/merge history refreshed.
  * New incremental ingest/log entry, updated git history snapshot, added roles source note, and refreshed state snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->