### PR TITLE
fix: add Jira CLI config fallback

### DIFF
--- a/plugins/lisa-copilot/hooks/setup-jira-cli.sh
+++ b/plugins/lisa-copilot/hooks/setup-jira-cli.sh
@@ -5,9 +5,9 @@
 #
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
-#   JIRA_SERVER       - Atlassian instance URL
+#   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
 #   JIRA_LOGIN        - login email
-#   JIRA_PROJECT      - default project key
+#   JIRA_PROJECT      - default project key (falls back to .lisa.config*.json jira.project)
 #   JIRA_API_TOKEN    - already expected by jira-cli natively
 #
 # Optional env vars:
@@ -30,6 +30,40 @@ fi
 
 CONFIG_DIR="${HOME}/.config/.jira"
 CONFIG_FILE="${CONFIG_DIR}/.config.yml"
+
+read_lisa_config() {
+  local query="$1"
+  local value=""
+
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  if [[ -f ".lisa.config.local.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.local.json 2>/dev/null || true)
+  fi
+
+  if [[ -z "${value}" && -f ".lisa.config.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.json 2>/dev/null || true)
+  fi
+
+  printf '%s' "${value}"
+}
+
+if [[ -z "${JIRA_SERVER:-}" ]]; then
+  ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"
+  if [[ -n "${ATLASSIAN_SITE}" ]]; then
+    if [[ "${ATLASSIAN_SITE}" == http://* || "${ATLASSIAN_SITE}" == https://* ]]; then
+      JIRA_SERVER="${ATLASSIAN_SITE}"
+    else
+      JIRA_SERVER="https://${ATLASSIAN_SITE}"
+    fi
+  fi
+fi
+
+if [[ -z "${JIRA_PROJECT:-}" ]]; then
+  JIRA_PROJECT="$(read_lisa_config '.jira.project')"
+fi
 
 # Skip config write if required vars are missing
 if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then

--- a/plugins/lisa-cursor/hooks/setup-jira-cli.sh
+++ b/plugins/lisa-cursor/hooks/setup-jira-cli.sh
@@ -5,9 +5,9 @@
 #
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
-#   JIRA_SERVER       - Atlassian instance URL
+#   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
 #   JIRA_LOGIN        - login email
-#   JIRA_PROJECT      - default project key
+#   JIRA_PROJECT      - default project key (falls back to .lisa.config*.json jira.project)
 #   JIRA_API_TOKEN    - already expected by jira-cli natively
 #
 # Optional env vars:
@@ -30,6 +30,40 @@ fi
 
 CONFIG_DIR="${HOME}/.config/.jira"
 CONFIG_FILE="${CONFIG_DIR}/.config.yml"
+
+read_lisa_config() {
+  local query="$1"
+  local value=""
+
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  if [[ -f ".lisa.config.local.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.local.json 2>/dev/null || true)
+  fi
+
+  if [[ -z "${value}" && -f ".lisa.config.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.json 2>/dev/null || true)
+  fi
+
+  printf '%s' "${value}"
+}
+
+if [[ -z "${JIRA_SERVER:-}" ]]; then
+  ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"
+  if [[ -n "${ATLASSIAN_SITE}" ]]; then
+    if [[ "${ATLASSIAN_SITE}" == http://* || "${ATLASSIAN_SITE}" == https://* ]]; then
+      JIRA_SERVER="${ATLASSIAN_SITE}"
+    else
+      JIRA_SERVER="https://${ATLASSIAN_SITE}"
+    fi
+  fi
+fi
+
+if [[ -z "${JIRA_PROJECT:-}" ]]; then
+  JIRA_PROJECT="$(read_lisa_config '.jira.project')"
+fi
 
 # Skip config write if required vars are missing
 if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then

--- a/plugins/lisa/hooks/setup-jira-cli.sh
+++ b/plugins/lisa/hooks/setup-jira-cli.sh
@@ -5,9 +5,9 @@
 #
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
-#   JIRA_SERVER       - Atlassian instance URL
+#   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
 #   JIRA_LOGIN        - login email
-#   JIRA_PROJECT      - default project key
+#   JIRA_PROJECT      - default project key (falls back to .lisa.config*.json jira.project)
 #   JIRA_API_TOKEN    - already expected by jira-cli natively
 #
 # Optional env vars:
@@ -30,6 +30,40 @@ fi
 
 CONFIG_DIR="${HOME}/.config/.jira"
 CONFIG_FILE="${CONFIG_DIR}/.config.yml"
+
+read_lisa_config() {
+  local query="$1"
+  local value=""
+
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  if [[ -f ".lisa.config.local.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.local.json 2>/dev/null || true)
+  fi
+
+  if [[ -z "${value}" && -f ".lisa.config.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.json 2>/dev/null || true)
+  fi
+
+  printf '%s' "${value}"
+}
+
+if [[ -z "${JIRA_SERVER:-}" ]]; then
+  ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"
+  if [[ -n "${ATLASSIAN_SITE}" ]]; then
+    if [[ "${ATLASSIAN_SITE}" == http://* || "${ATLASSIAN_SITE}" == https://* ]]; then
+      JIRA_SERVER="${ATLASSIAN_SITE}"
+    else
+      JIRA_SERVER="https://${ATLASSIAN_SITE}"
+    fi
+  fi
+fi
+
+if [[ -z "${JIRA_PROJECT:-}" ]]; then
+  JIRA_PROJECT="$(read_lisa_config '.jira.project')"
+fi
 
 # Skip config write if required vars are missing
 if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then

--- a/plugins/src/base/hooks/setup-jira-cli.sh
+++ b/plugins/src/base/hooks/setup-jira-cli.sh
@@ -5,9 +5,9 @@
 #
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
-#   JIRA_SERVER       - Atlassian instance URL
+#   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
 #   JIRA_LOGIN        - login email
-#   JIRA_PROJECT      - default project key
+#   JIRA_PROJECT      - default project key (falls back to .lisa.config*.json jira.project)
 #   JIRA_API_TOKEN    - already expected by jira-cli natively
 #
 # Optional env vars:
@@ -30,6 +30,40 @@ fi
 
 CONFIG_DIR="${HOME}/.config/.jira"
 CONFIG_FILE="${CONFIG_DIR}/.config.yml"
+
+read_lisa_config() {
+  local query="$1"
+  local value=""
+
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  if [[ -f ".lisa.config.local.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.local.json 2>/dev/null || true)
+  fi
+
+  if [[ -z "${value}" && -f ".lisa.config.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.json 2>/dev/null || true)
+  fi
+
+  printf '%s' "${value}"
+}
+
+if [[ -z "${JIRA_SERVER:-}" ]]; then
+  ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"
+  if [[ -n "${ATLASSIAN_SITE}" ]]; then
+    if [[ "${ATLASSIAN_SITE}" == http://* || "${ATLASSIAN_SITE}" == https://* ]]; then
+      JIRA_SERVER="${ATLASSIAN_SITE}"
+    else
+      JIRA_SERVER="https://${ATLASSIAN_SITE}"
+    fi
+  fi
+fi
+
+if [[ -z "${JIRA_PROJECT:-}" ]]; then
+  JIRA_PROJECT="$(read_lisa_config '.jira.project')"
+fi
 
 # Skip config write if required vars are missing
 if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then

--- a/src/codex/scripts/setup-jira-cli.sh
+++ b/src/codex/scripts/setup-jira-cli.sh
@@ -3,6 +3,40 @@
 # Writes jira-cli configuration from environment variables when available.
 set -euo pipefail
 
+read_lisa_config() {
+  local query="$1"
+  local value=""
+
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  if [[ -f ".lisa.config.local.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.local.json 2>/dev/null || true)
+  fi
+
+  if [[ -z "${value}" && -f ".lisa.config.json" ]]; then
+    value=$(jq -r "${query} // empty" .lisa.config.json 2>/dev/null || true)
+  fi
+
+  printf '%s' "${value}"
+}
+
+if [[ -z "${JIRA_SERVER:-}" ]]; then
+  ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"
+  if [[ -n "${ATLASSIAN_SITE}" ]]; then
+    if [[ "${ATLASSIAN_SITE}" == http://* || "${ATLASSIAN_SITE}" == https://* ]]; then
+      JIRA_SERVER="${ATLASSIAN_SITE}"
+    else
+      JIRA_SERVER="https://${ATLASSIAN_SITE}"
+    fi
+  fi
+fi
+
+if [[ -z "${JIRA_PROJECT:-}" ]]; then
+  JIRA_PROJECT="$(read_lisa_config '.jira.project')"
+fi
+
 if [[ -z "${JIRA_SERVER:-}" || -z "${JIRA_LOGIN:-}" ]]; then
   exit 0
 fi

--- a/src/opencode/plugin-templates/lisa-session-bootstrap.ts
+++ b/src/opencode/plugin-templates/lisa-session-bootstrap.ts
@@ -23,7 +23,8 @@ export const LisaSessionBootstrap = async ({
   worktree: string;
 }) => {
   const root = worktree;
-  const { existsSync, mkdirSync, writeFileSync } = await import("node:fs");
+  const { existsSync, mkdirSync, readFileSync, writeFileSync } =
+    await import("node:fs");
 
   // install-pkgs: bootstrap dependencies when they're missing.
   try {
@@ -46,9 +47,38 @@ export const LisaSessionBootstrap = async ({
     // fail open — never block startup on a dependency-install error
   }
 
-  // setup-jira-cli: write jira-cli config from environment variables.
+  // setup-jira-cli: write jira-cli config from environment variables and non-secret Lisa config.
   try {
-    const server = process.env.JIRA_SERVER;
+    const readLisaConfig = (path: string[]) => {
+      for (const file of [".lisa.config.local.json", ".lisa.config.json"]) {
+        const configPath = `${root}/${file}`;
+        if (!existsSync(configPath)) continue;
+        try {
+          let value: unknown = JSON.parse(readFileSync(configPath, "utf8"));
+          for (const key of path) {
+            if (!value || typeof value !== "object" || !(key in value)) {
+              value = undefined;
+              break;
+            }
+            value = (value as Record<string, unknown>)[key];
+          }
+          if (typeof value === "string" && value) return value;
+        } catch {
+          // ignore malformed local config and keep fail-open behavior
+        }
+      }
+      return undefined;
+    };
+    const atlassianSite = readLisaConfig(["atlassian", "site"]);
+    const server =
+      process.env.JIRA_SERVER ??
+      (atlassianSite?.startsWith("http")
+        ? atlassianSite
+        : atlassianSite
+          ? `https://${atlassianSite}`
+          : undefined);
+    const project =
+      process.env.JIRA_PROJECT ?? readLisaConfig(["jira", "project"]) ?? "";
     const login = process.env.JIRA_LOGIN;
     const home = process.env.HOME;
     if (server && login && home) {
@@ -58,7 +88,7 @@ export const LisaSessionBootstrap = async ({
         `installation: ${process.env.JIRA_INSTALLATION ?? "cloud"}`,
         `server: ${server}`,
         `login: ${login}`,
-        `project: ${process.env.JIRA_PROJECT ?? ""}`,
+        `project: ${project}`,
         `board: "${process.env.JIRA_BOARD ?? ""}"`,
         "auth_type: basic",
         "epic:",

--- a/src/opencode/plugin-templates/lisa-session-bootstrap.ts
+++ b/src/opencode/plugin-templates/lisa-session-bootstrap.ts
@@ -72,7 +72,7 @@ export const LisaSessionBootstrap = async ({
     const atlassianSite = readLisaConfig(["atlassian", "site"]);
     const server =
       process.env.JIRA_SERVER ??
-      (atlassianSite?.startsWith("http")
+      (/^https?:\/\//.test(atlassianSite ?? "")
         ? atlassianSite
         : atlassianSite
           ? `https://${atlassianSite}`

--- a/tests/unit/opencode/hooks-installer.test.ts
+++ b/tests/unit/opencode/hooks-installer.test.ts
@@ -201,6 +201,24 @@ describe("opencode/hooks-installer", () => {
       expect(body).toContain("export const LisaSessionBootstrap");
     });
 
+    it("session bootstrap uses strict https?:// URL-scheme check (not loose startsWith)", async () => {
+      await installHooks(destDir, [], []);
+      const body = await fs.readFile(
+        path.join(
+          destDir,
+          OPENCODE_CONFIG_DIR,
+          OPENCODE_PLUGIN_SUBDIR,
+          SESSION
+        ),
+        "utf8"
+      );
+      // Ensure the bootstrap uses a strict regex so that values like "httpfoo"
+      // are treated as bare hostnames and get https:// prepended, matching the
+      // behaviour of the shell hook (which checks http://* || https://*).
+      expect(body).toContain("/^https?:\\/\\//");
+      expect(body).not.toContain('.startsWith("http")');
+    });
+
     it("reports pluginCount equal to the emitted file count", async () => {
       const result = await installHooks(destDir, ["typescript"], []);
       const files = await listInstalledPluginFiles(destDir);

--- a/tests/unit/scripts/setup-jira-cli-config.test.ts
+++ b/tests/unit/scripts/setup-jira-cli-config.test.ts
@@ -1,0 +1,101 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const setupJiraCli = path.join(
+  repoRoot,
+  "plugins",
+  "src",
+  "base",
+  "hooks",
+  "setup-jira-cli.sh"
+);
+
+describe("setup-jira-cli hook config fallback", () => {
+  let tempDir: string;
+  let homeDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    homeDir = path.join(tempDir, "home");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(homeDir);
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("uses Lisa config for non-secret Jira values when env vars are missing", async () => {
+    await fs.writeJson(path.join(projectDir, ".lisa.config.json"), {
+      atlassian: { site: "example.atlassian.net" },
+      jira: { project: "LISA" },
+    });
+
+    await runHook({ JIRA_LOGIN: "bot@example.com" });
+
+    await expectJiraConfig([
+      "server: https://example.atlassian.net",
+      "login: bot@example.com",
+      "project: LISA",
+    ]);
+  });
+
+  it("keeps env vars ahead of local and global Lisa config", async () => {
+    await fs.writeJson(path.join(projectDir, ".lisa.config.json"), {
+      atlassian: { site: "global.atlassian.net" },
+      jira: { project: "GLOBAL" },
+    });
+    await fs.writeJson(path.join(projectDir, ".lisa.config.local.json"), {
+      atlassian: { site: "local.atlassian.net" },
+      jira: { project: "LOCAL" },
+    });
+
+    await runHook({
+      JIRA_LOGIN: "bot@example.com",
+      JIRA_PROJECT: "ENV",
+      JIRA_SERVER: "https://env.atlassian.net",
+    });
+
+    await expectJiraConfig([
+      "server: https://env.atlassian.net",
+      "project: ENV",
+    ]);
+  });
+
+  /**
+   * Execute the canonical setup-jira-cli hook inside the temporary project.
+   * @param env - Environment variables to expose to the hook process.
+   */
+  async function runHook(env: NodeJS.ProcessEnv) {
+    await execFileAsync("bash", [setupJiraCli], {
+      cwd: projectDir,
+      env: {
+        HOME: homeDir,
+        PATH: process.env.PATH ?? "",
+        ...env,
+      },
+    });
+  }
+
+  /**
+   * Assert that the generated jira-cli config contains each expected line.
+   * @param expectedLines - Config lines that must appear in the generated file.
+   */
+  async function expectJiraConfig(expectedLines: readonly string[]) {
+    const config = await fs.readFile(
+      path.join(homeDir, ".config", ".jira", ".config.yml"),
+      "utf8"
+    );
+    for (const line of expectedLines) {
+      expect(config).toContain(line);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- derive JIRA_SERVER from .lisa.config.local.json/.lisa.config.json atlassian.site when env is absent
- derive JIRA_PROJECT from Lisa config when env is absent while keeping login/token env-only
- apply the same behavior to Claude/Cursor/Copilot hook artifacts, Codex scripts, and OpenCode bootstrap
- add a regression test for config fallback and env precedence

## Verification
- bun test tests/unit/scripts/setup-jira-cli-config.test.ts
- bun run build:dist
- bun run build:plugins
- bun run check:plugins
- pre-push: slow lint, knip, vitest coverage, integration tests

Closes #1340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JIRA server and project settings can now automatically source from Lisa config files (`.lisa.config.json` and `.lisa.config.local.json`) when environment variables are not set, with environment variables retaining precedence.
  * Added URL normalization to ensure the JIRA server uses a proper `http(s)` scheme.
* **Tests**
  * Added/expanded unit tests to validate Jira CLI config fallback and precedence.
  * Added a unit test to enforce strict `http(s)://` URL-scheme checking in the session bootstrap output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->