### PR TITLE
fix(hooks): keep install package output off stdout

### DIFF
--- a/plugins/lisa-copilot/hooks/install-pkgs.sh
+++ b/plugins/lisa-copilot/hooks/install-pkgs.sh
@@ -20,7 +20,7 @@ link_primary_worktree_node_modules() {
   [ -d "$primary_root/node_modules" ] || return 1
 
   ln -s "$primary_root/node_modules" "node_modules"
-  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules" >&2
 }
 
 # Only run package installation when node_modules are missing.
@@ -60,12 +60,12 @@ detect_package_manager() {
 }
 
 PACKAGE_MANAGER="$(detect_package_manager)"
-echo "Detected package manager: ${PACKAGE_MANAGER}"
+echo "Detected package manager: ${PACKAGE_MANAGER}" >&2
 case "$PACKAGE_MANAGER" in
-  bun) bun install ;;
-  pnpm) pnpm install ;;
-  yarn) yarn install ;;
-  *) npm install ;;
+  bun) bun install >&2 ;;
+  pnpm) pnpm install >&2 ;;
+  yarn) yarn install >&2 ;;
+  *) npm install >&2 ;;
 esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
@@ -74,15 +74,15 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # Install Gitleaks for secret detection (pre-commit hook)
-echo "Installing Gitleaks for secret detection..."
+echo "Installing Gitleaks for secret detection..." >&2
 GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
-echo "Gitleaks installed: $(gitleaks version)"
+echo "Gitleaks installed: $(gitleaks version)" >&2
 
 # Install jira-cli for JIRA integration
 # The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
 # so we extract to a temp dir and copy the binary out.
-echo "Installing jira-cli for JIRA integration..."
+echo "Installing jira-cli for JIRA integration..." >&2
 JIRA_CLI_VERSION="1.7.0"
 JIRA_TMPDIR=$(mktemp -d)
 curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
@@ -90,12 +90,12 @@ curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_C
 cp "${JIRA_TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
 chmod +x /usr/local/bin/jira
 rm -rf "${JIRA_TMPDIR}"
-echo "jira-cli installed: $(jira version)"
+echo "jira-cli installed: $(jira version)" >&2
 
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
-echo "Installing Chromium for Lighthouse CI..."
-npx playwright install chromium
+echo "Installing Chromium for Lighthouse CI..." >&2
+npx playwright install chromium >&2
 
 # Find and export CHROME_PATH for Lighthouse CI
 # Use sort to ensure deterministic selection of the latest version
@@ -110,7 +110,7 @@ if [ -n "$CHROME_PATH" ]; then
   fi
 
   export CHROME_PATH="$CHROME_PATH"
-  echo "Chromium installed at: $CHROME_PATH"
+  echo "Chromium installed at: $CHROME_PATH" >&2
 fi
 
 exit 0

--- a/plugins/lisa-cursor/hooks/install-pkgs.sh
+++ b/plugins/lisa-cursor/hooks/install-pkgs.sh
@@ -20,7 +20,7 @@ link_primary_worktree_node_modules() {
   [ -d "$primary_root/node_modules" ] || return 1
 
   ln -s "$primary_root/node_modules" "node_modules"
-  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules" >&2
 }
 
 # Only run package installation when node_modules are missing.
@@ -60,12 +60,12 @@ detect_package_manager() {
 }
 
 PACKAGE_MANAGER="$(detect_package_manager)"
-echo "Detected package manager: ${PACKAGE_MANAGER}"
+echo "Detected package manager: ${PACKAGE_MANAGER}" >&2
 case "$PACKAGE_MANAGER" in
-  bun) bun install ;;
-  pnpm) pnpm install ;;
-  yarn) yarn install ;;
-  *) npm install ;;
+  bun) bun install >&2 ;;
+  pnpm) pnpm install >&2 ;;
+  yarn) yarn install >&2 ;;
+  *) npm install >&2 ;;
 esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
@@ -74,15 +74,15 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # Install Gitleaks for secret detection (pre-commit hook)
-echo "Installing Gitleaks for secret detection..."
+echo "Installing Gitleaks for secret detection..." >&2
 GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
-echo "Gitleaks installed: $(gitleaks version)"
+echo "Gitleaks installed: $(gitleaks version)" >&2
 
 # Install jira-cli for JIRA integration
 # The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
 # so we extract to a temp dir and copy the binary out.
