### PR TITLE
fix: harden release workflow failure handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ on:
 # Prevent concurrent runs of the same workflow on the same ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Required permissions for creating releases and OIDC publishing
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -839,7 +839,9 @@ jobs:
               -m "Correlation ID: ${{ needs.release_init.outputs.correlation_id }}"
           fi
 
-          echo "✅ Created signed tag: ${{ needs.version.outputs.tag }}"
+          git push origin "refs/tags/${{ needs.version.outputs.tag }}:refs/tags/${{ needs.version.outputs.tag }}"
+
+          echo "✅ Created and pushed signed tag: ${{ needs.version.outputs.tag }}"
 
       - name: Upload Signed Artifacts
         if: steps.sign.outputs.signed == 'true'
@@ -1111,16 +1113,16 @@ jobs:
             }')
 
           # Create release
-          RESPONSE=$(curl -X POST \
+          RESPONSE=$(curl --fail-with-body -sS -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             -d "$RELEASE_DATA" \
             "https://api.github.com/repos/${{ github.repository }}/releases")
 
           # Extract release information
-          echo "$RESPONSE" | jq -r '.html_url' > .release_url
-          echo "$RESPONSE" | jq -r '.id' > .release_id
-          echo "$RESPONSE" | jq -r '.upload_url' > .upload_url
+          echo "$RESPONSE" | jq -e -r '.html_url' > .release_url
+          echo "$RESPONSE" | jq -e -r '.id' > .release_id
+          echo "$RESPONSE" | jq -e -r '.upload_url' > .upload_url
 
           echo "html_url=$(cat .release_url)" >> $GITHUB_OUTPUT
           echo "id=$(cat .release_id)" >> $GITHUB_OUTPUT

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -14,6 +14,8 @@ const QUALITY_RAILS_YML = path.join(
   "workflows",
   "quality-rails.yml"
 );
+const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
+const DEPLOY_YML = path.join(REPO_ROOT, ".github", "workflows", "deploy.yml");
 
 /** Shape of a single `workflow_call` input declaration. */
 interface WorkflowInput {
@@ -56,6 +58,16 @@ interface QualityWorkflow {
   };
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
   jobs: Record<string, WorkflowJob>;
+}
+
+/** Root shape of the parsed `release.yml` reusable workflow. */
+interface ReleaseWorkflow {
+  jobs: Record<string, WorkflowJob>;
+}
+
+/** Root shape of the parsed `deploy.yml` workflow. */
+interface DeployWorkflow {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
 }
 
 describe("quality.yml reusable workflow", () => {
@@ -294,5 +306,48 @@ describe("quality.yml reusable workflow", () => {
       expect(run).toContain("$ghsa_ids | index($id)");
       expect(run).toContain("$cve_ids | index($cve)");
     });
+  });
+});
+
+describe("release and deploy workflows", () => {
+  let releaseWorkflow: ReleaseWorkflow;
+  let deployWorkflow: DeployWorkflow;
+
+  beforeAll(() => {
+    releaseWorkflow = yaml.load(
+      fs.readFileSync(RELEASE_YML, "utf8")
+    ) as ReleaseWorkflow;
+    deployWorkflow = yaml.load(
+      fs.readFileSync(DEPLOY_YML, "utf8")
+    ) as DeployWorkflow;
+  });
+
+  it("pushes signed release tags after creating them", () => {
+    const steps = releaseWorkflow.jobs.release_signing.steps ?? [];
+    const signTag = steps.find(s => s.name === "Create Signed Git Tag");
+    const run = signTag?.run ?? "";
+
+    expect(signTag).toBeDefined();
+    expect(run).toContain("git tag -s");
+    expect(run).toContain(
+      'git push origin "refs/tags/${{ needs.version.outputs.tag }}:refs/tags/${{ needs.version.outputs.tag }}"'
+    );
+  });
+
+  it("fails the job when GitHub release creation returns an API error", () => {
+    const steps = releaseWorkflow.jobs.github_release.steps ?? [];
+    const createRelease = steps.find(s => s.name === "Create GitHub Release");
+    const run = createRelease?.run ?? "";
+
+    expect(createRelease).toBeDefined();
+    expect(run).toContain("curl --fail-with-body -sS -X POST");
+    expect(run).toContain("jq -e -r '.html_url'");
+    expect(run).toContain("jq -e -r '.id'");
+    expect(run).toContain("jq -e -r '.upload_url'");
+  });
+
+  it("queues release deploy runs instead of cancelling in-flight publishes", () => {
+    expect(deployWorkflow.concurrency).toBeDefined();
+    expect(deployWorkflow.concurrency?.["cancel-in-progress"]).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Push signed release tags to origin after creating them.
- Make GitHub release creation fail the job on API errors and malformed/null release outputs.
- Queue release/deploy workflow runs instead of cancelling in-flight publishes.
- Add parser-based workflow regression coverage for the release/deploy guards.

Closes #1414

## Verification

- `bun test tests/integration/quality-workflow.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint` (passes with 6 pre-existing warnings)
- `bun run check:plugins`
- `bun run test`
- pre-push: production audit, slow lint, knip, coverage tests, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment runs on the same branch or workflow now queue instead of canceling in-progress work.
  * Signed release tags are now published reliably, and release creation will fail fast if the release service returns an error or unexpected response.
* **Tests**
  * Expanded automated coverage for release and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->