### PR TITLE
fix: tighten eslint rule coverage

### DIFF
--- a/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
+++ b/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
@@ -362,6 +362,26 @@ ruleTester.run("enforce-statement-order", rule, {
       ],
     },
 
+    // Awaited side effect before definition
+    {
+      code: `
+        async function loadData() {
+          await fetchData();
+          const data = [];
+          return data;
+        }
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
     // Console.log before definition
     {
       code: `

--- a/eslint-plugin-code-organization/rules/enforce-statement-order.js
+++ b/eslint-plugin-code-organization/rules/enforce-statement-order.js
@@ -24,7 +24,17 @@ module.exports = {
       recommended: true,
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          checkAwaitedCalls: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       wrongOrder:
         "{{current}} should come before {{previous}}. Expected order: definitions → side effects → return statement",
@@ -43,6 +53,25 @@ module.exports = {
       [ORDER.SIDE_EFFECT]: "Side effects",
       [ORDER.RETURN]: "Return statement",
     };
+    const options = context.options[0] || {};
+    const checkAwaitedCalls = options.checkAwaitedCalls !== false;
+
+    /**
+     * Removes transparent wrappers around a candidate side-effect expression.
+     * @param {import('eslint').Rule.Node | null | undefined} expression - Expression node
+     * @returns {import('eslint').Rule.Node | null | undefined} Unwrapped expression node
+     */
+    function unwrapExpression(expression) {
+      if (
+        expression &&
+        ((checkAwaitedCalls && expression.type === "AwaitExpression") ||
+          expression.type === "ChainExpression")
+      ) {
+        return unwrapExpression(expression.expression || expression.argument);
+      }
+
+      return expression;
+    }
 
     /**
      * Checks if an expression statement is a function call (side effect)
@@ -54,14 +83,10 @@ module.exports = {
         return false;
       }
 
-      const expression = statement.expression;
+      const expression = unwrapExpression(statement.expression);
 
       // Direct call: doSomething() or object.method()
-      if (expression.type === "CallExpression") {
-        return true;
-      }
-
-      return false;
+      return Boolean(expression && expression.type === "CallExpression");
     }
 
     /**

--- a/eslint-plugin-component-structure/__tests__/enforce-component-structure.test.js
+++ b/eslint-plugin-component-structure/__tests__/enforce-component-structure.test.js
@@ -1,0 +1,61 @@
+/**
+ * This file is managed by Lisa.
+ * Do not edit directly — changes will be overwritten on the next `lisa` run.
+ */
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { RuleTester } = require("eslint");
+
+const rule = require("../rules/enforce-component-structure");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+/**
+ * Creates an index file fixture whose component siblings are intentionally missing.
+ * @param {string} componentName Component directory name
+ * @returns {string} Absolute fixture index path
+ */
+function createComponentIndexFixture(componentName) {
+  const rootDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "lisa-component-structure-")
+  );
+  const componentDir = path.join(
+    rootDir,
+    "src",
+    "features",
+    "demo",
+    "components",
+    componentName
+  );
+  const filename = path.join(componentDir, "index.tsx");
+
+  fs.mkdirSync(componentDir, { recursive: true });
+  fs.writeFileSync(
+    filename,
+    `export { default } from "./${componentName}View";\n`
+  );
+  return filename;
+}
+
+ruleTester.run("enforce-component-structure", rule, {
+  valid: [],
+  invalid: [
+    {
+      code: `export { default } from "./MissingSiblingsView";`,
+      filename: createComponentIndexFixture("MissingSiblings"),
+      errors: [{ messageId: "missingContainer" }, { messageId: "missingView" }],
+    },
+  ],
+});

--- a/eslint-plugin-component-structure/rules/enforce-component-structure.js
+++ b/eslint-plugin-component-structure/rules/enforce-component-structure.js
@@ -116,36 +116,7 @@ module.exports = {
       return {};
     }
 