-echo "Installing jira-cli for JIRA integration..."
+echo "Installing jira-cli for JIRA integration..." >&2
 JIRA_CLI_VERSION="1.7.0"
 JIRA_TMPDIR=$(mktemp -d)
 curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
@@ -90,12 +90,12 @@ curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_C
 cp "${JIRA_TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
 chmod +x /usr/local/bin/jira
 rm -rf "${JIRA_TMPDIR}"
-echo "jira-cli installed: $(jira version)"
+echo "jira-cli installed: $(jira version)" >&2
 
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
-echo "Installing Chromium for Lighthouse CI..."
-npx playwright install chromium
+echo "Installing Chromium for Lighthouse CI..." >&2
+npx playwright install chromium >&2
 
 # Find and export CHROME_PATH for Lighthouse CI
 # Use sort to ensure deterministic selection of the latest version
@@ -110,7 +110,7 @@ if [ -n "$CHROME_PATH" ]; then
   fi
 
   export CHROME_PATH="$CHROME_PATH"
-  echo "Chromium installed at: $CHROME_PATH"
+  echo "Chromium installed at: $CHROME_PATH" >&2
 fi
 
 exit 0

--- a/plugins/lisa/hooks/install-pkgs.sh
+++ b/plugins/lisa/hooks/install-pkgs.sh
@@ -20,7 +20,7 @@ link_primary_worktree_node_modules() {
   [ -d "$primary_root/node_modules" ] || return 1
 
   ln -s "$primary_root/node_modules" "node_modules"
-  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules" >&2
 }
 
 # Only run package installation when node_modules are missing.
@@ -60,12 +60,12 @@ detect_package_manager() {
 }
 
 PACKAGE_MANAGER="$(detect_package_manager)"
-echo "Detected package manager: ${PACKAGE_MANAGER}"
+echo "Detected package manager: ${PACKAGE_MANAGER}" >&2
 case "$PACKAGE_MANAGER" in
-  bun) bun install ;;
-  pnpm) pnpm install ;;
-  yarn) yarn install ;;
-  *) npm install ;;
+  bun) bun install >&2 ;;
+  pnpm) pnpm install >&2 ;;
+  yarn) yarn install >&2 ;;
+  *) npm install >&2 ;;
 esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
@@ -74,15 +74,15 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # Install Gitleaks for secret detection (pre-commit hook)
-echo "Installing Gitleaks for secret detection..."
+echo "Installing Gitleaks for secret detection..." >&2
 GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
-echo "Gitleaks installed: $(gitleaks version)"
+echo "Gitleaks installed: $(gitleaks version)" >&2
 
 # Install jira-cli for JIRA integration
 # The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
 # so we extract to a temp dir and copy the binary out.
-echo "Installing jira-cli for JIRA integration..."
+echo "Installing jira-cli for JIRA integration..." >&2
 JIRA_CLI_VERSION="1.7.0"
 JIRA_TMPDIR=$(mktemp -d)
 curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
@@ -90,12 +90,12 @@ curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_C
 cp "${JIRA_TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
 chmod +x /usr/local/bin/jira
 rm -rf "${JIRA_TMPDIR}"
-echo "jira-cli installed: $(jira version)"
+echo "jira-cli installed: $(jira version)" >&2
 
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
-echo "Installing Chromium for Lighthouse CI..."
-npx playwright install chromium
+echo "Installing Chromium for Lighthouse CI..." >&2
+npx playwright install chromium >&2
 
 # Find and export CHROME_PATH for Lighthouse CI
 # Use sort to ensure deterministic selection of the latest version
@@ -110,7 +110,7 @@ if [ -n "$CHROME_PATH" ]; then
   fi
 
   export CHROME_PATH="$CHROME_PATH"
-  echo "Chromium installed at: $CHROME_PATH"
+  echo "Chromium installed at: $CHROME_PATH" >&2
 fi
 
 exit 0

--- a/plugins/src/base/hooks/install-pkgs.sh
+++ b/plugins/src/base/hooks/install-pkgs.sh
@@ -20,7 +20,7 @@ link_primary_worktree_node_modules() {
   [ -d "$primary_root/node_modules" ] || return 1
 
   ln -s "$primary_root/node_modules" "node_modules"
-  echo "Linked node_modules from primary worktree: $primary_root/node_modules"
+  echo "Linked node_modules from primary worktree: $primary_root/node_modules" >&2
 }
 
 # Only run package installation when node_modules are missing.
