### PR TITLE
fix(hooks): link node_modules in agent worktrees

### DIFF
--- a/plugins/lisa-copilot/hooks/install-pkgs.sh
+++ b/plugins/lisa-copilot/hooks/install-pkgs.sh
@@ -2,9 +2,34 @@
 # This file is managed by Lisa.
 # Do not edit directly — changes will be overwritten on the next `lisa` run.
 
+link_primary_worktree_node_modules() {
+  [ -f "package.json" ] || return 1
+  [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$repo_root" in
+    */.claude/worktrees/*)
+      primary_root="${repo_root%%/.claude/worktrees/*}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ "$primary_root" != "$repo_root" ] || return 1
+  [ -d "$primary_root/node_modules" ] || return 1
+
+  ln -s "$primary_root/node_modules" "node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+}
+
 # Only run package installation when node_modules are missing.
 # This covers remote environments, new worktrees, fresh clones, and CI.
 if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+if link_primary_worktree_node_modules && [ -d "node_modules" ]; then
   exit 0
 fi
 

--- a/plugins/lisa-cursor/hooks/install-pkgs.sh
+++ b/plugins/lisa-cursor/hooks/install-pkgs.sh
@@ -2,9 +2,34 @@
 # This file is managed by Lisa.
 # Do not edit directly — changes will be overwritten on the next `lisa` run.
 
+link_primary_worktree_node_modules() {
+  [ -f "package.json" ] || return 1
+  [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$repo_root" in
+    */.claude/worktrees/*)
+      primary_root="${repo_root%%/.claude/worktrees/*}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ "$primary_root" != "$repo_root" ] || return 1
+  [ -d "$primary_root/node_modules" ] || return 1
+
+  ln -s "$primary_root/node_modules" "node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+}
+
 # Only run package installation when node_modules are missing.
 # This covers remote environments, new worktrees, fresh clones, and CI.
 if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+if link_primary_worktree_node_modules && [ -d "node_modules" ]; then
   exit 0
 fi
 

--- a/plugins/lisa/hooks/install-pkgs.sh
+++ b/plugins/lisa/hooks/install-pkgs.sh
@@ -2,9 +2,34 @@
 # This file is managed by Lisa.
 # Do not edit directly — changes will be overwritten on the next `lisa` run.
 
+link_primary_worktree_node_modules() {
+  [ -f "package.json" ] || return 1
+  [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$repo_root" in
+    */.claude/worktrees/*)
+      primary_root="${repo_root%%/.claude/worktrees/*}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ "$primary_root" != "$repo_root" ] || return 1
+  [ -d "$primary_root/node_modules" ] || return 1
+
+  ln -s "$primary_root/node_modules" "node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+}
+
 # Only run package installation when node_modules are missing.
 # This covers remote environments, new worktrees, fresh clones, and CI.
 if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+if link_primary_worktree_node_modules && [ -d "node_modules" ]; then
   exit 0
 fi
 

--- a/plugins/src/base/hooks/install-pkgs.sh
+++ b/plugins/src/base/hooks/install-pkgs.sh
@@ -2,9 +2,34 @@
 # This file is managed by Lisa.
 # Do not edit directly — changes will be overwritten on the next `lisa` run.
 
+link_primary_worktree_node_modules() {
+  [ -f "package.json" ] || return 1
+  [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$repo_root" in
+    */.claude/worktrees/*)
+      primary_root="${repo_root%%/.claude/worktrees/*}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ "$primary_root" != "$repo_root" ] || return 1
+  [ -d "$primary_root/node_modules" ] || return 1
+
+  ln -s "$primary_root/node_modules" "node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+}
+
 # Only run package installation when node_modules are missing.
 # This covers remote environments, new worktrees, fresh clones, and CI.
 if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+if link_primary_worktree_node_modules && [ -d "node_modules" ]; then
   exit 0
 fi
 

--- a/src/codex/scripts/install-pkgs.sh
+++ b/src/codex/scripts/install-pkgs.sh
@@ -7,7 +7,33 @@ set -uo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root" 2>/dev/null || exit 0
 
-if [ -d "node_modules" ] || [ ! -f "package.json" ]; then
+if [ ! -f "package.json" ]; then
+  exit 0
+fi
+
+link_primary_worktree_node_modules() {
+  [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
+
+  case "$repo_root" in
+    */.claude/worktrees/*)
+      primary_root="${repo_root%%/.claude/worktrees/*}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ "$primary_root" != "$repo_root" ] || return 1
+  [ -d "$primary_root/node_modules" ] || return 1
+
+  ln -s "$primary_root/node_modules" "node_modules"
+}
+
+if [ -d "node_modules" ]; then
+  exit 0
+fi
+
+if link_primary_worktree_node_modules && [ -d "node_modules" ]; then
   exit 0
 fi
 

--- a/src/opencode/plugin-templates/lisa-session-bootstrap.ts
+++ b/src/opencode/plugin-templates/lisa-session-bootstrap.ts
@@ -23,7 +23,7 @@ export const LisaSessionBootstrap = async ({
   worktree: string;
 }) => {
   const root = worktree;
-  const { existsSync, mkdirSync, readFileSync, writeFileSync } =
+  const { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } =
     await import("node:fs");
 
   // install-pkgs: bootstrap dependencies when they're missing.
@@ -32,16 +32,29 @@ export const LisaSessionBootstrap = async ({
       existsSync(`${root}/package.json`) &&
       !existsSync(`${root}/node_modules`)
     ) {
+      let linkedPrimaryNodeModules = false;
+      const marker = "/.claude/worktrees/";
+      if (root.includes(marker)) {
+        const primaryRoot = root.slice(0, root.indexOf(marker));
+        const primaryNodeModules = `${primaryRoot}/node_modules`;
+        if (primaryRoot && existsSync(primaryNodeModules)) {
+          symlinkSync(primaryNodeModules, `${root}/node_modules`);
+          linkedPrimaryNodeModules = true;
+        }
+      }
+
       const has = (f: string) => existsSync(`${root}/${f}`);
       const install = async (cmd: string) => {
         if (Bun.which(cmd)) {
           await $`${cmd} install`.cwd(root).quiet().nothrow();
         }
       };
-      if (has("bun.lockb") || has("bun.lock")) await install("bun");
-      else if (has("pnpm-lock.yaml")) await install("pnpm");
-      else if (has("yarn.lock")) await install("yarn");
-      else await install("npm");
+      if (!linkedPrimaryNodeModules) {
+        if (has("bun.lockb") || has("bun.lock")) await install("bun");
+        else if (has("pnpm-lock.yaml")) await install("pnpm");
+        else if (has("yarn.lock")) await install("yarn");
+        else await install("npm");
+      }
     }
   } catch {
     // fail open — never block startup on a dependency-install error

--- a/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
+++ b/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const ROOT = process.cwd();
+const CLAUDE_INSTALL_PKGS = path.join(
+  ROOT,
+  "plugins/src/base/hooks/install-pkgs.sh"
+);
+const CODEX_INSTALL_PKGS = path.join(ROOT, "src/codex/scripts/install-pkgs.sh");
+
+describe("install-pkgs worktree node_modules handoff", () => {
+  let tempDir: string;
+  let primaryRoot: string;
+  let worktreeRoot: string;
+  let fakeBin: string;
+  let installMarker: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    primaryRoot = path.join(tempDir, "project");
+    worktreeRoot = path.join(primaryRoot, ".claude", "worktrees", "feature");
+    fakeBin = path.join(tempDir, "bin");
+    installMarker = path.join(tempDir, "package-manager-ran");
+
+    await fs.ensureDir(path.join(primaryRoot, "node_modules", ".bin"));
+    await fs.ensureDir(worktreeRoot);
+    await fs.writeFile(
+      path.join(worktreeRoot, "package.json"),
+      '{"name":"fixture"}\n',
+      "utf8"
+    );
+    await fs.ensureDir(fakeBin);
+    await writeExecutable(
+      path.join(fakeBin, "git"),
+      '#!/usr/bin/env bash\nif [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then pwd; exit 0; fi\nexit 1\n'
+    );
+
+    for (const name of ["bun", "npm", "pnpm", "yarn"]) {
+      await writeExecutable(
+        path.join(fakeBin, name),
+        `#!/usr/bin/env bash\ntouch "${installMarker}"\nexit 42\n`
+      );
+    }
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it.each([
+    ["Claude/plugin", CLAUDE_INSTALL_PKGS],
+    ["Codex", CODEX_INSTALL_PKGS],
+  ])(
+    "%s hook links primary node_modules before installing",
+    (_name, script) => {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
+      execFileSync("bash", [script], {
+        cwd: worktreeRoot,
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+        stdio: "pipe",
+      });
+
+      expect(fs.realpathSync(path.join(worktreeRoot, "node_modules"))).toBe(
+        fs.realpathSync(path.join(primaryRoot, "node_modules"))
+      );
+      expect(fs.existsSync(installMarker)).toBe(false);
+    }
+  );
+});
+
+/**
+ * Write a small executable helper used by the shell-hook fixture.
+ *
+ * @param file - Destination file path.
+ * @param content - Complete script body.
+ */
+async function writeExecutable(file: string, content: string): Promise<void> {
+  await fs.writeFile(file, content, "utf8");
+  // eslint-disable-next-line sonarjs/file-permissions -- Fixture scripts need execute bits to behave like real CLIs.
+  await fs.chmod(file, 0o755);
+}


### PR DESCRIPTION
## Summary
- link `.claude/worktrees/*` checkouts to the primary checkout `node_modules` when present
- keep Claude/plugin, Codex, and OpenCode startup dependency bootstraps in parity
- add shell-hook coverage proving the symlink path avoids package-manager installs

## Verification
- `bun vitest run tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts tests/unit/codex/hooks-installer.test.ts`
- `bun run typecheck`
- `bun run check:plugins`
- push hook: security audit, slow lint, knip, `vitest run --coverage`, `vitest run tests/integration`

Closes #1350