### PR TITLE
fix(plugins): load Lisa plugins/hooks in git worktree sessions

### DIFF
--- a/tests/unit/hooks/post-checkout.test.ts
+++ b/tests/unit/hooks/post-checkout.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the managed post-checkout worktree plugin-bootstrap hook.
+ *
+ * A git worktree is a distinct project path to Claude Code, so plugins enabled
+ * in .claude/settings.json are "not installed here" for the worktree until
+ * `claude plugin install --scope project` runs against that path — leaving
+ * guardrail hooks off in worktree sessions. The hook seeds those installs once,
+ * at `git worktree add` time, guarded so it only fires inside a worktree, on a
+ * branch checkout, once per worktree.
+ * @module tests/unit/hooks/post-checkout
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const HOOK_PATH = path.resolve("typescript/copy-contents/.husky/post-checkout");
+const SH_PATH = "/bin/sh";
+const GIT_PATH = "/usr/bin/git";
+const NULL_SHA = "0".repeat(40);
+const HEAD_SHA = "1".repeat(40);
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+const hasJq = spawnSync(SH_PATH, ["-c", "command -v jq"]).status === 0;
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  tempDirs = [];
+});
+
+/** A temp git repo wired with a fake `claude` for exercising the hook. */
+interface Repo {
+  /** Repo root (may sit under a .claude/worktrees/* path). */
+  readonly root: string;
+  /** Directory holding the fake `claude` binary, prepended to PATH. */
+  readonly binDir: string;
+  /** File the fake `claude` appends its argv to. */
+  readonly callsFile: string;
+}
+
+/**
+ * Create a git repo at `relativeRoot` under a fresh temp dir, seed
+ * .claude/settings.json with the given enabled plugins, and a fake `claude`
+ * binary that appends its argv to a log.
+ * @param relativeRoot - Path segments for the repo root under the temp dir
+ * @param enabledPlugins - Map written to .claude/settings.json enabledPlugins
+ * @returns The repo root, fake-bin directory, and the claude-call log path
+ */
+function createRepo(
+  relativeRoot: readonly string[],
+  enabledPlugins: Record<string, boolean>
+): Repo {
+  const base = mkdtempSync(path.join(tmpdir(), "lisa-post-checkout-"));
+  const root = path.join(base, ...relativeRoot);
+  const binDir = path.join(base, "bin");
+  const callsFile = path.join(base, "claude-calls.log");
+  const claudeBin = path.join(binDir, "claude");
+
+  tempDirs.push(base);
+  mkdirSync(path.join(root, ".claude"), { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root });
+  spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
+    cwd: root,
+    env: { ...process.env, ...GIT_IDENTITY },
+  });
+  writeFileSync(
+    path.join(root, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins })
+  );
+  writeFileSync(claudeBin, `#!/bin/sh\necho "$*" >> "${callsFile}"\n`);
+  chmodSync(claudeBin, 0o755);
+
+  return { root, binDir, callsFile };
+}
+
+/**
+ * Run the hook in the repo with a given checkout flag and the fake claude on PATH.
+ * @param repo - Repo context from createRepo
+ * @param flag - post-checkout's third arg ("1" = branch checkout, "0" = file)
+ * @returns The fake-claude calls recorded during the run
+ */
+function runHook(repo: Repo, flag: string): string[] {
+  spawnSync(SH_PATH, [HOOK_PATH, NULL_SHA, HEAD_SHA, flag], {
+    cwd: repo.root,
+    env: { ...process.env, PATH: `${repo.binDir}:${process.env.PATH ?? ""}` },
+    encoding: "utf-8",
+  });
+  if (!existsSync(repo.callsFile)) {
+    return [];
+  }
+  return readFileSync(repo.callsFile, "utf-8").split("\n").filter(Boolean);
+}
+
+const WORKTREE_ROOT = [".claude", "worktrees", "wtA"];
+
+describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
+  it("installs each enabled plugin at project scope inside a worktree", () => {
+    const repo = createRepo(WORKTREE_ROOT, {
+      "lisa@lisa": true,
+      "coderabbit@claude-plugins-official": true,
+    });
+    const calls = runHook(repo, "1");
+    expect(calls).toContain("plugin marketplace update lisa");
+    expect(calls).toContain("plugin install lisa@lisa --scope project");
+    expect(calls).toContain(
+      "plugin install coderabbit@claude-plugins-official --scope project"
+    );
+  });
+
+  it("skips plugin ids containing shell-unsafe characters", () => {
+    const repo = createRepo(WORKTREE_ROOT, {
+      "lisa@lisa": true,
+      "bad;rm -rf": true,
+    });
+    const calls = runHook(repo, "1");
+    expect(calls).toContain("plugin install lisa@lisa --scope project");
+    expect(calls.some(call => call.includes("bad;rm"))).toBe(false);
+  });
+
+  it("is idempotent: a second checkout is a no-op (sentinel)", () => {
+    const repo = createRepo(WORKTREE_ROOT, { "lisa@lisa": true });
+    const first = runHook(repo, "1");
+    const second = runHook(repo, "1");
+    expect(second).toEqual(first);
+  });
+
+  it("does nothing on a file checkout (flag 0)", () => {
+    const repo = createRepo(WORKTREE_ROOT, { "lisa@lisa": true });
+    expect(runHook(repo, "0")).toEqual([]);
+  });
+
+  it("does nothing in a non-worktree (main) checkout", () => {
+    const repo = createRepo(["mainproj"], { "lisa@lisa": true });
+    expect(runHook(repo, "1")).toEqual([]);
+  });
+});

