### PR TITLE
fix: avoid reserved github env names in verification gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -482,8 +482,8 @@ jobs:
           VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           VERIFY_PR_NUMBER: ${{ github.event.pull_request.number }}
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
+          VERIFY_GITHUB_REPOSITORY: ${{ github.repository }}
+          VERIFY_GITHUB_TOKEN: ${{ github.token }}
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -219,8 +219,10 @@ describe("quality.yml reusable workflow", () => {
       expect(check?.env?.VERIFY_PR_NUMBER).toBe(
         "${{ github.event.pull_request.number }}"
       );
-      expect(check?.env?.GITHUB_REPOSITORY).toBe("${{ github.repository }}");
-      expect(check?.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
+      expect(check?.env?.VERIFY_GITHUB_REPOSITORY).toBe(
+        "${{ github.repository }}"
+      );
+      expect(check?.env?.VERIFY_GITHUB_TOKEN).toBe("${{ github.token }}");
       expect(check?.env?.VERIFY_LABELS).toContain(
         "github.event.pull_request.labels"
       );

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -17,8 +17,8 @@
  *                        (e.g. "feat,chore"); if empty, derived from commit subjects
  *   VERIFY_LABELS        comma list of PR labels (fallback for `verification-exempt`)
  *   VERIFY_PR_NUMBER     pull request number for live label lookup
- *   GITHUB_REPOSITORY    owner/repo for live label lookup
- *   GITHUB_TOKEN         token with pull-requests: read for live label lookup
+ *   VERIFY_GITHUB_REPOSITORY owner/repo for live label lookup
+ *   VERIFY_GITHUB_TOKEN      token with pull-requests: read for live label lookup
  *
  * Exit 0 = satisfied / exempt / not-required. Exit 1 = required but missing.
  * @module scripts/check-verification-coverage
@@ -180,9 +180,9 @@ async function gatherContext() {
 
   const fallbackLabels = parseLabels(process.env.VERIFY_LABELS);
   const liveLabels = await fetchLivePullRequestLabels({
-    repository: process.env.GITHUB_REPOSITORY,
+    repository: process.env.VERIFY_GITHUB_REPOSITORY,
     prNumber: process.env.VERIFY_PR_NUMBER,
-    token: process.env.GITHUB_TOKEN,
+    token: process.env.VERIFY_GITHUB_TOKEN,
   });
   const labels = liveLabels ?? fallbackLabels;
 


### PR DESCRIPTION
## Summary

- Rename the verification coverage live-label env inputs away from GitHub's reserved `GITHUB_*` namespace.
- Keep the reusable quality workflow passing `github.repository` and `github.token` through non-reserved `VERIFY_*` names.
- Update workflow wiring tests for the new env names.

## Reviewer Replay

1. Open a PR that runs the reusable `🔍 CI Quality Checks` workflow.
2. Confirm the workflow creates jobs instead of ending with `startup_failure` before any jobs/logs exist.
3. For a repo with `verify_enforced: true`, confirm the verification coverage job can still read live PR labels.

## Verification

- PASS: `bunx vitest run tests/integration/quality-workflow.test.ts tests/unit/scripts/verification-coverage.test.ts`
- PASS: `bun run format:check`
- PASS: commit hook: gitleaks, `bun run typecheck`, lint-staged (`eslint --quiet --cache --fix`, prettier, ast-grep)
- PASS: pre-push hook: security audit, slow lint, knip, unit tests with coverage, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated verification checks to use dedicated verification environment variables, improving reliability of per-change validation.
  * Adjusted automated workflow coverage checks to match the new environment variable names.
  * Kept pull request number handling unchanged while refining how verification context is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->