### PR TITLE
fix(claude-remote): detect MCP token substrates

### DIFF
--- a/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
@@ -287,7 +287,7 @@ so the generator can render acquisition comments into its template:
       "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
       "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
       "headlessSubstrate": "SonarCloud Web API (token)",
-      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens",
       "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],

--- a/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/analyze-claude-remote/SKILL.md
@@ -133,11 +133,35 @@ Group the findings as:
    `RISK`/`GAP` (need a local process — only viable if the cloud session can spawn them from the
    repo). Flag interactively/OAuth-authed servers as `GAP` for headless auth — they cannot complete
    a browser flow headless **regardless of transport** (an HTTP MCP like `linear-server` is still a
-   `GAP` because its *auth* is OAuth, not because of its transport). When an OAuth MCP backs an
-   active tracker/source, do not stop at the `GAP` — cross-reference group 4a and point to the
-   integration's token substrate as the headless replacement (e.g. `linear-server` MCP → `LINEAR_API_KEY`
-   + Linear GraphQL). Note any user-scoped MCP (`~/.claude.json`) as `GAP` — it never reaches the
-   cloud; it must be moved into project `.mcp.json`.
+   `GAP` because its *auth* is OAuth, not because of its transport). Before finalizing any
+   OAuth/interactive/stdio MCP as a flat `GAP`, check for a documented headless substrate: a
+   static-token MCP header, a vendor CLI that can login from an env token, or a token-authenticated
+   REST API that the MCP wraps. If documented evidence exists, mark the MCP `headlessUsable: true`
+   in the inventory, mark the supporting secret `required: false` / `secret: true` unless the
+   integration is active, and set `replacedBy` to the concrete substrate rather than leaving it as
+   an impossible capability. When an OAuth MCP backs an active tracker/source, do not stop at the
+   `GAP` — cross-reference group 4a and point to the integration's token substrate as the headless
+   replacement (e.g. `linear-server` MCP -> `LINEAR_API_KEY` + Linear GraphQL). Note any user-scoped
+   MCP (`~/.claude.json`) as `GAP` — it never reaches the cloud; it must be moved into project
+   `.mcp.json`.
+
+   Use this data-driven hint table as seed evidence, and extend it only when you can cite a vendor
+   doc or committed access-skill reference:
+
+   | Match | Substrate | Env | Setup / wiring | Domains |
+   |---|---|---|---|---|
+   | `mcp.jam.dev`, `jam`, or Jam MCP entries | Jam CLI (`jam`) authenticated by PAT | `JAM_PAT` | install with `curl -fsSL https://native.jam.dev/install | bash`; export `~/.local/bin`; run `printf '%s' "$JAM_PAT" | jam auth login --token`; optionally `jam skills install` | `native.jam.dev`, `api.jam.dev` |
+   | `mcp/sonarqube`, `sonarqube`, or SonarCloud/SonarQube MCP entries | SonarCloud Web API | `SONAR_TOKEN` | use REST calls against `https://sonarcloud.io/api/`; if a host needs legacy token-as-basic-auth, put that in the access adapter | `sonarcloud.io` |
+
+   For PAT-bearer MCP substrates that really use the same MCP transport, include `mcpHeaders` in
+   the inventory with a snippet such as `headers: { "Authorization": "Bearer ${VAR}" }` so the
+   generator can print a commented `.mcp.json` example. Do **not** use that for Jam: Jam's preferred
+   headless substrate is the `jam` CLI, so the generator should emit CLI setup lines instead of an
+   `.mcp.json` header snippet.
+
+   When no documented substrate is known, keep the MCP as `headlessUsable: false` / `GAP`, and add
+   an action line like: `check the vendor for a documented PAT, API-key, CLI, or REST substrate`.
+   Never assert that no substrate exists unless the vendor documentation explicitly says so.
 
 6. **Config scope & memory gaps** — identify reliance on user-scoped config that will not load
    remotely: `~/.claude/CLAUDE.md`, user `enabledPlugins`, user skills/agents, user MCP. Most
@@ -250,10 +274,27 @@ so the generator can render acquisition comments into its template:
       "headlessSubstrate": "gh CLI (token)",
       "acquireUrl": "https://github.com/settings/personal-access-tokens",
       "accessScope": "fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R; +Workflows R/W if editing .github/workflows; +Projects R/W if using ProjectV2"
