### PR TITLE
docs(readme): align lifecycle prompt stage names with the pipeline list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Lisa organizes a piece of work as a pipeline of specialized agent roles. Concept
 Most people invoke only the first stages explicitly; the rest run as nested sub-flows. The same logic runs whether you trigger it by hand or a scheduled job triggers it unattended.
 
 > **Prompt for your coding agent**
-> "List the current Lisa lifecycle commands for this project — understand, plan, build, verify, debrief — with their exact names and arguments, and note any that run automatically as sub-steps. Read the installed commands, don't answer from memory."
+> "List the current Lisa lifecycle commands for this project — understand, plan, build, prove, learn — with their exact names and arguments, and note any that run automatically as sub-steps. Read the installed commands, don't answer from memory."
 
 ### Unattended and batch work
 


### PR DESCRIPTION
Fix-forward for the one CodeRabbit nitpick on #1392 that the auto-merge race left behind.

The lifecycle prompt asked the agent to map "understand, plan, build, **verify, debrief**" while the stage list above it names the stages "Understand, Plan, Build, **Prove, Learn**". This aligns the prompt to the same five stage labels so the README is internally consistent.

Context: #1392 auto-merged on its prior head the instant the CodeRabbit status check went green, before this fix commit could push — so it shipped everything except this one-line consistency tweak. Splitting it out here.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wording in the work lifecycle instructions to use the current stage names: understand, plan, build, prove, and learn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->