### PR TITLE
fix: repair-intake stale build coverage

### DIFF
--- a/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
@@ -264,7 +264,9 @@ function resolveRepairQueueArgument(config, source, tracker) {
   }
 
   const buildQueue = resolveBuildQueueArgument(config, tracker);
-  return `${buildQueue} intake_mode=build`;
+  return buildQueue.includes("intake_mode=")
+    ? buildQueue
+    : `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
@@ -263,9 +263,8 @@ function resolveRepairQueueArgument(config, source, tracker) {
     return "github intake_mode=both";
   }
 
-  throw new Error(
-    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
-  );
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  return `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-agy/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/repair-intake/SKILL.md
@@ -80,7 +80,7 @@ lifecycle state with provider-native closure and rollup state.
 |-------|---------|---------|
 | `<queue>` | Same queue identifier `lisa:intake` accepts (see Source dispatch). Required. | — |
 | `intake_mode` | `prd` \| `build` \| `both`. Only meaningful for a GitHub `org/repo` (or bare `github`) that hosts both PRD and build label namespaces. `both` is unique to repair — a repair sweep usefully covers both lifecycles in one schedule. Absent → `both` when both namespaces exist, else whichever lifecycle exists. | `both` for dual GitHub queues; otherwise infer |
-| `stale_after` | How long with no observable activity before an in-progress item counts as stalled. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
+| `stale_after` | How long since the last state-changing transition into the in-progress role, or since the last human / PR-side forward-progress activity, before an in-progress item counts as stalled. Automation self-comments do not reset this clock. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
 | `max_candidates` | Cap on how many stuck/close-out candidates to enumerate and evaluate. Repair every materially actionable candidate within this bounded set, then stop. Overrides config. | `100` |
 | `force` | `true` bypasses the loop-prevention backoff window (so a manual re-run re-attempts items even if their fingerprint is unchanged). It does **not** change the staleness rule — use `stale_after=0` for that. | `false` |
 
@@ -228,9 +228,19 @@ intakes use. Never call Atlassian MCP or `acli` directly — go through `lisa:at
 
 ## Staleness model
 
-An in-progress item (build `claimed`, PRD `in_review`) is **stalled** only if it shows no
-observable activity newer than the `stale_after` threshold. `blocked` items are NOT gated on
-staleness — their repairability is judged on current blocker/answer state, not elapsed time.
+An in-progress item (build `claimed`, PRD `in_review`) is **stalled** when the last
+state-changing transition into the in-progress role, or the last human / PR-side forward-progress
+activity after that transition, is older than the `stale_after` threshold. `blocked` items are NOT
+gated on staleness — their repairability is judged on current blocker/answer state, not elapsed
+time.
+
+Automation self-comments are not forward progress and must not reset the staleness clock. Status
+comments like `[claude-build-intake] PR remains open...`, `[codex-build-intake] Follow-up pushed...`,
+or `[lisa-repair-intake] ...` may be useful audit notes, but they cannot make a claimed item fresh
+forever. If a provider exposes a changelog/history surface, prefer the timestamp of the last
+transition into the claimed/In-Progress role over the item's generic `updated` timestamp. When the
+history surface is unavailable, ignore comments whose author/marker clearly belongs to Lisa or its
+automation agents, and use the newest human comment/edit or PR-side progress event instead.
 
 A build `claimed` leaf whose linked PR has **already merged** (`state == MERGED`) is likewise NOT
 gated on staleness. A merged PR is a settled terminal state, not in-flight work: the only thing
@@ -254,17 +264,24 @@ decision tree step 0, and the dedicated high-confidence ordering bucket).
 `stale_after=0` means "treat any in-progress item as stalled" — a manual full-recovery lever,
 and the only way to resume work on a provider that exposes no reliable activity timestamp.
 
-### Activity signal (most-recent-wins, portable across vendors)
+### Activity signal (state-change first, portable across vendors)
 
-Compute the item's newest activity timestamp from the highest-priority signal the vendor
+Compute the item's newest eligible activity timestamp from the highest-priority signal the vendor
 exposes, and compare it to `now - stale_after`:
 
-1. Provider-native item `updatedAt` / `last_edited_time` / `updated`.
-2. Latest lifecycle/progress **comment** on the item (and, for Linear PRDs, the sentinel
-   feedback issue).
-3. For build items, latest **PR activity** on the linked PR: newest commit, review, check-run,
+1. Provider-native status/label **transition** time into the in-progress role, when the provider
+   exposes it cleanly (JIRA changelog transition to `claimed` / In Progress, GitHub label event,
+   Linear state/label history, Notion/Confluence page move/status history).
+2. Latest human lifecycle/progress **comment** or edit on the item (and, for Linear PRDs, the
+   sentinel feedback issue). Exclude automation self-comments and Lisa audit markers such as
+   `[claude-build-intake]`, `[codex-build-intake]`, `[lisa-build-intake]`, and
+   `[lisa-repair-intake]`.
+3. For build items, latest **PR-side forward-progress activity** on the linked PR: newest commit,
+   review, check-run,
    or PR comment.
-4. Status/label **transition** time, when the provider exposes it cleanly.
+4. Provider-native item `updatedAt` / `last_edited_time` / `updated` only when the provider cannot
+   expose transition/comment authorship and the timestamp is not known to be driven by automation
+   self-comments.
 
 If ANY of these is newer than the threshold, the item is **active** → record it as `active` and
 skip it (read-only). For build `claimed`, an open PR with recent commits/checks is active. For

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -369,7 +369,7 @@ documented defaults, so existing projects need no config change.
 
 | Key | Required | Default | Notes |
 |-----|----------|---------|-------|
-| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
+| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may sit after its last state-changing transition into the in-progress role, or after the last human / PR-side forward-progress activity, before repair-intake treats it as stalled and resumes it. Automation self-comments and Lisa audit notes do not reset this clock. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
 
 ### Monitor audit config (`monitor`)

--- a/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
@@ -264,7 +264,9 @@ function resolveRepairQueueArgument(config, source, tracker) {
   }
 
   const buildQueue = resolveBuildQueueArgument(config, tracker);
-  return `${buildQueue} intake_mode=build`;
+  return buildQueue.includes("intake_mode=")
+    ? buildQueue
+    : `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
@@ -263,9 +263,8 @@ function resolveRepairQueueArgument(config, source, tracker) {
     return "github intake_mode=both";
   }
 