@@ -60,12 +60,12 @@ detect_package_manager() {
 }
 
 PACKAGE_MANAGER="$(detect_package_manager)"
-echo "Detected package manager: ${PACKAGE_MANAGER}"
+echo "Detected package manager: ${PACKAGE_MANAGER}" >&2
 case "$PACKAGE_MANAGER" in
-  bun) bun install ;;
-  pnpm) pnpm install ;;
-  yarn) yarn install ;;
-  *) npm install ;;
+  bun) bun install >&2 ;;
+  pnpm) pnpm install >&2 ;;
+  yarn) yarn install >&2 ;;
+  *) npm install >&2 ;;
 esac
 
 # The tools below use Linux-specific binaries and paths — skip on other platforms.
@@ -74,15 +74,15 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # Install Gitleaks for secret detection (pre-commit hook)
-echo "Installing Gitleaks for secret detection..."
+echo "Installing Gitleaks for secret detection..." >&2
 GITLEAKS_VERSION="8.18.4"
 curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz -C /usr/local/bin gitleaks
-echo "Gitleaks installed: $(gitleaks version)"
+echo "Gitleaks installed: $(gitleaks version)" >&2
 
 # Install jira-cli for JIRA integration
 # The tarball nests the binary at jira_VERSION_linux_x86_64/bin/jira,
 # so we extract to a temp dir and copy the binary out.
-echo "Installing jira-cli for JIRA integration..."
+echo "Installing jira-cli for JIRA integration..." >&2
 JIRA_CLI_VERSION="1.7.0"
 JIRA_TMPDIR=$(mktemp -d)
 curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/jira_${JIRA_CLI_VERSION}_linux_x86_64.tar.gz" \
@@ -90,12 +90,12 @@ curl -sSfL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_C
 cp "${JIRA_TMPDIR}/jira_${JIRA_CLI_VERSION}_linux_x86_64/bin/jira" /usr/local/bin/jira
 chmod +x /usr/local/bin/jira
 rm -rf "${JIRA_TMPDIR}"
-echo "jira-cli installed: $(jira version)"
+echo "jira-cli installed: $(jira version)" >&2
 
 # Install Chromium for Lighthouse CI (pre-push hook)
 # Playwright's bundled Chromium works with @lhci/cli
-echo "Installing Chromium for Lighthouse CI..."
-npx playwright install chromium
+echo "Installing Chromium for Lighthouse CI..." >&2
+npx playwright install chromium >&2
 
 # Find and export CHROME_PATH for Lighthouse CI
 # Use sort to ensure deterministic selection of the latest version
@@ -110,7 +110,7 @@ if [ -n "$CHROME_PATH" ]; then
   fi
 
   export CHROME_PATH="$CHROME_PATH"
-  echo "Chromium installed at: $CHROME_PATH"
+  echo "Chromium installed at: $CHROME_PATH" >&2
 fi
 
 exit 0

--- a/src/codex/scripts/install-pkgs.sh
+++ b/src/codex/scripts/install-pkgs.sh
@@ -65,10 +65,10 @@ detect_package_manager() {
 
 PACKAGE_MANAGER="$(detect_package_manager)"
 case "$PACKAGE_MANAGER" in
-  bun) command -v bun >/dev/null 2>&1 && bun install ;;
-  pnpm) command -v pnpm >/dev/null 2>&1 && pnpm install ;;
-  yarn) command -v yarn >/dev/null 2>&1 && yarn install ;;
-  *) command -v npm >/dev/null 2>&1 && npm install ;;
+  bun) command -v bun >/dev/null 2>&1 && bun install >&2 ;;
+  pnpm) command -v pnpm >/dev/null 2>&1 && pnpm install >&2 ;;
+  yarn) command -v yarn >/dev/null 2>&1 && yarn install >&2 ;;
+  *) command -v npm >/dev/null 2>&1 && npm install >&2 ;;
 esac
 
 exit 0

