### PR TITLE
fix(pm): detect & respect project package manager; scope bun audit to prod (SE-5221)

### DIFF
--- a/.claude-pr/.husky/pre-push
+++ b/.claude-pr/.husky/pre-push
@@ -150,7 +150,14 @@ else
     # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
     # apply the exclusion list ourselves with jq — same approach as the npm/yarn
     # paths above.
-    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    #
+    # `--production` scopes the audit to production dependencies, matching the
+    # npm branch (`npm audit --production`) and the yarn branch
+    # (`yarn audit --groups dependencies`). Without it, bun audits
+    # devDependencies too and the gate fails on dev-only CVEs that never ship —
+    # the SE-5221 false positive. bun honours `--production` even though
+    # `bun audit --help` omits it from the flag list.
+    AUDIT_JSON=$(bun audit --production --json 2>/dev/null || true)
     UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
       ($ids | split(" ") | map(select(length > 0))) as $ex
       | [ .[]? | .[]?

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -150,7 +150,14 @@ else
     # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
     # apply the exclusion list ourselves with jq — same approach as the npm/yarn
     # paths above.
-    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    #
+    # `--production` scopes the audit to production dependencies, matching the
+    # npm branch (`npm audit --production`) and the yarn branch
+    # (`yarn audit --groups dependencies`). Without it, bun audits
+    # devDependencies too and the gate fails on dev-only CVEs that never ship —
+    # the SE-5221 false positive. bun honours `--production` even though
+    # `bun audit --help` omits it from the flag list.
+    AUDIT_JSON=$(bun audit --production --json 2>/dev/null || true)
     UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
       ($ids | split(" ") | map(select(length > 0))) as $ex
       | [ .[]? | .[]?

--- a/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
@@ -108,7 +108,7 @@ require() { need "$1" || { echo "FATAL: required tool '$1' missing and install f
 # regression). Only install/PATH-export the manager actually selected below.
 detect_package_manager() {
   _field="" _forced="" _forbidden=""
-  if [ -f package.json ]; then
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
     _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
     _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
     _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)

--- a/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
@@ -101,12 +101,34 @@ need() { command -v "$1" >/dev/null 2>&1; }
 require() { need "$1" || { echo "FATAL: required tool '$1' missing and install failed" >&2; exit 1; }; }
 
 # --- package manager (REQUIRED) ---
-if ! need bun; then
+# Resolve the PM from packageManager/engines/lockfiles — emit the manager the
+# `packageManager` inventory field reported, NEVER a hardcoded bun. An npm-only
+# project (engines.bun = "please-use-npm") must install with npm; emitting
+# `bun install` would create a stray bun.lock and break it (the SE-5221
+# regression). Only install/PATH-export the manager actually selected below.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun && { printf 'bun\n'; return 0; }
+  [ -f pnpm-lock.yaml ] && _pm_allowed pnpm && { printf 'pnpm\n'; return 0; }
+  [ -f yarn.lock ] && _pm_allowed yarn && { printf 'yarn\n'; return 0; }
+  [ -f package-lock.json ] && _pm_allowed npm && { printf 'npm\n'; return 0; }
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+if [ "$PM" = "bun" ] && ! need bun; then
   curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
 fi
-export PATH="$HOME/.bun/bin:$PATH"
 # NOTE: bun has known proxy package-fetch issues in cloud sessions; retry to survive transient proxy errors.
-for i in 1 2 3; do bun install && break || sleep 5; done
+for i in 1 2 3; do "$PM" install && break || sleep 5; done
 
 # --- required CLIs ---
 need gh || (sudo apt-get update -y && sudo apt-get install -y gh)

--- a/plugins/lisa-copilot/hooks/install-pkgs.sh
+++ b/plugins/lisa-copilot/hooks/install-pkgs.sh
@@ -8,18 +8,40 @@ if [ -d "node_modules" ]; then
   exit 0
 fi
 
-# Detect package manager based on lock file presence
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-  bun install
-elif [ -f "pnpm-lock.yaml" ]; then
-  pnpm install
-elif [ -f "yarn.lock" ]; then
-  yarn install
-elif [ -f "package-lock.json" ]; then
-  npm install
-else
-  npm install
-fi
+# Detect the package manager this project wants, honoring explicit opt-outs.
+# Precedence: packageManager field > engines "please-use-<pm>" sentinel >
+# lockfile presence (minus any PM the engines forbid) > npm default.
+#
+# This must NOT key on lockfile presence alone. An npm-only project
+# (engines.bun = "please-use-npm", CI runs `npm ci`) that picks up a stray
+# bun.lock would otherwise get `bun install`, re-create the bun.lock, and break
+# — the SE-5221 regression. The engines/packageManager signals are
+# authoritative; lockfiles are only a fallback and never override an opt-out.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+
+PACKAGE_MANAGER="$(detect_package_manager)"
+echo "Detected package manager: ${PACKAGE_MANAGER}"
+case "$PACKAGE_MANAGER" in
+  bun) bun install ;;
+  pnpm) pnpm install ;;
+  yarn) yarn install ;;
+  *) npm install ;;
+esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
 if [ "$(uname -s)" != "Linux" ]; then

