### PR TITLE
feat(phaser): bundler module resolution + Vite 8 idioms

### DIFF
--- a/phaser/create-only/tsconfig.local.json
+++ b/phaser/create-only/tsconfig.local.json
@@ -1,0 +1,4 @@
+{
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "coverage"]
+}

--- a/plugins/lisa-phaser-agy/skills/phaser-build-deploy/SKILL.md
+++ b/plugins/lisa-phaser-agy/skills/phaser-build-deploy/SKILL.md
@@ -31,7 +31,10 @@ export default defineConfig({
     terserOptions: { compress: { passes: 2, drop_console: true }, format: { comments: false } },
     rollupOptions: {
       output: {
-        manualChunks: { phaser: ["phaser"] },          // engine in its own long-lived chunk
+        // Vite 8's rolldown bundler requires the FUNCTION form (the object form
+        // `{ phaser: ["phaser"] }` throws "manualChunks is not a function").
+        manualChunks: id =>
+          id.includes("node_modules/phaser") ? "phaser" : undefined,
         entryFileNames: "assets/[name]-[hash].js",      // content hash on everything
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash][extname]",
@@ -41,9 +44,11 @@ export default defineConfig({
 });
 ```
 
-`manualChunks: { phaser: ["phaser"] }` is the single highest-value line: Phaser is
-hundreds of KB and rarely changes, so isolating it means a gameplay tweak only
-busts the small app chunk. Two-pass terser squeezes meaningfully more than one.
+The `manualChunks` function is the single highest-value line: Phaser is hundreds
+of KB and rarely changes, so isolating it means a gameplay tweak only busts the
+small app chunk. Use the **function** form — Vite 8 ships the rolldown bundler,
+which requires it (the classic object form throws `manualChunks is not a
+function`). Two-pass terser squeezes meaningfully more than one.
 
 ## Asset hashing and immutable caching
 

--- a/plugins/lisa-phaser-copilot/skills/phaser-build-deploy/SKILL.md
+++ b/plugins/lisa-phaser-copilot/skills/phaser-build-deploy/SKILL.md
@@ -31,7 +31,10 @@ export default defineConfig({
     terserOptions: { compress: { passes: 2, drop_console: true }, format: { comments: false } },
     rollupOptions: {
       output: {
-        manualChunks: { phaser: ["phaser"] },          // engine in its own long-lived chunk
+        // Vite 8's rolldown bundler requires the FUNCTION form (the object form
+        // `{ phaser: ["phaser"] }` throws "manualChunks is not a function").
+        manualChunks: id =>
+          id.includes("node_modules/phaser") ? "phaser" : undefined,
         entryFileNames: "assets/[name]-[hash].js",      // content hash on everything
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash][extname]",
@@ -41,9 +44,11 @@ export default defineConfig({
 });
 ```
 
-`manualChunks: { phaser: ["phaser"] }` is the single highest-value line: Phaser is
-hundreds of KB and rarely changes, so isolating it means a gameplay tweak only
-busts the small app chunk. Two-pass terser squeezes meaningfully more than one.
+The `manualChunks` function is the single highest-value line: Phaser is hundreds
+of KB and rarely changes, so isolating it means a gameplay tweak only busts the
+small app chunk. Use the **function** form — Vite 8 ships the rolldown bundler,
+which requires it (the classic object form throws `manualChunks is not a
+function`). Two-pass terser squeezes meaningfully more than one.
 
 ## Asset hashing and immutable caching
 

--- a/plugins/lisa-phaser-cursor/skills/phaser-build-deploy/SKILL.md
+++ b/plugins/lisa-phaser-cursor/skills/phaser-build-deploy/SKILL.md
@@ -31,7 +31,10 @@ export default defineConfig({
     terserOptions: { compress: { passes: 2, drop_console: true }, format: { comments: false } },
     rollupOptions: {
       output: {
-        manualChunks: { phaser: ["phaser"] },          // engine in its own long-lived chunk
+        // Vite 8's rolldown bundler requires the FUNCTION form (the object form
+        // `{ phaser: ["phaser"] }` throws "manualChunks is not a function").
+        manualChunks: id =>
+          id.includes("node_modules/phaser") ? "phaser" : undefined,
         entryFileNames: "assets/[name]-[hash].js",      // content hash on everything
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash][extname]",
@@ -41,9 +44,11 @@ export default defineConfig({
 });
 ```
 
-`manualChunks: { phaser: ["phaser"] }` is the single highest-value line: Phaser is
-hundreds of KB and rarely changes, so isolating it means a gameplay tweak only
-busts the small app chunk. Two-pass terser squeezes meaningfully more than one.
+The `manualChunks` function is the single highest-value line: Phaser is hundreds
+of KB and rarely changes, so isolating it means a gameplay tweak only busts the
+small app chunk. Use the **function** form — Vite 8 ships the rolldown bundler,
+which requires it (the classic object form throws `manualChunks is not a
+function`). Two-pass terser squeezes meaningfully more than one.
 
 ## Asset hashing and immutable caching
 

--- a/plugins/lisa-phaser/skills/phaser-build-deploy/SKILL.md
+++ b/plugins/lisa-phaser/skills/phaser-build-deploy/SKILL.md
@@ -31,7 +31,10 @@ export default defineConfig({
     terserOptions: { compress: { passes: 2, drop_console: true }, format: { comments: false } },
     rollupOptions: {
       output: {
-        manualChunks: { phaser: ["phaser"] },          // engine in its own long-lived chunk
+        // Vite 8's rolldown bundler requires the FUNCTION form (the object form
+        // `{ phaser: ["phaser"] }` throws "manualChunks is not a function").
+        manualChunks: id =>
+          id.includes("node_modules/phaser") ? "phaser" : undefined,
         entryFileNames: "assets/[name]-[hash].js",      // content hash on everything
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash][extname]",
@@ -41,9 +44,11 @@ export default defineConfig({
 });
 ```
 
-`manualChunks: { phaser: ["phaser"] }` is the single highest-value line: Phaser is
-hundreds of KB and rarely changes, so isolating it means a gameplay tweak only
-busts the small app chunk. Two-pass terser squeezes meaningfully more than one.
+The `manualChunks` function is the single highest-value line: Phaser is hundreds
+of KB and rarely changes, so isolating it means a gameplay tweak only busts the
+small app chunk. Use the **function** form — Vite 8 ships the rolldown bundler,
+which requires it (the classic object form throws `manualChunks is not a
+function`). Two-pass terser squeezes meaningfully more than one.
 
 ## Asset hashing and immutable caching
 

--- a/plugins/src/phaser/skills/phaser-build-deploy/SKILL.md
+++ b/plugins/src/phaser/skills/phaser-build-deploy/SKILL.md
@@ -31,7 +31,10 @@ export default defineConfig({
     terserOptions: { compress: { passes: 2, drop_console: true }, format: { comments: false } },
     rollupOptions: {
       output: {
-        manualChunks: { phaser: ["phaser"] },          // engine in its own long-lived chunk
+        // Vite 8's rolldown bundler requires the FUNCTION form (the object form
+        // `{ phaser: ["phaser"] }` throws "manualChunks is not a function").
+        manualChunks: id =>
+          id.includes("node_modules/phaser") ? "phaser" : undefined,
         entryFileNames: "assets/[name]-[hash].js",      // content hash on everything
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash][extname]",
@@ -41,9 +44,11 @@ export default defineConfig({
 });
 ```
 
-`manualChunks: { phaser: ["phaser"] }` is the single highest-value line: Phaser is
-hundreds of KB and rarely changes, so isolating it means a gameplay tweak only
-busts the small app chunk. Two-pass terser squeezes meaningfully more than one.
+The `manualChunks` function is the single highest-value line: Phaser is hundreds
+of KB and rarely changes, so isolating it means a gameplay tweak only busts the
+small app chunk. Use the **function** form — Vite 8 ships the rolldown bundler,
+which requires it (the classic object form throws `manualChunks is not a
+function`). Two-pass terser squeezes meaningfully more than one.
 
 ## Asset hashing and immutable caching
 

--- a/src/configs/eslint/phaser.ts
+++ b/src/configs/eslint/phaser.ts
@@ -209,6 +209,11 @@ const PHASER_OVERRIDES: Linter.Config[] = [
       "phaser/no-create-in-update": "error",
       "phaser/no-allocation-in-update": "error",
       "phaser/require-shutdown-cleanup": "error",
+      // Game hot loops want the zero-allocation indexed for-loop
+      // (`for (let i = 0; …)`), which otherwise conflicts with
+      // no-allocation-in-update (for...of/.entries() allocate an iterator).
+      // Keep no-let everywhere else; allow it only in for-loop init.
+      "functional/no-let": ["error", { allowInForLoopInit: true }],
     },
   },
   // The architecture boundary: pure logic may not import Phaser.

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const PHASER_PACKAGE_LISA_TEMPLATE = "phaser/package-lisa/package.lisa.json";
 const PHASER_ESLINT_FACTORY = "src/configs/eslint/phaser.ts";
+const PHASER_TSCONFIG = "tsconfig/phaser.json";
 
 /**
  * Read a JSON template from the Lisa repository.
@@ -108,7 +109,7 @@ describe("Phaser templates", () => {
     expect(readText("phaser/copy-overwrite/tsconfig.eslint.json")).toMatch(
       assetGlobPattern
     );
-    expect(readText("tsconfig/phaser.json")).toMatch(assetGlobPattern);
+    expect(readText(PHASER_TSCONFIG)).toMatch(assetGlobPattern);
     expect(readText("oxlint/phaser.json")).toMatch(assetGlobPattern);
   });
 
@@ -179,7 +180,7 @@ describe("Phaser templates", () => {
   });
 
   it("applies game-strict TypeScript flags in tsconfig/phaser.json", () => {
-    const tsconfig = readJson("tsconfig/phaser.json") as {
+    const tsconfig = readJson(PHASER_TSCONFIG) as {
       readonly compilerOptions?: Record<string, unknown>;
     };
     const opts = tsconfig.compilerOptions ?? {};
@@ -275,5 +276,42 @@ describe("Phaser templates", () => {
     expect(template.defaults?.devDependencies?.["vite"]).toBe("^8.0.16");
     expect(template.force?.overrides?.["vite"]).toBe("$vite");
     expect(template.force?.resolutions?.["vite"]).toBe("$vite");
+  });
+
+  it("uses bundler module resolution (Vite app, not a Node library)", () => {
+    // NodeNext forces `.js` extensions on relative imports — wrong for a Vite
+    // app. Bundler resolution is idiomatic and extension-free. Also drop the
+    // rootDir/outDir that resolve into node_modules when this config is extended.
+    const tsconfig = readJson(PHASER_TSCONFIG) as {
+      readonly compilerOptions?: Record<string, unknown>;
+    };
+    const opts = tsconfig.compilerOptions ?? {};
+    expect(opts["moduleResolution"]).toBe("Bundler");
+    expect(opts["module"]).toBe("ESNext");
+    expect(opts["rootDir"]).toBeUndefined();
+    expect(opts["outDir"]).toBeUndefined();
+  });
+
+  it("typechecks tests via the phaser create-only tsconfig.local", () => {
+    const local = readJson("phaser/create-only/tsconfig.local.json") as {
+      readonly include?: readonly string[];
+      readonly exclude?: readonly string[];
+    };
+    expect(local.include).toContain("tests/**/*");
+    expect(local.exclude ?? []).not.toContain("**/*.test.ts");
+  });
+
+  it("allows let in for-loop init for zero-allocation game loops", () => {
+    const factory = readText(PHASER_ESLINT_FACTORY);
+    expect(factory).toContain("functional/no-let");
+    expect(factory).toContain("allowInForLoopInit");
+  });
+
+  it("documents the Vite 8 (rolldown) function-form manualChunks", () => {
+    const skill = readText(
+      "plugins/src/phaser/skills/phaser-build-deploy/SKILL.md"
+    );
+    expect(skill).toContain("manualChunks: id");
+    expect(skill).not.toContain('manualChunks: { phaser: ["phaser"] }');
   });
 });

--- a/tsconfig/phaser.json
+++ b/tsconfig/phaser.json
@@ -2,8 +2,8 @@
   "extends": "./typescript.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "rootDir": ".",
-    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "allowJs": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## Why
Building the Phaser starter surfaced a cluster of Node-library defaults that are wrong for a **Vite browser app**. This makes the phaser project type idiomatic so projects don't need local workarounds.

## Changes
- **`tsconfig/phaser.json`**: `module: ESNext` + `moduleResolution: Bundler` (drops the forced `.js` extensions on relative imports — NodeNext is for Node libs, not Vite apps). Removed `rootDir`/`outDir`, which resolve into `node_modules` when the config is extended.
- **`phaser/create-only/tsconfig.local.json`** (new): typechecks `tests/**` too. The generic typescript local excludes `*.test.ts`, so `tsc --noEmit` never type-checked tests.
- **eslint phaser src**: `functional/no-let` → `["error", { allowInForLoopInit: true }]`. The canonical zero-allocation indexed `for (let i…)` is now legal in hot paths — it otherwise conflicts with `no-allocation-in-update` (which forbids the `for...of`/`.entries()` iterator allocation). `no-let` stays strict everywhere else.
- **`phaser-build-deploy` skill**: `manualChunks` **function** form. Vite 8 ships the rolldown bundler, which throws `manualChunks is not a function` on the classic object form.

## Verification
typecheck, full lint, format, ast-grep, `check:plugins`, `check:rules-pairing`, and the extended template regression tests pass locally. No type is enforced/changed behaviorally beyond the phaser type's own config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)