+    },
+    {
+      "name": "JAM_PAT", "required": false, "secret": true, "integration": "jam",
+      "reason": "optional non-tracker MCP recovery; Jam CLI can authenticate headlessly from a PAT",
+      "headlessSubstrate": "jam CLI (PAT)",
+      "acquireUrl": "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens",
+      "accessScope": "Jam Personal Access Token for the workspace/team whose traces the routine needs to read",
+      "setupSnippet": "curl -fsSL https://native.jam.dev/install | bash; export PATH=\"$HOME/.local/bin:$PATH\"; printf '%s' \"$JAM_PAT\" | jam auth login --token; jam skills install"
+    },
+    {
+      "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
+      "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
+      "headlessSubstrate": "SonarCloud Web API (token)",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],
   "mcp": [
-    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
+    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true },
+    { "name": "jam", "transport": "http", "auth": "oauth", "headlessUsable": true, "replacedBy": "jam CLI + JAM_PAT", "dormant": true },
+    { "name": "sonarqube", "transport": "stdio", "auth": "local-wrapper", "headlessUsable": true, "replacedBy": "SONAR_TOKEN + SonarCloud Web API", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
   "platform": {
@@ -305,3 +346,6 @@ so the generator can render acquisition comments into its template:
   to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".
+- For non-tracker MCPs, a documented CLI, PAT/API-key, or REST substrate converts the finding from
+  a flat `GAP` into an `OPTIONAL` headless recovery path; unknown vendors remain gaps with a
+  vendor-substrate follow-up, not invented credentials.

--- a/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/generate-claude-remote-build-script/SKILL.md
@@ -66,6 +66,27 @@ tracker/source, plus the host project's own package manager and tooling — not 
    When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
    is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
    sibling repos reachable through the routine's GitHub proxy.
+   For OPTIONAL non-tracker MCP recovery entries discovered by
+   `/lisa:analyze-claude-remote`, preserve the same names-only behavior:
+   include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
+   only as optional secrets, with their acquire/scope comments when the analysis
+   supplied them. Never invent values or promote dormant substrates to required.
+
+3a. **Emit substrate setup snippets.** When the inventory marks an MCP
+   `headlessUsable: true` through a documented substrate, render the matching
+   wiring guidance as commented, opt-in setup:
+   - CLI substrates: emit the detected install/login commands gated on the
+     optional env var. For Jam, this means `curl -fsSL https://native.jam.dev/install | bash`,
+     `export PATH="$HOME/.local/bin:$PATH"`, `printf '%s' "$JAM_PAT" | jam auth login --token`,
+     and `jam skills install`, all inside `[ -n "${JAM_PAT:-}" ] && ...` guards so missing
+     optional secrets do not fail the environment build.
+   - REST substitute substrates: do not install an MCP. Emit comments naming the
+     REST host and env var (for example `SONAR_TOKEN` with `https://sonarcloud.io/api/`) and
+     rely on the access skill or generated consumer to call the API.
+   - PAT-bearer MCP substrates: print a commented `.mcp.json` `headers` snippet from the
+     inventory's `mcpHeaders`. Use this only when the analysis explicitly says the same MCP
+     transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
+     Jam's preferred headless substrate is its PAT-authenticated CLI.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user

--- a/plugins/lisa-agy/skills/jam-access/SKILL.md
+++ b/plugins/lisa-agy/skills/jam-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jam-access
-description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to JAM_PAT bearer auth for headless routines."
+description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to the JAM_PAT-authenticated Jam CLI for headless routines."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -24,16 +24,16 @@ Return parsed JSON or a concise structured summary in a `<result>` block.
 Probe in order:
 
 1. Jam MCP, if the tool is available and authenticated.
-2. `JAM_PAT` bearer token against Jam's MCP/trace HTTP substrate.
+2. Jam CLI authenticated with `JAM_PAT`.
 
-Jam documents personal access tokens for MCP clients so a browser OAuth flow is
-not required. The headless tier uses:
+Jam documents a PAT-authenticated CLI that is cleaner for remote routines than
+editing `.mcp.json` headers. The headless tier uses:
 
 ```bash
-curl -sS "https://mcp.jam.dev/mcp" \
-  -H "Authorization: Bearer $JAM_PAT" \
-  -H "Content-Type: application/json" \
-  --data-binary "$PAYLOAD"
+curl -fsSL https://native.jam.dev/install | bash
+export PATH="$HOME/.local/bin:$PATH"
+printf '%s' "$JAM_PAT" | jam auth login --token
+jam skills install
 ```
 
 If neither tier works, fail with:
@@ -45,7 +45,8 @@ Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PA
 ## Invariants
 
 - Fallback is gated on `JAM_PAT`; do not retry Jam MCP failures blindly.
-- Never commit a Jam PAT into `.mcp.json`. Use env interpolation in host MCP
-  config, for example `Authorization: Bearer ${JAM_PAT}`.
-- If a requested operation is not yet mapped to the Jam HTTP substrate, surface
+- Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
+- Headless Jam access requires `native.jam.dev` for the installer and
+  `api.jam.dev` for CLI/API calls in any custom remote network allowlist.
+- If a requested operation is not yet mapped to the Jam CLI substrate, surface
   that exact missing adapter instead of pretending the trace is unavailable.

--- a/plugins/lisa-copilot/rules/reference/integration-access-layer.md
+++ b/plugins/lisa-copilot/rules/reference/integration-access-layer.md
@@ -22,7 +22,7 @@ available.
 | Atlassian | `lisa:atlassian-access` | `ATLASSIAN_API_TOKEN` | Atlassian Cloud REST |
 | Notion | `lisa:notion-access` | `NOTION_API_TOKEN` | Notion REST |
 | Linear | `lisa:linear-access` | `LINEAR_API_KEY` | Linear GraphQL |
-| Jam | `lisa:jam-access` | `JAM_PAT` | Jam MCP HTTP endpoint with bearer PAT |
+| Jam | `lisa:jam-access` | `JAM_PAT` | Jam CLI |
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |

--- a/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
@@ -287,7 +287,7 @@ so the generator can render acquisition comments into its template:
       "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
       "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
       "headlessSubstrate": "SonarCloud Web API (token)",
-      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens",
       "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],

--- a/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/analyze-claude-remote/SKILL.md
@@ -133,11 +133,35 @@ Group the findings as:
    `RISK`/`GAP` (need a local process — only viable if the cloud session can spawn them from the
    repo). Flag interactively/OAuth-authed servers as `GAP` for headless auth — they cannot complete
    a browser flow headless **regardless of transport** (an HTTP MCP like `linear-server` is still a
-   `GAP` because its *auth* is OAuth, not because of its transport). When an OAuth MCP backs an
-   active tracker/source, do not stop at the `GAP` — cross-reference group 4a and point to the
-   integration's token substrate as the headless replacement (e.g. `linear-server` MCP → `LINEAR_API_KEY`
-   + Linear GraphQL). Note any user-scoped MCP (`~/.claude.json`) as `GAP` — it never reaches the
-   cloud; it must be moved into project `.mcp.json`.
+   `GAP` because its *auth* is OAuth, not because of its transport). Before finalizing any
+   OAuth/interactive/stdio MCP as a flat `GAP`, check for a documented headless substrate: a
+   static-token MCP header, a vendor CLI that can login from an env token, or a token-authenticated
+   REST API that the MCP wraps. If documented evidence exists, mark the MCP `headlessUsable: true`
+   in the inventory, mark the supporting secret `required: false` / `secret: true` unless the
+   integration is active, and set `replacedBy` to the concrete substrate rather than leaving it as
+   an impossible capability. When an OAuth MCP backs an active tracker/source, do not stop at the
+   `GAP` — cross-reference group 4a and point to the integration's token substrate as the headless
+   replacement (e.g. `linear-server` MCP -> `LINEAR_API_KEY` + Linear GraphQL). Note any user-scoped
+   MCP (`~/.claude.json`) as `GAP` — it never reaches the cloud; it must be moved into project
+   `.mcp.json`.
+
+   Use this data-driven hint table as seed evidence, and extend it only when you can cite a vendor
+   doc or committed access-skill reference:
+
+   | Match | Substrate | Env | Setup / wiring | Domains |
+   |---|---|---|---|---|
+   | `mcp.jam.dev`, `jam`, or Jam MCP entries | Jam CLI (`jam`) authenticated by PAT | `JAM_PAT` | install with `curl -fsSL https://native.jam.dev/install | bash`; export `~/.local/bin`; run `printf '%s' "$JAM_PAT" | jam auth login --token`; optionally `jam skills install` | `native.jam.dev`, `api.jam.dev` |
+   | `mcp/sonarqube`, `sonarqube`, or SonarCloud/SonarQube MCP entries | SonarCloud Web API | `SONAR_TOKEN` | use REST calls against `https://sonarcloud.io/api/`; if a host needs legacy token-as-basic-auth, put that in the access adapter | `sonarcloud.io` |
+
+   For PAT-bearer MCP substrates that really use the same MCP transport, include `mcpHeaders` in
+   the inventory with a snippet such as `headers: { "Authorization": "Bearer ${VAR}" }` so the
+   generator can print a commented `.mcp.json` example. Do **not** use that for Jam: Jam's preferred
+   headless substrate is the `jam` CLI, so the generator should emit CLI setup lines instead of an
+   `.mcp.json` header snippet.
+
+   When no documented substrate is known, keep the MCP as `headlessUsable: false` / `GAP`, and add
+   an action line like: `check the vendor for a documented PAT, API-key, CLI, or REST substrate`.
+   Never assert that no substrate exists unless the vendor documentation explicitly says so.
 
 6. **Config scope & memory gaps** — identify reliance on user-scoped config that will not load
    remotely: `~/.claude/CLAUDE.md`, user `enabledPlugins`, user skills/agents, user MCP. Most
@@ -250,10 +274,27 @@ so the generator can render acquisition comments into its template:
       "headlessSubstrate": "gh CLI (token)",
       "acquireUrl": "https://github.com/settings/personal-access-tokens",
       "accessScope": "fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R; +Workflows R/W if editing .github/workflows; +Projects R/W if using ProjectV2"
