### PR TITLE
feat(rules): add upstream-to-lisa rule for host-project agents

### DIFF
--- a/plugins/lisa-copilot/rules/eager/upstream-to-lisa.md
+++ b/plugins/lisa-copilot/rules/eager/upstream-to-lisa.md
@@ -1,0 +1,20 @@
+# Upstream To Lisa (load-bearing)
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project — a bug or gap in a Lisa-distributed template, rule, skill, agent, hook, or CI workflow, or a governance pattern worth generalizing back to the templates. Tell-tale signs: the file you want to change is Lisa-managed (carries Lisa governance markers, or lives in a path Lisa owns), and any edit you make here would be **overwritten on the next `lisa apply`**.
+
+When that happens, you have **two obligations — do both**:
+
+1. **Fix it locally so you are not blocked.** Apply the stopgap in this project so you can keep working. Treat it as temporary: it will be clobbered when the upstream fix ships and Lisa re-applies. Do not wait on the upstream fix.
+2. **File an upstream issue in the Lisa repository.** Use the `github-write-issue` skill (`lisa:github-write-issue`) to create an issue **in Lisa's source repo `CodySwannGT/lisa`** (pass it as the target repo, e.g. `gh ... --repo CodySwannGT/lisa`) — **not** in this project's own repo. Capture: the root cause, the symptom you hit here, and the proposed durable fix in Lisa's templates/rules/skills.
+
+## Do not
+
+- Do **not** only fix it locally and move on — the local fix is throwaway; without the upstream issue the root cause is lost and re-breaks on the next apply.
+- Do **not** try to edit Lisa's templates from inside this project — you are not in the Lisa repo; those edits don't exist upstream and get overwritten.
+- Do **not** file the issue in this project's repo — it must land in `CodySwannGT/lisa`.
+
+If you lack access to file an issue in `CodySwannGT/lisa`, surface that to the user with the proposed issue contents rather than silently dropping it.
+
+> Not applicable when you are already working **inside the Lisa repo itself** — there the fix is local, so just make it directly.
+
+Full procedure: [reference/upstream-to-lisa.md](../reference/upstream-to-lisa.md).

--- a/plugins/lisa-copilot/rules/reference/upstream-to-lisa.md
+++ b/plugins/lisa-copilot/rules/reference/upstream-to-lisa.md
@@ -1,0 +1,44 @@
+# Upstream To Lisa
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project. This rule defines what to do so the fix is both unblocking *now* and durable *later*.
+
+## When this applies
+
+You are working in a downstream/host project (not the Lisa source repo) and you discover one of:
+
+- A bug or gap in a Lisa-distributed **template, rule, skill, agent, hook, or CI workflow**.
+- A **governance pattern** discovered here that should be generalized back into Lisa's templates so every project benefits.
+- Anything where the file you want to change is **Lisa-managed** — it carries Lisa governance markers, lives in a path Lisa owns, or any edit would be **overwritten on the next `lisa apply`**.
+
+The defining test: *if I fix this only here, does `lisa apply` wipe it out next time?* If yes, the root cause lives in Lisa and must be upstreamed.
+
+## What to do — both steps, always
+
+### 1. Fix it locally so you are not blocked
+
+Apply the stopgap in this project so you can keep working. Do **not** stall waiting for an upstream fix to land. Treat the local change as temporary — it will be clobbered when the upstream fix ships and Lisa re-applies. That is expected and fine; the upstream issue (step 2) is what makes it durable.
+
+### 2. File an upstream issue in the Lisa repository
+
+Use the `github-write-issue` skill (`lisa:github-write-issue`) to create a GitHub Issue **in Lisa's source repository `CodySwannGT/lisa`** — not in this project's own repo. The skill uses the `gh` CLI; the target repo must be `CodySwannGT/lisa` (e.g. `gh issue create --repo CodySwannGT/lisa ...`), because the agent's default repo is this host project.
+
+The issue should capture, following the skill's three-audience / acceptance-criteria conventions:
+
+- **Root cause** — which Lisa template/rule/skill/agent/hook/workflow is wrong or missing, with the path under `plugins/src/...` (or the relevant template source) if known.
+- **Symptom** — what broke or was missing in *this* project, and how it surfaced. Reference this project so the fix can be validated against a real case.
+- **Proposed durable fix** — the change to make in Lisa's source so it propagates to all projects on the next apply.
+- **Local stopgap applied** — note that a temporary local fix is in place here, so the maintainer knows the host project is unblocked and the local change will be superseded.
+
+## Do not
+
+- Do **not** only fix it locally and move on. The local fix is throwaway; without the upstream issue the root cause is lost and re-breaks for every project on the next apply.
+- Do **not** edit Lisa's templates from inside this project. You are not in the Lisa repo; those edits don't exist upstream and get overwritten — they create the illusion of a fix while the real source stays broken.
+- Do **not** file the issue in this project's own repo. The durable fix is tracked in `CodySwannGT/lisa`.
+
+## Access fallback
+
+If you lack permission to create an issue in `CodySwannGT/lisa`, do not silently drop it. Surface the situation to the user along with the fully-drafted issue contents (root cause, symptom, proposed fix, local stopgap), so a human can file it or grant access.
+
+## Not applicable inside the Lisa repo itself
+
+When you are already working **inside the Lisa source repo** (`CodySwannGT/lisa`), this rule does not apply — the fix is local to that repo, so make it directly in `plugins/src/...` (and rebuild artifacts) rather than filing an issue against yourself.

