### PR TITLE
fix(plugins): harden worktree bootstrap + bound verification fetch

### DIFF
--- a/tests/unit/hooks/post-checkout.test.ts
+++ b/tests/unit/hooks/post-checkout.test.ts
@@ -61,7 +61,7 @@ afterEach(() => {
 
 /** A temp git repo wired with a fake `claude` for exercising the hook. */
 interface Repo {
-  /** Repo root (may sit under a .claude/worktrees/* path). */
+  /** Target root — a linked worktree, or the primary checkout. */
   readonly root: string;
   /** Directory holding the fake `claude` binary, prepended to PATH. */
   readonly binDir: string;
@@ -70,31 +70,46 @@ interface Repo {
 }
 
 /**
- * Create a git repo at `relativeRoot` under a fresh temp dir, seed
- * .claude/settings.json with the given enabled plugins, and a fake `claude`
- * binary that appends its argv to a log.
- * @param relativeRoot - Path segments for the repo root under the temp dir
+ * Create a temp git repo and, when requested, a REAL linked worktree off it,
+ * seed .claude/settings.json with the enabled plugins, and a fake `claude` that
+ * logs its argv. The hook detects linked worktrees via git metadata (private
+ * git dir ≠ common dir), so fixtures must be genuine worktrees rather than a
+ * directory that merely looks like one.
+ * @param options - Fixture shape
+ * @param options.worktree - Whether `root` is a linked worktree or the primary checkout
  * @param enabledPlugins - Map written to .claude/settings.json enabledPlugins
- * @returns The repo root, fake-bin directory, and the claude-call log path
+ * @returns The target root, fake-bin directory, and the claude-call log path
  */
 function createRepo(
-  relativeRoot: readonly string[],
+  options: { readonly worktree: boolean },
   enabledPlugins: Record<string, boolean>
 ): Repo {
   const base = mkdtempSync(path.join(tmpdir(), "lisa-post-checkout-"));
-  const root = path.join(base, ...relativeRoot);
+  const main = path.join(base, "main");
   const binDir = path.join(base, "bin");
   const callsFile = path.join(base, "claude-calls.log");
   const claudeBin = path.join(binDir, "claude");
+  const root = options.worktree
+    ? path.join(main, ".claude", "worktrees", "wtA")
+    : main;
 
   tempDirs.push(base);
-  mkdirSync(path.join(root, ".claude"), { recursive: true });
+  mkdirSync(main, { recursive: true });
   mkdirSync(binDir, { recursive: true });
-  spawnSync(GIT_PATH, ["init", "-q"], { cwd: root, env: cleanGitEnv() });
+  spawnSync(GIT_PATH, ["init", "-q"], { cwd: main, env: cleanGitEnv() });
   spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
-    cwd: root,
+    cwd: main,
     env: { ...cleanGitEnv(), ...GIT_IDENTITY },
   });
+
+  if (options.worktree) {
+    spawnSync(GIT_PATH, ["worktree", "add", "-q", "-b", "feat", root, "HEAD"], {
+      cwd: main,
+      env: { ...cleanGitEnv(), ...GIT_IDENTITY },
+    });
+  }
+
+  mkdirSync(path.join(root, ".claude"), { recursive: true });
   writeFileSync(
     path.join(root, ".claude", "settings.json"),
     JSON.stringify({ enabledPlugins })
@@ -123,12 +138,13 @@ function runHook(repo: Repo, flag: string): string[] {
   return readFileSync(repo.callsFile, "utf-8").split("\n").filter(Boolean);
 }
 
-const WORKTREE_ROOT = [".claude", "worktrees", "wtA"];
 const INSTALL_LISA = "plugin install lisa@lisa --scope project";
+const WORKTREE = { worktree: true } as const;
+const MAIN = { worktree: false } as const;
 
 describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
   it("installs each enabled plugin at project scope inside a worktree", () => {
-    const repo = createRepo(WORKTREE_ROOT, {
+    const repo = createRepo(WORKTREE, {
       "lisa@lisa": true,
       "coderabbit@claude-plugins-official": true,
     });
@@ -141,7 +157,7 @@ describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
   });
 
   it("skips plugin ids containing shell-unsafe characters", () => {
-    const repo = createRepo(WORKTREE_ROOT, {
+    const repo = createRepo(WORKTREE, {
       "lisa@lisa": true,
       "bad;rm -rf": true,
     });
@@ -151,7 +167,7 @@ describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
   });
 
   it("does not install plugins disabled (set to false) in settings", () => {
-    const repo = createRepo(WORKTREE_ROOT, {
+    const repo = createRepo(WORKTREE, {
       "lisa@lisa": true,
       "code-review@claude-plugins-official": false,
     });
@@ -161,19 +177,19 @@ describe.skipIf(!hasJq)("post-checkout worktree plugin bootstrap", () => {
   });
 
   it("is idempotent: a second checkout is a no-op (sentinel)", () => {
-    const repo = createRepo(WORKTREE_ROOT, { "lisa@lisa": true });
+    const repo = createRepo(WORKTREE, { "lisa@lisa": true });
     const first = runHook(repo, "1");
     const second = runHook(repo, "1");
     expect(second).toEqual(first);
   });
 
   it("does nothing on a file checkout (flag 0)", () => {
-    const repo = createRepo(WORKTREE_ROOT, { "lisa@lisa": true });
+    const repo = createRepo(WORKTREE, { "lisa@lisa": true });
     expect(runHook(repo, "0")).toEqual([]);
   });
 
-  it("does nothing in a non-worktree (main) checkout", () => {
-    const repo = createRepo(["mainproj"], { "lisa@lisa": true });
+  it("does nothing in the primary (non-worktree) checkout", () => {
+    const repo = createRepo(MAIN, { "lisa@lisa": true });
     expect(runHook(repo, "1")).toEqual([]);
   });
 });

--- a/tests/unit/scripts/verification-coverage.test.ts
+++ b/tests/unit/scripts/verification-coverage.test.ts
@@ -45,6 +45,7 @@ describe("check-verification-coverage", () => {
     readonly prNumber?: string;
     readonly token?: string;
     readonly fetchImpl?: typeof fetch;
+    readonly timeoutMs?: number;
   }) => Promise<string[] | null>;
 
   beforeAll(async () => {
@@ -135,6 +136,41 @@ describe("check-verification-coverage", () => {
       "https://api.github.com/repos/CodySwannGT/lisa/pulls/1371",
     ]);
     expect(labels).toEqual([EXEMPT_LABEL, "component:ci"]);
+  });
+
+  it("bounds the request with an abort signal", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return { ok: true, json: async () => ({ labels: [] }) };
+    }) as unknown as typeof fetch;
+
+    await fetchLivePullRequestLabels({
+      repository: REPOSITORY,
+      prNumber: "1371",
+      token: "token",
+      fetchImpl,
+    });
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("surfaces a clear error when the request times out", async () => {
+    const fetchImpl = (async () => {
+      const error = new Error("aborted");
+      error.name = "TimeoutError";
+      throw error;
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchLivePullRequestLabels({
+        repository: REPOSITORY,
+        prNumber: "1371",
+        token: "token",
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).rejects.toThrow(/timed out after 5ms/);
   });
 
   it("skips live label lookup when PR API context is absent", async () => {

--- a/typescript/copy-contents/.husky/post-checkout
+++ b/typescript/copy-contents/.husky/post-checkout
@@ -18,13 +18,29 @@
 # and standalone `cd && claude` sessions then resolve every enabled plugin.
 #
 # Guards keep it cheap and safe:
-#   - only inside a *.claude/worktrees/* path (the main checkout is handled by
-#     `lisa apply`'s plugin registration);
+#   - only in a LINKED git worktree (its private git dir differs from the shared
+#     common dir); the primary checkout is handled by `lisa apply`. This catches
+#     worktrees created anywhere (`git worktree add ../feature`), not just under
+#     .claude/worktrees;
 #   - only on a branch checkout ($3 = 1), never a file checkout;
 #   - only once per worktree (a sentinel in the worktree's private git dir), so
 #     ordinary branch switches do not re-run 10+ installs;
 #   - only when `claude` and `jq` are on PATH and settings exist (skips CI/remote);
+#   - each Claude call is time-bounded (when a `timeout` binary exists) so a
+#     stalled network can't hang `git worktree add` past the WorktreeCreate budget;
 #   - best-effort — never blocks or fails the checkout.
+
+# Run the Claude CLI with a wall-clock bound when `timeout`/`gtimeout` is
+# available, so a hung network call can't stall worktree creation indefinitely.
+_lisa_claude() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 45 claude "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 45 claude "$@"
+  else
+    claude "$@"
+  fi
+}
 
 _lisa_bootstrap_worktree_plugins() {
   # $3 == 1 -> branch checkout (worktree add / branch switch); 0 -> file checkout
@@ -32,19 +48,20 @@ _lisa_bootstrap_worktree_plugins() {
   command -v claude >/dev/null 2>&1 || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  _root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  case "$_root" in
-    */.claude/worktrees/*) : ;;
-    *) return 0 ;; # main checkout: `lisa apply` installs plugins there
-  esac
+  # Only LINKED worktrees need bootstrapping — detect via git metadata rather
+  # than a path substring, so worktrees created outside .claude/worktrees still
+  # get their project-scoped installs. Equal dirs ⇒ primary checkout ⇒ skip.
+  _gitdir="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
+  _common_gitdir="$(git rev-parse --git-common-dir 2>/dev/null || echo "$_gitdir")"
+  [ "$_gitdir" != "$_common_gitdir" ] || return 0
 
+  _root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   _settings="$_root/.claude/settings.json"
   [ -f "$_settings" ] || return 0
 
   # Per-worktree sentinel lives in the worktree's private git dir
   # (<main>/.git/worktrees/<name>), so it neither pollutes the tree nor leaks to
   # other worktrees, and survives branch switches.
-  _gitdir="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
   _sentinel="$_gitdir/lisa-plugins-bootstrapped"
   [ -f "$_sentinel" ] && return 0
 
@@ -53,14 +70,14 @@ _lisa_bootstrap_worktree_plugins() {
   [ -n "$_plugins" ] || return 0
 
   echo "🔌 Bootstrapping Claude Code plugins for new worktree (scope: project)…"
-  claude plugin marketplace update lisa >/dev/null 2>&1 || true
+  _lisa_claude plugin marketplace update lisa >/dev/null 2>&1 || true
   _had_failure=0
   for _p in $_plugins; do
     # Skip ids with shell-unsafe characters before interpolating into the CLI.
     case "$_p" in
       *[!A-Za-z0-9@._/-]*) continue ;;
     esac
-    if claude plugin install "$_p" --scope project >/dev/null 2>&1; then
+    if _lisa_claude plugin install "$_p" --scope project >/dev/null 2>&1; then
       echo "  ✓ $_p"
     else
       echo "  ⚠ $_p (skipped)"

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -52,6 +52,7 @@ function parseLabels(value) {
  * @param {string | undefined} input.prNumber - Pull request number
  * @param {string | undefined} input.token - GitHub token
  * @param {typeof fetch} [input.fetchImpl] - Fetch implementation for tests
+ * @param {number} [input.timeoutMs] - Abort the request after this many ms
  * @returns {Promise<string[] | null>} Live labels, or null when context is absent
  */
 export async function fetchLivePullRequestLabels({
@@ -59,6 +60,7 @@ export async function fetchLivePullRequestLabels({
   prNumber,
   token,
   fetchImpl = globalThis.fetch,
+  timeoutMs = 10000,
 }) {
   if (!repository || !prNumber || !token) {
     return null;
@@ -67,16 +69,32 @@ export async function fetchLivePullRequestLabels({
     throw new Error("Live label lookup requires a fetch implementation.");
   }
 
-  const response = await fetchImpl(
-    `https://api.github.com/repos/${repository}/pulls/${prNumber}`,
-    {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
+  // Bound the request so a stalled GitHub connection can't hang the gate until
+  // the outer CI timeout kills the job.
+  let response;
+  try {
+    response = await fetchImpl(
+      `https://api.github.com/repos/${repository}/pulls/${prNumber}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      }
+    );
+  } catch (error) {
+    if (
+      error &&
+      (error.name === "TimeoutError" || error.name === "AbortError")
+    ) {
+      throw new Error(
+        `Failed to fetch live PR labels: GitHub API request timed out after ${timeoutMs}ms.`
+      );
     }
-  );
+    throw error;
+  }
   if (!response.ok) {
     throw new Error(
       `Failed to fetch live PR labels: GitHub API returned ${response.status}.`


### PR DESCRIPTION
Follow-up to [#1375](https://github.com/CodySwannGT/lisa/pull/1375), addressing CodeRabbit review on the consumer PR ([CodySwannGT/grist#166](https://github.com/CodySwannGT/grist/pull/166)). These files are Lisa-managed, so the fixes belong here, not in the consumer.

- **post-checkout — detect linked worktrees via git metadata.** Replaces the `.claude/worktrees/*` path-substring guard with `git rev-parse --git-dir` ≠ `--git-common-dir`, so worktrees created anywhere (`git worktree add ../feature`, IDE-created) also get their project-scoped installs. The primary checkout (equal dirs) is still skipped.
- **post-checkout — bound each Claude call.** Wraps `claude` with `timeout`/`gtimeout` (when available) so a stalled network can't hang `git worktree add` past the `WorktreeCreate` budget. A timed-out install counts as failure → sentinel not written → retries next checkout.
- **check-verification-coverage — bound the live label fetch.** Adds `AbortSignal.timeout` (default 10s) around the GitHub API call so a hung connection can't stall the gate until the CI job timeout; surfaces a clear timeout error.

Tests now build **real linked worktrees** (the metadata detection requires genuine worktrees), plus abort-signal and timeout cases. Full suite green (3577), pushed through the pre-push gate.