+    },
+    {
+      "name": "JAM_PAT", "required": false, "secret": true, "integration": "jam",
+      "reason": "optional non-tracker MCP recovery; Jam CLI can authenticate headlessly from a PAT",
+      "headlessSubstrate": "jam CLI (PAT)",
+      "acquireUrl": "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens",
+      "accessScope": "Jam Personal Access Token for the workspace/team whose traces the routine needs to read",
+      "setupSnippet": "curl -fsSL https://native.jam.dev/install | bash; export PATH=\"$HOME/.local/bin:$PATH\"; printf '%s' \"$JAM_PAT\" | jam auth login --token; jam skills install"
+    },
+    {
+      "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
+      "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
+      "headlessSubstrate": "SonarCloud Web API (token)",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],
   "mcp": [
-    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
+    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true },
+    { "name": "jam", "transport": "http", "auth": "oauth", "headlessUsable": true, "replacedBy": "jam CLI + JAM_PAT", "dormant": true },
+    { "name": "sonarqube", "transport": "stdio", "auth": "local-wrapper", "headlessUsable": true, "replacedBy": "SONAR_TOKEN + SonarCloud Web API", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
   "platform": {
@@ -305,3 +346,6 @@ so the generator can render acquisition comments into its template:
   to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".
+- For non-tracker MCPs, a documented CLI, PAT/API-key, or REST substrate converts the finding from
+  a flat `GAP` into an `OPTIONAL` headless recovery path; unknown vendors remain gaps with a
+  vendor-substrate follow-up, not invented credentials.

--- a/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/generate-claude-remote-build-script/SKILL.md
@@ -66,6 +66,27 @@ tracker/source, plus the host project's own package manager and tooling — not 
    When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
    is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
    sibling repos reachable through the routine's GitHub proxy.
+   For OPTIONAL non-tracker MCP recovery entries discovered by
+   `/lisa:analyze-claude-remote`, preserve the same names-only behavior:
+   include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
+   only as optional secrets, with their acquire/scope comments when the analysis
+   supplied them. Never invent values or promote dormant substrates to required.
+
+3a. **Emit substrate setup snippets.** When the inventory marks an MCP
+   `headlessUsable: true` through a documented substrate, render the matching
+   wiring guidance as commented, opt-in setup:
+   - CLI substrates: emit the detected install/login commands gated on the
+     optional env var. For Jam, this means `curl -fsSL https://native.jam.dev/install | bash`,
+     `export PATH="$HOME/.local/bin:$PATH"`, `printf '%s' "$JAM_PAT" | jam auth login --token`,
+     and `jam skills install`, all inside `[ -n "${JAM_PAT:-}" ] && ...` guards so missing
+     optional secrets do not fail the environment build.
+   - REST substitute substrates: do not install an MCP. Emit comments naming the
+     REST host and env var (for example `SONAR_TOKEN` with `https://sonarcloud.io/api/`) and
+     rely on the access skill or generated consumer to call the API.
+   - PAT-bearer MCP substrates: print a commented `.mcp.json` `headers` snippet from the
+     inventory's `mcpHeaders`. Use this only when the analysis explicitly says the same MCP
+     transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
+     Jam's preferred headless substrate is its PAT-authenticated CLI.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user

--- a/plugins/lisa-copilot/skills/jam-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/jam-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jam-access
-description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to JAM_PAT bearer auth for headless routines."
+description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to the JAM_PAT-authenticated Jam CLI for headless routines."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -24,16 +24,16 @@ Return parsed JSON or a concise structured summary in a `<result>` block.
 Probe in order:
 
 1. Jam MCP, if the tool is available and authenticated.
-2. `JAM_PAT` bearer token against Jam's MCP/trace HTTP substrate.
+2. Jam CLI authenticated with `JAM_PAT`.
 
-Jam documents personal access tokens for MCP clients so a browser OAuth flow is
-not required. The headless tier uses:
+Jam documents a PAT-authenticated CLI that is cleaner for remote routines than
+editing `.mcp.json` headers. The headless tier uses:
 
 ```bash
-curl -sS "https://mcp.jam.dev/mcp" \
-  -H "Authorization: Bearer $JAM_PAT" \
-  -H "Content-Type: application/json" \
-  --data-binary "$PAYLOAD"
+curl -fsSL https://native.jam.dev/install | bash
+export PATH="$HOME/.local/bin:$PATH"
+printf '%s' "$JAM_PAT" | jam auth login --token
+jam skills install
 ```
 
 If neither tier works, fail with:
@@ -45,7 +45,8 @@ Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PA
 ## Invariants
 
 - Fallback is gated on `JAM_PAT`; do not retry Jam MCP failures blindly.
-- Never commit a Jam PAT into `.mcp.json`. Use env interpolation in host MCP
-  config, for example `Authorization: Bearer ${JAM_PAT}`.
-- If a requested operation is not yet mapped to the Jam HTTP substrate, surface
+- Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
+- Headless Jam access requires `native.jam.dev` for the installer and
+  `api.jam.dev` for CLI/API calls in any custom remote network allowlist.
+- If a requested operation is not yet mapped to the Jam CLI substrate, surface
   that exact missing adapter instead of pretending the trace is unavailable.

--- a/plugins/lisa-cursor/rules/integration-access-layer-reference.mdc
+++ b/plugins/lisa-cursor/rules/integration-access-layer-reference.mdc
@@ -27,7 +27,7 @@ available.
 | Atlassian | `lisa:atlassian-access` | `ATLASSIAN_API_TOKEN` | Atlassian Cloud REST |
 | Notion | `lisa:notion-access` | `NOTION_API_TOKEN` | Notion REST |
 | Linear | `lisa:linear-access` | `LINEAR_API_KEY` | Linear GraphQL |
-| Jam | `lisa:jam-access` | `JAM_PAT` | Jam MCP HTTP endpoint with bearer PAT |
+| Jam | `lisa:jam-access` | `JAM_PAT` | Jam CLI |
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |

--- a/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
@@ -287,7 +287,7 @@ so the generator can render acquisition comments into its template:
       "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
       "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
       "headlessSubstrate": "SonarCloud Web API (token)",
-      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens",
       "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],

--- a/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/analyze-claude-remote/SKILL.md
@@ -133,11 +133,35 @@ Group the findings as:
    `RISK`/`GAP` (need a local process — only viable if the cloud session can spawn them from the
    repo). Flag interactively/OAuth-authed servers as `GAP` for headless auth — they cannot complete
    a browser flow headless **regardless of transport** (an HTTP MCP like `linear-server` is still a
-   `GAP` because its *auth* is OAuth, not because of its transport). When an OAuth MCP backs an
-   active tracker/source, do not stop at the `GAP` — cross-reference group 4a and point to the
-   integration's token substrate as the headless replacement (e.g. `linear-server` MCP → `LINEAR_API_KEY`
-   + Linear GraphQL). Note any user-scoped MCP (`~/.claude.json`) as `GAP` — it never reaches the
-   cloud; it must be moved into project `.mcp.json`.
+   `GAP` because its *auth* is OAuth, not because of its transport). Before finalizing any
+   OAuth/interactive/stdio MCP as a flat `GAP`, check for a documented headless substrate: a
+   static-token MCP header, a vendor CLI that can login from an env token, or a token-authenticated
+   REST API that the MCP wraps. If documented evidence exists, mark the MCP `headlessUsable: true`
+   in the inventory, mark the supporting secret `required: false` / `secret: true` unless the
+   integration is active, and set `replacedBy` to the concrete substrate rather than leaving it as
+   an impossible capability. When an OAuth MCP backs an active tracker/source, do not stop at the
+   `GAP` — cross-reference group 4a and point to the integration's token substrate as the headless
+   replacement (e.g. `linear-server` MCP -> `LINEAR_API_KEY` + Linear GraphQL). Note any user-scoped
+   MCP (`~/.claude.json`) as `GAP` — it never reaches the cloud; it must be moved into project
+   `.mcp.json`.
+
+   Use this data-driven hint table as seed evidence, and extend it only when you can cite a vendor
+   doc or committed access-skill reference:
+
+   | Match | Substrate | Env | Setup / wiring | Domains |
+   |---|---|---|---|---|
+   | `mcp.jam.dev`, `jam`, or Jam MCP entries | Jam CLI (`jam`) authenticated by PAT | `JAM_PAT` | install with `curl -fsSL https://native.jam.dev/install | bash`; export `~/.local/bin`; run `printf '%s' "$JAM_PAT" | jam auth login --token`; optionally `jam skills install` | `native.jam.dev`, `api.jam.dev` |
+   | `mcp/sonarqube`, `sonarqube`, or SonarCloud/SonarQube MCP entries | SonarCloud Web API | `SONAR_TOKEN` | use REST calls against `https://sonarcloud.io/api/`; if a host needs legacy token-as-basic-auth, put that in the access adapter | `sonarcloud.io` |
+
+   For PAT-bearer MCP substrates that really use the same MCP transport, include `mcpHeaders` in
+   the inventory with a snippet such as `headers: { "Authorization": "Bearer ${VAR}" }` so the
+   generator can print a commented `.mcp.json` example. Do **not** use that for Jam: Jam's preferred
+   headless substrate is the `jam` CLI, so the generator should emit CLI setup lines instead of an
+   `.mcp.json` header snippet.
+
+   When no documented substrate is known, keep the MCP as `headlessUsable: false` / `GAP`, and add
+   an action line like: `check the vendor for a documented PAT, API-key, CLI, or REST substrate`.
+   Never assert that no substrate exists unless the vendor documentation explicitly says so.
 
 6. **Config scope & memory gaps** — identify reliance on user-scoped config that will not load
    remotely: `~/.claude/CLAUDE.md`, user `enabledPlugins`, user skills/agents, user MCP. Most