--- a/tests/unit/hooks/post-checkout.test.ts
+++ b/tests/unit/hooks/post-checkout.test.ts
@@ -110,6 +110,7 @@ function runHook(repo: Repo, flag: string): string[] {
 }
 
 const WORKTREE_ROOT = [".claude", "worktrees", "wtA"];
+const INSTALL_LISA = "plugin install lisa@lisa --scope project";
 
 describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
   it("installs each enabled plugin at project scope inside a worktree", () => {
@@ -119,7 +120,7 @@ describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
     });
     const calls = runHook(repo, "1");
     expect(calls).toContain("plugin marketplace update lisa");
-    expect(calls).toContain("plugin install lisa@lisa --scope project");
+    expect(calls).toContain(INSTALL_LISA);
     expect(calls).toContain(
       "plugin install coderabbit@claude-plugins-official --scope project"
     );
@@ -131,8 +132,18 @@ describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
       "bad;rm -rf": true,
     });
     const calls = runHook(repo, "1");
-    expect(calls).toContain("plugin install lisa@lisa --scope project");
+    expect(calls).toContain(INSTALL_LISA);
     expect(calls.some(call => call.includes("bad;rm"))).toBe(false);
+  });
+
+  it("does not install plugins disabled (set to false) in settings", () => {
+    const repo = createRepo(WORKTREE_ROOT, {
+      "lisa@lisa": true,
+      "code-review@claude-plugins-official": false,
+    });
+    const calls = runHook(repo, "1");
+    expect(calls).toContain(INSTALL_LISA);
+    expect(calls.some(call => call.includes("code-review"))).toBe(false);
   });
 
   it("is idempotent: a second checkout is a no-op (sentinel)", () => {

--- a/tests/unit/hooks/worktree-create.test.ts
+++ b/tests/unit/hooks/worktree-create.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the managed WorktreeCreate hook.
+ *
+ * Claude Code replaces its default worktree creation with this hook, so the
+ * contract is strict: create the worktree, print ONLY its absolute path on
+ * stdout, exit 0. The hook reads `{ name, cwd }` from stdin (the observed
+ * payload — the docs' `worktree_name`/`base_path` fields do not appear), mirrors
+ * the default `<cwd>/.claude/worktrees/<name>` layout on a `worktree-<name>`
+ * branch, and keeps all git chatter off stdout.
+ * @module tests/unit/hooks/worktree-create
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const HOOK_PATH = path.resolve(
+  "typescript/copy-overwrite/.claude/hooks/worktree-create.sh"
+);
+const SH_PATH = "/bin/sh";
+const GIT_PATH = "/usr/bin/git";
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+const hasJq = spawnSync(SH_PATH, ["-c", "command -v jq"]).status === 0;
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  tempDirs = [];
+});
+
+/**
+ * Create an initialized git repo in a fresh temp dir.
+ * @returns The repo root path
+ */
+function createGitRepo(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-worktree-create-"));
+  tempDirs.push(root);
+  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root });
+  spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
+    cwd: root,
+    env: { ...process.env, ...GIT_IDENTITY },
+  });
+  return root;
+}
+
+/**
+ * Run the hook with a WorktreeCreate stdin payload.
+ * @param root - Project root passed as `cwd` in the payload
+ * @param name - Worktree name
+ * @returns The hook's exit status, trimmed stdout, and stderr
+ */
+function runHook(
+  root: string,
+  name: string
+): { status: number | null; stdout: string; stderr: string } {
+  const payload = JSON.stringify({
+    hook_event_name: "WorktreeCreate",
+    name,
+    cwd: root,
+  });
+  const result = spawnSync(SH_PATH, [HOOK_PATH], {
+    cwd: root,
+    input: payload,
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
+  it("creates <cwd>/.claude/worktrees/<name> and prints only its path", () => {
+    const root = createGitRepo();
+    const { status, stdout } = runHook(root, "featureX");
+    const expected = path.join(root, ".claude", "worktrees", "featureX");
+
+    expect(status).toBe(0);
+    expect(stdout).toBe(expected);
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("checks out a worktree-<name> branch", () => {
+    const root = createGitRepo();
+    const { stdout } = runHook(root, "featureY");
+    const branch = spawnSync(GIT_PATH, ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: stdout,
+      encoding: "utf-8",
+    }).stdout.trim();
+    expect(branch).toBe("worktree-featureY");
+  });
+
+  it("is idempotent: re-creating returns the same path and succeeds", () => {
+    const root = createGitRepo();
+    const first = runHook(root, "featureZ");
+    const second = runHook(root, "featureZ");
+    expect(second.status).toBe(0);
+    expect(second.stdout).toBe(first.stdout);
+  });
+
+  it("prints nothing on stdout but the path (no git chatter)", () => {
+    const root = createGitRepo();
+    const { stdout } = runHook(root, "clean");
+    expect(stdout.split("\n")).toHaveLength(1);
+    expect(stdout).not.toMatch(/Preparing|HEAD is now/);
+  });
+
+  it("aborts with a non-zero exit when the payload has no name", () => {
+    const root = createGitRepo();
+    const result = spawnSync(SH_PATH, [HOOK_PATH], {
+      cwd: root,
+      input: JSON.stringify({ hook_event_name: "WorktreeCreate", cwd: root }),
+      encoding: "utf-8",
+    });
+    expect(result.status).not.toBe(0);
+    expect((result.stdout ?? "").trim()).toBe("");
+  });
+});

--- a/tests/unit/hooks/worktree-create.test.ts
+++ b/tests/unit/hooks/worktree-create.test.ts
@@ -72,21 +72,23 @@ function runHook(
     input: payload,
     encoding: "utf-8",
   });
+  // Raw stdout (not trimmed): the contract is "ONLY the path", so tests assert
+  // the exact `<path>\n` shape and catch any stray whitespace/chatter.
   return {
     status: result.status,
-    stdout: (result.stdout ?? "").trim(),
+    stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",
   };
 }
 
 describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