--- a/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
@@ -108,7 +108,7 @@ require() { need "$1" || { echo "FATAL: required tool '$1' missing and install f
 # regression). Only install/PATH-export the manager actually selected below.
 detect_package_manager() {
   _field="" _forced="" _forbidden=""
-  if [ -f package.json ]; then
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
     _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
     _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
     _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)

--- a/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
@@ -101,12 +101,34 @@ need() { command -v "$1" >/dev/null 2>&1; }
 require() { need "$1" || { echo "FATAL: required tool '$1' missing and install failed" >&2; exit 1; }; }
 
 # --- package manager (REQUIRED) ---
-if ! need bun; then
+# Resolve the PM from packageManager/engines/lockfiles — emit the manager the
+# `packageManager` inventory field reported, NEVER a hardcoded bun. An npm-only
+# project (engines.bun = "please-use-npm") must install with npm; emitting
+# `bun install` would create a stray bun.lock and break it (the SE-5221
+# regression). Only install/PATH-export the manager actually selected below.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun && { printf 'bun\n'; return 0; }
+  [ -f pnpm-lock.yaml ] && _pm_allowed pnpm && { printf 'pnpm\n'; return 0; }
+  [ -f yarn.lock ] && _pm_allowed yarn && { printf 'yarn\n'; return 0; }
+  [ -f package-lock.json ] && _pm_allowed npm && { printf 'npm\n'; return 0; }
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+if [ "$PM" = "bun" ] && ! need bun; then
   curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
 fi
-export PATH="$HOME/.bun/bin:$PATH"
 # NOTE: bun has known proxy package-fetch issues in cloud sessions; retry to survive transient proxy errors.
-for i in 1 2 3; do bun install && break || sleep 5; done
+for i in 1 2 3; do "$PM" install && break || sleep 5; done
 
 # --- required CLIs ---
 need gh || (sudo apt-get update -y && sudo apt-get install -y gh)

--- a/plugins/lisa-cursor/hooks/install-pkgs.sh
+++ b/plugins/lisa-cursor/hooks/install-pkgs.sh
@@ -8,18 +8,40 @@ if [ -d "node_modules" ]; then
   exit 0
 fi
 
-# Detect package manager based on lock file presence
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-  bun install
-elif [ -f "pnpm-lock.yaml" ]; then
-  pnpm install
-elif [ -f "yarn.lock" ]; then
-  yarn install
-elif [ -f "package-lock.json" ]; then
-  npm install
-else
-  npm install
-fi
+# Detect the package manager this project wants, honoring explicit opt-outs.
+# Precedence: packageManager field > engines "please-use-<pm>" sentinel >
+# lockfile presence (minus any PM the engines forbid) > npm default.
+#
+# This must NOT key on lockfile presence alone. An npm-only project
+# (engines.bun = "please-use-npm", CI runs `npm ci`) that picks up a stray
+# bun.lock would otherwise get `bun install`, re-create the bun.lock, and break
+# — the SE-5221 regression. The engines/packageManager signals are
+# authoritative; lockfiles are only a fallback and never override an opt-out.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+
+PACKAGE_MANAGER="$(detect_package_manager)"
+echo "Detected package manager: ${PACKAGE_MANAGER}"
+case "$PACKAGE_MANAGER" in
+  bun) bun install ;;
+  pnpm) pnpm install ;;
+  yarn) yarn install ;;
+  *) npm install ;;
+esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
 if [ "$(uname -s)" != "Linux" ]; then

--- a/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
@@ -108,7 +108,7 @@ require() { need "$1" || { echo "FATAL: required tool '$1' missing and install f
 # regression). Only install/PATH-export the manager actually selected below.
 detect_package_manager() {
   _field="" _forced="" _forbidden=""
-  if [ -f package.json ]; then
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
     _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
     _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
     _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)

--- a/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
@@ -101,12 +101,34 @@ need() { command -v "$1" >/dev/null 2>&1; }
 require() { need "$1" || { echo "FATAL: required tool '$1' missing and install failed" >&2; exit 1; }; }
 
 # --- package manager (REQUIRED) ---
-if ! need bun; then
+# Resolve the PM from packageManager/engines/lockfiles — emit the manager the
+# `packageManager` inventory field reported, NEVER a hardcoded bun. An npm-only
+# project (engines.bun = "please-use-npm") must install with npm; emitting
+# `bun install` would create a stray bun.lock and break it (the SE-5221
+# regression). Only install/PATH-export the manager actually selected below.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun && { printf 'bun\n'; return 0; }
+  [ -f pnpm-lock.yaml ] && _pm_allowed pnpm && { printf 'pnpm\n'; return 0; }
+  [ -f yarn.lock ] && _pm_allowed yarn && { printf 'yarn\n'; return 0; }
+  [ -f package-lock.json ] && _pm_allowed npm && { printf 'npm\n'; return 0; }
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+if [ "$PM" = "bun" ] && ! need bun; then
   curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
 fi
-export PATH="$HOME/.bun/bin:$PATH"
 # NOTE: bun has known proxy package-fetch issues in cloud sessions; retry to survive transient proxy errors.
-for i in 1 2 3; do bun install && break || sleep 5; done
+for i in 1 2 3; do "$PM" install && break || sleep 5; done
 
 # --- required CLIs ---
 need gh || (sudo apt-get update -y && sudo apt-get install -y gh)

--- a/plugins/lisa/hooks/install-pkgs.sh
+++ b/plugins/lisa/hooks/install-pkgs.sh
@@ -8,18 +8,40 @@ if [ -d "node_modules" ]; then
   exit 0
 fi
 
-# Detect package manager based on lock file presence
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-  bun install
-elif [ -f "pnpm-lock.yaml" ]; then
-  pnpm install
-elif [ -f "yarn.lock" ]; then
-  yarn install
-elif [ -f "package-lock.json" ]; then
-  npm install
-else
-  npm install
-fi
+# Detect the package manager this project wants, honoring explicit opt-outs.
+# Precedence: packageManager field > engines "please-use-<pm>" sentinel >
+# lockfile presence (minus any PM the engines forbid) > npm default.
+#
+# This must NOT key on lockfile presence alone. An npm-only project
+# (engines.bun = "please-use-npm", CI runs `npm ci`) that picks up a stray
+# bun.lock would otherwise get `bun install`, re-create the bun.lock, and break
+# — the SE-5221 regression. The engines/packageManager signals are
+# authoritative; lockfiles are only a fallback and never override an opt-out.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+
+PACKAGE_MANAGER="$(detect_package_manager)"
+echo "Detected package manager: ${PACKAGE_MANAGER}"
+case "$PACKAGE_MANAGER" in
+  bun) bun install ;;
+  pnpm) pnpm install ;;
+  yarn) yarn install ;;
+  *) npm install ;;
+esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
 if [ "$(uname -s)" != "Linux" ]; then

