### PR TITLE
fix: honor bun audit allowlist

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1432,17 +1432,43 @@ jobs:
               echo "::notice::No high or critical vulnerabilities found (excluding known false positives)"
             fi
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
-            # Build --ignore flags dynamically from exclusion list
-            BUN_IGNORE_FLAGS=""
-            for _id in $GHSA_IDS; do
-              BUN_IGNORE_FLAGS="$BUN_IGNORE_FLAGS --ignore=$_id"
-            done
+            GHSA_IDS_JSON=$(printf '%s\n' $GHSA_IDS | jq -R . | jq -s 'map(select(length > 0))')
+            CVE_IDS_JSON=$(printf '%s\n' $CVE_IDS | jq -R . | jq -s 'map(select(length > 0))')
+            AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+            if [ -z "$AUDIT_JSON" ]; then
+              AUDIT_JSON="{}"
+            fi
 
-            if ! bun audit --audit-level=high $BUN_IGNORE_FLAGS; then
-              echo "::warning::Found high or critical vulnerabilities"
+            BUN_HIGH_VULNS=$(echo "$AUDIT_JSON" | jq \
+              --argjson ghsa_ids "$GHSA_IDS_JSON" \
+              --argjson cve_ids "$CVE_IDS_JSON" \
+              '[
+                to_entries[]
+                | .key as $package
+                | (.value // [])[]?
+                | select(.severity == "high" or .severity == "critical")
+                | . + {
+                    package: $package,
+                    ghsa_id: (.url // "" | split("/") | last),
+                    advisory_id: (.id // "" | tostring),
+                    cves: ([.cve?, .cves[]?] | map(select(. != null and . != "")))
+                  }
+                | select(
+                    (
+                      ([.ghsa_id, .advisory_id] | map(select(. != "")) | any(. as $id | $ghsa_ids | index($id)))
+                      or (.cves | any(. as $cve | $cve_ids | index($cve)))
+                    )
+                    | not
+                  )
+              ]')
+            UNFIXED_HIGH=$(echo "$BUN_HIGH_VULNS" | jq 'length')
+
+            if [ "$UNFIXED_HIGH" -gt 0 ]; then
+              echo "::error::Found high or critical vulnerabilities (after excluding known false positives):"
+              echo "$BUN_HIGH_VULNS" | jq .
               exit 1
             fi
-            echo "::notice::No high or critical vulnerabilities found"
+            echo "::notice::No high or critical vulnerabilities found (excluding known false positives)"
           else
             echo "Unsupported package manager: ${{ inputs.package_manager }}"
             exit 1

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -221,4 +221,23 @@ describe("quality.yml reusable workflow", () => {
       expect(scan?.run).toContain('exit "$scan_status"');
     });
   });
+
+  describe("bun audit allowlist handling", () => {
+    it("filters bun audit JSON by GHSA, advisory id, and CVE allowlists", () => {
+      const steps = workflow.jobs.npm_security_scan.steps ?? [];
+      const audit = steps.find(s => s.name === "🔒 Run security audit");
+      const run = audit?.run ?? "";
+
+      expect(run).toContain("bun audit --json");
+      expect(run).not.toContain(
+        "bun audit --audit-level=high $BUN_IGNORE_FLAGS"
+      );
+      expect(run).not.toContain("--ignore=$_id");
+      expect(run).toContain('ghsa_id: (.url // "" | split("/") | last)');
+      expect(run).toContain('advisory_id: (.id // "" | tostring)');
+      expect(run).toContain("cves: ([.cve?, .cves[]?]");
+      expect(run).toContain("$ghsa_ids | index($id)");
+      expect(run).toContain("$cve_ids | index($cve)");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- replace the bun security-audit branch's inert `--ignore` flags with `bun audit --json` parsing
- filter high/critical bun advisories by allowlisted GHSA IDs, bun numeric advisory IDs, and CVE IDs when present
- add a workflow integration test that prevents reverting to the broken `--ignore` path

Closes #1322

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run test:integration tests/integration/quality-workflow.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- pre-push hook: security audit, slow lint, knip, unit tests with coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security vulnerability detection in quality checks workflow with improved filtering and allowlist handling.

* **Tests**
  * Added test coverage for security scanning configuration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->