### PR TITLE
fix(vitest): make .claude/worktrees exclusion cwd-aware

### DIFF
--- a/src/configs/vitest/base.ts
+++ b/src/configs/vitest/base.ts
@@ -67,7 +67,6 @@ export const defaultCoverageExclusions: readonly string[] = [
   "**/index.ts",
   "**/node_modules/**",
   "**/dist/**",
-  "**/.claude/worktrees/**",
   "**/*.test.ts",
   "**/*.spec.ts",
   "**/*.mock.ts",
@@ -80,14 +79,38 @@ export const defaultCoverageExclusions: readonly string[] = [
 
 /**
  * Default patterns to exclude from test discovery across all stacks.
- * Lisa manages `.claude/worktrees/` as scratch worktrees for subagents;
- * test files inside them should never be collected by the repo-level vitest run.
+ *
+ * The `.claude/worktrees/` exclusion is intentionally NOT baked in here —
+ * it is cwd-conditional and supplied by {@link worktreeExclusions} so that
+ * a vitest run launched from INSIDE a worktree can still discover its own
+ * tests. Stack factories spread `worktreeExclusions()` alongside this list.
  */
 export const defaultTestExclusions: readonly string[] = [
   "**/node_modules/**",
   "**/dist/**",
-  "**/.claude/worktrees/**",
 ];
+
+/**
+ * Returns the worktree exclusion glob a stack config should add to skip
+ * test files / coverage that live inside `.claude/worktrees/`.
+ *
+ * Lisa manages `.claude/worktrees/` as scratch worktrees for subagents.
+ * When vitest runs from the primary checkout, tests inside those worktrees
+ * should be skipped — each worktree has its own vitest run. When vitest runs
+ * from INSIDE a worktree (the project root *is* the worktree), the same glob
+ * matches every path under root and vitest finds zero tests. This returns the
+ * glob only when the current working directory is outside a worktree, so each
+ * stack factory can spread it into its `exclude` arrays without hand-rolling
+ * the conditional. Mirrors jest's `worktreeTestPathIgnorePatterns()`.
+ * @returns Single-entry array with the worktree exclude glob, or an empty array when already inside a worktree.
+ */
+export function worktreeExclusions(): readonly string[] {
+  const isInsideWorktree = /[/\\]\.claude[/\\]worktrees(?:[/\\]|$)/.test(
+    process.cwd()
+  );
+
+  return isInsideWorktree ? [] : ["**/.claude/worktrees/**"];
+}
 
 /**
  * Maps portable threshold format (with `global` wrapper) to Vitest's

--- a/src/configs/vitest/nestjs.ts
+++ b/src/configs/vitest/nestjs.ts
@@ -22,6 +22,7 @@ import {
   mapThresholds,
   mergeThresholds,
   mergeVitestConfigs,
+  worktreeExclusions,
 } from "./base.js";
 
 import type { PortableThresholds } from "./base.js";
@@ -34,6 +35,7 @@ export {
   mapThresholds,
   mergeThresholds,
   mergeVitestConfigs,
+  worktreeExclusions,
 };
 
 export type { PortableThresholds };
@@ -89,12 +91,12 @@ export const getNestjsVitestConfig = ({
     // on "No test files found" otherwise. See typescript.ts for rationale.
     passWithNoTests: true,
     include: ["**/*.spec.ts"],
-    exclude: [...defaultTestExclusions],
+    exclude: [...defaultTestExclusions, ...worktreeExclusions()],
     testTimeout: 10000,
     coverage: {
       provider: "v8",
       include: ["**/*.ts"],
-      exclude: [...nestjsCoverageExclusions],
+      exclude: [...nestjsCoverageExclusions, ...worktreeExclusions()],
       thresholds: mapThresholds(thresholds),
     },
   },

--- a/src/configs/vitest/typescript.ts
+++ b/src/configs/vitest/typescript.ts
@@ -18,6 +18,7 @@ import {
   mapThresholds,
   mergeThresholds,
   mergeVitestConfigs,
+  worktreeExclusions,
 } from "./base.js";
 
 import type { PortableThresholds } from "./base.js";
@@ -30,6 +31,7 @@ export {
   mapThresholds,
   mergeThresholds,
   mergeVitestConfigs,
+  worktreeExclusions,
 };
 
 export type { PortableThresholds };
@@ -64,12 +66,12 @@ export const getTypescriptVitestConfig = ({
     // the test-world analog of allowing `files: []` in tsconfig for zero sources.
     passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
-    exclude: [...defaultTestExclusions],
+    exclude: [...defaultTestExclusions, ...worktreeExclusions()],
     testTimeout: 10000,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: [...defaultCoverageExclusions],
+      exclude: [...defaultCoverageExclusions, ...worktreeExclusions()],
       thresholds: mapThresholds(thresholds),
     },
   },

--- a/tests/unit/config/vitest-base.test.ts
+++ b/tests/unit/config/vitest-base.test.ts
@@ -5,10 +5,12 @@ import {
   mergeThresholds,
   mergeVitestConfigs,
   mapThresholds,
+  worktreeExclusions,
 } from "../../../src/configs/vitest/base.js";
 import type { PortableThresholds } from "../../../src/configs/vitest/base.js";
 
 const DSTAR_TEST_TS = "**/*.test.ts";
+const WORKTREE_GLOB = "**/.claude/worktrees/**";
 const TESTS_GLOB = "tests/**/*.test.ts";
 const SRC_TEST_GLOB = "src/**/*.test.ts";
 const SRC_TS_GLOB = "src/**/*.ts";
@@ -54,18 +56,55 @@ describe("vitest.base", () => {
       expect(hasNegation).toBe(false);
     });
 
-    it("excludes scratch worktrees from coverage", () => {
-      expect(defaultCoverageExclusions).toContain("**/.claude/worktrees/**");
+    it("does not bake the worktree glob into the static list (supplied by worktreeExclusions)", () => {
+      expect(defaultCoverageExclusions).not.toContain(WORKTREE_GLOB);
     });
   });
 
   describe("defaultTestExclusions", () => {
-    it("excludes node_modules, dist, and scratch worktrees", () => {
+    it("excludes node_modules and dist (worktrees supplied by worktreeExclusions)", () => {
       expect(defaultTestExclusions).toEqual([
         "**/node_modules/**",
         "**/dist/**",
-        "**/.claude/worktrees/**",
       ]);
+    });
+  });
+
+  describe("worktreeExclusions", () => {
+    const realCwd = process.cwd;
+
+    afterEach(() => {
+      process.cwd = realCwd;
+    });
+
+    it("returns the worktree exclude glob when cwd is outside a worktree", () => {
+      process.cwd = () => "/some/project";
+
+      expect(worktreeExclusions()).toEqual([WORKTREE_GLOB]);
+    });
+
+    it("returns an empty array when cwd is inside a .claude/worktrees path", () => {
+      process.cwd = () => "/some/project/.claude/worktrees/feature-branch";
+
+      expect(worktreeExclusions()).toEqual([]);
+    });
+
+    it("detects a worktree in any path segment", () => {
+      process.cwd = () => "/Users/dev/project/.claude/worktrees/SE-123/subdir";
+
+      expect(worktreeExclusions()).toEqual([]);
+    });
+
+    it("returns an empty array for a Windows-style worktree path", () => {
+      process.cwd = () => "C:\\projects\\.claude\\worktrees\\feature-branch";
+
+      expect(worktreeExclusions()).toEqual([]);
+    });
+
+    it("returns the glob for a Windows-style path outside a worktree", () => {
+      process.cwd = () => "C:\\projects\\my-app";
+
+      expect(worktreeExclusions()).toEqual([WORKTREE_GLOB]);
     });
   });
 


### PR DESCRIPTION
## Problem
The Vitest base config unconditionally excludes `**/.claude/worktrees/**` from both test discovery and coverage. A worktree's own absolute path contains `.claude/worktrees/`, so running `vitest` **from inside** a worktree matches every path under it → `No test files found`. Subagents working in `.claude/worktrees/*` checkouts cannot run any tests.

The Jest base config already solved this with a cwd-aware helper (`worktreeTestPathIgnorePatterns()` returns `[]` when cwd is inside a worktree). Vitest never got the same treatment.

## Fix
- Add `worktreeExclusions()` to `src/configs/vitest/base.ts` — returns `["**/.claude/worktrees/**"]` only when cwd is **outside** a worktree, `[]` when inside (same regex as the Jest helper, incl. Windows paths).
- Remove the hardcoded worktree glob from `defaultTestExclusions` / `defaultCoverageExclusions`.
- Spread `worktreeExclusions()` into the test + coverage `exclude` arrays of both the `typescript` and `nestjs` factories.

Primary checkout still skips nested worktrees; a run launched **inside** a worktree now discovers its own tests.

## Tests
- 5 new `worktreeExclusions` cases (inside/outside worktree, POSIX + Windows), mirroring the existing Jest tests.
- Updated the `defaultTestExclusions` / `defaultCoverageExclusions` assertions (glob moved to the helper).
- All vitest config unit tests pass (`vitest-base`, `vitest-nestjs`, `vitest-typescript`).

## Verification
Built and synced into a downstream NestJS project's `node_modules`; a spec that previously reported "No test files found" from inside a worktree then ran successfully (110 tests).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test exclusion logic to conditionally exclude worktree paths based on the current working directory context.
  * Updated test and coverage configuration to better handle development scenarios where code may run from different directory locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->