--- a/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
@@ -108,7 +108,7 @@ require() { need "$1" || { echo "FATAL: required tool '$1' missing and install f
 # regression). Only install/PATH-export the manager actually selected below.
 detect_package_manager() {
   _field="" _forced="" _forbidden=""
-  if [ -f package.json ]; then
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
     _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
     _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
     _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)

--- a/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
@@ -101,12 +101,34 @@ need() { command -v "$1" >/dev/null 2>&1; }
 require() { need "$1" || { echo "FATAL: required tool '$1' missing and install failed" >&2; exit 1; }; }
 
 # --- package manager (REQUIRED) ---
-if ! need bun; then
+# Resolve the PM from packageManager/engines/lockfiles — emit the manager the
+# `packageManager` inventory field reported, NEVER a hardcoded bun. An npm-only
+# project (engines.bun = "please-use-npm") must install with npm; emitting
+# `bun install` would create a stray bun.lock and break it (the SE-5221
+# regression). Only install/PATH-export the manager actually selected below.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun && { printf 'bun\n'; return 0; }
+  [ -f pnpm-lock.yaml ] && _pm_allowed pnpm && { printf 'pnpm\n'; return 0; }
+  [ -f yarn.lock ] && _pm_allowed yarn && { printf 'yarn\n'; return 0; }
+  [ -f package-lock.json ] && _pm_allowed npm && { printf 'npm\n'; return 0; }
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+if [ "$PM" = "bun" ] && ! need bun; then
   curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
 fi
-export PATH="$HOME/.bun/bin:$PATH"
 # NOTE: bun has known proxy package-fetch issues in cloud sessions; retry to survive transient proxy errors.
-for i in 1 2 3; do bun install && break || sleep 5; done
+for i in 1 2 3; do "$PM" install && break || sleep 5; done
 
 # --- required CLIs ---
 need gh || (sudo apt-get update -y && sudo apt-get install -y gh)

--- a/plugins/src/base/hooks/install-pkgs.sh
+++ b/plugins/src/base/hooks/install-pkgs.sh
@@ -8,18 +8,40 @@ if [ -d "node_modules" ]; then
   exit 0
 fi
 
-# Detect package manager based on lock file presence
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-  bun install
-elif [ -f "pnpm-lock.yaml" ]; then
-  pnpm install
-elif [ -f "yarn.lock" ]; then
-  yarn install
-elif [ -f "package-lock.json" ]; then
-  npm install
-else
-  npm install
-fi
+# Detect the package manager this project wants, honoring explicit opt-outs.
+# Precedence: packageManager field > engines "please-use-<pm>" sentinel >
+# lockfile presence (minus any PM the engines forbid) > npm default.
+#
+# This must NOT key on lockfile presence alone. An npm-only project
+# (engines.bun = "please-use-npm", CI runs `npm ci`) that picks up a stray
+# bun.lock would otherwise get `bun install`, re-create the bun.lock, and break
+# — the SE-5221 regression. The engines/packageManager signals are
+# authoritative; lockfiles are only a fallback and never override an opt-out.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+
+PACKAGE_MANAGER="$(detect_package_manager)"
+echo "Detected package manager: ${PACKAGE_MANAGER}"
+case "$PACKAGE_MANAGER" in
+  bun) bun install ;;
+  pnpm) pnpm install ;;
+  yarn) yarn install ;;
+  *) npm install ;;
+esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
 if [ "$(uname -s)" != "Linux" ]; then

