### PR TITLE
fix: read live labels for verification coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   quality:
     name: 🔍 Quality Checks
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/quality.yml
     with:
       node_version: '22.21.1'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -455,6 +455,9 @@ jobs:
     name: ✅ Verification Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     # Per-change verification (UAT) gate: a feat/fix must ship a verification
     # (e2e) spec, unless labeled verification-exempt. Inert unless a project type
     # opts in via verify_enforced, and only meaningful on pull_request (needs the
@@ -477,7 +480,10 @@ jobs:
         env:
           VERIFY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VERIFY_PR_NUMBER: ${{ github.event.pull_request.number }}
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,9 @@ jobs:
   quality:
     name: 🔍 Quality Checks
     needs: [release_init, release_schedule]
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/quality.yml
     with:
       skip_jobs: ${{ inputs.skip_jobs }}

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -30,6 +30,7 @@ interface WorkflowStep {
   run?: string;
   uses?: string;
   if?: string;
+  env?: Record<string, unknown>;
   with?: Record<string, unknown>;
 }
 
@@ -40,6 +41,7 @@ interface WorkflowJob {
   "timeout-minutes"?: number;
   needs?: string | string[];
   if?: string;
+  permissions?: Record<string, unknown>;
   strategy?: { matrix?: Record<string, unknown>; "fail-fast"?: boolean };
   steps?: WorkflowStep[];
 }
