### PR TITLE
docs(wiki): ingest Lisa wiki state

### DIFF
--- a/wiki/architecture/template-governance.md
+++ b/wiki/architecture/template-governance.md
@@ -17,6 +17,8 @@ Template families observed in the monorepo include all, TypeScript, Expo, NestJS
 
 Recent additions extend the template surface to Phaser 4 and Harper Fabric. Phaser now has a stack pack with plugin metadata, templates, detection, and lint enforcement. Harper Fabric templates now include deploy workflow parity, generated-artifact edit guards, config-extension drop guards, and realtime skill support.
 
+The shared TypeScript audit-ignore template carries the esbuild `GHSA-gv7w-rqvm-qjhr` exclusion as of PR `#1287`. This keeps Lisa-managed downstream projects from failing the bun audit pre-push gate for the esbuild Deno install module advisory when their exposure is dev/build-time tooling through bun/npm dependency chains. Remove the template exclusion once the transitive `tsx`, `vite`, `vitest`, and `esbuild-register` chain reaches esbuild `>=0.28.1`.
+
 ## Practical Rule
 
 When updating Lisa templates, preserve the strategy contract. A downstream project may rely on Lisa overwriting one file while preserving another.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # Lisa Wiki Index
 
-Last updated by connector ingest on 2026-06-13 for Lisa `2.165.4` and current monorepo provenance through PR `#1284`.
+Last updated by connector ingest on 2026-06-14 for Lisa `2.165.6` and current monorepo provenance through PR `#1287`.
 
 ## Orientation
 
@@ -12,7 +12,7 @@ Last updated by connector ingest on 2026-06-13 for Lisa `2.165.4` and current mo
 
 - [Project Registry](projects/registry.md)
 - [Lisa Monorepo Snapshot](projects/lisa-monorepo.md)
-  - Current package version: `2.165.4`; latest captured merged PR: `#1284`.
+  - Current package version: `2.165.6`; latest captured merged PR: `#1287`.
 
 ## Documentation
 
@@ -30,7 +30,7 @@ Last updated by connector ingest on 2026-06-13 for Lisa `2.165.4` and current mo
 
 - [Lisa Architecture](architecture/lisa-architecture.md)
 - [Template Governance](architecture/template-governance.md)
-  - Current template surface includes Phaser 4 and Harper Fabric workflow/realtime guard additions.
+  - Current template surface includes Phaser 4, Harper Fabric workflow/realtime guard additions, and the esbuild audit-ignore template exclusion.
 - [Coding-Agent Parity Architecture](architecture/coding-agent-parity.md)
 - [Lisa Hook Per-Agent Ship List](architecture/lisa-hook-per-agent-ship-list.md)
 - [Pattern B Per-Agent Plugin Fan-Out Specification](architecture/pattern-b-fan-out-spec.md)
@@ -47,7 +47,7 @@ Last updated by connector ingest on 2026-06-13 for Lisa `2.165.4` and current mo
 ## Playbooks
 
 - [Lisa Workflow Playbook](playbooks/lisa-workflow-playbook.md)
-  - Codex repair-intake defaults, hook-write nudges, oxlint edit-time lint, lint-ignored file handling, executable plugin hooks, and bootstrapper build-context guards are captured here.
+  - Codex repair-intake defaults, hook-write nudges, oxlint edit-time lint, lint-ignored file handling, executable plugin hooks, bootstrapper build-context guards, and shared audit-ignore promotion guidance are captured here.
 - [Coding-Agent Parity Research Playbook](playbooks/coding-agent-parity-research.md)
 
 ## Concepts

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,14 @@
 # Lisa Wiki Log
 
+## 2026-06-14 - Incremental connector ingest
+
+- Synced the automation worktree with `origin/main` by fetching `origin` and created `wiki/ingest-20260614T000000Z` from current `origin/main` because the run started on a detached HEAD.
+- Ran the enabled non-external-write connector set in `wiki/lisa-wiki.config.json`: `git` and `roles`; project-scoped memory remained skipped because no eligible project-scoped Claude memory directory exists for this worktree, while global Codex memory remains out of scope.
+- No same-day git or roles source notes existed for `2026-06-14`, so no provenance preservation copy was needed before writing the new connector notes.
+- Refreshed the `git` source note with 7 new commits through `4bd9a9b749fa26376a5bfdd4d84cb1cb9fb51b93`, advanced the merged-PR cursor to `#1287`, and captured the release line through Lisa `2.165.6`.
+- Refreshed the `roles` source note with 0 declared roles and 0 staff pages.
+- Updated the monorepo snapshot, template governance, workflow playbook, and index for the prior wiki ingest merge, durable esbuild `GHSA-gv7w-rqvm-qjhr` audit-ignore template exclusion, and release-history changes through `2.165.6`.
+
 ## 2026-06-12 - Incremental connector ingest
 
 - Synced the automation worktree with `origin/main` by fetching `origin` and created `wiki/ingest-20260612T000000Z` from current `origin/main` because the run started on a detached HEAD.

