### PR TITLE
docs(claude-remote): encode routine platform network model

### DIFF
--- a/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
@@ -148,9 +148,14 @@ Group the findings as:
 7. **Platform constraints** — surface the non-config constraints as `GAP`/`RISK` so the user is
    not surprised: routines run with no interactive permission prompts and cannot ask the user
    mid-run; interactive auth (SSO/OAuth browser, keychain) is unavailable; GitHub org IP
-   allowlisting blocks cloud sessions; outbound traffic is proxied and custom domains need
-   allowlisting; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no desktop/computer-use; no
-   statusline/theme rendering.
+   allowlisting blocks cloud sessions; raw GitHub clone/fetch/push operations are handled by
+   Claude's connected-GitHub proxy/identity and do not need a separate PAT; the `gh` CLI is not the
+   same substrate and still needs `GH_TOKEN`; outbound traffic is controlled by the routine
+   environment network tier, where the default Trusted tier includes common development domains and
+   package registries but arbitrary integration hosts need Custom or Full access; environment
+   variables and setup scripts are stored in the cloud environment configuration and are visible to
+   anyone who can edit that environment; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no
+   desktop/computer-use; no statusline/theme rendering.
 
 8. **Host-project app needs** — note any build/test/run command a routine would invoke and any
    runtime service it depends on (database, queue, external API) that will not exist in a fresh
@@ -168,9 +173,18 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### GitHub — `tracker: github` and/or `source: github`
 - Headless substrate: `gh` CLI authed by token (every Lisa GitHub script gates on `gh auth status`).
-- Env: `GH_TOKEN` (the routine's built-in repo connection may not authenticate the `gh` CLI — verify; set `GH_TOKEN` if `gh auth status` fails). `PAT` only for cross-repo flows.
+- Platform substrate: Claude's connected-GitHub proxy/identity authenticates raw git
+  clone/fetch/push for repositories the routine can access. Do not ask for a PAT solely for raw git
+  or sibling-repo clones.
+- Env: `GH_TOKEN` for the `gh` CLI only; set it because Lisa's PR/issue lifecycle shells out to
+  `gh`. Do not describe it as required for raw git clone/fetch/push.
 - Acquire: fine-grained — `https://github.com/settings/personal-access-tokens`; classic — `https://github.com/settings/tokens`.
-- Access: fine-grained → Repository access to the target repo(s); Repository permissions: Contents R/W, Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Classic equivalent: `repo` + `workflow` (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
+- Access: fine-grained → Repository access to the repo(s) where Lisa will run `gh` commands (the
+  project repo, and the Lisa repo only if filing Lisa issues); Repository permissions: Contents R/W,
+  Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing
+  `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Do not include
+  sibling repos that are only cloned/fetched with raw git. Classic equivalent: `repo` + `workflow`
+  (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
@@ -242,6 +256,18 @@ so the generator can render acquisition comments into its template:
     { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
+  "platform": {
+    "githubProxy": {
+      "rawGitAuthenticated": true,
+      "crossRepoAccess": "repositories reachable by the connected GitHub identity/routine access do not need a PAT for raw git",
+      "ghCliNeedsToken": true
+    },
+    "secretsVisibility": "environment variables and setup scripts are visible to environment editors"
+  },
+  "networkAccess": {
+    "tier": "custom",
+    "allowlistDomains": []
+  },
   "allowlistDomains": []
 }
 ```
@@ -269,5 +295,13 @@ so the generator can render acquisition comments into its template:
   Lisa's `setup-*` skills) — transcribe them exactly; never guess at the access a token needs.
 - For the active `tracker`/`source`, always report the **env-var** form of the secret, never the OS
   keychain form — keychain reads do not work in a cloud routine.
+- For GitHub, keep the split explicit: raw git uses the platform GitHub proxy/identity, while
+  `GH_TOKEN` is for `gh` CLI commands. Sibling repos that are only cloned or fetched with raw git do
+  not belong in the token scope.
+- Add GitHub/npm/PyPI/Docker Hub/common development domains to neither `allowlistDomains` nor
+  `networkAccess.allowlistDomains`; those are covered by the routine environment's default Trusted
+  list. Only non-default integration hosts require Custom-network allowlisting.
+- Always include a `RISK`/`GAP` finding when environment secrets or setup scripts would be visible
+  to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".

--- a/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
@@ -30,8 +30,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
 ## Procedure
 
 1. **Inventory.** Invoke `/lisa:analyze-claude-remote --json` and parse its machine-readable
-   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `allowlistDomains`). If the
-   analysis cannot run, stop and report why — never emit a script from guesses.
+   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `platform`,
+   `networkAccess`, `allowlistDomains`). If the analysis cannot run, stop and report why — never
+   emit a script from guesses.
 
 2. **Compose the setup script** from the inventory. The script must be:
    - **Idempotent & detect-before-install** — every install guarded by a `command -v <tool>` check