--- a/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
@@ -108,7 +108,7 @@ require() { need "$1" || { echo "FATAL: required tool '$1' missing and install f
 # regression). Only install/PATH-export the manager actually selected below.
 detect_package_manager() {
   _field="" _forced="" _forbidden=""
-  if [ -f package.json ]; then
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
     _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
     _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
     _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)

--- a/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
@@ -101,12 +101,34 @@ need() { command -v "$1" >/dev/null 2>&1; }
 require() { need "$1" || { echo "FATAL: required tool '$1' missing and install failed" >&2; exit 1; }; }
 
 # --- package manager (REQUIRED) ---
-if ! need bun; then
+# Resolve the PM from packageManager/engines/lockfiles — emit the manager the
+# `packageManager` inventory field reported, NEVER a hardcoded bun. An npm-only
+# project (engines.bun = "please-use-npm") must install with npm; emitting
+# `bun install` would create a stray bun.lock and break it (the SE-5221
+# regression). Only install/PATH-export the manager actually selected below.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun && { printf 'bun\n'; return 0; }
+  [ -f pnpm-lock.yaml ] && _pm_allowed pnpm && { printf 'pnpm\n'; return 0; }
+  [ -f yarn.lock ] && _pm_allowed yarn && { printf 'yarn\n'; return 0; }
+  [ -f package-lock.json ] && _pm_allowed npm && { printf 'npm\n'; return 0; }
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+if [ "$PM" = "bun" ] && ! need bun; then
   curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
 fi
-export PATH="$HOME/.bun/bin:$PATH"
 # NOTE: bun has known proxy package-fetch issues in cloud sessions; retry to survive transient proxy errors.
-for i in 1 2 3; do bun install && break || sleep 5; done
+for i in 1 2 3; do "$PM" install && break || sleep 5; done
 
 # --- required CLIs ---
 need gh || (sudo apt-get update -y && sudo apt-get install -y gh)

--- a/scripts/claude-remote-setup.sh
+++ b/scripts/claude-remote-setup.sh
@@ -80,12 +80,40 @@ fi
 require gitleaks
 
 # --- project dependencies ---
+# Resolve the package manager from packageManager/engines/lockfiles rather than
+# hardcoding bun: an npm-only project (engines.bun = "please-use-npm", CI runs
+# `npm ci`) must install with npm, never `bun install` — which would create a
+# stray bun.lock and break the project (the SE-5221 regression). jq is required
+# above, so the package.json signals are always available here.
 # bun has known proxy package-fetch issues in cloud sessions; retry transient failures.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ]; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+PM="$(detect_package_manager)"
+case "$PM" in
+  bun) PM_INSTALL="bun install" ;;
+  pnpm) PM_INSTALL="pnpm install" ;;
+  yarn) PM_INSTALL="yarn install" ;;
+  *) PM_INSTALL="npm install" ;;
+esac
 if [ ! -d node_modules ]; then
-  echo "Installing project dependencies (bun install)..."
-  for i in 1 2 3; do bun install && break || { echo "bun install attempt $i failed; retrying..."; sleep 5; }; done
+  echo "Installing project dependencies (${PM_INSTALL})..."
+  for i in 1 2 3; do $PM_INSTALL && break || { echo "${PM_INSTALL} attempt $i failed; retrying..."; sleep 5; }; done
 fi
-[ -d node_modules ] || { echo "FATAL: bun install failed after retries" >&2; exit 1; }
+[ -d node_modules ] || { echo "FATAL: ${PM_INSTALL} failed after retries" >&2; exit 1; }
 
 # --- OPTIONAL (only with --include-optional; dormant stacks/integrations) ---
 if [ "$INCLUDE_OPTIONAL" = "1" ]; then

--- a/src/codex/scripts/install-pkgs.sh
+++ b/src/codex/scripts/install-pkgs.sh
@@ -11,16 +11,38 @@ if [ -d "node_modules" ] || [ ! -f "package.json" ]; then
   exit 0
 fi
 
-if [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then
-  command -v bun >/dev/null 2>&1 && bun install
-elif [ -f "pnpm-lock.yaml" ]; then
-  command -v pnpm >/dev/null 2>&1 && pnpm install
-elif [ -f "yarn.lock" ]; then
-  command -v yarn >/dev/null 2>&1 && yarn install
-elif [ -f "package-lock.json" ]; then
-  command -v npm >/dev/null 2>&1 && npm install
-else
-  command -v npm >/dev/null 2>&1 && npm install
-fi
+# Detect the package manager this project wants, honoring explicit opt-outs.
+# Precedence: packageManager field > engines "please-use-<pm>" sentinel >
+# lockfile presence (minus any PM the engines forbid) > npm default.
+#
+# This must NOT key on lockfile presence alone. An npm-only project
+# (engines.bun = "please-use-npm", CI runs `npm ci`) that picks up a stray
+# bun.lock would otherwise get `bun install`, re-create the bun.lock, and break
+# — the SE-5221 regression. The engines/packageManager signals are
+# authoritative; lockfiles are only a fallback and never override an opt-out.
+detect_package_manager() {
+  _field="" _forced="" _forbidden=""
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    _field=$(jq -r '(.packageManager // "") | sub("@.*$";"")' package.json 2>/dev/null)
+    _forced=$(jq -r 'first((.engines // {})[] | strings | capture("please-use-(?<pm>bun|npm|yarn|pnpm)")?.pm) // ""' package.json 2>/dev/null)
+    _forbidden=$(jq -r '[(.engines // {}) | to_entries[] | select(((.value|strings) // "") | test("please-use|do-not-use";"i")) | .key] | join(" ")' package.json 2>/dev/null)
+  fi
+  case "$_field" in bun | npm | yarn | pnpm) printf '%s\n' "$_field"; return 0 ;; esac
+  case "$_forced" in bun | npm | yarn | pnpm) printf '%s\n' "$_forced"; return 0 ;; esac
+  _pm_allowed() { case " $_forbidden " in *" $1 "*) return 1 ;; *) return 0 ;; esac; }
+  if { [ -f bun.lockb ] || [ -f bun.lock ]; } && _pm_allowed bun; then printf 'bun\n'; return 0; fi
+  if [ -f pnpm-lock.yaml ] && _pm_allowed pnpm; then printf 'pnpm\n'; return 0; fi
+  if [ -f yarn.lock ] && _pm_allowed yarn; then printf 'yarn\n'; return 0; fi
+  if [ -f package-lock.json ] && _pm_allowed npm; then printf 'npm\n'; return 0; fi
+  printf 'npm\n'
+}
+
+PACKAGE_MANAGER="$(detect_package_manager)"
+case "$PACKAGE_MANAGER" in
+  bun) command -v bun >/dev/null 2>&1 && bun install ;;
+  pnpm) command -v pnpm >/dev/null 2>&1 && pnpm install ;;
+  yarn) command -v yarn >/dev/null 2>&1 && yarn install ;;
+  *) command -v npm >/dev/null 2>&1 && npm install ;;
+esac
 
 exit 0

