### PR TITLE
fix(ci): drop contradictory setup-node cache input that breaks npm ci

### DIFF
--- a/.github/workflows/create-github-issue-on-failure.yml
+++ b/.github/workflows/create-github-issue-on-failure.yml
@@ -71,7 +71,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🔖 Create Issue
         uses: actions/github-script@v8

--- a/.github/workflows/create-jira-issue-on-failure.yml
+++ b/.github/workflows/create-jira-issue-on-failure.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🔖 Create Jira Issue
         id: create_jira_issue

--- a/.github/workflows/create-sentry-issue-on-failure.yml
+++ b/.github/workflows/create-sentry-issue-on-failure.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🔴 Create Sentry Issue
         id: create_sentry_issue

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: '🍞 Setup Bun'
         if: inputs.package_manager == 'bun'

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -98,7 +98,6 @@ jobs:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -192,7 +192,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -275,7 +274,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -330,7 +328,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -370,7 +367,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -410,7 +406,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -457,7 +452,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -526,7 +520,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -591,7 +584,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -657,7 +649,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -839,7 +830,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -979,7 +969,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: steps.check_playwright.outputs.has_config == 'true' && inputs.package_manager == 'bun'
@@ -1068,7 +1057,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1108,7 +1096,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1190,7 +1177,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1236,7 +1222,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1314,7 +1299,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1593,7 +1577,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -1741,7 +1724,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: 🍞 Setup Bun
         if: inputs.package_manager == 'bun'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,7 +478,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'

--- a/.github/workflows/zap-baseline-expo.yml
+++ b/.github/workflows/zap-baseline-expo.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'

--- a/.github/workflows/zap-baseline-nestjs.yml
+++ b/.github/workflows/zap-baseline-nestjs.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
-          cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: Setup Bun
         if: inputs.package_manager == 'bun'


### PR DESCRIPTION
## Problem

The reusable workflow `.github/workflows/quality.yml` (consumed fleet-wide as `uses: CodySwannGT/lisa/.github/workflows/quality.yml@main`) deterministically fails the **📦 Install Dependencies** job — and every downstream Quality Check job — for npm projects with:

```
npm error code EUSAGE
The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json
```

Confirmed from live CI logs: gunnertech/thumbwar-infrastructure PR #163 and qualis-infrastructure PR #165 (runs 27874046550 / 27874095325).

## Root cause

The `@v4`→`@v6` `actions/setup-node` bump (7bd3fcf3 lineage, originally 7a06fd00) configured setup-node with **both** `package-manager-cache: false` **and** `cache: <pm>` — a contradiction. In v6 this pair makes setup-node restore a tiny (713 B) "npm" cache and extract it with `tar -P -C /home/runner/work/<repo>/<repo>` directly over the checked-out tree, removing `package-lock.json` before `npm ci` runs.

It's a **poisoned-cache landmine**, not a date-specific change: the first run for a given lockfile hash *saves* the broken entry; every later run *restores* it. That's why the `2026-06-16` fleet update passed and the `2026-06-20` runs fail.

The **Lint job has no `actions/cache` step at all** — only `setup-node` — and fails identically, proving setup-node is the root cause (the explicit `actions/cache` is a harmless secondary; on a non-exact restore-key, `npm ci` still rebuilds `node_modules` from the intact lockfile).

## Fix

`package-manager-cache: false` already disables setup-node's built-in cache; the leftover `cache:` input re-enables the broken path. Remove it — matching the many workflows here (`build.yml`, `ci.yml`, `release-rails.yml`, all `reusable-claude-*`) that already use `package-manager-cache: false` with no `cache:` line.

Applied to all 9 affected workflows (quality.yml ×18 occurrences, plus release, publish-to-npm, lighthouse, zap-baseline-expo/nestjs, and the 3 create-*-issue-on-failure workflows), since each carries the identical landmine and would break the fleet as its cache poisons.

Pure deletion (26 lines); all 9 files validated as parseable YAML.

## Validation plan

After merge to `main`, re-run thumbwar-infrastructure #163's Quality Checks and confirm **Install Dependencies** passes.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js configuration across continuous integration workflows to standardize dependency caching behavior and ensure consistent build environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->