--- a/wiki/playbooks/lisa-workflow-playbook.md
+++ b/wiki/playbooks/lisa-workflow-playbook.md
@@ -76,4 +76,6 @@ Plugin hook scripts must retain executable bits in the published plugin payload 
 
 Before shipping Lisa changes, expect local hooks and CI to run typecheck, formatting, linting, slow lint, dead-code detection, tests, coverage, security audit, and integration checks depending on the action.
 
+Audit-ignore entries can be promoted into shared templates when a vulnerability is non-applicable across Lisa-managed projects and is causing routine gate failures. The esbuild `GHSA-gv7w-rqvm-qjhr` exclusion is the current example: it belongs in the TypeScript audit-ignore template until the build-tool dependency chain upgrades past the affected esbuild range.
+
 The wiki has a separate lint path. Normal ESLint defaults ignore `wiki/**`, while wiki integrity continues to be checked through the Lisa wiki lint scripts.

--- a/wiki/projects/lisa-monorepo.md
+++ b/wiki/projects/lisa-monorepo.md
@@ -20,16 +20,19 @@ The Lisa monorepo is the primary ingestion source for this wiki.
 
 ## Current Snapshot
 
-- Ingest branch: `wiki/ingest-20260613T000000Z` created from synced `origin/main`
-- HEAD at 2026-06-13 incremental ingest: `05853e6ce16319386f642adcc8a55fefbb3a0ec2`
-- Current package version: `2.165.4`
-- Total commits on HEAD: 3160
-- Latest merged PR captured in the incremental git snapshot: `#1284`
-- New commits since the previous incremental git cursor: `14`
+- Ingest branch: `wiki/ingest-20260614T000000Z` created from synced `origin/main`
+- HEAD at 2026-06-14 incremental ingest: `4bd9a9b749fa26376a5bfdd4d84cb1cb9fb51b93`
+- Current package version: `2.165.6`
+- Total commits on HEAD: 3167
+- Latest merged PR captured in the incremental git snapshot: `#1287`
+- New commits since the previous incremental git cursor: `7`
 - Project-scoped memory skipped this cycle because no eligible project-scoped Claude memory directory exists; global Codex memory remains out of scope.
 
 ## Recent Changes Since The 2026-05-14 Baseline
 
+- Release automation advanced the monorepo through `2.165.6`.
+- PR `#1287` added the esbuild `GHSA-gv7w-rqvm-qjhr` audit exclusion to the shared TypeScript audit-ignore template as a durable cross-project fix for a dev/build-time Deno install module advisory.
+- PR `#1285` merged the prior wiki ingestion through Lisa `2.165.4`.
 - Release automation advanced the monorepo through `2.165.4`.
 - PR `#1284` allows lint-ignored edit files to pass through edit-time lint handling.
 - PR `#1283` preserves executable bits for shipped plugin hook scripts.

