### PR TITLE
fix(enforce-team-first): accept implicit-team Agent spawn (Claude Code ≥ 2.1.178)

### DIFF
--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -64,7 +64,7 @@
         ]
       },
       {
-        "matcher": "TeamCreate",
+        "matcher": "TeamCreate|Agent",
         "hooks": [
           {
             "type": "command",

--- a/plugins/lisa/hooks/enforce-team-first.sh
+++ b/plugins/lisa/hooks/enforce-team-first.sh
@@ -9,10 +9,13 @@
 #   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake|debrief in the
 #                         raw prompt and arms enforcement for the session
 #   - PreToolUse        : detects the same skills via a `Skill` tool call,
-#                         arms enforcement, and blocks bypass tool calls
-#                         until ToolSearch+TeamCreate have fired in Claude
-#   - PostToolUse       : on a successful Claude TeamCreate, marks the session as
-#                         team-created (lifts enforcement)
+#                         arms enforcement, and blocks bypass tool calls until
+#                         the team is established — i.e. until a TeamCreate
+#                         (older Claude Code) or the first Agent spawn
+#                         (implicit-team model, Claude Code >= 2.1.178) fires
+#   - PostToolUse       : on a successful Claude TeamCreate OR a successful
+#                         Agent spawn (implicit team), marks the session as
+#                         team-established (lifts enforcement)
 #   - SubagentStart     : marks the new subagent session as a teammate so
 #                         it is exempt — teammates inherit the lead's team
 #                         and must never create a second team (double-create
@@ -85,7 +88,12 @@ case "$HOOK_EVENT" in
 
   PostToolUse)
     TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
-    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+    # A successful TeamCreate (older Claude Code) OR a successful Agent spawn
+    # (Claude Code >= 2.1.178, where TeamCreate/TeamDelete were removed in favor
+    # of the implicit-team model — the team forms automatically when the lead
+    # spawns its first teammate via the Agent tool) marks the session as
+    # team-established and lifts enforcement.
+    if [ "$TOOL_NAME" = "TeamCreate" ] || [ "$TOOL_NAME" = "Agent" ]; then
       ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
       IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
       if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
@@ -136,9 +144,12 @@ if [ -f "$TEAM_FLAG" ]; then
   exit 0
 fi
 
-# These two are the path forward; never block them.
+# These are the path forward; never block them.
+#   - ToolSearch / TeamCreate : the older explicit-team path (Claude Code < 2.1.178)
+#   - Agent                   : the implicit-team path (Claude Code >= 2.1.178) —
+#                               spawning the first teammate IS what forms the team
 case "$TOOL_NAME" in
-  ToolSearch|TeamCreate)
+  ToolSearch|TeamCreate|Agent)
     exit 0
     ;;
 esac
@@ -163,21 +174,25 @@ fi
 ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
 cat >&2 <<EOF
 Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
-In Claude, before any other tool call, you must:
+In Claude, before any other tool call, you must establish the team by spawning
+your first teammate:
 
