### PR TITLE
feat(expo): add Play Store access skill

### DIFF
--- a/plugins/lisa-copilot/rules/reference/integration-access-layer.md
+++ b/plugins/lisa-copilot/rules/reference/integration-access-layer.md
@@ -26,6 +26,7 @@ available.
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |
+| Google Play | `lisa-expo:play-store-access` | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` or `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` | Google Play Developer API |
 
 ## Current Coupling Matrix
 
@@ -41,6 +42,7 @@ Source audit date: 2026-06-23. Scope: `plugins/src/**/skills/**` and
 | SonarCloud | None in `plugins/src` at audit time | No access layer | Access layer added for host rules that include SonarCloud gate triage. |
 | Sentry | No Sentry MCP references in `plugins/src`; CLI/REST mentions only | CLI/REST scattered in observability docs | Access layer added for future MCP-backed consumers. |
 | PostHog | No PostHog MCP references in `plugins/src`; observability docs mention PostHog detection | No access layer | Access layer added for future MCP-backed consumers. |
+| Google Play | No MCP surface; EAS submit docs only | `play-store-access` for Expo post-submit release visibility | Done for Expo stack. |
 
 ## Migration Rule For Consumers
 

--- a/plugins/lisa-cursor/rules/integration-access-layer-reference.mdc
+++ b/plugins/lisa-cursor/rules/integration-access-layer-reference.mdc
@@ -31,6 +31,7 @@ available.
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |
+| Google Play | `lisa-expo:play-store-access` | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` or `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` | Google Play Developer API |
 
 ## Current Coupling Matrix
 
@@ -46,6 +47,7 @@ Source audit date: 2026-06-23. Scope: `plugins/src/**/skills/**` and
 | SonarCloud | None in `plugins/src` at audit time | No access layer | Access layer added for host rules that include SonarCloud gate triage. |
 | Sentry | No Sentry MCP references in `plugins/src`; CLI/REST mentions only | CLI/REST scattered in observability docs | Access layer added for future MCP-backed consumers. |
 | PostHog | No PostHog MCP references in `plugins/src`; observability docs mention PostHog detection | No access layer | Access layer added for future MCP-backed consumers. |
+| Google Play | No MCP surface; EAS submit docs only | `play-store-access` for Expo post-submit release visibility | Done for Expo stack. |
 
 ## Migration Rule For Consumers
 

--- a/plugins/lisa-expo-agy/skills/expo-deployment/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/expo-deployment/SKILL.md
@@ -19,6 +19,9 @@ Consult these resources as needed:
 - ./references/play-store.md -- Submitting Android builds to Google Play Store
 - ./references/ios-app-store.md -- iOS App Store submission and review process
 
+For post-submit Android release visibility, use the `play-store-access` skill to
+query Google Play production-track state without opening Play Console.
+
 ## Quick Start
 
 ### Install EAS CLI

--- a/plugins/lisa-expo-agy/skills/expo-deployment/references/play-store.md
+++ b/plugins/lisa-expo-agy/skills/expo-deployment/references/play-store.md
@@ -237,6 +237,24 @@ eas submit:list -p android
 eas submit:view SUBMISSION_ID
 ```
 
+## Monitoring Production Track State
+
+EAS can submit Android builds, but Play Console owns review, production release,
+and staged-rollout state. For non-interactive visibility into whether a version
+is live or rolling out on Google Play, use the `play-store-access` skill.
+
+The skill configures a read-only Google Play Developer API service account and
+queries `androidpublisher` v3:
+
+1. Resolve the package name from `.lisa.config.json` or Expo app config.
+2. Create a short-lived read-only edit.
+3. Read the target track, usually `production`.
+4. Delete the edit without making changes.
+
+It reports release `versionCodes`, `status`, and `userFraction` when a staged
+rollout is active. It does not promote tracks, adjust rollout percentages, or
+submit builds.
+
 ## Tips
 
 - Start with `internal` track for testing before production

--- a/plugins/lisa-expo-agy/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/play-store-access/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: play-store-access
+description: "Read-only Google Play Console access layer for Expo projects. Use when an operator or agent needs to set up Play Developer API credentials, resolve the Android package name, or check the production track release state without using the Play Console UI. Reads the androidpublisher v3 API only; track promotion, rollout changes, and submissions are out of scope."
+version: 1.0.0
+license: MIT
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Play Store Access: $ARGUMENTS
+
+Read-only access layer for Google Play release state in Expo projects. Use it to
+answer whether the Android app is live, halted, draft, or in staged rollout on a
+Play track after EAS submission.
+
+This skill MUST NOT promote tracks, change rollout percentages, create releases,
+or submit builds. EAS remains the submission path.
+
+## Invocation Contract
+
+```text
+operation: setup
+operation: production-status [track:production] [package:<android.package>]
+operation: track-status track:<track> [package:<android.package>]
+operation: resolve-package
+```
+
+Return a concise result with the package name, track, release `name` /
+`versionCodes`, `status`, `userFraction` when present, and any `countryTargeting`
+or in-app update priority fields present in the API response.
+
+## Configuration
+
+Project-safe config can live in `.lisa.config.json`:
+
+```json
+{
+  "playStore": {
+    "packageName": "com.example.app",
+    "track": "production"
+  }
+}
+```
+
+Local credential config belongs in `.lisa.config.local.json`, which must stay
+gitignored:
+
+```json
+{
+  "playStore": {
+    "serviceAccountKeyPath": "./google-play-service-account.json"
+  }
+}
+```
+
+Supported credential locations, in resolution order:
+
+1. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` containing the raw service-account JSON.
+2. `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` containing base64 JSON.
+3. `.lisa.config.local.json` `playStore.serviceAccountKeyPath`.
+4. Darwin keychain item `lisa-google-play` account `<packageName>`.
+
+Fail closed if no credential is available. Never prompt indefinitely and never
+fall back to Play Console UI scraping.
+
+## One-Time Setup Flow
+
+For `operation: setup`:
+
+1. Confirm the project is an Expo app by checking for `app.json`,
+   `app.config.js`, or `app.config.ts`.
+2. Resolve or ask the operator to provide the Android package name. Prefer
+   `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
+   app config.
+3. In Google Cloud Console, create a service account dedicated to read-only Play
+   release visibility and create a JSON key for it.
+4. In Play Console, open **Setup -> API access**, link the Google Cloud project if
+   needed, then grant the service-account email app access with read-level
+   release visibility. Do not grant release-management write permissions for v1.
+5. Store the key locally using one of the credential locations above. If using a
+   path, add the path to `.gitignore` and record only the path in
+   `.lisa.config.local.json`.
+6. Record non-secret defaults in `.lisa.config.json`:
+
+   ```bash
+   jq '.playStore.packageName = "com.example.app" | .playStore.track = "production"' \
+     .lisa.config.json > /tmp/lisa-config.json && mv /tmp/lisa-config.json .lisa.config.json
+   ```
+
+The key material itself must never be committed.
+
+## Resolve Package Name
+
+Resolution order:
+
+1. Explicit `package:<value>` argument.
+2. `.lisa.config.json` `playStore.packageName`.
+3. `app.json` / `app.config.json` `expo.android.package`.
+4. `app.config.ts` / `app.config.js` by running Expo config export:
+
+   ```bash
+   npx expo config --json | jq -r '.android.package // empty'
+   ```
+
+If the package still cannot be resolved, fail with:
+
+```text
+Error: Google Play package name is not configured. Set playStore.packageName in .lisa.config.json or pass package:<name>.
+```
+
+## Read Track State
+
+The androidpublisher API requires an edit even for track reads. Create the edit,
+list the track, then delete the edit. Do not commit the edit.
+
+```bash
+PACKAGE_NAME="${PACKAGE_NAME:-$(jq -r '.playStore.packageName // empty' .lisa.config.json)}"
+TRACK="${TRACK:-$(jq -r '.playStore.track // "production"' .lisa.config.json)}"
+KEY_PATH="$(jq -r '.playStore.serviceAccountKeyPath // empty' .lisa.config.local.json 2>/dev/null)"
+
+read_service_account_json() {
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"
+    return
+  fi
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode 2>/dev/null ||
+      printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 -D
+    return
+  fi
+  if [ -n "$KEY_PATH" ] && [ -f "$KEY_PATH" ]; then
+    cat "$KEY_PATH"
+    return
+  fi
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "$PACKAGE_NAME" ]; then
+    security find-generic-password -s lisa-google-play -a "$PACKAGE_NAME" -w 2>/dev/null
+    return
+  fi
+}
+
+SERVICE_ACCOUNT_JSON="$(read_service_account_json)"
+[ -n "$SERVICE_ACCOUNT_JSON" ] || {
+  echo "Error: no Google Play service-account key found. Run play-store-access operation: setup." >&2
+  exit 1
+}
+[ -n "$PACKAGE_NAME" ] || {
+  echo "Error: Google Play package name is not configured. Set playStore.packageName or pass package:<name>." >&2
+  exit 1
+}
+
+ACCESS_TOKEN="$(
+  SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" node <<'NODE'
+const crypto = require("crypto");
+
+const account = JSON.parse(process.env.SERVICE_ACCOUNT_JSON);
+const now = Math.floor(Date.now() / 1000);
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+  iss: account.client_email,
+  scope: "https://www.googleapis.com/auth/androidpublisher",
+  aud: "https://oauth2.googleapis.com/token",
+  iat: now,
+  exp: now + 3600,
+})}`;
+const signature = crypto
+  .createSign("RSA-SHA256")
+  .update(unsigned)
+  .sign(account.private_key, "base64url");
+
+fetch("https://oauth2.googleapis.com/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`,
+  }),
+})
+  .then(async (response) => {
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(JSON.stringify(body));
+    }
+    process.stdout.write(body.access_token);
+  })
+  .catch((error) => {
+    console.error(`Error: failed to obtain Google Play access token: ${error.message}`);
+    process.exit(1);
+  });
+NODE
+)"
+
+BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+EDIT_ID="$(curl -fsS -X POST "${BASE}/edits" -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.id')"
+trap 'curl -fsS -X DELETE "${BASE}/edits/${EDIT_ID}" -H "Authorization: Bearer ${ACCESS_TOKEN}" >/dev/null 2>&1 || true' EXIT
+
+curl -fsS "${BASE}/edits/${EDIT_ID}/tracks/${TRACK}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" |
+  jq --arg packageName "$PACKAGE_NAME" \
+    '{packageName: $packageName, track: .track, releases: (.releases // [])}'
+```
+
+Interpretation:
+
+- `status: completed` means the release is live on that track.
+- `status: inProgress` means staged rollout; inspect `userFraction`.
+- `status: halted` means rollout was stopped.
+- `status: draft` means it is not live.
+- Absence of a production release means the app has no watchable production-track
+  release through the API.
+
+Known limitation: androidpublisher exposes track/release state well, but
+pre-publication review state is coarse. The reliable watchable signal is whether
+the target version is live on the production track.
+
+## Error Handling
+
+- `401` / token exchange failure: service-account key is invalid or expired.
+- `403`: service account is not invited to the Play Console app or lacks read
+  access to releases.
+- `404`: package name is wrong, the app is not created in Play Console, or the
+  service account has no access to that app.
+
+In all cases, report the package name and credential source used, but never print
+private key material or the access token.

--- a/plugins/lisa-expo-agy/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/play-store-access/SKILL.md
@@ -69,7 +69,7 @@ fall back to Play Console UI scraping.
 For `operation: setup`:
 
 1. Confirm the project is an Expo app by checking for `app.json`,
-   `app.config.js`, or `app.config.ts`.
+   `app.config.json`, `app.config.js`, or `app.config.ts`.
 2. Resolve or ask the operator to provide the Android package name. Prefer
    `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
    app config.

--- a/plugins/lisa-expo-copilot/skills/expo-deployment/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/expo-deployment/SKILL.md
@@ -19,6 +19,9 @@ Consult these resources as needed:
 - ./references/play-store.md -- Submitting Android builds to Google Play Store
 - ./references/ios-app-store.md -- iOS App Store submission and review process
 
+For post-submit Android release visibility, use the `play-store-access` skill to
+query Google Play production-track state without opening Play Console.
+
 ## Quick Start
 
 ### Install EAS CLI

--- a/plugins/lisa-expo-copilot/skills/expo-deployment/references/play-store.md
+++ b/plugins/lisa-expo-copilot/skills/expo-deployment/references/play-store.md
@@ -237,6 +237,24 @@ eas submit:list -p android
 eas submit:view SUBMISSION_ID
 ```
 
+## Monitoring Production Track State
+
+EAS can submit Android builds, but Play Console owns review, production release,
+and staged-rollout state. For non-interactive visibility into whether a version
+is live or rolling out on Google Play, use the `play-store-access` skill.
+
+The skill configures a read-only Google Play Developer API service account and
+queries `androidpublisher` v3:
+
+1. Resolve the package name from `.lisa.config.json` or Expo app config.
+2. Create a short-lived read-only edit.
+3. Read the target track, usually `production`.
+4. Delete the edit without making changes.
+
+It reports release `versionCodes`, `status`, and `userFraction` when a staged
+rollout is active. It does not promote tracks, adjust rollout percentages, or
+submit builds.
+
 ## Tips
 
 - Start with `internal` track for testing before production

--- a/plugins/lisa-expo-copilot/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/play-store-access/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: play-store-access
+description: "Read-only Google Play Console access layer for Expo projects. Use when an operator or agent needs to set up Play Developer API credentials, resolve the Android package name, or check the production track release state without using the Play Console UI. Reads the androidpublisher v3 API only; track promotion, rollout changes, and submissions are out of scope."
+version: 1.0.0
+license: MIT
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Play Store Access: $ARGUMENTS
+
+Read-only access layer for Google Play release state in Expo projects. Use it to
+answer whether the Android app is live, halted, draft, or in staged rollout on a
+Play track after EAS submission.
+
+This skill MUST NOT promote tracks, change rollout percentages, create releases,
+or submit builds. EAS remains the submission path.
+
+## Invocation Contract
+
+```text
+operation: setup
+operation: production-status [track:production] [package:<android.package>]
+operation: track-status track:<track> [package:<android.package>]
+operation: resolve-package
+```
+
+Return a concise result with the package name, track, release `name` /
+`versionCodes`, `status`, `userFraction` when present, and any `countryTargeting`
+or in-app update priority fields present in the API response.
+
+## Configuration
+
+Project-safe config can live in `.lisa.config.json`:
+
+```json
+{
+  "playStore": {
+    "packageName": "com.example.app",
+    "track": "production"
+  }
+}
+```
+
+Local credential config belongs in `.lisa.config.local.json`, which must stay
+gitignored:
+
+```json
+{
+  "playStore": {
+    "serviceAccountKeyPath": "./google-play-service-account.json"
+  }
+}
+```
+
+Supported credential locations, in resolution order:
+
+1. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` containing the raw service-account JSON.
+2. `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` containing base64 JSON.
+3. `.lisa.config.local.json` `playStore.serviceAccountKeyPath`.
+4. Darwin keychain item `lisa-google-play` account `<packageName>`.
+
+Fail closed if no credential is available. Never prompt indefinitely and never
+fall back to Play Console UI scraping.
+
+## One-Time Setup Flow
+
+For `operation: setup`:
+
+1. Confirm the project is an Expo app by checking for `app.json`,
+   `app.config.js`, or `app.config.ts`.
+2. Resolve or ask the operator to provide the Android package name. Prefer
+   `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
+   app config.
+3. In Google Cloud Console, create a service account dedicated to read-only Play
+   release visibility and create a JSON key for it.
+4. In Play Console, open **Setup -> API access**, link the Google Cloud project if
+   needed, then grant the service-account email app access with read-level
+   release visibility. Do not grant release-management write permissions for v1.
+5. Store the key locally using one of the credential locations above. If using a
+   path, add the path to `.gitignore` and record only the path in
+   `.lisa.config.local.json`.
+6. Record non-secret defaults in `.lisa.config.json`:
+
+   ```bash
+   jq '.playStore.packageName = "com.example.app" | .playStore.track = "production"' \
+     .lisa.config.json > /tmp/lisa-config.json && mv /tmp/lisa-config.json .lisa.config.json
+   ```
+
+The key material itself must never be committed.
+
+## Resolve Package Name
+
+Resolution order:
+
+1. Explicit `package:<value>` argument.
+2. `.lisa.config.json` `playStore.packageName`.
+3. `app.json` / `app.config.json` `expo.android.package`.
+4. `app.config.ts` / `app.config.js` by running Expo config export:
+
+   ```bash
+   npx expo config --json | jq -r '.android.package // empty'
+   ```
+
+If the package still cannot be resolved, fail with:
+
+```text
+Error: Google Play package name is not configured. Set playStore.packageName in .lisa.config.json or pass package:<name>.
+```
+
+## Read Track State
+
+The androidpublisher API requires an edit even for track reads. Create the edit,
+list the track, then delete the edit. Do not commit the edit.
+
+```bash
+PACKAGE_NAME="${PACKAGE_NAME:-$(jq -r '.playStore.packageName // empty' .lisa.config.json)}"
+TRACK="${TRACK:-$(jq -r '.playStore.track // "production"' .lisa.config.json)}"
+KEY_PATH="$(jq -r '.playStore.serviceAccountKeyPath // empty' .lisa.config.local.json 2>/dev/null)"
+
+read_service_account_json() {
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"
+    return
+  fi
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode 2>/dev/null ||
+      printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 -D
+    return
+  fi
+  if [ -n "$KEY_PATH" ] && [ -f "$KEY_PATH" ]; then
+    cat "$KEY_PATH"
+    return
+  fi
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "$PACKAGE_NAME" ]; then
+    security find-generic-password -s lisa-google-play -a "$PACKAGE_NAME" -w 2>/dev/null
+    return
+  fi
+}
+
+SERVICE_ACCOUNT_JSON="$(read_service_account_json)"
+[ -n "$SERVICE_ACCOUNT_JSON" ] || {
+  echo "Error: no Google Play service-account key found. Run play-store-access operation: setup." >&2
+  exit 1
+}
+[ -n "$PACKAGE_NAME" ] || {
+  echo "Error: Google Play package name is not configured. Set playStore.packageName or pass package:<name>." >&2
+  exit 1
+}
+
+ACCESS_TOKEN="$(
+  SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" node <<'NODE'
+const crypto = require("crypto");
+
+const account = JSON.parse(process.env.SERVICE_ACCOUNT_JSON);
+const now = Math.floor(Date.now() / 1000);
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+  iss: account.client_email,
+  scope: "https://www.googleapis.com/auth/androidpublisher",
+  aud: "https://oauth2.googleapis.com/token",
+  iat: now,
+  exp: now + 3600,
+})}`;
+const signature = crypto
+  .createSign("RSA-SHA256")
+  .update(unsigned)
+  .sign(account.private_key, "base64url");
+
+fetch("https://oauth2.googleapis.com/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`,
+  }),
+})
+  .then(async (response) => {
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(JSON.stringify(body));
+    }
+    process.stdout.write(body.access_token);
+  })
+  .catch((error) => {
+    console.error(`Error: failed to obtain Google Play access token: ${error.message}`);
+    process.exit(1);
+  });
+NODE
+)"
+
+BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+EDIT_ID="$(curl -fsS -X POST "${BASE}/edits" -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.id')"
+trap 'curl -fsS -X DELETE "${BASE}/edits/${EDIT_ID}" -H "Authorization: Bearer ${ACCESS_TOKEN}" >/dev/null 2>&1 || true' EXIT
+
+curl -fsS "${BASE}/edits/${EDIT_ID}/tracks/${TRACK}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" |
+  jq --arg packageName "$PACKAGE_NAME" \
+    '{packageName: $packageName, track: .track, releases: (.releases // [])}'
+```
+
+Interpretation:
+
+- `status: completed` means the release is live on that track.
+- `status: inProgress` means staged rollout; inspect `userFraction`.
+- `status: halted` means rollout was stopped.
+- `status: draft` means it is not live.
+- Absence of a production release means the app has no watchable production-track
+  release through the API.
+
+Known limitation: androidpublisher exposes track/release state well, but
+pre-publication review state is coarse. The reliable watchable signal is whether
+the target version is live on the production track.
+
+## Error Handling
+
+- `401` / token exchange failure: service-account key is invalid or expired.
+- `403`: service account is not invited to the Play Console app or lacks read
+  access to releases.
+- `404`: package name is wrong, the app is not created in Play Console, or the
+  service account has no access to that app.
+
+In all cases, report the package name and credential source used, but never print
+private key material or the access token.

--- a/plugins/lisa-expo-copilot/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/play-store-access/SKILL.md
@@ -69,7 +69,7 @@ fall back to Play Console UI scraping.
 For `operation: setup`:
 
 1. Confirm the project is an Expo app by checking for `app.json`,
-   `app.config.js`, or `app.config.ts`.
+   `app.config.json`, `app.config.js`, or `app.config.ts`.
 2. Resolve or ask the operator to provide the Android package name. Prefer
    `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
    app config.

--- a/plugins/lisa-expo-cursor/skills/expo-deployment/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/expo-deployment/SKILL.md
@@ -19,6 +19,9 @@ Consult these resources as needed:
 - ./references/play-store.md -- Submitting Android builds to Google Play Store
 - ./references/ios-app-store.md -- iOS App Store submission and review process
 
+For post-submit Android release visibility, use the `play-store-access` skill to
+query Google Play production-track state without opening Play Console.
+
 ## Quick Start
 
 ### Install EAS CLI

--- a/plugins/lisa-expo-cursor/skills/expo-deployment/references/play-store.md
+++ b/plugins/lisa-expo-cursor/skills/expo-deployment/references/play-store.md
@@ -237,6 +237,24 @@ eas submit:list -p android
 eas submit:view SUBMISSION_ID
 ```
 
+## Monitoring Production Track State
+
+EAS can submit Android builds, but Play Console owns review, production release,
+and staged-rollout state. For non-interactive visibility into whether a version
+is live or rolling out on Google Play, use the `play-store-access` skill.
+
+The skill configures a read-only Google Play Developer API service account and
+queries `androidpublisher` v3:
+
+1. Resolve the package name from `.lisa.config.json` or Expo app config.
+2. Create a short-lived read-only edit.
+3. Read the target track, usually `production`.
+4. Delete the edit without making changes.
+
+It reports release `versionCodes`, `status`, and `userFraction` when a staged
+rollout is active. It does not promote tracks, adjust rollout percentages, or
+submit builds.
+
 ## Tips
 
 - Start with `internal` track for testing before production

--- a/plugins/lisa-expo-cursor/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/play-store-access/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: play-store-access
+description: "Read-only Google Play Console access layer for Expo projects. Use when an operator or agent needs to set up Play Developer API credentials, resolve the Android package name, or check the production track release state without using the Play Console UI. Reads the androidpublisher v3 API only; track promotion, rollout changes, and submissions are out of scope."
+version: 1.0.0
+license: MIT
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Play Store Access: $ARGUMENTS
+
+Read-only access layer for Google Play release state in Expo projects. Use it to
+answer whether the Android app is live, halted, draft, or in staged rollout on a
+Play track after EAS submission.
+
+This skill MUST NOT promote tracks, change rollout percentages, create releases,
+or submit builds. EAS remains the submission path.
+
+## Invocation Contract
+
+```text
+operation: setup
+operation: production-status [track:production] [package:<android.package>]
+operation: track-status track:<track> [package:<android.package>]
+operation: resolve-package
+```
+
+Return a concise result with the package name, track, release `name` /
+`versionCodes`, `status`, `userFraction` when present, and any `countryTargeting`
+or in-app update priority fields present in the API response.
+
+## Configuration
+
+Project-safe config can live in `.lisa.config.json`:
+
+```json
+{
+  "playStore": {
+    "packageName": "com.example.app",
+    "track": "production"
+  }
+}
+```
+
+Local credential config belongs in `.lisa.config.local.json`, which must stay
+gitignored:
+
+```json
+{
+  "playStore": {
+    "serviceAccountKeyPath": "./google-play-service-account.json"
+  }
+}
+```
+
+Supported credential locations, in resolution order:
+
+1. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` containing the raw service-account JSON.
+2. `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` containing base64 JSON.
+3. `.lisa.config.local.json` `playStore.serviceAccountKeyPath`.
+4. Darwin keychain item `lisa-google-play` account `<packageName>`.
+
+Fail closed if no credential is available. Never prompt indefinitely and never
+fall back to Play Console UI scraping.
+
+## One-Time Setup Flow
+
+For `operation: setup`:
+
+1. Confirm the project is an Expo app by checking for `app.json`,
+   `app.config.js`, or `app.config.ts`.
+2. Resolve or ask the operator to provide the Android package name. Prefer
+   `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
+   app config.
+3. In Google Cloud Console, create a service account dedicated to read-only Play
+   release visibility and create a JSON key for it.
+4. In Play Console, open **Setup -> API access**, link the Google Cloud project if
+   needed, then grant the service-account email app access with read-level
+   release visibility. Do not grant release-management write permissions for v1.
+5. Store the key locally using one of the credential locations above. If using a
+   path, add the path to `.gitignore` and record only the path in
+   `.lisa.config.local.json`.
+6. Record non-secret defaults in `.lisa.config.json`:
+
+   ```bash
+   jq '.playStore.packageName = "com.example.app" | .playStore.track = "production"' \
+     .lisa.config.json > /tmp/lisa-config.json && mv /tmp/lisa-config.json .lisa.config.json
+   ```
+
+The key material itself must never be committed.
+
+## Resolve Package Name
+
+Resolution order:
+
+1. Explicit `package:<value>` argument.
+2. `.lisa.config.json` `playStore.packageName`.
+3. `app.json` / `app.config.json` `expo.android.package`.
+4. `app.config.ts` / `app.config.js` by running Expo config export:
+
+   ```bash
+   npx expo config --json | jq -r '.android.package // empty'
+   ```
+
+If the package still cannot be resolved, fail with:
+
+```text
+Error: Google Play package name is not configured. Set playStore.packageName in .lisa.config.json or pass package:<name>.
+```
+
+## Read Track State
+
+The androidpublisher API requires an edit even for track reads. Create the edit,
+list the track, then delete the edit. Do not commit the edit.
+
+```bash
+PACKAGE_NAME="${PACKAGE_NAME:-$(jq -r '.playStore.packageName // empty' .lisa.config.json)}"
+TRACK="${TRACK:-$(jq -r '.playStore.track // "production"' .lisa.config.json)}"
+KEY_PATH="$(jq -r '.playStore.serviceAccountKeyPath // empty' .lisa.config.local.json 2>/dev/null)"
+
+read_service_account_json() {
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"
+    return
+  fi
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode 2>/dev/null ||
+      printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 -D
+    return
+  fi
+  if [ -n "$KEY_PATH" ] && [ -f "$KEY_PATH" ]; then
+    cat "$KEY_PATH"
+    return
+  fi
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "$PACKAGE_NAME" ]; then
+    security find-generic-password -s lisa-google-play -a "$PACKAGE_NAME" -w 2>/dev/null
+    return
+  fi
+}
+
+SERVICE_ACCOUNT_JSON="$(read_service_account_json)"
+[ -n "$SERVICE_ACCOUNT_JSON" ] || {
+  echo "Error: no Google Play service-account key found. Run play-store-access operation: setup." >&2
+  exit 1
+}
+[ -n "$PACKAGE_NAME" ] || {
+  echo "Error: Google Play package name is not configured. Set playStore.packageName or pass package:<name>." >&2
+  exit 1
+}
+
+ACCESS_TOKEN="$(
+  SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" node <<'NODE'
+const crypto = require("crypto");
+
+const account = JSON.parse(process.env.SERVICE_ACCOUNT_JSON);
+const now = Math.floor(Date.now() / 1000);
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+  iss: account.client_email,
+  scope: "https://www.googleapis.com/auth/androidpublisher",
+  aud: "https://oauth2.googleapis.com/token",
+  iat: now,
+  exp: now + 3600,
+})}`;
+const signature = crypto
+  .createSign("RSA-SHA256")
+  .update(unsigned)
+  .sign(account.private_key, "base64url");
+
+fetch("https://oauth2.googleapis.com/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`,
+  }),
+})
+  .then(async (response) => {
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(JSON.stringify(body));
+    }
+    process.stdout.write(body.access_token);
+  })
+  .catch((error) => {
+    console.error(`Error: failed to obtain Google Play access token: ${error.message}`);
+    process.exit(1);
+  });
+NODE
+)"
+
+BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+EDIT_ID="$(curl -fsS -X POST "${BASE}/edits" -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.id')"
+trap 'curl -fsS -X DELETE "${BASE}/edits/${EDIT_ID}" -H "Authorization: Bearer ${ACCESS_TOKEN}" >/dev/null 2>&1 || true' EXIT
+
+curl -fsS "${BASE}/edits/${EDIT_ID}/tracks/${TRACK}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" |
+  jq --arg packageName "$PACKAGE_NAME" \
+    '{packageName: $packageName, track: .track, releases: (.releases // [])}'
+```
+
+Interpretation:
+
+- `status: completed` means the release is live on that track.
+- `status: inProgress` means staged rollout; inspect `userFraction`.
+- `status: halted` means rollout was stopped.
+- `status: draft` means it is not live.
+- Absence of a production release means the app has no watchable production-track
+  release through the API.
+
+Known limitation: androidpublisher exposes track/release state well, but
+pre-publication review state is coarse. The reliable watchable signal is whether
+the target version is live on the production track.
+
+## Error Handling
+
+- `401` / token exchange failure: service-account key is invalid or expired.
+- `403`: service account is not invited to the Play Console app or lacks read
+  access to releases.
+- `404`: package name is wrong, the app is not created in Play Console, or the
+  service account has no access to that app.
+
+In all cases, report the package name and credential source used, but never print
+private key material or the access token.

--- a/plugins/lisa-expo-cursor/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/play-store-access/SKILL.md
@@ -69,7 +69,7 @@ fall back to Play Console UI scraping.
 For `operation: setup`:
 
 1. Confirm the project is an Expo app by checking for `app.json`,
-   `app.config.js`, or `app.config.ts`.
+   `app.config.json`, `app.config.js`, or `app.config.ts`.
 2. Resolve or ask the operator to provide the Android package name. Prefer
    `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
    app config.

--- a/plugins/lisa-expo/skills/expo-deployment/SKILL.md
+++ b/plugins/lisa-expo/skills/expo-deployment/SKILL.md
@@ -19,6 +19,9 @@ Consult these resources as needed:
 - ./references/play-store.md -- Submitting Android builds to Google Play Store
 - ./references/ios-app-store.md -- iOS App Store submission and review process
 
+For post-submit Android release visibility, use the `play-store-access` skill to
+query Google Play production-track state without opening Play Console.
+
 ## Quick Start
 
 ### Install EAS CLI

--- a/plugins/lisa-expo/skills/expo-deployment/references/play-store.md
+++ b/plugins/lisa-expo/skills/expo-deployment/references/play-store.md
@@ -237,6 +237,24 @@ eas submit:list -p android
 eas submit:view SUBMISSION_ID
 ```
 
+## Monitoring Production Track State
+
+EAS can submit Android builds, but Play Console owns review, production release,
+and staged-rollout state. For non-interactive visibility into whether a version
+is live or rolling out on Google Play, use the `play-store-access` skill.
+
+The skill configures a read-only Google Play Developer API service account and
+queries `androidpublisher` v3:
+
+1. Resolve the package name from `.lisa.config.json` or Expo app config.
+2. Create a short-lived read-only edit.
+3. Read the target track, usually `production`.
+4. Delete the edit without making changes.
+
+It reports release `versionCodes`, `status`, and `userFraction` when a staged
+rollout is active. It does not promote tracks, adjust rollout percentages, or
+submit builds.
+
 ## Tips
 
 - Start with `internal` track for testing before production

--- a/plugins/lisa-expo/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo/skills/play-store-access/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: play-store-access
+description: "Read-only Google Play Console access layer for Expo projects. Use when an operator or agent needs to set up Play Developer API credentials, resolve the Android package name, or check the production track release state without using the Play Console UI. Reads the androidpublisher v3 API only; track promotion, rollout changes, and submissions are out of scope."
+version: 1.0.0
+license: MIT
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Play Store Access: $ARGUMENTS
+
+Read-only access layer for Google Play release state in Expo projects. Use it to
+answer whether the Android app is live, halted, draft, or in staged rollout on a
+Play track after EAS submission.
+
+This skill MUST NOT promote tracks, change rollout percentages, create releases,
+or submit builds. EAS remains the submission path.
+
+## Invocation Contract
+
+```text
+operation: setup
+operation: production-status [track:production] [package:<android.package>]
+operation: track-status track:<track> [package:<android.package>]
+operation: resolve-package
+```
+
+Return a concise result with the package name, track, release `name` /
+`versionCodes`, `status`, `userFraction` when present, and any `countryTargeting`
+or in-app update priority fields present in the API response.
+
+## Configuration
+
+Project-safe config can live in `.lisa.config.json`:
+
+```json
+{
+  "playStore": {
+    "packageName": "com.example.app",
+    "track": "production"
+  }
+}
+```
+
+Local credential config belongs in `.lisa.config.local.json`, which must stay
+gitignored:
+
+```json
+{
+  "playStore": {
+    "serviceAccountKeyPath": "./google-play-service-account.json"
+  }
+}
+```
+
+Supported credential locations, in resolution order:
+
+1. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` containing the raw service-account JSON.
+2. `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` containing base64 JSON.
+3. `.lisa.config.local.json` `playStore.serviceAccountKeyPath`.
+4. Darwin keychain item `lisa-google-play` account `<packageName>`.
+
+Fail closed if no credential is available. Never prompt indefinitely and never
+fall back to Play Console UI scraping.
+
+## One-Time Setup Flow
+
+For `operation: setup`:
+
+1. Confirm the project is an Expo app by checking for `app.json`,
+   `app.config.js`, or `app.config.ts`.
+2. Resolve or ask the operator to provide the Android package name. Prefer
+   `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
+   app config.
+3. In Google Cloud Console, create a service account dedicated to read-only Play
+   release visibility and create a JSON key for it.
+4. In Play Console, open **Setup -> API access**, link the Google Cloud project if
+   needed, then grant the service-account email app access with read-level
+   release visibility. Do not grant release-management write permissions for v1.
+5. Store the key locally using one of the credential locations above. If using a
+   path, add the path to `.gitignore` and record only the path in
+   `.lisa.config.local.json`.
+6. Record non-secret defaults in `.lisa.config.json`:
+
+   ```bash
+   jq '.playStore.packageName = "com.example.app" | .playStore.track = "production"' \
+     .lisa.config.json > /tmp/lisa-config.json && mv /tmp/lisa-config.json .lisa.config.json
+   ```
+
+The key material itself must never be committed.
+
+## Resolve Package Name
+
+Resolution order:
+
+1. Explicit `package:<value>` argument.
+2. `.lisa.config.json` `playStore.packageName`.
+3. `app.json` / `app.config.json` `expo.android.package`.
+4. `app.config.ts` / `app.config.js` by running Expo config export:
+
+   ```bash
+   npx expo config --json | jq -r '.android.package // empty'
+   ```
+
+If the package still cannot be resolved, fail with:
+
+```text
+Error: Google Play package name is not configured. Set playStore.packageName in .lisa.config.json or pass package:<name>.
+```
+
+## Read Track State
+
+The androidpublisher API requires an edit even for track reads. Create the edit,
+list the track, then delete the edit. Do not commit the edit.
+
+```bash
+PACKAGE_NAME="${PACKAGE_NAME:-$(jq -r '.playStore.packageName // empty' .lisa.config.json)}"
+TRACK="${TRACK:-$(jq -r '.playStore.track // "production"' .lisa.config.json)}"
+KEY_PATH="$(jq -r '.playStore.serviceAccountKeyPath // empty' .lisa.config.local.json 2>/dev/null)"
+
+read_service_account_json() {
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"
+    return
+  fi
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode 2>/dev/null ||
+      printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 -D
+    return
+  fi
+  if [ -n "$KEY_PATH" ] && [ -f "$KEY_PATH" ]; then
+    cat "$KEY_PATH"
+    return
+  fi
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "$PACKAGE_NAME" ]; then
+    security find-generic-password -s lisa-google-play -a "$PACKAGE_NAME" -w 2>/dev/null
+    return
+  fi
+}
+
+SERVICE_ACCOUNT_JSON="$(read_service_account_json)"
+[ -n "$SERVICE_ACCOUNT_JSON" ] || {
+  echo "Error: no Google Play service-account key found. Run play-store-access operation: setup." >&2
+  exit 1
+}
+[ -n "$PACKAGE_NAME" ] || {
+  echo "Error: Google Play package name is not configured. Set playStore.packageName or pass package:<name>." >&2
+  exit 1
+}
+
+ACCESS_TOKEN="$(
+  SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" node <<'NODE'
+const crypto = require("crypto");
+
+const account = JSON.parse(process.env.SERVICE_ACCOUNT_JSON);
+const now = Math.floor(Date.now() / 1000);
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+  iss: account.client_email,
+  scope: "https://www.googleapis.com/auth/androidpublisher",
+  aud: "https://oauth2.googleapis.com/token",
+  iat: now,
+  exp: now + 3600,
+})}`;
+const signature = crypto
+  .createSign("RSA-SHA256")
+  .update(unsigned)
+  .sign(account.private_key, "base64url");
+
+fetch("https://oauth2.googleapis.com/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`,
+  }),
+})
+  .then(async (response) => {
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(JSON.stringify(body));
+    }
+    process.stdout.write(body.access_token);
+  })
+  .catch((error) => {
+    console.error(`Error: failed to obtain Google Play access token: ${error.message}`);
+    process.exit(1);
+  });
+NODE
+)"
+
+BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+EDIT_ID="$(curl -fsS -X POST "${BASE}/edits" -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.id')"
+trap 'curl -fsS -X DELETE "${BASE}/edits/${EDIT_ID}" -H "Authorization: Bearer ${ACCESS_TOKEN}" >/dev/null 2>&1 || true' EXIT
+
+curl -fsS "${BASE}/edits/${EDIT_ID}/tracks/${TRACK}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" |
+  jq --arg packageName "$PACKAGE_NAME" \
+    '{packageName: $packageName, track: .track, releases: (.releases // [])}'
+```
+
+Interpretation:
+
+- `status: completed` means the release is live on that track.
+- `status: inProgress` means staged rollout; inspect `userFraction`.
+- `status: halted` means rollout was stopped.
+- `status: draft` means it is not live.
+- Absence of a production release means the app has no watchable production-track
+  release through the API.
+
+Known limitation: androidpublisher exposes track/release state well, but
+pre-publication review state is coarse. The reliable watchable signal is whether
+the target version is live on the production track.
+
+## Error Handling
+
+- `401` / token exchange failure: service-account key is invalid or expired.
+- `403`: service account is not invited to the Play Console app or lacks read
+  access to releases.
+- `404`: package name is wrong, the app is not created in Play Console, or the
+  service account has no access to that app.
+
+In all cases, report the package name and credential source used, but never print
+private key material or the access token.

--- a/plugins/lisa-expo/skills/play-store-access/SKILL.md
+++ b/plugins/lisa-expo/skills/play-store-access/SKILL.md
@@ -69,7 +69,7 @@ fall back to Play Console UI scraping.
 For `operation: setup`:
 
 1. Confirm the project is an Expo app by checking for `app.json`,
-   `app.config.js`, or `app.config.ts`.
+   `app.config.json`, `app.config.js`, or `app.config.ts`.
 2. Resolve or ask the operator to provide the Android package name. Prefer
    `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
    app config.

--- a/plugins/lisa-expo/skills/play-store-access/agents/openai.yaml
+++ b/plugins/lisa-expo/skills/play-store-access/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Play Store Access"
+short_description: "Read-only Google Play Console access layer for Expo projects"
+default_prompt:
+  - "Use $play-store-access: Read-only Google Play Console access layer for Expo projects."

--- a/plugins/lisa/rules/reference/integration-access-layer.md
+++ b/plugins/lisa/rules/reference/integration-access-layer.md
@@ -26,6 +26,7 @@ available.
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |
+| Google Play | `lisa-expo:play-store-access` | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` or `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` | Google Play Developer API |
 
 ## Current Coupling Matrix
 
@@ -41,6 +42,7 @@ Source audit date: 2026-06-23. Scope: `plugins/src/**/skills/**` and
 | SonarCloud | None in `plugins/src` at audit time | No access layer | Access layer added for host rules that include SonarCloud gate triage. |
 | Sentry | No Sentry MCP references in `plugins/src`; CLI/REST mentions only | CLI/REST scattered in observability docs | Access layer added for future MCP-backed consumers. |
 | PostHog | No PostHog MCP references in `plugins/src`; observability docs mention PostHog detection | No access layer | Access layer added for future MCP-backed consumers. |
+| Google Play | No MCP surface; EAS submit docs only | `play-store-access` for Expo post-submit release visibility | Done for Expo stack. |
 
 ## Migration Rule For Consumers
 

--- a/plugins/src/base/rules/reference/integration-access-layer.md
+++ b/plugins/src/base/rules/reference/integration-access-layer.md
@@ -26,6 +26,7 @@ available.
 | SonarCloud | `lisa:sonarcloud-access` | `SONAR_TOKEN` | SonarCloud Web API |
 | Sentry | `lisa:sentry-access` | `SENTRY_AUTH_TOKEN` | Sentry REST API |
 | PostHog | `lisa:posthog-access` | `POSTHOG_PERSONAL_API_KEY` | PostHog REST API |
+| Google Play | `lisa-expo:play-store-access` | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` or `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` | Google Play Developer API |
 
 ## Current Coupling Matrix
 
@@ -41,6 +42,7 @@ Source audit date: 2026-06-23. Scope: `plugins/src/**/skills/**` and
 | SonarCloud | None in `plugins/src` at audit time | No access layer | Access layer added for host rules that include SonarCloud gate triage. |
 | Sentry | No Sentry MCP references in `plugins/src`; CLI/REST mentions only | CLI/REST scattered in observability docs | Access layer added for future MCP-backed consumers. |
 | PostHog | No PostHog MCP references in `plugins/src`; observability docs mention PostHog detection | No access layer | Access layer added for future MCP-backed consumers. |
+| Google Play | No MCP surface; EAS submit docs only | `play-store-access` for Expo post-submit release visibility | Done for Expo stack. |
 
 ## Migration Rule For Consumers
 

--- a/plugins/src/expo/skills/expo-deployment/SKILL.md
+++ b/plugins/src/expo/skills/expo-deployment/SKILL.md
@@ -19,6 +19,9 @@ Consult these resources as needed:
 - ./references/play-store.md -- Submitting Android builds to Google Play Store
 - ./references/ios-app-store.md -- iOS App Store submission and review process
 
+For post-submit Android release visibility, use the `play-store-access` skill to
+query Google Play production-track state without opening Play Console.
+
 ## Quick Start
 
 ### Install EAS CLI

--- a/plugins/src/expo/skills/expo-deployment/references/play-store.md
+++ b/plugins/src/expo/skills/expo-deployment/references/play-store.md
@@ -237,6 +237,24 @@ eas submit:list -p android
 eas submit:view SUBMISSION_ID
 ```
 
+## Monitoring Production Track State
+
+EAS can submit Android builds, but Play Console owns review, production release,
+and staged-rollout state. For non-interactive visibility into whether a version
+is live or rolling out on Google Play, use the `play-store-access` skill.
+
+The skill configures a read-only Google Play Developer API service account and
+queries `androidpublisher` v3:
+
+1. Resolve the package name from `.lisa.config.json` or Expo app config.
+2. Create a short-lived read-only edit.
+3. Read the target track, usually `production`.
+4. Delete the edit without making changes.
+
+It reports release `versionCodes`, `status`, and `userFraction` when a staged
+rollout is active. It does not promote tracks, adjust rollout percentages, or
+submit builds.
+
 ## Tips
 
 - Start with `internal` track for testing before production

--- a/plugins/src/expo/skills/play-store-access/SKILL.md
+++ b/plugins/src/expo/skills/play-store-access/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: play-store-access
+description: "Read-only Google Play Console access layer for Expo projects. Use when an operator or agent needs to set up Play Developer API credentials, resolve the Android package name, or check the production track release state without using the Play Console UI. Reads the androidpublisher v3 API only; track promotion, rollout changes, and submissions are out of scope."
+version: 1.0.0
+license: MIT
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Play Store Access: $ARGUMENTS
+
+Read-only access layer for Google Play release state in Expo projects. Use it to
+answer whether the Android app is live, halted, draft, or in staged rollout on a
+Play track after EAS submission.
+
+This skill MUST NOT promote tracks, change rollout percentages, create releases,
+or submit builds. EAS remains the submission path.
+
+## Invocation Contract
+
+```text
+operation: setup
+operation: production-status [track:production] [package:<android.package>]
+operation: track-status track:<track> [package:<android.package>]
+operation: resolve-package
+```
+
+Return a concise result with the package name, track, release `name` /
+`versionCodes`, `status`, `userFraction` when present, and any `countryTargeting`
+or in-app update priority fields present in the API response.
+
+## Configuration
+
+Project-safe config can live in `.lisa.config.json`:
+
+```json
+{
+  "playStore": {
+    "packageName": "com.example.app",
+    "track": "production"
+  }
+}
+```
+
+Local credential config belongs in `.lisa.config.local.json`, which must stay
+gitignored:
+
+```json
+{
+  "playStore": {
+    "serviceAccountKeyPath": "./google-play-service-account.json"
+  }
+}
+```
+
+Supported credential locations, in resolution order:
+
+1. `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` containing the raw service-account JSON.
+2. `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64` containing base64 JSON.
+3. `.lisa.config.local.json` `playStore.serviceAccountKeyPath`.
+4. Darwin keychain item `lisa-google-play` account `<packageName>`.
+
+Fail closed if no credential is available. Never prompt indefinitely and never
+fall back to Play Console UI scraping.
+
+## One-Time Setup Flow
+
+For `operation: setup`:
+
+1. Confirm the project is an Expo app by checking for `app.json`,
+   `app.config.js`, or `app.config.ts`.
+2. Resolve or ask the operator to provide the Android package name. Prefer
+   `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
+   app config.
+3. In Google Cloud Console, create a service account dedicated to read-only Play
+   release visibility and create a JSON key for it.
+4. In Play Console, open **Setup -> API access**, link the Google Cloud project if
+   needed, then grant the service-account email app access with read-level
+   release visibility. Do not grant release-management write permissions for v1.
+5. Store the key locally using one of the credential locations above. If using a
+   path, add the path to `.gitignore` and record only the path in
+   `.lisa.config.local.json`.
+6. Record non-secret defaults in `.lisa.config.json`:
+
+   ```bash
+   jq '.playStore.packageName = "com.example.app" | .playStore.track = "production"' \
+     .lisa.config.json > /tmp/lisa-config.json && mv /tmp/lisa-config.json .lisa.config.json
+   ```
+
+The key material itself must never be committed.
+
+## Resolve Package Name
+
+Resolution order:
+
+1. Explicit `package:<value>` argument.
+2. `.lisa.config.json` `playStore.packageName`.
+3. `app.json` / `app.config.json` `expo.android.package`.
+4. `app.config.ts` / `app.config.js` by running Expo config export:
+
+   ```bash
+   npx expo config --json | jq -r '.android.package // empty'
+   ```
+
+If the package still cannot be resolved, fail with:
+
+```text
+Error: Google Play package name is not configured. Set playStore.packageName in .lisa.config.json or pass package:<name>.
+```
+
+## Read Track State
+
+The androidpublisher API requires an edit even for track reads. Create the edit,
+list the track, then delete the edit. Do not commit the edit.
+
+```bash
+PACKAGE_NAME="${PACKAGE_NAME:-$(jq -r '.playStore.packageName // empty' .lisa.config.json)}"
+TRACK="${TRACK:-$(jq -r '.playStore.track // "production"' .lisa.config.json)}"
+KEY_PATH="$(jq -r '.playStore.serviceAccountKeyPath // empty' .lisa.config.local.json 2>/dev/null)"
+
+read_service_account_json() {
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"
+    return
+  fi
+  if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64:-}" ]; then
+    printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode 2>/dev/null ||
+      printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 -D
+    return
+  fi
+  if [ -n "$KEY_PATH" ] && [ -f "$KEY_PATH" ]; then
+    cat "$KEY_PATH"
+    return
+  fi
+  if [ "$(uname -s)" = "Darwin" ] && [ -n "$PACKAGE_NAME" ]; then
+    security find-generic-password -s lisa-google-play -a "$PACKAGE_NAME" -w 2>/dev/null
+    return
+  fi
+}
+
+SERVICE_ACCOUNT_JSON="$(read_service_account_json)"
+[ -n "$SERVICE_ACCOUNT_JSON" ] || {
+  echo "Error: no Google Play service-account key found. Run play-store-access operation: setup." >&2
+  exit 1
+}
+[ -n "$PACKAGE_NAME" ] || {
+  echo "Error: Google Play package name is not configured. Set playStore.packageName or pass package:<name>." >&2
+  exit 1
+}
+
+ACCESS_TOKEN="$(
+  SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" node <<'NODE'
+const crypto = require("crypto");
+
+const account = JSON.parse(process.env.SERVICE_ACCOUNT_JSON);
+const now = Math.floor(Date.now() / 1000);
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+const unsigned = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({
+  iss: account.client_email,
+  scope: "https://www.googleapis.com/auth/androidpublisher",
+  aud: "https://oauth2.googleapis.com/token",
+  iat: now,
+  exp: now + 3600,
+})}`;
+const signature = crypto
+  .createSign("RSA-SHA256")
+  .update(unsigned)
+  .sign(account.private_key, "base64url");
+
+fetch("https://oauth2.googleapis.com/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`,
+  }),
+})
+  .then(async (response) => {
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(JSON.stringify(body));
+    }
+    process.stdout.write(body.access_token);
+  })
+  .catch((error) => {
+    console.error(`Error: failed to obtain Google Play access token: ${error.message}`);
+    process.exit(1);
+  });
+NODE
+)"
+
+BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+EDIT_ID="$(curl -fsS -X POST "${BASE}/edits" -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.id')"
+trap 'curl -fsS -X DELETE "${BASE}/edits/${EDIT_ID}" -H "Authorization: Bearer ${ACCESS_TOKEN}" >/dev/null 2>&1 || true' EXIT
+
+curl -fsS "${BASE}/edits/${EDIT_ID}/tracks/${TRACK}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" |
+  jq --arg packageName "$PACKAGE_NAME" \
+    '{packageName: $packageName, track: .track, releases: (.releases // [])}'
+```
+
+Interpretation:
+
+- `status: completed` means the release is live on that track.
+- `status: inProgress` means staged rollout; inspect `userFraction`.
+- `status: halted` means rollout was stopped.
+- `status: draft` means it is not live.
+- Absence of a production release means the app has no watchable production-track
+  release through the API.
+
+Known limitation: androidpublisher exposes track/release state well, but
+pre-publication review state is coarse. The reliable watchable signal is whether
+the target version is live on the production track.
+
+## Error Handling
+
+- `401` / token exchange failure: service-account key is invalid or expired.
+- `403`: service account is not invited to the Play Console app or lacks read
+  access to releases.
+- `404`: package name is wrong, the app is not created in Play Console, or the
+  service account has no access to that app.
+
+In all cases, report the package name and credential source used, but never print
+private key material or the access token.

--- a/plugins/src/expo/skills/play-store-access/SKILL.md
+++ b/plugins/src/expo/skills/play-store-access/SKILL.md
@@ -69,7 +69,7 @@ fall back to Play Console UI scraping.
 For `operation: setup`:
 
 1. Confirm the project is an Expo app by checking for `app.json`,
-   `app.config.js`, or `app.config.ts`.
+   `app.config.json`, `app.config.js`, or `app.config.ts`.
 2. Resolve or ask the operator to provide the Android package name. Prefer
    `.lisa.config.json` `playStore.packageName`, then `expo.android.package` from
    app config.


### PR DESCRIPTION
## Summary
- add an Expo `play-store-access` skill for read-only Google Play production-track status
- document credential setup, package-name resolution, and androidpublisher v3 track reads
- link the skill from Expo deployment guidance and regenerate plugin variants

## Verification
- bun run build:plugins
- bun run check:plugins
- git commit hook: gitleaks, tsc --noEmit, prettier via lint-staged
- git push hook: production audit, eslint slow config, knip, vitest run --coverage, vitest run tests/integration

Closes #1421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Play production/track release visibility for Expo projects.
  * Introduced a read-only `play-store-access` skill for non-interactive checks without opening Play Console.
* **Documentation**
  * Updated integration access layer and Expo deployment references with required credential options, package/track resolution, and reported fields.
  * Added detailed “Monitoring Production Track State” guidance and status interpretation.
* **Bug Fixes**
  * Clarified and documented strict read-only behavior (no submissions, promotions, or rollout changes), plus expected error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->