--- a/wiki/sources/git/2026-06-14-lisa-monorepo-git.md
+++ b/wiki/sources/git/2026-06-14-lisa-monorepo-git.md
@@ -1,0 +1,38 @@
+---
+type: source
+created: 2026-06-14
+updated: 2026-06-14
+related: []
+sources: []
+source_system: git
+project: lisa-monorepo
+---
+
+# git history - lisa-monorepo (2026-06-14)
+
+- Repo: `.`
+- HEAD: `4bd9a9b749fa26376a5bfdd4d84cb1cb9fb51b93`
+- Total commits on HEAD: 3167
+- New commits since last ingest (`05853e6ce16319386f642adcc8a55fefbb3a0ec2`): 7
+- Merged PRs since last cursor: `#1285`, `#1287`; latest #1287 "chore(security): exclude esbuild GHSA-gv7w-rqvm-qjhr from audit template"
+
+## New commits
+
+- 4bd9a9b7 - 2026-06-13 - chore(release): 2.165.6 [skip ci]
+- 4f21d25a - 2026-06-13 - Merge pull request #1287 from CodySwannGT/chore/audit-exclude-esbuild
+- c68a75ae - 2026-06-13 - chore(security): exclude esbuild GHSA-gv7w-rqvm-qjhr from audit template
+- df3409fb - 2026-06-13 - chore(release): 2.165.5 [skip ci]
+- b1dd966a - 2026-06-13 - Merge pull request #1285 from CodySwannGT/wiki/ingest-20260613T000000Z
+- 61488cf1 - 2026-06-13 - fix(security): exclude esbuild GHSA-gv7w-rqvm-qjhr from audit
+- 8f1b9dc9 - 2026-06-13 - docs(wiki): ingest Lisa wiki state
+
+## Merged PRs captured
+
+- #1287 - 2026-06-13T12:07:28Z - `chore/audit-exclude-esbuild` - chore(security): exclude esbuild GHSA-gv7w-rqvm-qjhr from audit template
+- #1285 - 2026-06-13T06:59:45Z - `wiki/ingest-20260613T000000Z` - docs(wiki): ingest Lisa wiki state
+
+## Changed surface
+
+- Lisa advanced from `2.165.4` through `2.165.6`.
+- The prior wiki ingestion PR merged after all CI and CodeRabbit checks passed.
+- The shared TypeScript audit-ignore template now excludes `GHSA-gv7w-rqvm-qjhr` for the esbuild Deno install module advisory. The exclusion is scoped as a durable cross-project fix because Lisa-managed projects use esbuild as dev/build tooling through bun/npm dependency chains rather than the Deno install path, and the note should be removed once the transitive toolchain reaches esbuild `>=0.28.1`.

--- a/wiki/sources/roles/2026-06-14-roles.md
+++ b/wiki/sources/roles/2026-06-14-roles.md
@@ -1,0 +1,20 @@
+---
+type: source
+created: 2026-06-14
+updated: 2026-06-14
+related: []
+sources: []
+source_system: roles
+---
+
+# digital staff roster (2026-06-14)
+
+Declared roles: 0; staff doc pages: 0.
+
+## Roles
+
+_(no roles declared in config.staff[])_
+
+## Staff pages
+
+_(none)_

--- a/wiki/state/git/latest.json
+++ b/wiki/state/git/latest.json
@@ -1,12 +1,12 @@
 {
   "connector": "git",
   "profile": "lisa-monorepo",
-  "ingested_at": "2026-06-13T00:00:00Z",
+  "ingested_at": "2026-06-14T00:00:00Z",
   "cursor": {
-    "lastCommit": "05853e6ce16319386f642adcc8a55fefbb3a0ec2",
-    "lastPr": 1284
+    "lastCommit": "4bd9a9b749fa26376a5bfdd4d84cb1cb9fb51b93",
+    "lastPr": 1287
   },
   "source_notes": [
-    "wiki/sources/git/2026-06-13-lisa-monorepo-git.md"
+    "wiki/sources/git/2026-06-14-lisa-monorepo-git.md"
   ]
 }

--- a/wiki/state/roles/latest.json
+++ b/wiki/state/roles/latest.json
@@ -1,13 +1,13 @@
 {
   "connector": "roles",
   "profile": "project",
-  "ingested_at": "2026-06-13T00:00:00Z",
+  "ingested_at": "2026-06-14T00:00:00Z",
   "cursor": {
     "roles": 0,
     "pages": 0,
-    "lastIngest": "2026-06-13"
+    "lastIngest": "2026-06-14"
   },
   "source_notes": [
-    "wiki/sources/roles/2026-06-13-roles.md"
+    "wiki/sources/roles/2026-06-14-roles.md"
   ]
 }


### PR DESCRIPTION
## Summary
- ingest Lisa git and roles source notes through 2.165.6
- advance wiki cursors to PR #1287 / commit 4bd9a9b7
- document the durable esbuild GHSA-gv7w-rqvm-qjhr audit-ignore template exclusion

## Verification
- git diff --check
- node plugins/lisa-wiki/scripts/verify-wiki-safety.mjs --wiki-root wiki
- node plugins/lisa-wiki/scripts/lint-wiki.mjs --wiki-root wiki (existing warnings only)
- commit hook: tsc --noEmit + lint-staged Prettier
- pre-push hook: bun audit, eslint slow lint, knip, vitest run --coverage, vitest run tests/integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture governance templates with new audit-ignore guidance for managing security exclusions across managed projects.
  * Enhanced workflow playbooks to include quality gate best practices for promoting audit-ignore entries into shared templates when vulnerabilities are non-applicable across the ecosystem.

* **Chores**
  * Updated project metadata and activity logs to reflect latest ingestion cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->