--- a/plugins/lisa-cursor/rules/upstream-to-lisa-reference.mdc
+++ b/plugins/lisa-cursor/rules/upstream-to-lisa-reference.mdc
@@ -1,0 +1,49 @@
+---
+description: "Upstream To Lisa"
+alwaysApply: false
+---
+
+# Upstream To Lisa
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project. This rule defines what to do so the fix is both unblocking *now* and durable *later*.
+
+## When this applies
+
+You are working in a downstream/host project (not the Lisa source repo) and you discover one of:
+
+- A bug or gap in a Lisa-distributed **template, rule, skill, agent, hook, or CI workflow**.
+- A **governance pattern** discovered here that should be generalized back into Lisa's templates so every project benefits.
+- Anything where the file you want to change is **Lisa-managed** — it carries Lisa governance markers, lives in a path Lisa owns, or any edit would be **overwritten on the next `lisa apply`**.
+
+The defining test: *if I fix this only here, does `lisa apply` wipe it out next time?* If yes, the root cause lives in Lisa and must be upstreamed.
+
+## What to do — both steps, always
+
+### 1. Fix it locally so you are not blocked
+
+Apply the stopgap in this project so you can keep working. Do **not** stall waiting for an upstream fix to land. Treat the local change as temporary — it will be clobbered when the upstream fix ships and Lisa re-applies. That is expected and fine; the upstream issue (step 2) is what makes it durable.
+
+### 2. File an upstream issue in the Lisa repository
+
+Use the `github-write-issue` skill (`lisa:github-write-issue`) to create a GitHub Issue **in Lisa's source repository `CodySwannGT/lisa`** — not in this project's own repo. The skill uses the `gh` CLI; the target repo must be `CodySwannGT/lisa` (e.g. `gh issue create --repo CodySwannGT/lisa ...`), because the agent's default repo is this host project.
+
+The issue should capture, following the skill's three-audience / acceptance-criteria conventions:
+
+- **Root cause** — which Lisa template/rule/skill/agent/hook/workflow is wrong or missing, with the path under `plugins/src/...` (or the relevant template source) if known.
+- **Symptom** — what broke or was missing in *this* project, and how it surfaced. Reference this project so the fix can be validated against a real case.
+- **Proposed durable fix** — the change to make in Lisa's source so it propagates to all projects on the next apply.
+- **Local stopgap applied** — note that a temporary local fix is in place here, so the maintainer knows the host project is unblocked and the local change will be superseded.
+
+## Do not
+
+- Do **not** only fix it locally and move on. The local fix is throwaway; without the upstream issue the root cause is lost and re-breaks for every project on the next apply.
+- Do **not** edit Lisa's templates from inside this project. You are not in the Lisa repo; those edits don't exist upstream and get overwritten — they create the illusion of a fix while the real source stays broken.
+- Do **not** file the issue in this project's own repo. The durable fix is tracked in `CodySwannGT/lisa`.
+
+## Access fallback
+
+If you lack permission to create an issue in `CodySwannGT/lisa`, do not silently drop it. Surface the situation to the user along with the fully-drafted issue contents (root cause, symptom, proposed fix, local stopgap), so a human can file it or grant access.
+
+## Not applicable inside the Lisa repo itself
+
+When you are already working **inside the Lisa source repo** (`CodySwannGT/lisa`), this rule does not apply — the fix is local to that repo, so make it directly in `plugins/src/...` (and rebuild artifacts) rather than filing an issue against yourself.

