### PR TITLE
feat(mutation-testing): configurable opt-in mutation gate for TS and Rails

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -43,7 +43,7 @@ on:
         type: string
         default: 'test'
       skip_jobs:
-        description: 'Comma-separated list of jobs to skip (lint, security, test, code_quality, secret_scanning, sg_scan, license_compliance, zap_baseline)'
+        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, license_compliance, zap_baseline)'
         required: false
         type: string
         default: ''
@@ -178,6 +178,56 @@ jobs:
 
       - name: 🧪 Run tests
         run: bundle exec rspec
+
+  mutation:
+    name: 🧬 Mutation Testing Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Diff-only mutation gate. Self-skips instantly when disabled
+    # (mutation.gate.yml: enabled: false). PostgreSQL-based; MySQL projects can
+    # adapt the service block or skip via skip_jobs: mutation.
+    if: ${{ !contains(inputs.skip_jobs, 'mutation') && inputs.database_type == 'postgres' }}
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ${{ inputs.database_name }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/${{ inputs.database_name }}
+      # Diff against the PR base branch (falls back to 'main' outside PRs).
+      MUTATION_SINCE: ${{ github.base_ref || 'main' }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Full history so the gate can diff changed files against the PR base.
+          fetch-depth: 0
+
+      - name: 💎 Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: 🗄️ Prepare database
+        run: bin/rails db:prepare
+
+      - name: 🧬 Run mutation-testing gate (diff-only, self-skips when disabled)
+        run: |
+          if [ -f scripts/lisa-mutation.sh ]; then
+            bash scripts/lisa-mutation.sh
+          else
+            echo "Skipping mutation gate - scripts/lisa-mutation.sh not found"
+          fi
 
   code-quality:
     name: Code Quality

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,7 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:integration,test:e2e,maestro_e2e,playwright_e2e,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -486,6 +486,74 @@ jobs:
       - name: ⏭️ Skip unit tests (no test:unit script)
         if: steps.check_script.outputs.exists == 'false'
         run: echo "Skipping unit tests - test:unit script not found in package.json"
+
+  test_mutation:
+    name: 🧬 Mutation Testing Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: ${{ !contains(inputs.skip_jobs, 'test:mutation') }}
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Full history so the gate can diff changed files against the PR base.
+          fetch-depth: 0
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
+
+      - name: 🍞 Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: 🔍 Check for test:mutation script
+        id: check_script
+        run: |
+          if [ -f "package.json" ] && grep -q '"test:mutation"' package.json; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 📦 Install dependencies
+        if: steps.check_script.outputs.exists == 'true'
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧬 Run mutation-testing gate (diff-only, self-skips when disabled)
+        if: steps.check_script.outputs.exists == 'true'
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm run test:mutation
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn test:mutation
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun run test:mutation
+          fi
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+          # Diff against the PR base branch (falls back to 'main' outside PRs).
+          MUTATION_SINCE: ${{ github.base_ref || 'main' }}
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: ⏭️ Skip mutation gate (no test:mutation script)
+        if: steps.check_script.outputs.exists == 'false'
+        run: echo "Skipping mutation-testing gate - test:mutation script not found in package.json"
 
   test_integration:
     name: 🧪 Run Integration Tests

--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -10,6 +10,7 @@
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:integration": "vitest run tests/integration --passWithNoTests",
       "test:cov": "vitest run --coverage",
+      "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint": "oxlint && eslint . --quiet",
       "lint:fix": "oxlint --fix && eslint . --fix"
@@ -28,7 +29,9 @@
       "@vitest/coverage-v8": "^4.1.0",
       "eslint-plugin-oxlint": "^1.62.0",
       "oxlint": "^1.62.0",
-      "oxlint-tsgolint": "^0.22.1"
+      "oxlint-tsgolint": "^0.22.1",
+      "@stryker-mutator/core": "^9.0.0",
+      "@stryker-mutator/vitest-runner": "^9.0.0"
     },
     "bin": {
       "infrastructure": "bin/infrastructure.js"

--- a/expo/create-only/stryker.conf.json
+++ b/expo/create-only/stryker.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "custom",
+    "configFile": "jest.config.ts",
+    "enableFindRelatedTests": true
+  },
+  "reporters": ["clear-text", "progress", "html"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": true,
+  "incremental": true,
+  "mutate": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "!src/**/*.spec.ts",
+    "!src/**/*.spec.tsx",
+    "!src/**/*.test.ts",
+    "!src/**/*.test.tsx",
+    "!src/**/*.d.ts",
+    "!src/**/*.stories.tsx"
+  ],
+  "thresholds": {
+    "high": 80,
+    "low": 60,
+    "break": 60
+  }
+}

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -49,6 +49,7 @@
       "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
       "test:cov": "NODE_ENV=test jest --coverage",