@@ -200,6 +202,28 @@ describe("quality.yml reusable workflow", () => {
       // per-shard checks that coexist with the aggregator's unsuffixed
       // context under the same display name.
       expect(workflow.jobs.playwright_e2e.name).toBe("🎭 Playwright E2E Tests");
+    });
+  });
+
+  describe("verification coverage labels", () => {
+    it("passes live pull request context to the coverage script", () => {
+      const job = workflow.jobs.verification_coverage;
+      expect(job.permissions?.contents).toBe("read");
+      expect(job.permissions?.["pull-requests"]).toBe("read");
+
+      const steps = job.steps ?? [];
+      const check = steps.find(s =>
+        s.run?.includes("check-verification-coverage.mjs")
+      );
+      expect(check).toBeDefined();
+      expect(check?.env?.VERIFY_PR_NUMBER).toBe(
+        "${{ github.event.pull_request.number }}"
+      );
+      expect(check?.env?.GITHUB_REPOSITORY).toBe("${{ github.repository }}");
+      expect(check?.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
+      expect(check?.env?.VERIFY_LABELS).toContain(
+        "github.event.pull_request.labels"
+      );
     });
   });
 

--- a/tests/unit/scripts/verification-coverage.test.ts
+++ b/tests/unit/scripts/verification-coverage.test.ts
@@ -11,6 +11,8 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPT_REL =
   "typescript/copy-overwrite/scripts/check-verification-coverage.mjs";
 const GAME_SCENE = "src/game/scenes/Game.ts";
+const REPOSITORY = "CodySwannGT/lisa";
+const EXEMPT_LABEL = "verification-exempt";
 
 /**
  * Read a repo-relative text file.
@@ -38,11 +40,18 @@ interface CoverageResult {
 describe("check-verification-coverage", () => {
   // Dynamic import via a runtime URL keeps this typed as `any` (no .mjs decls).
   let evaluate: (input: CoverageInput) => CoverageResult;
+  let fetchLivePullRequestLabels: (input: {
+    readonly repository?: string;
+    readonly prNumber?: string;
+    readonly token?: string;
+    readonly fetchImpl?: typeof fetch;
+  }) => Promise<string[] | null>;
 
   beforeAll(async () => {
     const url = pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href;
     const mod = await import(url);
     evaluate = mod.evaluateVerificationCoverage;
+    fetchLivePullRequestLabels = mod.fetchLivePullRequestLabels;
   });
 
   it("does not require a delta for non-behavioral changes", () => {
@@ -97,10 +106,48 @@ describe("check-verification-coverage", () => {
     const r = evaluate({
       changedFiles: [GAME_SCENE],
       changeTypes: ["fix"],
-      labels: ["verification-exempt"],
+      labels: [EXEMPT_LABEL],
     });
     expect(r.ok).toBe(true);
     expect(r.exempt).toBe(true);
+  });
+
+  it("fetches live pull request labels when GitHub context is present", async () => {
+    const calls: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      calls.push(url);
+      return {
+        ok: true,
+        json: async () => ({
+          labels: [{ name: EXEMPT_LABEL }, { name: "component:ci" }],
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const labels = await fetchLivePullRequestLabels({
+      repository: REPOSITORY,
+      prNumber: "1371",
+      token: "token",
+      fetchImpl,
+    });
+
+    expect(calls).toEqual([
+      "https://api.github.com/repos/CodySwannGT/lisa/pulls/1371",
+    ]);
+    expect(labels).toEqual([EXEMPT_LABEL, "component:ci"]);
+  });
+
+  it("skips live label lookup when PR API context is absent", async () => {
+    const labels = await fetchLivePullRequestLabels({
+      repository: REPOSITORY,
+      prNumber: "1371",
+      token: undefined,
+      fetchImpl: (() => {
+        throw new Error("fetch should not be called");
+      }) as unknown as typeof fetch,
+    });
+
+    expect(labels).toBeNull();
   });
 });
 

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -15,7 +15,10 @@
  *   VERIFY_BASE_REF      base branch for the fallback range (default main)
  *   VERIFY_CHANGE_TYPES  comma list of conventional-commit types in the change
  *                        (e.g. "feat,chore"); if empty, derived from commit subjects
- *   VERIFY_LABELS        comma list of PR labels (for `verification-exempt`)
+ *   VERIFY_LABELS        comma list of PR labels (fallback for `verification-exempt`)
+ *   VERIFY_PR_NUMBER     pull request number for live label lookup
+ *   GITHUB_REPOSITORY    owner/repo for live label lookup
+ *   GITHUB_TOKEN         token with pull-requests: read for live label lookup
  *
  * Exit 0 = satisfied / exempt / not-required. Exit 1 = required but missing.
  * @module scripts/check-verification-coverage
@@ -29,6 +32,64 @@ const EXEMPT_LABEL = "verification-exempt";
 // or a tests/verification/ tree — NOT an arbitrary path that merely contains an
 // "e2e" segment (e.g. src/e2e/helpers.ts must not satisfy the gate).
 const VERIFICATION_PATH = /^e2e\/|(^|\/)tests\/(e2e|verification)\//;
+
+/**
+ * Parse a comma-delimited label list.
+ * @param {string | undefined} value - Comma-delimited labels
+ * @returns {string[]} Parsed labels
+ */
+function parseLabels(value) {
+  return (value || "")
+    .split(",")
+    .map(label => label.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Fetch the current PR label set from GitHub when CI provides PR context.
+ * @param {object} input - GitHub API context
+ * @param {string | undefined} input.repository - Repository in owner/name form
+ * @param {string | undefined} input.prNumber - Pull request number
+ * @param {string | undefined} input.token - GitHub token
+ * @param {typeof fetch} [input.fetchImpl] - Fetch implementation for tests
+ * @returns {Promise<string[] | null>} Live labels, or null when context is absent
+ */
+export async function fetchLivePullRequestLabels({
+  repository,
+  prNumber,
+  token,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (!repository || !prNumber || !token) {
+    return null;
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Live label lookup requires a fetch implementation.");
+  }
+
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${repository}/pulls/${prNumber}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch live PR labels: GitHub API returned ${response.status}.`
+    );
+  }
+
+  const pullRequest = await response.json();
+  return Array.isArray(pullRequest.labels)
+    ? pullRequest.labels
+        .map(label => label?.name)
+        .filter(label => typeof label === "string" && label.length > 0)
+    : [];
+}
 
 /**
  * Pure decision: is a verification-spec delta required, and is it satisfied?
@@ -78,9 +139,9 @@ export function evaluateVerificationCoverage({
 
 /**
  * Gather the change context from git + env.
- * @returns {{changedFiles: string[], changeTypes: string[], labels: string[]}} Context
+ * @returns {Promise<{changedFiles: string[], changeTypes: string[], labels: string[]}>} Context
  */
-function gatherContext() {
+async function gatherContext() {
   const head = process.env.VERIFY_HEAD_SHA || "HEAD";
   const baseRef = process.env.VERIFY_BASE_REF || "main";
   const base = process.env.VERIFY_BASE_SHA || `origin/${baseRef}`;
@@ -117,20 +178,23 @@ function gatherContext() {
         .filter(Boolean);
   const changeTypes = [...new Set([...fromEnv, ...fromCommits])];
 
-  const labels = (process.env.VERIFY_LABELS || "")
-    .split(",")
-    .map(value => value.trim())
-    .filter(Boolean);
+  const fallbackLabels = parseLabels(process.env.VERIFY_LABELS);
+  const liveLabels = await fetchLivePullRequestLabels({
+    repository: process.env.GITHUB_REPOSITORY,
+    prNumber: process.env.VERIFY_PR_NUMBER,
+    token: process.env.GITHUB_TOKEN,
+  });
+  const labels = liveLabels ?? fallbackLabels;
 
   return { changedFiles, changeTypes, labels };
 }
 
 /**
  * CLI entry: evaluate and exit non-zero when a required verification delta is missing.
- * @returns {void}
+ * @returns {Promise<void>}
  */
-function main() {
-  const context = gatherContext();
+async function main() {
+  const context = await gatherContext();
   const result = evaluateVerificationCoverage(context);
   console.log(
     `[verification-coverage] types=[${context.changeTypes.join(
@@ -155,5 +219,8 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  main();
+  main().catch(error => {
+    console.error(`[verification-coverage] FAIL: ${error.message}`);
+    process.exit(1);
+  });
 }

--- a/typescript/create-only/.github/workflows/ci.yml
+++ b/typescript/create-only/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   quality:
     name: 🔍 Quality Checks
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'


### PR DESCRIPTION
## Summary
- Fetch current pull request labels at Verification Coverage runtime when PR/token context is available
- Keep VERIFY_LABELS as the fallback for local and non-PR runs
- Pass PR number, repository, token, and pull-requests: read permission from quality.yml

Closes #1371

## Verification
- bunx vitest run tests/unit/scripts/verification-coverage.test.ts
- bunx vitest run tests/integration/quality-workflow.test.ts
- bun run typecheck
- bunx eslint --quiet tests/unit/scripts/verification-coverage.test.ts tests/integration/quality-workflow.test.ts typescript/copy-overwrite/scripts/check-verification-coverage.mjs
- pre-push hook: security audit, slow lint, knip, unit coverage, integration tests