-  throw new Error(
-    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
-  );
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  return `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-copilot/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/repair-intake/SKILL.md
@@ -80,7 +80,7 @@ lifecycle state with provider-native closure and rollup state.
 |-------|---------|---------|
 | `<queue>` | Same queue identifier `lisa:intake` accepts (see Source dispatch). Required. | — |
 | `intake_mode` | `prd` \| `build` \| `both`. Only meaningful for a GitHub `org/repo` (or bare `github`) that hosts both PRD and build label namespaces. `both` is unique to repair — a repair sweep usefully covers both lifecycles in one schedule. Absent → `both` when both namespaces exist, else whichever lifecycle exists. | `both` for dual GitHub queues; otherwise infer |
-| `stale_after` | How long with no observable activity before an in-progress item counts as stalled. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
+| `stale_after` | How long since the last state-changing transition into the in-progress role, or since the last human / PR-side forward-progress activity, before an in-progress item counts as stalled. Automation self-comments do not reset this clock. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
 | `max_candidates` | Cap on how many stuck/close-out candidates to enumerate and evaluate. Repair every materially actionable candidate within this bounded set, then stop. Overrides config. | `100` |
 | `force` | `true` bypasses the loop-prevention backoff window (so a manual re-run re-attempts items even if their fingerprint is unchanged). It does **not** change the staleness rule — use `stale_after=0` for that. | `false` |
 
@@ -228,9 +228,19 @@ intakes use. Never call Atlassian MCP or `acli` directly — go through `lisa:at
 
 ## Staleness model
 
-An in-progress item (build `claimed`, PRD `in_review`) is **stalled** only if it shows no
-observable activity newer than the `stale_after` threshold. `blocked` items are NOT gated on
-staleness — their repairability is judged on current blocker/answer state, not elapsed time.
+An in-progress item (build `claimed`, PRD `in_review`) is **stalled** when the last
+state-changing transition into the in-progress role, or the last human / PR-side forward-progress
+activity after that transition, is older than the `stale_after` threshold. `blocked` items are NOT
+gated on staleness — their repairability is judged on current blocker/answer state, not elapsed
+time.
+
+Automation self-comments are not forward progress and must not reset the staleness clock. Status
+comments like `[claude-build-intake] PR remains open...`, `[codex-build-intake] Follow-up pushed...`,
+or `[lisa-repair-intake] ...` may be useful audit notes, but they cannot make a claimed item fresh
+forever. If a provider exposes a changelog/history surface, prefer the timestamp of the last
+transition into the claimed/In-Progress role over the item's generic `updated` timestamp. When the
+history surface is unavailable, ignore comments whose author/marker clearly belongs to Lisa or its
+automation agents, and use the newest human comment/edit or PR-side progress event instead.
 
 A build `claimed` leaf whose linked PR has **already merged** (`state == MERGED`) is likewise NOT
 gated on staleness. A merged PR is a settled terminal state, not in-flight work: the only thing
