### PR TITLE
fix(ci): make Playwright quality job framework-aware; pin underscore in phaser starter

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -723,6 +723,25 @@ jobs:
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      - name: 🔍 Check for Playwright config
+        id: check_playwright
+        run: |
+          if [ -f "playwright.config.ts" ] || [ -f "playwright.config.js" ]; then
+            echo "has_config=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_config=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      # A `test:e2e` script that drives Playwright needs the browser binaries.
+      # Without this the run dies with "Looks like Playwright was just installed
+      # … run npx playwright install". Gated on a Playwright config so non-
+      # Playwright e2e suites (Cypress, etc.) don't pay for an unused install.
+      - name: 🎭 Install Playwright browsers
+        if: steps.check_script.outputs.exists == 'true' && steps.check_playwright.outputs.has_config == 'true'
+        run: npx playwright install --with-deps
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: 🧪 Run E2E tests
         if: steps.check_script.outputs.exists == 'true'
         run: |
@@ -907,6 +926,25 @@ jobs:
         run: ${{ inputs.playwright_setup_command }}
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # The web-export build below assumes an Expo project (`expo export`).
+      # Non-Expo web projects (e.g. Vite/Phaser) build + serve themselves via
+      # the Playwright config's `webServer`, so `expo export` is both wrong
+      # (no Metro/Expo config → "No platforms are configured to use the Metro
+      # bundler") and unnecessary. Detect Expo and gate the export/cache steps
+      # on it; non-Expo projects skip straight to the browser install + test run.
+      - name: 🔍 Detect Expo project
+        id: check_expo
+        run: |
+          if [ -f "app.json" ] || [ -f "app.config.js" ] || [ -f "app.config.ts" ] \
+            || { [ -f "package.json" ] && grep -q '"expo"[[:space:]]*:' package.json; }; then
+            echo "is_expo=true" >> $GITHUB_OUTPUT
+            echo "✅ Expo project detected — will run \`expo export\`"
+          else
+            echo "is_expo=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ Non-Expo project — skipping \`expo export\` (Playwright webServer self-builds)"
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       # Expo build cache — opt-in via `cache_build: true`.
       #
       # Cache invalidation contract:
@@ -919,7 +957,7 @@ jobs:
       #   - .expo/            Expo CLI metadata and bundler cache
       #   - node_modules/.cache  Metro/Babel bundler caches
       - name: 💾 Restore Expo build cache
-        if: steps.check_playwright.outputs.has_config == 'true' && inputs.cache_build == true
+        if: steps.check_playwright.outputs.has_config == 'true' && steps.check_expo.outputs.is_expo == 'true' && inputs.cache_build == true
         id: expo_cache
         uses: actions/cache@v5
         with:
@@ -932,12 +970,12 @@ jobs:
             ${{ runner.os }}-expo-build-
 
       - name: 🌐 Build web export
-        if: steps.check_playwright.outputs.has_config == 'true' && (inputs.cache_build != true || steps.expo_cache.outputs.cache-hit != 'true')
+        if: steps.check_playwright.outputs.has_config == 'true' && steps.check_expo.outputs.is_expo == 'true' && (inputs.cache_build != true || steps.expo_cache.outputs.cache-hit != 'true')
         run: npx expo export --platform web
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: ⏭️ Expo build cache hit — skipping expo export
-        if: steps.check_playwright.outputs.has_config == 'true' && inputs.cache_build == true && steps.expo_cache.outputs.cache-hit == 'true'
+        if: steps.check_playwright.outputs.has_config == 'true' && steps.check_expo.outputs.is_expo == 'true' && inputs.cache_build == true && steps.expo_cache.outputs.cache-hit == 'true'
         run: echo "::notice::Expo build cache hit — skipped \`npx expo export --platform web\`"
         working-directory: ${{ inputs.working_directory || '.' }}
 

--- a/phaser/package-lisa/package.lisa.json
+++ b/phaser/package-lisa/package.lisa.json
@@ -54,10 +54,12 @@
     "packageManager": "bun@1.3.11",
     "private": true,
     "resolutions": {
-      "vite": "$vite"
+      "vite": "$vite",
+      "underscore": "^1.13.8"
     },
     "overrides": {
-      "vite": "$vite"
+      "vite": "$vite",
+      "underscore": "^1.13.8"
     }
   },
   "merge": {

--- a/phaser/package-lisa/package.lisa.json
+++ b/phaser/package-lisa/package.lisa.json
@@ -55,11 +55,13 @@
     "private": true,
     "resolutions": {
       "vite": "$vite",
-      "underscore": "^1.13.8"
+      "underscore": "^1.13.8",
+      "minimist": "^1.2.8"
     },
     "overrides": {
       "vite": "$vite",
-      "underscore": "^1.13.8"
+      "underscore": "^1.13.8",
+      "minimist": "^1.2.8"
     }
   },
   "merge": {


### PR DESCRIPTION
## Problem

The reusable `quality.yml` Playwright job assumes every project is **Expo**. It unconditionally runs `npx expo export --platform web` before the tests. On a **Vite/Phaser** project (e.g. the `phaserstarter`), this fails with:

> `CommandError: No platforms are configured to use the Metro bundler in the project Expo config.`

…which kills the shard before any test runs, and the downstream report-merge then fails with `Directory does not exist: all-blob-reports`. Separately, the generic `test_e2e` job runs `bun run test:e2e` (= `playwright test`) **without installing browsers**, so it dies with *"Looks like Playwright was just installed … run npx playwright install."*

Surfaced by [phaserstarter#1](https://github.com/CodySwannGT/phaserstarter/pull/1), where 3 checks were red: both Playwright gates + Security Scan.

## Changes

**`.github/workflows/quality.yml`**
- `playwright_e2e`: new `🔍 Detect Expo project` step (checks `app.json` / `app.config.*` / an `expo` dependency). The `expo export` build **and its cache** are now gated on `is_expo == 'true'`. Non-Expo projects skip the export and rely on the Playwright config's `webServer` to build + serve (e.g. Vite `build && preview`).
  - **Playwright is _not_ disabled for non-Expo projects** — browser install and `npx playwright test` are unchanged (gated only on `has_config`). They run in full; only the wrong Expo pre-build is skipped.
- `test_e2e`: install Playwright browsers when a `playwright.config.{ts,js}` is present, before running `test:e2e`.

**`phaser/package-lisa/package.lisa.json`**
- Force `underscore@^1.13.8` via `overrides`/`resolutions`. The dev-only `audiosprite` build tool pins the vulnerable `underscore@~1.8.3` (GHSA-cf4h-3jhx-xvhq, GHSA-qpx9-hpmf-5gmw). 1.13.8 is the patched release and audiosprite only uses stable APIs (`after`/`extend`/`flatten`/`uniq`), so this is a **real remediation**, not an audit suppression. audiosprite is unmaintained (0.7.2 is latest), so an override is the highest-available fix rung.

## Verification

Ran the phaserstarter e2e suite locally with the override + webServer approach (no expo export): **5/5 passed**, driven by `vite build` + `vite preview`. Also typecheck / unit tests / build green.

🤖 Generated with Claude Code