--- a/src/utils/package-manager-detect.ts
+++ b/src/utils/package-manager-detect.ts
@@ -1,0 +1,140 @@
+/**
+ * @file package-manager-detect.ts
+ * @description Package-manager detection + lockfile-regen plans shared by the
+ * postinstall reconciliation trampoline. Split out from postinstall-trampoline
+ * so the detection surface (which manager a project actually uses, and which it
+ * explicitly forbids via `engines`) lives in one cohesive, well-tested module.
+ * @module utils
+ */
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Known package managers whose lockfiles must be regenerated when Lisa's apply
+ * mutates package.json (e.g., adds/updates resolutions or overrides entries).
+ */
+export type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
+
+/**
+ * Description of a package manager's lockfile file + the command Lisa should run
+ * to rebuild the lockfile without running install scripts.
+ */
+export interface LockfileRegenPlan {
+  readonly pm: PackageManager;
+  readonly lockfile: string;
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+const INSTALL = "install";
+const IGNORE_SCRIPTS = "--ignore-scripts";
+
+/**
+ * Per-PM lockfile + regen command mapping. The regen commands are all
+ * "sync lockfile without running scripts" variants — we do NOT want to
+ * re-run lifecycle scripts (that would re-trigger the trampoline).
+ *
+ * bun: `bun install` is the canonical way to sync bun.lock after package.json
+ * changes. As of bun 1.x there is no `--lockfile-only` flag; `bun install`
+ * is already fast when node_modules is up-to-date and will simply update
+ * bun.lock to match package.json. We pass `--ignore-scripts` to avoid re-running
+ * the parent PM's lifecycle hooks (which triggered this trampoline to begin with).
+ */
+export const LOCKFILE_REGEN_PLANS: Readonly<
+  Record<PackageManager, LockfileRegenPlan>
+> = {
+  bun: {
+    pm: "bun",
+    lockfile: "bun.lock",
+    command: "bun",
+    args: [INSTALL, IGNORE_SCRIPTS],
+  },
+  npm: {
+    pm: "npm",
+    lockfile: "package-lock.json",
+    command: "npm",
+    args: [INSTALL, "--package-lock-only", IGNORE_SCRIPTS],
+  },
+  pnpm: {
+    pm: "pnpm",
+    lockfile: "pnpm-lock.yaml",
+    command: "pnpm",
+    args: [INSTALL, "--lockfile-only", IGNORE_SCRIPTS],
+  },
+  yarn: {
+    pm: "yarn",
+    lockfile: "yarn.lock",
+    command: "yarn",
+    args: [INSTALL, "--mode", "update-lockfile"],
+  },
+} as const;
+
+/**
+ * Read the set of package managers a project explicitly opts OUT of via its
+ * package.json `engines` field. The repo-wide convention is to pin an unwanted
+ * package manager to a sentinel string such as `"please-use-npm"` (e.g. an
+ * npm-only project sets `engines.bun = "please-use-npm"`). Such a manager must
+ * never have its lockfile regenerated — even if a stray lockfile for it is
+ * present — because doing so re-creates the stray lockfile via that manager's
+ * `install`. That is the SE-5221 regression: a stray `bun.lock` in an npm-only
+ * project kept alive by `bun install`, which then misroutes the pre-push hook's
+ * package-manager detection to the bun branch.
+ * @param projectDir - Absolute path to the project directory
+ * @returns Set of package managers the project forbids (possibly empty)
+ */
+export function enginesForbiddenManagers(
+  projectDir: string
+): ReadonlySet<PackageManager> {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.join(projectDir, "package.json"), "utf8")
+    ) as { readonly engines?: Record<string, unknown> };
+    const engines = pkg.engines ?? {};
+    const managers = ["bun", "npm", "yarn", "pnpm"] as const;
+    return new Set(
+      managers.filter(pm => {
+        const value = engines[pm];
+        return (
+          typeof value === "string" && /please-use|do-not-use/i.test(value)
+        );
+      })
+    );
+  } catch {
+    // No package.json, or it is unreadable/invalid — nothing is forbidden.
+    return new Set();
+  }
+}
+
+/**
+ * Detect which package managers the project uses based on lockfile presence,
+ * excluding any manager the project explicitly forbids via `engines`.
+ *
+ * A project may have more than one lockfile (the CDK dual-lockfile pattern
+ * keeps `bun.lock` for local dev while publishing `package-lock.json` for
+ * consumers), in which case every present lockfile must be regenerated so both
+ * stay in sync with package.json.
+ *
+ * Managers opted out via an `engines` sentinel (e.g. `bun = "please-use-npm"`)
+ * are dropped even when their lockfile is present, so the reconciliation never
+ * re-creates a stray lockfile the project deliberately disallows (SE-5221).
+ * @param projectDir - Absolute path to the project directory
+ * @returns Ordered list of detected package managers (possibly empty)
+ */
+export function detectPackageManagers(
+  projectDir: string
+): readonly PackageManager[] {
+  const forbidden = enginesForbiddenManagers(projectDir);
+  return Object.values(LOCKFILE_REGEN_PLANS)
+    .filter(plan => existsSync(path.join(projectDir, plan.lockfile)))
+    .map(plan => plan.pm)
+    .filter(pm => !forbidden.has(pm));
+}
+
+/**
+ * Get the regen plan (command/args/lockfile) for a given package manager.
+ * @param pm - Package manager to look up
+ * @returns Regen plan describing which command to spawn
+ */
+export function getLockfileRegenPlan(pm: PackageManager): LockfileRegenPlan {
+  return LOCKFILE_REGEN_PLANS[pm];
+}

