### PR TITLE
fix(rules): make security-audit remediation autonomous via decision ladder

### DIFF
--- a/plugins/lisa-copilot/rules/eager/security-audit-handling.md
+++ b/plugins/lisa-copilot/rules/eager/security-audit-handling.md
@@ -1,35 +1,40 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Do not stop to ask the user except at the one rung that explicitly requires it. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## Decision ladder (do not skip rungs)
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+For each high/critical advisory the gate reports, take the **first** action that is possible:
 
-## Core rule
+1. **Update the offending package.** Upgrade the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, retry the gate. Done.
+2. **If an upgrade isn't possible** (no compatible patched version on the dependency graph): **force a resolution/override** on the vulnerable leaf package (both `resolutions` and `overrides`), regenerate the lockfile, retry. Done.
+3. **If an override isn't possible either** (would break a dependent, or no fixed version exists anywhere): **evaluate whether the advisory actually affects this project** — is the vulnerable code path reachable, does it process untrusted input, is it runtime vs. dev/build-only?
+4. **If it does affect the project** and neither (1) nor (2) was possible: **ask a human** what to do. This is the only rung that pauses for a person.
+5. **If it does not affect the project**: **add a documented exclusion yourself** to `audit.ignore.local.json` (`{"id", "package", "reason"}` — reason states the impact evaluation), commit, retry. No human approval needed.
+
+Steps 1, 2, 3, and 5 are autonomous. Only step 4 escalates.
+
+## Core override rule
 
 Override the actually-vulnerable **leaf package**, not its parent. The audit chain shows `parent › intermediate › vulnerable` — only the vulnerable leaf needs the override.
 
 **Never override a parent package to force a lower major version.** Other packages may depend on the newer major; a forced downgrade breaks them.
 
-Before adding any override, verify:
+Before adding any override (step 2), verify:
 - You are targeting the actually-vulnerable package, not a parent in the chain.
 - The override is compatible with all dependents (check via `bun why <pkg>` or `npm ls <pkg>`).
 - The override does not downgrade across a major version boundary other deps require.
 
-## Node.js (GHSA)
+If those checks fail, the override is "not possible" — drop to step 3.
 
-1. Note GHSA ID, package, advisory URL.
-2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+## Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never escalate to a human (step 4) before genuinely attempting steps 1–3.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
 
 ## Rails (bundler-audit)
 
-1. Note advisory ID, gem, URL.
-2. If direct dep with patch: update Gemfile constraint, `bundle update <gem>`, commit, retry.
-3. If transitive with patch: `bundle update <gem>` to bump the lockfile only, commit, retry.
-4. If no patch but safe: document the exception, retry.
+Same ladder. Note advisory ID, gem, URL. (1) Direct dep with patch → update Gemfile constraint, `bundle update <gem>`, retry. (2) Transitive with patch → `bundle update <gem>` to bump the lockfile only, retry. (3) No patch → evaluate impact. (4) Affects the project → ask a human. (5) Doesn't affect → document the exception, retry.
 
 Full procedure with examples: [reference/security-audit-handling.md](../reference/security-audit-handling.md).

--- a/plugins/lisa-copilot/rules/reference/security-audit-handling.md
+++ b/plugins/lisa-copilot/rules/reference/security-audit-handling.md
@@ -1,19 +1,28 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Only one rung pauses to ask a human. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## The decision ladder
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+The remediation for any high/critical advisory is a simple, ordered decision — not a question to forward to the user. For each advisory, take the **first** action that is possible:
+
+1. **Update the offending package** to a patched version.
+2. **If that's not possible**, force a resolution/override on the vulnerable leaf package.
+3. **If that's not possible**, evaluate whether the advisory actually affects the project.
+4. **If it affects the project** (and 1 and 2 weren't possible), ask a human what to do.
+5. **If it doesn't affect the project**, add it to the ignore list yourself.
+
+Steps 1, 2, 3, and 5 are autonomous. Do not stop and ask the user except at step 4, and only after you have genuinely attempted steps 1 and 2 and performed the step-3 evaluation.
 
 ## Node.js Projects (GHSA advisories)
 
-1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
-2. Check the advisory URL to determine if a patched version of the vulnerable package exists
-3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output.
+2. Check the advisory URL to determine whether a patched version of the vulnerable package exists.
+3. **Step 1 — update:** If a patched version exists and is compatible, add a resolution/override in `package.json` to force the patched version (add to **both** `resolutions` and `overrides`), run the package manager install to regenerate the lockfile, commit, and retry the push.
+4. **Step 2 — force override:** If no straight upgrade lands the patched version but a compatible patched version exists somewhere on the graph, pin it via `resolutions` + `overrides` on the **leaf** package (see "Override the vulnerable package, not its parent" below), regenerate the lockfile, commit, and retry.
+5. **Step 3 — evaluate impact:** If neither an upgrade nor an override is possible (no fixed version exists, or every compatible pin breaks a dependent), determine whether the vulnerability actually affects this project. Consider: is the vulnerable code path reachable from this project's usage? Does it process untrusted input? Is the dependency runtime, or dev/build-only? Record the conclusion.
+6. **Step 4 — escalate:** If the evaluation shows the vulnerability **does** affect the project and neither step 1 nor step 2 was possible, ask the user what to do. This is the only step that pauses for a human.
+7. **Step 5 — ignore:** If the evaluation shows the vulnerability **does not** affect the project, add an exclusion entry to `audit.ignore.local.json` yourself, in the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "<impact evaluation: why this advisory does not affect this project>"}`, then commit and retry the push. No human approval is required for this step — the `reason` field is the record of your evaluation.
 
 ### Critical: Override the vulnerable package, not its parent
 
@@ -21,16 +30,26 @@ When the audit output shows a dependency chain like `@expo/cli › glob › mini
 
 **Never override a parent package to force a lower major version** — other packages in the project may depend on a newer major version, and a resolution/override forces ALL installations to the specified version. For example, overriding `glob` to `^8.1.0` will break `@expo/cli` which requires `glob@^13.0.0`, causing `expo prebuild` to fail with `files.map is not a function`.
 
