### PR TITLE
fix(hooks): support OpenCode commit attribution

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -93,23 +93,56 @@ fi
 
 echo "🤖 Checking for AI co-authorship..."
 
-# Accept attribution from any supported coding agent (Claude or Codex),
-# case-insensitively. Claude Code emits "Co-Authored-By: Claude"; the Codex CLI
-# emits "Co-authored-by: Codex <noreply@openai.com>".
-if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; then
+# Accept attribution from any supported coding agent, case-insensitively.
+# Claude Code emits "Co-Authored-By: Claude"; Codex can emit
+# "Co-authored-by: Codex <noreply@openai.com>"; OpenCode-authored commits
+# should identify OpenCode and include model/effort metadata trailers.
+if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex|OpenCode)"; then
   echo ""
   echo "❌ Commit message must include AI co-authorship!"
   echo ""
-  echo "All commits must include a Co-authored-by line for a coding agent (Claude or Codex)."
+  echo "All commits must include a Co-authored-by line for a supported coding agent."
   echo ""
   echo "Expected one of these trailers:"
   echo "  Co-authored-by: Claude <noreply@anthropic.com>"
   echo "  Co-authored-by: Codex <codex@openai.com>"
+  echo "  Co-authored-by: OpenCode <noreply@opencode.ai>"
+  echo ""
+  echo "OpenCode commits must also include:"
+  echo "  AI-Agent: OpenCode"
+  echo "  AI-Model: <provider/model>"
+  echo "  AI-Effort: <effort or runtime value>"
   echo ""
   echo "If you're using Claude Code, use the /git:commit command"
   echo "If you're using Codex, enable commit_attribution in .codex/config.toml"
+  echo "If you're using OpenCode, include the OpenCode trailer and AI-* metadata"
   echo ""
   exit 1
+fi
+
+if echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*OpenCode"; then
+  missing_opencode_metadata=0
+  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Agent:[[:space:]]*OpenCode[[:space:]]*$"; then
+    missing_opencode_metadata=1
+  fi
+  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Model:[[:space:]]*[^[:space:]].*$"; then
+    missing_opencode_metadata=1
+  fi
+  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Effort:[[:space:]]*[^[:space:]].*$"; then
+    missing_opencode_metadata=1
+  fi
+
+  if [ "$missing_opencode_metadata" -eq 1 ]; then
+    echo ""
+    echo "❌ OpenCode commits must include AI metadata trailers!"
+    echo ""
+    echo "Expected trailers:"
+    echo "  AI-Agent: OpenCode"
+    echo "  AI-Model: <provider/model>"
+    echo "  AI-Effort: <effort or runtime value>"
+    echo ""
+    exit 1
+  fi
 fi
 
 # END: AI GUARDRAILS

--- a/tests/unit/hooks/commit-msg.test.ts
+++ b/tests/unit/hooks/commit-msg.test.ts
@@ -21,6 +21,12 @@ import { afterEach, describe, expect, it } from "vitest";
 const HOOK_PATH = path.resolve(".husky/commit-msg");
 const BASH_PATH = "/bin/bash";
 const GIT_PATH = "/usr/bin/git";
+const VALID_SUBJECT = "fix: clarify hook output";
+const PASSING_COMMITLINT_BIN = "exit 0\n";
+const OPENCODE_TRAILER = "Co-authored-by: OpenCode <noreply@opencode.ai>";
+const OPENCODE_AGENT_TRAILER = "AI-Agent: OpenCode";
+const OPENCODE_MODEL_HINT = "AI-Model: <provider/model>";
+const OPENCODE_EFFORT_HINT = "AI-Effort: <effort or runtime value>";
 
 let tempDirs: string[] = [];
 
@@ -54,8 +60,8 @@ describe("commit-msg hook diagnostics", () => {
   it("prints exact expected attribution trailers", () => {
     const project = createProject({
       binName: "npx",
-      binBody: "exit 0\n",
-      message: "fix: clarify hook output\n",
+      binBody: PASSING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n`,
     });
 
     const result = runHook(project);
@@ -66,6 +72,48 @@ describe("commit-msg hook diagnostics", () => {
       "Co-authored-by: Claude <noreply@anthropic.com>"
     );
     expect(result.stdout).toContain("Co-authored-by: Codex <codex@openai.com>");
+    expect(result.stdout).toContain(OPENCODE_TRAILER);
+    expect(result.stdout).toContain(OPENCODE_AGENT_TRAILER);
+    expect(result.stdout).toContain(OPENCODE_MODEL_HINT);
+    expect(result.stdout).toContain(OPENCODE_EFFORT_HINT);
+  });
+
+  it("accepts OpenCode attribution with model and effort metadata", () => {
+    const project = createProject({
+      binName: "npx",
+      binBody: PASSING_COMMITLINT_BIN,
+      message: [
+        VALID_SUBJECT,
+        "",
+        OPENCODE_TRAILER,
+        OPENCODE_AGENT_TRAILER,
+        "AI-Model: openai/gpt-5.5",
+        "AI-Effort: not exposed by runtime",
+        "",
+      ].join("\n"),
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("rejects OpenCode attribution without model and effort metadata", () => {
+    const project = createProject({
+      binName: "npx",
+      binBody: PASSING_COMMITLINT_BIN,
+      message: [VALID_SUBJECT, "", OPENCODE_TRAILER, ""].join("\n"),
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "OpenCode commits must include AI metadata trailers"
+    );
+    expect(result.stdout).toContain(OPENCODE_AGENT_TRAILER);
+    expect(result.stdout).toContain(OPENCODE_MODEL_HINT);
+    expect(result.stdout).toContain(OPENCODE_EFFORT_HINT);
   });
 });
 


### PR DESCRIPTION
## Summary
- allow OpenCode as a supported AI co-author in the commit-msg hook
- require OpenCode commits to include AI-Agent, AI-Model, and AI-Effort trailers
- add regression tests for expected diagnostics, accepted OpenCode attribution, and missing metadata rejection

## Verification
- bun vitest run tests/unit/hooks/commit-msg.test.ts
- bun run typecheck
- pre-push: full unit and integration test suite