@@ -254,17 +264,24 @@ decision tree step 0, and the dedicated high-confidence ordering bucket).
 `stale_after=0` means "treat any in-progress item as stalled" — a manual full-recovery lever,
 and the only way to resume work on a provider that exposes no reliable activity timestamp.
 
-### Activity signal (most-recent-wins, portable across vendors)
+### Activity signal (state-change first, portable across vendors)
 
-Compute the item's newest activity timestamp from the highest-priority signal the vendor
+Compute the item's newest eligible activity timestamp from the highest-priority signal the vendor
 exposes, and compare it to `now - stale_after`:
 
-1. Provider-native item `updatedAt` / `last_edited_time` / `updated`.
-2. Latest lifecycle/progress **comment** on the item (and, for Linear PRDs, the sentinel
-   feedback issue).
-3. For build items, latest **PR activity** on the linked PR: newest commit, review, check-run,
+1. Provider-native status/label **transition** time into the in-progress role, when the provider
+   exposes it cleanly (JIRA changelog transition to `claimed` / In Progress, GitHub label event,
+   Linear state/label history, Notion/Confluence page move/status history).
+2. Latest human lifecycle/progress **comment** or edit on the item (and, for Linear PRDs, the
+   sentinel feedback issue). Exclude automation self-comments and Lisa audit markers such as
+   `[claude-build-intake]`, `[codex-build-intake]`, `[lisa-build-intake]`, and
+   `[lisa-repair-intake]`.
+3. For build items, latest **PR-side forward-progress activity** on the linked PR: newest commit,
+   review, check-run,
    or PR comment.
-4. Status/label **transition** time, when the provider exposes it cleanly.
+4. Provider-native item `updatedAt` / `last_edited_time` / `updated` only when the provider cannot
+   expose transition/comment authorship and the timestamp is not known to be driven by automation
+   self-comments.
 
 If ANY of these is newer than the threshold, the item is **active** → record it as `active` and
 skip it (read-only). For build `claimed`, an open PR with recent commits/checks is active. For

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -374,7 +374,7 @@ documented defaults, so existing projects need no config change.
 
 | Key | Required | Default | Notes |
 |-----|----------|---------|-------|
-| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
+| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may sit after its last state-changing transition into the in-progress role, or after the last human / PR-side forward-progress activity, before repair-intake treats it as stalled and resumes it. Automation self-comments and Lisa audit notes do not reset this clock. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
 
 ### Monitor audit config (`monitor`)

--- a/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
@@ -264,7 +264,9 @@ function resolveRepairQueueArgument(config, source, tracker) {
   }
 
   const buildQueue = resolveBuildQueueArgument(config, tracker);
-  return `${buildQueue} intake_mode=build`;
+  return buildQueue.includes("intake_mode=")
+    ? buildQueue
+    : `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
@@ -263,9 +263,8 @@ function resolveRepairQueueArgument(config, source, tracker) {
     return "github intake_mode=both";
   }
 
-  throw new Error(
-    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
-  );
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  return `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa-cursor/skills/repair-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/repair-intake/SKILL.md
@@ -80,7 +80,7 @@ lifecycle state with provider-native closure and rollup state.
 |-------|---------|---------|
 | `<queue>` | Same queue identifier `lisa:intake` accepts (see Source dispatch). Required. | — |
 | `intake_mode` | `prd` \| `build` \| `both`. Only meaningful for a GitHub `org/repo` (or bare `github`) that hosts both PRD and build label namespaces. `both` is unique to repair — a repair sweep usefully covers both lifecycles in one schedule. Absent → `both` when both namespaces exist, else whichever lifecycle exists. | `both` for dual GitHub queues; otherwise infer |
-| `stale_after` | How long with no observable activity before an in-progress item counts as stalled. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
+| `stale_after` | How long since the last state-changing transition into the in-progress role, or since the last human / PR-side forward-progress activity, before an in-progress item counts as stalled. Automation self-comments do not reset this clock. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
 | `max_candidates` | Cap on how many stuck/close-out candidates to enumerate and evaluate. Repair every materially actionable candidate within this bounded set, then stop. Overrides config. | `100` |
 | `force` | `true` bypasses the loop-prevention backoff window (so a manual re-run re-attempts items even if their fingerprint is unchanged). It does **not** change the staleness rule — use `stale_after=0` for that. | `false` |
 
