### PR TITLE
fix(ci): restore cross-repo verification gate wiring

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -455,9 +455,6 @@ jobs:
     name: ✅ Verification Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
     # Per-change verification (UAT) gate: a feat/fix must ship a verification
     # (e2e) spec, unless labeled verification-exempt. Inert unless a project type
     # opts in via verify_enforced, and only meaningful on pull_request (needs the
@@ -480,9 +477,7 @@ jobs:
         env:
           VERIFY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          VERIFY_PR_NUMBER: ${{ github.event.pull_request.number }}
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          VERIFY_GITHUB_REPOSITORY: ${{ github.repository }}
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -207,22 +207,17 @@ describe("quality.yml reusable workflow", () => {
   });
 
   describe("verification coverage labels", () => {
-    it("passes live pull request context to the coverage script", () => {
+    it("passes event labels to the coverage script without live GitHub context", () => {
       const job = workflow.jobs.verification_coverage;
-      expect(job.permissions?.contents).toBe("read");
-      expect(job.permissions?.["pull-requests"]).toBe("read");
+      expect(job.permissions).toBeUndefined();
 
       const steps = job.steps ?? [];
       const check = steps.find(s =>
         s.run?.includes("check-verification-coverage.mjs")
       );
       expect(check).toBeDefined();
-      expect(check?.env?.VERIFY_PR_NUMBER).toBe(
-        "${{ github.event.pull_request.number }}"
-      );
-      expect(check?.env?.VERIFY_GITHUB_REPOSITORY).toBe(
-        "${{ github.repository }}"
-      );
+      expect(check?.env?.VERIFY_PR_NUMBER).toBeUndefined();
+      expect(check?.env?.VERIFY_GITHUB_REPOSITORY).toBeUndefined();
       expect(check?.env?.VERIFY_GITHUB_TOKEN).toBeUndefined();
       expect(check?.env?.VERIFY_LABELS).toContain(
         "github.event.pull_request.labels"


### PR DESCRIPTION
## Summary
- remove the verification coverage job permissions block from the reusable quality workflow
- stop passing live PR number/repository metadata from the cross-repo reusable job
- keep event-label fallback wiring for verification-exempt handling

## Verification
- actionlint -ignore 'shellcheck reported issue' .github/workflows/quality.yml
- bun test tests/integration/quality-workflow.test.ts tests/unit/scripts/verification-coverage.test.ts
- pre-push hook: slow lint, knip, full unit coverage, integration tests

## Reviewer replay
1. Open a downstream repo PR whose CI calls CodySwannGT/lisa/.github/workflows/quality.yml@main.
2. Dispatch the downstream CI workflow.
3. Confirm the caller creates reusable-workflow jobs instead of ending as zero-job startup_failure.