@@ -62,11 +63,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
    that the analysis reported (including any per-account suffixed form like `LINEAR_API_KEY_<slug>`);
    never emit a keychain instruction — keychain does not exist in a cloud routine.
+   When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
+   is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
+   sibling repos reachable through the routine's GitHub proxy.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
-   (from `allowlistDomains`) that the user must add to the environment's network access, and echo
-   the `gaps` from the analysis (auto-memory not synced, interactive-auth/stdio-MCP unavailable,
-   etc.) as a header comment so the user knows what the script **cannot** fix.
+   (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
+   must add when the environment needs Custom network access. Do not include default Trusted domains
+   such as GitHub, npm/PyPI registries, or Docker Hub. Echo the `gaps` from the analysis
+   (auto-memory not synced, interactive-auth/stdio-MCP unavailable, etc.) and the
+   `platform.secretsVisibility` warning as a header comment so the user knows what the script
+   **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
    `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
@@ -92,9 +99,11 @@ shape, not a fixed payload):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R
+#   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
+#   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-# NETWORK: allowlist these domains in the environment if not on full access:
-#   - <allowlistDomains, if any>
+# NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
+#   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
 
 need() { command -v "$1" >/dev/null 2>&1; }
@@ -152,8 +161,12 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.
+- For `GH_TOKEN`, preserve the analysis's GitHub proxy split: it is for `gh` CLI commands only, and
+  raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
+- Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
+  domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.
 - Preserve the inventory's `REQUIRED` vs `OPTIONAL` distinction in both fail-behavior (fatal vs
   warn) and section placement.

--- a/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
@@ -148,9 +148,14 @@ Group the findings as:
 7. **Platform constraints** — surface the non-config constraints as `GAP`/`RISK` so the user is
    not surprised: routines run with no interactive permission prompts and cannot ask the user
    mid-run; interactive auth (SSO/OAuth browser, keychain) is unavailable; GitHub org IP
-   allowlisting blocks cloud sessions; outbound traffic is proxied and custom domains need
-   allowlisting; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no desktop/computer-use; no
-   statusline/theme rendering.
+   allowlisting blocks cloud sessions; raw GitHub clone/fetch/push operations are handled by
+   Claude's connected-GitHub proxy/identity and do not need a separate PAT; the `gh` CLI is not the
+   same substrate and still needs `GH_TOKEN`; outbound traffic is controlled by the routine
+   environment network tier, where the default Trusted tier includes common development domains and
+   package registries but arbitrary integration hosts need Custom or Full access; environment
+   variables and setup scripts are stored in the cloud environment configuration and are visible to
+   anyone who can edit that environment; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no
+   desktop/computer-use; no statusline/theme rendering.
 
 8. **Host-project app needs** — note any build/test/run command a routine would invoke and any
    runtime service it depends on (database, queue, external API) that will not exist in a fresh
@@ -168,9 +173,18 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### GitHub — `tracker: github` and/or `source: github`
 - Headless substrate: `gh` CLI authed by token (every Lisa GitHub script gates on `gh auth status`).
-- Env: `GH_TOKEN` (the routine's built-in repo connection may not authenticate the `gh` CLI — verify; set `GH_TOKEN` if `gh auth status` fails). `PAT` only for cross-repo flows.
+- Platform substrate: Claude's connected-GitHub proxy/identity authenticates raw git
+  clone/fetch/push for repositories the routine can access. Do not ask for a PAT solely for raw git
+  or sibling-repo clones.
+- Env: `GH_TOKEN` for the `gh` CLI only; set it because Lisa's PR/issue lifecycle shells out to
+  `gh`. Do not describe it as required for raw git clone/fetch/push.
 - Acquire: fine-grained — `https://github.com/settings/personal-access-tokens`; classic — `https://github.com/settings/tokens`.
-- Access: fine-grained → Repository access to the target repo(s); Repository permissions: Contents R/W, Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Classic equivalent: `repo` + `workflow` (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
+- Access: fine-grained → Repository access to the repo(s) where Lisa will run `gh` commands (the
+  project repo, and the Lisa repo only if filing Lisa issues); Repository permissions: Contents R/W,
+  Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing
+  `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Do not include
+  sibling repos that are only cloned/fetched with raw git. Classic equivalent: `repo` + `workflow`
+  (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
@@ -242,6 +256,18 @@ so the generator can render acquisition comments into its template:
     { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
+  "platform": {
+    "githubProxy": {
+      "rawGitAuthenticated": true,
+      "crossRepoAccess": "repositories reachable by the connected GitHub identity/routine access do not need a PAT for raw git",
+      "ghCliNeedsToken": true
+    },
+    "secretsVisibility": "environment variables and setup scripts are visible to environment editors"
+  },
+  "networkAccess": {
+    "tier": "custom",
+    "allowlistDomains": []
+  },
   "allowlistDomains": []
 }
 ```
@@ -269,5 +295,13 @@ so the generator can render acquisition comments into its template:
   Lisa's `setup-*` skills) — transcribe them exactly; never guess at the access a token needs.
 - For the active `tracker`/`source`, always report the **env-var** form of the secret, never the OS
   keychain form — keychain reads do not work in a cloud routine.
+- For GitHub, keep the split explicit: raw git uses the platform GitHub proxy/identity, while
+  `GH_TOKEN` is for `gh` CLI commands. Sibling repos that are only cloned or fetched with raw git do
+  not belong in the token scope.
+- Add GitHub/npm/PyPI/Docker Hub/common development domains to neither `allowlistDomains` nor
+  `networkAccess.allowlistDomains`; those are covered by the routine environment's default Trusted
+  list. Only non-default integration hosts require Custom-network allowlisting.
+- Always include a `RISK`/`GAP` finding when environment secrets or setup scripts would be visible
+  to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".

--- a/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
@@ -30,8 +30,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
 ## Procedure
 
 1. **Inventory.** Invoke `/lisa:analyze-claude-remote --json` and parse its machine-readable
-   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `allowlistDomains`). If the
-   analysis cannot run, stop and report why — never emit a script from guesses.
+   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `platform`,
+   `networkAccess`, `allowlistDomains`). If the analysis cannot run, stop and report why — never
+   emit a script from guesses.
 
 2. **Compose the setup script** from the inventory. The script must be:
    - **Idempotent & detect-before-install** — every install guarded by a `command -v <tool>` check
