### PR TITLE
feat(build-intake): assign an unassigned claimed item to the authenticated user

### DIFF
--- a/plugins/lisa-agy/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/github-build-intake/SKILL.md
@@ -245,6 +245,10 @@ A blocker is active if it is open and has no cleared status label. Treat `status
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
+# Assign to the authenticated user ONLY when the issue is currently unassigned (attributable claim;
+# do not pile a second assignee onto an issue that already has an owner):
+gh issue view <number> --repo <org>/<repo> --json assignees -q '.assignees | length' # → if 0:
+gh issue edit <number> --repo <org>/<repo> --add-assignee "@me"
 gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Claimed by Claude. Starting build."
 ```
 

--- a/plugins/lisa-agy/skills/jira-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/jira-build-intake/SKILL.md
@@ -177,6 +177,7 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 #### 3b. Claim
 
 Transition the ticket from `$READY` to `$CLAIMED` by invoking `lisa:atlassian-access` `operation: transition key: <TICKET> to: "$CLAIMED"`.
+- **Assign to the authenticated user when the ticket is unassigned.** A claim must be attributable. If the ticket has no assignee, assign it to the authenticated account — prefer acli `--assignee @me` (resolves server-side to the authenticated user, which avoids the federated-`accountId` mis-assignment), or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents. Leave an already-assigned ticket's assignee untouched — never reassign work that already has an owner.
 - Post a `[claude-build-intake]` comment via `lisa:atlassian-access` `operation: comment key: <TICKET> body: "Claimed by Claude. Starting build."`
 - This is the idempotency lock — a re-entrant cycle's `Status = $READY` filter will not see this ticket again.
 

--- a/plugins/lisa-agy/skills/linear-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/linear-build-intake/SKILL.md
@@ -186,6 +186,8 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 
 Update labels via `mcp__linear-server__save_issue`: remove `$READY`, add `$CLAIMED`. Resolve label IDs via `list_issue_labels` (create `$CLAIMED` if missing).
 
