### PR TITLE
feat(verification): make verification (UAT) concrete and per-change enforced

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -465,6 +465,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -139,6 +139,11 @@ on:
         required: false
         default: ''
         type: string
+      verify_enforced:
+        description: 'Require per-change verification (UAT) coverage: a feat/fix PR must add or extend a verification (e2e) spec, unless labeled verification-exempt. Default false = inert (the verification_coverage job is skipped) so a project type without a drive mechanism is never wedged. A type opts in by passing true from its ci.yml.'
+        required: false
+        default: false
+        type: boolean
     secrets:
       SONAR_TOKEN:
         description: 'SonarCloud token for SAST analysis'
@@ -445,6 +450,33 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6144
         working-directory: ${{ inputs.working_directory || '.' }}
+
+  verification_coverage:
+    name: ✅ Verification Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Per-change verification (UAT) gate: a feat/fix must ship a verification
+    # (e2e) spec, unless labeled verification-exempt. Inert unless a project type
+    # opts in via verify_enforced, and only meaningful on pull_request (needs the
+    # base/head SHAs to diff). When skipped, GitHub reports success.
+    if: ${{ inputs.verify_enforced && github.event_name == 'pull_request' }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+      - name: ✅ Require a verification (e2e) spec delta on feat/fix
+        run: node scripts/check-verification-coverage.mjs
+        working-directory: ${{ inputs.working_directory || '.' }}
+        env:
+          VERIFY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/.prettierignore
+++ b/.prettierignore
@@ -33,3 +33,8 @@ coverage
 # stays formatted.
 plugins/lisa/**/openai.yaml
 plugins/lisa-*/**/openai.yaml
+
+# Committed verification (UAT) evidence is agent-written proof, not source —
+# never reformat it. Enforced project types add the same ignore to their own
+# .prettierignore alongside enabling verification.
+evidence/**

--- a/docs/design/uat-acceptance-verification-gate.md
+++ b/docs/design/uat-acceptance-verification-gate.md
@@ -1,0 +1,129 @@
+# Design: Making Verification Concrete (agent-played UAT)
+
+> Status: **Design / PRD — for review.** Implementation in progress (PR A).
+> Date: 2026-06-27 · Scope: Lisa base verification lifecycle + per-type drive
+> mechanisms (phaser first).
+
+## 0. Terminology (read first)
+
+**Verification IS UAT.** There is exactly one concept and one gate. "Use the
+software the way a user would, against the acceptance criteria" *is* User
+Acceptance Testing. This design does **not** add a parallel "UAT" gate, skill, or
+vocabulary — it makes the **existing** `verification` rule/flow more concrete.
+Where this doc says "UAT" it means verification.
+
+## 1. Problem & goal
+
+Lisa already has a strong verification spine: the `verification` eager rule
+("verification is using the software like a user; codify it; reviewer replay
+steps"), the non-bypassable `enforce-verification-gate.sh` Stop hook (blocks
+"done" until `.lisa/verification-status.json` shows every acceptance criterion
+`pass`), the `[EVIDENCE: name]` Per-Work-Unit Evidence Contract, and the
+`codify-verification` skill. What's missing is **concreteness + teeth**:
+
+- the codified verification isn't distinctly **required in CI** per type;
+- evidence isn't **committed to the repo**;
+- there's no **per-change** enforcement that a behavioral change shipped a
+  verification spec.
+
+**Goal:** nothing is "done" until an agent has actually exercised the running
+software against the acceptance criteria, the proof is **committed**, and it is
+**codified as a check CI re-runs** — with a **per-change** requirement.
+
+### Locked decisions (from review)
+- **Tier 1 + Tier 2:** a required CI verification check (must exist & pass) PLUS
+  the existing no-bypass lifecycle gate (agent playthrough + evidence).
+- **Per-change:** every `feat`/`fix` adds/extends a verification spec.
+- **Generalized** via a base contract + per-type drive mechanisms; **phaser
+  first**.
+- **Evidence committed** to `evidence/<ticket>/`.
+- **One concept:** verification == UAT (no separate skill/gate).
+- **`/lisa:product-walkthrough`** is the shared playthrough driver.
+- **`verification-exempt`** label (logged, never silent) for non-behavioral changes.
+
+## 2. Build on what exists — the delta only
+
+| Already in Lisa | This work adds |
+| --- | --- |
+| `verification` rule + reference | Concreteness: committed evidence, CI re-run, per-change requirement (all framed as verification) |
+| `enforce-verification-gate.sh` (Stop hook, verdict-gated) | Reused **as-is**; committed evidence + codified spec become preconditions of a `pass` verdict |
+| `[EVIDENCE: name]` manifest (tracker) | The named artifacts are **also committed** under `evidence/<ticket>/` |
+| `codify-verification` (Playwright/e2e) | Codified spec lands in `tests/e2e/**` and is the CI gate; writes committed evidence |
+| existing CI e2e/Playwright job | Made **required** for enforced types; + a new `verification-coverage` check |
+
+No new parallel rule. No `acceptance-uat` skill.
+
+## 3. Concrete mechanics
+
+1. **Codified proof re-runs in CI.** `codify-verification` puts the spec in
+   `tests/e2e/**`; the existing e2e/Playwright CI job runs it; for a type with
+   verification **enforced** it is a required check.
+2. **Committed evidence** at `evidence/<ticket>/`:
+   ```
+   evidence/<ticket>/
+     verdict.json   # criteria + per-criterion pass/fail + note, verdict, ticket,
+                    # commit, lisaVersion, agent, stampedAt (stamped, not generated mid-run)
+     state.json     # observed runtime state asserted against
+     screenshots/*.png   # downscaled, capped
+   ```
+   `evidence/**` ignored by lint/format/knip/coverage (proof, not source).
+3. **Per-change enforcement.** CI `verification-coverage` job runs
+   `scripts/check-verification-coverage.mjs`: a `feat`/`fix` with no
+   `tests/e2e/**` (or `tests/verification/**`) delta fails, unless it carries the
+   **logged** `verification-exempt` label.
+4. **Flag-gated rollout.** A `verify_enforced` workflow input (default `false`)
+   gates the CI teeth so types without a drive mechanism are never wedged.
+
+## 4. Per-type drive mechanism (not a new concept — just "how you exercise it")
+
+`/lisa:product-walkthrough` is the shared driver; each type supplies how it drives
+the running build:
+- **phaser** — Playwright + an in-game **verification test bridge** (env-guarded,
+  stripped from prod): seed RNG, read typed state, inject semantic input, step
+  frames; deterministic rendering (software GL, fixed `pixelArt`/`antialias`,
+  frozen frame) for stable screenshots.
+- **nestjs/cdk** — drive HTTP/integration against a running service.
+- **rails** — system/request specs. **expo** — Maestro / Playwright-web.
+
+## 5. The loop
+
+```
+/lisa:implement (or /lisa:verify)
+  ├─ /lisa:product-walkthrough drives the running build through the acceptance flow
+  ├─ judge each acceptance criterion vs the spec
+  ├─ write committed evidence/<ticket>/ (verdict + state + screenshots)
+  └─ codify-verification → tests/e2e/<ticket>.spec.ts (re-runs in CI)
+Gate: enforce-verification-gate.sh blocks "done" until the verdict passes
+CI: e2e/Playwright job (required when enforced) + verification-coverage (delta present)
+```
+
+## 6. Honest limits
+- **CI can't prove a spec covers *this* criterion** — only that *a* verification
+  spec changed. The semantic guarantee is Tier 2 (the agent's playthrough + the
+  committed verdict). By design.
+- **Local hooks are bypassable;** the required CI checks are the real teeth.
+- **Canvas verification flakes** without determinism — the bridge's seed/step +
+  software GL are mandatory.
+- **Committed screenshots add git weight** — mandate downscaled + capped PNGs;
+  `verdict.json`/`state.json` are the diffable record. Fallback if it bloats:
+  commit verdict+state, screenshots as CI artifacts.
+
+## 7. Rollout
+- **PR A (base):** extend `verification.md` (+reference) with the three concrete
+  mandates; extend `codify-verification`; `scripts/check-verification-coverage.mjs`
+  + a `verification-coverage` CI job behind `verify_enforced` (default off);
+  `evidence/**` ignores; tests; rebuild plugin artifacts. Existing types
+  unaffected (enforced off).
+- **PR B (phaser):** the in-game verification test bridge + structure/lint rule,
+  deterministic Playwright e2e config, `verify_enforced: true` in phaser's
+  `ci.yml`, phaser-specific guidance in the `phaser-testing` skill, template wiring.
+- **PR C+:** nestjs / rails / expo / cdk drive mechanisms, each flipping
+  `verify_enforced` on when ready.
+
+## 8. Implementation checklist (PR A)
+Extend `verification.md` eager (+reference "Making verification concrete (UAT)");
+extend `codify-verification`; `scripts/check-verification-coverage.mjs` (pure
+`evaluateVerificationCoverage` + CLI, `verification-exempt`); `quality.yml`
+`verification-coverage` job + `verify_enforced` input (default false);
+`evidence/**` ignored by eslint/prettier/knip/coverage; tests (coverage fn,
+workflow + rule wiring); rebuild plugin artifacts; gates; PR.

--- a/plugins/lisa-agy/skills/codify-verification/SKILL.md
+++ b/plugins/lisa-agy/skills/codify-verification/SKILL.md
@@ -88,6 +88,16 @@ For Playwright UI tests specifically:
 - Capture a trace or screenshot only if the project's existing tests do; do not invent a new artifact convention
 - Mirror the project's existing config for base URL, retries, and test isolation
 
+**Concrete verification (UAT) contract.** Verification *is* UAT — codifying it is
+how the playthrough becomes durable. For a runtime/behavioral `feat`/`fix`: place
+the codified test where the project's e2e/Playwright tests live (`tests/e2e/**`)
+so CI re-runs it, and commit the evidence artifact to `evidence/<ticket>/`
+(`verdict.json` + state + screenshots). For a Phaser game, drive the canvas
+through the in-game verification test bridge (seed RNG, read state, inject input,
+step frames) with deterministic rendering. CI's `verification-coverage` check
+requires a verification-spec delta on every behavioral change. See the
+`reference/verification.md` "Making verification concrete (UAT)" section.
+
 ### 4. Run the test in isolation
 
 Run only the new test, using whatever per-test invocation the project supports:

--- a/plugins/lisa-copilot/rules/eager/verification.md
+++ b/plugins/lisa-copilot/rules/eager/verification.md
@@ -4,12 +4,18 @@
 
 **Verification is using the resulting software the way a user would** — interacting with the UI, calling the API, running the CLI, observing behavior. Tests pass in isolation; verification proves the system works as a whole.
 
+**Verification IS UAT** (User Acceptance Testing) — the same single gate, not two concepts. "Use the software as a user, against the acceptance criteria" *is* UAT. Everything below makes that one process concrete: a committed evidence artifact, a codified check that re-runs in CI, and a per-change requirement.
+
 ## Mandatory
 
 - **Never claim success without runtime evidence.** "The code looks correct" is not evidence.
 - **If all you did was run tests, typecheck, and lint — you have NOT verified.**
 - **Before starting implementation, state your verification plan** — how you will USE the resulting software to prove it works. A plan that only lists `test`/`typecheck`/`lint` commands is not a plan. Do not begin until confirmed.
 - **After verifying empirically, codify it as a regression test** via the `codify-verification` skill — Playwright for UI, integration test for API/DB/auth, benchmark for performance. Codification is mandatory for every verification type except PR/Documentation/Deploy and Investigate-Only spikes.
+- **The codified proof re-runs in CI.** Codified runtime verification lives where the project's e2e/Playwright tests live (`tests/e2e/**`) and runs as a required CI check for types with verification enforced — so the proof re-runs on every PR, not once by hand.
+- **Commit the evidence.** Write a durable artifact to `evidence/<ticket>/` — the acceptance criteria with per-criterion pass/fail + note, the observed state, screenshots/recording, and a `verdict.json`. The transient `.lisa/verification-status.json` is the session gate; `evidence/<ticket>/` is the committed proof.
+- **Per-change verification is mandatory.** Every `feat`/`fix` adds or extends a verification (e2e) spec mapped to its acceptance criteria. The only exception is a genuinely non-behavioral change explicitly marked with the **logged** `verification-exempt` label — never a silent skip.
+- **Drive the playthrough with `/lisa:product-walkthrough`** (it walks the live product through a real browser); each project type plugs in its own drive mechanism (e.g. a Phaser game is driven through Playwright + an in-game verification test bridge that seeds RNG, reads state, injects input, and steps frames).
 - **Every PR must include reviewer replay steps** — the exact human steps to use the software and confirm the change works. Not test commands. If a reviewer can't reproduce from the PR description alone, the PR is incomplete.
 - **Exhaust credential sources before deferring runtime verification** — check project e2e / Playwright config and fixtures first, then `.lisa.config.local.json` / environment variables, then documented ticket credentials such as `Sign-in Required`.
 - **Never mark required runtime verification done on artifact-only evidence** — if credentials are genuinely unavailable after all sources are checked, post the blocker, transition the item to the configured blocked state, apply the configured `needs-human` / `human-review` label, and label the evidence as `artifact-only / verification deferred`.

--- a/plugins/lisa-copilot/rules/reference/verification.md
+++ b/plugins/lisa-copilot/rules/reference/verification.md
@@ -135,4 +135,51 @@ Evidence and summaries must explicitly distinguish `verified empirically` from `
 
 ---
 
+## Making verification concrete (UAT)
+
+Verification **is** UAT — one gate, not two. This section makes the single
+verification process concrete so "an agent actually exercised the running
+software against the acceptance criteria" is durable and re-checkable, not a
+one-off claim. It builds on the **Per-Work-Unit Evidence Contract** above (the
+`[EVIDENCE: name]` manifest), adding three concrete requirements:
+
+**1. The codified proof re-runs in CI.** After local verification passes,
+`codify-verification` encodes it where the project's e2e/Playwright tests live
+(`tests/e2e/**`). That suite runs in CI (the existing e2e/Playwright job); for a
+project type with verification **enforced**, it is a required check — so the proof
+re-runs on every PR instead of being proven once by hand.
+
+**2. Evidence is committed to the repo.** The named artifacts from the work
+unit's evidence manifest are committed under `evidence/<ticket>/` (in addition to
+any tracker attachment), so the proof lives with the code and is reviewable in the
+PR:
+
+```
+evidence/<ticket>/
+  verdict.json       # acceptance criteria + per-criterion pass/fail + note,
+                     # overall verdict, ticket, commit, lisaVersion, agent, stampedAt
+  state.json         # observed runtime state asserted against
+  screenshots/*.png  # downscaled, capped; key frames of the playthrough
+```
+
+`evidence/**` is ignored by lint/format/knip/coverage — it is proof, not source.
+
+**3. Per-change verification is enforced.** Every `feat`/`fix` adds or extends a
+verification (e2e) spec mapped to its acceptance criteria. CI's
+`verification-coverage` check requires that delta. The sole exception is a
+genuinely non-behavioral change carrying the **logged** `verification-exempt`
+label — the check prints why it was exempted; it is never a silent skip.
+
+**Playthrough driver.** `/lisa:product-walkthrough` is the shared driver (it walks
+the live product through a real browser). Each project type supplies its own drive
+mechanism: a Phaser game is driven through Playwright + an in-game verification
+test bridge (seed RNG, read state, inject semantic input, step frames); API types
+drive HTTP against a running service; etc.
+
+**Rollout.** Enforcement is per-type and flag-gated (the `verify_enforced`
+workflow input, default off) so a type without a drive mechanism is never wedged.
+Phaser is the first enforced type.
+
+---
+
 For the full verification lifecycle (classify, check tooling, plan, execute, loop), surfaces, escalation protocol, and proof artifact requirements, see the `verification-lifecycle` skill loaded by the `verification-specialist` agent.

--- a/plugins/lisa-copilot/skills/codify-verification/SKILL.md
+++ b/plugins/lisa-copilot/skills/codify-verification/SKILL.md
@@ -88,6 +88,16 @@ For Playwright UI tests specifically:
 - Capture a trace or screenshot only if the project's existing tests do; do not invent a new artifact convention
 - Mirror the project's existing config for base URL, retries, and test isolation
 
+**Concrete verification (UAT) contract.** Verification *is* UAT — codifying it is
+how the playthrough becomes durable. For a runtime/behavioral `feat`/`fix`: place
+the codified test where the project's e2e/Playwright tests live (`tests/e2e/**`)
+so CI re-runs it, and commit the evidence artifact to `evidence/<ticket>/`
+(`verdict.json` + state + screenshots). For a Phaser game, drive the canvas
+through the in-game verification test bridge (seed RNG, read state, inject input,
+step frames) with deterministic rendering. CI's `verification-coverage` check
+requires a verification-spec delta on every behavioral change. See the
+`reference/verification.md` "Making verification concrete (UAT)" section.
+
 ### 4. Run the test in isolation
 
 Run only the new test, using whatever per-test invocation the project supports:

--- a/plugins/lisa-cursor/rules/verification-reference.mdc
+++ b/plugins/lisa-cursor/rules/verification-reference.mdc
@@ -140,4 +140,51 @@ Evidence and summaries must explicitly distinguish `verified empirically` from `
 
 ---
 
+## Making verification concrete (UAT)
+
+Verification **is** UAT — one gate, not two. This section makes the single
+verification process concrete so "an agent actually exercised the running
+software against the acceptance criteria" is durable and re-checkable, not a
+one-off claim. It builds on the **Per-Work-Unit Evidence Contract** above (the
+`[EVIDENCE: name]` manifest), adding three concrete requirements:
+
+**1. The codified proof re-runs in CI.** After local verification passes,
+`codify-verification` encodes it where the project's e2e/Playwright tests live
+(`tests/e2e/**`). That suite runs in CI (the existing e2e/Playwright job); for a
+project type with verification **enforced**, it is a required check — so the proof
+re-runs on every PR instead of being proven once by hand.
+
+**2. Evidence is committed to the repo.** The named artifacts from the work
+unit's evidence manifest are committed under `evidence/<ticket>/` (in addition to
+any tracker attachment), so the proof lives with the code and is reviewable in the
+PR:
+
+```
+evidence/<ticket>/
+  verdict.json       # acceptance criteria + per-criterion pass/fail + note,
+                     # overall verdict, ticket, commit, lisaVersion, agent, stampedAt
+  state.json         # observed runtime state asserted against
+  screenshots/*.png  # downscaled, capped; key frames of the playthrough
+```
+
+`evidence/**` is ignored by lint/format/knip/coverage — it is proof, not source.
+
+**3. Per-change verification is enforced.** Every `feat`/`fix` adds or extends a
+verification (e2e) spec mapped to its acceptance criteria. CI's
+`verification-coverage` check requires that delta. The sole exception is a
+genuinely non-behavioral change carrying the **logged** `verification-exempt`
+label — the check prints why it was exempted; it is never a silent skip.
+
+**Playthrough driver.** `/lisa:product-walkthrough` is the shared driver (it walks
+the live product through a real browser). Each project type supplies its own drive
+mechanism: a Phaser game is driven through Playwright + an in-game verification
+test bridge (seed RNG, read state, inject semantic input, step frames); API types
+drive HTTP against a running service; etc.
+
+**Rollout.** Enforcement is per-type and flag-gated (the `verify_enforced`
+workflow input, default off) so a type without a drive mechanism is never wedged.
+Phaser is the first enforced type.
+
+---
+
 For the full verification lifecycle (classify, check tooling, plan, execute, loop), surfaces, escalation protocol, and proof artifact requirements, see the `verification-lifecycle` skill loaded by the `verification-specialist` agent.

--- a/plugins/lisa-cursor/rules/verification.mdc
+++ b/plugins/lisa-cursor/rules/verification.mdc
@@ -9,12 +9,18 @@ alwaysApply: true
 
 **Verification is using the resulting software the way a user would** — interacting with the UI, calling the API, running the CLI, observing behavior. Tests pass in isolation; verification proves the system works as a whole.
 
+**Verification IS UAT** (User Acceptance Testing) — the same single gate, not two concepts. "Use the software as a user, against the acceptance criteria" *is* UAT. Everything below makes that one process concrete: a committed evidence artifact, a codified check that re-runs in CI, and a per-change requirement.
+
 ## Mandatory
 
 - **Never claim success without runtime evidence.** "The code looks correct" is not evidence.
 - **If all you did was run tests, typecheck, and lint — you have NOT verified.**
 - **Before starting implementation, state your verification plan** — how you will USE the resulting software to prove it works. A plan that only lists `test`/`typecheck`/`lint` commands is not a plan. Do not begin until confirmed.
 - **After verifying empirically, codify it as a regression test** via the `codify-verification` skill — Playwright for UI, integration test for API/DB/auth, benchmark for performance. Codification is mandatory for every verification type except PR/Documentation/Deploy and Investigate-Only spikes.
+- **The codified proof re-runs in CI.** Codified runtime verification lives where the project's e2e/Playwright tests live (`tests/e2e/**`) and runs as a required CI check for types with verification enforced — so the proof re-runs on every PR, not once by hand.
+- **Commit the evidence.** Write a durable artifact to `evidence/<ticket>/` — the acceptance criteria with per-criterion pass/fail + note, the observed state, screenshots/recording, and a `verdict.json`. The transient `.lisa/verification-status.json` is the session gate; `evidence/<ticket>/` is the committed proof.
+- **Per-change verification is mandatory.** Every `feat`/`fix` adds or extends a verification (e2e) spec mapped to its acceptance criteria. The only exception is a genuinely non-behavioral change explicitly marked with the **logged** `verification-exempt` label — never a silent skip.
+- **Drive the playthrough with `/lisa:product-walkthrough`** (it walks the live product through a real browser); each project type plugs in its own drive mechanism (e.g. a Phaser game is driven through Playwright + an in-game verification test bridge that seeds RNG, reads state, injects input, and steps frames).
 - **Every PR must include reviewer replay steps** — the exact human steps to use the software and confirm the change works. Not test commands. If a reviewer can't reproduce from the PR description alone, the PR is incomplete.
 - **Exhaust credential sources before deferring runtime verification** — check project e2e / Playwright config and fixtures first, then `.lisa.config.local.json` / environment variables, then documented ticket credentials such as `Sign-in Required`.
 - **Never mark required runtime verification done on artifact-only evidence** — if credentials are genuinely unavailable after all sources are checked, post the blocker, transition the item to the configured blocked state, apply the configured `needs-human` / `human-review` label, and label the evidence as `artifact-only / verification deferred`.

--- a/plugins/lisa-cursor/skills/codify-verification/SKILL.md
+++ b/plugins/lisa-cursor/skills/codify-verification/SKILL.md
@@ -88,6 +88,16 @@ For Playwright UI tests specifically:
 - Capture a trace or screenshot only if the project's existing tests do; do not invent a new artifact convention
 - Mirror the project's existing config for base URL, retries, and test isolation
 
+**Concrete verification (UAT) contract.** Verification *is* UAT — codifying it is
+how the playthrough becomes durable. For a runtime/behavioral `feat`/`fix`: place
+the codified test where the project's e2e/Playwright tests live (`tests/e2e/**`)
+so CI re-runs it, and commit the evidence artifact to `evidence/<ticket>/`
+(`verdict.json` + state + screenshots). For a Phaser game, drive the canvas
+through the in-game verification test bridge (seed RNG, read state, inject input,
+step frames) with deterministic rendering. CI's `verification-coverage` check
+requires a verification-spec delta on every behavioral change. See the
+`reference/verification.md` "Making verification concrete (UAT)" section.
+
 ### 4. Run the test in isolation
 
 Run only the new test, using whatever per-test invocation the project supports:

--- a/plugins/lisa/rules/eager/verification.md
+++ b/plugins/lisa/rules/eager/verification.md
@@ -4,12 +4,18 @@
 
 **Verification is using the resulting software the way a user would** — interacting with the UI, calling the API, running the CLI, observing behavior. Tests pass in isolation; verification proves the system works as a whole.
 
+**Verification IS UAT** (User Acceptance Testing) — the same single gate, not two concepts. "Use the software as a user, against the acceptance criteria" *is* UAT. Everything below makes that one process concrete: a committed evidence artifact, a codified check that re-runs in CI, and a per-change requirement.
+
 ## Mandatory
 
 - **Never claim success without runtime evidence.** "The code looks correct" is not evidence.
 - **If all you did was run tests, typecheck, and lint — you have NOT verified.**
 - **Before starting implementation, state your verification plan** — how you will USE the resulting software to prove it works. A plan that only lists `test`/`typecheck`/`lint` commands is not a plan. Do not begin until confirmed.
 - **After verifying empirically, codify it as a regression test** via the `codify-verification` skill — Playwright for UI, integration test for API/DB/auth, benchmark for performance. Codification is mandatory for every verification type except PR/Documentation/Deploy and Investigate-Only spikes.
+- **The codified proof re-runs in CI.** Codified runtime verification lives where the project's e2e/Playwright tests live (`tests/e2e/**`) and runs as a required CI check for types with verification enforced — so the proof re-runs on every PR, not once by hand.
+- **Commit the evidence.** Write a durable artifact to `evidence/<ticket>/` — the acceptance criteria with per-criterion pass/fail + note, the observed state, screenshots/recording, and a `verdict.json`. The transient `.lisa/verification-status.json` is the session gate; `evidence/<ticket>/` is the committed proof.
+- **Per-change verification is mandatory.** Every `feat`/`fix` adds or extends a verification (e2e) spec mapped to its acceptance criteria. The only exception is a genuinely non-behavioral change explicitly marked with the **logged** `verification-exempt` label — never a silent skip.
+- **Drive the playthrough with `/lisa:product-walkthrough`** (it walks the live product through a real browser); each project type plugs in its own drive mechanism (e.g. a Phaser game is driven through Playwright + an in-game verification test bridge that seeds RNG, reads state, injects input, and steps frames).
 - **Every PR must include reviewer replay steps** — the exact human steps to use the software and confirm the change works. Not test commands. If a reviewer can't reproduce from the PR description alone, the PR is incomplete.
 - **Exhaust credential sources before deferring runtime verification** — check project e2e / Playwright config and fixtures first, then `.lisa.config.local.json` / environment variables, then documented ticket credentials such as `Sign-in Required`.
 - **Never mark required runtime verification done on artifact-only evidence** — if credentials are genuinely unavailable after all sources are checked, post the blocker, transition the item to the configured blocked state, apply the configured `needs-human` / `human-review` label, and label the evidence as `artifact-only / verification deferred`.

--- a/plugins/lisa/rules/reference/verification.md
+++ b/plugins/lisa/rules/reference/verification.md
@@ -135,4 +135,51 @@ Evidence and summaries must explicitly distinguish `verified empirically` from `
 
 ---
 
+## Making verification concrete (UAT)
+
+Verification **is** UAT — one gate, not two. This section makes the single
+verification process concrete so "an agent actually exercised the running
+software against the acceptance criteria" is durable and re-checkable, not a
+one-off claim. It builds on the **Per-Work-Unit Evidence Contract** above (the
+`[EVIDENCE: name]` manifest), adding three concrete requirements:
+
+**1. The codified proof re-runs in CI.** After local verification passes,
+`codify-verification` encodes it where the project's e2e/Playwright tests live
+(`tests/e2e/**`). That suite runs in CI (the existing e2e/Playwright job); for a
+project type with verification **enforced**, it is a required check — so the proof
+re-runs on every PR instead of being proven once by hand.
+
+**2. Evidence is committed to the repo.** The named artifacts from the work
+unit's evidence manifest are committed under `evidence/<ticket>/` (in addition to
+any tracker attachment), so the proof lives with the code and is reviewable in the
+PR:
+
+```
+evidence/<ticket>/
+  verdict.json       # acceptance criteria + per-criterion pass/fail + note,
+                     # overall verdict, ticket, commit, lisaVersion, agent, stampedAt
+  state.json         # observed runtime state asserted against
+  screenshots/*.png  # downscaled, capped; key frames of the playthrough
+```
+
+`evidence/**` is ignored by lint/format/knip/coverage — it is proof, not source.
+
+**3. Per-change verification is enforced.** Every `feat`/`fix` adds or extends a
+verification (e2e) spec mapped to its acceptance criteria. CI's
+`verification-coverage` check requires that delta. The sole exception is a
+genuinely non-behavioral change carrying the **logged** `verification-exempt`
+label — the check prints why it was exempted; it is never a silent skip.
+
+**Playthrough driver.** `/lisa:product-walkthrough` is the shared driver (it walks
+the live product through a real browser). Each project type supplies its own drive
+mechanism: a Phaser game is driven through Playwright + an in-game verification
+test bridge (seed RNG, read state, inject semantic input, step frames); API types
+drive HTTP against a running service; etc.
+
+**Rollout.** Enforcement is per-type and flag-gated (the `verify_enforced`
+workflow input, default off) so a type without a drive mechanism is never wedged.
+Phaser is the first enforced type.
+
+---
+
 For the full verification lifecycle (classify, check tooling, plan, execute, loop), surfaces, escalation protocol, and proof artifact requirements, see the `verification-lifecycle` skill loaded by the `verification-specialist` agent.

--- a/plugins/lisa/skills/codify-verification/SKILL.md
+++ b/plugins/lisa/skills/codify-verification/SKILL.md
@@ -88,6 +88,16 @@ For Playwright UI tests specifically:
 - Capture a trace or screenshot only if the project's existing tests do; do not invent a new artifact convention
 - Mirror the project's existing config for base URL, retries, and test isolation
 
+**Concrete verification (UAT) contract.** Verification *is* UAT — codifying it is
+how the playthrough becomes durable. For a runtime/behavioral `feat`/`fix`: place
+the codified test where the project's e2e/Playwright tests live (`tests/e2e/**`)
+so CI re-runs it, and commit the evidence artifact to `evidence/<ticket>/`
+(`verdict.json` + state + screenshots). For a Phaser game, drive the canvas
+through the in-game verification test bridge (seed RNG, read state, inject input,
+step frames) with deterministic rendering. CI's `verification-coverage` check
+requires a verification-spec delta on every behavioral change. See the
+`reference/verification.md` "Making verification concrete (UAT)" section.
+
 ### 4. Run the test in isolation
 
 Run only the new test, using whatever per-test invocation the project supports:

--- a/plugins/src/base/rules/eager/verification.md
+++ b/plugins/src/base/rules/eager/verification.md
@@ -4,12 +4,18 @@
 
 **Verification is using the resulting software the way a user would** — interacting with the UI, calling the API, running the CLI, observing behavior. Tests pass in isolation; verification proves the system works as a whole.
 
+**Verification IS UAT** (User Acceptance Testing) — the same single gate, not two concepts. "Use the software as a user, against the acceptance criteria" *is* UAT. Everything below makes that one process concrete: a committed evidence artifact, a codified check that re-runs in CI, and a per-change requirement.
+
 ## Mandatory
 
 - **Never claim success without runtime evidence.** "The code looks correct" is not evidence.
 - **If all you did was run tests, typecheck, and lint — you have NOT verified.**
 - **Before starting implementation, state your verification plan** — how you will USE the resulting software to prove it works. A plan that only lists `test`/`typecheck`/`lint` commands is not a plan. Do not begin until confirmed.
 - **After verifying empirically, codify it as a regression test** via the `codify-verification` skill — Playwright for UI, integration test for API/DB/auth, benchmark for performance. Codification is mandatory for every verification type except PR/Documentation/Deploy and Investigate-Only spikes.
+- **The codified proof re-runs in CI.** Codified runtime verification lives where the project's e2e/Playwright tests live (`tests/e2e/**`) and runs as a required CI check for types with verification enforced — so the proof re-runs on every PR, not once by hand.
+- **Commit the evidence.** Write a durable artifact to `evidence/<ticket>/` — the acceptance criteria with per-criterion pass/fail + note, the observed state, screenshots/recording, and a `verdict.json`. The transient `.lisa/verification-status.json` is the session gate; `evidence/<ticket>/` is the committed proof.
+- **Per-change verification is mandatory.** Every `feat`/`fix` adds or extends a verification (e2e) spec mapped to its acceptance criteria. The only exception is a genuinely non-behavioral change explicitly marked with the **logged** `verification-exempt` label — never a silent skip.
+- **Drive the playthrough with `/lisa:product-walkthrough`** (it walks the live product through a real browser); each project type plugs in its own drive mechanism (e.g. a Phaser game is driven through Playwright + an in-game verification test bridge that seeds RNG, reads state, injects input, and steps frames).
 - **Every PR must include reviewer replay steps** — the exact human steps to use the software and confirm the change works. Not test commands. If a reviewer can't reproduce from the PR description alone, the PR is incomplete.
 - **Exhaust credential sources before deferring runtime verification** — check project e2e / Playwright config and fixtures first, then `.lisa.config.local.json` / environment variables, then documented ticket credentials such as `Sign-in Required`.
 - **Never mark required runtime verification done on artifact-only evidence** — if credentials are genuinely unavailable after all sources are checked, post the blocker, transition the item to the configured blocked state, apply the configured `needs-human` / `human-review` label, and label the evidence as `artifact-only / verification deferred`.

--- a/plugins/src/base/rules/reference/verification.md
+++ b/plugins/src/base/rules/reference/verification.md
@@ -135,4 +135,51 @@ Evidence and summaries must explicitly distinguish `verified empirically` from `
 
 ---
 
+## Making verification concrete (UAT)
+
+Verification **is** UAT — one gate, not two. This section makes the single
+verification process concrete so "an agent actually exercised the running
+software against the acceptance criteria" is durable and re-checkable, not a
+one-off claim. It builds on the **Per-Work-Unit Evidence Contract** above (the
+`[EVIDENCE: name]` manifest), adding three concrete requirements:
+
+**1. The codified proof re-runs in CI.** After local verification passes,
+`codify-verification` encodes it where the project's e2e/Playwright tests live
+(`tests/e2e/**`). That suite runs in CI (the existing e2e/Playwright job); for a
+project type with verification **enforced**, it is a required check — so the proof
+re-runs on every PR instead of being proven once by hand.
+
+**2. Evidence is committed to the repo.** The named artifacts from the work
+unit's evidence manifest are committed under `evidence/<ticket>/` (in addition to
+any tracker attachment), so the proof lives with the code and is reviewable in the
+PR:
+
+```
+evidence/<ticket>/
+  verdict.json       # acceptance criteria + per-criterion pass/fail + note,
+                     # overall verdict, ticket, commit, lisaVersion, agent, stampedAt
+  state.json         # observed runtime state asserted against
+  screenshots/*.png  # downscaled, capped; key frames of the playthrough
+```
+
+`evidence/**` is ignored by lint/format/knip/coverage — it is proof, not source.
+
+**3. Per-change verification is enforced.** Every `feat`/`fix` adds or extends a
+verification (e2e) spec mapped to its acceptance criteria. CI's
+`verification-coverage` check requires that delta. The sole exception is a
+genuinely non-behavioral change carrying the **logged** `verification-exempt`
+label — the check prints why it was exempted; it is never a silent skip.
+
+**Playthrough driver.** `/lisa:product-walkthrough` is the shared driver (it walks
+the live product through a real browser). Each project type supplies its own drive
+mechanism: a Phaser game is driven through Playwright + an in-game verification
+test bridge (seed RNG, read state, inject semantic input, step frames); API types
+drive HTTP against a running service; etc.
+
+**Rollout.** Enforcement is per-type and flag-gated (the `verify_enforced`
+workflow input, default off) so a type without a drive mechanism is never wedged.
+Phaser is the first enforced type.
+
+---
+
 For the full verification lifecycle (classify, check tooling, plan, execute, loop), surfaces, escalation protocol, and proof artifact requirements, see the `verification-lifecycle` skill loaded by the `verification-specialist` agent.

--- a/plugins/src/base/skills/codify-verification/SKILL.md
+++ b/plugins/src/base/skills/codify-verification/SKILL.md
@@ -88,6 +88,16 @@ For Playwright UI tests specifically:
 - Capture a trace or screenshot only if the project's existing tests do; do not invent a new artifact convention
 - Mirror the project's existing config for base URL, retries, and test isolation
 
+**Concrete verification (UAT) contract.** Verification *is* UAT — codifying it is
+how the playthrough becomes durable. For a runtime/behavioral `feat`/`fix`: place
+the codified test where the project's e2e/Playwright tests live (`tests/e2e/**`)
+so CI re-runs it, and commit the evidence artifact to `evidence/<ticket>/`
+(`verdict.json` + state + screenshots). For a Phaser game, drive the canvas
+through the in-game verification test bridge (seed RNG, read state, inject input,
+step frames) with deterministic rendering. CI's `verification-coverage` check
+requires a verification-spec delta on every behavioral change. See the
+`reference/verification.md` "Making verification concrete (UAT)" section.
+
 ### 4. Run the test in isolation
 
 Run only the new test, using whatever per-test invocation the project supports:

--- a/tests/unit/scripts/verification-coverage.test.ts
+++ b/tests/unit/scripts/verification-coverage.test.ts
@@ -84,6 +84,15 @@ describe("check-verification-coverage", () => {
     expect(r.ok).toBe(false);
   });
 
+  it("does not count an arbitrary path that merely contains an e2e segment", () => {
+    const r = evaluate({
+      changedFiles: [GAME_SCENE, "src/e2e/helpers.ts"],
+      changeTypes: ["feat"],
+      labels: [],
+    });
+    expect(r.ok).toBe(false);
+  });
+
   it("allows a behavioral change with the logged verification-exempt label", () => {
     const r = evaluate({
       changedFiles: [GAME_SCENE],

--- a/tests/unit/scripts/verification-coverage.test.ts
+++ b/tests/unit/scripts/verification-coverage.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the per-change verification (UAT) coverage gate and its wiring.
+ * Verification IS UAT — one concept; this guards the concrete enforcement layer.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT_REL =
+  "typescript/copy-overwrite/scripts/check-verification-coverage.mjs";
+const GAME_SCENE = "src/game/scenes/Game.ts";
+
+/**
+ * Read a repo-relative text file.
+ * @param relativePath - Repo-relative path
+ * @returns File contents
+ */
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+/** Input to the pure coverage evaluator. */
+interface CoverageInput {
+  readonly changedFiles: string[];
+  readonly changeTypes: string[];
+  readonly labels: string[];
+}
+/** Verdict from the pure coverage evaluator. */
+interface CoverageResult {
+  readonly required: boolean;
+  readonly ok: boolean;
+  readonly exempt?: boolean;
+  readonly reason: string;
+}
+
+describe("check-verification-coverage", () => {
+  // Dynamic import via a runtime URL keeps this typed as `any` (no .mjs decls).
+  let evaluate: (input: CoverageInput) => CoverageResult;
+
+  beforeAll(async () => {
+    const url = pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href;
+    const mod = await import(url);
+    evaluate = mod.evaluateVerificationCoverage;
+  });
+
+  it("does not require a delta for non-behavioral changes", () => {
+    const r = evaluate({
+      changedFiles: ["src/foo.ts"],
+      changeTypes: ["chore", "docs"],
+      labels: [],
+    });
+    expect(r.required).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  it("passes a feat that ships a tests/e2e spec", () => {
+    const r = evaluate({
+      changedFiles: [GAME_SCENE, "tests/e2e/game.spec.ts"],
+      changeTypes: ["feat"],
+      labels: [],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.exempt).toBeUndefined();
+  });
+
+  it("passes a fix that ships a tests/verification spec", () => {
+    const r = evaluate({
+      changedFiles: ["src/logic/score.ts", "tests/verification/score.spec.ts"],
+      changeTypes: ["fix"],
+      labels: [],
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("fails a feat with no verification delta and no exempt label", () => {
+    const r = evaluate({
+      changedFiles: [GAME_SCENE],
+      changeTypes: ["feat"],
+      labels: [],
+    });
+    expect(r.required).toBe(true);
+    expect(r.ok).toBe(false);
+  });
+
+  it("allows a behavioral change with the logged verification-exempt label", () => {
+    const r = evaluate({
+      changedFiles: [GAME_SCENE],
+      changeTypes: ["fix"],
+      labels: ["verification-exempt"],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.exempt).toBe(true);
+  });
+});
+
+describe("verification (UAT) gate wiring", () => {
+  it("frames verification AS UAT (one concept) in the eager rule", () => {
+    const rule = read("plugins/src/base/rules/eager/verification.md");
+    expect(rule).toContain("Verification IS UAT");
+    expect(rule).toContain("evidence/<ticket>/");
+    expect(rule).toContain("verification-exempt");
+    expect(rule).toContain("product-walkthrough");
+    // No parallel "acceptance-uat" skill should be referenced.
+    expect(rule).not.toContain("acceptance-uat");
+  });
+
+  it("does not ship a parallel acceptance-uat skill", () => {
+    expect(
+      fs.existsSync(
+        path.join(REPO_ROOT, "plugins/src/base/skills/acceptance-uat")
+      )
+    ).toBe(false);
+  });
+
+  it("wires the verification_coverage CI job behind verify_enforced", () => {
+    const wf = read(".github/workflows/quality.yml");
+    expect(wf).toContain("verify_enforced");
+    expect(wf).toContain("verification_coverage");
+    expect(wf).toContain("check-verification-coverage.mjs");
+  });
+
+  it("ships the coverage script as a managed downstream script", () => {
+    expect(fs.existsSync(path.join(REPO_ROOT, SCRIPT_REL))).toBe(true);
+  });
+
+  it("ignores committed evidence from prettier", () => {
+    expect(read(".prettierignore")).toContain("evidence/**");
+  });
+});

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * check-verification-coverage — per-change verification (UAT) gate.
+ *
+ * Verification IS UAT — one gate, not two. This fails a feat/fix change that
+ * ships no verification-spec delta (the project's e2e/Playwright tests, where
+ * `codify-verification` lands the codified playthrough), so every behavioral
+ * change carries an acceptance test an agent's verification produced. A genuinely
+ * non-behavioral change may carry the `verification-exempt` label, which this
+ * check honors but LOGS (never a silent skip).
+ *
+ * Inputs (all via env, CI-friendly):
+ *   VERIFY_BASE_SHA      diff base (else falls back to `origin/<VERIFY_BASE_REF|main>...HEAD`)
+ *   VERIFY_HEAD_SHA      diff head (default HEAD)
+ *   VERIFY_BASE_REF      base branch for the fallback range (default main)
+ *   VERIFY_CHANGE_TYPES  comma list of conventional-commit types in the change
+ *                        (e.g. "feat,chore"); if empty, derived from commit subjects
+ *   VERIFY_LABELS        comma list of PR labels (for `verification-exempt`)
+ *
+ * Exit 0 = satisfied / exempt / not-required. Exit 1 = required but missing.
+ * @module scripts/check-verification-coverage
+ */
+import { execSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const BEHAVIORAL_TYPES = new Set(["feat", "fix"]);
+const EXEMPT_LABEL = "verification-exempt";
+// A verification spec = the project's e2e/Playwright tests (where codified
+// verification lives), or a dedicated tests/verification tree.
+const VERIFICATION_PATH = /(^|\/)e2e\/|(^|\/)tests\/verification\//;
+
+/**
+ * Pure decision: is a verification-spec delta required, and is it satisfied?
+ * @param {object} input - Evaluation input
+ * @param {string[]} input.changedFiles - Paths changed in the range
+ * @param {string[]} input.changeTypes - Conventional-commit types present
+ * @param {string[]} input.labels - PR labels
+ * @returns {{required: boolean, ok: boolean, exempt?: boolean, reason: string}} Verdict
+ */
+export function evaluateVerificationCoverage({
+  changedFiles,
+  changeTypes,
+  labels,
+}) {
+  const isBehavioral = changeTypes.some(type => BEHAVIORAL_TYPES.has(type));
+  const isExempt = labels.includes(EXEMPT_LABEL);
+  const hasDelta = changedFiles.some(file => VERIFICATION_PATH.test(file));
+
+  if (!isBehavioral) {
+    return {
+      required: false,
+      ok: true,
+      reason: "No feat/fix change — a verification-spec delta is not required.",
+    };
+  }
+  if (isExempt) {
+    return {
+      required: true,
+      ok: true,
+      exempt: true,
+      reason: `Behavioral change exempted by the '${EXEMPT_LABEL}' label.`,
+    };
+  }
+  if (hasDelta) {
+    return {
+      required: true,
+      ok: true,
+      reason: "Behavioral change ships a verification (e2e) spec delta.",
+    };
+  }
+  return {
+    required: true,
+    ok: false,
+    reason: `Behavioral change (feat/fix) ships NO verification (e2e) spec and is not labeled '${EXEMPT_LABEL}'.`,
+  };
+}
+
+/**
+ * Gather the change context from git + env.
+ * @returns {{changedFiles: string[], changeTypes: string[], labels: string[]}} Context
+ */
+function gatherContext() {
+  const head = process.env.VERIFY_HEAD_SHA || "HEAD";
+  const baseRef = process.env.VERIFY_BASE_REF || "main";
+  const range = process.env.VERIFY_BASE_SHA
+    ? `${process.env.VERIFY_BASE_SHA} ${head}`
+    : `origin/${baseRef}...HEAD`;
+
+  const runGit = (cmd, fallback) => {
+    try {
+      return execSync(cmd, { encoding: "utf8" });
+    } catch {
+      return fallback;
+    }
+  };
+
+  const changedFiles = runGit(`git diff --name-only ${range}`, "")
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  const fromEnv = (process.env.VERIFY_CHANGE_TYPES || "")
+    .split(",")
+    .map(value => value.trim().toLowerCase())
+    .filter(Boolean);
+  const fromCommits = fromEnv.length
+    ? []
+    : runGit(`git log --format=%s ${range.replace("...", "..")}`, "")
+        .split("\n")
+        .map(subject => {
+          const match = subject.match(/^(\w+)[(!:]/);
+          return match ? match[1].toLowerCase() : null;
+        })
+        .filter(Boolean);
+  const changeTypes = [...new Set([...fromEnv, ...fromCommits])];
+
+  const labels = (process.env.VERIFY_LABELS || "")
+    .split(",")
+    .map(value => value.trim())
+    .filter(Boolean);
+
+  return { changedFiles, changeTypes, labels };
+}
+
+/**
+ * CLI entry: evaluate and exit non-zero when a required verification delta is missing.
+ * @returns {void}
+ */
+function main() {
+  const context = gatherContext();
+  const result = evaluateVerificationCoverage(context);
+  console.log(
+    `[verification-coverage] types=[${context.changeTypes.join(
+      ","
+    )}] labels=[${context.labels.join(",")}]`
+  );
+  console.log(`[verification-coverage] ${result.reason}`);
+  if (result.exempt) {
+    console.log(
+      "[verification-coverage] EXEMPT (logged): proceeding without a verification delta for a declared non-behavioral change."
+    );
+  }
+  if (!result.ok) {
+    console.error(`[verification-coverage] FAIL: ${result.reason}`);
+    process.exit(1);
+  }
+  console.log("[verification-coverage] OK");
+}
+
+// Run only when invoked directly — importing for tests must have no side effects.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -25,9 +25,10 @@ import { pathToFileURL } from "node:url";
 
 const BEHAVIORAL_TYPES = new Set(["feat", "fix"]);
 const EXEMPT_LABEL = "verification-exempt";
-// A verification spec = the project's e2e/Playwright tests (where codified
-// verification lives), or a dedicated tests/verification tree.
-const VERIFICATION_PATH = /(^|\/)e2e\/|(^|\/)tests\/verification\//;
+// A verification spec lives in a top-level e2e/ dir, a nested tests/e2e/ tree,
+// or a tests/verification/ tree — NOT an arbitrary path that merely contains an
+// "e2e" segment (e.g. src/e2e/helpers.ts must not satisfy the gate).
+const VERIFICATION_PATH = /^e2e\/|(^|\/)tests\/(e2e|verification)\//;
 
 /**
  * Pure decision: is a verification-spec delta required, and is it satisfied?
@@ -82,9 +83,11 @@ export function evaluateVerificationCoverage({
 function gatherContext() {
   const head = process.env.VERIFY_HEAD_SHA || "HEAD";
   const baseRef = process.env.VERIFY_BASE_REF || "main";
-  const range = process.env.VERIFY_BASE_SHA
-    ? `${process.env.VERIFY_BASE_SHA} ${head}`
-    : `origin/${baseRef}...HEAD`;
+  const base = process.env.VERIFY_BASE_SHA || `origin/${baseRef}`;
+  // Three-dot diff = the PR's "files changed" (merge-base), matching GitHub.
+  // Two-dot log = the commits the PR introduces (not both tips).
+  const diffRange = `${base}...${head}`;
+  const logRange = `${base}..${head}`;
 
   const runGit = (cmd, fallback) => {
     try {
@@ -94,7 +97,7 @@ function gatherContext() {
     }
   };
 
-  const changedFiles = runGit(`git diff --name-only ${range}`, "")
+  const changedFiles = runGit(`git diff --name-only ${diffRange}`, "")
     .split("\n")
     .map(line => line.trim())
     .filter(Boolean);
@@ -105,7 +108,7 @@ function gatherContext() {
     .filter(Boolean);
   const fromCommits = fromEnv.length
     ? []
-    : runGit(`git log --format=%s ${range.replace("...", "..")}`, "")
+    : runGit(`git log --format=%s ${logRange}`, "")
         .split("\n")
         .map(subject => {
           const match = subject.match(/^(\w+)[(!:]/);


### PR DESCRIPTION
## Context
Per design `docs/design/uat-acceptance-verification-gate.md`. **Verification IS UAT — one gate, not two.** This does NOT add a parallel "UAT" concept/skill; it makes the *existing* verification lifecycle concrete and gives it teeth.

## What it builds on (unchanged)
`verification.md` rule, the non-bypassable `enforce-verification-gate.sh` Stop hook, the `[EVIDENCE: name]` Per-Work-Unit Evidence Contract, and `codify-verification`.

## The delta
- **`verification.md` eager rule (+reference):** states plainly "Verification IS UAT," then adds three concrete mandates — (1) the codified proof **re-runs in CI** (`tests/e2e/**`); (2) evidence is **committed** to `evidence/<ticket>/`; (3) every `feat`/`fix` ships a **verification spec** (with a *logged* `verification-exempt` escape hatch). `/lisa:product-walkthrough` is the shared playthrough driver.
- **`codify-verification` skill:** codified runtime verification lands in `tests/e2e/**` and writes the committed evidence artifact.
- **`scripts/check-verification-coverage.mjs`** (shipped via `typescript/copy-overwrite`, zero deps): per-change gate with a pure, unit-tested `evaluateVerificationCoverage`.
- **`quality.yml`:** new `verification_coverage` job behind a **`verify_enforced` input (default `false`)** — skipped/inert for every existing type; a type opts in from its `ci.yml`.
- **`.prettierignore`:** `evidence/**` is committed proof, never reformatted.

## Rollout safety
`verify_enforced` defaults off, so **no existing project type is wedged**. Phaser opts in (with its Playwright + in-game verification bridge) in the follow-up adapter PR; other types follow.

## Verification
typecheck, full lint, format, ast-grep, knip, `check:plugins`, `check:rules-pairing`, 3482 unit tests pass locally; the new evaluator + wiring guards are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-change verification coverage check for behavioral updates, with an optional enforcement flag in CI.
  * Introduced support for committed verification evidence and clearer handling for exempt non-behavioral changes.

* **Documentation**
  * Expanded verification guidance to define the new acceptance-testing workflow and where verification artifacts should live.

* **Chores**
  * Updated formatting rules to skip verification evidence files and related generated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->