@@ -62,11 +63,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
    that the analysis reported (including any per-account suffixed form like `LINEAR_API_KEY_<slug>`);
    never emit a keychain instruction — keychain does not exist in a cloud routine.
+   When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
+   is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
+   sibling repos reachable through the routine's GitHub proxy.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
-   (from `allowlistDomains`) that the user must add to the environment's network access, and echo
-   the `gaps` from the analysis (auto-memory not synced, interactive-auth/stdio-MCP unavailable,
-   etc.) as a header comment so the user knows what the script **cannot** fix.
+   (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
+   must add when the environment needs Custom network access. Do not include default Trusted domains
+   such as GitHub, npm/PyPI registries, or Docker Hub. Echo the `gaps` from the analysis
+   (auto-memory not synced, interactive-auth/stdio-MCP unavailable, etc.) and the
+   `platform.secretsVisibility` warning as a header comment so the user knows what the script
+   **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
    `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
@@ -92,9 +99,11 @@ shape, not a fixed payload):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R
+#   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
+#   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-# NETWORK: allowlist these domains in the environment if not on full access:
-#   - <allowlistDomains, if any>
+# NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
+#   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
 
 need() { command -v "$1" >/dev/null 2>&1; }
@@ -152,8 +161,12 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.
+- For `GH_TOKEN`, preserve the analysis's GitHub proxy split: it is for `gh` CLI commands only, and
+  raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
+- Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
+  domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.
 - Preserve the inventory's `REQUIRED` vs `OPTIONAL` distinction in both fail-behavior (fatal vs
   warn) and section placement.

--- a/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
@@ -148,9 +148,14 @@ Group the findings as:
 7. **Platform constraints** — surface the non-config constraints as `GAP`/`RISK` so the user is
    not surprised: routines run with no interactive permission prompts and cannot ask the user
    mid-run; interactive auth (SSO/OAuth browser, keychain) is unavailable; GitHub org IP
-   allowlisting blocks cloud sessions; outbound traffic is proxied and custom domains need
-   allowlisting; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no desktop/computer-use; no
-   statusline/theme rendering.
+   allowlisting blocks cloud sessions; raw GitHub clone/fetch/push operations are handled by
+   Claude's connected-GitHub proxy/identity and do not need a separate PAT; the `gh` CLI is not the
+   same substrate and still needs `GH_TOKEN`; outbound traffic is controlled by the routine
+   environment network tier, where the default Trusted tier includes common development domains and
+   package registries but arbitrary integration hosts need Custom or Full access; environment
+   variables and setup scripts are stored in the cloud environment configuration and are visible to
+   anyone who can edit that environment; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no
+   desktop/computer-use; no statusline/theme rendering.
 
 8. **Host-project app needs** — note any build/test/run command a routine would invoke and any
    runtime service it depends on (database, queue, external API) that will not exist in a fresh
@@ -168,9 +173,18 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### GitHub — `tracker: github` and/or `source: github`
 - Headless substrate: `gh` CLI authed by token (every Lisa GitHub script gates on `gh auth status`).
-- Env: `GH_TOKEN` (the routine's built-in repo connection may not authenticate the `gh` CLI — verify; set `GH_TOKEN` if `gh auth status` fails). `PAT` only for cross-repo flows.
+- Platform substrate: Claude's connected-GitHub proxy/identity authenticates raw git
+  clone/fetch/push for repositories the routine can access. Do not ask for a PAT solely for raw git
+  or sibling-repo clones.
+- Env: `GH_TOKEN` for the `gh` CLI only; set it because Lisa's PR/issue lifecycle shells out to
+  `gh`. Do not describe it as required for raw git clone/fetch/push.
 - Acquire: fine-grained — `https://github.com/settings/personal-access-tokens`; classic — `https://github.com/settings/tokens`.
-- Access: fine-grained → Repository access to the target repo(s); Repository permissions: Contents R/W, Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Classic equivalent: `repo` + `workflow` (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
+- Access: fine-grained → Repository access to the repo(s) where Lisa will run `gh` commands (the
+  project repo, and the Lisa repo only if filing Lisa issues); Repository permissions: Contents R/W,
+  Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing
+  `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Do not include
+  sibling repos that are only cloned/fetched with raw git. Classic equivalent: `repo` + `workflow`
+  (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
@@ -242,6 +256,18 @@ so the generator can render acquisition comments into its template:
     { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
+  "platform": {
+    "githubProxy": {
+      "rawGitAuthenticated": true,
+      "crossRepoAccess": "repositories reachable by the connected GitHub identity/routine access do not need a PAT for raw git",
+      "ghCliNeedsToken": true
+    },
+    "secretsVisibility": "environment variables and setup scripts are visible to environment editors"
+  },
+  "networkAccess": {
+    "tier": "custom",
+    "allowlistDomains": []
+  },
   "allowlistDomains": []
 }
 ```
@@ -269,5 +295,13 @@ so the generator can render acquisition comments into its template:
   Lisa's `setup-*` skills) — transcribe them exactly; never guess at the access a token needs.
 - For the active `tracker`/`source`, always report the **env-var** form of the secret, never the OS
   keychain form — keychain reads do not work in a cloud routine.
+- For GitHub, keep the split explicit: raw git uses the platform GitHub proxy/identity, while
+  `GH_TOKEN` is for `gh` CLI commands. Sibling repos that are only cloned or fetched with raw git do
+  not belong in the token scope.
+- Add GitHub/npm/PyPI/Docker Hub/common development domains to neither `allowlistDomains` nor
+  `networkAccess.allowlistDomains`; those are covered by the routine environment's default Trusted
+  list. Only non-default integration hosts require Custom-network allowlisting.
+- Always include a `RISK`/`GAP` finding when environment secrets or setup scripts would be visible
+  to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".

--- a/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
@@ -30,8 +30,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
 ## Procedure
 
 1. **Inventory.** Invoke `/lisa:analyze-claude-remote --json` and parse its machine-readable
-   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `allowlistDomains`). If the
-   analysis cannot run, stop and report why — never emit a script from guesses.
+   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `platform`,
+   `networkAccess`, `allowlistDomains`). If the analysis cannot run, stop and report why — never
+   emit a script from guesses.
 
 2. **Compose the setup script** from the inventory. The script must be:
    - **Idempotent & detect-before-install** — every install guarded by a `command -v <tool>` check