--- a/src/utils/package-manager-detect.ts
+++ b/src/utils/package-manager-detect.ts
@@ -22,6 +22,8 @@ export type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
 export interface LockfileRegenPlan {
   readonly pm: PackageManager;
   readonly lockfile: string;
+  /** Additional lockfile names for the same PM (e.g. bun.lockb for bun). */
+  readonly lockfileAlternatives?: readonly string[];
   readonly command: string;
   readonly args: readonly string[];
 }
@@ -46,6 +48,7 @@ export const LOCKFILE_REGEN_PLANS: Readonly<
   bun: {
     pm: "bun",
     lockfile: "bun.lock",
+    lockfileAlternatives: ["bun.lockb"],
     command: "bun",
     args: [INSTALL, IGNORE_SCRIPTS],
   },
@@ -125,7 +128,11 @@ export function detectPackageManagers(
 ): readonly PackageManager[] {
   const forbidden = enginesForbiddenManagers(projectDir);
   return Object.values(LOCKFILE_REGEN_PLANS)
-    .filter(plan => existsSync(path.join(projectDir, plan.lockfile)))
+    .filter(plan =>
+      [plan.lockfile, ...(plan.lockfileAlternatives ?? [])].some(f =>
+        existsSync(path.join(projectDir, f))
+      )
+    )
     .map(plan => plan.pm)
     .filter(pm => !forbidden.has(pm));
 }

--- a/src/utils/postinstall-trampoline.ts
+++ b/src/utils/postinstall-trampoline.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -8,6 +8,14 @@ import {
   PM_PATH_ENV_PREFIXES,
   sanitizeEnvForReconciliation,
 } from "./pm-env.js";
+import {
+  type LockfileRegenPlan,
+  type PackageManager,
+  LOCKFILE_REGEN_PLANS,
+  detectPackageManagers,
+  enginesForbiddenManagers,
+  getLockfileRegenPlan,
+} from "./package-manager-detect.js";
 
 /**
  * Env var set by npm/bun/yarn/pnpm when running lifecycle scripts (postinstall, etc.).
@@ -38,65 +46,16 @@ const POLL_INTERVAL_MS = 100;
  */
 const SETTLE_DELAY_MS = 250;
 