@@ -228,9 +228,19 @@ intakes use. Never call Atlassian MCP or `acli` directly — go through `lisa:at
 
 ## Staleness model
 
-An in-progress item (build `claimed`, PRD `in_review`) is **stalled** only if it shows no
-observable activity newer than the `stale_after` threshold. `blocked` items are NOT gated on
-staleness — their repairability is judged on current blocker/answer state, not elapsed time.
+An in-progress item (build `claimed`, PRD `in_review`) is **stalled** when the last
+state-changing transition into the in-progress role, or the last human / PR-side forward-progress
+activity after that transition, is older than the `stale_after` threshold. `blocked` items are NOT
+gated on staleness — their repairability is judged on current blocker/answer state, not elapsed
+time.
+
+Automation self-comments are not forward progress and must not reset the staleness clock. Status
+comments like `[claude-build-intake] PR remains open...`, `[codex-build-intake] Follow-up pushed...`,
+or `[lisa-repair-intake] ...` may be useful audit notes, but they cannot make a claimed item fresh
+forever. If a provider exposes a changelog/history surface, prefer the timestamp of the last
+transition into the claimed/In-Progress role over the item's generic `updated` timestamp. When the
+history surface is unavailable, ignore comments whose author/marker clearly belongs to Lisa or its
+automation agents, and use the newest human comment/edit or PR-side progress event instead.
 
 A build `claimed` leaf whose linked PR has **already merged** (`state == MERGED`) is likewise NOT
 gated on staleness. A merged PR is a settled terminal state, not in-flight work: the only thing
@@ -254,17 +264,24 @@ decision tree step 0, and the dedicated high-confidence ordering bucket).
 `stale_after=0` means "treat any in-progress item as stalled" — a manual full-recovery lever,
 and the only way to resume work on a provider that exposes no reliable activity timestamp.
 
-### Activity signal (most-recent-wins, portable across vendors)
+### Activity signal (state-change first, portable across vendors)
 
-Compute the item's newest activity timestamp from the highest-priority signal the vendor
+Compute the item's newest eligible activity timestamp from the highest-priority signal the vendor
 exposes, and compare it to `now - stale_after`:
 
-1. Provider-native item `updatedAt` / `last_edited_time` / `updated`.
-2. Latest lifecycle/progress **comment** on the item (and, for Linear PRDs, the sentinel
-   feedback issue).
-3. For build items, latest **PR activity** on the linked PR: newest commit, review, check-run,
+1. Provider-native status/label **transition** time into the in-progress role, when the provider
+   exposes it cleanly (JIRA changelog transition to `claimed` / In Progress, GitHub label event,
+   Linear state/label history, Notion/Confluence page move/status history).
+2. Latest human lifecycle/progress **comment** or edit on the item (and, for Linear PRDs, the
+   sentinel feedback issue). Exclude automation self-comments and Lisa audit markers such as
+   `[claude-build-intake]`, `[codex-build-intake]`, `[lisa-build-intake]`, and
+   `[lisa-repair-intake]`.
+3. For build items, latest **PR-side forward-progress activity** on the linked PR: newest commit,
+   review, check-run,
    or PR comment.
-4. Status/label **transition** time, when the provider exposes it cleanly.
+4. Provider-native item `updatedAt` / `last_edited_time` / `updated` only when the provider cannot
+   expose transition/comment authorship and the timestamp is not known to be driven by automation
+   self-comments.
 
 If ANY of these is newer than the threshold, the item is **active** → record it as `active` and
 skip it (read-only). For build `claimed`, an open PR with recent commits/checks is active. For

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -369,7 +369,7 @@ documented defaults, so existing projects need no config change.
 
 | Key | Required | Default | Notes |
 |-----|----------|---------|-------|
-| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
+| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may sit after its last state-changing transition into the in-progress role, or after the last human / PR-side forward-progress activity, before repair-intake treats it as stalled and resumes it. Automation self-comments and Lisa audit notes do not reset this clock. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
 
 ### Monitor audit config (`monitor`)

--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -264,7 +264,9 @@ function resolveRepairQueueArgument(config, source, tracker) {
   }
 
   const buildQueue = resolveBuildQueueArgument(config, tracker);
-  return `${buildQueue} intake_mode=build`;
+  return buildQueue.includes("intake_mode=")
+    ? buildQueue
+    : `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -263,9 +263,8 @@ function resolveRepairQueueArgument(config, source, tracker) {
     return "github intake_mode=both";
   }
 