-  it("creates <cwd>/.claude/worktrees/<name> and prints only its path", () => {
+  it("creates <cwd>/.claude/worktrees/<name> and prints exactly its path", () => {
     const root = createGitRepo();
     const { status, stdout } = runHook(root, "featureX");
     const expected = path.join(root, ".claude", "worktrees", "featureX");
 
     expect(status).toBe(0);
-    expect(stdout).toBe(expected);
+    expect(stdout).toBe(`${expected}\n`);
     expect(existsSync(expected)).toBe(true);
   });
 
@@ -94,7 +96,7 @@ describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
     const root = createGitRepo();
     const { stdout } = runHook(root, "featureY");
     const branch = spawnSync(GIT_PATH, ["rev-parse", "--abbrev-ref", "HEAD"], {
-      cwd: stdout,
+      cwd: stdout.trim(),
       encoding: "utf-8",
     }).stdout.trim();
     expect(branch).toBe("worktree-featureY");
@@ -108,11 +110,10 @@ describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
     expect(second.stdout).toBe(first.stdout);
   });
 
-  it("prints nothing on stdout but the path (no git chatter)", () => {
+  it("emits only the path on stdout — no git chatter", () => {
     const root = createGitRepo();
-    const { stdout } = runHook(root, "clean");
-    expect(stdout.split("\n")).toHaveLength(1);
-    expect(stdout).not.toMatch(/Preparing|HEAD is now/);
+    const expected = path.join(root, ".claude", "worktrees", "clean");
+    expect(runHook(root, "clean").stdout).toBe(`${expected}\n`);
   });
 
   it("aborts with a non-zero exit when the payload has no name", () => {
@@ -124,5 +125,13 @@ describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
     });
     expect(result.status).not.toBe(0);
     expect((result.stdout ?? "").trim()).toBe("");
+  });
+
+  it("rejects an unsafe worktree name (path traversal) without creating it", () => {
+    const root = createGitRepo();
+    const { status, stdout } = runHook(root, "../escape");
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(existsSync(path.join(root, "..", "escape"))).toBe(false);
   });
 });

