### PR TITLE
fix(security-overrides): deliver form-data + aws-cdk-lib security floors on updates

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -23,7 +23,7 @@
       "source-map-support": "^0.5.21"
     },
     "devDependencies": {
-      "aws-cdk": "^2.1104.0",
+      "aws-cdk": "^2.1127.0",
       "vite": "^8.0.5",
       "vitest": "^4.1.0",
       "@vitest/coverage-v8": "^4.1.0",
@@ -36,7 +36,13 @@
     "bin": {
       "infrastructure": "bin/infrastructure.js"
     },
-    "private": true
+    "private": true,
+    "overrides": {
+      "aws-cdk-lib": ">=2.246.0"
+    },
+    "resolutions": {
+      "aws-cdk-lib": ">=2.246.0"
+    }
   },
   "defaults": {
     "devDependencies": {

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -32,7 +32,8 @@
       "handlebars": ">=4.7.9",
       "lodash": ">=4.18.1",
       "vite": ">=8.0.16",
-      "ws": ">=8.21.0"
+      "ws": ">=8.21.0",
+      "form-data": ">=4.0.6"
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
@@ -41,7 +42,8 @@
       "handlebars": ">=4.7.9",
       "lodash": ">=4.18.1",
       "vite": "^8.0.16",
-      "ws": ">=8.21.0"
+      "ws": ">=8.21.0",
+      "form-data": ">=4.0.6"
     }
   },
   "defaults": {


### PR DESCRIPTION
## Summary

Follow-up to #1306 (the package-lisa skip-git-check fix, shipped in 2.171.4). During the fleet `lisa-update-projects` run, the CI Security Scan (which resolves deps fresh and does NOT honor `audit.ignore.config.json`) surfaced two override gaps that #1306 didn't cover:

- **`form-data`** GHSA-hmw2-7cc7-3qxx (patched 4.0.6; 4.0.5 still vulnerable) — was not in Lisa's force overrides at all, so projects fresh-resolved a vulnerable transitive `form-data`. Added `form-data: ">=4.0.6"` to the typescript stack `force.overrides` + `force.resolutions`.
- **`aws-cdk-lib`** GHSA-999r-qq7v-r334 — #1306 bumped it in cdk `force.dependencies`, but the skip-git-check apply path (per #1306) only applies `force.overrides`/`force.resolutions`, so the 2.246.0 floor was NOT delivered to existing cdk projects on update. Added `aws-cdk-lib: ">=2.246.0"` to cdk `force.overrides` + `force.resolutions` so the security floor is delivered on the update/postinstall path. Also bumped the `aws-cdk` CLI floor `^2.1104.0` → `^2.1127.0` because aws-cdk-lib 2.246 emits cloud-assembly schema 53, which CLIs < ~2.112x (max schema 50) cannot read → CDK Synth fails.

All four affected cdk/frontend projects were already fixed per-PR during the fleet run; this makes the floors durable for future `lisa apply` updates.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS CDK dependencies and version constraints
  * Added form-data and websocket dependency constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->