### PR TITLE
fix(ci): avoid implicit token in verification gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -483,7 +483,6 @@ jobs:
           VERIFY_PR_NUMBER: ${{ github.event.pull_request.number }}
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           VERIFY_GITHUB_REPOSITORY: ${{ github.repository }}
-          VERIFY_GITHUB_TOKEN: ${{ github.token }}
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -223,7 +223,7 @@ describe("quality.yml reusable workflow", () => {
       expect(check?.env?.VERIFY_GITHUB_REPOSITORY).toBe(
         "${{ github.repository }}"
       );
-      expect(check?.env?.VERIFY_GITHUB_TOKEN).toBe("${{ github.token }}");
+      expect(check?.env?.VERIFY_GITHUB_TOKEN).toBeUndefined();
       expect(check?.env?.VERIFY_LABELS).toContain(
         "github.event.pull_request.labels"
       );


### PR DESCRIPTION
## Summary
- remove the implicit github.token env injection from the reusable verification coverage job
- keep PR number/repository/label context so the check falls back safely without wedging cross-repo callers

## Verification
- actionlint -ignore 'shellcheck reported issue' .github/workflows/quality.yml
- bun test tests/integration/quality-workflow.test.ts tests/unit/scripts/verification-coverage.test.ts
- pre-push hook: slow lint, knip, full unit coverage, integration tests

## Reviewer replay
1. Open a downstream repo PR that calls CodySwannGT/lisa/.github/workflows/quality.yml@main.
2. Dispatch or rerun the downstream CI workflow.
3. Confirm GitHub creates jobs instead of ending the parent workflow as zero-job startup_failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the verification coverage workflow to stop passing a GitHub token to the coverage check step.
  * Adjusted automated checks to reflect the new workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->