### PR TITLE
fix: add sealed design system guards to Expo skills

### DIFF
--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/SKILL.md
@@ -10,6 +10,14 @@ description: |
 
 This skill enforces Brad Frost's atomic design methodology adapted for React Native/Expo projects using Gluestack UI v3 + NativeWind v4. It provides clear guidelines for component categorization, directory structure, composition patterns, and testing strategies for each atomic level.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Keep the atomic hierarchy concepts only when they match the local seal. Do not redefine the atom library as `@/components/ui`, use Gluestack compound trees as canonical atoms, or recommend `className` and raw Gluestack tokens where the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 ### The Atomic Hierarchy

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_atomic_structure.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_atomic_structure import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -13,6 +13,7 @@ Usage:
     If no path provided, validates the entire project from current directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -44,29 +45,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -77,20 +94,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 # Patterns to identify atomic level from file path

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -29,6 +29,70 @@ ATOMIC_LEVELS = {
     "app": 4,      # Expo Router pages
 }
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 # Patterns to identify atomic level from file path
 LEVEL_PATTERNS = [
     (r"/components/atoms/", "atoms"),
@@ -302,6 +366,11 @@ def main():
     if not os.path.exists(path):
         print(f"Error: Path '{path}' does not exist")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack atomic-design validation.")
+        sys.exit(0)
 
     print(f"Validating atomic design structure in: {path}")
     print("-" * 60)

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -127,9 +127,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/SKILL.md
@@ -7,6 +7,14 @@ description: This skill enforces Gluestack UI v3 and NativeWind v4 design patter
 
 This skill enforces constrained, opinionated styling patterns that reduce decision fatigue, improve performance, enable consistent theming, and limit the solution space to canonical patterns.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, this skill does not apply. Defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Do not instruct `@/components/ui` imports, Gluestack compound trees, raw shade tokens, margins, or `className` usage above the atom layer when the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 1. **Gluestack components over React Native primitives** - Gluestack wraps RN with theming, accessibility, and cross-platform consistency

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_styling.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_styling import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -197,9 +197,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -99,6 +99,70 @@ SKIP_PATTERNS = [
 ]
 
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 def should_skip_file(file_path: str) -> bool:
     """Check if file should be skipped."""
     for pattern in SKIP_PATTERNS:
@@ -269,6 +333,11 @@ def main():
     if not os.path.exists(path):
         print(f"❌ Path not found: {path}")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack NativeWind validation.")
+        sys.exit(0)
 
     print(f"🔍 Validating styling patterns in: {path}\n")
 

--- a/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-agy/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -19,6 +19,7 @@ Arguments:
             Can be a file or directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -114,29 +115,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -147,20 +164,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 def should_skip_file(file_path: str) -> bool:

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/SKILL.md
@@ -10,6 +10,14 @@ description: |
 
 This skill enforces Brad Frost's atomic design methodology adapted for React Native/Expo projects using Gluestack UI v3 + NativeWind v4. It provides clear guidelines for component categorization, directory structure, composition patterns, and testing strategies for each atomic level.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Keep the atomic hierarchy concepts only when they match the local seal. Do not redefine the atom library as `@/components/ui`, use Gluestack compound trees as canonical atoms, or recommend `className` and raw Gluestack tokens where the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 ### The Atomic Hierarchy

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_atomic_structure.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_atomic_structure import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -13,6 +13,7 @@ Usage:
     If no path provided, validates the entire project from current directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -44,29 +45,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -77,20 +94,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 # Patterns to identify atomic level from file path

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -29,6 +29,70 @@ ATOMIC_LEVELS = {
     "app": 4,      # Expo Router pages
 }
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 # Patterns to identify atomic level from file path
 LEVEL_PATTERNS = [
     (r"/components/atoms/", "atoms"),
@@ -302,6 +366,11 @@ def main():
     if not os.path.exists(path):
         print(f"Error: Path '{path}' does not exist")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack atomic-design validation.")
+        sys.exit(0)
 
     print(f"Validating atomic design structure in: {path}")
     print("-" * 60)

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -127,9 +127,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/SKILL.md
@@ -7,6 +7,14 @@ description: This skill enforces Gluestack UI v3 and NativeWind v4 design patter
 
 This skill enforces constrained, opinionated styling patterns that reduce decision fatigue, improve performance, enable consistent theming, and limit the solution space to canonical patterns.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, this skill does not apply. Defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Do not instruct `@/components/ui` imports, Gluestack compound trees, raw shade tokens, margins, or `className` usage above the atom layer when the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 1. **Gluestack components over React Native primitives** - Gluestack wraps RN with theming, accessibility, and cross-platform consistency

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_styling.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_styling import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -197,9 +197,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -99,6 +99,70 @@ SKIP_PATTERNS = [
 ]
 
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 def should_skip_file(file_path: str) -> bool:
     """Check if file should be skipped."""
     for pattern in SKIP_PATTERNS:
@@ -269,6 +333,11 @@ def main():
     if not os.path.exists(path):
         print(f"❌ Path not found: {path}")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack NativeWind validation.")
+        sys.exit(0)
 
     print(f"🔍 Validating styling patterns in: {path}\n")
 

--- a/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-copilot/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -19,6 +19,7 @@ Arguments:
             Can be a file or directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -114,29 +115,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -147,20 +164,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 def should_skip_file(file_path: str) -> bool:

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/SKILL.md
@@ -10,6 +10,14 @@ description: |
 
 This skill enforces Brad Frost's atomic design methodology adapted for React Native/Expo projects using Gluestack UI v3 + NativeWind v4. It provides clear guidelines for component categorization, directory structure, composition patterns, and testing strategies for each atomic level.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Keep the atomic hierarchy concepts only when they match the local seal. Do not redefine the atom library as `@/components/ui`, use Gluestack compound trees as canonical atoms, or recommend `className` and raw Gluestack tokens where the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 ### The Atomic Hierarchy

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_atomic_structure.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_atomic_structure import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -13,6 +13,7 @@ Usage:
     If no path provided, validates the entire project from current directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -44,29 +45,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -77,20 +94,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 # Patterns to identify atomic level from file path

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -29,6 +29,70 @@ ATOMIC_LEVELS = {
     "app": 4,      # Expo Router pages
 }
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 # Patterns to identify atomic level from file path
 LEVEL_PATTERNS = [
     (r"/components/atoms/", "atoms"),
@@ -302,6 +366,11 @@ def main():
     if not os.path.exists(path):
         print(f"Error: Path '{path}' does not exist")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack atomic-design validation.")
+        sys.exit(0)
 
     print(f"Validating atomic design structure in: {path}")
     print("-" * 60)

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -127,9 +127,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/SKILL.md
@@ -7,6 +7,14 @@ description: This skill enforces Gluestack UI v3 and NativeWind v4 design patter
 
 This skill enforces constrained, opinionated styling patterns that reduce decision fatigue, improve performance, enable consistent theming, and limit the solution space to canonical patterns.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, this skill does not apply. Defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Do not instruct `@/components/ui` imports, Gluestack compound trees, raw shade tokens, margins, or `className` usage above the atom layer when the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 1. **Gluestack components over React Native primitives** - Gluestack wraps RN with theming, accessibility, and cross-platform consistency

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_styling.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_styling import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -197,9 +197,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -99,6 +99,70 @@ SKIP_PATTERNS = [
 ]
 
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 def should_skip_file(file_path: str) -> bool:
     """Check if file should be skipped."""
     for pattern in SKIP_PATTERNS:
@@ -269,6 +333,11 @@ def main():
     if not os.path.exists(path):
         print(f"❌ Path not found: {path}")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack NativeWind validation.")
+        sys.exit(0)
 
     print(f"🔍 Validating styling patterns in: {path}\n")
 

--- a/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo-cursor/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -19,6 +19,7 @@ Arguments:
             Can be a file or directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -114,29 +115,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -147,20 +164,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 def should_skip_file(file_path: str) -> bool:

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/SKILL.md
@@ -10,6 +10,14 @@ description: |
 
 This skill enforces Brad Frost's atomic design methodology adapted for React Native/Expo projects using Gluestack UI v3 + NativeWind v4. It provides clear guidelines for component categorization, directory structure, composition patterns, and testing strategies for each atomic level.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Keep the atomic hierarchy concepts only when they match the local seal. Do not redefine the atom library as `@/components/ui`, use Gluestack compound trees as canonical atoms, or recommend `className` and raw Gluestack tokens where the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 ### The Atomic Hierarchy

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_atomic_structure.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_atomic_structure import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -13,6 +13,7 @@ Usage:
     If no path provided, validates the entire project from current directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -44,29 +45,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -77,20 +94,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 # Patterns to identify atomic level from file path

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -29,6 +29,70 @@ ATOMIC_LEVELS = {
     "app": 4,      # Expo Router pages
 }
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 # Patterns to identify atomic level from file path
 LEVEL_PATTERNS = [
     (r"/components/atoms/", "atoms"),
@@ -302,6 +366,11 @@ def main():
     if not os.path.exists(path):
         print(f"Error: Path '{path}' does not exist")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack atomic-design validation.")
+        sys.exit(0)
 
     print(f"Validating atomic design structure in: {path}")
     print("-" * 60)

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -127,9 +127,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo/skills/gluestack-nativewind/SKILL.md
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/SKILL.md
@@ -7,6 +7,14 @@ description: This skill enforces Gluestack UI v3 and NativeWind v4 design patter
 
 This skill enforces constrained, opinionated styling patterns that reduce decision fatigue, improve performance, enable consistent theming, and limit the solution space to canonical patterns.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, this skill does not apply. Defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Do not instruct `@/components/ui` imports, Gluestack compound trees, raw shade tokens, margins, or `className` usage above the atom layer when the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 1. **Gluestack components over React Native primitives** - Gluestack wraps RN with theming, accessibility, and cross-platform consistency

--- a/plugins/lisa-expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/lisa-expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_styling.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_styling import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -197,9 +197,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -99,6 +99,70 @@ SKIP_PATTERNS = [
 ]
 
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 def should_skip_file(file_path: str) -> bool:
     """Check if file should be skipped."""
     for pattern in SKIP_PATTERNS:
@@ -269,6 +333,11 @@ def main():
     if not os.path.exists(path):
         print(f"❌ Path not found: {path}")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack NativeWind validation.")
+        sys.exit(0)
 
     print(f"🔍 Validating styling patterns in: {path}\n")
 

--- a/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/lisa-expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -19,6 +19,7 @@ Arguments:
             Can be a file or directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -114,29 +115,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -147,20 +164,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 def should_skip_file(file_path: str) -> bool:

--- a/plugins/src/expo/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/src/expo/skills/atomic-design-gluestack/SKILL.md
@@ -10,6 +10,14 @@ description: |
 
 This skill enforces Brad Frost's atomic design methodology adapted for React Native/Expo projects using Gluestack UI v3 + NativeWind v4. It provides clear guidelines for component categorization, directory structure, composition patterns, and testing strategies for each atomic level.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Keep the atomic hierarchy concepts only when they match the local seal. Do not redefine the atom library as `@/components/ui`, use Gluestack compound trees as canonical atoms, or recommend `className` and raw Gluestack tokens where the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 ### The Atomic Hierarchy

--- a/plugins/src/expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/src/expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/src/expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
+++ b/plugins/src/expo/skills/atomic-design-gluestack/scripts/test_validate_atomic_structure.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_atomic_structure.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_atomic_structure import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -13,6 +13,7 @@ Usage:
     If no path provided, validates the entire project from current directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -44,29 +45,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -77,20 +94,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 # Patterns to identify atomic level from file path

--- a/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -29,6 +29,70 @@ ATOMIC_LEVELS = {
     "app": 4,      # Expo Router pages
 }
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 # Patterns to identify atomic level from file path
 LEVEL_PATTERNS = [
     (r"/components/atoms/", "atoms"),
@@ -302,6 +366,11 @@ def main():
     if not os.path.exists(path):
         print(f"Error: Path '{path}' does not exist")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack atomic-design validation.")
+        sys.exit(0)
 
     print(f"Validating atomic design structure in: {path}")
     print("-" * 60)

--- a/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
+++ b/plugins/src/expo/skills/atomic-design-gluestack/scripts/validate_atomic_structure.py
@@ -127,9 +127,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/src/expo/skills/gluestack-nativewind/SKILL.md
+++ b/plugins/src/expo/skills/gluestack-nativewind/SKILL.md
@@ -7,6 +7,14 @@ description: This skill enforces Gluestack UI v3 and NativeWind v4 design patter
 
 This skill enforces constrained, opinionated styling patterns that reduce decision fatigue, improve performance, enable consistent theming, and limit the solution space to canonical patterns.
 
+## Sealed Design System Guard
+
+Before applying this skill, check whether the target project has a sealed or closed design system. Common markers include `.claude/rules/use-the-design-library.md`, `.claude/rules/figma-design-system.md`, design-system ESLint rules, or a project-owned `@/components/atoms` barrel paired with design-system docs/configuration.
+
+If a sealed design system is present, this skill does not apply. Defer to the project's design-library rules and skills instead, such as `use-the-design-library` and `add-design-library-item`. Do not instruct `@/components/ui` imports, Gluestack compound trees, raw shade tokens, margins, or `className` usage above the atom layer when the project seal forbids them.
+
+For open Gluestack UI v3 + NativeWind v4 projects without those seal markers, continue with the guidance below.
+
 ## Core Principles
 
 1. **Gluestack components over React Native primitives** - Gluestack wraps RN with theming, accessibility, and cross-platform consistency

--- a/plugins/src/expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/src/expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -42,9 +42,10 @@ class TestFindProjectRoots(unittest.TestCase):
             source_file.mkdir(parents=True)
 
             roots = find_project_roots(str(source_file))
-            # Both the inner package root and the workspace root should be returned
-            self.assertIn(inner, roots)
-            self.assertIn(workspace, roots)
+            # Both the inner package root and the workspace root should be returned.
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertIn(inner.resolve(), roots)
+            self.assertIn(workspace.resolve(), roots)
 
     def test_returns_single_root_for_simple_project(self) -> None:
         """A flat project returns its single root."""
@@ -56,7 +57,8 @@ class TestFindProjectRoots(unittest.TestCase):
 
             roots = find_project_roots(str(project / "src"))
             self.assertEqual(len(roots), 1)
-            self.assertEqual(roots[0], project)
+            # Use .resolve() to handle symlinked temp dirs (e.g. /var → /private/var on macOS).
+            self.assertEqual(roots[0], project.resolve())
 
     def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
         """When no package.json or .git exists, returns the starting path."""
@@ -164,6 +166,42 @@ class TestHasDesignSystemEslintRule(unittest.TestCase):
             self.assertFalse(
                 has_design_system_eslint_rule(root),
                 msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystem(unittest.TestCase):
+    """has_sealed_design_system seal-detection logic."""
+
+    def test_seal_marker_alone_is_sufficient(self) -> None:
+        """A seal marker without an atom barrel or .claude/rules directory seals the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            docs = project / "docs"
+            docs.mkdir()
+            (docs / "design-system-rfc.md").write_text("", encoding="utf-8")
+            # Deliberately NO atom barrel and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="A single seal marker must be sufficient to detect a sealed design system",
+            )
+
+    def test_atom_barrel_alone_is_sufficient(self) -> None:
+        """A project exposing only an atoms barrel is treated as having a sealed design system."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / ".git").mkdir()
+            atoms = project / "src" / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+            # Deliberately NO seal marker and NO .claude/rules directory.
+
+            self.assertTrue(
+                has_sealed_design_system(str(project)),
+                msg="An atoms barrel alone must be sufficient to detect a sealed design system",
             )
 
 

--- a/plugins/src/expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
+++ b/plugins/src/expo/skills/gluestack-nativewind/scripts/test_validate_styling.py
@@ -1,0 +1,202 @@
+"""
+Tests for validate_styling.py seal detection helpers.
+
+Covers:
+- find_project_roots: should return ALL ancestor roots (not just first)
+- has_design_system_eslint_rule: should only match actual rule/plugin syntax
+- has_design_system_eslint_rule: should check .eslintrc.yaml/.yml, eslint.config.mts/.cts
+- has_design_system_eslint_rule: should parse package.json eslintConfig field
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_styling import (
+    find_project_roots,
+    has_design_system_eslint_rule,
+    has_sealed_design_system,
+)
+
+
+class TestFindProjectRoots(unittest.TestCase):
+    """find_project_roots should return ALL package boundaries, not just the nearest."""
+
+    def test_returns_all_ancestor_roots_in_monorepo(self) -> None:
+        """In a monorepo, both the inner package root and the workspace root are returned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: has .git
+            (workspace / ".git").mkdir()
+            # inner package: has package.json
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+
+            source_file = inner / "src" / "components"
+            source_file.mkdir(parents=True)
+
+            roots = find_project_roots(str(source_file))
+            # Both the inner package root and the workspace root should be returned
+            self.assertIn(inner, roots)
+            self.assertIn(workspace, roots)
+
+    def test_returns_single_root_for_simple_project(self) -> None:
+        """A flat project returns its single root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "package.json").write_text("{}", encoding="utf-8")
+            (project / ".git").mkdir()
+
+            roots = find_project_roots(str(project / "src"))
+            self.assertEqual(len(roots), 1)
+            self.assertEqual(roots[0], project)
+
+    def test_falls_back_to_current_directory_when_no_root_found(self) -> None:
+        """When no package.json or .git exists, returns the starting path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "orphan" / "dir"
+            orphan.mkdir(parents=True)
+            roots = find_project_roots(str(orphan))
+            self.assertEqual(len(roots), 1)
+
+
+class TestHasDesignSystemEslintRule(unittest.TestCase):
+    """has_design_system_eslint_rule should match actual rule/plugin identifiers only."""
+
+    def test_ignores_comment_containing_design_system_substring(self) -> None:
+        """A comment that mentions 'design-system' without a slash must not trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {}, "// note": "do not use design-system here"}',
+                encoding="utf-8",
+            )
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="Plain 'design-system' substring in a comment must not match",
+            )
+
+    def test_matches_design_system_slash_rule_syntax(self) -> None:
+        """An ESLint rule like 'design-system/no-raw-colors' should trigger the seal."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            eslint = root / ".eslintrc.json"
+            eslint.write_text(
+                '{"rules": {"design-system/no-raw-colors": "error"}}',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yaml(self) -> None:
+        """.eslintrc.yaml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yaml_config = root / ".eslintrc.yaml"
+            yaml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslintrc_yml(self) -> None:
+        """.eslintrc.yml is a valid ESLint config and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            yml_config = root / ".eslintrc.yml"
+            yml_config.write_text(
+                'rules:\n  design-system/no-raw-colors: error\n',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_mts(self) -> None:
+        """eslint.config.mts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mts_config = root / "eslint.config.mts"
+            mts_config.write_text(
+                'export default [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_eslint_config_cts(self) -> None:
+        """eslint.config.cts is a valid ESLint flat-config entry point and must be checked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cts_config = root / "eslint.config.cts"
+            cts_config.write_text(
+                'module.exports = [{"rules": {"design-system/no-raw-colors": "error"}}];',
+                encoding="utf-8",
+            )
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_checks_package_json_eslintconfig_field(self) -> None:
+        """The eslintConfig key in package.json must be checked for design-system rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "eslintConfig": {
+                    "rules": {"design-system/no-raw-colors": "error"}
+                },
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertTrue(has_design_system_eslint_rule(root))
+
+    def test_package_json_non_eslintconfig_does_not_trigger(self) -> None:
+        """A 'design-system' substring in package.json outside eslintConfig must not match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pkg = {
+                "name": "my-app",
+                "dependencies": {"design-system": "^1.0.0"},
+            }
+            (root / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+            self.assertFalse(
+                has_design_system_eslint_rule(root),
+                msg="'design-system' in dependencies must not trigger the ESLint seal check",
+            )
+
+
+class TestHasSealedDesignSystemMonorepo(unittest.TestCase):
+    """has_sealed_design_system should find seal markers in ancestor (workspace) roots."""
+
+    def test_finds_seal_marker_at_workspace_root_not_inner_package(self) -> None:
+        """Seal markers placed at the workspace root must be respected for inner packages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            inner = workspace / "apps" / "mobile"
+            inner.mkdir(parents=True)
+
+            # workspace root: .git + seal marker
+            (workspace / ".git").mkdir()
+            rules_dir = workspace / ".claude" / "rules"
+            rules_dir.mkdir(parents=True)
+            (rules_dir / "use-the-design-library.md").write_text("", encoding="utf-8")
+
+            # inner package: package.json + atom barrel
+            (inner / "package.json").write_text("{}", encoding="utf-8")
+            atoms = inner / "components" / "atoms"
+            atoms.mkdir(parents=True)
+            (atoms / "index.ts").write_text("", encoding="utf-8")
+
+            target_dir = inner / "src" / "components" / "atoms"
+            target_dir.mkdir(parents=True)
+
+            self.assertTrue(
+                has_sealed_design_system(str(target_dir)),
+                msg="Seal marker at workspace root must be detected even for nested packages",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -197,9 +197,8 @@ def has_sealed_design_system(path: str) -> bool:
         for root in project_roots
         for marker in ATOM_BARREL_MARKERS
     )
-    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or has_claude_rules):
+    if has_seal_marker or has_atom_barrel:
         return True
     return any(has_design_system_eslint_rule(root) for root in project_roots)
 

--- a/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -99,6 +99,70 @@ SKIP_PATTERNS = [
 ]
 
 
+SEALED_DESIGN_SYSTEM_MARKERS = [
+    ".claude/rules/use-the-design-library.md",
+    ".claude/rules/figma-design-system.md",
+    "docs/design-system/tokens.md",
+    "docs/design-system-rfc.md",
+]
+
+ATOM_BARREL_MARKERS = [
+    "components/atoms/index.ts",
+    "components/atoms/index.tsx",
+    "src/components/atoms/index.ts",
+    "src/components/atoms/index.tsx",
+]
+
+
+def find_project_root(path: str) -> Path:
+    """Find the nearest project root for marker detection."""
+    current = Path(path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in [current, *current.parents]:
+        if (candidate / "package.json").exists() or (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def has_design_system_eslint_rule(project_root: Path) -> bool:
+    """Detect project-owned design-system lint rules."""
+    eslint_files = [
+        ".eslintrc",
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.json",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+    ]
+
+    for eslint_file in eslint_files:
+        path = project_root / eslint_file
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "design-system" in content:
+            return True
+    return False
+
+
+def has_sealed_design_system(path: str) -> bool:
+    """Check whether this project has a closed local design-system seal."""
+    project_root = find_project_root(path)
+    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
+    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+
+    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+        return True
+    return has_design_system_eslint_rule(project_root)
+
+
 def should_skip_file(file_path: str) -> bool:
     """Check if file should be skipped."""
     for pattern in SKIP_PATTERNS:
@@ -269,6 +333,11 @@ def main():
     if not os.path.exists(path):
         print(f"❌ Path not found: {path}")
         sys.exit(1)
+
+    if has_sealed_design_system(path):
+        print("Sealed design system detected; deferring to the project's design-library rules.")
+        print("Skipping generic Gluestack NativeWind validation.")
+        sys.exit(0)
 
     print(f"🔍 Validating styling patterns in: {path}\n")
 

--- a/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
+++ b/plugins/src/expo/skills/gluestack-nativewind/scripts/validate_styling.py
@@ -19,6 +19,7 @@ Arguments:
             Can be a file or directory.
 """
 
+import json
 import os
 import re
 import sys
@@ -114,29 +115,45 @@ ATOM_BARREL_MARKERS = [
 ]
 
 
-def find_project_root(path: str) -> Path:
-    """Find the nearest project root for marker detection."""
+def find_project_roots(path: str) -> list[Path]:
+    """Find candidate roots for marker detection, from nearest to farthest.
+
+    Returns all package boundaries (package.json or .git directories) found
+    when walking up from ``path``.  In a monorepo this means both the inner
+    package root and the workspace root are returned, so seal markers stored at
+    the workspace level are not missed.
+    """
     current = Path(path).resolve()
     if current.is_file():
         current = current.parent
 
-    for candidate in [current, *current.parents]:
-        if (candidate / "package.json").exists() or (candidate / ".git").exists():
-            return candidate
-    return current
+    return [
+        candidate
+        for candidate in [current, *current.parents]
+        if (candidate / "package.json").exists() or (candidate / ".git").exists()
+    ] or [current]
 
 
 def has_design_system_eslint_rule(project_root: Path) -> bool:
-    """Detect project-owned design-system lint rules."""
+    """Detect project-owned design-system lint rules.
+
+    Only matches actual rule/plugin identifier syntax (``design-system/``) so
+    that comments, package names, or arbitrary strings containing
+    ``design-system`` as a substring do not trigger a false positive.
+    """
     eslint_files = [
         ".eslintrc",
         ".eslintrc.js",
         ".eslintrc.cjs",
+        ".eslintrc.yaml",
+        ".eslintrc.yml",
         ".eslintrc.json",
         "eslint.config.js",
         "eslint.config.mjs",
         "eslint.config.cjs",
         "eslint.config.ts",
+        "eslint.config.mts",
+        "eslint.config.cts",
     ]
 
     for eslint_file in eslint_files:
@@ -147,20 +164,44 @@ def has_design_system_eslint_rule(project_root: Path) -> bool:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
-        if "design-system" in content:
+        if re.search(r"\bdesign-system/", content):
             return True
+
+    # Check package.json eslintConfig field explicitly so that dependency
+    # names (e.g. "design-system" in dependencies) don't cause false positives.
+    package_json_path = project_root / "package.json"
+    if package_json_path.exists() and package_json_path.is_file():
+        try:
+            pkg = json.loads(package_json_path.read_text(encoding="utf-8"))
+            eslint_config = pkg.get("eslintConfig")
+            if eslint_config is not None:
+                eslint_config_str = json.dumps(eslint_config)
+                if re.search(r"\bdesign-system/", eslint_config_str):
+                    return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+
     return False
 
 
 def has_sealed_design_system(path: str) -> bool:
     """Check whether this project has a closed local design-system seal."""
-    project_root = find_project_root(path)
-    has_seal_marker = any((project_root / marker).exists() for marker in SEALED_DESIGN_SYSTEM_MARKERS)
-    has_atom_barrel = any((project_root / marker).exists() for marker in ATOM_BARREL_MARKERS)
+    project_roots = find_project_roots(path)
+    has_seal_marker = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in SEALED_DESIGN_SYSTEM_MARKERS
+    )
+    has_atom_barrel = any(
+        (root / marker).exists()
+        for root in project_roots
+        for marker in ATOM_BARREL_MARKERS
+    )
+    has_claude_rules = any((root / ".claude/rules").exists() for root in project_roots)
 
-    if has_seal_marker and (has_atom_barrel or (project_root / ".claude/rules").exists()):
+    if has_seal_marker and (has_atom_barrel or has_claude_rules):
         return True
-    return has_design_system_eslint_rule(project_root)
+    return any(has_design_system_eslint_rule(root) for root in project_roots)
 
 
 def should_skip_file(file_path: str) -> bool:


### PR DESCRIPTION
## Summary
- add sealed/closed design-system guards to the Expo Gluestack NativeWind and atomic-design skill docs
- make both validators defer when strong project seal markers are present instead of enforcing generic open-project rules
- regenerate lisa-expo plugin variants for Cursor, agy, and Copilot

Closes #1351

## Verification
- targeted sealed/open validator probes for gluestack-nativewind
- targeted sealed/open validator probes for atomic-design-gluestack
- bun run build:plugins
- bun run check:plugins
- push hook: security audit, eslint slow config, knip, vitest run --coverage, vitest run tests/integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Sealed Design System Guard” to Gluestack + Atomic Design skill documentation, directing reviews to defer when a project manages its own design-library rules.
  * Updated Gluestack NativeWind and Atomic Design validators to auto-skip generic checks when sealed design-system signals are detected.

* **Bug Fixes**
  * Prevents conflicting guidance by avoiding generic styling/atomic-structure recommendations in sealed projects.

* **Tests**
  * Added unit tests to verify sealed-design detection and correct ESLint/rule-marker matching across common config formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->