### PR TITLE
fix(hooks): allow lint-ignored edit files

### DIFF
--- a/plugins/lisa-typescript-copilot/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript-copilot/hooks/lint-on-edit.sh
@@ -79,6 +79,12 @@ echo "Running oxlint on: $FILE_PATH"
 OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
+    case "$OX_OUTPUT" in
+        *"No files found to lint"* | *" on 0 files"* | *" on 0 file"*)
+            echo "oxlint: Ignored by lint config: $FILE_PATH"
+            exit 0
+            ;;
+    esac
     echo "oxlint found errors in: $FILE_PATH" >&2
     echo "$OX_OUTPUT" >&2
     exit 2

--- a/plugins/lisa-typescript-cursor/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript-cursor/hooks/lint-on-edit.sh
@@ -79,6 +79,12 @@ echo "Running oxlint on: $FILE_PATH"
 OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
+    case "$OX_OUTPUT" in
+        *"No files found to lint"* | *" on 0 files"* | *" on 0 file"*)
+            echo "oxlint: Ignored by lint config: $FILE_PATH"
+            exit 0
+            ;;
+    esac
     echo "oxlint found errors in: $FILE_PATH" >&2
     echo "$OX_OUTPUT" >&2
     exit 2

--- a/plugins/lisa-typescript/hooks/lint-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/lint-on-edit.sh
@@ -79,6 +79,12 @@ echo "Running oxlint on: $FILE_PATH"
 OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
+    case "$OX_OUTPUT" in
+        *"No files found to lint"* | *" on 0 files"* | *" on 0 file"*)
+            echo "oxlint: Ignored by lint config: $FILE_PATH"
+            exit 0
+            ;;
+    esac
     echo "oxlint found errors in: $FILE_PATH" >&2
     echo "$OX_OUTPUT" >&2
     exit 2

--- a/plugins/src/typescript/hooks/lint-on-edit.sh
+++ b/plugins/src/typescript/hooks/lint-on-edit.sh
@@ -79,6 +79,12 @@ echo "Running oxlint on: $FILE_PATH"
 OX_OUTPUT=$($OXLINT_CMD --quiet "$FILE_PATH" 2>&1)
 OX_EXIT=$?
 if [ $OX_EXIT -ne 0 ]; then
+    case "$OX_OUTPUT" in
+        *"No files found to lint"* | *" on 0 files"* | *" on 0 file"*)
+            echo "oxlint: Ignored by lint config: $FILE_PATH"
+            exit 0
+            ;;
+    esac
     echo "oxlint found errors in: $FILE_PATH" >&2
     echo "$OX_OUTPUT" >&2
     exit 2

--- a/src/codex/scripts/lint-on-edit.sh
+++ b/src/codex/scripts/lint-on-edit.sh
@@ -31,7 +31,18 @@ while IFS= read -r FILE_PATH; do
     ts | tsx | js | jsx | mjs | cjs) ;;
     *) continue ;;
   esac
-  "$OXLINT" --quiet "${FILE_PATH}" || STATUS=1
+  OX_OUTPUT=$("$OXLINT" --quiet "${FILE_PATH}" 2>&1)
+  OX_EXIT=$?
+  if [ "$OX_EXIT" -eq 0 ]; then
+    continue
+  fi
+  case "$OX_OUTPUT" in
+    *"No files found to lint"* | *" on 0 files"* | *" on 0 file"*)
+      continue
+      ;;
+  esac
+  echo "$OX_OUTPUT" >&2
+  STATUS=1
 done <<EOF
 $(lisa_extract_edit_paths "$JSON_INPUT")
 EOF

--- a/src/opencode/plugin-templates/lisa-lint-on-edit.ts
+++ b/src/opencode/plugin-templates/lisa-lint-on-edit.ts
@@ -44,6 +44,13 @@ export const LisaLintOnEdit = async ({
       if (res.exitCode === 0) return;
       const out =
         `${res.stdout?.toString() ?? ""}${res.stderr?.toString() ?? ""}`.trim();
+      if (
+        out.includes("No files found to lint") ||
+        out.includes(" on 0 files") ||
+        out.includes(" on 0 file")
+      ) {
+        return;
+      }
       throw new Error(
         `lint-on-edit: oxlint reported problems in ${filePath}:\n${out}`
       );

--- a/tests/unit/hooks/lint-on-edit.test.ts
+++ b/tests/unit/hooks/lint-on-edit.test.ts
@@ -66,13 +66,50 @@ describe("lint-on-edit hooks", () => {
     expect(readLog(project)).toContain(`oxlint --quiet ${sourcePath}`);
     expect(readLog(project)).not.toContain("eslint");
   });
+
+  it("treats oxlint zero-file matches as pass for Codex edit hooks", () => {
+    const project = createProject({
+      oxlintBody:
+        'printf "No files found to lint\\nFinished in 3ms on 0 files with 159 rules\\n" >&2\nexit 1\n',
+    });
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const result = spawnSync(BASH_PATH, [CODEX_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      input: JSON.stringify({
+        tool_name: "Edit",
+        tool_input: { file_path: sourcePath },
+      }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("treats oxlint zero-file matches as pass for TypeScript-stack edit hooks", () => {
+    const project = createProject({
+      oxlintBody:
+        'printf "No files found to lint\\nFinished in 3ms on 0 files with 159 rules\\n" >&2\nexit 1\n',
+    });
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const result = spawnSync(BASH_PATH, [TYPESCRIPT_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+      input: JSON.stringify({ tool_input: { file_path: sourcePath } }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Ignored by lint config");
+  });
 });
 
 /**
  * Create a temp project with fake local linter binaries.
+ * @param options - Fake binary configuration.
+ * @param options.oxlintBody - Shell body for the fake oxlint binary.
  * @returns The temp project root.
  */
-function createProject(): string {
+function createProject(options: { oxlintBody?: string } = {}): string {
   const project = mkdtempSync(path.join(tmpdir(), "lisa-lint-on-edit-"));
   tempDirs.push(project);
   mkdirSync(path.join(project, "src"), { recursive: true });
@@ -85,7 +122,7 @@ function createProject(): string {
   writeBin(
     project,
     "oxlint",
-    'printf \'oxlint %s\\n\' "$*" >> "$PWD/lint.log"\n'
+    options.oxlintBody ?? 'printf \'oxlint %s\\n\' "$*" >> "$PWD/lint.log"\n'
   );
   writeBin(
     project,


### PR DESCRIPTION
## Summary
- Treat oxlint zero-file/no-match output as an ignored-file pass in Codex and TypeScript edit-time hooks
- Mirror the behavior in the OpenCode lint-on-edit template
- Add regression tests for Codex and TypeScript hook zero-file output

Fixes #1263

## Verification
- bun test tests/unit/hooks/lint-on-edit.test.ts
- bun run build
- bun run check:plugins
- pre-push hook: slow lint, knip, unit coverage, integration tests