-  throw new Error(
-    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
-  );
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  return `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/lisa/skills/repair-intake/SKILL.md
+++ b/plugins/lisa/skills/repair-intake/SKILL.md
@@ -80,7 +80,7 @@ lifecycle state with provider-native closure and rollup state.
 |-------|---------|---------|
 | `<queue>` | Same queue identifier `lisa:intake` accepts (see Source dispatch). Required. | — |
 | `intake_mode` | `prd` \| `build` \| `both`. Only meaningful for a GitHub `org/repo` (or bare `github`) that hosts both PRD and build label namespaces. `both` is unique to repair — a repair sweep usefully covers both lifecycles in one schedule. Absent → `both` when both namespaces exist, else whichever lifecycle exists. | `both` for dual GitHub queues; otherwise infer |
-| `stale_after` | How long with no observable activity before an in-progress item counts as stalled. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
+| `stale_after` | How long since the last state-changing transition into the in-progress role, or since the last human / PR-side forward-progress activity, before an in-progress item counts as stalled. Automation self-comments do not reset this clock. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
 | `max_candidates` | Cap on how many stuck/close-out candidates to enumerate and evaluate. Repair every materially actionable candidate within this bounded set, then stop. Overrides config. | `100` |
 | `force` | `true` bypasses the loop-prevention backoff window (so a manual re-run re-attempts items even if their fingerprint is unchanged). It does **not** change the staleness rule — use `stale_after=0` for that. | `false` |
 
@@ -228,9 +228,19 @@ intakes use. Never call Atlassian MCP or `acli` directly — go through `lisa:at
 
 ## Staleness model
 
-An in-progress item (build `claimed`, PRD `in_review`) is **stalled** only if it shows no
-observable activity newer than the `stale_after` threshold. `blocked` items are NOT gated on
-staleness — their repairability is judged on current blocker/answer state, not elapsed time.
+An in-progress item (build `claimed`, PRD `in_review`) is **stalled** when the last
+state-changing transition into the in-progress role, or the last human / PR-side forward-progress
+activity after that transition, is older than the `stale_after` threshold. `blocked` items are NOT
+gated on staleness — their repairability is judged on current blocker/answer state, not elapsed
+time.
+
+Automation self-comments are not forward progress and must not reset the staleness clock. Status
+comments like `[claude-build-intake] PR remains open...`, `[codex-build-intake] Follow-up pushed...`,
+or `[lisa-repair-intake] ...` may be useful audit notes, but they cannot make a claimed item fresh
+forever. If a provider exposes a changelog/history surface, prefer the timestamp of the last
+transition into the claimed/In-Progress role over the item's generic `updated` timestamp. When the
+history surface is unavailable, ignore comments whose author/marker clearly belongs to Lisa or its
+automation agents, and use the newest human comment/edit or PR-side progress event instead.
 
 A build `claimed` leaf whose linked PR has **already merged** (`state == MERGED`) is likewise NOT
 gated on staleness. A merged PR is a settled terminal state, not in-flight work: the only thing
@@ -254,17 +264,24 @@ decision tree step 0, and the dedicated high-confidence ordering bucket).
 `stale_after=0` means "treat any in-progress item as stalled" — a manual full-recovery lever,
 and the only way to resume work on a provider that exposes no reliable activity timestamp.
 
-### Activity signal (most-recent-wins, portable across vendors)
+### Activity signal (state-change first, portable across vendors)
 
-Compute the item's newest activity timestamp from the highest-priority signal the vendor
+Compute the item's newest eligible activity timestamp from the highest-priority signal the vendor
 exposes, and compare it to `now - stale_after`:
 
-1. Provider-native item `updatedAt` / `last_edited_time` / `updated`.
-2. Latest lifecycle/progress **comment** on the item (and, for Linear PRDs, the sentinel
-   feedback issue).
-3. For build items, latest **PR activity** on the linked PR: newest commit, review, check-run,
+1. Provider-native status/label **transition** time into the in-progress role, when the provider
+   exposes it cleanly (JIRA changelog transition to `claimed` / In Progress, GitHub label event,
+   Linear state/label history, Notion/Confluence page move/status history).
+2. Latest human lifecycle/progress **comment** or edit on the item (and, for Linear PRDs, the
+   sentinel feedback issue). Exclude automation self-comments and Lisa audit markers such as
+   `[claude-build-intake]`, `[codex-build-intake]`, `[lisa-build-intake]`, and
+   `[lisa-repair-intake]`.
+3. For build items, latest **PR-side forward-progress activity** on the linked PR: newest commit,
+   review, check-run,
    or PR comment.
