### PR TITLE
fix(ci): pass Bun audit ignore flags with equals

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1435,7 +1435,7 @@ jobs:
             # Build --ignore flags dynamically from exclusion list
             BUN_IGNORE_FLAGS=""
             for _id in $GHSA_IDS; do
-              BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore $_id"
+              BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore=$_id"
             done
 
             if ! bun audit --audit-level=high $BUN_IGNORE_FLAGS; then


### PR DESCRIPTION
## Summary
- emit Bun audit ignore flags as `--ignore=<id>` in the reusable quality workflow
- fixes Bun projects where configured GHSA exclusions are still reported because `--ignore <id>` is not honored by Bun 1.3.8+

## Verification
- pre-push security audit passed
- pre-push slow lint passed
- pre-push knip passed
- pre-push unit tests with coverage passed
- pre-push integration tests passed

Refs: frontend-v2 PR #5500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to refine how security audit commands are executed during continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->