### PR TITLE
Complete statement-order coverage for function bodies

### DIFF
--- a/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
+++ b/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
@@ -228,6 +228,20 @@ ruleTester.run("enforce-statement-order", rule, {
         }
       `,
     },
+
+    // Compatibility mode preserves the legacy variable/function-declaration scan
+    {
+      code: `
+        class Processor {
+          run() {
+            initialize();
+            const config = getConfig();
+            return config;
+          }
+        }
+      `,
+      options: [{ checkAllFunctionBodies: false }],
+    },
   ],
 
   invalid: [
@@ -471,6 +485,90 @@ ruleTester.run("enforce-statement-order", rule, {
     {
       code: `
         const process = () => {
+          initialize();
+          const config = getConfig();
+          return config;
+        };
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
+    // Class method with side effect before definition
+    {
+      code: `
+        class Processor {
+          run() {
+            initialize();
+            const config = getConfig();
+            return config;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
+    // Object method with side effect before definition
+    {
+      code: `
+        const processor = {
+          run() {
+            initialize();
+            const config = getConfig();
+            return config;
+          },
+        };
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
+    // Callback body with side effect before definition
+    {
+      code: `
+        items.map(item => {
+          track(item);
+          const label = item.label;
+          return label;
+        });
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
+    // Default-exported arrow function with side effect before definition
+    {
+      code: `
+        export default () => {
           initialize();
           const config = getConfig();
           return config;

--- a/eslint-plugin-code-organization/rules/enforce-statement-order.js
+++ b/eslint-plugin-code-organization/rules/enforce-statement-order.js
@@ -31,6 +31,9 @@ module.exports = {
           checkAwaitedCalls: {
             type: "boolean",
           },
+          checkAllFunctionBodies: {
+            type: "boolean",
+          },
         },
         additionalProperties: false,
       },
@@ -55,6 +58,7 @@ module.exports = {
     };
     const options = context.options[0] || {};
     const checkAwaitedCalls = options.checkAwaitedCalls !== false;
+    const checkAllFunctionBodies = options.checkAllFunctionBodies !== false;
 
     /**
      * Removes transparent wrappers around a candidate side-effect expression.
@@ -166,13 +170,21 @@ module.exports = {
       });
     }
 
+    if (checkAllFunctionBodies) {
+      return {
+        "FunctionDeclaration, FunctionExpression, ArrowFunctionExpression"(
+          node
+        ) {
+          checkBodyOrder(node);
+        },
+      };
+    }
+
     return {
-      // Check all function declarations
       FunctionDeclaration(node) {
         checkBodyOrder(node);
       },
 
-      // Check all arrow functions and function expressions assigned to variables
       VariableDeclarator(node) {
         if (
           node.init &&

--- a/eslint.config.local.ts
+++ b/eslint.config.local.ts
@@ -44,12 +44,12 @@ export default [
   },
   {
     rules: {
-      // Lisa's own codebase has existing awaited side effects before later
-      // declarations. Keep the published rule stricter by default while this repo
-      // carries that cleanup as separate follow-up work.
+      // Lisa's own codebase has existing awaited and nested-function side effects
+      // before later declarations. Keep the published rule stricter by default
+      // while this repo carries that cleanup as separate follow-up work.
       "code-organization/enforce-statement-order": [
         "error",
-        { checkAwaitedCalls: false },
+        { checkAllFunctionBodies: false, checkAwaitedCalls: false },
       ],
     },
   },


### PR DESCRIPTION
## Summary

Completes the remaining #1415 statement-order rule scope after #1430 covered index required-files and awaited calls:

- check `FunctionExpression` and `ArrowFunctionExpression` bodies directly, so class methods, object methods, callbacks, and default-exported arrows are covered by the rule default
- add RuleTester regressions for class methods, object methods, callbacks, default-exported arrows, and compatibility mode
- add a Lisa-local compatibility option to keep this monorepo's existing nested-function ordering debt out of this bugfix PR while preserving the stricter published default

Fixes #1415.

## Verification

- `node eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js`
- `bun run lint` (existing 6 warnings, 0 errors)
- `bun run typecheck`
- `bun run format:check`
- `bun run check:plugins`
- `bun run test` (219 files / 3691 tests)
- pre-push: production audit, slow lint, knip, coverage tests, integration tests