@@ -250,10 +274,27 @@ so the generator can render acquisition comments into its template:
       "headlessSubstrate": "gh CLI (token)",
       "acquireUrl": "https://github.com/settings/personal-access-tokens",
       "accessScope": "fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R; +Workflows R/W if editing .github/workflows; +Projects R/W if using ProjectV2"
+    },
+    {
+      "name": "JAM_PAT", "required": false, "secret": true, "integration": "jam",
+      "reason": "optional non-tracker MCP recovery; Jam CLI can authenticate headlessly from a PAT",
+      "headlessSubstrate": "jam CLI (PAT)",
+      "acquireUrl": "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens",
+      "accessScope": "Jam Personal Access Token for the workspace/team whose traces the routine needs to read",
+      "setupSnippet": "curl -fsSL https://native.jam.dev/install | bash; export PATH=\"$HOME/.local/bin:$PATH\"; printf '%s' \"$JAM_PAT\" | jam auth login --token; jam skills install"
+    },
+    {
+      "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
+      "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
+      "headlessSubstrate": "SonarCloud Web API (token)",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],
   "mcp": [
-    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
+    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true },
+    { "name": "jam", "transport": "http", "auth": "oauth", "headlessUsable": true, "replacedBy": "jam CLI + JAM_PAT", "dormant": true },
+    { "name": "sonarqube", "transport": "stdio", "auth": "local-wrapper", "headlessUsable": true, "replacedBy": "SONAR_TOKEN + SonarCloud Web API", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
   "platform": {
@@ -305,3 +346,6 @@ so the generator can render acquisition comments into its template:
   to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".
+- For non-tracker MCPs, a documented CLI, PAT/API-key, or REST substrate converts the finding from
+  a flat `GAP` into an `OPTIONAL` headless recovery path; unknown vendors remain gaps with a
+  vendor-substrate follow-up, not invented credentials.

--- a/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/generate-claude-remote-build-script/SKILL.md
@@ -66,6 +66,27 @@ tracker/source, plus the host project's own package manager and tooling — not 
    When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
    is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
    sibling repos reachable through the routine's GitHub proxy.
+   For OPTIONAL non-tracker MCP recovery entries discovered by
+   `/lisa:analyze-claude-remote`, preserve the same names-only behavior:
+   include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
+   only as optional secrets, with their acquire/scope comments when the analysis
+   supplied them. Never invent values or promote dormant substrates to required.
+
+3a. **Emit substrate setup snippets.** When the inventory marks an MCP
+   `headlessUsable: true` through a documented substrate, render the matching
+   wiring guidance as commented, opt-in setup:
+   - CLI substrates: emit the detected install/login commands gated on the
+     optional env var. For Jam, this means `curl -fsSL https://native.jam.dev/install | bash`,
+     `export PATH="$HOME/.local/bin:$PATH"`, `printf '%s' "$JAM_PAT" | jam auth login --token`,
+     and `jam skills install`, all inside `[ -n "${JAM_PAT:-}" ] && ...` guards so missing
+     optional secrets do not fail the environment build.
+   - REST substitute substrates: do not install an MCP. Emit comments naming the
+     REST host and env var (for example `SONAR_TOKEN` with `https://sonarcloud.io/api/`) and
+     rely on the access skill or generated consumer to call the API.
+   - PAT-bearer MCP substrates: print a commented `.mcp.json` `headers` snippet from the
+     inventory's `mcpHeaders`. Use this only when the analysis explicitly says the same MCP
+     transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
+     Jam's preferred headless substrate is its PAT-authenticated CLI.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user

--- a/plugins/lisa-cursor/skills/jam-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/jam-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jam-access
-description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to JAM_PAT bearer auth for headless routines."
+description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to the JAM_PAT-authenticated Jam CLI for headless routines."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -24,16 +24,16 @@ Return parsed JSON or a concise structured summary in a `<result>` block.
 Probe in order:
 
 1. Jam MCP, if the tool is available and authenticated.
-2. `JAM_PAT` bearer token against Jam's MCP/trace HTTP substrate.
+2. Jam CLI authenticated with `JAM_PAT`.
 
-Jam documents personal access tokens for MCP clients so a browser OAuth flow is
-not required. The headless tier uses:
+Jam documents a PAT-authenticated CLI that is cleaner for remote routines than
+editing `.mcp.json` headers. The headless tier uses:
 
 ```bash
-curl -sS "https://mcp.jam.dev/mcp" \
-  -H "Authorization: Bearer $JAM_PAT" \
-  -H "Content-Type: application/json" \
-  --data-binary "$PAYLOAD"
+curl -fsSL https://native.jam.dev/install | bash
+export PATH="$HOME/.local/bin:$PATH"
+printf '%s' "$JAM_PAT" | jam auth login --token
+jam skills install
 ```
 
 If neither tier works, fail with:
@@ -45,7 +45,8 @@ Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PA
 ## Invariants
 
 - Fallback is gated on `JAM_PAT`; do not retry Jam MCP failures blindly.
-- Never commit a Jam PAT into `.mcp.json`. Use env interpolation in host MCP
-  config, for example `Authorization: Bearer ${JAM_PAT}`.
-- If a requested operation is not yet mapped to the Jam HTTP substrate, surface
+- Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
+- Headless Jam access requires `native.jam.dev` for the installer and
+  `api.jam.dev` for CLI/API calls in any custom remote network allowlist.
+- If a requested operation is not yet mapped to the Jam CLI substrate, surface
   that exact missing adapter instead of pretending the trace is unavailable.

--- a/plugins/lisa/rules/reference/integration-access-layer.md
+++ b/plugins/lisa/rules/reference/integration-access-layer.md
@@ -22,7 +22,7 @@ available.
 | Atlassian | `lisa:atlassian-access` | `ATLASSIAN_API_TOKEN` | Atlassian Cloud REST |
 | Notion | `lisa:notion-access` | `NOTION_API_TOKEN` | Notion REST |
 | Linear | `lisa:linear-access` | `LINEAR_API_KEY` | Linear GraphQL |
-| Jam | `lisa:jam-access` | `JAM_PAT` | Jam MCP HTTP endpoint with bearer PAT |
+| Jam | `lisa:jam-access` | `JAM_PAT` | Jam CLI |
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |

--- a/plugins/lisa/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/analyze-claude-remote/SKILL.md
@@ -287,7 +287,7 @@ so the generator can render acquisition comments into its template:
       "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
       "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
       "headlessSubstrate": "SonarCloud Web API (token)",
-      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens",
       "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],

--- a/plugins/lisa/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/analyze-claude-remote/SKILL.md
@@ -133,11 +133,35 @@ Group the findings as:
    `RISK`/`GAP` (need a local process — only viable if the cloud session can spawn them from the
    repo). Flag interactively/OAuth-authed servers as `GAP` for headless auth — they cannot complete
    a browser flow headless **regardless of transport** (an HTTP MCP like `linear-server` is still a
-   `GAP` because its *auth* is OAuth, not because of its transport). When an OAuth MCP backs an
-   active tracker/source, do not stop at the `GAP` — cross-reference group 4a and point to the
-   integration's token substrate as the headless replacement (e.g. `linear-server` MCP → `LINEAR_API_KEY`
-   + Linear GraphQL). Note any user-scoped MCP (`~/.claude.json`) as `GAP` — it never reaches the
-   cloud; it must be moved into project `.mcp.json`.
+   `GAP` because its *auth* is OAuth, not because of its transport). Before finalizing any
+   OAuth/interactive/stdio MCP as a flat `GAP`, check for a documented headless substrate: a
+   static-token MCP header, a vendor CLI that can login from an env token, or a token-authenticated
+   REST API that the MCP wraps. If documented evidence exists, mark the MCP `headlessUsable: true`
+   in the inventory, mark the supporting secret `required: false` / `secret: true` unless the
+   integration is active, and set `replacedBy` to the concrete substrate rather than leaving it as
+   an impossible capability. When an OAuth MCP backs an active tracker/source, do not stop at the
+   `GAP` — cross-reference group 4a and point to the integration's token substrate as the headless
+   replacement (e.g. `linear-server` MCP -> `LINEAR_API_KEY` + Linear GraphQL). Note any user-scoped
+   MCP (`~/.claude.json`) as `GAP` — it never reaches the cloud; it must be moved into project
+   `.mcp.json`.
+
+   Use this data-driven hint table as seed evidence, and extend it only when you can cite a vendor
+   doc or committed access-skill reference:
+
+   | Match | Substrate | Env | Setup / wiring | Domains |
+   |---|---|---|---|---|
+   | `mcp.jam.dev`, `jam`, or Jam MCP entries | Jam CLI (`jam`) authenticated by PAT | `JAM_PAT` | install with `curl -fsSL https://native.jam.dev/install | bash`; export `~/.local/bin`; run `printf '%s' "$JAM_PAT" | jam auth login --token`; optionally `jam skills install` | `native.jam.dev`, `api.jam.dev` |
+   | `mcp/sonarqube`, `sonarqube`, or SonarCloud/SonarQube MCP entries | SonarCloud Web API | `SONAR_TOKEN` | use REST calls against `https://sonarcloud.io/api/`; if a host needs legacy token-as-basic-auth, put that in the access adapter | `sonarcloud.io` |
+
+   For PAT-bearer MCP substrates that really use the same MCP transport, include `mcpHeaders` in
+   the inventory with a snippet such as `headers: { "Authorization": "Bearer ${VAR}" }` so the
+   generator can print a commented `.mcp.json` example. Do **not** use that for Jam: Jam's preferred
+   headless substrate is the `jam` CLI, so the generator should emit CLI setup lines instead of an
+   `.mcp.json` header snippet.
+
+   When no documented substrate is known, keep the MCP as `headlessUsable: false` / `GAP`, and add
+   an action line like: `check the vendor for a documented PAT, API-key, CLI, or REST substrate`.
+   Never assert that no substrate exists unless the vendor documentation explicitly says so.
 
 6. **Config scope & memory gaps** — identify reliance on user-scoped config that will not load
    remotely: `~/.claude/CLAUDE.md`, user `enabledPlugins`, user skills/agents, user MCP. Most
