### PR TITLE
fix(husky): run pre-push in Claude remote

### DIFF
--- a/.claude-pr/.husky/pre-push
+++ b/.claude-pr/.husky/pre-push
@@ -1,12 +1,5 @@
 # BEGIN: AI GUARDRAILS
 
-# Skip pre-push checks in Claude Code remote environment
-# These checks run in CI/CD anyway, and remote environments have limited resources
-if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
-  echo "ℹ️  Skipping pre-push checks (running in Claude Code remote environment)"
-  exit 0
-fi
-
 # Detect package manager (check if tool is available before using it)
 # Priority: bun > yarn > npm (bun first since package.json engines prefer it)
 if ([ -f "bun.lockb" ] || [ -f "bun.lock" ]) && command -v bun >/dev/null 2>&1; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,5 @@
 # BEGIN: AI GUARDRAILS
 
-# Skip pre-push checks in Claude Code remote environment
-# These checks run in CI/CD anyway, and remote environments have limited resources
-if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
-  echo "ℹ️  Skipping pre-push checks (running in Claude Code remote environment)"
-  exit 0
-fi
-
 # Detect package manager (check if tool is available before using it)
 # Priority: bun > yarn > npm (bun first since package.json engines prefer it)
 if ([ -f "bun.lockb" ] || [ -f "bun.lock" ]) && command -v bun >/dev/null 2>&1; then

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -1,12 +1,5 @@
 # BEGIN: AI GUARDRAILS
 
-# Skip pre-push checks in Claude Code remote environment
-# These checks run in CI/CD anyway, and remote environments have limited resources
-if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
-  echo "ℹ️  Skipping pre-push checks (running in Claude Code remote environment)"
-  exit 0
-fi
-
 # Detect package manager (check if tool is available before using it)
 # Priority: bun > yarn > npm (bun first since package.json engines prefer it)
 if ([ -f "bun.lockb" ] || [ -f "bun.lock" ]) && command -v bun >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove the blanket CLAUDE_CODE_REMOTE early exit from Lisa's own pre-push hook
- remove the same early exit from the lisa-typescript distributed hook template
- keep the .claude-pr pre-push surface aligned so remote PR routines run the same guardrails

Closes #1349

## Verification
- sh -n .husky/pre-push
- sh -n typescript/copy-contents/.husky/pre-push
- sh -n .claude-pr/.husky/pre-push
- bun run check:plugins
- bun run typecheck
- git diff --check
- rg -n "CLAUDE_CODE_REMOTE.*exit 0|Skipping pre-push checks|Claude Code remote environment" .husky typescript .claude-pr plugins/src plugins/lisa plugins/lisa-* -g '!node_modules' (no matches)
- git push pre-push hook: security audit, slow lint, knip, unit tests with coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-push checks now run consistently in remote development environments instead of being skipped.
  * Improved enforcement so audit, lint, and test steps are no longer bypassed before pushing changes.
* **Chores**
  * Updated the end-of-script guard marker placement to keep hook behavior aligned across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->