-Before adding a resolution/override, verify:
-- You are targeting the **actually vulnerable package**, not a parent in the chain
-- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`)
-- The override does not **downgrade** a package across a major version boundary that other dependencies require
+Before adding a resolution/override (step 2), verify:
+- You are targeting the **actually vulnerable package**, not a parent in the chain.
+- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`).
+- The override does not **downgrade** a package across a major version boundary that other dependencies require.
+
+If any of these checks fail, the override is "not possible" for the purposes of the ladder — drop to step 3 (evaluate impact).
+
+### Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never jump to step 4 (ask a human) before genuinely attempting steps 1–3.
+- Never add a step-5 ignore entry without an impact evaluation recorded in its `reason`.
 
 ## Rails Projects (bundler-audit)
 
-1. Note the advisory ID, affected gem, and advisory URL from the error output
-2. Check if a patched version of the gem exists
-3. If a patched version exists:
-   - If the gem is a **direct dependency** (listed in Gemfile): update its version constraint in Gemfile, run `bundle update <gem>`, commit the changes, and retry the push
-   - If the gem is a **transitive dependency** (not in Gemfile, only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project: document the exception and retry the push
+Same ladder, bundler mechanics:
+
+1. Note the advisory ID, affected gem, and advisory URL from the error output.
+2. Check whether a patched version of the gem exists.
+3. **Step 1 — update:** If a patched version exists:
+   - **Direct dependency** (in Gemfile): update its version constraint, run `bundle update <gem>`, commit, retry.
+   - **Transitive dependency** (only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, retry.
+4. **Steps 3–5 — no patch:** If no patched version exists, evaluate whether the advisory affects the project. If it **does** and no fix is possible, ask the user (step 4). If it **does not**, document the exception and retry (step 5).

--- a/plugins/lisa-cursor/rules/security-audit-handling-reference.mdc
+++ b/plugins/lisa-cursor/rules/security-audit-handling-reference.mdc
@@ -5,20 +5,29 @@ alwaysApply: false
 
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Only one rung pauses to ask a human. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## The decision ladder
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+The remediation for any high/critical advisory is a simple, ordered decision — not a question to forward to the user. For each advisory, take the **first** action that is possible:
+
+1. **Update the offending package** to a patched version.
+2. **If that's not possible**, force a resolution/override on the vulnerable leaf package.
+3. **If that's not possible**, evaluate whether the advisory actually affects the project.
+4. **If it affects the project** (and 1 and 2 weren't possible), ask a human what to do.
+5. **If it doesn't affect the project**, add it to the ignore list yourself.
+
+Steps 1, 2, 3, and 5 are autonomous. Do not stop and ask the user except at step 4, and only after you have genuinely attempted steps 1 and 2 and performed the step-3 evaluation.
 
 ## Node.js Projects (GHSA advisories)
 
-1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
-2. Check the advisory URL to determine if a patched version of the vulnerable package exists
-3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output.
+2. Check the advisory URL to determine whether a patched version of the vulnerable package exists.
+3. **Step 1 — update:** If a patched version exists and is compatible, add a resolution/override in `package.json` to force the patched version (add to **both** `resolutions` and `overrides`), run the package manager install to regenerate the lockfile, commit, and retry the push.
+4. **Step 2 — force override:** If no straight upgrade lands the patched version but a compatible patched version exists somewhere on the graph, pin it via `resolutions` + `overrides` on the **leaf** package (see "Override the vulnerable package, not its parent" below), regenerate the lockfile, commit, and retry.
+5. **Step 3 — evaluate impact:** If neither an upgrade nor an override is possible (no fixed version exists, or every compatible pin breaks a dependent), determine whether the vulnerability actually affects this project. Consider: is the vulnerable code path reachable from this project's usage? Does it process untrusted input? Is the dependency runtime, or dev/build-only? Record the conclusion.
+6. **Step 4 — escalate:** If the evaluation shows the vulnerability **does** affect the project and neither step 1 nor step 2 was possible, ask the user what to do. This is the only step that pauses for a human.
+7. **Step 5 — ignore:** If the evaluation shows the vulnerability **does not** affect the project, add an exclusion entry to `audit.ignore.local.json` yourself, in the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "<impact evaluation: why this advisory does not affect this project>"}`, then commit and retry the push. No human approval is required for this step — the `reason` field is the record of your evaluation.
 
 ### Critical: Override the vulnerable package, not its parent
 
@@ -26,16 +35,26 @@ When the audit output shows a dependency chain like `@expo/cli › glob › mini
 
 **Never override a parent package to force a lower major version** — other packages in the project may depend on a newer major version, and a resolution/override forces ALL installations to the specified version. For example, overriding `glob` to `^8.1.0` will break `@expo/cli` which requires `glob@^13.0.0`, causing `expo prebuild` to fail with `files.map is not a function`.
 
-Before adding a resolution/override, verify:
-- You are targeting the **actually vulnerable package**, not a parent in the chain
-- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`)
-- The override does not **downgrade** a package across a major version boundary that other dependencies require
+Before adding a resolution/override (step 2), verify:
+- You are targeting the **actually vulnerable package**, not a parent in the chain.
+- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`).
+- The override does not **downgrade** a package across a major version boundary that other dependencies require.
+
+If any of these checks fail, the override is "not possible" for the purposes of the ladder — drop to step 3 (evaluate impact).
+
+### Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never jump to step 4 (ask a human) before genuinely attempting steps 1–3.
+- Never add a step-5 ignore entry without an impact evaluation recorded in its `reason`.
 
 ## Rails Projects (bundler-audit)
 
-1. Note the advisory ID, affected gem, and advisory URL from the error output
-2. Check if a patched version of the gem exists
-3. If a patched version exists:
-   - If the gem is a **direct dependency** (listed in Gemfile): update its version constraint in Gemfile, run `bundle update <gem>`, commit the changes, and retry the push
-   - If the gem is a **transitive dependency** (not in Gemfile, only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project: document the exception and retry the push
+Same ladder, bundler mechanics:
+
+1. Note the advisory ID, affected gem, and advisory URL from the error output.
+2. Check whether a patched version of the gem exists.
+3. **Step 1 — update:** If a patched version exists:
+   - **Direct dependency** (in Gemfile): update its version constraint, run `bundle update <gem>`, commit, retry.
+   - **Transitive dependency** (only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, retry.
+4. **Steps 3–5 — no patch:** If no patched version exists, evaluate whether the advisory affects the project. If it **does** and no fix is possible, ask the user (step 4). If it **does not**, document the exception and retry (step 5).

--- a/plugins/lisa-cursor/rules/security-audit-handling.mdc
+++ b/plugins/lisa-cursor/rules/security-audit-handling.mdc
@@ -5,36 +5,41 @@ alwaysApply: true
 
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Do not stop to ask the user except at the one rung that explicitly requires it. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## Decision ladder (do not skip rungs)
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+For each high/critical advisory the gate reports, take the **first** action that is possible:
 
-## Core rule
+1. **Update the offending package.** Upgrade the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, retry the gate. Done.
+2. **If an upgrade isn't possible** (no compatible patched version on the dependency graph): **force a resolution/override** on the vulnerable leaf package (both `resolutions` and `overrides`), regenerate the lockfile, retry. Done.
+3. **If an override isn't possible either** (would break a dependent, or no fixed version exists anywhere): **evaluate whether the advisory actually affects this project** — is the vulnerable code path reachable, does it process untrusted input, is it runtime vs. dev/build-only?
+4. **If it does affect the project** and neither (1) nor (2) was possible: **ask a human** what to do. This is the only rung that pauses for a person.
+5. **If it does not affect the project**: **add a documented exclusion yourself** to `audit.ignore.local.json` (`{"id", "package", "reason"}` — reason states the impact evaluation), commit, retry. No human approval needed.
+
+Steps 1, 2, 3, and 5 are autonomous. Only step 4 escalates.
+
+## Core override rule
 
 Override the actually-vulnerable **leaf package**, not its parent. The audit chain shows `parent › intermediate › vulnerable` — only the vulnerable leaf needs the override.
 
 **Never override a parent package to force a lower major version.** Other packages may depend on the newer major; a forced downgrade breaks them.
 
-Before adding any override, verify:
+Before adding any override (step 2), verify:
 - You are targeting the actually-vulnerable package, not a parent in the chain.
 - The override is compatible with all dependents (check via `bun why <pkg>` or `npm ls <pkg>`).
 - The override does not downgrade across a major version boundary other deps require.
 
-## Node.js (GHSA)
+If those checks fail, the override is "not possible" — drop to step 3.
 
-1. Note GHSA ID, package, advisory URL.
-2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+## Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never escalate to a human (step 4) before genuinely attempting steps 1–3.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
 
 ## Rails (bundler-audit)
 
-1. Note advisory ID, gem, URL.
-2. If direct dep with patch: update Gemfile constraint, `bundle update <gem>`, commit, retry.
-3. If transitive with patch: `bundle update <gem>` to bump the lockfile only, commit, retry.
-4. If no patch but safe: document the exception, retry.
+Same ladder. Note advisory ID, gem, URL. (1) Direct dep with patch → update Gemfile constraint, `bundle update <gem>`, retry. (2) Transitive with patch → `bundle update <gem>` to bump the lockfile only, retry. (3) No patch → evaluate impact. (4) Affects the project → ask a human. (5) Doesn't affect → document the exception, retry.
 
 Full procedure with examples: [reference/security-audit-handling.md](security-audit-handling-reference.mdc).

--- a/plugins/lisa/rules/eager/security-audit-handling.md
+++ b/plugins/lisa/rules/eager/security-audit-handling.md
@@ -1,35 +1,40 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Do not stop to ask the user except at the one rung that explicitly requires it. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## Decision ladder (do not skip rungs)
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+For each high/critical advisory the gate reports, take the **first** action that is possible:
 
-## Core rule
+1. **Update the offending package.** Upgrade the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, retry the gate. Done.
+2. **If an upgrade isn't possible** (no compatible patched version on the dependency graph): **force a resolution/override** on the vulnerable leaf package (both `resolutions` and `overrides`), regenerate the lockfile, retry. Done.
+3. **If an override isn't possible either** (would break a dependent, or no fixed version exists anywhere): **evaluate whether the advisory actually affects this project** — is the vulnerable code path reachable, does it process untrusted input, is it runtime vs. dev/build-only?
+4. **If it does affect the project** and neither (1) nor (2) was possible: **ask a human** what to do. This is the only rung that pauses for a person.
+5. **If it does not affect the project**: **add a documented exclusion yourself** to `audit.ignore.local.json` (`{"id", "package", "reason"}` — reason states the impact evaluation), commit, retry. No human approval needed.
+
+Steps 1, 2, 3, and 5 are autonomous. Only step 4 escalates.
+
+## Core override rule
 
 Override the actually-vulnerable **leaf package**, not its parent. The audit chain shows `parent › intermediate › vulnerable` — only the vulnerable leaf needs the override.
 
 **Never override a parent package to force a lower major version.** Other packages may depend on the newer major; a forced downgrade breaks them.
 
-Before adding any override, verify:
+Before adding any override (step 2), verify:
 - You are targeting the actually-vulnerable package, not a parent in the chain.
 - The override is compatible with all dependents (check via `bun why <pkg>` or `npm ls <pkg>`).
 - The override does not downgrade across a major version boundary other deps require.
 
-## Node.js (GHSA)
+If those checks fail, the override is "not possible" — drop to step 3.
 
-1. Note GHSA ID, package, advisory URL.
-2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+## Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never escalate to a human (step 4) before genuinely attempting steps 1–3.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
 
 ## Rails (bundler-audit)
 
-1. Note advisory ID, gem, URL.
-2. If direct dep with patch: update Gemfile constraint, `bundle update <gem>`, commit, retry.
-3. If transitive with patch: `bundle update <gem>` to bump the lockfile only, commit, retry.
-4. If no patch but safe: document the exception, retry.
+Same ladder. Note advisory ID, gem, URL. (1) Direct dep with patch → update Gemfile constraint, `bundle update <gem>`, retry. (2) Transitive with patch → `bundle update <gem>` to bump the lockfile only, retry. (3) No patch → evaluate impact. (4) Affects the project → ask a human. (5) Doesn't affect → document the exception, retry.
 
 Full procedure with examples: [reference/security-audit-handling.md](../reference/security-audit-handling.md).

--- a/plugins/lisa/rules/eager/security-audit-handling.md
+++ b/plugins/lisa/rules/eager/security-audit-handling.md
@@ -31,7 +31,7 @@ If those checks fail, the override is "not possible" — drop to step 3.
 
 - Never add a blanket audit bypass or lower the configured audit level.
 - Never escalate to a human (step 4) before genuinely attempting steps 1–3.
-- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`. (This is a policy requirement enforced by convention. The `reason` field is not programmatically validated by Lisa tooling, so its presence relies on Claude following this rule faithfully.)
 
 ## Rails (bundler-audit)
 

--- a/plugins/lisa/rules/reference/security-audit-handling.md
+++ b/plugins/lisa/rules/reference/security-audit-handling.md
@@ -1,19 +1,28 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Only one rung pauses to ask a human. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## The decision ladder
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+The remediation for any high/critical advisory is a simple, ordered decision — not a question to forward to the user. For each advisory, take the **first** action that is possible:
+
+1. **Update the offending package** to a patched version.
+2. **If that's not possible**, force a resolution/override on the vulnerable leaf package.
+3. **If that's not possible**, evaluate whether the advisory actually affects the project.
+4. **If it affects the project** (and 1 and 2 weren't possible), ask a human what to do.
+5. **If it doesn't affect the project**, add it to the ignore list yourself.
+
+Steps 1, 2, 3, and 5 are autonomous. Do not stop and ask the user except at step 4, and only after you have genuinely attempted steps 1 and 2 and performed the step-3 evaluation.
 
 ## Node.js Projects (GHSA advisories)
 
-1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
-2. Check the advisory URL to determine if a patched version of the vulnerable package exists
-3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output.
+2. Check the advisory URL to determine whether a patched version of the vulnerable package exists.
+3. **Step 1 — update:** If a patched version exists and is compatible, add a resolution/override in `package.json` to force the patched version (add to **both** `resolutions` and `overrides`), run the package manager install to regenerate the lockfile, commit, and retry the push.
+4. **Step 2 — force override:** If no straight upgrade lands the patched version but a compatible patched version exists somewhere on the graph, pin it via `resolutions` + `overrides` on the **leaf** package (see "Override the vulnerable package, not its parent" below), regenerate the lockfile, commit, and retry.
+5. **Step 3 — evaluate impact:** If neither an upgrade nor an override is possible (no fixed version exists, or every compatible pin breaks a dependent), determine whether the vulnerability actually affects this project. Consider: is the vulnerable code path reachable from this project's usage? Does it process untrusted input? Is the dependency runtime, or dev/build-only? Record the conclusion.
+6. **Step 4 — escalate:** If the evaluation shows the vulnerability **does** affect the project and neither step 1 nor step 2 was possible, ask the user what to do. This is the only step that pauses for a human.
+7. **Step 5 — ignore:** If the evaluation shows the vulnerability **does not** affect the project, add an exclusion entry to `audit.ignore.local.json` yourself, in the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "<impact evaluation: why this advisory does not affect this project>"}`, then commit and retry the push. No human approval is required for this step — the `reason` field is the record of your evaluation.
 
 ### Critical: Override the vulnerable package, not its parent
 
@@ -21,16 +30,26 @@ When the audit output shows a dependency chain like `@expo/cli › glob › mini
 
 **Never override a parent package to force a lower major version** — other packages in the project may depend on a newer major version, and a resolution/override forces ALL installations to the specified version. For example, overriding `glob` to `^8.1.0` will break `@expo/cli` which requires `glob@^13.0.0`, causing `expo prebuild` to fail with `files.map is not a function`.
 
-Before adding a resolution/override, verify:
-- You are targeting the **actually vulnerable package**, not a parent in the chain
-- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`)
-- The override does not **downgrade** a package across a major version boundary that other dependencies require
+Before adding a resolution/override (step 2), verify:
+- You are targeting the **actually vulnerable package**, not a parent in the chain.
+- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`).
+- The override does not **downgrade** a package across a major version boundary that other dependencies require.
+
+If any of these checks fail, the override is "not possible" for the purposes of the ladder — drop to step 3 (evaluate impact).
+
+### Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never jump to step 4 (ask a human) before genuinely attempting steps 1–3.
+- Never add a step-5 ignore entry without an impact evaluation recorded in its `reason`.
 
 ## Rails Projects (bundler-audit)
 
-1. Note the advisory ID, affected gem, and advisory URL from the error output
-2. Check if a patched version of the gem exists
-3. If a patched version exists:
-   - If the gem is a **direct dependency** (listed in Gemfile): update its version constraint in Gemfile, run `bundle update <gem>`, commit the changes, and retry the push
-   - If the gem is a **transitive dependency** (not in Gemfile, only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project: document the exception and retry the push
+Same ladder, bundler mechanics:
+
+1. Note the advisory ID, affected gem, and advisory URL from the error output.
+2. Check whether a patched version of the gem exists.
+3. **Step 1 — update:** If a patched version exists:
+   - **Direct dependency** (in Gemfile): update its version constraint, run `bundle update <gem>`, commit, retry.
+   - **Transitive dependency** (only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, retry.
+4. **Steps 3–5 — no patch:** If no patched version exists, evaluate whether the advisory affects the project. If it **does** and no fix is possible, ask the user (step 4). If it **does not**, document the exception and retry (step 5).

--- a/plugins/src/base/rules/eager/security-audit-handling.md
+++ b/plugins/src/base/rules/eager/security-audit-handling.md
@@ -1,35 +1,40 @@
 # Security Audit Handling (load-bearing)
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow the rules below. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Do not stop to ask the user except at the one rung that explicitly requires it. **Never use `--no-verify`**, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## Decision ladder (do not skip rungs)
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+For each high/critical advisory the gate reports, take the **first** action that is possible:
 
-## Core rule
+1. **Update the offending package.** Upgrade the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, retry the gate. Done.
+2. **If an upgrade isn't possible** (no compatible patched version on the dependency graph): **force a resolution/override** on the vulnerable leaf package (both `resolutions` and `overrides`), regenerate the lockfile, retry. Done.
+3. **If an override isn't possible either** (would break a dependent, or no fixed version exists anywhere): **evaluate whether the advisory actually affects this project** — is the vulnerable code path reachable, does it process untrusted input, is it runtime vs. dev/build-only?
+4. **If it does affect the project** and neither (1) nor (2) was possible: **ask a human** what to do. This is the only rung that pauses for a person.
+5. **If it does not affect the project**: **add a documented exclusion yourself** to `audit.ignore.local.json` (`{"id", "package", "reason"}` — reason states the impact evaluation), commit, retry. No human approval needed.
+
+Steps 1, 2, 3, and 5 are autonomous. Only step 4 escalates.
+
+## Core override rule
 
 Override the actually-vulnerable **leaf package**, not its parent. The audit chain shows `parent › intermediate › vulnerable` — only the vulnerable leaf needs the override.
 
 **Never override a parent package to force a lower major version.** Other packages may depend on the newer major; a forced downgrade breaks them.
 
-Before adding any override, verify:
+Before adding any override (step 2), verify:
 - You are targeting the actually-vulnerable package, not a parent in the chain.
 - The override is compatible with all dependents (check via `bun why <pkg>` or `npm ls <pkg>`).
 - The override does not downgrade across a major version boundary other deps require.
 
-## Node.js (GHSA)
+If those checks fail, the override is "not possible" — drop to step 3.
 
-1. Note GHSA ID, package, advisory URL.
-2. If a patched version exists: add a resolution AND override in `package.json` for the leaf package, regenerate the lockfile, commit, retry.
-3. If no patch but safe (transitive, no untrusted input, dev/build only): ask the user to make the risk-acceptance decision, then add an exclusion to `audit.ignore.local.json` with `{"id", "package", "reason"}`, commit, retry.
+## Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never escalate to a human (step 4) before genuinely attempting steps 1–3.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
 
 ## Rails (bundler-audit)
 
-1. Note advisory ID, gem, URL.
-2. If direct dep with patch: update Gemfile constraint, `bundle update <gem>`, commit, retry.
-3. If transitive with patch: `bundle update <gem>` to bump the lockfile only, commit, retry.
-4. If no patch but safe: document the exception, retry.
+Same ladder. Note advisory ID, gem, URL. (1) Direct dep with patch → update Gemfile constraint, `bundle update <gem>`, retry. (2) Transitive with patch → `bundle update <gem>` to bump the lockfile only, retry. (3) No patch → evaluate impact. (4) Affects the project → ask a human. (5) Doesn't affect → document the exception, retry.
 
 Full procedure with examples: [reference/security-audit-handling.md](../reference/security-audit-handling.md).

--- a/plugins/src/base/rules/eager/security-audit-handling.md
+++ b/plugins/src/base/rules/eager/security-audit-handling.md
@@ -31,7 +31,7 @@ If those checks fail, the override is "not possible" — drop to step 3.
 
 - Never add a blanket audit bypass or lower the configured audit level.
 - Never escalate to a human (step 4) before genuinely attempting steps 1–3.
-- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`.
+- Never add an ignore entry (step 5) without an impact evaluation recorded in its `reason`. (This is a policy requirement enforced by convention. The `reason` field is not programmatically validated by Lisa tooling, so its presence relies on Claude following this rule faithfully.)
 
 ## Rails (bundler-audit)
 

--- a/plugins/src/base/rules/reference/security-audit-handling.md
+++ b/plugins/src/base/rules/reference/security-audit-handling.md
@@ -1,19 +1,28 @@
 # Security Audit Handling
 
-If `git push` fails because the pre-push hook reports security vulnerabilities, follow these steps. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
+If `git push` fails because the pre-push hook reports security vulnerabilities, work the decision ladder below **autonomously**. Only one rung pauses to ask a human. Never use `--no-verify`, `HUSKY=0`, `core.hooksPath`, or any other hook bypass to skip the security audit.
 
-## Fix before ignore
+## The decision ladder
 
-1. Fix the root cause first: upgrade or override the actually-vulnerable leaf package to a patched compatible version, regenerate the lockfile, and retry the gate.
-2. Only if no safe fix exists, ask the user to make the risk-acceptance decision. Add a narrow documented ignore for the specific advisory, package, and reason.
-3. Never add a blanket audit bypass, lower an audit level, or self-approve a new risk-acceptance entry.
+The remediation for any high/critical advisory is a simple, ordered decision — not a question to forward to the user. For each advisory, take the **first** action that is possible:
+
+1. **Update the offending package** to a patched version.
+2. **If that's not possible**, force a resolution/override on the vulnerable leaf package.
+3. **If that's not possible**, evaluate whether the advisory actually affects the project.
+4. **If it affects the project** (and 1 and 2 weren't possible), ask a human what to do.
+5. **If it doesn't affect the project**, add it to the ignore list yourself.
+
+Steps 1, 2, 3, and 5 are autonomous. Do not stop and ask the user except at step 4, and only after you have genuinely attempted steps 1 and 2 and performed the step-3 evaluation.
 
 ## Node.js Projects (GHSA advisories)
 
-1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output
-2. Check the advisory URL to determine if a patched version of the vulnerable package exists
-3. If a patched version exists: add a resolution/override in package.json to force the patched version (add to both `resolutions` and `overrides` sections), then run the package manager install command to regenerate the lockfile, commit the changes, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project (e.g., transitive dependency with no untrusted input, devDeps only, or build tool only): ask the user to make the risk-acceptance decision, then add an exclusion entry to `audit.ignore.local.json` with the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "why this is safe for this project"}`, then commit and retry the push
+1. Note the GHSA ID(s), affected package(s), and advisory URL from the error output.
+2. Check the advisory URL to determine whether a patched version of the vulnerable package exists.
+3. **Step 1 — update:** If a patched version exists and is compatible, add a resolution/override in `package.json` to force the patched version (add to **both** `resolutions` and `overrides`), run the package manager install to regenerate the lockfile, commit, and retry the push.
+4. **Step 2 — force override:** If no straight upgrade lands the patched version but a compatible patched version exists somewhere on the graph, pin it via `resolutions` + `overrides` on the **leaf** package (see "Override the vulnerable package, not its parent" below), regenerate the lockfile, commit, and retry.
+5. **Step 3 — evaluate impact:** If neither an upgrade nor an override is possible (no fixed version exists, or every compatible pin breaks a dependent), determine whether the vulnerability actually affects this project. Consider: is the vulnerable code path reachable from this project's usage? Does it process untrusted input? Is the dependency runtime, or dev/build-only? Record the conclusion.
+6. **Step 4 — escalate:** If the evaluation shows the vulnerability **does** affect the project and neither step 1 nor step 2 was possible, ask the user what to do. This is the only step that pauses for a human.
+7. **Step 5 — ignore:** If the evaluation shows the vulnerability **does not** affect the project, add an exclusion entry to `audit.ignore.local.json` yourself, in the format `{"id": "GHSA-xxx", "package": "pkg-name", "reason": "<impact evaluation: why this advisory does not affect this project>"}`, then commit and retry the push. No human approval is required for this step — the `reason` field is the record of your evaluation.
 
 ### Critical: Override the vulnerable package, not its parent
 
@@ -21,16 +30,26 @@ When the audit output shows a dependency chain like `@expo/cli › glob › mini
 
 **Never override a parent package to force a lower major version** — other packages in the project may depend on a newer major version, and a resolution/override forces ALL installations to the specified version. For example, overriding `glob` to `^8.1.0` will break `@expo/cli` which requires `glob@^13.0.0`, causing `expo prebuild` to fail with `files.map is not a function`.
 
-Before adding a resolution/override, verify:
-- You are targeting the **actually vulnerable package**, not a parent in the chain
-- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`)
-- The override does not **downgrade** a package across a major version boundary that other dependencies require
+Before adding a resolution/override (step 2), verify:
+- You are targeting the **actually vulnerable package**, not a parent in the chain.
+- The override version is **compatible with all dependents** (check with `bun why <package>` or `npm ls <package>`).
+- The override does not **downgrade** a package across a major version boundary that other dependencies require.
+
+If any of these checks fail, the override is "not possible" for the purposes of the ladder — drop to step 3 (evaluate impact).
+
+### Never
+
+- Never add a blanket audit bypass or lower the configured audit level.
+- Never jump to step 4 (ask a human) before genuinely attempting steps 1–3.
+- Never add a step-5 ignore entry without an impact evaluation recorded in its `reason`.
 
 ## Rails Projects (bundler-audit)
 
-1. Note the advisory ID, affected gem, and advisory URL from the error output
-2. Check if a patched version of the gem exists
-3. If a patched version exists:
-   - If the gem is a **direct dependency** (listed in Gemfile): update its version constraint in Gemfile, run `bundle update <gem>`, commit the changes, and retry the push
-   - If the gem is a **transitive dependency** (not in Gemfile, only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, and retry the push
-4. If no patched version exists and the vulnerability is safe for this project: document the exception and retry the push
+Same ladder, bundler mechanics:
+
+1. Note the advisory ID, affected gem, and advisory URL from the error output.
+2. Check whether a patched version of the gem exists.
+3. **Step 1 — update:** If a patched version exists:
+   - **Direct dependency** (in Gemfile): update its version constraint, run `bundle update <gem>`, commit, retry.
+   - **Transitive dependency** (only in Gemfile.lock): run `bundle update <gem>` to pull the patched version without changing the Gemfile, commit the lockfile change, retry.
+4. **Steps 3–5 — no patch:** If no patched version exists, evaluate whether the advisory affects the project. If it **does** and no fix is possible, ask the user (step 4). If it **does not**, document the exception and retry (step 5).

--- a/src/migrations/ensure-audit-ignore-local-exclusions.ts
+++ b/src/migrations/ensure-audit-ignore-local-exclusions.ts
@@ -12,7 +12,13 @@ const AUDIT_CONFIG = "audit.ignore.config.json";
 const AUDIT_LOCAL = "audit.ignore.local.json";
 
 /**
- * One exclusion entry (partial — we only read `id` to detect duplicates)
+ * One exclusion entry (partial — we only read `id` to detect duplicates).
+ *
+ * Per security-audit-handling.md, every exclusion entry added by Claude must
+ * include a `reason` field documenting the impact evaluation. That requirement
+ * is a behavioural policy enforced by convention, not validated here. The
+ * migration treats all fields other than `id` as opaque so that entries are
+ * relocated intact regardless of their completeness.
  */
 interface Exclusion {
   readonly id?: string;


### PR DESCRIPTION
## Problem

Host projects were "getting hung up" on the pre-push bun/npm security audit — not because the gate was broken, but because the `security-audit-handling` rule told agents to **escalate to the user too early**. It said "only if no safe fix exists, ask the user" and "never self-approve a risk-acceptance entry," so almost every high/critical advisory without a one-shot upgrade bounced back to a human as a question.

## Fix

Rewrote both the eager and reference `security-audit-handling` rules to encode a deterministic 5-rung ladder where **only one rung pauses for a person**:

1. **Update** the offending leaf package to a patched version → retry.
2. Else **force a resolution/override** on the leaf (not the parent) → retry.
3. Else **evaluate** whether the advisory actually affects the project (reachable path? untrusted input? runtime vs dev/build-only?).
4. If it **does** affect it and 1+2 failed → **ask a human** (the only escalation).
5. If it **doesn't** affect it → **add a documented exclusion to `audit.ignore.local.json` autonomously**, with the impact evaluation recorded in `reason` → retry.

Steps 1, 2, 3, and 5 are autonomous; only step 4 escalates.

## Guards preserved

- No `--no-verify` / `HUSKY=0` / `core.hooksPath` / hook bypass.
- Override the vulnerable **leaf**, never a parent (no forced major downgrade).
- No blanket audit bypass or lowered audit level.
- Step-5 ignore entries must carry an impact evaluation in `reason`.

## Mechanics

- Source of truth edited under `plugins/src/base/rules/{eager,reference}/security-audit-handling.md`.
- `bun run build:plugins` regenerated all variants (base / copilot / cursor `.mdc`).
- `bun run check:plugins` passes on a clean tree (artifacts in sync, marketplace registers every plugin).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured security vulnerability handling workflow into a structured decision ladder with a five-step remediation process.
  * Unified guidance for Node.js and Rails dependency audits with consistent, step-by-step procedures.
  * Added explicit constraints on mitigation strategies, bypass mechanisms, and human escalation points.
  * Enhanced requirements for documenting security vulnerability exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->