--- a/plugins/lisa-cursor/rules/upstream-to-lisa.mdc
+++ b/plugins/lisa-cursor/rules/upstream-to-lisa.mdc
@@ -1,0 +1,25 @@
+---
+description: "Upstream To Lisa (load-bearing)"
+alwaysApply: true
+---
+
+# Upstream To Lisa (load-bearing)
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project — a bug or gap in a Lisa-distributed template, rule, skill, agent, hook, or CI workflow, or a governance pattern worth generalizing back to the templates. Tell-tale signs: the file you want to change is Lisa-managed (carries Lisa governance markers, or lives in a path Lisa owns), and any edit you make here would be **overwritten on the next `lisa apply`**.
+
+When that happens, you have **two obligations — do both**:
+
+1. **Fix it locally so you are not blocked.** Apply the stopgap in this project so you can keep working. Treat it as temporary: it will be clobbered when the upstream fix ships and Lisa re-applies. Do not wait on the upstream fix.
+2. **File an upstream issue in the Lisa repository.** Use the `github-write-issue` skill (`lisa:github-write-issue`) to create an issue **in Lisa's source repo `CodySwannGT/lisa`** (pass it as the target repo, e.g. `gh ... --repo CodySwannGT/lisa`) — **not** in this project's own repo. Capture: the root cause, the symptom you hit here, and the proposed durable fix in Lisa's templates/rules/skills.
+
+## Do not
+
+- Do **not** only fix it locally and move on — the local fix is throwaway; without the upstream issue the root cause is lost and re-breaks on the next apply.
+- Do **not** try to edit Lisa's templates from inside this project — you are not in the Lisa repo; those edits don't exist upstream and get overwritten.
+- Do **not** file the issue in this project's repo — it must land in `CodySwannGT/lisa`.
+
+If you lack access to file an issue in `CodySwannGT/lisa`, surface that to the user with the proposed issue contents rather than silently dropping it.
+
+> Not applicable when you are already working **inside the Lisa repo itself** — there the fix is local, so just make it directly.
+
+Full procedure: [reference/upstream-to-lisa.md](upstream-to-lisa-reference.mdc).

--- a/plugins/lisa/rules/eager/upstream-to-lisa.md
+++ b/plugins/lisa/rules/eager/upstream-to-lisa.md
@@ -1,0 +1,20 @@
+# Upstream To Lisa (load-bearing)
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project — a bug or gap in a Lisa-distributed template, rule, skill, agent, hook, or CI workflow, or a governance pattern worth generalizing back to the templates. Tell-tale signs: the file you want to change is Lisa-managed (carries Lisa governance markers, or lives in a path Lisa owns), and any edit you make here would be **overwritten on the next `lisa apply`**.
+
+When that happens, you have **two obligations — do both**:
+
+1. **Fix it locally so you are not blocked.** Apply the stopgap in this project so you can keep working. Treat it as temporary: it will be clobbered when the upstream fix ships and Lisa re-applies. Do not wait on the upstream fix.
+2. **File an upstream issue in the Lisa repository.** Use the `github-write-issue` skill (`lisa:github-write-issue`) to create an issue **in Lisa's source repo `CodySwannGT/lisa`** (pass it as the target repo, e.g. `gh ... --repo CodySwannGT/lisa`) — **not** in this project's own repo. Capture: the root cause, the symptom you hit here, and the proposed durable fix in Lisa's templates/rules/skills.
+
+## Do not
+
+- Do **not** only fix it locally and move on — the local fix is throwaway; without the upstream issue the root cause is lost and re-breaks on the next apply.
+- Do **not** try to edit Lisa's templates from inside this project — you are not in the Lisa repo; those edits don't exist upstream and get overwritten.
+- Do **not** file the issue in this project's repo — it must land in `CodySwannGT/lisa`.
+
+If you lack access to file an issue in `CodySwannGT/lisa`, surface that to the user with the proposed issue contents rather than silently dropping it.
+
+> Not applicable when you are already working **inside the Lisa repo itself** — there the fix is local, so just make it directly.
+
+Full procedure: [reference/upstream-to-lisa.md](../reference/upstream-to-lisa.md).

