### PR TITLE
fix(ci): remove reserved github env from sonar scan

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1541,7 +1541,6 @@ jobs:
         id: sonar_scan
         uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: -Dsonar.qualitygate.wait=true

--- a/src/migrations/untrack-codex-marketplace.ts
+++ b/src/migrations/untrack-codex-marketplace.ts
@@ -8,6 +8,17 @@ import type {
 
 /** Generated Codex marketplace, relative to a project root (posix, git-style). */
 const MARKETPLACE_PATH = ".agents/plugins/marketplace.json";
+const GIT_COMMAND_ENV: NodeJS.ProcessEnv = {
+  PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+};
+
+/**
+ * Return the minimal environment needed for project-scoped git commands.
+ * @returns Environment safe from caller git hook state
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  return GIT_COMMAND_ENV;
+}
 
 /**
  * Run a fixed git command in a directory, returning success.
@@ -24,7 +35,7 @@ async function tryGit(command: string, cwd: string): Promise<boolean> {
   const { promisify } = await import("node:util");
   const run = promisify(exec);
   try {
-    await run(command, { cwd });
+    await run(command, { cwd, env: cleanGitEnv() });
     return true;
   } catch {
     return false;
@@ -44,7 +55,7 @@ async function runGit(command: string, cwd: string): Promise<void> {
   const { exec } = await import("node:child_process");
   const { promisify } = await import("node:util");
   const run = promisify(exec);
-  await run(command, { cwd });
+  await run(command, { cwd, env: cleanGitEnv() });
 }
 
 /**

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -230,15 +230,27 @@ describe("quality.yml reusable workflow", () => {
   });
 
   describe("cross-repo reusable workflow token handling", () => {
-    it("uses github.token for SonarCloud instead of requiring callers to pass GITHUB_TOKEN", () => {
+    it("does not declare reserved GITHUB_* environment keys", () => {
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        for (const step of job.steps ?? []) {
+          const envKeys = Object.keys(step.env ?? {});
+          const reservedKeys = envKeys.filter(key => key.startsWith("GITHUB_"));
+          expect(reservedKeys, `${jobName}: ${step.name ?? step.id}`).toEqual(
+            []
+          );
+        }
+      }
+    });
+
+    it("passes only SonarCloud's token to the SonarCloud action", () => {
       const steps = workflow.jobs.sonarcloud.steps ?? [];
       const scan = steps.find(
         s => s.uses === "SonarSource/sonarqube-scan-action@v6.0.0"
       );
 
       expect(scan).toBeDefined();
-      expect(scan?.env?.GITHUB_TOKEN).toBe("${{ github.token }}");
-      expect(scan?.env?.GITHUB_TOKEN).not.toContain("secrets.GITHUB_TOKEN");
+      expect(scan?.env?.SONAR_TOKEN).toBe("${{ secrets.SONAR_TOKEN }}");
+      expect(scan?.env).not.toHaveProperty("GITHUB_TOKEN");
     });
   });
 

--- a/tests/unit/hooks/post-checkout.test.ts
+++ b/tests/unit/hooks/post-checkout.test.ts
@@ -36,6 +36,20 @@ const GIT_IDENTITY = {
 };
 const hasJq = spawnSync(SH_PATH, ["-c", "command -v jq"]).status === 0;
 
+/**
+ * Return process env without outer git hook state for nested temp repos.
+ * @returns Environment safe for fixture git commands
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 let tempDirs: string[] = [];
 
 afterEach(() => {
@@ -76,10 +90,10 @@ function createRepo(
   tempDirs.push(base);
   mkdirSync(path.join(root, ".claude"), { recursive: true });
   mkdirSync(binDir, { recursive: true });
-  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root });
+  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root, env: cleanGitEnv() });
   spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
     cwd: root,
-    env: { ...process.env, ...GIT_IDENTITY },
+    env: { ...cleanGitEnv(), ...GIT_IDENTITY },
   });
   writeFileSync(
     path.join(root, ".claude", "settings.json"),
@@ -100,7 +114,7 @@ function createRepo(
 function runHook(repo: Repo, flag: string): string[] {
   spawnSync(SH_PATH, [HOOK_PATH, NULL_SHA, HEAD_SHA, flag], {
     cwd: repo.root,
-    env: { ...process.env, PATH: `${repo.binDir}:${process.env.PATH ?? ""}` },
+    env: { ...cleanGitEnv(), PATH: `${repo.binDir}:${process.env.PATH ?? ""}` },
     encoding: "utf-8",
   });
   if (!existsSync(repo.callsFile)) {

--- a/tests/unit/hooks/worktree-create.test.ts
+++ b/tests/unit/hooks/worktree-create.test.ts
@@ -28,6 +28,20 @@ const GIT_IDENTITY = {
 };
 const hasJq = spawnSync(SH_PATH, ["-c", "command -v jq"]).status === 0;
 
+/**
+ * Return process env without outer git hook state for nested temp repos.
+ * @returns Environment safe for fixture git commands
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 let tempDirs: string[] = [];
 
 afterEach(() => {
@@ -44,10 +58,10 @@ afterEach(() => {
 function createGitRepo(): string {
   const root = mkdtempSync(path.join(tmpdir(), "lisa-worktree-create-"));
   tempDirs.push(root);
-  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root });
+  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root, env: cleanGitEnv() });
   spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
     cwd: root,
-    env: { ...process.env, ...GIT_IDENTITY },
+    env: { ...cleanGitEnv(), ...GIT_IDENTITY },
   });
   return root;
 }
@@ -69,6 +83,7 @@ function runHook(
   });
   const result = spawnSync(SH_PATH, [HOOK_PATH], {
     cwd: root,
+    env: cleanGitEnv(),
     input: payload,
     encoding: "utf-8",
   });
@@ -97,6 +112,7 @@ describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
     const { stdout } = runHook(root, "featureY");
     const branch = spawnSync(GIT_PATH, ["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: stdout.trim(),
+      env: cleanGitEnv(),
       encoding: "utf-8",
     }).stdout.trim();
     expect(branch).toBe("worktree-featureY");
@@ -120,6 +136,7 @@ describe.skipIf(!hasJq)("WorktreeCreate hook", () => {
     const root = createGitRepo();
     const result = spawnSync(SH_PATH, [HOOK_PATH], {
       cwd: root,
+      env: cleanGitEnv(),
       input: JSON.stringify({ hook_event_name: "WorktreeCreate", cwd: root }),
       encoding: "utf-8",
     });

--- a/tests/unit/migrations/untrack-codex-marketplace.test.ts
+++ b/tests/unit/migrations/untrack-codex-marketplace.test.ts
@@ -14,6 +14,20 @@ import type { MigrationContext } from "../../../src/migrations/migration.interfa
 
 const MARKETPLACE = ".agents/plugins/marketplace.json";
 
+/**
+ * Return process env without outer git hook state for nested temp repos.
+ * @returns Environment safe for fixture git commands
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 describe("UntrackCodexMarketplaceMigration", () => {
   const migration = new UntrackCodexMarketplaceMigration();
   let tempDir: string;
@@ -41,13 +55,19 @@ describe("UntrackCodexMarketplaceMigration", () => {
   });
 
   const initRepo = (): void => {
-    execSync("git init", { cwd: projectDir, stdio: "ignore" });
+    execSync("git init", {
+      cwd: projectDir,
+      env: cleanGitEnv(),
+      stdio: "ignore",
+    });
     execSync('git config user.email "test@example.com"', {
       cwd: projectDir,
+      env: cleanGitEnv(),
       stdio: "ignore",
     });
     execSync('git config user.name "Test"', {
       cwd: projectDir,
+      env: cleanGitEnv(),
       stdio: "ignore",
     });
   };
@@ -55,10 +75,12 @@ describe("UntrackCodexMarketplaceMigration", () => {
   const commitMarketplace = (): void => {
     execSync("git add .agents/plugins/marketplace.json", {
       cwd: projectDir,
+      env: cleanGitEnv(),
       stdio: "ignore",
     });
     execSync('git commit -m "add marketplace"', {
       cwd: projectDir,
+      env: cleanGitEnv(),
       stdio: "ignore",
     });
   };
@@ -76,7 +98,7 @@ describe("UntrackCodexMarketplaceMigration", () => {
     try {
       execSync(
         "git ls-files --error-unmatch .agents/plugins/marketplace.json",
-        { cwd: projectDir, stdio: "ignore" }
+        { cwd: projectDir, env: cleanGitEnv(), stdio: "ignore" }
       );
       return true;
     } catch {


### PR DESCRIPTION
## Summary
- remove the explicit reserved `GITHUB_TOKEN` env key from the reusable SonarCloud scan step
- add workflow coverage that forbids generated `GITHUB_*` env keys
- harden nested git-command test/runtime paths against inherited outer git hook state

## Verification
- bun test tests/unit/migrations/untrack-codex-marketplace.test.ts tests/unit/hooks/worktree-create.test.ts tests/unit/hooks/post-checkout.test.ts tests/integration/quality-workflow.test.ts
- pre-push hook: security audit, slow lint, knip, vitest coverage, integration tests

## Reviewer Replay
1. Open this branch's `.github/workflows/quality.yml`.
2. Confirm the SonarCloud scan step defines `SONAR_TOKEN` only and no `GITHUB_TOKEN` env key.
3. Run `bun test tests/integration/quality-workflow.test.ts` and confirm the reserved env-key regression test passes.
