### PR TITLE
feat(phaser): enable lisa-wiki as the docs source

### DIFF
--- a/phaser/create-only/wiki/lisa-wiki.config.json
+++ b/phaser/create-only/wiki/lisa-wiki.config.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "1.0.0",
+  "org": "Game",
+  "displayName": "Game Docs Wiki",
+  "purpose": "The durable knowledge base and source of documentation for this Phaser 4 game — architecture, conventions, design decisions, and playbooks. Keep it current as the game evolves; it is the canonical reference, with the README a thin pointer.",
+  "mode": "embedded",
+  "wikiRoot": "wiki",
+  "frontmatter": true,
+  "categories": [
+    "architecture",
+    "concepts",
+    "conventions",
+    "decisions",
+    "playbooks",
+    "open-questions"
+  ],
+  "sources": { "layout": "by-system" },
+  "git": {
+    "prPerIngestion": true,
+    "autoMerge": true,
+    "targetBranch": "main",
+    "branchPrefix": "wiki/"
+  },
+  "sensitivity": { "enabled": false, "default": "internal" },
+  "sourceRetention": "sanitized-note-only",
+  "readme": { "mode": "rich" },
+  "documentation": { "absorb": true },
+  "staff": [],
+  "connectors": {
+    "git": { "enabled": true, "sideEffects": "read-only-ingest" },
+    "memory": { "enabled": true, "sideEffects": "read-only-ingest" }
+  }
+}

--- a/phaser/merge/.claude/settings.json
+++ b/phaser/merge/.claude/settings.json
@@ -11,7 +11,8 @@
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
-    "lisa-phaser@lisa": true
+    "lisa-phaser@lisa": true,
+    "lisa-wiki@lisa": true
   },
   "extraKnownMarketplaces": {
     "CodySwannGT/lisa": {

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -10,6 +10,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const PHASER_PACKAGE_LISA_TEMPLATE = "phaser/package-lisa/package.lisa.json";
 const PHASER_ESLINT_FACTORY = "src/configs/eslint/phaser.ts";
 const PHASER_TSCONFIG = "tsconfig/phaser.json";
+const PHASER_MERGE_SETTINGS = "phaser/merge/.claude/settings.json";
 
 /**
  * Read a JSON template from the Lisa repository.
@@ -115,11 +116,35 @@ describe("Phaser templates", () => {
   });
 
   it("enables the lisa-phaser plugin in merged Claude settings", () => {
-    const settings = readJson("phaser/merge/.claude/settings.json") as {
+    const settings = readJson(PHASER_MERGE_SETTINGS) as {
       readonly enabledPlugins?: Record<string, boolean>;
     };
 
     expect(settings.enabledPlugins?.["lisa-phaser@lisa"]).toBe(true);
+  });
+
+  it("enables the lisa-wiki plugin for the docs wiki", () => {
+    const settings = readJson(PHASER_MERGE_SETTINGS) as {
+      readonly enabledPlugins?: Record<string, boolean>;
+    };
+    expect(settings.enabledPlugins?.["lisa-wiki@lisa"]).toBe(true);
+  });
+
+  it("ships a docs-focused wiki config with no business roster", () => {
+    const config = readJson(
+      "phaser/create-only/wiki/lisa-wiki.config.json"
+    ) as {
+      readonly mode?: string;
+      readonly wikiRoot?: string;
+      readonly staff?: readonly unknown[];
+      readonly categories?: readonly string[];
+    };
+    expect(config.mode).toBe("embedded");
+    expect(config.wikiRoot).toBe("wiki");
+    // Docs-only: opt out of the default Chief/Sales/Marketing/Finance roster.
+    expect(config.staff).toEqual([]);
+    expect(config.categories).toContain("architecture");
+    expect(config.categories).toContain("conventions");
   });
 
   it("bans Phaser 3 idioms in the ESLint factory", () => {
@@ -243,7 +268,7 @@ describe("Phaser templates", () => {
     };
     expect(mcp.mcpServers?.["phaser-editor"]?.command).toBe("npx");
 
-    const settings = readJson("phaser/merge/.claude/settings.json") as {
+    const settings = readJson(PHASER_MERGE_SETTINGS) as {
       readonly disabledMcpjsonServers?: readonly string[];
     };
     expect(settings.disabledMcpjsonServers).toContain("phaser-editor");


### PR DESCRIPTION
Standardizes the phaser project type on a **Lisa LLM Wiki** as its documentation source.

- Enable `lisa-wiki@lisa` in the phaser merged Claude settings → every phaser project (and `setup-project --type phaser`) gets the wiki plugin, commands, and skills.
- Ship a **docs-focused** `create-only/wiki/lisa-wiki.config.json`: categories `architecture/concepts/conventions/decisions/playbooks/open-questions`, with the default business staff roster **opted out** (`staff: []`) — it's a code-docs wiki, not an ops team. Validated against the wiki config schema.

The published `phaserstarter` template will ship a scaffolded, populated `wiki/` (separate change) so projects start with real docs; this PR makes the wiki a standard part of the type.

Tests: phaser-template regression tests assert the plugin is enabled and the config is docs-focused/roster-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded wiki support for Phaser docs with frontmatter, fixed categories, and read-only ingestion from source content.
  * Enabled the wiki plugin alongside the existing Phaser plugin in the merge setup.
  * Configured wiki publishing to use wiki-prefixed branches with automatic merging into the main branch.

* **Tests**
  * Expanded coverage to verify the new wiki configuration and updated merge settings behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->