+**Assign to the authenticated user when the Issue is unassigned.** A claim must be attributable. If the Issue has no assignee, set its `assigneeId` to the authenticated viewer (resolve the viewer's id via the Linear MCP identity — e.g. `get_user` for the current actor) through `mcp__linear-server__save_issue`. Leave an already-assigned Issue's assignee untouched — never reassign work that already has an owner.
+
 Post a `[claude-build-intake]` comment via `save_comment`: `"Claimed by Claude. Starting build."`
 
 This is the idempotency lock — a re-entrant cycle's `label: $READY` filter will not see this Issue again.

--- a/plugins/lisa-copilot/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/github-build-intake/SKILL.md
@@ -245,6 +245,10 @@ A blocker is active if it is open and has no cleared status label. Treat `status
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
+# Assign to the authenticated user ONLY when the issue is currently unassigned (attributable claim;
+# do not pile a second assignee onto an issue that already has an owner):
+gh issue view <number> --repo <org>/<repo> --json assignees -q '.assignees | length' # → if 0:
+gh issue edit <number> --repo <org>/<repo> --add-assignee "@me"
 gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Claimed by Claude. Starting build."
 ```
 

--- a/plugins/lisa-copilot/skills/jira-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/jira-build-intake/SKILL.md
@@ -177,6 +177,7 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 #### 3b. Claim
 
 Transition the ticket from `$READY` to `$CLAIMED` by invoking `lisa:atlassian-access` `operation: transition key: <TICKET> to: "$CLAIMED"`.
+- **Assign to the authenticated user when the ticket is unassigned.** A claim must be attributable. If the ticket has no assignee, assign it to the authenticated account — prefer acli `--assignee @me` (resolves server-side to the authenticated user, which avoids the federated-`accountId` mis-assignment), or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents. Leave an already-assigned ticket's assignee untouched — never reassign work that already has an owner.
 - Post a `[claude-build-intake]` comment via `lisa:atlassian-access` `operation: comment key: <TICKET> body: "Claimed by Claude. Starting build."`
 - This is the idempotency lock — a re-entrant cycle's `Status = $READY` filter will not see this ticket again.
 

--- a/plugins/lisa-copilot/skills/linear-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/linear-build-intake/SKILL.md
@@ -186,6 +186,8 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 
 Update labels via `mcp__linear-server__save_issue`: remove `$READY`, add `$CLAIMED`. Resolve label IDs via `list_issue_labels` (create `$CLAIMED` if missing).
 
+**Assign to the authenticated user when the Issue is unassigned.** A claim must be attributable. If the Issue has no assignee, set its `assigneeId` to the authenticated viewer (resolve the viewer's id via the Linear MCP identity — e.g. `get_user` for the current actor) through `mcp__linear-server__save_issue`. Leave an already-assigned Issue's assignee untouched — never reassign work that already has an owner.
+
 Post a `[claude-build-intake]` comment via `save_comment`: `"Claimed by Claude. Starting build."`
 
 This is the idempotency lock — a re-entrant cycle's `label: $READY` filter will not see this Issue again.

--- a/plugins/lisa-cursor/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/github-build-intake/SKILL.md
@@ -245,6 +245,10 @@ A blocker is active if it is open and has no cleared status label. Treat `status
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
+# Assign to the authenticated user ONLY when the issue is currently unassigned (attributable claim;
+# do not pile a second assignee onto an issue that already has an owner):
+gh issue view <number> --repo <org>/<repo> --json assignees -q '.assignees | length' # → if 0:
+gh issue edit <number> --repo <org>/<repo> --add-assignee "@me"
 gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Claimed by Claude. Starting build."
 ```
 

--- a/plugins/lisa-cursor/skills/jira-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/jira-build-intake/SKILL.md
@@ -177,6 +177,7 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 #### 3b. Claim
 
 Transition the ticket from `$READY` to `$CLAIMED` by invoking `lisa:atlassian-access` `operation: transition key: <TICKET> to: "$CLAIMED"`.
+- **Assign to the authenticated user when the ticket is unassigned.** A claim must be attributable. If the ticket has no assignee, assign it to the authenticated account — prefer acli `--assignee @me` (resolves server-side to the authenticated user, which avoids the federated-`accountId` mis-assignment), or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents. Leave an already-assigned ticket's assignee untouched — never reassign work that already has an owner.
 - Post a `[claude-build-intake]` comment via `lisa:atlassian-access` `operation: comment key: <TICKET> body: "Claimed by Claude. Starting build."`
 - This is the idempotency lock — a re-entrant cycle's `Status = $READY` filter will not see this ticket again.
 

--- a/plugins/lisa-cursor/skills/linear-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/linear-build-intake/SKILL.md
@@ -186,6 +186,8 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 
 Update labels via `mcp__linear-server__save_issue`: remove `$READY`, add `$CLAIMED`. Resolve label IDs via `list_issue_labels` (create `$CLAIMED` if missing).
 
+**Assign to the authenticated user when the Issue is unassigned.** A claim must be attributable. If the Issue has no assignee, set its `assigneeId` to the authenticated viewer (resolve the viewer's id via the Linear MCP identity — e.g. `get_user` for the current actor) through `mcp__linear-server__save_issue`. Leave an already-assigned Issue's assignee untouched — never reassign work that already has an owner.
+
 Post a `[claude-build-intake]` comment via `save_comment`: `"Claimed by Claude. Starting build."`
 
 This is the idempotency lock — a re-entrant cycle's `label: $READY` filter will not see this Issue again.

--- a/plugins/lisa/skills/github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/github-build-intake/SKILL.md
@@ -245,6 +245,10 @@ A blocker is active if it is open and has no cleared status label. Treat `status
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
+# Assign to the authenticated user ONLY when the issue is currently unassigned (attributable claim;
+# do not pile a second assignee onto an issue that already has an owner):
+gh issue view <number> --repo <org>/<repo> --json assignees -q '.assignees | length' # → if 0:
+gh issue edit <number> --repo <org>/<repo> --add-assignee "@me"
 gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Claimed by Claude. Starting build."
 ```
 

--- a/plugins/lisa/skills/jira-build-intake/SKILL.md
+++ b/plugins/lisa/skills/jira-build-intake/SKILL.md
@@ -177,6 +177,7 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 #### 3b. Claim
 
 Transition the ticket from `$READY` to `$CLAIMED` by invoking `lisa:atlassian-access` `operation: transition key: <TICKET> to: "$CLAIMED"`.
+- **Assign to the authenticated user when the ticket is unassigned.** A claim must be attributable. If the ticket has no assignee, assign it to the authenticated account — prefer acli `--assignee @me` (resolves server-side to the authenticated user, which avoids the federated-`accountId` mis-assignment), or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents. Leave an already-assigned ticket's assignee untouched — never reassign work that already has an owner.
 - Post a `[claude-build-intake]` comment via `lisa:atlassian-access` `operation: comment key: <TICKET> body: "Claimed by Claude. Starting build."`
 - This is the idempotency lock — a re-entrant cycle's `Status = $READY` filter will not see this ticket again.
 

--- a/plugins/lisa/skills/linear-build-intake/SKILL.md
+++ b/plugins/lisa/skills/linear-build-intake/SKILL.md
@@ -186,6 +186,8 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 
 Update labels via `mcp__linear-server__save_issue`: remove `$READY`, add `$CLAIMED`. Resolve label IDs via `list_issue_labels` (create `$CLAIMED` if missing).
 
+**Assign to the authenticated user when the Issue is unassigned.** A claim must be attributable. If the Issue has no assignee, set its `assigneeId` to the authenticated viewer (resolve the viewer's id via the Linear MCP identity — e.g. `get_user` for the current actor) through `mcp__linear-server__save_issue`. Leave an already-assigned Issue's assignee untouched — never reassign work that already has an owner.
+
 Post a `[claude-build-intake]` comment via `save_comment`: `"Claimed by Claude. Starting build."`
 
 This is the idempotency lock — a re-entrant cycle's `label: $READY` filter will not see this Issue again.

--- a/plugins/src/base/skills/github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/github-build-intake/SKILL.md
@@ -245,6 +245,10 @@ A blocker is active if it is open and has no cleared status label. Treat `status
 
 ```bash
 gh issue edit <number> --repo <org>/<repo> --remove-label "$READY" --add-label "$CLAIMED"
+# Assign to the authenticated user ONLY when the issue is currently unassigned (attributable claim;
+# do not pile a second assignee onto an issue that already has an owner):
+gh issue view <number> --repo <org>/<repo> --json assignees -q '.assignees | length' # → if 0:
+gh issue edit <number> --repo <org>/<repo> --add-assignee "@me"
 gh issue comment <number> --repo <org>/<repo> --body "[claude-build-intake] Claimed by Claude. Starting build."
 ```
 

--- a/plugins/src/base/skills/jira-build-intake/SKILL.md
+++ b/plugins/src/base/skills/jira-build-intake/SKILL.md
@@ -177,6 +177,7 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 #### 3b. Claim
 
 Transition the ticket from `$READY` to `$CLAIMED` by invoking `lisa:atlassian-access` `operation: transition key: <TICKET> to: "$CLAIMED"`.
+- **Assign to the authenticated user when the ticket is unassigned.** A claim must be attributable. If the ticket has no assignee, assign it to the authenticated account — prefer acli `--assignee @me` (resolves server-side to the authenticated user, which avoids the federated-`accountId` mis-assignment), or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents. Leave an already-assigned ticket's assignee untouched — never reassign work that already has an owner.
 - Post a `[claude-build-intake]` comment via `lisa:atlassian-access` `operation: comment key: <TICKET> body: "Claimed by Claude. Starting build."`
 - This is the idempotency lock — a re-entrant cycle's `Status = $READY` filter will not see this ticket again.
 

--- a/plugins/src/base/skills/linear-build-intake/SKILL.md
+++ b/plugins/src/base/skills/linear-build-intake/SKILL.md
@@ -186,6 +186,8 @@ This gate never blocks a legitimate flat Task/Bug: those have no open children a
 
 Update labels via `mcp__linear-server__save_issue`: remove `$READY`, add `$CLAIMED`. Resolve label IDs via `list_issue_labels` (create `$CLAIMED` if missing).
 
+**Assign to the authenticated user when the Issue is unassigned.** A claim must be attributable. If the Issue has no assignee, set its `assigneeId` to the authenticated viewer (resolve the viewer's id via the Linear MCP identity — e.g. `get_user` for the current actor) through `mcp__linear-server__save_issue`. Leave an already-assigned Issue's assignee untouched — never reassign work that already has an owner.
+
 Post a `[claude-build-intake]` comment via `save_comment`: `"Claimed by Claude. Starting build."`
 
 This is the idempotency lock — a re-entrant cycle's `label: $READY` filter will not see this Issue again.


### PR DESCRIPTION
## What

When `build-intake` claims a ready work item (Phase 3b), if the item is **unassigned**, assign it to the **currently authenticated user**. An already-assigned item is left untouched — we never reassign work that already has an owner.

## Why

Previously the claim was attributable only through the `[claude-build-intake] Claimed by Claude` comment; an item that started unassigned stayed unassigned through its whole in-progress life. That reads as unowned on the board and is easy to lose track of. Assigning the claimer makes the in-progress state self-describing and pairs naturally with the `$READY → $CLAIMED` transition that already happens here.

## Mechanics (vendor-correct)

- **JIRA** (`jira-build-intake`): acli `--assignee @me` — resolves server-side to the authenticated account, which avoids the federated-`accountId` silent-unassign bug — or `write-ticket` with the `accountId` from the `/rest/api/3/myself` identity probe the access skill already documents.
- **GitHub** (`github-build-intake`): `gh issue edit --add-assignee @me`, guarded on `assignees | length == 0`.
- **Linear** (`linear-build-intake`): set `assigneeId` to the authenticated viewer via `save_issue`.

## Scope

Edits the three vendor build-intake source skills (`plugins/src/base/skills/*-build-intake/SKILL.md`) and their four generated copies each (`lisa`, `lisa-agy`, `lisa-copilot`, `lisa-cursor`) — 15 files, all byte-identical per skill, so `check:plugins` stays in sync. `tracker-build-intake` is a thin dispatcher with no claim step and is unchanged.

🤖 Generated with Claude Code