### PR TITLE
feat(phaser): enforce verification (UAT) coverage in CI

### DIFF
--- a/phaser/copy-overwrite/.github/workflows/ci.yml
+++ b/phaser/copy-overwrite/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       node_version: '22.21.1'
       package_manager: 'bun'
       skip_jobs: ''
+      # Verification IS UAT: a feat/fix must ship a tests/e2e verification spec
+      # (an agent playing the game), unless labeled verification-exempt.
+      verify_enforced: true
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -307,6 +307,11 @@ describe("Phaser templates", () => {
     expect(factory).toContain("allowInForLoopInit");
   });
 
+  it("enforces verification (UAT) coverage in the phaser CI workflow", () => {
+    const ci = readText("phaser/copy-overwrite/.github/workflows/ci.yml");
+    expect(ci).toContain("verify_enforced: true");
+  });
+
   it("documents the Vite 8 (rolldown) function-form manualChunks", () => {
     const skill = readText(
       "plugins/src/phaser/skills/phaser-build-deploy/SKILL.md"

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { load as loadYaml } from "js-yaml";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const PHASER_PACKAGE_LISA_TEMPLATE = "phaser/package-lisa/package.lisa.json";
@@ -308,8 +309,14 @@ describe("Phaser templates", () => {
   });
 
   it("enforces verification (UAT) coverage in the phaser CI workflow", () => {
-    const ci = readText("phaser/copy-overwrite/.github/workflows/ci.yml");
-    expect(ci).toContain("verify_enforced: true");
+    const ci = loadYaml(
+      readText("phaser/copy-overwrite/.github/workflows/ci.yml")
+    ) as {
+      readonly jobs?: {
+        readonly quality?: { readonly with?: Record<string, unknown> };
+      };
+    };
+    expect(ci.jobs?.quality?.with?.["verify_enforced"]).toBe(true);
   });
 
   it("documents the Vite 8 (rolldown) function-form manualChunks", () => {


### PR DESCRIPTION
With the phaser starter now shipping a `tests/e2e` verification suite (an agent playing the game through the `window.__VERIFY__` bridge), flip **`verify_enforced: true`** in the phaser CI workflow.

Effect: a `feat`/`fix` PR in a phaser project must add or extend a verification (e2e) spec, or carry the logged `verification-exempt` label — enforced by the `verification_coverage` job shipped in 2.181.0. This completes the "nothing is done until an agent has played the game" gate for the phaser type.

Verification: phaser-template regression test asserts `verify_enforced: true`; lint/format/typecheck/tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened verification requirements so changes must include the expected test/validation coverage before shipping.
* **Tests**
  * Added a regression test to ensure the CI workflow keeps enforcement enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->