### PR TITLE
fix(ci): scope the bun security audit to production deps (align local + CI gates)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1498,7 +1498,18 @@ jobs:
           elif [ "${{ inputs.package_manager }}" = "bun" ]; then
             GHSA_IDS_JSON=$(printf '%s\n' $GHSA_IDS | jq -R . | jq -s 'map(select(length > 0))')
             CVE_IDS_JSON=$(printf '%s\n' $CVE_IDS | jq -R . | jq -s 'map(select(length > 0))')
-            AUDIT_JSON=$(bun audit --json 2>/dev/null || true)
+            # `--production` scopes the audit to production dependencies, matching
+            # every other audit path: the pre-push hook's bun branch
+            # (`bun audit --production`, which documents this same rationale), and
+            # both this workflow's own npm branch (`npm audit --production`) and
+            # yarn branch (`yarn audit --groups dependencies`). Without it, bun
+            # alone audited devDependencies too, so this gate failed on dev-only
+            # build-tool advisories that never ship (e.g. audiosprite -> underscore/
+            # minimist) while the identical local hook passed — a confusing
+            # local/CI split. Dev-dependency / supply-chain coverage is owned by
+            # the dedicated Snyk step (`--all-projects`), not this ship-scope gate.
+            # bun honours `--production` even though `bun audit --help` omits it.
+            AUDIT_JSON=$(bun audit --production --json 2>/dev/null || true)
             if [ -z "$AUDIT_JSON" ]; then
               AUDIT_JSON="{}"
             fi

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -281,7 +281,9 @@ describe("quality.yml reusable workflow", () => {
       const audit = steps.find(s => s.name === "🔒 Run security audit");
       const run = audit?.run ?? "";
 
-      expect(run).toContain("bun audit --json");
+      // Production-scoped, matching the pre-push hook and the npm/yarn paths so
+      // the local and CI audit gates agree (dev/supply-chain is Snyk's job).
+      expect(run).toContain("bun audit --production --json");
       expect(run).not.toContain(
         "bun audit --audit-level=high $BUN_IGNORE_FLAGS"
       );


### PR DESCRIPTION
## Problem

The security-audit gate behaves differently locally vs. in CI. A push whose only high/critical advisories come from **dev-only build tooling** passes the local pre-push hook but **fails the CI Security Scan** — even though nothing changed in production deps and nothing ships to users. (Surfaced concretely on phaser-starter: `audiosprite → underscore/minimist` dev advisories; same root cause grist hit.)

## Root cause — one missing flag

Five of six audit paths are production-scoped; **CI's bun branch is the lone outlier**:

| Path | Command | Scope |
|---|---|---|
| pre-push hook — bun | `bun audit **--production**` | prod |
| pre-push hook — npm | `npm audit **--production**` | prod |
| pre-push hook — yarn | `yarn audit **--groups dependencies**` | prod |
| CI — npm | `npm audit **--production**` | prod |
| CI — yarn | `yarn audit **--groups dependencies**` | prod |
| **CI — bun** | `bun audit --json` | **dev + prod** ⟵ outlier |

The pre-push hook's bun branch even carries a comment documenting the `--production` rationale — CI's bun branch just never got the flag.

## Fix

Add `--production` to CI's `bun audit` so all six paths agree on scope.

**This does not create a blind spot:** dev-dependency / supply-chain coverage is intentionally owned by the dedicated **Snyk step** (`--all-projects --severity-threshold=high`), not this ship-scope gate. (bun honours `--production` even though `bun audit --help` omits it.)

## Blast radius

`quality.yml` is a **reusable workflow** referenced by every Lisa-governed project via `uses: …@ref` (no per-project copy), so this one change aligns the gate everywhere on release.

## Verification

- Updated the `quality-workflow` integration test to assert the production-scoped command (locks in the intent); `tests/integration/quality-workflow.test.ts` → 20/20 pass.
- Full pre-push suite (typecheck, lint, `test:cov`, integration, mutation gate) passed locally.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security check workflow so Bun audits only production dependencies, matching the app’s release-focused checks.
  * Added clearer guidance in the workflow notes about how dependency scanning is split between tools.
* **Tests**
  * Adjusted integration coverage to expect the production-scoped Bun audit command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->