### PR TITLE
chore(plugins): recognize implicit-team model in enforce-team-first hook

### DIFF
--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -64,7 +64,7 @@
         ]
       },
       {
-        "matcher": "TeamCreate",
+        "matcher": "TeamCreate|Agent",
         "hooks": [
           {
             "type": "command",

--- a/plugins/lisa/hooks/enforce-team-first.sh
+++ b/plugins/lisa/hooks/enforce-team-first.sh
@@ -9,10 +9,13 @@
 #   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake|debrief in the
 #                         raw prompt and arms enforcement for the session
 #   - PreToolUse        : detects the same skills via a `Skill` tool call,
-#                         arms enforcement, and blocks bypass tool calls
-#                         until ToolSearch+TeamCreate have fired in Claude
-#   - PostToolUse       : on a successful Claude TeamCreate, marks the session as
-#                         team-created (lifts enforcement)
+#                         arms enforcement, and blocks bypass tool calls until
+#                         the team is established — i.e. until a TeamCreate
+#                         (older Claude Code) or the first Agent spawn
+#                         (implicit-team model, Claude Code >= 2.1.178) fires
+#   - PostToolUse       : on a successful Claude TeamCreate OR a successful
+#                         Agent spawn (implicit team), marks the session as
+#                         team-established (lifts enforcement)
 #   - SubagentStart     : marks the new subagent session as a teammate so
 #                         it is exempt — teammates inherit the lead's team
 #                         and must never create a second team (double-create
@@ -85,7 +88,12 @@ case "$HOOK_EVENT" in
 
   PostToolUse)
     TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
-    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+    # A successful TeamCreate (older Claude Code) OR a successful Agent spawn
+    # (Claude Code >= 2.1.178, where TeamCreate/TeamDelete were removed in favor
+    # of the implicit-team model — the team forms automatically when the lead
+    # spawns its first teammate via the Agent tool) marks the session as
+    # team-established and lifts enforcement.
+    if [ "$TOOL_NAME" = "TeamCreate" ] || [ "$TOOL_NAME" = "Agent" ]; then
       ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
       IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
       if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
@@ -136,9 +144,12 @@ if [ -f "$TEAM_FLAG" ]; then
   exit 0
 fi
 
-# These two are the path forward; never block them.
+# These are the path forward; never block them.
+#   - ToolSearch / TeamCreate : the older explicit-team path (Claude Code < 2.1.178)
+#   - Agent                   : the implicit-team path (Claude Code >= 2.1.178) —
+#                               spawning the first teammate IS what forms the team
 case "$TOOL_NAME" in
-  ToolSearch|TeamCreate)
+  ToolSearch|TeamCreate|Agent)
     exit 0
     ;;
 esac
@@ -163,21 +174,25 @@ fi
 ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
 cat >&2 <<EOF
 Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
-In Claude, before any other tool call, you must:
+In Claude, before any other tool call, you must establish the team by spawning
+your first teammate:
 
