### PR TITLE
test(hooks): pin non-mutating lint on edit

### DIFF
--- a/plugins/lisa-copilot/rules/eager/base-rules.md
+++ b/plugins/lisa-copilot/rules/eager/base-rules.md
@@ -17,7 +17,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 
 - Atomic commits with conventional commit messages.
 - Document the **why**, not the what.
-- Add new imports and their first usage in the same edit (the lint-on-edit hook strips unused imports).
+- Add new imports and their first usage in the same edit so lint-on-edit verification stays green.
 - Delete old code completely when replacing it. No deprecation comments unless asked.
 - Fix bugs at root cause. Never work around them or assume a failure is "pre-existing."
 - Test empirically. Never assume test expectations before observing actual behavior.

--- a/plugins/lisa-copilot/rules/reference/base-rules.md
+++ b/plugins/lisa-copilot/rules/reference/base-rules.md
@@ -36,7 +36,7 @@ Code Quality:
 - Make atomic commits with clear conventional commit messages.
 - Create clear documentation preambles for new code. Update preambles when modifying existing code.
 - Document the "why", not the "what". Code explains what it does; documentation explains why it exists.
-- Always add new imports and their first usage in the same edit. The lint-on-edit hook runs `eslint --fix` after every Edit, which auto-removes unused imports. If you add an import in one edit and plan to use it in a second edit, the hook will strip the import before the second edit runs.
+- Always add new imports and their first usage in the same edit. The lint-on-edit hook verifies changed files after every Edit, so unused-import diagnostics should be fixed in the same edit that introduced them.
 - Add language specifiers to fenced code blocks in Markdown.
 - Use project-relative paths rather than absolute paths in documentation and Markdown.
 - Delete old code completely when replacing it. No deprecation unless specifically requested.

--- a/plugins/lisa-cursor/rules/base-rules-reference.mdc
+++ b/plugins/lisa-cursor/rules/base-rules-reference.mdc
@@ -41,7 +41,7 @@ Code Quality:
 - Make atomic commits with clear conventional commit messages.
 - Create clear documentation preambles for new code. Update preambles when modifying existing code.
 - Document the "why", not the "what". Code explains what it does; documentation explains why it exists.
-- Always add new imports and their first usage in the same edit. The lint-on-edit hook runs `eslint --fix` after every Edit, which auto-removes unused imports. If you add an import in one edit and plan to use it in a second edit, the hook will strip the import before the second edit runs.
+- Always add new imports and their first usage in the same edit. The lint-on-edit hook verifies changed files after every Edit, so unused-import diagnostics should be fixed in the same edit that introduced them.
 - Add language specifiers to fenced code blocks in Markdown.
 - Use project-relative paths rather than absolute paths in documentation and Markdown.
 - Delete old code completely when replacing it. No deprecation unless specifically requested.

--- a/plugins/lisa-cursor/rules/base-rules.mdc
+++ b/plugins/lisa-cursor/rules/base-rules.mdc
@@ -22,7 +22,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 
 - Atomic commits with conventional commit messages.
 - Document the **why**, not the what.
-- Add new imports and their first usage in the same edit (the lint-on-edit hook strips unused imports).
+- Add new imports and their first usage in the same edit so lint-on-edit verification stays green.
 - Delete old code completely when replacing it. No deprecation comments unless asked.
 - Fix bugs at root cause. Never work around them or assume a failure is "pre-existing."
 - Test empirically. Never assume test expectations before observing actual behavior.

--- a/plugins/lisa/rules/eager/base-rules.md
+++ b/plugins/lisa/rules/eager/base-rules.md
@@ -17,7 +17,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 
 - Atomic commits with conventional commit messages.
 - Document the **why**, not the what.
-- Add new imports and their first usage in the same edit (the lint-on-edit hook strips unused imports).
+- Add new imports and their first usage in the same edit so lint-on-edit verification stays green.
 - Delete old code completely when replacing it. No deprecation comments unless asked.
 - Fix bugs at root cause. Never work around them or assume a failure is "pre-existing."
 - Test empirically. Never assume test expectations before observing actual behavior.

--- a/plugins/lisa/rules/reference/base-rules.md
+++ b/plugins/lisa/rules/reference/base-rules.md
@@ -36,7 +36,7 @@ Code Quality:
 - Make atomic commits with clear conventional commit messages.
 - Create clear documentation preambles for new code. Update preambles when modifying existing code.
 - Document the "why", not the "what". Code explains what it does; documentation explains why it exists.
-- Always add new imports and their first usage in the same edit. The lint-on-edit hook runs `eslint --fix` after every Edit, which auto-removes unused imports. If you add an import in one edit and plan to use it in a second edit, the hook will strip the import before the second edit runs.
+- Always add new imports and their first usage in the same edit. The lint-on-edit hook verifies changed files after every Edit, so unused-import diagnostics should be fixed in the same edit that introduced them.
 - Add language specifiers to fenced code blocks in Markdown.
 - Use project-relative paths rather than absolute paths in documentation and Markdown.
 - Delete old code completely when replacing it. No deprecation unless specifically requested.

