### PR TITLE
feat(quality): add opt-in concurrency_group input to mutex cross-run E2E

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -134,6 +134,11 @@ on:
         required: false
         default: false
         type: boolean
+      concurrency_group:
+        description: 'Optional concurrency group to serialize whole workflow runs that share mutable external state (e.g. Playwright E2E that switches the server-side org of a shared test user; concurrent runs otherwise stomp each other). When set, every run passing the same string queues one-behind-another (cancel-in-progress: false). It MUST differ from the calling workflow concurrency group, or parent/child runs sharing a group can deadlock. Default empty = no cross-run serialization (a unique group per run, prior behavior preserved).'
+        required: false
+        default: ''
+        type: string
     secrets:
       SONAR_TOKEN:
         description: 'SonarCloud token for SAST analysis'
@@ -151,8 +156,24 @@ on:
         description: 'Maestro Cloud API key for mobile E2E testing'
         required: false
 
-# Concurrency is managed by the parent workflow that calls this one
-# This avoids deadlocks between parent and child workflows
+# Cross-run serialization is opt-in via the `concurrency_group` input.
+#
+# Historically this workflow set NO concurrency and deferred entirely to the
+# calling workflow, to avoid parent/child deadlocks (a parent run holding a
+# group slot while waiting on a child that queues on the same group). That
+# hazard only exists when parent and child SHARE a group with
+# `cancel-in-progress: false`, so this opt-in is deadlock-safe by construction:
+#   - default (input empty): the group is unique per run (github.run_id), so no
+#     run ever waits on another — behavior is identical to having no concurrency.
+#   - set: callers pass a constant string DISTINCT from their own top-level
+#     concurrency group, serializing these runs across PRs without ever sharing
+#     a group with the parent.
+# Used to mutex suites that mutate shared external state — e.g. Playwright E2E
+# that switches a shared test user's server-side org (concurrent CI runs across
+# PRs otherwise stomp each other's org context).
+concurrency:
+  group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('lisa-quality-no-serialize-{0}', github.run_id) }}
+  cancel-in-progress: false
 
 jobs:
   # Central dependency installation job to optimize performance

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -51,6 +51,7 @@ interface QualityWorkflow {
       inputs?: Record<string, WorkflowInput>;
     };
   };
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
   jobs: Record<string, WorkflowJob>;
 }
 
@@ -77,6 +78,33 @@ describe("quality.yml reusable workflow", () => {
       expect(input?.required).toBe(false);
       expect(input?.default).toBe(false);
       expect(input?.type).toBe("boolean");
+    });
+  });
+
+  describe("cross-run concurrency mutex (opt-in)", () => {
+    it("declares concurrency_group input defaulting to '' (no serialization)", () => {
+      const input = workflow.on.workflow_call?.inputs?.concurrency_group;
+      expect(input).toBeDefined();
+      expect(input?.required).toBe(false);
+      expect(input?.default).toBe("");
+      expect(input?.type).toBe("string");
+    });
+
+    it("sets a top-level concurrency that queues rather than cancels", () => {
+      // cancel-in-progress must be false so opted-in runs queue (serialize)
+      // instead of cancelling each other — cancelling mid-run is what leaves
+      // shared external state (e.g. a test user's server-side org) dirty.
+      expect(workflow.concurrency).toBeDefined();
+      expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    });
+
+    it("falls back to a per-run unique group when the input is unset", () => {
+      // Default behavior must be identical to having no concurrency: when
+      // concurrency_group is empty the group resolves to a github.run_id-keyed
+      // string, so no run ever waits on another (and no parent/child deadlock).
+      const group = workflow.concurrency?.group ?? "";
+      expect(group).toContain("inputs.concurrency_group");
+      expect(group).toContain("github.run_id");
     });
   });
 


### PR DESCRIPTION
## Why

The reusable `quality.yml` workflow sets **no concurrency** and defers it entirely to the caller. That leaves no way to serialize *across* runs/PRs — which is exactly what's needed for suites that mutate **shared external state**.

Concrete case (frontend-v2 Playwright E2E): the suite authenticates as a **shared** test user and switches that user's **server-side "current organization"** via `logIntoOrganization`. The org pointer is global to the user (not per-token, not per-shard), so under concurrent CI (multiple PRs × 4 shards each) runs stomp each other's org context mid-test and cascade failures (`MEMBER's org returned zero players`, empty-org). A single PR usually passes; overlapping PRs fail. This blocked real PRs and was worked around by hand-serializing runs.

## What

- New opt-in input **`concurrency_group`** (string, default `''`).
- A top-level **`concurrency`** block.

**Deadlock-safe by construction** — the original reason concurrency was deferred to the parent was the parent/child deadlock hazard (a parent holding a group slot while waiting on a child that queues on the *same* group). That only happens when parent and child **share** a group with `cancel-in-progress: false`. This design avoids it:

- **Default (input empty):** group resolves to a per-run-unique value via `github.run_id`, so no run ever waits on another — behavior is identical to having no concurrency.
- **Set:** callers pass a constant string **distinct** from their own top-level concurrency group, serializing those runs across PRs (`cancel-in-progress: false` → queue, never cancel) without ever sharing a group with the parent.

```yaml
concurrency:
  group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('lisa-quality-no-serialize-{0}', github.run_id) }}
  cancel-in-progress: false
```

## Consumer usage

A consumer opts in with an **env-aware** group (the shared user is per-environment), e.g.:

```yaml
uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
with:
  concurrency_group: e2e-shared-test-user-${{ github.base_ref }}
```

(frontend-v2 PR to follow, once this lands.)

## Tests

Extended `tests/integration/quality-workflow.test.ts`: asserts the `concurrency_group` input default, `cancel-in-progress: false`, and the per-run-unique fallback. Full file passes (15/15).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `concurrency_group` input for controlling workflow run serialization. When set to a value, all runs using the same group name queue sequentially; when left empty (default), each run executes independently.

* **Tests**
  * Added test coverage for the new concurrency input and group-based queuing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->