-4. Status/label **transition** time, when the provider exposes it cleanly.
+4. Provider-native item `updatedAt` / `last_edited_time` / `updated` only when the provider cannot
+   expose transition/comment authorship and the timestamp is not known to be driven by automation
+   self-comments.
 
 If ANY of these is newer than the threshold, the item is **active** → record it as `active` and
 skip it (read-only). For build `claimed`, an open PR with recent commits/checks is active. For

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -369,7 +369,7 @@ documented defaults, so existing projects need no config change.
 
 | Key | Required | Default | Notes |
 |-----|----------|---------|-------|
-| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may show no observable activity before repair-intake treats it as stalled and resumes it. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
+| `intake.repair.staleAfterHours` | no | `2` | How long an in-progress item (build `claimed`, PRD `in_review`) may sit after its last state-changing transition into the in-progress role, or after the last human / PR-side forward-progress activity, before repair-intake treats it as stalled and resumes it. Automation self-comments and Lisa audit notes do not reset this clock. `blocked` items are judged on blocker/answer state, not this threshold. Overridable per-run via `stale_after=<dur>` in `$ARGUMENTS` (which always wins). The same value is the default backoff window for loop-prevention notes. |
 | `intake.repair.maxCandidates` | no | `100` | Upper bound on how many stuck items repair-intake enumerates while searching for the first actionable one. Bounds scan cost. Overridable per-run via `max_candidates=<n>`. |
 
 ### Monitor audit config (`monitor`)

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -264,7 +264,9 @@ function resolveRepairQueueArgument(config, source, tracker) {
   }
 
   const buildQueue = resolveBuildQueueArgument(config, tracker);
-  return `${buildQueue} intake_mode=build`;
+  return buildQueue.includes("intake_mode=")
+    ? buildQueue
+    : `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -263,9 +263,8 @@ function resolveRepairQueueArgument(config, source, tracker) {
     return "github intake_mode=both";
   }
 
-  throw new Error(
-    `Unable to resolve a single repair-intake queue for tracker=${String(tracker)} and source=${String(source)} without guessing.`
-  );
+  const buildQueue = resolveBuildQueueArgument(config, tracker);
+  return `${buildQueue} intake_mode=build`;
 }
 
 /**

--- a/plugins/src/base/skills/repair-intake/SKILL.md
+++ b/plugins/src/base/skills/repair-intake/SKILL.md
@@ -80,7 +80,7 @@ lifecycle state with provider-native closure and rollup state.
 |-------|---------|---------|
 | `<queue>` | Same queue identifier `lisa:intake` accepts (see Source dispatch). Required. | — |
 | `intake_mode` | `prd` \| `build` \| `both`. Only meaningful for a GitHub `org/repo` (or bare `github`) that hosts both PRD and build label namespaces. `both` is unique to repair — a repair sweep usefully covers both lifecycles in one schedule. Absent → `both` when both namespaces exist, else whichever lifecycle exists. | `both` for dual GitHub queues; otherwise infer |
-| `stale_after` | How long with no observable activity before an in-progress item counts as stalled. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
+| `stale_after` | How long since the last state-changing transition into the in-progress role, or since the last human / PR-side forward-progress activity, before an in-progress item counts as stalled. Automation self-comments do not reset this clock. Accepts `24h`, `90m`, `2d`, or `0` (treat any in-progress item as stalled — manual recovery, also the only way to resume work on a provider that exposes no reliable timestamp). Overrides config. | `2h` |
 | `max_candidates` | Cap on how many stuck/close-out candidates to enumerate and evaluate. Repair every materially actionable candidate within this bounded set, then stop. Overrides config. | `100` |
 | `force` | `true` bypasses the loop-prevention backoff window (so a manual re-run re-attempts items even if their fingerprint is unchanged). It does **not** change the staleness rule — use `stale_after=0` for that. | `false` |
 
@@ -228,9 +228,19 @@ intakes use. Never call Atlassian MCP or `acli` directly — go through `lisa:at
 
 ## Staleness model
 
-An in-progress item (build `claimed`, PRD `in_review`) is **stalled** only if it shows no
-observable activity newer than the `stale_after` threshold. `blocked` items are NOT gated on
-staleness — their repairability is judged on current blocker/answer state, not elapsed time.
+An in-progress item (build `claimed`, PRD `in_review`) is **stalled** when the last
+state-changing transition into the in-progress role, or the last human / PR-side forward-progress
+activity after that transition, is older than the `stale_after` threshold. `blocked` items are NOT
+gated on staleness — their repairability is judged on current blocker/answer state, not elapsed
+time.
+
+Automation self-comments are not forward progress and must not reset the staleness clock. Status
+comments like `[claude-build-intake] PR remains open...`, `[codex-build-intake] Follow-up pushed...`,
+or `[lisa-repair-intake] ...` may be useful audit notes, but they cannot make a claimed item fresh
+forever. If a provider exposes a changelog/history surface, prefer the timestamp of the last
+transition into the claimed/In-Progress role over the item's generic `updated` timestamp. When the
+history surface is unavailable, ignore comments whose author/marker clearly belongs to Lisa or its
+automation agents, and use the newest human comment/edit or PR-side progress event instead.
 
 A build `claimed` leaf whose linked PR has **already merged** (`state == MERGED`) is likewise NOT
 gated on staleness. A merged PR is a settled terminal state, not in-flight work: the only thing
