### PR TITLE
fix: enforce fix-before-ignore hook policy

### DIFF
--- a/plugins/lisa-agy/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa-agy/hooks/block-no-verify.agy.sh
@@ -25,7 +25,7 @@ allow() {
 }
 
 deny() {
-  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (lint, tests, formatting) or ask the user before bypassing."}'
+  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (security audit, lint, typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never bypass the hook."}'
   exit 0
 }
 

--- a/plugins/lisa-copilot/hooks/block-no-verify.sh
+++ b/plugins/lisa-copilot/hooks/block-no-verify.sh
@@ -91,11 +91,10 @@ PY
 then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
-or core.hooksPath disabling). Fix the underlying issue (lint error, failing
-test, formatting) or ask the user before bypassing.
-
-If the user has explicitly authorized the bypass for this specific command,
-re-run after they confirm.
+or core.hooksPath disabling). Fix the underlying issue (security audit, lint,
+typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the
+user to make the risk-acceptance decision and add a specific documented ignore;
+never bypass the hook.
 EOF
   exit 2
 fi

--- a/plugins/lisa-copilot/rules/eager/base-rules.md
+++ b/plugins/lisa-copilot/rules/eager/base-rules.md
@@ -25,6 +25,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 ## Git Discipline
 
 - **Never use `--no-verify`** or bypass any git hook.
+- When a hook or quality gate fails, fix the root cause first. If no fix is genuinely possible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never use a blanket bypass.
 - **Never bypass branch protection** — no `--admin`, `--force`, no merging a PR with failing CI. "Green in CI" is the definition of done.
 - Never commit directly to environment branches (`dev`, `staging`, `main`).
 - Prefix `git push` with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.

--- a/plugins/lisa-copilot/rules/eager/security-audit-handling.md
+++ b/plugins/lisa-copilot/rules/eager/security-audit-handling.md
@@ -1,6 +1,12 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`** to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Core rule
 
@@ -17,7 +23,7 @@ Before adding any override, verify:
 
 1. Note GHSA ID, package, advisory URL.
 2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
 
 ## Rails (bundler-audit)
 

--- a/plugins/lisa-copilot/rules/reference/base-rules.md
+++ b/plugins/lisa-copilot/rules/reference/base-rules.md
@@ -50,6 +50,7 @@ Git Discipline:
 - Prefix git push with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.
 - Never commit directly to an environment branch (dev, staging, main).
 - Never use --no-verify or attempt to bypass a git hook.
+- When a pre-commit, pre-push, CI, or other quality gate fails, fix the root cause first: upgrade the vulnerable dependency, fix the lint/type/test failure, remove the secret, or repair the failing check. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a narrow, documented ignore for the specific failing rule or advisory. Never use `--no-verify`, hook environment switches, blanket ignores, or threshold reductions as a substitute for fixing the gate.
 - Never bypass branch protection. Never use `--admin`, `--force`, or any other flag to merge a PR that has failing CI checks. If CI fails, fix it. If you cannot fix it, escalate to the human. There are zero exceptions. "Green in CI" is the definition of done — not "green locally." A PR is not complete until CI passes on the actual PR branch.
 - Never stash changes you cannot commit. Either fix whatever is preventing the commit or fail out and let the human know why.
 - Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change.

--- a/plugins/lisa-copilot/rules/reference/security-audit-handling.md
+++ b/plugins/lisa-copilot/rules/reference/security-audit-handling.md
@@ -1,13 +1,19 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify` to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Node.js Projects (GHSA advisories)
 
 1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
 2. Check the advisory URL to determine if a patched version of the vulnerable package exists
 3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
 
 ### Critical: Override the vulnerable package, not its parent
 

--- a/plugins/lisa-cursor/hooks/block-no-verify.sh
+++ b/plugins/lisa-cursor/hooks/block-no-verify.sh
@@ -91,11 +91,10 @@ PY
 then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
-or core.hooksPath disabling). Fix the underlying issue (lint error, failing
-test, formatting) or ask the user before bypassing.
-
-If the user has explicitly authorized the bypass for this specific command,
-re-run after they confirm.
+or core.hooksPath disabling). Fix the underlying issue (security audit, lint,
+typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the
+user to make the risk-acceptance decision and add a specific documented ignore;
+never bypass the hook.
 EOF
   exit 2
 fi

--- a/plugins/lisa-cursor/rules/base-rules-reference.mdc
+++ b/plugins/lisa-cursor/rules/base-rules-reference.mdc
@@ -55,6 +55,7 @@ Git Discipline:
 - Prefix git push with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.
 - Never commit directly to an environment branch (dev, staging, main).
 - Never use --no-verify or attempt to bypass a git hook.
+- When a pre-commit, pre-push, CI, or other quality gate fails, fix the root cause first: upgrade the vulnerable dependency, fix the lint/type/test failure, remove the secret, or repair the failing check. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a narrow, documented ignore for the specific failing rule or advisory. Never use `--no-verify`, hook environment switches, blanket ignores, or threshold reductions as a substitute for fixing the gate.
 - Never bypass branch protection. Never use `--admin`, `--force`, or any other flag to merge a PR that has failing CI checks. If CI fails, fix it. If you cannot fix it, escalate to the human. There are zero exceptions. "Green in CI" is the definition of done — not "green locally." A PR is not complete until CI passes on the actual PR branch.
 - Never stash changes you cannot commit. Either fix whatever is preventing the commit or fail out and let the human know why.
 - Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change.

--- a/plugins/lisa-cursor/rules/base-rules.mdc
+++ b/plugins/lisa-cursor/rules/base-rules.mdc
@@ -30,6 +30,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 ## Git Discipline
 
 - **Never use `--no-verify`** or bypass any git hook.
+- When a hook or quality gate fails, fix the root cause first. If no fix is genuinely possible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never use a blanket bypass.
 - **Never bypass branch protection** — no `--admin`, `--force`, no merging a PR with failing CI. "Green in CI" is the definition of done.
 - Never commit directly to environment branches (`dev`, `staging`, `main`).
 - Prefix `git push` with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.

--- a/plugins/lisa-cursor/rules/security-audit-handling-reference.mdc
+++ b/plugins/lisa-cursor/rules/security-audit-handling-reference.mdc
@@ -5,14 +5,20 @@ alwaysApply: false
 
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify` to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Node.js Projects (GHSA advisories)
 
 1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
 2. Check the advisory URL to determine if a patched version of the vulnerable package exists
 3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
 
 ### Critical: Override the vulnerable package, not its parent
 

--- a/plugins/lisa-cursor/rules/security-audit-handling.mdc
+++ b/plugins/lisa-cursor/rules/security-audit-handling.mdc
@@ -5,7 +5,13 @@ alwaysApply: true
 
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`** to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Core rule
 
@@ -22,7 +28,7 @@ Before adding any override, verify:
 
 1. Note GHSA ID, package, advisory URL.
 2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
 
 ## Rails (bundler-audit)
 

--- a/plugins/lisa/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa/hooks/block-no-verify.agy.sh
@@ -25,7 +25,7 @@ allow() {
 }
 
 deny() {
-  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (lint, tests, formatting) or ask the user before bypassing."}'
+  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (security audit, lint, typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never bypass the hook."}'
   exit 0
 }
 

--- a/plugins/lisa/hooks/block-no-verify.sh
+++ b/plugins/lisa/hooks/block-no-verify.sh
@@ -91,11 +91,10 @@ PY
 then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
-or core.hooksPath disabling). Fix the underlying issue (lint error, failing
-test, formatting) or ask the user before bypassing.
-
-If the user has explicitly authorized the bypass for this specific command,
-re-run after they confirm.
+or core.hooksPath disabling). Fix the underlying issue (security audit, lint,
+typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the
+user to make the risk-acceptance decision and add a specific documented ignore;
+never bypass the hook.
 EOF
   exit 2
 fi

--- a/plugins/lisa/rules/eager/base-rules.md
+++ b/plugins/lisa/rules/eager/base-rules.md
@@ -25,6 +25,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 ## Git Discipline
 
 - **Never use `--no-verify`** or bypass any git hook.
+- When a hook or quality gate fails, fix the root cause first. If no fix is genuinely possible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never use a blanket bypass.
 - **Never bypass branch protection** — no `--admin`, `--force`, no merging a PR with failing CI. "Green in CI" is the definition of done.
 - Never commit directly to environment branches (`dev`, `staging`, `main`).
 - Prefix `git push` with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.

--- a/plugins/lisa/rules/eager/security-audit-handling.md
+++ b/plugins/lisa/rules/eager/security-audit-handling.md
@@ -1,6 +1,12 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`** to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Core rule
 
@@ -17,7 +23,7 @@ Before adding any override, verify:
 
 1. Note GHSA ID, package, advisory URL.
 2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
 
 ## Rails (bundler-audit)
 

--- a/plugins/lisa/rules/reference/base-rules.md
+++ b/plugins/lisa/rules/reference/base-rules.md
@@ -50,6 +50,7 @@ Git Discipline:
 - Prefix git push with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.
 - Never commit directly to an environment branch (dev, staging, main).
 - Never use --no-verify or attempt to bypass a git hook.
+- When a pre-commit, pre-push, CI, or other quality gate fails, fix the root cause first: upgrade the vulnerable dependency, fix the lint/type/test failure, remove the secret, or repair the failing check. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a narrow, documented ignore for the specific failing rule or advisory. Never use `--no-verify`, hook environment switches, blanket ignores, or threshold reductions as a substitute for fixing the gate.
 - Never bypass branch protection. Never use `--admin`, `--force`, or any other flag to merge a PR that has failing CI checks. If CI fails, fix it. If you cannot fix it, escalate to the human. There are zero exceptions. "Green in CI" is the definition of done — not "green locally." A PR is not complete until CI passes on the actual PR branch.
 - Never stash changes you cannot commit. Either fix whatever is preventing the commit or fail out and let the human know why.
 - Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change.

--- a/plugins/lisa/rules/reference/security-audit-handling.md
+++ b/plugins/lisa/rules/reference/security-audit-handling.md
@@ -1,13 +1,19 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify` to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Node.js Projects (GHSA advisories)
 
 1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
 2. Check the advisory URL to determine if a patched version of the vulnerable package exists
 3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
 
 ### Critical: Override the vulnerable package, not its parent
 

--- a/plugins/src/base/hooks/block-no-verify.agy.sh
+++ b/plugins/src/base/hooks/block-no-verify.agy.sh
@@ -25,7 +25,7 @@ allow() {
 }
 
 deny() {
-  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (lint, tests, formatting) or ask the user before bypassing."}'
+  printf '%s\n' '{"decision":"deny","reason":"This command bypasses Lisa pre-commit/pre-push quality gates (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (security audit, lint, typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never bypass the hook."}'
   exit 0
 }
 

--- a/plugins/src/base/hooks/block-no-verify.sh
+++ b/plugins/src/base/hooks/block-no-verify.sh
@@ -91,11 +91,10 @@ PY
 then
   cat >&2 <<'EOF'
 Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0,
-or core.hooksPath disabling). Fix the underlying issue (lint error, failing
-test, formatting) or ask the user before bypassing.
-
-If the user has explicitly authorized the bypass for this specific command,
-re-run after they confirm.
+or core.hooksPath disabling). Fix the underlying issue (security audit, lint,
+typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the
+user to make the risk-acceptance decision and add a specific documented ignore;
+never bypass the hook.
 EOF
   exit 2
 fi

--- a/plugins/src/base/rules/eager/base-rules.md
+++ b/plugins/src/base/rules/eager/base-rules.md
@@ -25,6 +25,7 @@ Do not begin work if there are blockers, ambiguities, access requirements, or un
 ## Git Discipline
 
 - **Never use `--no-verify`** or bypass any git hook.
+- When a hook or quality gate fails, fix the root cause first. If no fix is genuinely possible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never use a blanket bypass.
 - **Never bypass branch protection** — no `--admin`, `--force`, no merging a PR with failing CI. "Green in CI" is the definition of done.
 - Never commit directly to environment branches (`dev`, `staging`, `main`).
 - Prefix `git push` with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.

--- a/plugins/src/base/rules/eager/security-audit-handling.md
+++ b/plugins/src/base/rules/eager/security-audit-handling.md
@@ -1,6 +1,12 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`** to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Core rule
 
@@ -17,7 +23,7 @@ Before adding any override, verify:
 
 1. Note GHSA ID, package, advisory URL.
 2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
 
 ## Rails (bundler-audit)
 

--- a/plugins/src/base/rules/reference/base-rules.md
+++ b/plugins/src/base/rules/reference/base-rules.md
@@ -50,6 +50,7 @@ Git Discipline:
 - Prefix git push with `GIT_SSH_COMMAND="ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=5"`.
 - Never commit directly to an environment branch (dev, staging, main).
 - Never use --no-verify or attempt to bypass a git hook.
+- When a pre-commit, pre-push, CI, or other quality gate fails, fix the root cause first: upgrade the vulnerable dependency, fix the lint/type/test failure, remove the secret, or repair the failing check. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a narrow, documented ignore for the specific failing rule or advisory. Never use `--no-verify`, hook environment switches, blanket ignores, or threshold reductions as a substitute for fixing the gate.
 - Never bypass branch protection. Never use `--admin`, `--force`, or any other flag to merge a PR that has failing CI checks. If CI fails, fix it. If you cannot fix it, escalate to the human. There are zero exceptions. "Green in CI" is the definition of done — not "green locally." A PR is not complete until CI passes on the actual PR branch.
 - Never stash changes you cannot commit. Either fix whatever is preventing the commit or fail out and let the human know why.
 - Never add "BREAKING CHANGE" to a commit message unless there is actually a breaking change.

--- a/plugins/src/base/rules/reference/security-audit-handling.md
+++ b/plugins/src/base/rules/reference/security-audit-handling.md
@@ -1,13 +1,19 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify` to bypass the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+
+## Fix before ignore
+
+1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
+2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
+3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
 
 ## Node.js Projects (GHSA advisories)
 
 1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
 2. Check the advisory URL to determine if a patched version of the vulnerable package exists
 3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
 
 ### Critical: Override the vulnerable package, not its parent
 

--- a/src/codex/scripts/block-no-verify.sh
+++ b/src/codex/scripts/block-no-verify.sh
@@ -81,7 +81,7 @@ then
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",
       "permissionDecision": "deny",
-      "permissionDecisionReason": "Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue or ask the user before bypassing."
+      "permissionDecisionReason": "Blocked: this command bypasses pre-commit/pre-push hooks (--no-verify, HUSKY=0, or core.hooksPath disabling). Fix the underlying issue (security audit, lint, typecheck, tests, formatting) instead. If a fix is genuinely impossible, ask the user to make the risk-acceptance decision and add a specific documented ignore; never bypass the hook."
     }
   }'
 fi