+      "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "NODE_ENV=test jest --watch",
       "lint": "oxlint && eslint . --quiet",
       "lint:fix": "oxlint --fix && eslint . --fix"
@@ -90,6 +91,8 @@
       "@types/jest": "^30.0.0",
       "@jest/test-sequencer": "^30.2.0",
       "jest-environment-jsdom": "^30.2.0",
+      "@stryker-mutator/core": "^9.0.0",
+      "@stryker-mutator/jest-runner": "^9.0.0",
       "serve": "^14.2.0",
       "eslint-plugin-oxlint": "^1.62.0",
       "oxlint": "^1.62.0",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -39,6 +39,7 @@
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:integration": "vitest run '.integration.' --passWithNoTests",
       "test:cov": "vitest run --coverage",
+      "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint": "oxlint && eslint . --quiet",
       "lint:fix": "oxlint --fix && eslint . --fix"
@@ -91,7 +92,9 @@
       "@vitest/coverage-v8": "^4.1.0",
       "eslint-plugin-oxlint": "^1.62.0",
       "oxlint": "^1.62.0",
-      "oxlint-tsgolint": "^0.22.1"
+      "oxlint-tsgolint": "^0.22.1",
+      "@stryker-mutator/core": "^9.0.0",
+      "@stryker-mutator/vitest-runner": "^9.0.0"
     }
   }
 }

--- a/rails/copy-contents/scripts/lisa-mutation.sh
+++ b/rails/copy-contents/scripts/lisa-mutation.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa.
+# -----------------------------------------------------------------------------
+# Mutation-testing gate (mutant) for Rails
+# -----------------------------------------------------------------------------
+# Opt-in, diff-only mutation-testing gate shared by the lefthook pre-push hook
+# and CI.
+#
+# Behavior:
+#   1. Reads `mutation.gate.yml`. If the gate is disabled (the default), it
+#      prints a notice and exits 0 — pushes and CI are never slowed down until a
+#      project explicitly opts in.
+#   2. When enabled, it runs mutant with `--since <ref>` so only code changed on
+#      this branch (vs the configured `since` ref) is mutated. Mutation testing
+#      is slow, so a full-suite run is never done by this gate.
+#   3. The subjects to mutate are defined in `.mutant.yml` (matcher.subjects);
+#      mutant exits non-zero when surviving mutants remain in the changed code,
+#      which fails the gate.
+#
+# NOTE: mutant is commercially licensed for closed-source projects (free for
+#       open source). Enabling this gate requires a valid license or switching
+#       the integration to a permissively licensed alternative.
+#
+# Configuration (`mutation.gate.yml`, project-owned / create-only):
+#   enabled: false
+#   since: main
+#
+# Overridable via env: MUTATION_ENABLED=true|false, MUTATION_SINCE=<ref>.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+GATE_FILE="mutation.gate.yml"
+
+read_gate() {
+  local key="$1" default="$2"
+  if [ -f "$GATE_FILE" ] && command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -e "puts (YAML.load_file('${GATE_FILE}') || {}).fetch('${key}', '${default}')" 2>/dev/null || echo "$default"
+  else
+    echo "$default"
+  fi
+}
+
+ENABLED="${MUTATION_ENABLED:-$(read_gate enabled false)}"
+SINCE="${MUTATION_SINCE:-$(read_gate since main)}"
+
+if [ "$ENABLED" != "true" ]; then
+  echo "⚪ Mutation-testing gate disabled (mutation.gate.yml: enabled: false). Skipping."
+  echo "   Set enabled: true (and configure matcher.subjects in .mutant.yml) to turn it on."
+  exit 0
+fi
+
+# Only mutate when changed Ruby files exist under app/ or lib/.
+BASE=""
+for ref in "origin/${SINCE}" "${SINCE}"; do
+  if BASE="$(git merge-base "$ref" HEAD 2>/dev/null)"; then
+    [ -n "$BASE" ] && break
+  fi
+done
+
+if [ -z "$BASE" ]; then
+  echo "⚪ Mutation gate: could not resolve a merge-base against '${SINCE}'. Skipping."
+  exit 0
+fi
+
+CHANGED="$(git diff --name-only --diff-filter=ACMR "${BASE}...HEAD" -- 'app/**/*.rb' 'lib/**/*.rb' || true)"
+if [ -z "$CHANGED" ]; then
+  echo "⚪ Mutation gate: no changed Ruby files under app/ or lib/ vs ${SINCE}. Nothing to mutate."
+  exit 0
+fi
+
+echo "🧬 Mutation gate: running mutant (--since ${SINCE}) on changed subjects..."
+exec bundle exec mutant run --since "$SINCE"

