### PR TITLE
fix(typescript): use endsWith in mutation script to satisfy oxlint

### DIFF
--- a/typescript/copy-overwrite/scripts/lisa-mutation.mjs
+++ b/typescript/copy-overwrite/scripts/lisa-mutation.mjs
@@ -100,8 +100,8 @@ if (!base) {
 const isMutable = f =>
   /\.(ts|tsx)$/.test(f) &&
   !/\.(spec|test)\.(ts|tsx)$/.test(f) &&
-  !/\.d\.ts$/.test(f) &&
-  !/\.stories\.tsx$/.test(f) &&
+  !f.endsWith(".d.ts") &&
+  !f.endsWith(".stories.tsx") &&
   (f.startsWith("src/") || f.startsWith("lib/"));
 
 let changed = [];


### PR DESCRIPTION
## What

The shipped `scripts/lisa-mutation.mjs` (typescript copy-overwrite template) used regex tests `/\.d\.ts$/` and `/\.stories\.tsx$/` for single-suffix checks. These trip the `unicorn/prefer-string-starts-ends-with` oxlint rule that the same template ships, producing warnings in every consuming project (surfaced in the phaser starter).

## Fix

Switch the two single-suffix checks to `.endsWith()`. The multi-extension checks (`/\.(ts|tsx)$/`, `/\.(spec|test)\.(ts|tsx)$/`) genuinely require regex and are left as-is.

## Verification

Lint-only change to a template script; behavior is identical. Confirmed against the phaser starter where the warnings originated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)