--- a/tests/unit/hooks/block-no-verify.test.ts
+++ b/tests/unit/hooks/block-no-verify.test.ts
@@ -38,8 +38,11 @@ const runHook = (
 describe("block-no-verify.sh", () => {
   describe("blocks commands with --no-verify", () => {
     it("blocks a simple git commit --no-verify", () => {
-      const { status } = runHook("Bash", "git commit --no-verify");
+      const { status, stderr } = runHook("Bash", "git commit --no-verify");
       expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("Fix the underlying issue");
+      expect(stderr).toContain("specific documented ignore");
+      expect(stderr).not.toContain("ask the user before bypassing");
     });
 
     it("blocks --no-verify followed by additional flags", () => {


### PR DESCRIPTION
## Summary
- tighten block-no-verify hook messaging so bypasses are never allowed, even with user confirmation
- add fix-before-ignore policy to base/security-audit rules and regenerated plugin variants
- add a regression assertion for the stricter hook guidance

## Verification
- bun test tests/unit/hooks/block-no-verify.test.ts tests/unit/hooks/parity-safety-net.test.ts
- bun test tests/unit/agy/block-no-verify-agy.test.ts tests/unit/codex/codex-edit-hooks.test.ts
- bun run build:dist
- bun run check:plugins
- git push pre-push gate: audit, slow lint, knip, full unit coverage, integration tests

Closes #1291