@@ -62,11 +63,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
    that the analysis reported (including any per-account suffixed form like `LINEAR_API_KEY_<slug>`);
    never emit a keychain instruction — keychain does not exist in a cloud routine.
+   When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
+   is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
+   sibling repos reachable through the routine's GitHub proxy.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
-   (from `allowlistDomains`) that the user must add to the environment's network access, and echo
-   the `gaps` from the analysis (auto-memory not synced, interactive-auth/stdio-MCP unavailable,
-   etc.) as a header comment so the user knows what the script **cannot** fix.
+   (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
+   must add when the environment needs Custom network access. Do not include default Trusted domains
+   such as GitHub, npm/PyPI registries, or Docker Hub. Echo the `gaps` from the analysis
+   (auto-memory not synced, interactive-auth/stdio-MCP unavailable, etc.) and the
+   `platform.secretsVisibility` warning as a header comment so the user knows what the script
+   **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
    `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
@@ -92,9 +99,11 @@ shape, not a fixed payload):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R
+#   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
+#   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-# NETWORK: allowlist these domains in the environment if not on full access:
-#   - <allowlistDomains, if any>
+# NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
+#   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
 
 need() { command -v "$1" >/dev/null 2>&1; }
@@ -152,8 +161,12 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.
+- For `GH_TOKEN`, preserve the analysis's GitHub proxy split: it is for `gh` CLI commands only, and
+  raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
+- Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
+  domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.
 - Preserve the inventory's `REQUIRED` vs `OPTIONAL` distinction in both fail-behavior (fatal vs
   warn) and section placement.

--- a/plugins/lisa/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/analyze-claude-remote/SKILL.md
@@ -148,9 +148,14 @@ Group the findings as:
 7. **Platform constraints** — surface the non-config constraints as `GAP`/`RISK` so the user is
    not surprised: routines run with no interactive permission prompts and cannot ask the user
    mid-run; interactive auth (SSO/OAuth browser, keychain) is unavailable; GitHub org IP
-   allowlisting blocks cloud sessions; outbound traffic is proxied and custom domains need
-   allowlisting; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no desktop/computer-use; no
-   statusline/theme rendering.
+   allowlisting blocks cloud sessions; raw GitHub clone/fetch/push operations are handled by
+   Claude's connected-GitHub proxy/identity and do not need a separate PAT; the `gh` CLI is not the
+   same substrate and still needs `GH_TOKEN`; outbound traffic is controlled by the routine
+   environment network tier, where the default Trusted tier includes common development domains and
+   package registries but arbitrary integration hosts need Custom or Full access; environment
+   variables and setup scripts are stored in the cloud environment configuration and are visible to
+   anyone who can edit that environment; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no
+   desktop/computer-use; no statusline/theme rendering.
 
 8. **Host-project app needs** — note any build/test/run command a routine would invoke and any
    runtime service it depends on (database, queue, external API) that will not exist in a fresh
@@ -168,9 +173,18 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### GitHub — `tracker: github` and/or `source: github`
 - Headless substrate: `gh` CLI authed by token (every Lisa GitHub script gates on `gh auth status`).
-- Env: `GH_TOKEN` (the routine's built-in repo connection may not authenticate the `gh` CLI — verify; set `GH_TOKEN` if `gh auth status` fails). `PAT` only for cross-repo flows.
+- Platform substrate: Claude's connected-GitHub proxy/identity authenticates raw git
+  clone/fetch/push for repositories the routine can access. Do not ask for a PAT solely for raw git
+  or sibling-repo clones.
+- Env: `GH_TOKEN` for the `gh` CLI only; set it because Lisa's PR/issue lifecycle shells out to
+  `gh`. Do not describe it as required for raw git clone/fetch/push.
 - Acquire: fine-grained — `https://github.com/settings/personal-access-tokens`; classic — `https://github.com/settings/tokens`.
-- Access: fine-grained → Repository access to the target repo(s); Repository permissions: Contents R/W, Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Classic equivalent: `repo` + `workflow` (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
+- Access: fine-grained → Repository access to the repo(s) where Lisa will run `gh` commands (the
+  project repo, and the Lisa repo only if filing Lisa issues); Repository permissions: Contents R/W,
+  Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing
+  `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Do not include
+  sibling repos that are only cloned/fetched with raw git. Classic equivalent: `repo` + `workflow`
+  (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
@@ -242,6 +256,18 @@ so the generator can render acquisition comments into its template:
     { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
+  "platform": {
+    "githubProxy": {
+      "rawGitAuthenticated": true,
+      "crossRepoAccess": "repositories reachable by the connected GitHub identity/routine access do not need a PAT for raw git",
+      "ghCliNeedsToken": true
+    },
+    "secretsVisibility": "environment variables and setup scripts are visible to environment editors"
+  },
+  "networkAccess": {
+    "tier": "custom",
+    "allowlistDomains": []
+  },
   "allowlistDomains": []
 }
 ```
@@ -269,5 +295,13 @@ so the generator can render acquisition comments into its template:
   Lisa's `setup-*` skills) — transcribe them exactly; never guess at the access a token needs.
 - For the active `tracker`/`source`, always report the **env-var** form of the secret, never the OS
   keychain form — keychain reads do not work in a cloud routine.
+- For GitHub, keep the split explicit: raw git uses the platform GitHub proxy/identity, while
+  `GH_TOKEN` is for `gh` CLI commands. Sibling repos that are only cloned or fetched with raw git do
+  not belong in the token scope.
+- Add GitHub/npm/PyPI/Docker Hub/common development domains to neither `allowlistDomains` nor
+  `networkAccess.allowlistDomains`; those are covered by the routine environment's default Trusted
+  list. Only non-default integration hosts require Custom-network allowlisting.
+- Always include a `RISK`/`GAP` finding when environment secrets or setup scripts would be visible
+  to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".

--- a/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
@@ -30,8 +30,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
 ## Procedure
 
 1. **Inventory.** Invoke `/lisa:analyze-claude-remote --json` and parse its machine-readable
-   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `allowlistDomains`). If the
-   analysis cannot run, stop and report why — never emit a script from guesses.
+   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `platform`,
+   `networkAccess`, `allowlistDomains`). If the analysis cannot run, stop and report why — never
+   emit a script from guesses.
 
 2. **Compose the setup script** from the inventory. The script must be:
    - **Idempotent & detect-before-install** — every install guarded by a `command -v <tool>` check