--- a/typescript/copy-contents/.husky/post-checkout
+++ b/typescript/copy-contents/.husky/post-checkout
@@ -48,11 +48,13 @@ _lisa_bootstrap_worktree_plugins() {
   _sentinel="$_gitdir/lisa-plugins-bootstrapped"
   [ -f "$_sentinel" ] && return 0
 
-  _plugins="$(jq -r '(.enabledPlugins // {}) | keys[]' "$_settings" 2>/dev/null)"
+  # Only the truthy entries — an explicit `false` means "disabled", not "install".
+  _plugins="$(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' "$_settings" 2>/dev/null)"
   [ -n "$_plugins" ] || return 0
 
   echo "🔌 Bootstrapping Claude Code plugins for new worktree (scope: project)…"
   claude plugin marketplace update lisa >/dev/null 2>&1 || true
+  _had_failure=0
   for _p in $_plugins; do
     # Skip ids with shell-unsafe characters before interpolating into the CLI.
     case "$_p" in
@@ -62,10 +64,15 @@ _lisa_bootstrap_worktree_plugins() {
       echo "  ✓ $_p"
     else
       echo "  ⚠ $_p (skipped)"
+      _had_failure=1
     fi
   done
 
-  : >"$_sentinel" 2>/dev/null || true
+  # Mark bootstrapped only when every install succeeded, so a transient failure
+  # retries on the next checkout instead of being skipped forever.
+  if [ "$_had_failure" = "0" ]; then
+    : >"$_sentinel" 2>/dev/null || true
+  fi
 }
 
 # Never let a bootstrap hiccup block the checkout.

--- a/typescript/copy-contents/.husky/post-checkout
+++ b/typescript/copy-contents/.husky/post-checkout
@@ -1,0 +1,76 @@
+# BEGIN: AI GUARDRAILS
+
+# Worktree plugin bootstrap.
+#
+# A git worktree is a DISTINCT project path to Claude Code, so the plugins
+# enabled in .claude/settings.json are "enabled in project settings but isn't
+# installed here" for the worktree until `claude plugin install --scope project`
+# runs against that path. The result: Lisa's guardrail hooks (block-no-verify,
+# the verification gate, inject-rules) AND the other managed plugins
+# (coderabbit / sentry / atlassian / safety-net / …) load ZERO hooks in a
+# worktree session started as `cd <worktree> && claude`. (A `claude -w` session
+# inherits the marketplace plugins, but the project-scoped ones still report
+# "not installed here".)
+#
+# git fires post-checkout INSIDE the new worktree at `git worktree add` time
+# (which `claude -w` and Fleet both use), so this is a deadlock-free place to
+# seed those installs once, before any session loads plugins. Both `claude -w`
+# and standalone `cd && claude` sessions then resolve every enabled plugin.
+#
+# Guards keep it cheap and safe:
+#   - only inside a *.claude/worktrees/* path (the main checkout is handled by
+#     `lisa apply`'s plugin registration);
+#   - only on a branch checkout ($3 = 1), never a file checkout;
+#   - only once per worktree (a sentinel in the worktree's private git dir), so
+#     ordinary branch switches do not re-run 10+ installs;
+#   - only when `claude` and `jq` are on PATH and settings exist (skips CI/remote);
+#   - best-effort — never blocks or fails the checkout.
+
+_lisa_bootstrap_worktree_plugins() {
+  # $3 == 1 -> branch checkout (worktree add / branch switch); 0 -> file checkout
+  [ "${3:-1}" = "1" ] || return 0
+  command -v claude >/dev/null 2>&1 || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  _root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  case "$_root" in
+    */.claude/worktrees/*) : ;;
+    *) return 0 ;; # main checkout: `lisa apply` installs plugins there
+  esac
+
+  _settings="$_root/.claude/settings.json"
+  [ -f "$_settings" ] || return 0
+
+  # Per-worktree sentinel lives in the worktree's private git dir
+  # (<main>/.git/worktrees/<name>), so it neither pollutes the tree nor leaks to
+  # other worktrees, and survives branch switches.
+  _gitdir="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
+  _sentinel="$_gitdir/lisa-plugins-bootstrapped"
+  [ -f "$_sentinel" ] && return 0
+
+  _plugins="$(jq -r '(.enabledPlugins // {}) | keys[]' "$_settings" 2>/dev/null)"
+  [ -n "$_plugins" ] || return 0
+
+  echo "🔌 Bootstrapping Claude Code plugins for new worktree (scope: project)…"
+  claude plugin marketplace update lisa >/dev/null 2>&1 || true
+  for _p in $_plugins; do
+    # Skip ids with shell-unsafe characters before interpolating into the CLI.
+    case "$_p" in
+      *[!A-Za-z0-9@._/-]*) continue ;;
+    esac
+    if claude plugin install "$_p" --scope project >/dev/null 2>&1; then
+      echo "  ✓ $_p"
+    else
+      echo "  ⚠ $_p (skipped)"
+    fi
+  done
+
+  : >"$_sentinel" 2>/dev/null || true
+}
+
+# Never let a bootstrap hiccup block the checkout.
+_lisa_bootstrap_worktree_plugins "$@" || true
+
+exit 0
+
+# END: AI GUARDRAILS

--- a/typescript/copy-overwrite/.claude/hooks/worktree-create.sh
+++ b/typescript/copy-overwrite/.claude/hooks/worktree-create.sh
@@ -34,6 +34,15 @@ if [ -z "${_name:-}" ]; then
   exit 1
 fi
 
+# The name is interpolated into a filesystem path and a git ref, so reject path
+# traversal/separators, a leading dash, and any character outside a safe slug.
+case "$_name" in
+  *..* | /* | -* | *[!A-Za-z0-9._-]*)
+    _log "WorktreeCreate: unsafe worktree name '$_name'; aborting."
+    exit 1
+    ;;
+esac
+
 _root="${_cwd:-$(pwd)}"
 _base="$_root/.claude/worktrees"
 _path="$_base/$_name"
@@ -52,7 +61,7 @@ _log "Creating worktree $_path (branch: $_wt_branch)…"
 # Reuse the worktree branch if it already exists, else create it from HEAD.
 # All git output is kept off stdout (its "Preparing worktree…" line would
 # corrupt the path contract and hang Claude).
-if git show-ref --verify --quiet "refs/heads/$_wt_branch" 2>/dev/null; then
+if git -C "$_root" show-ref --verify --quiet "refs/heads/$_wt_branch" 2>/dev/null; then
   git -C "$_root" worktree add "$_path" "$_wt_branch" >/dev/null 2>&1
 else
   git -C "$_root" worktree add -b "$_wt_branch" "$_path" HEAD >/dev/null 2>&1

--- a/typescript/copy-overwrite/.claude/hooks/worktree-create.sh
+++ b/typescript/copy-overwrite/.claude/hooks/worktree-create.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# WorktreeCreate hook — fast-path setup for `claude -w` / `isolation: worktree`.
+#
+# Claude Code REPLACES its default git worktree creation with this hook, so it
+# MUST: create the worktree, print ONLY its absolute path on stdout, and exit 0.
+# Any non-zero exit, or extra text on stdout, aborts/breaks worktree creation —
+# so every git command redirects its output off stdout, and progress goes to
+# stderr (NOT /dev/tty, which is "not configured" in headless `-p`/CI sessions).
+#
+# It mirrors Claude's default layout — <cwd>/.claude/worktrees/<name> on a fresh
+# `worktree-<name>` branch — so behavior is unchanged; the value is clean,
+# pre-TUI output and an explicit, durable creation path. The plugin bootstrap
+# itself is done by the `post-checkout` hook that `git worktree add` fires, so
+# `claude -w` and standalone `cd && claude` sessions converge on the same state.
+#
+# Payload (observed, Claude Code stdin):
+#   { "name": "<worktree>", "cwd": "<project root>", "hook_event_name": ... }
+
+_log() { echo "$*" >&2; }
+
+_payload="$(cat)"
+
+if command -v jq >/dev/null 2>&1; then
+  _name="$(printf '%s' "$_payload" | jq -r '.name // .worktree_name // empty' 2>/dev/null)"
+  _cwd="$(printf '%s' "$_payload" | jq -r '.cwd // empty' 2>/dev/null)"
+fi
+
+# A new worktree needs a name; without one (or jq) we cannot honor the contract.
+if [ -z "${_name:-}" ]; then
+  _log "WorktreeCreate: no worktree name in payload; aborting."
+  exit 1
+fi
+
+_root="${_cwd:-$(pwd)}"
+_base="$_root/.claude/worktrees"
+_path="$_base/$_name"
+_wt_branch="worktree-$_name"
+
+# Idempotent: an existing worktree just gets its path returned.
+if [ -d "$_path" ]; then
+  _log "Worktree already exists: $_path"
+  printf '%s\n' "$_path"
+  exit 0
+fi
+
+mkdir -p "$_base" 2>/dev/null || true
+_log "Creating worktree $_path (branch: $_wt_branch)…"
+
+# Reuse the worktree branch if it already exists, else create it from HEAD.
+# All git output is kept off stdout (its "Preparing worktree…" line would
+# corrupt the path contract and hang Claude).
+if git show-ref --verify --quiet "refs/heads/$_wt_branch" 2>/dev/null; then
+  git -C "$_root" worktree add "$_path" "$_wt_branch" >/dev/null 2>&1
+else
+  git -C "$_root" worktree add -b "$_wt_branch" "$_path" HEAD >/dev/null 2>&1
+fi
+
+if [ ! -d "$_path" ]; then
+  _log "WorktreeCreate: git worktree add failed for $_path."
+  exit 1
+fi
+
+# THE ONLY thing on stdout: the absolute worktree path.
+printf '%s\n' "$_path"
+exit 0

--- a/typescript/merge/.claude/settings.json
+++ b/typescript/merge/.claude/settings.json
@@ -30,5 +30,18 @@
   "permissions": {
     "deny": ["Read(./.entire/metadata/**)"]
   },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-create.sh",
+            "timeout": 60000
+          }
+        ]
+      }
+    ]
+  },
   "plansDirectory": "./plans"
 }


### PR DESCRIPTION
## Problem

A git worktree is a **distinct project path** to Claude Code, so plugins enabled in `.claude/settings.json` are *"enabled in project settings but isn't installed here"* until `claude plugin install --scope project` runs for that path. In a worktree session started as `cd <wt> && claude` (Fleet, agent isolation, manual `git worktree add`), Lisa's guardrail hooks (`block-no-verify`, the verification gate, `inject-rules`) **and** the managed marketplace plugins (coderabbit/sentry/atlassian/safety-net/…) register **0 hooks** — guardrails silently off. It surfaced when projects moved to `fleet` and began running sessions in worktrees.

This is the documented Claude Code worktree behavior — see [anthropics/claude-code#46808](https://github.com/anthropics/claude-code/issues/46808), [#36360](https://github.com/anthropics/claude-code/issues/36360). (`claude -w` happens to inherit the marketplace plugins from the parent, which is why that path appeared to work — but standalone/Fleet sessions don't.)

## Fix — two complementary, deadlock-free mechanisms

Hooks stay packaged in the plugin; installs stay `--scope project`.

1. **`.husky/post-checkout`** (copy-contents) — the actual fix. git fires it **inside** a new worktree at `git worktree add` time, so it seeds `claude plugin install --scope project` for every enabled plugin. Guarded: worktree-only, branch-checkout-only, once-per-worktree (sentinel), `claude`+`jq` present, best-effort (never blocks the checkout). Covers **all** creation paths (`claude -w`, Fleet, manual) and is agent-agnostic.
2. **`WorktreeCreate` hook** (`.claude/hooks/worktree-create.sh` via copy-overwrite + the settings.json hook via merge) — clean, pre-TUI worktree creation for the `claude -w` fast path. Mirrors Claude's default layout (`<cwd>/.claude/worktrees/<name>` on a `worktree-<name>` branch) and prints only the path on stdout.

> ⚠️ The official docs' `WorktreeCreate` payload (`worktree_name`/`base_path`/`branch`) **does not match reality** — the real stdin is `{ name, cwd }`. Verified against live `claude -w`; the hook reads the real fields. Blind-shipping the documented schema would have aborted `claude -w` for every project.

## Validation

Verified end to end against real `claude -w` and standalone sessions in a host project: a standalone `cd && claude` session in a freshly created worktree goes from **0 → 30 registered hooks**, with no "not installed here" plugin errors. `claude -w` creates the worktree cleanly and the session loads all hooks.

`+10` unit tests (hook guards, idempotency, stdout contract, payload parsing). Full suite green, 81% coverage, pre-push gate passed.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for new Git worktrees, including creating the worktree path and branch consistently.
  * Enabled plugin bootstrapping for worktree checkouts so configured plugins are installed automatically in the right scope.
* **Bug Fixes**
  * Skips file checkouts and main-repo checkouts to avoid unnecessary actions.
  * Prevents duplicate installs by making repeated worktree checkouts idempotent.
  * Ignores unsafe plugin IDs and keeps checkout flow non-blocking if setup steps fail.
* **Tests**
  * Added coverage for worktree creation and post-checkout behavior, including edge cases and repeat runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->