@@ -250,10 +274,27 @@ so the generator can render acquisition comments into its template:
       "headlessSubstrate": "gh CLI (token)",
       "acquireUrl": "https://github.com/settings/personal-access-tokens",
       "accessScope": "fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R; +Workflows R/W if editing .github/workflows; +Projects R/W if using ProjectV2"
+    },
+    {
+      "name": "JAM_PAT", "required": false, "secret": true, "integration": "jam",
+      "reason": "optional non-tracker MCP recovery; Jam CLI can authenticate headlessly from a PAT",
+      "headlessSubstrate": "jam CLI (PAT)",
+      "acquireUrl": "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens",
+      "accessScope": "Jam Personal Access Token for the workspace/team whose traces the routine needs to read",
+      "setupSnippet": "curl -fsSL https://native.jam.dev/install | bash; export PATH=\"$HOME/.local/bin:$PATH\"; printf '%s' \"$JAM_PAT\" | jam auth login --token; jam skills install"
+    },
+    {
+      "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
+      "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
+      "headlessSubstrate": "SonarCloud Web API (token)",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],
   "mcp": [
-    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
+    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true },
+    { "name": "jam", "transport": "http", "auth": "oauth", "headlessUsable": true, "replacedBy": "jam CLI + JAM_PAT", "dormant": true },
+    { "name": "sonarqube", "transport": "stdio", "auth": "local-wrapper", "headlessUsable": true, "replacedBy": "SONAR_TOKEN + SonarCloud Web API", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
   "platform": {
@@ -305,3 +346,6 @@ so the generator can render acquisition comments into its template:
   to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".
+- For non-tracker MCPs, a documented CLI, PAT/API-key, or REST substrate converts the finding from
+  a flat `GAP` into an `OPTIONAL` headless recovery path; unknown vendors remain gaps with a
+  vendor-substrate follow-up, not invented credentials.

--- a/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/generate-claude-remote-build-script/SKILL.md
@@ -66,6 +66,27 @@ tracker/source, plus the host project's own package manager and tooling — not 
    When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
    is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
    sibling repos reachable through the routine's GitHub proxy.
+   For OPTIONAL non-tracker MCP recovery entries discovered by
+   `/lisa:analyze-claude-remote`, preserve the same names-only behavior:
+   include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
+   only as optional secrets, with their acquire/scope comments when the analysis
+   supplied them. Never invent values or promote dormant substrates to required.
+
+3a. **Emit substrate setup snippets.** When the inventory marks an MCP
+   `headlessUsable: true` through a documented substrate, render the matching
+   wiring guidance as commented, opt-in setup:
+   - CLI substrates: emit the detected install/login commands gated on the
+     optional env var. For Jam, this means `curl -fsSL https://native.jam.dev/install | bash`,
+     `export PATH="$HOME/.local/bin:$PATH"`, `printf '%s' "$JAM_PAT" | jam auth login --token`,
+     and `jam skills install`, all inside `[ -n "${JAM_PAT:-}" ] && ...` guards so missing
+     optional secrets do not fail the environment build.
+   - REST substitute substrates: do not install an MCP. Emit comments naming the
+     REST host and env var (for example `SONAR_TOKEN` with `https://sonarcloud.io/api/`) and
+     rely on the access skill or generated consumer to call the API.
+   - PAT-bearer MCP substrates: print a commented `.mcp.json` `headers` snippet from the
+     inventory's `mcpHeaders`. Use this only when the analysis explicitly says the same MCP
+     transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
+     Jam's preferred headless substrate is its PAT-authenticated CLI.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user

--- a/plugins/lisa/skills/jam-access/SKILL.md
+++ b/plugins/lisa/skills/jam-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jam-access
-description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to JAM_PAT bearer auth for headless routines."
+description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to the JAM_PAT-authenticated Jam CLI for headless routines."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -24,16 +24,16 @@ Return parsed JSON or a concise structured summary in a `<result>` block.
 Probe in order:
 
 1. Jam MCP, if the tool is available and authenticated.
-2. `JAM_PAT` bearer token against Jam's MCP/trace HTTP substrate.
+2. Jam CLI authenticated with `JAM_PAT`.
 
-Jam documents personal access tokens for MCP clients so a browser OAuth flow is
-not required. The headless tier uses:
+Jam documents a PAT-authenticated CLI that is cleaner for remote routines than
+editing `.mcp.json` headers. The headless tier uses:
 
 ```bash
-curl -sS "https://mcp.jam.dev/mcp" \
-  -H "Authorization: Bearer $JAM_PAT" \
-  -H "Content-Type: application/json" \
-  --data-binary "$PAYLOAD"
+curl -fsSL https://native.jam.dev/install | bash
+export PATH="$HOME/.local/bin:$PATH"
+printf '%s' "$JAM_PAT" | jam auth login --token
+jam skills install
 ```
 
 If neither tier works, fail with:
@@ -45,7 +45,8 @@ Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PA
 ## Invariants
 
 - Fallback is gated on `JAM_PAT`; do not retry Jam MCP failures blindly.
-- Never commit a Jam PAT into `.mcp.json`. Use env interpolation in host MCP
-  config, for example `Authorization: Bearer ${JAM_PAT}`.
-- If a requested operation is not yet mapped to the Jam HTTP substrate, surface
+- Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
+- Headless Jam access requires `native.jam.dev` for the installer and
+  `api.jam.dev` for CLI/API calls in any custom remote network allowlist.
+- If a requested operation is not yet mapped to the Jam CLI substrate, surface
   that exact missing adapter instead of pretending the trace is unavailable.

--- a/plugins/src/base/rules/reference/integration-access-layer.md
+++ b/plugins/src/base/rules/reference/integration-access-layer.md
@@ -22,7 +22,7 @@ available.
 | Atlassian | `lisa:atlassian-access` | `ATLASSIAN_API_TOKEN` | Atlassian Cloud REST |
 | Notion | `lisa:notion-access` | `NOTION_API_TOKEN` | Notion REST |
 | Linear | `lisa:linear-access` | `LINEAR_API_KEY` | Linear GraphQL |
-| Jam | `lisa:jam-access` | `JAM_PAT` | Jam MCP HTTP endpoint with bearer PAT |
+| Jam | `lisa:jam-access` | `JAM_PAT` | Jam CLI |
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |

--- a/plugins/src/base/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/analyze-claude-remote/SKILL.md
@@ -287,7 +287,7 @@ so the generator can render acquisition comments into its template:
       "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
       "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
       "headlessSubstrate": "SonarCloud Web API (token)",
-      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens",
       "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],

--- a/plugins/src/base/skills/analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/analyze-claude-remote/SKILL.md
@@ -133,11 +133,35 @@ Group the findings as:
    `RISK`/`GAP` (need a local process — only viable if the cloud session can spawn them from the
    repo). Flag interactively/OAuth-authed servers as `GAP` for headless auth — they cannot complete
    a browser flow headless **regardless of transport** (an HTTP MCP like `linear-server` is still a
-   `GAP` because its *auth* is OAuth, not because of its transport). When an OAuth MCP backs an
-   active tracker/source, do not stop at the `GAP` — cross-reference group 4a and point to the
-   integration's token substrate as the headless replacement (e.g. `linear-server` MCP → `LINEAR_API_KEY`
-   + Linear GraphQL). Note any user-scoped MCP (`~/.claude.json`) as `GAP` — it never reaches the
-   cloud; it must be moved into project `.mcp.json`.
+   `GAP` because its *auth* is OAuth, not because of its transport). Before finalizing any
+   OAuth/interactive/stdio MCP as a flat `GAP`, check for a documented headless substrate: a
+   static-token MCP header, a vendor CLI that can login from an env token, or a token-authenticated
+   REST API that the MCP wraps. If documented evidence exists, mark the MCP `headlessUsable: true`
+   in the inventory, mark the supporting secret `required: false` / `secret: true` unless the
+   integration is active, and set `replacedBy` to the concrete substrate rather than leaving it as
+   an impossible capability. When an OAuth MCP backs an active tracker/source, do not stop at the
+   `GAP` — cross-reference group 4a and point to the integration's token substrate as the headless
+   replacement (e.g. `linear-server` MCP -> `LINEAR_API_KEY` + Linear GraphQL). Note any user-scoped
+   MCP (`~/.claude.json`) as `GAP` — it never reaches the cloud; it must be moved into project
+   `.mcp.json`.
+
+   Use this data-driven hint table as seed evidence, and extend it only when you can cite a vendor
+   doc or committed access-skill reference:
+
+   | Match | Substrate | Env | Setup / wiring | Domains |
+   |---|---|---|---|---|
+   | `mcp.jam.dev`, `jam`, or Jam MCP entries | Jam CLI (`jam`) authenticated by PAT | `JAM_PAT` | install with `curl -fsSL https://native.jam.dev/install | bash`; export `~/.local/bin`; run `printf '%s' "$JAM_PAT" | jam auth login --token`; optionally `jam skills install` | `native.jam.dev`, `api.jam.dev` |
+   | `mcp/sonarqube`, `sonarqube`, or SonarCloud/SonarQube MCP entries | SonarCloud Web API | `SONAR_TOKEN` | use REST calls against `https://sonarcloud.io/api/`; if a host needs legacy token-as-basic-auth, put that in the access adapter | `sonarcloud.io` |
+
+   For PAT-bearer MCP substrates that really use the same MCP transport, include `mcpHeaders` in
+   the inventory with a snippet such as `headers: { "Authorization": "Bearer ${VAR}" }` so the
+   generator can print a commented `.mcp.json` example. Do **not** use that for Jam: Jam's preferred
+   headless substrate is the `jam` CLI, so the generator should emit CLI setup lines instead of an
+   `.mcp.json` header snippet.
+
+   When no documented substrate is known, keep the MCP as `headlessUsable: false` / `GAP`, and add
+   an action line like: `check the vendor for a documented PAT, API-key, CLI, or REST substrate`.
+   Never assert that no substrate exists unless the vendor documentation explicitly says so.
 
 6. **Config scope & memory gaps** — identify reliance on user-scoped config that will not load
    remotely: `~/.claude/CLAUDE.md`, user `enabledPlugins`, user skills/agents, user MCP. Most
