### PR TITLE
feat(cli): register phaser setup-type

### DIFF
--- a/phaser/copy-overwrite/tsconfig.eslint.json
+++ b/phaser/copy-overwrite/tsconfig.eslint.json
@@ -14,7 +14,9 @@
     "eslint.config.local.ts",
     "eslint.slow.config.ts",
     "vitest.config.ts",
-    "vitest.config.local.ts"
+    "vitest.config.local.ts",
+    "vite.config.ts",
+    "playwright.config.ts"
   ],
   "exclude": ["node_modules", "dist", "coverage", "public/assets"]
 }

--- a/src/cli/starters.ts
+++ b/src/cli/starters.ts
@@ -4,6 +4,7 @@ export const SETUP_TYPES = [
   "expo",
   "nestjs",
   "cdk",
+  "phaser",
   "wiki",
   "harper-wiki",
 ] as const;
@@ -32,6 +33,7 @@ export const STARTERS: Record<SetupType, Starter> = {
   expo: { owner: "CodySwannGT", repo: "expostarter", template: true },
   nestjs: { owner: "CodySwannGT", repo: "nestjsstarter", template: true },
   cdk: { owner: "CodySwannGT", repo: "cdkstarter", template: true },
+  phaser: { owner: "CodySwannGT", repo: "phaserstarter", template: true },
   wiki: { owner: "CodySwannGT", repo: "wikistarter", template: true },
   "harper-wiki": {
     owner: "CodySwannGT",

--- a/tests/unit/cli/starters.test.ts
+++ b/tests/unit/cli/starters.test.ts
@@ -24,6 +24,7 @@ describe("starter registry", () => {
       expo: { owner: "CodySwannGT", repo: "expostarter", template: true },
       nestjs: { owner: "CodySwannGT", repo: "nestjsstarter", template: true },
       cdk: { owner: "CodySwannGT", repo: "cdkstarter", template: true },
+      phaser: { owner: "CodySwannGT", repo: "phaserstarter", template: true },
       wiki: { owner: "CodySwannGT", repo: "wikistarter", template: true },
       "harper-wiki": {
         owner: "CodySwannGT",

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -293,6 +293,16 @@ describe("Phaser templates", () => {
     expect(opts["outDir"]).toBeUndefined();
   });
 
+  it("includes app config files in the eslint tsconfig (type-aware slow lint)", () => {
+    // vite.config.ts / playwright.config.ts must be in the eslint TS project, or
+    // the type-aware slow lint errors "file not found in any of the projects".
+    const tsconfig = readJson("phaser/copy-overwrite/tsconfig.eslint.json") as {
+      readonly include?: readonly string[];
+    };
+    expect(tsconfig.include).toContain("vite.config.ts");
+    expect(tsconfig.include).toContain("playwright.config.ts");
+  });
+
   it("typechecks tests via the phaser create-only tsconfig.local", () => {
     const local = readJson("phaser/create-only/tsconfig.local.json") as {
       readonly include?: readonly string[];


### PR DESCRIPTION
Registers `phaser` as a starter-backed setup type now that the **CodySwannGT/phaserstarter** template repo is published.

- `setup-project --type phaser <name>` scaffolds from `CodySwannGT/phaserstarter` (template) then applies Lisa.
- Fixes a config-lint gap (item from the starter build): the phaser `tsconfig.eslint.json` now includes `vite.config.ts` + `playwright.config.ts`, so the type-aware slow lint can resolve app config files instead of erroring "file not found in any of the projects". (Required for `setup-project` users to pass `lint:slow`.)

Tests: starter-registry + phaser-template regression tests updated; typecheck/lint/format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)