-    // Check file naming
     if (
-      fileName === "index.ts" ||
-      fileName === "index.tsx" ||
-      fileName === "index.jsx"
-    ) {
-      // Check if index.tsx exports the Container
-      return {
-        Program(node) {
-          const sourceCode = context.getSourceCode();
-          const text = sourceCode.getText();
-
-          // Check for export patterns (allow Container or View)
-          const defaultExportPattern = new RegExp(
-            `export\\s*{\\s*default\\s*}\\s*from\\s*['"\`]\\.\\/${componentName}(Container|View)['"\`]|` +
-              `export\\s*\\*\\s*from\\s*['"\`]\\.\\/${componentName}(Container|View)['"\`]|` +
-              `export\\s*{\\s*${componentName}(Container|View)\\s*as\\s*default\\s*}|` +
-              `export\\s*default\\s*${componentName}(Container|View)`
-          );
-
-          if (!defaultExportPattern.test(text)) {
-            context.report({
-              node,
-              messageId: "incorrectIndexExport",
-              data: { componentName },
-            });
-          }
-        },
-      };
-    } else if (
       fileName.endsWith("Container.tsx") ||
       fileName.endsWith("Container.jsx")
     ) {
@@ -196,7 +167,7 @@ module.exports = {
             f === `${componentName}View.tsx` || f === `${componentName}View.jsx`
         );
         const hasIndex = files.some(
-          f => f === "index.tsx" || f === "index.jsx"
+          f => f === "index.ts" || f === "index.tsx" || f === "index.jsx"
         );
 
         if (!hasContainer) {
@@ -226,8 +197,43 @@ module.exports = {
     };
 
     // Only check once per file
-    if (fileName === "index.tsx" || fileName === "index.jsx") {
+    if (
+      fileName === "index.ts" ||
+      fileName === "index.tsx" ||
+      fileName === "index.jsx"
+    ) {
       checkRequiredFiles();
+    }
+
+    // Check file naming
+    if (
+      fileName === "index.ts" ||
+      fileName === "index.tsx" ||
+      fileName === "index.jsx"
+    ) {
+      // Check if index.tsx exports the Container
+      return {
+        Program(node) {
+          const sourceCode = context.getSourceCode();
+          const text = sourceCode.getText();
+
+          // Check for export patterns (allow Container or View)
+          const defaultExportPattern = new RegExp(
+            `export\\s*{\\s*default\\s*}\\s*from\\s*['"\`]\\.\\/${componentName}(Container|View)['"\`]|` +
+              `export\\s*\\*\\s*from\\s*['"\`]\\.\\/${componentName}(Container|View)['"\`]|` +
+              `export\\s*{\\s*${componentName}(Container|View)\\s*as\\s*default\\s*}|` +
+              `export\\s*default\\s*${componentName}(Container|View)`
+          );
+
+          if (!defaultExportPattern.test(text)) {
+            context.report({
+              node,
+              messageId: "incorrectIndexExport",
+              data: { componentName },
+            });
+          }
+        },
+      };
     }
 
     return {};

--- a/eslint.config.local.ts
+++ b/eslint.config.local.ts
@@ -42,4 +42,15 @@ export default [
       "src/opencode/plugin-templates/**",
     ],
   },
+  {
+    rules: {
+      // Lisa's own codebase has existing awaited side effects before later
+      // declarations. Keep the published rule stricter by default while this repo
+      // carries that cleanup as separate follow-up work.
+      "code-organization/enforce-statement-order": [
+        "error",
+        { checkAwaitedCalls: false },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- fixes component-structure index files so required sibling checks run before returning the export visitor
- detects awaited and optional call expressions as statement-order side effects by default
- adds focused RuleTester coverage for missing component siblings and awaited side effects
- keeps Lisa's own existing awaited-order cleanup out of this PR via a local compatibility override

Closes #1415

## Verification

- `node eslint-plugin-component-structure/__tests__/enforce-component-structure.test.js && node eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js`
- `bun run typecheck`
- `bun run format:check`
- `bun run check:plugins`
- `bun run lint` (6 pre-existing warnings, 0 errors)
- `bun run test` (219 files / 3690 tests)
- pre-push: production audit, slow lint, knip, coverage tests, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded linting support for awaited and optional-chained function calls in statement-order checks, with a new option to control whether awaited calls are included.
  * Improved component structure checks to recognize TypeScript index files alongside existing JSX/TSX support.

* **Bug Fixes**
  * Reduced false “missing index” and incorrect export reports for TypeScript component folders.
  * Added coverage for missing sibling component files and awaited side-effect ordering cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->