@@ -250,10 +274,27 @@ so the generator can render acquisition comments into its template:
       "headlessSubstrate": "gh CLI (token)",
       "acquireUrl": "https://github.com/settings/personal-access-tokens",
       "accessScope": "fine-grained PAT on target repo: Contents R/W, Issues R/W, Pull requests R/W, Metadata R; +Workflows R/W if editing .github/workflows; +Projects R/W if using ProjectV2"
+    },
+    {
+      "name": "JAM_PAT", "required": false, "secret": true, "integration": "jam",
+      "reason": "optional non-tracker MCP recovery; Jam CLI can authenticate headlessly from a PAT",
+      "headlessSubstrate": "jam CLI (PAT)",
+      "acquireUrl": "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens",
+      "accessScope": "Jam Personal Access Token for the workspace/team whose traces the routine needs to read",
+      "setupSnippet": "curl -fsSL https://native.jam.dev/install | bash; export PATH=\"$HOME/.local/bin:$PATH\"; printf '%s' \"$JAM_PAT\" | jam auth login --token; jam skills install"
+    },
+    {
+      "name": "SONAR_TOKEN", "required": false, "secret": true, "integration": "sonarcloud",
+      "reason": "optional non-tracker MCP recovery; SonarQube MCP wraps the token-authenticated SonarCloud Web API",
+      "headlessSubstrate": "SonarCloud Web API (token)",
+      "acquireUrl": "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/",
+      "accessScope": "token must be able to read the target SonarCloud organization/project quality gate, issues, hotspots, rules, and source snippets"
     }
   ],
   "mcp": [
-    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true }
+    { "name": "linear-server", "transport": "http", "auth": "oauth", "headlessUsable": false, "replacedBy": "LINEAR_API_KEY + Linear GraphQL", "dormant": true },
+    { "name": "jam", "transport": "http", "auth": "oauth", "headlessUsable": true, "replacedBy": "jam CLI + JAM_PAT", "dormant": true },
+    { "name": "sonarqube", "transport": "stdio", "auth": "local-wrapper", "headlessUsable": true, "replacedBy": "SONAR_TOKEN + SonarCloud Web API", "dormant": true }
   ],
   "gaps": [ "auto-memory not synced to cloud", "bun package fetch behind proxy", "OS keychain absent — env-var token form only" ],
   "platform": {
@@ -305,3 +346,6 @@ so the generator can render acquisition comments into its template:
   to environment editors; never imply the generated script can hide them.
 - A browser-OAuth MCP (or interactively-authed CLI) backing an active integration is a `GAP`; the
   remediation is its token substrate from the table, not "authenticate the MCP".
+- For non-tracker MCPs, a documented CLI, PAT/API-key, or REST substrate converts the finding from
+  a flat `GAP` into an `OPTIONAL` headless recovery path; unknown vendors remain gaps with a
+  vendor-substrate follow-up, not invented credentials.

--- a/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/generate-claude-remote-build-script/SKILL.md
@@ -66,6 +66,27 @@ tracker/source, plus the host project's own package manager and tooling — not 
    When the entry is `GH_TOKEN`, add a comment from `platform.githubProxy` clarifying that the token
    is for `gh` CLI commands against the project/Lisa repos, not for raw git clone/fetch/push or
    sibling repos reachable through the routine's GitHub proxy.
+   For OPTIONAL non-tracker MCP recovery entries discovered by
+   `/lisa:analyze-claude-remote`, preserve the same names-only behavior:
+   include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
+   only as optional secrets, with their acquire/scope comments when the analysis
+   supplied them. Never invent values or promote dormant substrates to required.
+
+3a. **Emit substrate setup snippets.** When the inventory marks an MCP
+   `headlessUsable: true` through a documented substrate, render the matching
+   wiring guidance as commented, opt-in setup:
+   - CLI substrates: emit the detected install/login commands gated on the
+     optional env var. For Jam, this means `curl -fsSL https://native.jam.dev/install | bash`,
+     `export PATH="$HOME/.local/bin:$PATH"`, `printf '%s' "$JAM_PAT" | jam auth login --token`,
+     and `jam skills install`, all inside `[ -n "${JAM_PAT:-}" ] && ...` guards so missing
+     optional secrets do not fail the environment build.
+   - REST substitute substrates: do not install an MCP. Emit comments naming the
+     REST host and env var (for example `SONAR_TOKEN` with `https://sonarcloud.io/api/`) and
+     rely on the access skill or generated consumer to call the API.
+   - PAT-bearer MCP substrates: print a commented `.mcp.json` `headers` snippet from the
+     inventory's `mcpHeaders`. Use this only when the analysis explicitly says the same MCP
+     transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
+     Jam's preferred headless substrate is its PAT-authenticated CLI.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user

--- a/plugins/src/base/skills/jam-access/SKILL.md
+++ b/plugins/src/base/skills/jam-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jam-access
-description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to JAM_PAT bearer auth for headless routines."
+description: "Vendor-neutral access layer for Jam. Jam triage rules and skills MUST delegate through this skill rather than calling Jam MCP tools directly. Resolves Jam MCP first when available, then falls back to the JAM_PAT-authenticated Jam CLI for headless routines."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -24,16 +24,16 @@ Return parsed JSON or a concise structured summary in a `<result>` block.
 Probe in order:
 
 1. Jam MCP, if the tool is available and authenticated.
-2. `JAM_PAT` bearer token against Jam's MCP/trace HTTP substrate.
+2. Jam CLI authenticated with `JAM_PAT`.
 
-Jam documents personal access tokens for MCP clients so a browser OAuth flow is
-not required. The headless tier uses:
+Jam documents a PAT-authenticated CLI that is cleaner for remote routines than
+editing `.mcp.json` headers. The headless tier uses:
 
 ```bash
-curl -sS "https://mcp.jam.dev/mcp" \
-  -H "Authorization: Bearer $JAM_PAT" \
-  -H "Content-Type: application/json" \
-  --data-binary "$PAYLOAD"
+curl -fsSL https://native.jam.dev/install | bash
+export PATH="$HOME/.local/bin:$PATH"
+printf '%s' "$JAM_PAT" | jam auth login --token
+jam skills install
 ```
 
 If neither tier works, fail with:
@@ -45,7 +45,8 @@ Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PA
 ## Invariants
 
 - Fallback is gated on `JAM_PAT`; do not retry Jam MCP failures blindly.
-- Never commit a Jam PAT into `.mcp.json`. Use env interpolation in host MCP
-  config, for example `Authorization: Bearer ${JAM_PAT}`.
-- If a requested operation is not yet mapped to the Jam HTTP substrate, surface
+- Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
+- Headless Jam access requires `native.jam.dev` for the installer and
+  `api.jam.dev` for CLI/API calls in any custom remote network allowlist.
+- If a requested operation is not yet mapped to the Jam CLI substrate, surface
   that exact missing adapter instead of pretending the trace is unavailable.

--- a/tests/unit/strategies/claude-remote-substrates.test.ts
+++ b/tests/unit/strategies/claude-remote-substrates.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression coverage for non-tracker MCP headless substrate guidance.
+ *
+ * Issue #1342: analyze-claude-remote must not classify every OAuth/stdio MCP
+ * as a flat remote-routine gap. Documented CLI, PAT, and REST substrates should
+ * become optional headless recovery paths that the generator can surface.
+ *
+ * @module tests/unit/strategies/claude-remote-substrates
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base/skills", "plugins/lisa/skills"] as const;
+
+const readSkill = (root: string, slug: string): string =>
+  readFileSync(path.resolve(root, slug, "SKILL.md"), "utf8");
+
+describe("analyze-claude-remote non-tracker MCP substrate guidance", () => {
+  describe.each(ROOTS)("%s/analyze-claude-remote", root => {
+    const content = readSkill(root, "analyze-claude-remote");
+
+    it("checks documented substrates before finalizing an MCP as a flat GAP", () => {
+      expect(content).toMatch(
+        /Before finalizing any\s+OAuth\/interactive\/stdio MCP as a flat `GAP`/i
+      );
+      expect(content).toMatch(/vendor CLI/i);
+      expect(content).toMatch(/token-authenticated\s+REST API/i);
+      expect(content).toContain("headlessUsable: true");
+      expect(content).toMatch(/check the vendor for a documented PAT/i);
+    });
+
+    it("seeds Jam as CLI plus JAM_PAT, not an MCP header substrate", () => {
+      expect(content).toContain("Jam CLI (`jam`) authenticated by PAT");
+      expect(content).toContain("JAM_PAT");
+      expect(content).toContain("native.jam.dev");
+      expect(content).toContain("api.jam.dev");
+      expect(content).toContain(
+        "https://jam.dev/docs/debug-a-jam/mcp/personal-access-tokens"
+      );
+      expect(content).toContain("setupSnippet");
+      expect(content).toMatch(/Do \*\*not\*\* use that for Jam/i);
+      expect(content).not.toContain("mcp.jam.dev`, `JAM_PAT` (`jam_pat_`");
+    });
+
+    it("seeds SonarCloud as SONAR_TOKEN plus REST", () => {
+      expect(content).toContain("SonarCloud Web API");
+      expect(content).toContain("SONAR_TOKEN");
+      expect(content).toContain("https://sonarcloud.io/api/");
+      expect(content).toContain(
+        "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/"
+      );
+      expect(content).toContain("sonarcloud.io");
+    });
+  });
+});
+
+describe("generate-claude-remote-build-script substrate output", () => {
+  describe.each(ROOTS)("%s/generate-claude-remote-build-script", root => {
+    const content = readSkill(root, "generate-claude-remote-build-script");
+
+    it("renders optional substrate env vars without promoting them to required", () => {
+      expect(content).toMatch(/OPTIONAL non-tracker MCP recovery entries/i);
+      expect(content).toContain("JAM_PAT");
+      expect(content).toContain("SONAR_TOKEN");
+      expect(content).toMatch(
+        /Never invent values or promote dormant substrates to required/i
+      );
+    });
+
+    it("prints Jam CLI setup and reserves .mcp.json headers for true MCP bearer substrates", () => {
+      expect(content).toContain(
+        "curl -fsSL https://native.jam.dev/install | bash"
+      );
+      expect(content).toContain(
+        "printf '%s' \"$JAM_PAT\" | jam auth login --token"
+      );
+      expect(content).toContain("jam skills install");
+      expect(content).toMatch(
+        /Do not print a Jam `.mcp\.json` header snippet/i
+      );
+      expect(content).toContain("mcpHeaders");
+    });
+  });
+});

--- a/tests/unit/strategies/claude-remote-substrates.test.ts
+++ b/tests/unit/strategies/claude-remote-substrates.test.ts
@@ -41,7 +41,10 @@ describe("analyze-claude-remote non-tracker MCP substrate guidance", () => {
       );
       expect(content).toContain("setupSnippet");
       expect(content).toMatch(/Do \*\*not\*\* use that for Jam/i);
-      expect(content).not.toContain("mcp.jam.dev`, `JAM_PAT` (`jam_pat_`");
+      // Ensure Jam is not seeded as an MCP bearer substrate in the inventory
+      expect(content).not.toMatch(
+        /`mcp\.jam\.dev`\s*[,`]\s*`?JAM_PAT`.*mcpHeaders/i
+      );
     });
 
     it("seeds SonarCloud as SONAR_TOKEN plus REST", () => {
@@ -49,7 +52,7 @@ describe("analyze-claude-remote non-tracker MCP substrate guidance", () => {
       expect(content).toContain("SONAR_TOKEN");
       expect(content).toContain("https://sonarcloud.io/api/");
       expect(content).toContain(
-        "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/generating-and-using-tokens/"
+        "https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens"
       );
       expect(content).toContain("sonarcloud.io");
     });


### PR DESCRIPTION
## Summary

- Teach `analyze-claude-remote` to check documented non-tracker MCP substrates before declaring a flat remote-routine GAP.
- Seed Jam as a `JAM_PAT`-authenticated CLI substrate and SonarCloud as a `SONAR_TOKEN` Web API substrate, with optional env inventory metadata and custom-network hosts.
- Update `generate-claude-remote-build-script` guidance to render optional substrate env vars, Jam CLI setup snippets, REST substitute notes, and `.mcp.json` headers only for true PAT-bearer MCP transports.
- Align `jam-access` and integration-access docs with the corrected Jam CLI path, then regenerate plugin variants.
- Add regression coverage for the base and generated Lisa skills.

Closes #1342

## Verification

- `bun test tests/unit/strategies/claude-remote-substrates.test.ts`
- `bun run typecheck`
- `bun run build:plugins`
- `bun run check:plugins`
- `bun run check:rules-pairing`
- pre-push hook: security audit, slow lint, knip, `bun run test:cov`, `bun run test:integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved Claude Remote audit guidance to only mark OAuth/interactive/stdio MCPs as headless-usable when documented headless evidence exists, otherwise keeping them as gaps or downgrading only documented non-tracker substrates to optional recovery.
  * Expanded Jam and SonarQube/SonarCloud examples to use `JAM_PAT`/`SONAR_TOKEN` as optional secrets and added clear recovery/wiring instructions (including when to avoid emitting `.mcp.json` header snippets).
  * Updated Jam access guidance to prioritize a PAT-authenticated Jam CLI headless flow over bearer-token MCP/HTTP approaches, with tightened environment/security rules.

* **Tests**
  * Added regression coverage for the new MCP headless decisioning and optional recovery environment handling in Claude Remote flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->