### PR TITLE
fix(ci): use workflow token for Sonar scan

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1541,7 +1541,7 @@ jobs:
         id: sonar_scan
         uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: -Dsonar.qualitygate.wait=true

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -229,6 +229,19 @@ describe("quality.yml reusable workflow", () => {
     });
   });
 
+  describe("cross-repo reusable workflow token handling", () => {
+    it("uses github.token for SonarCloud instead of requiring callers to pass GITHUB_TOKEN", () => {
+      const steps = workflow.jobs.sonarcloud.steps ?? [];
+      const scan = steps.find(
+        s => s.uses === "SonarSource/sonarqube-scan-action@v6.0.0"
+      );
+
+      expect(scan).toBeDefined();
+      expect(scan?.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
+      expect(scan?.env?.GITHUB_TOKEN).not.toContain("secrets.GITHUB_TOKEN");
+    });
+  });
+
   describe("GitGuardian quota exhaustion", () => {
     it.each([
       ["quality.yml", QUALITY_YML],


### PR DESCRIPTION
## Summary
- use `github.token` for SonarCloud scanner auth inside the reusable quality workflow
- add a workflow regression test so cross-repo callers do not need to pass `GITHUB_TOKEN` as a secret

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- commit hook: gitleaks, typecheck, lint-staged, prettier, eslint, ast-grep, commitlint
- pre-push hook: security audit, slow lint, knip, full `vitest run --coverage`, `vitest run tests/integration`

## Reviewer Replay
1. Open the advisory-rankings caller workflow that invokes `CodySwannGT/lisa/.github/workflows/quality.yml@main` with explicit secrets only.
2. Confirm the called SonarCloud step uses `${{ github.token }}` for `GITHUB_TOKEN`, so the caller does not need to pass or declare a `GITHUB_TOKEN` secret.
3. Run `bun test tests/integration/quality-workflow.test.ts` and confirm the cross-repo token assertion passes.