--- a/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
+++ b/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
@@ -37,6 +37,10 @@ describe("install-pkgs worktree node_modules handoff", () => {
       path.join(fakeBin, "git"),
       '#!/usr/bin/env bash\nif [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then pwd; exit 0; fi\nexit 1\n'
     );
+    await writeExecutable(
+      path.join(fakeBin, "uname"),
+      "#!/usr/bin/env bash\necho Darwin\n"
+    );
 
     for (const name of ["bun", "npm", "pnpm", "yarn"]) {
       await writeExecutable(
@@ -57,16 +61,48 @@ describe("install-pkgs worktree node_modules handoff", () => {
     "%s hook links primary node_modules before installing",
     (_name, script) => {
       // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
-      execFileSync("bash", [script], {
+      const output = execFileSync("bash", [script], {
         cwd: worktreeRoot,
         env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
         stdio: "pipe",
       });
 
+      expect(output.toString("utf8")).toBe("");
       expect(fs.realpathSync(path.join(worktreeRoot, "node_modules"))).toBe(
         fs.realpathSync(path.join(primaryRoot, "node_modules"))
       );
       expect(fs.existsSync(installMarker)).toBe(false);
+    }
+  );
+
+  it.each([
+    ["Claude/plugin", CLAUDE_INSTALL_PKGS],
+    ["Codex", CODEX_INSTALL_PKGS],
+  ])(
+    "%s hook keeps package-manager output off stdout",
+    async (_name, script) => {
+      const projectRoot = path.join(tempDir, `install-${_name}`);
+      fs.ensureDirSync(projectRoot);
+      fs.writeFileSync(
+        path.join(projectRoot, "package.json"),
+        '{"name":"fixture","engines":{"npm":"please-use-npm"}}\n',
+        "utf8"
+      );
+
+      await writeExecutable(
+        path.join(fakeBin, "npm"),
+        `#!/usr/bin/env bash\necho "fake npm stdout"\necho "fake npm stderr" >&2\ntouch "${installMarker}"\nexit 0\n`
+      );
+
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
+      const output = execFileSync("bash", [script], {
+        cwd: projectRoot,
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+        stdio: "pipe",
+      });
+
+      expect(output.toString("utf8")).toBe("");
+      expect(fs.existsSync(installMarker)).toBe(true);
     }
   );
 });

--- a/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
+++ b/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
@@ -57,16 +57,48 @@ describe("install-pkgs worktree node_modules handoff", () => {
     "%s hook links primary node_modules before installing",
     (_name, script) => {
       // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
-      execFileSync("bash", [script], {
+      const output = execFileSync("bash", [script], {
         cwd: worktreeRoot,
         env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
         stdio: "pipe",
       });
 
+      expect(output.toString("utf8")).toBe("");
       expect(fs.realpathSync(path.join(worktreeRoot, "node_modules"))).toBe(
         fs.realpathSync(path.join(primaryRoot, "node_modules"))
       );
       expect(fs.existsSync(installMarker)).toBe(false);
+    }
+  );
+
+  it.each([
+    ["Claude/plugin", CLAUDE_INSTALL_PKGS],
+    ["Codex", CODEX_INSTALL_PKGS],
+  ])(
+    "%s hook keeps package-manager output off stdout",
+    async (_name, script) => {
+      const projectRoot = path.join(tempDir, `install-${_name}`);
+      fs.ensureDirSync(projectRoot);
+      fs.writeFileSync(
+        path.join(projectRoot, "package.json"),
+        '{"name":"fixture","engines":{"npm":"please-use-npm"}}\n',
+        "utf8"
+      );
+
+      await writeExecutable(
+        path.join(fakeBin, "npm"),
+        `#!/usr/bin/env bash\necho "fake npm stdout"\necho "fake npm stderr" >&2\ntouch "${installMarker}"\nexit 0\n`
+      );
+
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
+      const output = execFileSync("bash", [script], {
+        cwd: projectRoot,
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+        stdio: "pipe",
+      });
+
+      expect(output.toString("utf8")).toBe("");
+      expect(fs.existsSync(installMarker)).toBe(true);
     }
   );
 });


### PR DESCRIPTION
## Summary
- redirect install-pkgs hook progress and package-manager output to stderr
- preserve empty stdout for Claude/plugin and Codex hook contracts
- add regression coverage for worktree node_modules handoff and package-manager stdout suppression

## Verification
- bun vitest run tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
- bun run check:plugins
- pre-push: full unit and integration test suite