--- a/plugins/lisa/rules/reference/upstream-to-lisa.md
+++ b/plugins/lisa/rules/reference/upstream-to-lisa.md
@@ -1,0 +1,44 @@
+# Upstream To Lisa
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project. This rule defines what to do so the fix is both unblocking *now* and durable *later*.
+
+## When this applies
+
+You are working in a downstream/host project (not the Lisa source repo) and you discover one of:
+
+- A bug or gap in a Lisa-distributed **template, rule, skill, agent, hook, or CI workflow**.
+- A **governance pattern** discovered here that should be generalized back into Lisa's templates so every project benefits.
+- Anything where the file you want to change is **Lisa-managed** — it carries Lisa governance markers, lives in a path Lisa owns, or any edit would be **overwritten on the next `lisa apply`**.
+
+The defining test: *if I fix this only here, does `lisa apply` wipe it out next time?* If yes, the root cause lives in Lisa and must be upstreamed.
+
+## What to do — both steps, always
+
+### 1. Fix it locally so you are not blocked
+
+Apply the stopgap in this project so you can keep working. Do **not** stall waiting for an upstream fix to land. Treat the local change as temporary — it will be clobbered when the upstream fix ships and Lisa re-applies. That is expected and fine; the upstream issue (step 2) is what makes it durable.
+
+### 2. File an upstream issue in the Lisa repository
+
+Use the `github-write-issue` skill (`lisa:github-write-issue`) to create a GitHub Issue **in Lisa's source repository `CodySwannGT/lisa`** — not in this project's own repo. The skill uses the `gh` CLI; the target repo must be `CodySwannGT/lisa` (e.g. `gh issue create --repo CodySwannGT/lisa ...`), because the agent's default repo is this host project.
+
+The issue should capture, following the skill's three-audience / acceptance-criteria conventions:
+
+- **Root cause** — which Lisa template/rule/skill/agent/hook/workflow is wrong or missing, with the path under `plugins/src/...` (or the relevant template source) if known.
+- **Symptom** — what broke or was missing in *this* project, and how it surfaced. Reference this project so the fix can be validated against a real case.
+- **Proposed durable fix** — the change to make in Lisa's source so it propagates to all projects on the next apply.
+- **Local stopgap applied** — note that a temporary local fix is in place here, so the maintainer knows the host project is unblocked and the local change will be superseded.
+
+## Do not
+
+- Do **not** only fix it locally and move on. The local fix is throwaway; without the upstream issue the root cause is lost and re-breaks for every project on the next apply.
+- Do **not** edit Lisa's templates from inside this project. You are not in the Lisa repo; those edits don't exist upstream and get overwritten — they create the illusion of a fix while the real source stays broken.
+- Do **not** file the issue in this project's own repo. The durable fix is tracked in `CodySwannGT/lisa`.
+
+## Access fallback
+
+If you lack permission to create an issue in `CodySwannGT/lisa`, do not silently drop it. Surface the situation to the user along with the fully-drafted issue contents (root cause, symptom, proposed fix, local stopgap), so a human can file it or grant access.
+
+## Not applicable inside the Lisa repo itself
+
+When you are already working **inside the Lisa source repo** (`CodySwannGT/lisa`), this rule does not apply — the fix is local to that repo, so make it directly in `plugins/src/...` (and rebuild artifacts) rather than filing an issue against yourself.