@@ -254,17 +264,24 @@ decision tree step 0, and the dedicated high-confidence ordering bucket).
 `stale_after=0` means "treat any in-progress item as stalled" — a manual full-recovery lever,
 and the only way to resume work on a provider that exposes no reliable activity timestamp.
 
-### Activity signal (most-recent-wins, portable across vendors)
+### Activity signal (state-change first, portable across vendors)
 
-Compute the item's newest activity timestamp from the highest-priority signal the vendor
+Compute the item's newest eligible activity timestamp from the highest-priority signal the vendor
 exposes, and compare it to `now - stale_after`:
 
-1. Provider-native item `updatedAt` / `last_edited_time` / `updated`.
-2. Latest lifecycle/progress **comment** on the item (and, for Linear PRDs, the sentinel
-   feedback issue).
-3. For build items, latest **PR activity** on the linked PR: newest commit, review, check-run,
+1. Provider-native status/label **transition** time into the in-progress role, when the provider
+   exposes it cleanly (JIRA changelog transition to `claimed` / In Progress, GitHub label event,
+   Linear state/label history, Notion/Confluence page move/status history).
+2. Latest human lifecycle/progress **comment** or edit on the item (and, for Linear PRDs, the
+   sentinel feedback issue). Exclude automation self-comments and Lisa audit markers such as
+   `[claude-build-intake]`, `[codex-build-intake]`, `[lisa-build-intake]`, and
+   `[lisa-repair-intake]`.
+3. For build items, latest **PR-side forward-progress activity** on the linked PR: newest commit,
+   review, check-run,
    or PR comment.
-4. Status/label **transition** time, when the provider exposes it cleanly.
+4. Provider-native item `updatedAt` / `last_edited_time` / `updated` only when the provider cannot
+   expose transition/comment authorship and the timestamp is not known to be driven by automation
+   self-comments.
 
 If ANY of these is newer than the threshold, the item is **active** → record it as `active` and
 skip it (read-only). For build `claimed`, an open PR with recent commits/checks is active. For

--- a/tests/unit/strategies/automation-status-expected-fleet.test.ts
+++ b/tests/unit/strategies/automation-status-expected-fleet.test.ts
@@ -92,18 +92,24 @@ describe("automation-status expected fleet (#799)", () => {
     expect(fleet.unsupported).toEqual([]);
   });
 
