### PR TITLE
fix: rerun CI on PR label changes

### DIFF
--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: 🔍 CI Quality Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 jobs:

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: 🔍 CI Quality Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
     # Optional knobs forwarded to the reusable quality workflow. Both default
     # to values that preserve pre-SE-4551/SE-4552 behavior (single runner, no

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: 🔍 CI Quality Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 jobs:

--- a/rails/create-only/.github/workflows/ci.yml
+++ b/rails/create-only/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 jobs:

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -268,7 +268,7 @@ export async function createMockLisaDir(dir: string): Promise<void> {
   await fs.ensureDir(path.join(railsCreateOnly, ".github", "workflows"));
   await fs.writeFile(
     path.join(railsCreateOnly, ".github", "workflows", "ci.yml"),
-    "name: CI\n\non:\n  pull_request:\n  workflow_dispatch:\n\njobs:\n  quality:\n    name: Quality Checks\n    uses: ./.github/workflows/quality.yml\n    secrets: inherit\n"
+    "name: CI\n\non:\n  pull_request:\n    types: [opened, synchronize, reopened, labeled, unlabeled]\n  workflow_dispatch:\n\njobs:\n  quality:\n    name: Quality Checks\n    uses: ./.github/workflows/quality.yml\n    secrets: inherit\n"
   );
   await fs.writeFile(
     path.join(railsCreateOnly, ".github", "workflows", "quality.yml"),

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -743,6 +743,9 @@ describe("Lisa Integration Tests", () => {
       const ciPath = path.join(destDir, ".github", "workflows", "ci.yml");
       expect(await fs.pathExists(ciPath)).toBe(true);
       const content = await fs.readFile(ciPath, "utf-8");
+      expect(content).toContain(
+        "types: [opened, synchronize, reopened, labeled, unlabeled]"
+      );
       expect(content).toContain("uses: ./.github/workflows/quality.yml");
       expect(content).toContain("secrets: inherit");
     });

--- a/typescript/create-only/.github/workflows/ci.yml
+++ b/typescript/create-only/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: 🔍 CI Quality Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `labeled` and `unlabeled` pull_request trigger types to Lisa-managed CI wrappers for TypeScript, Expo, NestJS, CDK, and Rails templates
- Update the Rails create-only fixture and integration assertion so generated `ci.yml` keeps the expanded trigger

Closes #1370

## Verification
- `bun test tests/integration/lisa.test.ts --test-name-pattern "deploys ci.yml wrapper via create-only"`
- `bun run typecheck`
- `bunx eslint tests/helpers/test-utils.ts tests/integration/lisa.test.ts`
- `bun run lint` (passes with existing warnings)
- `bash .husky/pre-push`
- push hook repeated the pre-push suite successfully

Co-authored-by: Codex <codex@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI workflows across several project templates to run on a defined set of pull request activities only.
  * Ensured workflow checks also respond to label-related pull request updates.
  * Aligned automated test coverage with the new workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->