### PR TITLE
chore(security): exclude esbuild GHSA-gv7w-rqvm-qjhr from audit template

### DIFF
--- a/typescript/copy-overwrite/audit.ignore.config.json
+++ b/typescript/copy-overwrite/audit.ignore.config.json
@@ -141,12 +141,17 @@
     {
       "id": "GHSA-v39h-62p7-jpjc",
       "package": "fast-uri",
-      "reason": "Host confusion via percent-encoded authority delimiters in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time — its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+      "reason": "Host confusion via percent-encoded authority delimiters in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time \u2014 its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
     },
     {
       "id": "GHSA-q3j6-qgpj-74h6",
       "package": "fast-uri",
-      "reason": "Path traversal via percent-encoded dot segments in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time — its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+      "reason": "Path traversal via percent-encoded dot segments in fast-uri parser. Reachable transitively via eslint > @eslint/eslintrc > ajv > fast-uri and (in CDK projects) via aws-cdk-lib's bundled JSON Schema validator. aws-cdk-lib is invoked only at build/synth/deploy time \u2014 its ajv usage validates CloudFormation/CDK schemas authored by the developer, not attacker-controlled URIs. No runtime/production code path passes attacker-controlled URIs through ajv schema validation that relies on fast-uri parsing."
+    },
+    {
+      "id": "GHSA-gv7w-rqvm-qjhr",
+      "package": "esbuild",
+      "reason": "Missing binary integrity verification in esbuild's Deno install module enables RCE via a malicious NPM_CONFIG_REGISTRY. esbuild is dev/build-time only \u2014 transitive via tsx, vitest, and esbuild-register \u2014 and is never in a shipped bundle or runtime code path. Lisa-managed projects install via bun/npm (not the Deno module path) and do not use attacker-controlled NPM_CONFIG_REGISTRY at install. Remove once the tsx/vitest/esbuild-register chain bumps esbuild >= 0.28.1."
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds `GHSA-gv7w-rqvm-qjhr` (esbuild) to the shared audit-ignore template (`typescript/copy-overwrite/audit.ignore.config.json`) so every Lisa-managed project inherits the exclusion.

## Why
The advisory was freshly published and immediately started failing the `bun audit` pre-push guardrail hook across managed projects (first hit in geminisportsai/frontend-v2). The vuln is in esbuild's **Deno install module** (missing binary integrity verification → RCE via a malicious `NPM_CONFIG_REGISTRY`). It does not apply to Lisa projects:
- esbuild is **dev/build-time only** — transitive via `tsx`, `vitest`, and `esbuild-register`; it never ships in a runtime bundle.
- Projects install via bun/npm, **not** the Deno module path, and don't use attacker-controlled `NPM_CONFIG_REGISTRY` at install.

Remove once the `tsx`/`vitest`/`esbuild-register` chain bumps esbuild >= 0.28.1.

## Note
frontend-v2 carries the same exclusion in its project-owned `audit.ignore.local.json` for the immediate unblock; this template change is the durable cross-project fix. The two coexist harmlessly (the hook dedupes by id; the local-exclusions migration won't relocate an id once it's in the template).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit configurations to refine vulnerability assessment models and add new exclusion criteria for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->