--- a/plugins/src/base/rules/eager/base-rules.md
+++ b/plugins/src/base/rules/eager/base-rules.md
@@ -17,7 +17,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 
 - Atomic commits with conventional commit messages.
 - Document the **why**, not the what.
-- Add new imports and their first usage in the same edit (the lint-on-edit hook strips unused imports).
+- Add new imports and their first usage in the same edit so lint-on-edit verification stays green.
 - Delete old code completely when replacing it. No deprecation comments unless asked.
 - Fix bugs at root cause. Never work around them or assume a failure is "pre-existing."
 - Test empirically. Never assume test expectations before observing actual behavior.

--- a/plugins/src/base/rules/reference/base-rules.md
+++ b/plugins/src/base/rules/reference/base-rules.md
@@ -36,7 +36,7 @@ Code Quality:
 - Make atomic commits with clear conventional commit messages.
 - Create clear documentation preambles for new code. Update preambles when modifying existing code.
 - Document the "why", not the "what". Code explains what it does; documentation explains why it exists.
-- Always add new imports and their first usage in the same edit. The lint-on-edit hook runs `eslint --fix` after every Edit, which auto-removes unused imports. If you add an import in one edit and plan to use it in a second edit, the hook will strip the import before the second edit runs.
+- Always add new imports and their first usage in the same edit. The lint-on-edit hook verifies changed files after every Edit, so unused-import diagnostics should be fixed in the same edit that introduced them.
 - Add language specifiers to fenced code blocks in Markdown.
 - Use project-relative paths rather than absolute paths in documentation and Markdown.
 - Delete old code completely when replacing it. No deprecation unless specifically requested.

--- a/tests/unit/hooks/lint-on-edit.test.ts
+++ b/tests/unit/hooks/lint-on-edit.test.ts
@@ -101,6 +101,44 @@ describe("lint-on-edit hooks", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Ignored by lint config");
   });
+
+  it("reports Codex edit-hook diagnostics without rewriting the edited file", () => {
+    const project = createProject({ oxlintBody: mutatingOnlyWithFixOxlint() });
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const originalSource = readFileSync(sourcePath, "utf8");
+    const result = spawnSync(BASH_PATH, [CODEX_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      input: JSON.stringify({
+        tool_name: "Edit",
+        tool_input: { file_path: sourcePath },
+      }),
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("simulated fixable issue");
+    expect(readFileSync(sourcePath, "utf8")).toBe(originalSource);
+    expect(readLog(project)).toContain(`oxlint --quiet ${sourcePath}`);
+    expect(readLog(project)).not.toContain("--fix");
+  });
+
+  it("reports TypeScript-stack edit-hook diagnostics without rewriting the edited file", () => {
+    const project = createProject({ oxlintBody: mutatingOnlyWithFixOxlint() });
+    const sourcePath = path.join(project, EXAMPLE_SOURCE_RELATIVE_PATH);
+    const originalSource = readFileSync(sourcePath, "utf8");
+    const result = spawnSync(BASH_PATH, [TYPESCRIPT_HOOK_PATH], {
+      cwd: project,
+      encoding: "utf8",
+      env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+      input: JSON.stringify({ tool_input: { file_path: sourcePath } }),
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("simulated fixable issue");
+    expect(readFileSync(sourcePath, "utf8")).toBe(originalSource);
+    expect(readLog(project)).toContain(`oxlint --quiet ${sourcePath}`);
+    expect(readLog(project)).not.toContain("--fix");
+  });
 });
 
 /**
@@ -151,4 +189,22 @@ function writeBin(project: string, name: string, body: string): void {
  */
 function readLog(project: string): string {
   return readFileSync(path.join(project, "lint.log"), "utf8");
+}
+
+/**
+ * Fake linter that would mutate only when called with --fix.
+ * @returns Shell body for the fake oxlint binary.
+ */
+function mutatingOnlyWithFixOxlint(): string {
+  return `
+printf 'oxlint %s\\n' "$*" >> "$PWD/lint.log"
+target="\${@: -1}"
+for arg in "$@"; do
+  if [ "$arg" = "--fix" ]; then
+    printf 'export const rewritten = true;\\n' > "$target"
+  fi
+done
+printf 'simulated fixable issue\\n' >&2
+exit 1
+`;
 }


### PR DESCRIPTION
## Summary
- add regression coverage proving edit-time lint diagnostics do not rewrite Codex or TypeScript hook targets
- update generated/source agent rule guidance to describe verification-only lint-on-edit behavior

Closes #1262

## Verification
- bun test tests/unit/hooks/lint-on-edit.test.ts
- bun run typecheck
- bun run build:plugins
- bun run check:plugins
- git commit hooks: gitleaks, typecheck, lint-staged, ast-grep, commitlint, coauthor check
- git push hook: security audit, slow lint, knip, full unit coverage, integration tests

Note: repo labels `codex` and `codex-automation` are not present, so no PR labels were applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to clarify that new imports and their first usage must be added in the same edit to maintain lint-on-edit verification integrity.

* **Tests**
  * Added test coverage to validate that edit-time lint hooks properly report fixable diagnostics without modifying source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->