--- a/plugins/src/base/rules/eager/upstream-to-lisa.md
+++ b/plugins/src/base/rules/eager/upstream-to-lisa.md
@@ -1,0 +1,20 @@
+# Upstream To Lisa (load-bearing)
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project — a bug or gap in a Lisa-distributed template, rule, skill, agent, hook, or CI workflow, or a governance pattern worth generalizing back to the templates. Tell-tale signs: the file you want to change is Lisa-managed (carries Lisa governance markers, or lives in a path Lisa owns), and any edit you make here would be **overwritten on the next `lisa apply`**.
+
+When that happens, you have **two obligations — do both**:
+
+1. **Fix it locally so you are not blocked.** Apply the stopgap in this project so you can keep working. Treat it as temporary: it will be clobbered when the upstream fix ships and Lisa re-applies. Do not wait on the upstream fix.
+2. **File an upstream issue in the Lisa repository.** Use the `github-write-issue` skill (`lisa:github-write-issue`) to create an issue **in Lisa's source repo `CodySwannGT/lisa`** (pass it as the target repo, e.g. `gh ... --repo CodySwannGT/lisa`) — **not** in this project's own repo. Capture: the root cause, the symptom you hit here, and the proposed durable fix in Lisa's templates/rules/skills.
+
+## Do not
+
+- Do **not** only fix it locally and move on — the local fix is throwaway; without the upstream issue the root cause is lost and re-breaks on the next apply.
+- Do **not** try to edit Lisa's templates from inside this project — you are not in the Lisa repo; those edits don't exist upstream and get overwritten.
+- Do **not** file the issue in this project's repo — it must land in `CodySwannGT/lisa`.
+
+If you lack access to file an issue in `CodySwannGT/lisa`, surface that to the user with the proposed issue contents rather than silently dropping it.
+
+> Not applicable when you are already working **inside the Lisa repo itself** — there the fix is local, so just make it directly.
+
+Full procedure: [reference/upstream-to-lisa.md](../reference/upstream-to-lisa.md).

--- a/plugins/src/base/rules/reference/upstream-to-lisa.md
+++ b/plugins/src/base/rules/reference/upstream-to-lisa.md
@@ -1,0 +1,44 @@
+# Upstream To Lisa
+
+When working in a project that has Lisa installed, you will sometimes find that the **real fix belongs upstream in Lisa**, not in this project. This rule defines what to do so the fix is both unblocking *now* and durable *later*.
+
+## When this applies
+
+You are working in a downstream/host project (not the Lisa source repo) and you discover one of:
+
+- A bug or gap in a Lisa-distributed **template, rule, skill, agent, hook, or CI workflow**.
+- A **governance pattern** discovered here that should be generalized back into Lisa's templates so every project benefits.
+- Anything where the file you want to change is **Lisa-managed** — it carries Lisa governance markers, lives in a path Lisa owns, or any edit would be **overwritten on the next `lisa apply`**.
+
+The defining test: *if I fix this only here, does `lisa apply` wipe it out next time?* If yes, the root cause lives in Lisa and must be upstreamed.
+
+## What to do — both steps, always
+
+### 1. Fix it locally so you are not blocked
+
+Apply the stopgap in this project so you can keep working. Do **not** stall waiting for an upstream fix to land. Treat the local change as temporary — it will be clobbered when the upstream fix ships and Lisa re-applies. That is expected and fine; the upstream issue (step 2) is what makes it durable.
+
+### 2. File an upstream issue in the Lisa repository
+
+Use the `github-write-issue` skill (`lisa:github-write-issue`) to create a GitHub Issue **in Lisa's source repository `CodySwannGT/lisa`** — not in this project's own repo. The skill uses the `gh` CLI; the target repo must be `CodySwannGT/lisa` (e.g. `gh issue create --repo CodySwannGT/lisa ...`), because the agent's default repo is this host project.
+
+The issue should capture, following the skill's three-audience / acceptance-criteria conventions:
+
+- **Root cause** — which Lisa template/rule/skill/agent/hook/workflow is wrong or missing, with the path under `plugins/src/...` (or the relevant template source) if known.
+- **Symptom** — what broke or was missing in *this* project, and how it surfaced. Reference this project so the fix can be validated against a real case.
+- **Proposed durable fix** — the change to make in Lisa's source so it propagates to all projects on the next apply.
+- **Local stopgap applied** — note that a temporary local fix is in place here, so the maintainer knows the host project is unblocked and the local change will be superseded.
+
+## Do not
+
+- Do **not** only fix it locally and move on. The local fix is throwaway; without the upstream issue the root cause is lost and re-breaks for every project on the next apply.
+- Do **not** edit Lisa's templates from inside this project. You are not in the Lisa repo; those edits don't exist upstream and get overwritten — they create the illusion of a fix while the real source stays broken.
+- Do **not** file the issue in this project's own repo. The durable fix is tracked in `CodySwannGT/lisa`.
+
+## Access fallback
+
+If you lack permission to create an issue in `CodySwannGT/lisa`, do not silently drop it. Surface the situation to the user along with the fully-drafted issue contents (root cause, symptom, proposed fix, local stopgap), so a human can file it or grant access.
+
+## Not applicable inside the Lisa repo itself
+
+When you are already working **inside the Lisa source repo** (`CodySwannGT/lisa`), this rule does not apply — the fix is local to that repo, so make it directly in `plugins/src/...` (and rebuild artifacts) rather than filing an issue against yourself.