-/**
- * Known package managers whose lockfiles must be regenerated when Lisa's apply
- * mutates package.json (e.g., adds/updates resolutions or overrides entries).
- */
-export type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
-
-/**
- * Description of a package manager's lockfile file + the command Lisa should run
- * to rebuild the lockfile without running install scripts.
- */
-export interface LockfileRegenPlan {
-  readonly pm: PackageManager;
-  readonly lockfile: string;
-  readonly command: string;
-  readonly args: readonly string[];
-}
-
-/**
- * Per-PM lockfile + regen command mapping. The regen commands are all
- * "sync lockfile without running scripts" variants — we do NOT want to
- * re-run lifecycle scripts (that would re-trigger the trampoline).
- *
- * bun: `bun install` is the canonical way to sync bun.lock after package.json
- * changes. As of bun 1.x there is no `--lockfile-only` flag; `bun install`
- * is already fast when node_modules is up-to-date and will simply update
- * bun.lock to match package.json. We pass `--ignore-scripts` to avoid re-running
- * the parent PM's lifecycle hooks (which triggered this trampoline to begin with).
- */
-const INSTALL = "install";
-const IGNORE_SCRIPTS = "--ignore-scripts";
-
-const LOCKFILE_REGEN_PLANS: Readonly<
-  Record<PackageManager, LockfileRegenPlan>
-> = {
-  bun: {
-    pm: "bun",
-    lockfile: "bun.lock",
-    command: "bun",
-    args: [INSTALL, IGNORE_SCRIPTS],
-  },
-  npm: {
-    pm: "npm",
-    lockfile: "package-lock.json",
-    command: "npm",
-    args: [INSTALL, "--package-lock-only", IGNORE_SCRIPTS],
-  },
-  pnpm: {
-    pm: "pnpm",
-    lockfile: "pnpm-lock.yaml",
-    command: "pnpm",
-    args: [INSTALL, "--lockfile-only", IGNORE_SCRIPTS],
-  },
-  yarn: {
-    pm: "yarn",
-    lockfile: "yarn.lock",
-    command: "yarn",
-    args: [INSTALL, "--mode", "update-lockfile"],
-  },
-} as const;
+// Re-export the package-manager detection surface (imported above from
+// package-manager-detect.ts) so existing importers/tests can keep importing it
+// from this module.
+export {
+  LOCKFILE_REGEN_PLANS,
+  detectPackageManagers,
+  enginesForbiddenManagers,
+  getLockfileRegenPlan,
+};
+export type { LockfileRegenPlan, PackageManager };
 
 /**
  * Read an env var by name without widening the project-wide process.env ban.
@@ -204,33 +163,6 @@ export function getLisaDistDir(moduleUrl: string): string {
   const filename = fileURLToPath(moduleUrl);
   // Walk from <dist>/utils/postinstall-trampoline.js → <dist>
   return path.resolve(path.dirname(filename), "..");
-}
-
-/**
- * Detect which package managers the project uses based on lockfile presence.
- *
- * A project may have more than one lockfile (the CDK dual-lockfile pattern
- * keeps `bun.lock` for local dev while publishing `package-lock.json` for
- * consumers), in which case every present lockfile must be regenerated so both
- * stay in sync with package.json.
- * @param projectDir - Absolute path to the project directory
- * @returns Ordered list of detected package managers (possibly empty)
- */
-export function detectPackageManagers(
-  projectDir: string
-): readonly PackageManager[] {
-  return Object.values(LOCKFILE_REGEN_PLANS)
-    .filter(plan => existsSync(path.join(projectDir, plan.lockfile)))
-    .map(plan => plan.pm);
-}
-
-/**
- * Get the regen plan (command/args/lockfile) for a given package manager.
- * @param pm - Package manager to look up
- * @returns Regen plan describing which command to spawn
- */
-export function getLockfileRegenPlan(pm: PackageManager): LockfileRegenPlan {
-  return LOCKFILE_REGEN_PLANS[pm];
 }
 
 /**
@@ -491,10 +423,24 @@ function buildTrampolineHelpers(literals: {
       catch { return null; }
     }
 
+    function enginesForbiddenManagers(dir) {
+      try {
+        const pkg = JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+        const engines = (pkg && pkg.engines) || {};
+        return ["bun", "npm", "yarn", "pnpm"].filter(
+          (pm) => typeof engines[pm] === "string" && /please-use|do-not-use/i.test(engines[pm])
+        );
+      } catch {
+        return [];
+      }
+    }
+
     function detectPackageManagers(dir) {
+      const forbidden = enginesForbiddenManagers(dir);
       return Object.values(LOCKFILE_PLANS)
         .filter((plan) => existsSync(path.join(dir, plan.lockfile)))
-        .map((plan) => plan.pm);
+        .map((plan) => plan.pm)
+        .filter((pm) => forbidden.indexOf(pm) === -1);
     }
 
     async function waitForParent() {

--- a/src/utils/postinstall-trampoline.ts
+++ b/src/utils/postinstall-trampoline.ts
@@ -438,7 +438,7 @@ function buildTrampolineHelpers(literals: {
     function detectPackageManagers(dir) {
       const forbidden = enginesForbiddenManagers(dir);
       return Object.values(LOCKFILE_PLANS)
-        .filter((plan) => existsSync(path.join(dir, plan.lockfile)))
+        .filter((plan) => [plan.lockfile].concat(plan.lockfileAlternatives || []).some((f) => existsSync(path.join(dir, f))))
         .map((plan) => plan.pm)
         .filter((pm) => forbidden.indexOf(pm) === -1);
     }

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -20,6 +20,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   detectPackageManagers,
+  enginesForbiddenManagers,
   getLisaDistDir,
   getLockfileRegenPlan,
   hashFile,
@@ -234,6 +235,95 @@ describe("postinstall-trampoline", () => {
         expect(detected).toContain("bun");
         expect(detected).toContain("npm");
         expect(detected.length).toBe(2);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    /**
+     * Create a disposable directory with lockfile sentinels plus a package.json
+     * carrying the supplied `engines` block. Used to exercise the engines-based
+     * opt-out that excludes a forbidden manager even when its lockfile is present.
+     * @param lockfiles - Lockfile base names to create
+     * @param engines - engines object to write into package.json
+     * @returns Absolute path to the scratch directory
+     */
+    function withProject(
+      lockfiles: readonly string[],
+      engines: Readonly<Record<string, string>>
+    ): string {
+      const dir = withLockfiles(lockfiles);
+      fs.writeFileSync(
+        path.join(dir, PACKAGE_JSON),
+        JSON.stringify({ engines }, null, 2)
+      );
+      return dir;
+    }
+
+    it("excludes a manager forbidden via engines sentinel even when its lockfile is present (SE-5221)", () => {
+      // npm-only project with a stray bun.lock — bun must be dropped so the
+      // reconciliation never re-creates the bun.lock via `bun install`.
+      const dir = withProject([BUN_LOCK, NPM_LOCK], { bun: "please-use-npm" });
+      try {
+        expect(detectPackageManagers(dir)).toEqual(["npm"]);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("keeps bun when it is the engines-sanctioned manager (npm forbidden)", () => {
+      const dir = withProject([BUN_LOCK], {
+        npm: "please-use-bun",
+        bun: "1.3.8",
+      });
+      try {
+        expect(detectPackageManagers(dir)).toEqual(["bun"]);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("enginesForbiddenManagers", () => {
+    /**
+     * Write a package.json with the given engines block into a scratch dir.
+     * @param engines - engines object (omit to write no engines field)
+     * @returns Absolute path to the scratch directory
+     */
+    function withEngines(engines?: Readonly<Record<string, string>>): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-forbidden-pm-"));
+      const pkg = engines === undefined ? {} : { engines };
+      fs.writeFileSync(
+        path.join(dir, PACKAGE_JSON),
+        JSON.stringify(pkg, null, 2)
+      );
+      return dir;
+    }
+
+    it("returns an empty set when there is no package.json", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-no-pkg-"));
+      try {
+        expect(enginesForbiddenManagers(dir).size).toBe(0);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("flags a manager pinned to a please-use sentinel", () => {
+      const dir = withEngines({ bun: "please-use-npm", node: ">=20" });
+      try {
+        const forbidden = enginesForbiddenManagers(dir);
+        expect(forbidden.has("bun")).toBe(true);
+        expect(forbidden.has("npm")).toBe(false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not flag a manager pinned to a real version range", () => {
+      const dir = withEngines({ npm: ">=10", node: ">=20" });
+      try {
+        expect(enginesForbiddenManagers(dir).size).toBe(0);
       } finally {
         fs.rmSync(dir, { recursive: true, force: true });
       }

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -43,6 +43,7 @@ const FAKE_PACKAGE_JSON_PATH = "./fake/project/package.json";
 // Lockfile base names used across detection, plan, and hash tests. Named constants
 // silence sonarjs/no-duplicate-string and make the intent obvious at call sites.
 const BUN_LOCK = "bun.lock";
+const BUN_LOCKB = "bun.lockb";
 const NPM_LOCK = "package-lock.json";
 const PNPM_LOCK = "pnpm-lock.yaml";
 const YARN_LOCK = "yarn.lock";
@@ -194,6 +195,24 @@ describe("postinstall-trampoline", () => {
 
     it("detects bun from bun.lock", () => {
       const dir = withLockfiles([BUN_LOCK]);
+      try {
+        expect(detectPackageManagers(dir)).toEqual(["bun"]);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("detects bun from bun.lockb (legacy binary lockfile format)", () => {
+      const dir = withLockfiles([BUN_LOCKB]);
+      try {
+        expect(detectPackageManagers(dir)).toEqual(["bun"]);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("detects bun once when both bun.lock and bun.lockb coexist", () => {
+      const dir = withLockfiles([BUN_LOCK, BUN_LOCKB]);
       try {
         expect(detectPackageManagers(dir)).toEqual(["bun"]);
       } finally {

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -150,7 +150,14 @@ else
     # `bun audit --audit-level=high --ignore ...`, parse `bun audit --json` and
     # apply the exclusion list ourselves with jq — same approach as the npm/yarn
     # paths above.
-    AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+    #
+    # `--production` scopes the audit to production dependencies, matching the
+    # npm branch (`npm audit --production`) and the yarn branch
+    # (`yarn audit --groups dependencies`). Without it, bun audits
+    # devDependencies too and the gate fails on dev-only CVEs that never ship —
+    # the SE-5221 false positive. bun honours `--production` even though
+    # `bun audit --help` omits it from the flag list.
+    AUDIT_JSON=$(bun audit --production --json 2>/dev/null || true)
     UNFIXED_HIGH=$(echo "$AUDIT_JSON" | jq -r --arg ids "$AUDIT_EXCLUSIONS" '
       ($ids | split(" ") | map(select(length > 0))) as $ex
       | [ .[]? | .[]?


### PR DESCRIPTION
## Summary

Fixes the root cause behind **SE-5221**: lisa's bootstrap forced `bun install` on an npm-only project, creating a tracked `bun.lock` that re-broke the project on every push.

infrastructure-v2 is npm-only (`engines.bun = "please-use-npm"`, CI runs `npm ci`). But lisa's bootstrap ran `bun install`, producing a tracked `bun.lock`. That stray lockfile misrouted the lisa-generated husky **pre-push** hook's package-manager detection (priority `bun > yarn > npm`) into the **bun** branch, whose `bun audit` lacked the `--production` filter the npm/yarn branches use — so the gate failed on pre-existing **dev-only** CVEs that never ship to production.

## Fix 1 — Bootstrap detects & respects the project package manager

The installers no longer key on lockfile presence alone. They now resolve the PM with this precedence:

1. `packageManager` field (corepack, e.g. `npm@10`)
2. `engines` `"please-use-<pm>"` sentinel (e.g. `engines.bun = "please-use-npm"` ⇒ **npm**)
3. lockfile presence, **minus any PM the engines forbid** (`package-lock.json`→npm, `yarn.lock`→yarn, `pnpm-lock.yaml`→pnpm, `bun.lock(b)`→bun)
4. npm default

An npm-only project never runs `bun install` or gets a `bun.lock` — **even when a stray `bun.lock` is already present**.

Applied to:
- `plugins/src/base/hooks/install-pkgs.sh` (Claude SessionStart hook) + regenerated plugin copies
- `src/codex/scripts/install-pkgs.sh` (Codex SessionStart hook)
- `scripts/claude-remote-setup.sh` (was hardcoded `bun install`)
- `plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md` example
- `src/utils/postinstall-trampoline.ts` — `detectPackageManagers` now drops any engines-forbidden manager, so the reconciliation trampoline never regenerates a disallowed lockfile. Detection extracted to a new `src/utils/package-manager-detect.ts` (with `enginesForbiddenManagers`).

## Fix 2 — Pre-push hook bun-audit parity (defense in depth)

The bun branch now runs `bun audit --production --json`, matching `npm audit --production` and `yarn audit --groups dependencies`, so the gate only blocks on **production** high/critical CVEs. Verified empirically: a dev-only `minimist@0.0.8` advisory disappears with `--production` (bun honours the flag even though `bun audit --help` omits it). Applied to all three tracked hook copies: `typescript/copy-contents/.husky/pre-push`, `.husky/pre-push`, `.claude-pr/.husky/pre-push`.

## Testing

- `typecheck` ✓ · `lint` ✓ (0 errors) · `knip` ✓ · `build` ✓ · `check:plugins` ✓ (in sync)
- `test:unit` ✓ — **3236 passed**, incl. 5 new cases for `enginesForbiddenManagers` / the engines-based exclusion
- Shell detection unit-checked across 7 scenarios (npm-only + stray bun.lock → npm, corepack field, bun-legit, yarn, no-signals, …)

## Notes for reviewer

Both `dev`/`staging` approval gating and any merge-policy conventions are untouched. Opened without auto-merge — please advise if this repo prefers auto-merge.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced package manager detection across install flows by using project settings and lockfiles to choose the correct package manager.
  * Updated generated remote setup/skill scripts to install with the detected package manager (instead of assuming Bun).
* **Bug Fixes**
  * Scoped pre-push security audits to production dependencies only.
  * Improved dependency installation behavior to avoid incorrect manager selection and better honor project constraints.
* **Tests**
  * Added unit test coverage for package manager detection, including legacy Bun lockfiles and engines-based include/exclude rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->