@@ -62,11 +63,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
    that the analysis reported (including any per-account suffixed form like `LINEAR_API_KEY_<slug>`);
    never emit a keychain instruction — keychain does not exist in a cloud routine.
+   When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
+   is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
+   sibling repos reachable through the routine's GitHub proxy.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
-   (from `allowlistDomains`) that the user must add to the environment's network access, and echo
-   the `gaps` from the analysis (auto-memory not synced, interactive-auth/stdio-MCP unavailable,
-   etc.) as a header comment so the user knows what the script **cannot** fix.
+   (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
+   must add when the environment needs Custom network access. Do not include default Trusted domains
+   such as GitHub, npm/PyPI registries, or Docker Hub. Echo the `gaps` from the analysis
+   (auto-memory not synced, interactive-auth/stdio-MCP unavailable, etc.) and the
+   `platform.secretsVisibility` warning as a header comment so the user knows what the script
+   **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
    `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
@@ -92,9 +99,11 @@ shape, not a fixed payload):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R
+#   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
+#   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-# NETWORK: allowlist these domains in the environment if not on full access:
-#   - <allowlistDomains, if any>
+# NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
+#   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
 
 need() { command -v "$1" >/dev/null 2>&1; }
@@ -152,8 +161,12 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.
+- For `GH_TOKEN`, preserve the analysis's GitHub proxy split: it is for `gh` CLI commands only, and
+  raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
+- Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
+  domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.
 - Preserve the inventory's `REQUIRED` vs `OPTIONAL` distinction in both fail-behavior (fatal vs
   warn) and section placement.

--- a/plugins/src/base/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/analyze-claude-remote/SKILL.md
@@ -148,9 +148,14 @@ Group the findings as:
 7. **Platform constraints** — surface the non-config constraints as `GAP`/`RISK` so the user is
    not surprised: routines run with no interactive permission prompts and cannot ask the user
    mid-run; interactive auth (SSO/OAuth browser, keychain) is unavailable; GitHub org IP
-   allowlisting blocks cloud sessions; outbound traffic is proxied and custom domains need
-   allowlisting; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no desktop/computer-use; no
-   statusline/theme rendering.
+   allowlisting blocks cloud sessions; raw GitHub clone/fetch/push operations are handled by
+   Claude's connected-GitHub proxy/identity and do not need a separate PAT; the `gh` CLI is not the
+   same substrate and still needs `GH_TOKEN`; outbound traffic is controlled by the routine
+   environment network tier, where the default Trusted tier includes common development domains and
+   package registries but arbitrary integration hosts need Custom or Full access; environment
+   variables and setup scripts are stored in the cloud environment configuration and are visible to
+   anyone who can edit that environment; resource limits (~4 vCPU / 16 GB RAM / 30 GB disk); no
+   desktop/computer-use; no statusline/theme rendering.
 
 8. **Host-project app needs** — note any build/test/run command a routine would invoke and any
    runtime service it depends on (database, queue, external API) that will not exist in a fresh
@@ -168,9 +173,18 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### GitHub — `tracker: github` and/or `source: github`
 - Headless substrate: `gh` CLI authed by token (every Lisa GitHub script gates on `gh auth status`).
-- Env: `GH_TOKEN` (the routine's built-in repo connection may not authenticate the `gh` CLI — verify; set `GH_TOKEN` if `gh auth status` fails). `PAT` only for cross-repo flows.
+- Platform substrate: Claude's connected-GitHub proxy/identity authenticates raw git
+  clone/fetch/push for repositories the routine can access. Do not ask for a PAT solely for raw git
+  or sibling-repo clones.
+- Env: `GH_TOKEN` for the `gh` CLI only; set it because Lisa's PR/issue lifecycle shells out to
+  `gh`. Do not describe it as required for raw git clone/fetch/push.
 - Acquire: fine-grained — `https://github.com/settings/personal-access-tokens`; classic — `https://github.com/settings/tokens`.
-- Access: fine-grained → Repository access to the target repo(s); Repository permissions: Contents R/W, Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Classic equivalent: `repo` + `workflow` (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
+- Access: fine-grained → Repository access to the repo(s) where Lisa will run `gh` commands (the
+  project repo, and the Lisa repo only if filing Lisa issues); Repository permissions: Contents R/W,
+  Issues R/W, Pull requests R/W, Metadata R (mandatory); add Workflows R/W only if editing
+  `.github/workflows`, and Organization → Projects R/W only if using ProjectV2. Do not include
+  sibling repos that are only cloned/fetched with raw git. Classic equivalent: `repo` + `workflow`
+  (+ `project`, `read:org` for boards). The identity must hold WRITE/MAINTAIN/ADMIN on the repo.
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
@@ -242,6 +256,18 @@ so the generator can render acquisition comments into its template:
     { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
+  "platform": {
+    "githubProxy": {
+      "rawGitAuthenticated": true,
+      "crossRepoAccess": "repositories reachable by the connected GitHub identity/routine access do not need a PAT for raw git",
+      "ghCliNeedsToken": true
+    },
+    "secretsVisibility": "environment variables and setup scripts are visible to environment editors"
+  },
+  "networkAccess": {
+    "tier": "custom",
+    "allowlistDomains": []
+  },
   "allowlistDomains": []
 }
 ```
@@ -269,5 +295,13 @@ so the generator can render acquisition comments into its template:
   Lisa's `setup-*` skills) — transcribe them exactly; never guess at the access a token needs.
 - For the active `tracker`/`source`, always report the **env-var** form of the secret, never the OS
   keychain form — keychain reads do not work in a cloud routine.
+- For GitHub, keep the split explicit: raw git uses the platform GitHub proxy/identity, while
+  `GH_TOKEN` is for `gh` CLI commands. Sibling repos that are only cloned or fetched with raw git do
+  not belong in the token scope.
+- Add GitHub/npm/PyPI/Docker Hub/common development domains to neither `allowlistDomains` nor
+  `networkAccess.allowlistDomains`; those are covered by the routine environment's default Trusted
+  list. Only non-default integration hosts require Custom-network allowlisting.
+- Always include a `RISK`/`GAP` finding when environment secrets or setup scripts would be visible
+  to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".

--- a/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
@@ -30,8 +30,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
 ## Procedure
 
 1. **Inventory.** Invoke `/lisa:analyze-claude-remote --json` and parse its machine-readable
-   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `allowlistDomains`). If the
-   analysis cannot run, stop and report why — never emit a script from guesses.
+   inventory block (`packageManager`, `tools`, `env`, `mcp`, `gaps`, `platform`,
+   `networkAccess`, `allowlistDomains`). If the analysis cannot run, stop and report why — never
+   emit a script from guesses.
 
 2. **Compose the setup script** from the inventory. The script must be:
    - **Idempotent & detect-before-install** — every install guarded by a `command -v <tool>` check
@@ -62,11 +63,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    where to get the token and what permissions it needs. Emit only the **env-var form** of the name
    that the analysis reported (including any per-account suffixed form like `LINEAR_API_KEY_<slug>`);
    never emit a keychain instruction — keychain does not exist in a cloud routine.
+   When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
+   is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
+   sibling repos reachable through the routine's GitHub proxy.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
-   (from `allowlistDomains`) that the user must add to the environment's network access, and echo
-   the `gaps` from the analysis (auto-memory not synced, interactive-auth/stdio-MCP unavailable,
-   etc.) as a header comment so the user knows what the script **cannot** fix.
+   (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
+   must add when the environment needs Custom network access. Do not include default Trusted domains
+   such as GitHub, npm/PyPI registries, or Docker Hub. Echo the `gaps` from the analysis
+   (auto-memory not synced, interactive-auth/stdio-MCP unavailable, etc.) and the
+   `platform.secretsVisibility` warning as a header comment so the user knows what the script
+   **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
    `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
@@ -92,9 +99,11 @@ shape, not a fixed payload):
 #   # --- credentials for the active tracker/source (set in the environment UI) ---
 #   # Acquire: https://github.com/settings/personal-access-tokens
 #   # Access:  fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R
+#   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
+#   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-# NETWORK: allowlist these domains in the environment if not on full access:
-#   - <allowlistDomains, if any>
+# NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
+#   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
 
 need() { command -v "$1" >/dev/null 2>&1; }
@@ -152,8 +161,12 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.
+- For `GH_TOKEN`, preserve the analysis's GitHub proxy split: it is for `gh` CLI commands only, and
+  raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
+- Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
+  domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.
 - Preserve the inventory's `REQUIRED` vs `OPTIONAL` distinction in both fail-behavior (fatal vs
   warn) and section placement.


### PR DESCRIPTION
## Summary
- frame GH_TOKEN as a gh CLI credential, while raw git uses Claude's connected-GitHub proxy/identity
- add platform and networkAccess inventory fields for GitHub proxy, Custom-network domains, and secrets visibility
- teach the generator contract to consume networkAccess and preserve the GH_TOKEN/raw-git split
- regenerate Lisa, Cursor, Agy, and Copilot plugin skill artifacts

## Verification
- bun run typecheck
- bun run build:dist
- bun run build:plugins
- bun run check:plugins
- bun run check:rules-pairing
- bun audit --production --json with repo exclusion filter: 0 unignored high/critical production advisories
- bun run lint:slow
- bun run knip:check
- bun run test:cov
- bun run test:integration

Closes #1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified GitHub credential requirements: authentication tokens are now explicitly scoped to CLI operations only, while raw repository operations use platform-provided proxy identity.
  * Enhanced cloud environment security guidance with explicit warnings about setup script and credential visibility to environment editors.
  * Standardized network allowlisting behavior to distinguish custom domains from default trusted services.
  * Updated generated setup script templates to reflect refined authentication and networking policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->