### PR TITLE
feat(phaser): mirror the verification (UAT) gate on pre-push

### DIFF
--- a/phaser/copy-overwrite/.husky/pre-push.verify
+++ b/phaser/copy-overwrite/.husky/pre-push.verify
@@ -1,0 +1,19 @@
+# This file is managed by Lisa.
+# Do not edit directly -- changes will be overwritten on the next `lisa` run.
+#
+# Verification IS UAT — local mirror of the CI verification_coverage gate.
+# Sourced by .husky/pre-push (the managed verification extension slot). Blocks a
+# push whose feat/fix commits ship no verification (e2e) spec delta, so the gate
+# is caught locally before code leaves the machine, not only in CI.
+#
+# The check (scripts/check-verification-coverage.mjs) falls back to diffing
+# origin/main...HEAD and derives the change types from commit subjects. PR labels
+# are not available locally, so the escape hatch for a genuinely non-behavioral
+# change is an env var:
+#
+#   VERIFY_LABELS=verification-exempt git push
+#
+if [ -f scripts/check-verification-coverage.mjs ]; then
+  echo "✅ Verification (UAT) coverage check..."
+  node scripts/check-verification-coverage.mjs || exit 1
+fi

--- a/tests/unit/config/phaser-template.test.ts
+++ b/tests/unit/config/phaser-template.test.ts
@@ -361,4 +361,22 @@ describe("Phaser templates", () => {
     expect(skill).toContain("manualChunks: id");
     expect(skill).not.toContain('manualChunks: { phaser: ["phaser"] }');
   });
+
+  it("ships a pre-push verification (UAT) snippet that runs the coverage check", () => {
+    // Mirrors the CI verification_coverage gate locally. Sourced (not a static
+    // node_modules pointer) so it is safe to commit and works in worktrees.
+    const verify = readText("phaser/copy-overwrite/.husky/pre-push.verify");
+
+    expect(verify).toContain("scripts/check-verification-coverage.mjs");
+    // Local escape hatch (no PR labels available on pre-push).
+    expect(verify).toContain("VERIFY_LABELS=verification-exempt");
+  });
+
+  it("base pre-push sources the managed verification slot (per-type opt-in)", () => {
+    // The check ships only with opt-in types (phaser); the base hook must source
+    // it when present, and no-op otherwise, so non-opt-in TS projects are unaffected.
+    const prePush = readText("typescript/copy-contents/.husky/pre-push");
+
+    expect(prePush).toContain(".husky/pre-push.verify");
+  });
 });

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -308,6 +308,19 @@ fi
 #   fi
 # fi
 
+# Managed verification (UAT) extension slot (see .husky/pre-push.verify).
+# Opt-in project types (e.g. phaser) ship this snippet via Lisa; it mirrors the
+# CI verification_coverage gate locally. It is absent for types that have not
+# opted into verify_enforced, so this block is a no-op for them.
+if [ -f .husky/pre-push.verify ]; then
+  # shellcheck source=/dev/null
+  . .husky/pre-push.verify
+  if [ $? -ne 0 ]; then
+    echo "❌ Verification (UAT) coverage check failed."
+    exit 1
+  fi
+fi
+
 # Project-specific extension slot (see .husky/pre-push.local).
 # This hook sources pre-push.local if present so per-project checks
 # (e.g., app-boot verification, schema validation) survive Lisa template


### PR DESCRIPTION
Closes #1367.

## What

Brings the CI `verification_coverage` gate to **pre-push** for verify-enforced project types, so a feat/fix push with no verification (e2e) spec delta is caught locally before it leaves the machine — not only in CI.

- **Base hook** (`typescript/copy-contents/.husky/pre-push`): adds a *managed verification extension slot* that sources `.husky/pre-push.verify` when present (and no-ops otherwise).
- **Phaser stack** (`phaser/copy-overwrite/.husky/pre-push.verify`): ships the snippet that runs `scripts/check-verification-coverage.mjs`. Only opt-in types ship it, so the slot is inert for TypeScript projects that didn't opt into `verify_enforced` — matching the per-type CI model.
- **Worktree-safe:** it's a *sourced snippet*, not a committed `node_modules` pointer, so it doesn't reintroduce the worktree breakage tracked in #1366.
- **Escape hatch** (no PR labels locally): `VERIFY_LABELS=verification-exempt git push`.
- Tests added in `tests/unit/config/phaser-template.test.ts` (snippet present + base hook sources it).

Proven in `grist` and `phaserstarter` (added to `.husky/pre-push.local`); this upstreams it as the managed default for phaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)