-  it("fails loudly instead of inventing a mixed-vendor repair queue", () => {
-    expect(() =>
-      resolveExpectedAutomationFleet({
-        config: {
-          tracker: "jira",
-          source: "notion",
-          jira: { project: "ENG" },
-          notion: { prdDatabaseId: "db-123" },
-          github: { org: "Acme", repo: "platform" },
-        },
+  it("covers the build repair queue for mixed PRD source and JIRA tracker repos", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: "jira",
+        source: "notion",
+        jira: { project: "SE" },
+        notion: { prdDatabaseId: "db-123" },
+        github: { org: "GeminiSportsAI", repo: "frontend-v2" },
+      },
+    });
+
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: "intake-repair",
+        automationId: "lisa-auto-geminisportsai-frontend-v2-intake-repair",
+        expectedCommand: "/lisa:repair-intake SE intake_mode=build",
       })
-    ).toThrow(/single repair-intake queue/i);
+    );
   });
 
   it("falls back to the GitHub remote when config does not carry the repo identity", () => {

--- a/tests/unit/strategies/automation-status-expected-fleet.test.ts
+++ b/tests/unit/strategies/automation-status-expected-fleet.test.ts
@@ -13,11 +13,14 @@ import {
   resolveExpectedAutomationFleet,
 } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
 
+const GITHUB_TRACKER = "github";
+const INTAKE_REPAIR_ID = "intake-repair";
+
 describe("automation-status expected fleet (#799)", () => {
   it("resolves the self-host GitHub Lisa fleet and flags unsupported exploratory-bugs", () => {
     const fleet = resolveExpectedAutomationFleet({
       config: {
-        tracker: "github",
+        tracker: GITHUB_TRACKER,
         github: {
           org: "CodySwannGT",
           repo: "lisa",
@@ -30,7 +33,7 @@ describe("automation-status expected fleet (#799)", () => {
     expect(fleet.automationPrefix).toBe("lisa-auto-codyswanngt-lisa-");
     expect(fleet.expected).toEqual([
       expect.objectContaining({
-        id: "intake-repair",
+        id: INTAKE_REPAIR_ID,
         automationId: "lisa-auto-codyswanngt-lisa-intake-repair",
         expectedCadence: "every 60 minutes",
         expectedRRule: "FREQ=HOURLY;INTERVAL=1",
@@ -64,8 +67,8 @@ describe("automation-status expected fleet (#799)", () => {
   it("emits the stack-specific exploratory command and auto-start flags when supported", () => {
     const fleet = resolveExpectedAutomationFleet({
       config: {
-        tracker: "github",
-        source: "github",
+        tracker: GITHUB_TRACKER,
+        source: GITHUB_TRACKER,
         github: {
           org: "Acme",
           repo: "mobile-app",
@@ -105,9 +108,27 @@ describe("automation-status expected fleet (#799)", () => {
 
     expect(fleet.expected).toContainEqual(
       expect.objectContaining({
-        id: "intake-repair",
+        id: INTAKE_REPAIR_ID,
         automationId: "lisa-auto-geminisportsai-frontend-v2-intake-repair",
         expectedCommand: "/lisa:repair-intake SE intake_mode=build",
+      })
+    );
+  });
+
+  it("does not duplicate intake_mode=build when the GitHub build queue already carries it", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: GITHUB_TRACKER,
+        source: "notion",
+        github: { org: "CodySwannGT", repo: "lisa" },
+        notion: { prdDatabaseId: "db-123" },
+      },
+    });
+
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: INTAKE_REPAIR_ID,
+        expectedCommand: "/lisa:repair-intake github intake_mode=build",
       })
     );
   });
@@ -115,7 +136,7 @@ describe("automation-status expected fleet (#799)", () => {
   it("falls back to the GitHub remote when config does not carry the repo identity", () => {
     expect(
       resolveAutomationProjectIdentity({
-        config: { tracker: "github" },
+        config: { tracker: GITHUB_TRACKER },
         gitRemoteUrl: "git@github.com:CodySwannGT/lisa.git",
       })
     ).toEqual({

--- a/tests/unit/strategies/repair-intake-contract.test.ts
+++ b/tests/unit/strategies/repair-intake-contract.test.ts
@@ -127,6 +127,16 @@ describe("repair-intake contract", () => {
       expect(skill).toMatch(/defaults to `--state open`/);
     });
 
+    it("does not let automation self-comments reset the stalled claimed clock", () => {
+      expect(skill).toMatch(
+        /last state-changing transition into the in-progress role/i
+      );
+      expect(skill).toMatch(/automation self-comments/i);
+      expect(skill).toMatch(/must not reset the staleness clock/i);
+      expect(skill).toMatch(/\[claude-build-intake\]/);
+      expect(skill).toMatch(/\[codex-build-intake\]/);
+    });
+
     it("heals missing native sub-issue links on build Epic/Story containers", () => {
       // The native-link repair is no longer PRD-only: build containers whose
       // children were recorded as prose parentage (e.g. created by an external


### PR DESCRIPTION
## Summary\n- Treat repair-intake staleness as state-change/human/PR progress based, so automation self-comments do not keep claimed work fresh forever.\n- Resolve mixed PRD-source/build-tracker automation fleets to a build repair schedule, e.g. /lisa:repair-intake SE intake_mode=build.\n- Regenerate Lisa plugin variants and add regression coverage for both contracts.\n\nFixes #1386\n\n## Verification\n- bun test tests/unit/strategies/automation-status-expected-fleet.test.ts\n- bun test tests/unit/strategies/repair-intake-contract.test.ts\n- bun run check:plugins\n- git push pre-push hook: security audit, slow lint, knip, full unit coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repair intake no longer fails when an exact queue can’t be resolved; it derives the repair queue from the build queue and appends `intake_mode=build` when needed.
  * Refined stalled-item detection and progress timestamp precedence so automation self-comments don’t reset the staleness clock and “human/PR-side” activity is prioritized correctly.

* **Documentation**
  * Updated repair-intake and `intake.repair.staleAfterHours` docs to clearly define the staleness clock inputs and ordering rules.

* **Tests**
  * Added/updated regression tests covering mixed queue setups and the stalled-clock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->