--- a/rails/copy-overwrite/Gemfile.lisa
+++ b/rails/copy-overwrite/Gemfile.lisa
@@ -31,6 +31,11 @@ group :development, :test do
   gem "flog", "~> 4.8", require: false
   gem "flay", "~> 2.13", require: false
 
+  # Mutation testing (opt-in gate — see mutation.gate.yml / scripts/lisa-mutation.sh).
+  # NOTE: mutant is commercially licensed for closed-source projects (free for OSS).
+  # The gate is disabled by default, so the gem is never invoked until opted in.
+  gem "mutant-rspec", "~> 0.12", require: false
+
   # Security
   gem "brakeman", "~> 7.0", require: false
   gem "bundler-audit", "~> 0.9", require: false

--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -28,3 +28,7 @@ pre-push:
       run: bundle exec flog --all --group app/ lib/
     flay:
       run: bundle exec flay app/ lib/
+    mutation:
+      # Opt-in, diff-only mutation gate. Self-skips instantly when disabled
+      # (mutation.gate.yml: enabled: false), so it adds no cost until opted in.
+      run: bash scripts/lisa-mutation.sh

--- a/rails/create-only/.mutant.yml
+++ b/rails/create-only/.mutant.yml
@@ -1,0 +1,21 @@
+# Mutant configuration (project-owned).
+# Docs: https://github.com/mbj/mutant/blob/main/docs/configuration.md
+#
+# The gate runs `mutant run --since <ref>` (see scripts/lisa-mutation.sh), so
+# only code changed on the branch is mutated. Define the subject scope below —
+# replace the example matcher with your application's top-level namespace(s).
+---
+integration:
+  name: rspec
+# `usage` must reflect your license: opensource | commercial | restricted.
+usage: opensource
+requires:
+  - ./config/environment
+includes:
+  - app
+  - lib
+matcher:
+  # Replace with your app's namespace(s), e.g. ["MyApp*"]. Mutant will only
+  # mutate subjects matching these expressions that are also in the diff.
+  subjects:
+    - '*'

--- a/rails/create-only/mutation.gate.yml
+++ b/rails/create-only/mutation.gate.yml
@@ -1,0 +1,8 @@
+# Mutation-testing gate toggle (project-owned).
+# Flip `enabled` to true to turn on the diff-only mutant gate in the pre-push
+# hook and CI. The mutation subjects are configured in `.mutant.yml`.
+#
+# NOTE: mutant requires a commercial license for closed-source projects.
+---
+enabled: false
+since: main

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -224,6 +224,20 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Run mutation-testing gate - only if script exists.
+# The test:mutation script self-skips instantly when the gate is disabled
+# (mutation.gate.json: "enabled": false), so this adds no cost to projects that
+# have not opted in. When enabled, it runs Stryker diff-only on changed files
+# and fails the push when the mutation score is below thresholds.break.
+if jq -e '.scripts["test:mutation"]' package.json >/dev/null 2>&1; then
+  echo "🧬 Running mutation-testing gate..."
+  $RUNNER test:mutation
+  if [ $? -ne 0 ]; then
+    echo "❌ Mutation-testing gate failed (mutation score below threshold). Strengthen tests before pushing."
+    exit 1
+  fi
+fi
+
 # Run Lighthouse CI performance audit (only if installed)
 # Disable Lighthouse beause it takes too long to run on push. Just let it run in ci/cd 
 # Check if lighthouse:check script exists in package.json

