### PR TITLE
fix(package-lisa): $name self-ref for direct-dep overrides (aws-cdk-lib, vite)

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -38,10 +38,12 @@
     },
     "private": true,
     "overrides": {
-      "aws-cdk-lib": ">=2.246.0"
+      "aws-cdk-lib": "$aws-cdk-lib",
+      "vite": "$vite"
     },
     "resolutions": {
-      "aws-cdk-lib": ">=2.246.0"
+      "aws-cdk-lib": "$aws-cdk-lib",
+      "vite": "$vite"
     }
   },
   "defaults": {

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -95,6 +95,12 @@
       "oxlint-tsgolint": "^0.22.1",
       "@stryker-mutator/core": "^9.0.0",
       "@stryker-mutator/vitest-runner": "^9.0.0"
+    },
+    "overrides": {
+      "vite": "$vite"
+    },
+    "resolutions": {
+      "vite": "$vite"
     }
   }
 }

--- a/npm-package/package-lisa/package.lisa.json
+++ b/npm-package/package-lisa/package.lisa.json
@@ -9,6 +9,12 @@
       "vite": "^8.0.16",
       "vitest": "^4.1.0",
       "@vitest/coverage-v8": "^4.1.0"
+    },
+    "overrides": {
+      "vite": "$vite"
+    },
+    "resolutions": {
+      "vite": "$vite"
     }
   },
   "defaults": {

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -47,6 +47,12 @@
       "knip": "^5.0.0",
       "@ast-grep/cli": "^0.40.4",
       "vite": "^8.0.16"
+    },
+    "overrides": {
+      "vite": "$vite"
+    },
+    "resolutions": {
+      "vite": "$vite"
     }
   },
   "defaults": {


### PR DESCRIPTION
Follow-up to #1330. `npm install --package-lock-only` empirically EOVERRIDEs on `aws-cdk-lib` (cdk forces it direct `2.246.0` but overrides `>=2.246.0`) — which #1330's same-spec vite alignment did not cover (it bit geminisportsai/infrastructure-v2). Convert direct-dep overrides/resolutions to npm's self-reference form (`$aws-cdk-lib`, `$vite`) in the child templates; typescript base keeps vite as a ranged transitive floor. Verified no EOVERRIDE. Matches the documented convention.

🤖 Generated with Claude Code