-  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
-  2. TeamCreate                                   (actually create the team)
+  Call the \`Agent\` tool with an appropriate \`subagent_type\`.
+
+The team forms automatically the moment the lead spawns its first teammate —
+this is the implicit-team model on Claude Code >= 2.1.178, where the explicit
+\`TeamCreate\`/\`TeamDelete\` tools were removed. (On older Claude Code the
+\`TeamCreate\` tool path still works and is also accepted.)
 
 The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
 the ticket, exploring the code, fetching context — those are tasks for the
-team you are about to create, not for the lead session before the team
-exists.
+team you are about to spawn, not for the lead session before the team exists.
 
 If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
-ToolSearch.
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning a
+teammate with the \`Agent\` tool.
 EOF
 exit 2

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -47,7 +47,7 @@
         ]
       },
       {
-        "matcher": "TeamCreate",
+        "matcher": "TeamCreate|Agent",
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
         ]

--- a/plugins/src/base/hooks/enforce-team-first.sh
+++ b/plugins/src/base/hooks/enforce-team-first.sh
@@ -9,10 +9,13 @@
 #   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake|debrief in the
 #                         raw prompt and arms enforcement for the session
 #   - PreToolUse        : detects the same skills via a `Skill` tool call,
-#                         arms enforcement, and blocks bypass tool calls
-#                         until ToolSearch+TeamCreate have fired in Claude
-#   - PostToolUse       : on a successful Claude TeamCreate, marks the session as
-#                         team-created (lifts enforcement)
+#                         arms enforcement, and blocks bypass tool calls until
+#                         the team is established — i.e. until a TeamCreate
+#                         (older Claude Code) or the first Agent spawn
+#                         (implicit-team model, Claude Code >= 2.1.178) fires
+#   - PostToolUse       : on a successful Claude TeamCreate OR a successful
+#                         Agent spawn (implicit team), marks the session as
+#                         team-established (lifts enforcement)
 #   - SubagentStart     : marks the new subagent session as a teammate so
 #                         it is exempt — teammates inherit the lead's team
 #                         and must never create a second team (double-create
@@ -85,7 +88,12 @@ case "$HOOK_EVENT" in
 
   PostToolUse)
     TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
-    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+    # A successful TeamCreate (older Claude Code) OR a successful Agent spawn
+    # (Claude Code >= 2.1.178, where TeamCreate/TeamDelete were removed in favor
+    # of the implicit-team model — the team forms automatically when the lead
+    # spawns its first teammate via the Agent tool) marks the session as
+    # team-established and lifts enforcement.
+    if [ "$TOOL_NAME" = "TeamCreate" ] || [ "$TOOL_NAME" = "Agent" ]; then
       ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
       IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
       if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
@@ -136,9 +144,12 @@ if [ -f "$TEAM_FLAG" ]; then
   exit 0
 fi
 
-# These two are the path forward; never block them.
+# These are the path forward; never block them.
+#   - ToolSearch / TeamCreate : the older explicit-team path (Claude Code < 2.1.178)
+#   - Agent                   : the implicit-team path (Claude Code >= 2.1.178) —
+#                               spawning the first teammate IS what forms the team
 case "$TOOL_NAME" in
-  ToolSearch|TeamCreate)
+  ToolSearch|TeamCreate|Agent)
     exit 0
     ;;
 esac
@@ -163,21 +174,25 @@ fi
 ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
 cat >&2 <<EOF
 Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
-In Claude, before any other tool call, you must:
+In Claude, before any other tool call, you must establish the team by spawning
+your first teammate:
 
-  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
-  2. TeamCreate                                   (actually create the team)
+  Call the \`Agent\` tool with an appropriate \`subagent_type\`.
+
+The team forms automatically the moment the lead spawns its first teammate —
+this is the implicit-team model on Claude Code >= 2.1.178, where the explicit
+\`TeamCreate\`/\`TeamDelete\` tools were removed. (On older Claude Code the
+\`TeamCreate\` tool path still works and is also accepted.)
 
 The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
 the ticket, exploring the code, fetching context — those are tasks for the
-team you are about to create, not for the lead session before the team
-exists.
+team you are about to spawn, not for the lead session before the team exists.
 
 If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
-ToolSearch.
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning a
+teammate with the \`Agent\` tool.
 EOF
 exit 2

--- a/tests/unit/hooks/enforce-team-first.test.ts
+++ b/tests/unit/hooks/enforce-team-first.test.ts
@@ -2,9 +2,10 @@
  * Tests for the enforce-team-first.sh hook.
  *
  * The hook arms enforcement when /lisa:research|plan|implement|intake is
- * invoked, blocks bypass tool calls until ToolSearch+TeamCreate fire,
- * and exempts subagent (teammate) sessions because they inherit the
- * lead's team.
+ * invoked, blocks bypass tool calls until the team is established — a
+ * TeamCreate (older Claude Code) or the first Agent spawn (implicit-team
+ * model, Claude Code >= 2.1.178) — and exempts subagent (teammate)
+ * sessions because they inherit the lead's team.
  * @module tests/unit/hooks/enforce-team-first
  */
 import { spawnSync } from "child_process";
@@ -133,7 +134,10 @@ describe("enforce-team-first.sh", () => {
     it("explains the path forward in the block message", () => {
       armSession("msg");
       const { stderr } = preToolUse("msg", "Task", {});
-      expect(stderr).toContain("ToolSearch");
+      // The path forward under the implicit-team model is spawning a teammate
+      // via the Agent tool; the message still names TeamCreate for older
+      // Claude Code, and the active skill.
+      expect(stderr).toContain("Agent");
       expect(stderr).toContain("TeamCreate");
       expect(stderr).toContain("/lisa:implement");
     });
@@ -143,6 +147,7 @@ describe("enforce-team-first.sh", () => {
     it.each([
       ["ToolSearch", { query: "select:TeamCreate" }],
       ["TeamCreate", {}],
+      ["Agent", { subagent_type: "general-purpose" }],
       ["TodoWrite", { todos: [] }],
       ["AskUserQuestion", {}],
     ])("allows %s while armed", (tool, input) => {
@@ -153,7 +158,7 @@ describe("enforce-team-first.sh", () => {
     });
   });
 
-  describe("PostToolUse on TeamCreate", () => {
+  describe("PostToolUse team-established signal", () => {
     it("lifts enforcement when TeamCreate succeeds", () => {
       const sid = "post-ok";
       armSession(sid);
@@ -167,6 +172,26 @@ describe("enforce-team-first.sh", () => {
         tool_name: "TeamCreate",
         tool_input: {},
         tool_response: { team_id: "team-xyz" },
+      });
+      expect(existsSync(flagPath(sid, "team"))).toBe(true);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+
+    it("lifts enforcement when the first Agent spawn succeeds (implicit team)", () => {
+      const sid = "post-ok-agent";
+      armSession(sid);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_BLOCKED
+      );
+
+      runHook({
+        hook_event_name: "PostToolUse",
+        session_id: sid,
+        tool_name: "Agent",
+        tool_input: { subagent_type: "general-purpose" },
+        tool_response: { agentId: "a1234-abcd" },
       });
       expect(existsSync(flagPath(sid, "team"))).toBe(true);
       expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(


### PR DESCRIPTION
## Problem

Claude Code **removed the explicit `TeamCreate`/`TeamDelete` tools in v2.1.178**, replacing them with an **implicit-team model**: the team forms automatically the moment the lead spawns its first teammate via the `Agent` tool (team auto-named from the session, auto-torn-down on session exit).

The `enforce-team-first.sh` hook only lifted enforcement on a successful **`TeamCreate`** `PostToolUse` (registered via `plugin.json` matcher `"TeamCreate"`). On Claude Code ≥ 2.1.178 that tool can never fire, so the `.team` flag is never set and the `PreToolUse` gate (matcher `""`, fires on every tool) **blocks every tool forever** — a hard deadlock for `/lisa:implement` and the other agent-team lifecycle flows. The block message even instructs `ToolSearch select:TeamCreate` → `TeamCreate`, pointing at a removed tool.

## Fix (additive / backward-compatible — the old `TeamCreate` path still works)

- **`plugin.json`**: PostToolUse matcher `"TeamCreate"` → `"TeamCreate|Agent"` so the hook actually runs after an `Agent` spawn.
- **hook**: lift the gate on a successful `TeamCreate` **or** `Agent` PostToolUse; add `Agent` to the never-block PreToolUse allowlist (so the lead can make that first spawn); rewrite the block message to instruct spawning a teammate via the `Agent` tool, while still naming the legacy `TeamCreate` path for older Claude Code.
- Regenerated the built `plugins/lisa/` artifacts from `plugins/src/base/` via `bun run build:plugins`.
- **tests**: updated the path-forward assertion (now `Agent`), added `Agent` to the armed-allowlist cases, and added a PostToolUse test asserting the first successful `Agent` spawn lifts enforcement.

## Verification

- `bun run build:plugins` — clean; only the 2 source files + their 2 regenerated artifacts differ.
- `bash -n` on the hook, JSON valid on all plugin.json.
- Pre-push gates all green: gitleaks, `tsc --noEmit`, slow lint, unit + coverage (`enforce-team-first.test.ts`: 36 passed), integration (54 passed).

🤖 Generated with Claude Code