### PR TITLE
fix(ci): drop dynamic approval environment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2330,13 +2330,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.require_approval == true && inputs.compliance_framework != 'none' && inputs.approval_environment != '' }}
     needs: [compliance_validation]
-    environment:
-      name: ${{ inputs.approval_environment }}
-      # NOTE: This environment must be created in your repository before using this workflow
-      # To create it:
-      # 1. Go to Settings > Environments > New environment
-      # 2. Name it to match the approval_environment input (default: "production")
-      # 3. Add protection rules (required reviewers, deployment branches, etc.)
     steps:
       - name: 📝 Log approval
         run: |

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -41,6 +41,7 @@ interface WorkflowJob {
   "timeout-minutes"?: number;
   needs?: string | string[];
   if?: string;
+  environment?: unknown;
   permissions?: Record<string, unknown>;
   strategy?: { matrix?: Record<string, unknown>; "fail-fast"?: boolean };
   steps?: WorkflowStep[];
@@ -251,6 +252,12 @@ describe("quality.yml reusable workflow", () => {
       expect(scan).toBeDefined();
       expect(scan?.env?.SONAR_TOKEN).toBe("${{ secrets.SONAR_TOKEN }}");
       expect(scan?.env).not.toHaveProperty("GITHUB_TOKEN");
+    });
+  });
+
+  describe("cross-repo reusable workflow approval gate", () => {
+    it("does not bind a dynamic environment in the optional approval job", () => {
+      expect(workflow.jobs.approval_gate.environment).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- remove the dynamic `environment` binding from the optional quality approval gate
- add integration coverage to keep the reusable quality workflow free of that cross-repo startup risk

## Verification
- bun test tests/integration/quality-workflow.test.ts
- pre-push hook: security audit, slow lint, knip, vitest coverage, integration tests

## Reviewer Replay
1. Open `.github/workflows/quality.yml` on this branch.
2. Confirm `approval_gate` still has its `if` guard but no `environment:` binding.
3. Run `bun test tests/integration/quality-workflow.test.ts`.