--- a/typescript/copy-contents/scripts/lisa-mutation.mjs
+++ b/typescript/copy-contents/scripts/lisa-mutation.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// This file is managed by Lisa.
+// -----------------------------------------------------------------------------
+// Mutation-testing gate (StrykerJS)
+// -----------------------------------------------------------------------------
+// Opt-in, diff-only mutation-testing gate shared by the pre-push hook and CI.
+//
+// Behavior:
+//   1. Reads `mutation.gate.json`. If the gate is disabled (the default), it
+//      prints a notice and exits 0 — pushes and CI are never slowed down until
+//      a project explicitly opts in.
+//   2. When enabled, it computes the source files changed on this branch
+//      (vs the merge-base with the configured `since` ref) and runs Stryker on
+//      ONLY those files. Mutation testing is slow, so a full-repo run is never
+//      done by this gate.
+//   3. The mutation-score threshold itself lives in `stryker.conf.*`
+//      (`thresholds.break`) — Stryker exits non-zero when the score is below it,
+//      which fails the gate.
+//
+// Configuration (`mutation.gate.json`, project-owned / create-only):
+//   { "enabled": false, "since": "main" }
+//
+// Overridable via env: MUTATION_ENABLED=true|false, MUTATION_SINCE=<ref>.
+// -----------------------------------------------------------------------------
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const CWD = process.cwd();
+
+const readGate = () => {
+  const gatePath = path.join(CWD, "mutation.gate.json");
+  if (!fs.existsSync(gatePath)) {
+    return { enabled: false, since: "main" };
+  }
+  try {
+    return JSON.parse(fs.readFileSync(gatePath, "utf8"));
+  } catch (err) {
+    console.error(`⚠️  Could not parse mutation.gate.json: ${err.message}`);
+    return { enabled: false, since: "main" };
+  }
+};
+
+const envFlag = name => {
+  const v = process.env[name];
+  if (v === undefined) return undefined;
+  return v === "true" || v === "1";
+};
+
+const gate = readGate();
+const enabled = envFlag("MUTATION_ENABLED") ?? gate.enabled === true;
+const since = process.env.MUTATION_SINCE || gate.since || "main";
+
+if (!enabled) {
+  console.log(
+    '⚪ Mutation-testing gate disabled (mutation.gate.json: "enabled": false). Skipping.\n' +
+      '   Flip "enabled": true (and tune thresholds.break in stryker.conf.json) to turn it on.'
+  );
+  process.exit(0);
+}
+
+// --- Resolve the diff base (merge-base with the `since` ref) -----------------
+// stderr is ignored: failed merge-base/diff probes are expected (e.g. a missing
+// origin/<ref> candidate) and handled by the surrounding try/catch.
+const git = args =>
+  execFileSync("git", args, {
+    cwd: CWD,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+
+let base;
+try {
+  // Prefer the remote ref when present (CI checks out detached); fall back to local.
+  const candidates = [`origin/${since}`, since];
+  let resolved = "";
+  for (const ref of candidates) {
+    try {
+      resolved = git(["merge-base", ref, "HEAD"]);
+      if (resolved) break;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  base = resolved;
+} catch {
+  base = "";
+}
+
+if (!base) {
+  console.log(
+    `⚪ Mutation gate: could not resolve a merge-base against "${since}" ` +
+      "(shallow clone or unknown ref). Skipping rather than mutating the whole repo."
+  );
+  process.exit(0);
+}
+
+// --- Compute changed, mutate-eligible source files ---------------------------
+const isMutable = f =>
+  /\.(ts|tsx)$/.test(f) &&
+  !/\.(spec|test)\.(ts|tsx)$/.test(f) &&
+  !/\.d\.ts$/.test(f) &&
+  !/\.stories\.tsx$/.test(f) &&
+  (f.startsWith("src/") || f.startsWith("lib/"));
+
+let changed = [];
+try {
+  changed = git(["diff", "--name-only", "--diff-filter=ACMR", `${base}...HEAD`])
+    .split("\n")
+    .map(f => f.trim())
+    .filter(Boolean)
+    .filter(isMutable)
+    .filter(f => fs.existsSync(path.join(CWD, f)));
+} catch (err) {
+  console.error(`⚠️  Could not compute changed files: ${err.message}`);
+  process.exit(0);
+}
+
+if (changed.length === 0) {
+  console.log(
+    "⚪ Mutation gate: no changed source files vs " +
+      since +
+      ". Nothing to mutate."
+  );
+  process.exit(0);
+}
+
+console.log(
+  `🧬 Mutation gate: running Stryker on ${changed.length} changed file(s):`
+);
+for (const f of changed) console.log(`   • ${f}`);
+
+// --- Run Stryker on just the changed files (diff-only) -----------------------
+const strykerBin = path.join(
+  CWD,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "stryker.cmd" : "stryker"
+);
+const useLocal = fs.existsSync(strykerBin);
+const command = useLocal ? strykerBin : "npx";
+const args = useLocal
+  ? ["run", "--mutate", changed.join(",")]
+  : ["--yes", "stryker", "run", "--mutate", changed.join(",")];
+
+const result = spawnSync(command, args, {
+  cwd: CWD,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+process.exit(result.status ?? 1);

--- a/typescript/create-only/mutation.gate.json
+++ b/typescript/create-only/mutation.gate.json
@@ -1,0 +1,4 @@
+{
+  "enabled": false,
+  "since": "main"
+}

--- a/typescript/create-only/stryker.conf.json
+++ b/typescript/create-only/stryker.conf.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "testRunner": "vitest",
+  "reporters": ["clear-text", "progress", "html"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": true,
+  "incremental": true,
+  "mutate": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "!src/**/*.spec.ts",
+    "!src/**/*.spec.tsx",
+    "!src/**/*.test.ts",
+    "!src/**/*.test.tsx",
+    "!src/**/*.d.ts",
+    "!src/**/*.stories.tsx"
+  ],
+  "thresholds": {
+    "high": 80,
+    "low": 60,
+    "break": 60
+  }
+}

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -8,6 +8,7 @@
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:cov": "vitest run --coverage",
+      "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint:fix": "oxlint --fix && eslint . --fix",
       "lint:slow": "eslint . --config eslint.slow.config.ts --quiet",
@@ -20,7 +21,9 @@
     "devDependencies": {
       "eslint-plugin-oxlint": "^1.62.0",
       "oxlint": "^1.62.0",
-      "oxlint-tsgolint": "^0.22.1"
+      "oxlint-tsgolint": "^0.22.1",
+      "@stryker-mutator/core": "^9.0.0",
+      "@stryker-mutator/vitest-runner": "^9.0.0"
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",


### PR DESCRIPTION
## Summary

- Adds a **configurable, opt-in mutation-testing gate** to the TypeScript and Rails stacks, wired into the two enforcement points used by test coverage: the **pre-push hook** and **CI** (`quality.yml` / `quality-rails.yml`).
- Follows Lisa's coverage philosophy — **force the mechanism, leave the threshold project-tunable** — with **no nightly ratchet**.
- **Disabled by default**: the runner self-skips instantly when off, so existing projects get no slower pushes until they opt in. When on, it runs **diff-only** (mutates only source files changed vs the merge-base with the configured `since` ref).

### TypeScript (StrykerJS)
Shipped from the `typescript` stack, inherited by nestjs/cdk/expo (expo overrides the config for Jest):
- `test:mutation` forced into `force.scripts`; `@stryker-mutator/core` (+ `vitest-runner`; expo `jest-runner`) forced into devDeps.
- Create-only `mutation.gate.json` (`{enabled:false, since:"main"}`) — the toggle; `stryker.conf.json` whose `thresholds.break` is the configurable mutation score.
- `scripts/lisa-mutation.mjs` — self-skips when disabled, else computes changed `src/`/`lib/` files and runs `stryker run --mutate <files>`.
- Pre-push step + skippable `test_mutation` job in `quality.yml` (`fetch-depth: 0`, diffs against PR base).

### Rails (mutant)
- `mutant-rspec` in `Gemfile.lisa` (commercially licensed; only invoked when enabled).
- Create-only `.mutant.yml` + `mutation.gate.yml`.
- `scripts/lisa-mutation.sh` runs `mutant run --since <ref>`.
- lefthook pre-push command + skippable `mutation` job in `quality-rails.yml`.

## Test plan

- [x] TS runner verified end-to-end in a sandbox with a fake `stryker` bin: disabled→skips (exit 0), enabled+no-change→skips, enabled+changed→mutates only changed source files (test files excluded), non-zero Stryker exit propagates to fail the gate.
- [x] All JSON/YAML/bash syntax validated; new files pass Prettier; child-wins create-only ownership confirmed for the expo Jest override.
- [ ] Rails path is **config-validated only** — no Rails app in-repo to run `mutant` against.

## Notes

- `quality.yml` / `quality-rails.yml` are referenced remotely `@main`, so the new jobs reach downstream projects on merge. They self-skip when no `test:mutation` script / `enabled` flag is present, so they are dormant by default.
- Stryker `vitest-runner` 9.x against Vitest 4 is new; a project *enabling* the gate may need a runner-version bump. Harmless until enabled.

🤖 Generated with Claude Code