### PR TITLE
fix(workflows): fail EAS Build workflow when a queued remote build errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,63 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies
         run: bun install
+      # Builds are queued with --no-wait so profiles fan out without holding a
+      # runner per compile; the "Wait for EAS builds" step below polls the queued
+      # build IDs so a remote build failure still fails this workflow.
       - name: Build Dev Preview
         if: inputs.environment == 'dev'
-        run: eas build --platform all --non-interactive --no-wait --profile=dev-preview
+        shell: bash
+        run: eas build --platform all --non-interactive --no-wait --profile=dev-preview --json | tee eas-builds-dev-preview.json
       - name: Build Dev
         if: inputs.environment == 'dev'
-        run: eas build --platform all --non-interactive --no-wait --profile=dev
+        shell: bash
+        run: eas build --platform all --non-interactive --no-wait --profile=dev --json | tee eas-builds-dev.json
       - name: Build Staging
         if: inputs.environment == 'staging'
-        run: eas build --platform all --non-interactive --no-wait --profile=staging --auto-submit
+        shell: bash
+        run: eas build --platform all --non-interactive --no-wait --profile=staging --auto-submit --json | tee eas-builds-staging.json
       - name: Build Production
         if: inputs.environment == 'main'
-        run: eas build --platform all --non-interactive --no-wait --profile=production --auto-submit
+        shell: bash
+        run: eas build --platform all --non-interactive --no-wait --profile=production --auto-submit --json | tee eas-builds-production.json
+      - name: Wait for EAS builds
+        timeout-minutes: 120
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(eas-builds-*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No builds were queued for environment '${{ inputs.environment }}'; nothing to wait for."
+            exit 0
+          fi
+
+          ids=$(jq -r '.[].id' "${files[@]}")
+          echo "Monitoring EAS builds:"
+          echo "$ids"
+
+          while true; do
+            pending=0
+            failed=0
+            for id in $ids; do
+              status=$(eas build:view "$id" --json | jq -r '.status')
+              echo "$(date -u +%H:%M:%S) build $id: $status"
+              case "$status" in
+                FINISHED) ;;
+                ERRORED|CANCELED) failed=1 ;;
+                *) pending=1 ;;
+              esac
+            done
+            if [ "$pending" -eq 0 ]; then
+              break
+            fi
+            sleep 120
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more EAS builds errored or were canceled. See build logs on expo.dev."
+            for id in $ids; do
+              eas build:view "$id" --json | jq -r '"\(.id) [\(.platform) \(.buildProfile)] \(.status): \(.error.message // "ok")"'
+            done
+            exit 1
+          fi
+          echo "All EAS builds finished successfully."


### PR DESCRIPTION
## Problem

The reusable `build.yml` workflow invokes `eas build` with `--no-wait`, so the workflow goes green the moment builds are **queued**. A remote build failure produces no CI signal at all.

This bit PropSwap on 2026-06-11: the Expo SDK 56 runtime bump (`runtimeVersion` 1.0.5 → 1.1.0) triggered a staging build that errored on both platforms on EAS's servers (iOS pod install failure, Android gradle error). CI showed success, `--auto-submit` had nothing to submit, and no TestFlight/Play build existed for the new runtime for three weeks — which also silently broke every `eas update` published to the staging channel (no installed binary matched runtime 1.1.0).

## Fix

- Keep `--no-wait` so profiles fan out without holding a runner per compile.
- Capture queued build IDs from each `eas build ... --json` invocation.
- Add a final **Wait for EAS builds** step (timeout 120 min) that polls `eas build:view` every 2 minutes until all builds reach a terminal state, failing the job if any are `ERRORED`/`CANCELED` and printing each build's error message.
- Piped build steps use `shell: bash` so `pipefail` applies and `tee` can't mask a queue-time failure.

## Verification

- YAML parses (`yaml.safe_load`) and the wait script passes `bash -n`.
- Statuses matched against real `eas build:view --json` output (`FINISHED`/`ERRORED` observed on the PropSwap project's June 11 builds).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline checks so builds are fully verified before completion.
  * Failed or canceled builds will now stop the workflow instead of passing unnoticed, helping prevent broken releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->