-  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
-  2. TeamCreate                                   (actually create the team)
+  Call the \`Agent\` tool with an appropriate \`subagent_type\`.
+
+The team forms automatically the moment the lead spawns its first teammate —
+this is the implicit-team model on Claude Code >= 2.1.178, where the explicit
+\`TeamCreate\`/\`TeamDelete\` tools were removed. (On older Claude Code the
+\`TeamCreate\` tool path still works and is also accepted.)
 
 The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
 the ticket, exploring the code, fetching context — those are tasks for the
-team you are about to create, not for the lead session before the team
-exists.
+team you are about to spawn, not for the lead session before the team exists.
 
 If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
-ToolSearch.
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning a
+teammate with the \`Agent\` tool.
 EOF
 exit 2

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -47,7 +47,7 @@
         ]
       },
       {
-        "matcher": "TeamCreate",
+        "matcher": "TeamCreate|Agent",
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
         ]

--- a/plugins/src/base/hooks/enforce-team-first.sh
+++ b/plugins/src/base/hooks/enforce-team-first.sh
@@ -9,10 +9,13 @@
 #   - UserPromptSubmit  : detects /lisa:research|plan|implement|intake|debrief in the
 #                         raw prompt and arms enforcement for the session
 #   - PreToolUse        : detects the same skills via a `Skill` tool call,
-#                         arms enforcement, and blocks bypass tool calls
-#                         until ToolSearch+TeamCreate have fired in Claude
-#   - PostToolUse       : on a successful Claude TeamCreate, marks the session as
-#                         team-created (lifts enforcement)
+#                         arms enforcement, and blocks bypass tool calls until
+#                         the team is established — i.e. until a TeamCreate
+#                         (older Claude Code) or the first Agent spawn
+#                         (implicit-team model, Claude Code >= 2.1.178) fires
+#   - PostToolUse       : on a successful Claude TeamCreate OR a successful
+#                         Agent spawn (implicit team), marks the session as
+#                         team-established (lifts enforcement)
 #   - SubagentStart     : marks the new subagent session as a teammate so
 #                         it is exempt — teammates inherit the lead's team
 #                         and must never create a second team (double-create
@@ -85,7 +88,12 @@ case "$HOOK_EVENT" in
 
   PostToolUse)
     TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
-    if [ "$TOOL_NAME" = "TeamCreate" ]; then
+    # A successful TeamCreate (older Claude Code) OR a successful Agent spawn
+    # (Claude Code >= 2.1.178, where TeamCreate/TeamDelete were removed in favor
+    # of the implicit-team model — the team forms automatically when the lead
+    # spawns its first teammate via the Agent tool) marks the session as
+    # team-established and lifts enforcement.
+    if [ "$TOOL_NAME" = "TeamCreate" ] || [ "$TOOL_NAME" = "Agent" ]; then
       ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.error // empty' 2>/dev/null || true)
       IS_ERROR=$(printf '%s' "$INPUT" | jq -r '.tool_response.is_error // empty' 2>/dev/null || true)
       if [ -z "$ERROR" ] && [ "$IS_ERROR" != "true" ]; then
@@ -136,9 +144,12 @@ if [ -f "$TEAM_FLAG" ]; then
   exit 0
 fi
 
-# These two are the path forward; never block them.
+# These are the path forward; never block them.
+#   - ToolSearch / TeamCreate : the older explicit-team path (Claude Code < 2.1.178)
+#   - Agent                   : the implicit-team path (Claude Code >= 2.1.178) —
+#                               spawning the first teammate IS what forms the team
 case "$TOOL_NAME" in
-  ToolSearch|TeamCreate)
+  ToolSearch|TeamCreate|Agent)
     exit 0
     ;;
 esac
@@ -163,21 +174,25 @@ fi
 ACTIVE_SKILL=$(cat "$SKILL_FLAG" 2>/dev/null || echo "lisa:???")
 cat >&2 <<EOF
 Blocked: this session invoked /${ACTIVE_SKILL}, which is an agent-team flow.
-In Claude, before any other tool call, you must:
+In Claude, before any other tool call, you must establish the team by spawning
+your first teammate:
 
-  1. ToolSearch with query: "select:TeamCreate"  (load the deferred schema)
-  2. TeamCreate                                   (actually create the team)
+  Call the \`Agent\` tool with an appropriate \`subagent_type\`.
+
+The team forms automatically the moment the lead spawns its first teammate —
+this is the implicit-team model on Claude Code >= 2.1.178, where the explicit
+\`TeamCreate\`/\`TeamDelete\` tools were removed. (On older Claude Code the
+\`TeamCreate\` tool path still works and is also accepted.)
 
 The current attempt to call \`${TOOL_NAME}\` is a team-bypass path. Reading
 the ticket, exploring the code, fetching context — those are tasks for the
-team you are about to create, not for the lead session before the team
-exists.
+team you are about to spawn, not for the lead session before the team exists.
 
 If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start with
-ToolSearch.
+Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning a
+teammate with the \`Agent\` tool.
 EOF
 exit 2

--- a/tests/unit/hooks/enforce-team-first.test.ts
+++ b/tests/unit/hooks/enforce-team-first.test.ts
@@ -2,9 +2,10 @@
  * Tests for the enforce-team-first.sh hook.
  *
  * The hook arms enforcement when /lisa:research|plan|implement|intake is
- * invoked, blocks bypass tool calls until ToolSearch+TeamCreate fire,
- * and exempts subagent (teammate) sessions because they inherit the
- * lead's team.
+ * invoked, blocks bypass tool calls until the team is established — a
+ * TeamCreate (older Claude Code) or the first Agent spawn (implicit-team
+ * model, Claude Code >= 2.1.178) — and exempts subagent (teammate)
+ * sessions because they inherit the lead's team.
  * @module tests/unit/hooks/enforce-team-first
  */
 import { spawnSync } from "child_process";
@@ -133,7 +134,7 @@ describe("enforce-team-first.sh", () => {
     it("explains the path forward in the block message", () => {
       armSession("msg");
       const { stderr } = preToolUse("msg", "Task", {});
-      expect(stderr).toContain("ToolSearch");
+      expect(stderr).toContain("Agent");
       expect(stderr).toContain("TeamCreate");
       expect(stderr).toContain("/lisa:implement");
     });
@@ -143,6 +144,7 @@ describe("enforce-team-first.sh", () => {
     it.each([
       ["ToolSearch", { query: "select:TeamCreate" }],
       ["TeamCreate", {}],
+      ["Agent", { subagent_type: "Explore" }],
       ["TodoWrite", { todos: [] }],
       ["AskUserQuestion", {}],
     ])("allows %s while armed", (tool, input) => {
@@ -153,7 +155,7 @@ describe("enforce-team-first.sh", () => {
     });
   });
 
-  describe("PostToolUse on TeamCreate", () => {
+  describe("PostToolUse on TeamCreate or Agent", () => {
     it("lifts enforcement when TeamCreate succeeds", () => {
       const sid = "post-ok";
       armSession(sid);
@@ -167,6 +169,26 @@ describe("enforce-team-first.sh", () => {
         tool_name: "TeamCreate",
         tool_input: {},
         tool_response: { team_id: "team-xyz" },
+      });
+      expect(existsSync(flagPath(sid, "team"))).toBe(true);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+
+    it("lifts enforcement when the first Agent spawn succeeds (implicit team)", () => {
+      const sid = "post-agent-ok";
+      armSession(sid);
+      expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(
+        EXIT_BLOCKED
+      );
+
+      runHook({
+        hook_event_name: "PostToolUse",
+        session_id: sid,
+        tool_name: "Agent",
+        tool_input: { subagent_type: "Explore" },
+        tool_response: { agent_id: "agent-xyz" },
       });
       expect(existsSync(flagPath(sid, "team"))).toBe(true);
       expect(preToolUse(sid, "Bash", { command: "ls" }).status).toBe(


### PR DESCRIPTION
## Summary

Claude Code >= 2.1.178 removed the explicit `TeamCreate`/`TeamDelete` tools in favor of an **implicit-team model**: the team forms automatically the moment the lead spawns its first teammate via the `Agent` tool. The `enforce-team-first` hook previously only recognized `TeamCreate`, so under newer Claude Code a lead could never satisfy the gate.

This teaches the hook to treat a successful `Agent` spawn as team-established, while keeping the legacy `TeamCreate` path working for older Claude Code (fully backward-compatible).

## Changes

- **`plugin.json`** — broaden the PostToolUse matcher from `"TeamCreate"` → `"TeamCreate|Agent"`.
- **`enforce-team-first.sh`** —
  - PostToolUse lifts enforcement on a successful `TeamCreate` **or** `Agent` spawn.
  - `Agent` added to the never-block allowlist (`ToolSearch|TeamCreate|Agent`).
  - Blocked-guidance message now instructs spawning a teammate with the `Agent` tool; legacy `TeamCreate` path still documented and accepted.
- **tests** — assert the new path forward: `Agent` is allowed while armed, a successful `Agent` PostToolUse lifts enforcement, and the block message names `Agent`.

Both the source (`plugins/src/base/...`) and the generated artifact (`plugins/lisa/...`) are updated together. Reproducibility verified locally: `bun run build:plugins` produces no new diff, so the `🧩 Plugins Sync` guard passes.

## Test plan

- [x] `vitest run tests/unit/hooks/enforce-team-first.test.ts` — 36 passed
- [x] Full pre-push suite (unit + coverage + integration) — green
- [x] Plugins sync reproducibility — rebuild yields no extra changes

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team establishment now supports implicit-team creation through agent spawning, in addition to the existing explicit team creation method, enabling compatibility with newer Claude versions.

* **Bug Fixes**
  * Updated enforcement logic and user-facing messages to reflect the expanded team-formation workflows.

* **Tests**
  * Extended test coverage to validate team establishment through both creation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->