--- a/tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts
+++ b/tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts
@@ -44,7 +44,7 @@ describe("committed Cursor artifacts (regression — issue #1055)", () => {
     const mdcFiles = (): readonly string[] =>
       fs.readdirSync(rulesDir).filter(f => f.endsWith(".mdc"));
 
-    it("ships 28 flat .mdc (14 eager + 14 reference), no nested dirs, no plain .md", () => {
+    it("ships 30 flat .mdc (15 eager + 15 reference), no nested dirs, no plain .md", () => {
       expect(fs.existsSync(rulesDir)).toBe(true);
       expect(fs.existsSync(path.join(rulesDir, "eager"))).toBe(false);
       expect(fs.existsSync(path.join(rulesDir, "reference"))).toBe(false);
@@ -53,9 +53,9 @@ describe("committed Cursor artifacts (regression — issue #1055)", () => {
         expect(e.name.endsWith(".mdc")).toBe(true);
       }
       const mdc = mdcFiles();
-      expect(mdc.length).toBe(28);
-      expect(mdc.filter(f => f.endsWith(REFERENCE_SUFFIX)).length).toBe(14);
-      expect(mdc.filter(f => !f.endsWith(REFERENCE_SUFFIX)).length).toBe(14);
+      expect(mdc.length).toBe(30);
+      expect(mdc.filter(f => f.endsWith(REFERENCE_SUFFIX)).length).toBe(15);
+      expect(mdc.filter(f => !f.endsWith(REFERENCE_SUFFIX)).length).toBe(15);
     });
 
     it("eager rules carry alwaysApply:true; reference rules alwaysApply:false + description", () => {


### PR DESCRIPTION
## Problem

When an agent works inside a *host/downstream* project (frontend-v2, propswap, gemini, etc.) and discovers that the real fix belongs **upstream in Lisa** — a bug/gap in a Lisa-distributed template, rule, skill, agent, hook, or CI workflow, or a governance pattern worth generalizing — it had no defined path. It either patched locally (wiped out on the next `lisa apply`) or dropped the insight entirely.

## Fix

New load-bearing eager rule (+ reference), shipped via the base plugin into host projects: `upstream-to-lisa`. When the situation arises, the agent must do **both**:

1. **Fix it locally so it isn't blocked** — apply the stopgap in the host project and keep working. Treated as temporary; the upstream fix will supersede it on the next apply.
2. **File an upstream issue in Lisa's source repo** — use the `github-write-issue` skill to create an issue **in `CodySwannGT/lisa`** (cross-repo target via `gh ... --repo CodySwannGT/lisa`), **not** in the host project's own repo. Captures root cause, host-project symptom, and the proposed durable fix.

## Guards

- Never only-fix-locally and move on (root cause would be lost and re-break every project on the next apply).
- Never edit Lisa's templates from inside a host project (those edits don't exist upstream and get overwritten).
- Never file the issue in the host project's own repo.
- If the agent lacks access to `CodySwannGT/lisa`, surface the fully-drafted issue to the user rather than dropping it.
- Explicitly **not applicable inside the Lisa repo itself** — there the fix is local.

## Mechanics

- Source: `plugins/src/base/rules/{eager,reference}/upstream-to-lisa.md`.
- `bun run build:plugins` regenerated all variants (lisa / copilot / cursor `.mdc`); agy carries no `rules/` dir, same surface as the existing `security-audit-handling` rule family.
- Bumped the hardcoded Cursor artifact count (28→30, 14→15 eager/reference) in `generate-cursor-plugin-artifacts.artifacts.test.ts`.
- `bun run check:plugins` passes on a clean tree.

🤖 Generated with Claude Code