### PR TITLE
Fix Codex and OpenCode plugin fanout

### DIFF
--- a/src/codex/hooks-installer.ts
+++ b/src/codex/hooks-installer.ts
@@ -36,16 +36,11 @@
  * @module codex/hooks-installer
  */
 import * as fse from "fs-extra";
-import {
-  chmod,
-  copyFile,
-  readFile,
-  readdir,
-  writeFile,
-} from "node:fs/promises";
+import { chmod, copyFile, readFile, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ProjectType } from "../core/config.js";
+import { mirrorLisaRules } from "../core/lisa-rules-mirror.js";
 import {
   type CodexHookEvent,
   type HooksFile,
@@ -258,7 +253,7 @@ export async function installHooks(
   const ruleFiles: readonly string[] = applicable.some(
     e => e.id === "inject-rules"
   )
-    ? (await mirrorRules(lisaDir, rulesDir, detectedTypes)).map(file =>
+    ? (await mirrorLisaRules(lisaDir, rulesDir, detectedTypes)).map(file =>
         path.join(LISA_RULES_SUBDIR, file)
       )
     : [];
@@ -349,117 +344,3 @@ function resolveBundledScript(filename: string): string {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
   return path.join(moduleDir, "scripts", filename);
 }
-
-/**
- * Subdirectories under each plugin's rules/ that carry rule .md files.
- * The split is:
- *   - eager/     — load-bearing prescriptions injected at every SessionStart
- *   - reference/ — long-form bodies mirrored alongside; loaded on demand via
- *                  the breadcrumb the eager head points to
- * For backward compatibility with older plugin builds, .md files directly
- * under rules/ (flat, no subdir) are also mirrored.
- */
-const RULE_SUBDIRS = ["eager", "reference"] as const;
-
-/**
- * Copy every .md file from Lisa's base and detected stack plugin `rules/`
- * directories into the host's `.codex/lisa-rules/`, preserving the
- * `eager/` and `reference/` subdir structure.
- * @param lisaDir - Absolute path to the Lisa repo / installed package
- * @param rulesDestDir - Absolute path to `<destDir>/.codex/lisa-rules/`
- * @param detectedTypes - Project types Lisa detected for the host
- * @returns Relative paths (subdir/file or file) of every rule .md file copied
- */
-async function mirrorRules(
-  lisaDir: string,
-  rulesDestDir: string,
-  detectedTypes: readonly ProjectType[]
-): Promise<readonly string[]> {
-  const pluginNames = ["lisa", ...detectedTypes.map(type => `lisa-${type}`)];
-
-  // First pass: list all .md files per plugin (eager/, reference/, and flat
-  // root for backward compat) without copying. Entries are built immutably
-  // with flatMap/concat so each plugin's collected files are a derived value
-  // rather than a mutated buffer (project functional/immutable-data rule).
-  const filesByPlugin = await Promise.all(
-    pluginNames.map(async pluginName => {
-      const rulesRoot = path.join(lisaDir, "plugins", pluginName, "rules");
-      if (!(await fse.pathExists(rulesRoot))) {
-        return { rulesRoot, entries: [] as readonly RuleFileEntry[] };
-      }
-
-      // Subdir entries: eager/*.md, reference/*.md
-      const subdirEntriesByDir = await Promise.all(
-        RULE_SUBDIRS.map(async sub => {
-          const subDir = path.join(rulesRoot, sub);
-          if (!(await fse.pathExists(subDir))) {
-            return [] as readonly RuleFileEntry[];
-          }
-          const subFiles = (await readdir(subDir)).filter(name =>
-            name.endsWith(".md")
-          );
-          return subFiles.map<RuleFileEntry>(file => ({
-            absSource: path.join(subDir, file),
-            relPath: path.join(sub, file),
-          }));
-        })
-      );
-
-      // Backward-compat: flat rules/*.md (older plugin builds that haven't
-      // adopted the eager/reference split yet). Only direct .md children
-      // count; files inside subdirs are handled by the subdir pass.
-      const rootChildren = await readdir(rulesRoot, { withFileTypes: true });
-      const flatEntries: readonly RuleFileEntry[] = rootChildren
-        .filter(d => d.isFile() && d.name.endsWith(".md"))
-        .map<RuleFileEntry>(d => ({
-          absSource: path.join(rulesRoot, d.name),
-          relPath: d.name,
-        }));
-
-      const entries: readonly RuleFileEntry[] = [
-        ...subdirEntriesByDir.flat(),
-        ...flatEntries,
-      ];
-
-      return { rulesRoot, entries };
-    })
-  );
-
-  // Detect relative-path collisions before performing any copies. Subdir
-  // structure is preserved, so two plugins shipping "eager/base-rules.md"
-  // would collide, but "eager/foo.md" and "reference/foo.md" do not.
-  const allRelPaths = filesByPlugin.flatMap(({ entries }) =>
-    entries.map(e => e.relPath)
-  );
-  if (new Set(allRelPaths).size !== allRelPaths.length) {
-    const duplicate = allRelPaths.find(
-      (name, index) => allRelPaths.indexOf(name) !== index
-    );
-    throw new Error(
-      `Duplicate Lisa rule path "${duplicate ?? "unknown"}" across plugin rules/ directories`
-    );
-  }
-
-  // Ensure destination subdirs exist before copying. fs-extra's ensureDir is
-  // idempotent and cheap.
-  await Promise.all(
-    RULE_SUBDIRS.map(sub => fse.ensureDir(path.join(rulesDestDir, sub)))
-  );
-
-  // Second pass: copy files now that we know there are no collisions.
-  await Promise.all(
-    filesByPlugin.flatMap(({ entries }) =>
-      entries.map(entry =>
-        copyFile(entry.absSource, path.join(rulesDestDir, entry.relPath))
-      )
-    )
-  );
-
-  return Object.freeze(allRelPaths);
-}
-
-/** One rule file slated for mirroring, with the destination-relative path. */
-type RuleFileEntry = {
-  readonly absSource: string;
-  readonly relPath: string;
-};

--- a/src/codex/plugin-marketplace-installer.ts
+++ b/src/codex/plugin-marketplace-installer.ts
@@ -27,6 +27,7 @@ const LISA_CODEX_PLUGINS = [
   "lisa-phaser",
   "lisa-rails",
   "lisa-wiki",
+  "lisa-openclaw",
 ] as const;
 
 /** Marketplace category should match each generated `.codex-plugin` manifest. */
@@ -40,6 +41,7 @@ const LISA_CODEX_PLUGIN_CATEGORIES: Readonly<Record<string, string>> = {
   "lisa-phaser": "Coding",
   "lisa-rails": "Coding",
   "lisa-wiki": "Productivity",
+  "lisa-openclaw": "Productivity",
 };
 
 /** Result of a marketplace install pass */

--- a/src/codex/skills-installer.ts
+++ b/src/codex/skills-installer.ts
@@ -30,6 +30,7 @@ import {
   type LisaCommandSource,
   discoverBundledSkills,
   discoverLisaCommands,
+  isHarnessVariantPlugin,
   loadSkillDenylist,
 } from "../core/lisa-skill-sources.js";
 import { convertCommandToSkill } from "./command-skill-transformer.js";
@@ -92,7 +93,11 @@ export async function installSkills(
   );
 
   // Step 1: bundled skills
-  const bundled = await discoverBundledSkills(lisaDir, denylistedSkills);
+  const bundled = await discoverBundledSkills(
+    lisaDir,
+    denylistedSkills,
+    pluginName => !isHarnessVariantPlugin(pluginName)
+  );
   const bundledInstalls = await Promise.all(
     bundled.map(source => copyBundledSkill(source, skillsDir))
   );
@@ -106,9 +111,12 @@ export async function installSkills(
   // owns the target name — e.g. `lisa-implement` ships as a bundled skill, so
   // the thin command wrapper would only duplicate it on Codex).
   const bundledSkillNames = new Set(bundled.map(source => source.skillName));
-  const commandSkills = (await discoverLisaCommands(lisaDir)).filter(
-    cmd => !bundledSkillNames.has(cmd.skillName)
-  );
+  const commandSkills = (
+    await discoverLisaCommands(
+      lisaDir,
+      pluginName => !isHarnessVariantPlugin(pluginName)
+    )
+  ).filter(cmd => !bundledSkillNames.has(cmd.skillName));
   const commandInstalls = await Promise.all(
     commandSkills.map(cmd => emitCommandAsSkill(cmd, skillsDir))
   );

--- a/src/core/lisa-rules-mirror.ts
+++ b/src/core/lisa-rules-mirror.ts
@@ -1,0 +1,102 @@
+/**
+ * Mirror Lisa rule Markdown files into a harness-owned host directory.
+ *
+ * Lisa plugins split rules into:
+ * - `rules/eager/` for always-loaded operational guidance.
+ * - `rules/reference/` for larger bodies loaded on demand by breadcrumbs.
+ *
+ * Harness installers can copy the same source tree into their own managed
+ * config directory and then point their native instruction mechanism at it.
+ * @module core/lisa-rules-mirror
+ */
+import * as fse from "fs-extra";
+import { copyFile, readdir } from "node:fs/promises";
+import * as path from "node:path";
+import type { ProjectType } from "./config.js";
+
+/** Subdirectories under each plugin's rules/ that carry rule .md files. */
+const RULE_SUBDIRS = ["eager", "reference"] as const;
+
+/** One rule file slated for mirroring, with the destination-relative path. */
+type RuleFileEntry = {
+  readonly absSource: string;
+  readonly relPath: string;
+};
+
+/**
+ * Copy every .md file from Lisa's base and detected stack plugin `rules/`
+ * directories into a harness-owned rules directory, preserving the
+ * `eager/` and `reference/` subdir structure.
+ * @param lisaDir - Absolute path to the Lisa repo / installed package.
+ * @param rulesDestDir - Absolute path to the harness-owned rules directory.
+ * @param detectedTypes - Project types Lisa detected for the host.
+ * @returns Relative paths (subdir/file or file) of every rule .md file copied.
+ */
+export async function mirrorLisaRules(
+  lisaDir: string,
+  rulesDestDir: string,
+  detectedTypes: readonly ProjectType[]
+): Promise<readonly string[]> {
+  const pluginNames = ["lisa", ...detectedTypes.map(type => `lisa-${type}`)];
+
+  const filesByPlugin = await Promise.all(
+    pluginNames.map(async pluginName => {
+      const rulesRoot = path.join(lisaDir, "plugins", pluginName, "rules");
+      if (!(await fse.pathExists(rulesRoot))) {
+        return { entries: [] as readonly RuleFileEntry[] };
+      }
+
+      const subdirEntriesByDir = await Promise.all(
+        RULE_SUBDIRS.map(async sub => {
+          const subDir = path.join(rulesRoot, sub);
+          if (!(await fse.pathExists(subDir))) {
+            return [] as readonly RuleFileEntry[];
+          }
+          const subFiles = (await readdir(subDir)).filter(name =>
+            name.endsWith(".md")
+          );
+          return subFiles.map<RuleFileEntry>(file => ({
+            absSource: path.join(subDir, file),
+            relPath: path.join(sub, file),
+          }));
+        })
+      );
+
+      const rootChildren = await readdir(rulesRoot, { withFileTypes: true });
+      const flatEntries: readonly RuleFileEntry[] = rootChildren
+        .filter(d => d.isFile() && d.name.endsWith(".md"))
+        .map<RuleFileEntry>(d => ({
+          absSource: path.join(rulesRoot, d.name),
+          relPath: d.name,
+        }));
+
+      return { entries: [...subdirEntriesByDir.flat(), ...flatEntries] };
+    })
+  );
+
+  const allRelPaths = filesByPlugin.flatMap(({ entries }) =>
+    entries.map(e => e.relPath)
+  );
+  if (new Set(allRelPaths).size !== allRelPaths.length) {
+    const duplicate = allRelPaths.find(
+      (name, index) => allRelPaths.indexOf(name) !== index
+    );
+    throw new Error(
+      `Duplicate Lisa rule path "${duplicate ?? "unknown"}" across plugin rules/ directories`
+    );
+  }
+
+  await Promise.all(
+    RULE_SUBDIRS.map(sub => fse.ensureDir(path.join(rulesDestDir, sub)))
+  );
+
+  await Promise.all(
+    filesByPlugin.flatMap(({ entries }) =>
+      entries.map(entry =>
+        copyFile(entry.absSource, path.join(rulesDestDir, entry.relPath))
+      )
+    )
+  );
+
+  return Object.freeze(allRelPaths);
+}

--- a/src/core/lisa-skill-sources.ts
+++ b/src/core/lisa-skill-sources.ts
@@ -123,17 +123,20 @@ export async function loadSkillDenylist(
  * the name sorts.
  * @param lisaDir - Absolute path to the Lisa repo / installed package.
  * @param denylistedSkills - Skill names that must not ship to host projects.
+ * @param pluginFilter - Optional predicate to restrict which plugin directories
+ *   are walked. Defaults to including every plugin.
  * @returns De-duplicated bundled-skill sources, sorted by skill name.
  */
 export async function discoverBundledSkills(
   lisaDir: string,
-  denylistedSkills: ReadonlySet<string>
+  denylistedSkills: ReadonlySet<string>,
+  pluginFilter?: PluginFilter
 ): Promise<readonly BundledSkillSource[]> {
   const pluginsDir = path.join(lisaDir, "plugins");
   if (!(await fse.pathExists(pluginsDir))) {
     return [];
   }
-  const plugins = await orderedPluginNames(pluginsDir);
+  const plugins = await orderedPluginNames(pluginsDir, pluginFilter);
   const candidatesByPlugin = await Promise.all(
     plugins.map(pluginName => discoverSkillsInPlugin(pluginsDir, pluginName))
   );

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -1059,6 +1059,7 @@ export class Lisa {
     // Hooks: block-no-verify maps to opencode.json `permission.bash`; the
     // runtime-behavior hooks ship as `.opencode/plugin/lisa-*.ts` modules.
     const hooksResult = await installOpencodeHooks(
+      this.config.lisaDir,
       this.config.destDir,
       this.detectedTypes,
       previous.files

--- a/src/opencode/hooks-installer.ts
+++ b/src/opencode/hooks-installer.ts
@@ -12,8 +12,9 @@
  *   - format-on-edit → OpenCode's BUILT-IN prettier formatter already formats on
  *     edit, so Lisa emits no formatter config (overriding it would be worse than
  *     the default). This is why there is no format plugin below.
- *   - inject-rules → not needed; rules ship via the canonical `AGENTS.md`, which
- *     OpenCode reads natively (handled by the skills/AGENTS.md emit).
+ *   - inject-rules → OpenCode has no SessionStart additional-context hook like
+ *     Codex, so Lisa mirrors eager rules into `.opencode/lisa-rules/` and merges
+ *     those files into `opencode.json` `instructions`.
  *   - everything that needs runtime behavior (blocking suppression directives /
  *     migration edits, linting / scanning just-edited files, session bootstrap)
  *     → a `.opencode/plugin/lisa-*.ts` module. OpenCode loads project plugins
@@ -37,6 +38,7 @@ import {
   type ParseError,
 } from "jsonc-parser";
 import type { ProjectType } from "../core/config.js";
+import { mirrorLisaRules } from "../core/lisa-rules-mirror.js";
 import { OPENCODE_CONFIG_DIR } from "./manifest.js";
 import { OPENCODE_SCHEMA_URL } from "./settings-installer.js";
 
@@ -48,6 +50,12 @@ export const OPENCODE_CONFIG_FILENAME = "opencode.json";
 
 /** Prefix every Lisa-managed plugin filename carries (used for stale cleanup) */
 const LISA_PLUGIN_PREFIX = "lisa-";
+
+/** Subdirectory inside `.opencode/` for Lisa rule instruction files. */
+export const OPENCODE_LISA_RULES_SUBDIR = "lisa-rules";
+
+/** OpenCode instruction glob that loads Lisa eager rules every session. */
+export const OPENCODE_EAGER_RULES_INSTRUCTION = `${OPENCODE_CONFIG_DIR}/${OPENCODE_LISA_RULES_SUBDIR}/eager/*.md`;
 
 /**
  * `permission.bash` deny patterns that replace Lisa's `block-no-verify` hook.
@@ -123,7 +131,9 @@ export interface OpencodeHooksInstallResult {
 
 /**
  * Install Lisa's OpenCode hooks: merge `permission.bash` deny rules into
- * `opencode.json` and emit the applicable `.opencode/plugin/lisa-*.ts` modules.
+ * `opencode.json`, mirror Lisa rule files for `instructions`, and emit the
+ * applicable `.opencode/plugin/lisa-*.ts` modules.
+ * @param lisaDir - Absolute path to the Lisa repo root or installed package.
  *
  * `opencode.json` lives at the host ROOT (outside `.opencode/`), is a shared
  * merged file, and is intentionally NOT returned in `managedFiles` — the
@@ -137,11 +147,22 @@ export interface OpencodeHooksInstallResult {
  * @returns Result describing what was written + removed.
  */
 export async function installHooks(
+  lisaDir: string,
   destDir: string,
   detectedTypes: readonly ProjectType[],
   previousManagedFiles: readonly string[]
 ): Promise<OpencodeHooksInstallResult> {
   const configCreated = await mergeOpencodeConfig(destDir);
+
+  const rulesDir = path.join(
+    destDir,
+    OPENCODE_CONFIG_DIR,
+    OPENCODE_LISA_RULES_SUBDIR
+  );
+  await fse.ensureDir(rulesDir);
+  const ruleFiles = (
+    await mirrorLisaRules(lisaDir, rulesDir, detectedTypes)
+  ).map(file => path.join(OPENCODE_LISA_RULES_SUBDIR, file));
 
   const pluginDir = path.join(
     destDir,
@@ -170,7 +191,7 @@ export async function installHooks(
   );
 
   return {
-    managedFiles: Object.freeze(managedFiles),
+    managedFiles: Object.freeze([...managedFiles, ...ruleFiles]),
     pluginCount: applicable.length,
     configCreated,
     deleted,
@@ -252,9 +273,9 @@ const FORMATTING_OPTIONS = {
 } as const;
 
 /**
- * Merge Lisa's `permission.bash` deny rules into the host's `opencode.json`,
- * preserving every other key, comment, and formatting choice. Creates the file
- * (with `$schema`) when absent.
+ * Merge Lisa's `permission.bash` deny rules and eager-rules instruction glob
+ * into the host's `opencode.json`, preserving every other key, comment, and
+ * formatting choice. Creates the file (with `$schema`) when absent.
  *
  * Edits the document surgically via `jsonc-parser` — the same host-preserving
  * approach the sibling OpenCode settings/MCP installers use, so the three
@@ -289,6 +310,7 @@ export function mergeNoVerifyDenyRules(existingJsonc: string): string {
     const fresh = {
       $schema: OPENCODE_SCHEMA_URL,
       permission: { bash: { ...NO_VERIFY_DENY_PATTERNS } },
+      instructions: [OPENCODE_EAGER_RULES_INSTRUCTION],
     };
     return `${JSON.stringify(fresh, null, 2)}\n`;
   }
@@ -319,7 +341,29 @@ export function mergeNoVerifyDenyRules(existingJsonc: string): string {
       ? upsertKey(withBash, ["$schema"], OPENCODE_SCHEMA_URL, undefined)
       : withBash;
 
-  return withSchema.endsWith("\n") ? withSchema : `${withSchema}\n`;
+  const withInstructions = addLisaRuleInstructions(withSchema);
+
+  return withInstructions.endsWith("\n")
+    ? withInstructions
+    : `${withInstructions}\n`;
+}
+
+/**
+ * Add Lisa eager rules to OpenCode's native `instructions` array.
+ * @param text - Current document text.
+ * @returns The edited document text.
+ */
+function addLisaRuleInstructions(text: string): string {
+  const current = parseJsoncOrThrow(text);
+  const instructions = current["instructions"];
+  const nextInstructions = Array.isArray(instructions)
+    ? instructions.includes(OPENCODE_EAGER_RULES_INSTRUCTION)
+      ? undefined
+      : [...instructions, OPENCODE_EAGER_RULES_INSTRUCTION]
+    : [OPENCODE_EAGER_RULES_INSTRUCTION];
+  return nextInstructions === undefined
+    ? text
+    : upsertKey(text, ["instructions"], nextInstructions, instructions);
 }
 
 /**

--- a/src/opencode/skills-installer.ts
+++ b/src/opencode/skills-installer.ts
@@ -28,6 +28,7 @@ import {
   type LisaCommandSource,
   discoverBundledSkills,
   discoverLisaCommands,
+  isHarnessVariantPlugin,
   loadSkillDenylist,
 } from "../core/lisa-skill-sources.js";
 import { convertCommandToSkill } from "../codex/command-skill-transformer.js";
@@ -91,7 +92,11 @@ export async function installSkills(
   );
 
   // Step 1: bundled skills
-  const bundled = await discoverBundledSkills(lisaDir, denylistedSkills);
+  const bundled = await discoverBundledSkills(
+    lisaDir,
+    denylistedSkills,
+    pluginName => !isHarnessVariantPlugin(pluginName)
+  );
   const bundledInstalls = await Promise.all(
     bundled.map(source => copyBundledSkill(source, skillsDir))
   );
@@ -104,9 +109,12 @@ export async function installSkills(
   // Step 2: command-as-skill conversions (skip when the bundled skill already
   // owns the target name — native `/lisa:*` commands cover Claude-style entry).
   const bundledSkillNames = new Set(bundled.map(source => source.skillName));
-  const commandSkills = (await discoverLisaCommands(lisaDir)).filter(
-    cmd => !bundledSkillNames.has(cmd.skillName)
-  );
+  const commandSkills = (
+    await discoverLisaCommands(
+      lisaDir,
+      pluginName => !isHarnessVariantPlugin(pluginName)
+    )
+  ).filter(cmd => !bundledSkillNames.has(cmd.skillName));
   const commandInstalls = await Promise.all(
     commandSkills.map(cmd => emitCommandAsSkill(cmd, skillsDir))
   );

--- a/tests/unit/codex/plugin-marketplace-installer.test.ts
+++ b/tests/unit/codex/plugin-marketplace-installer.test.ts
@@ -36,7 +36,7 @@ describe("codex/plugin-marketplace-installer", () => {
   it("creates a repo-local marketplace with Lisa plugin entries", async () => {
     const result = await installCodexMarketplace(lisaDir, destDir);
     expect(result.created).toBe(true);
-    expect(result.pluginEntries).toBe(9);
+    expect(result.pluginEntries).toBe(10);
 
     const marketplacePath = path.join(destDir, CODEX_MARKETPLACE_PATH);
     const parsed = JSON.parse(await fs.readFile(marketplacePath, "utf8"));
@@ -53,6 +53,7 @@ describe("codex/plugin-marketplace-installer", () => {
       "lisa-phaser",
       "lisa-rails",
       "lisa-wiki",
+      "lisa-openclaw",
     ]);
     expect(parsed.plugins[0].source.path).toBe(
       "./node_modules/@codyswann/lisa/plugins/lisa"
@@ -75,6 +76,7 @@ describe("codex/plugin-marketplace-installer", () => {
       "lisa-phaser": "Coding",
       "lisa-rails": "Coding",
       "lisa-wiki": "Productivity",
+      "lisa-openclaw": "Productivity",
     });
   });
 

--- a/tests/unit/codex/skills-installer-variant-filter.test.ts
+++ b/tests/unit/codex/skills-installer-variant-filter.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression coverage for Codex skill discovery across generated plugin
+ * variants.
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  LISA_SKILLS_SUBDIR,
+  installSkills,
+} from "../../../src/codex/skills-installer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+/** Reusable bundled-skill name for the variant regression. */
+const BUG_TRIAGE = "lisa-bug-triage";
+/** Skill manifest filename. */
+const SKILL_MD = "SKILL.md";
+
+const SAMPLE_SKILL_MD = `---
+name: bug-triage
+description: Triage a bug
+---
+
+Body content here.
+`;
+
+describe("codex/skills-installer variant filtering", () => {
+  let tempDir: string;
+  let lisaDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a fake plugin skill tree.
+   * @param pluginName - Plugin directory name.
+   * @param skillName - Skill directory name.
+   * @param files - Relative filename to content map.
+   */
+  async function seedSkill(
+    pluginName: string,
+    skillName: string,
+    files: Record<string, string>
+  ): Promise<void> {
+    const skillDir = path.join(
+      lisaDir,
+      "plugins",
+      pluginName,
+      "skills",
+      skillName
+    );
+    await fs.ensureDir(skillDir);
+    await Promise.all(
+      Object.entries(files).map(async ([filename, content]) => {
+        const filePath = path.join(skillDir, filename);
+        await fs.ensureDir(path.dirname(filePath));
+        await fs.writeFile(filePath, content, "utf8");
+      })
+    );
+  }
+
+  it("installs Codex-shaped artifacts instead of generated cursor variants", async () => {
+    const codexContent = `${SAMPLE_SKILL_MD}\nCodex sidecar.\n`;
+    const cursorContent = `${SAMPLE_SKILL_MD}\nCursor copy.\n`;
+    await seedSkill("lisa", BUG_TRIAGE, {
+      [SKILL_MD]: codexContent,
+      "agents/openai.yaml": "name: bug-triage\n",
+    });
+    await seedSkill("lisa-cursor", BUG_TRIAGE, {
+      [SKILL_MD]: cursorContent,
+    });
+
+    await installSkills(lisaDir, destDir, []);
+    const skillDir = path.join(
+      destDir,
+      ".codex",
+      LISA_SKILLS_SUBDIR,
+      BUG_TRIAGE
+    );
+
+    expect(await fs.readFile(path.join(skillDir, SKILL_MD), "utf8")).toBe(
+      codexContent
+    );
+    expect(
+      await fs.pathExists(path.join(skillDir, "agents", "openai.yaml"))
+    ).toBe(true);
+  });
+});

--- a/tests/unit/opencode/hooks-installer.test.ts
+++ b/tests/unit/opencode/hooks-installer.test.ts
@@ -10,7 +10,9 @@ import * as fs from "fs-extra";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  OPENCODE_EAGER_RULES_INSTRUCTION,
   OPENCODE_CONFIG_FILENAME,
+  OPENCODE_LISA_RULES_SUBDIR,
   OPENCODE_PLUGIN_SUBDIR,
   installHooks,
   listInstalledPluginFiles,
@@ -25,16 +27,23 @@ const SUPPRESS = "lisa-block-suppress-directives.ts";
 const SGSCAN = "lisa-sg-scan-on-edit.ts";
 const MIGRATION = "lisa-block-migration-edits.ts";
 const RUBOCOP = "lisa-rubocop-on-edit.ts";
+const BASE_RULES = "base-rules.md";
 
 describe("opencode/hooks-installer", () => {
+  let tempDir: string;
+  let lisaDir: string;
   let destDir: string;
 
   beforeEach(async () => {
-    destDir = await createTempDir();
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    destDir = path.join(tempDir, "project");
+    await fs.ensureDir(lisaDir);
+    await fs.ensureDir(destDir);
   });
 
   afterEach(async () => {
-    await cleanupTempDir(destDir);
+    await cleanupTempDir(tempDir);
   });
 
   /**
@@ -59,9 +68,31 @@ describe("opencode/hooks-installer", () => {
     return permission["bash"] as Record<string, string>;
   }
 
+  /**
+   * Write a fake Lisa rule file under plugins/<plugin>/rules/<relPath>.
+   * @param pluginName - Plugin directory name.
+   * @param relPath - Path under rules/ (for example eager/base-rules.md).
+   * @param body - Rule Markdown body.
+   */
+  async function seedRule(
+    pluginName: string,
+    relPath: string,
+    body: string
+  ): Promise<void> {
+    const filePath = path.join(
+      lisaDir,
+      "plugins",
+      pluginName,
+      "rules",
+      relPath
+    );
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, body, "utf8");
+  }
+
   describe("opencode.json permission.bash (block-no-verify)", () => {
     it("creates opencode.json with deny rules when absent", async () => {
-      const result = await installHooks(destDir, ["typescript"], []);
+      const result = await installHooks(lisaDir, destDir, ["typescript"], []);
       expect(result.configCreated).toBe(true);
       const bash = await readBash();
       expect(bash["*--no-verify*"]).toBe("deny");
@@ -70,14 +101,36 @@ describe("opencode/hooks-installer", () => {
       expect(bash["*core.hooksPath*/dev/null*"]).toBe("deny");
     });
 
+    it("adds Lisa eager rules to OpenCode instructions", async () => {
+      await installHooks(lisaDir, destDir, [], []);
+      const config = await readConfig();
+      expect(config["instructions"]).toContain(
+        OPENCODE_EAGER_RULES_INSTRUCTION
+      );
+    });
+
+    it("preserves host instructions while adding Lisa eager rules", async () => {
+      await fs.writeFile(
+        path.join(destDir, OPENCODE_CONFIG_FILENAME),
+        JSON.stringify({ instructions: ["docs/standards.md"] }),
+        "utf8"
+      );
+      await installHooks(lisaDir, destDir, [], []);
+      const config = await readConfig();
+      expect(config["instructions"]).toEqual([
+        "docs/standards.md",
+        OPENCODE_EAGER_RULES_INSTRUCTION,
+      ]);
+    });
+
     it("stamps the $schema on a freshly created config", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const config = await readConfig();
       expect(config["$schema"]).toBe("https://opencode.ai/config.json");
     });
 
     it("writes the config with a trailing newline", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const raw = await fs.readFile(
         path.join(destDir, OPENCODE_CONFIG_FILENAME),
         "utf8"
@@ -95,7 +148,7 @@ describe("opencode/hooks-installer", () => {
         }),
         "utf8"
       );
-      const result = await installHooks(destDir, [], []);
+      const result = await installHooks(lisaDir, destDir, [], []);
       expect(result.configCreated).toBe(false);
       const config = await readConfig();
       expect(config["theme"]).toBe("tokyonight");
@@ -113,19 +166,19 @@ describe("opencode/hooks-installer", () => {
         JSON.stringify({ permission: { bash: "allow" } }),
         "utf8"
       );
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const bash = await readBash();
       expect(bash["*"]).toBe("allow");
       expect(bash["*--no-verify*"]).toBe("deny");
     });
 
     it("is idempotent across repeated installs", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const first = await fs.readFile(
         path.join(destDir, OPENCODE_CONFIG_FILENAME),
         "utf8"
       );
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const second = await fs.readFile(
         path.join(destDir, OPENCODE_CONFIG_FILENAME),
         "utf8"
@@ -139,11 +192,11 @@ describe("opencode/hooks-installer", () => {
         "{ not json",
         "utf8"
       );
-      await expect(installHooks(destDir, [], [])).rejects.toThrow();
+      await expect(installHooks(lisaDir, destDir, [], [])).rejects.toThrow();
     });
 
     it("does not list opencode.json in managedFiles", async () => {
-      const result = await installHooks(destDir, ["typescript"], []);
+      const result = await installHooks(lisaDir, destDir, ["typescript"], []);
       expect(result.managedFiles).not.toContain(OPENCODE_CONFIG_FILENAME);
       expect(
         result.managedFiles.every(f =>
@@ -155,40 +208,73 @@ describe("opencode/hooks-installer", () => {
 
   describe("plugin emission + project-type gating", () => {
     it("always ships the universal session-bootstrap plugin", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).toContain(SESSION);
     });
 
+    it("mirrors eager and reference rule files for OpenCode instructions", async () => {
+      await seedRule(
+        "lisa",
+        path.join("eager", BASE_RULES),
+        "Always do the thing.\n"
+      );
+      await seedRule(
+        "lisa",
+        path.join("reference", BASE_RULES),
+        "Detailed body.\n"
+      );
+      const result = await installHooks(lisaDir, destDir, [], []);
+
+      expect(result.managedFiles).toContain(
+        path.join(OPENCODE_LISA_RULES_SUBDIR, "eager", BASE_RULES)
+      );
+      expect(result.managedFiles).toContain(
+        path.join(OPENCODE_LISA_RULES_SUBDIR, "reference", BASE_RULES)
+      );
+      expect(
+        await fs.readFile(
+          path.join(
+            destDir,
+            OPENCODE_CONFIG_DIR,
+            OPENCODE_LISA_RULES_SUBDIR,
+            "eager",
+            BASE_RULES
+          ),
+          "utf8"
+        )
+      ).toContain("Always do the thing.");
+    });
+
     it("ships the typescript guards for a typescript project", async () => {
-      await installHooks(destDir, ["typescript"], []);
+      await installHooks(lisaDir, destDir, ["typescript"], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).toEqual([SUPPRESS, LINT, SESSION, SGSCAN]);
     });
 
     it("adds the migration guard for a nestjs project", async () => {
       // detectedTypes arrive already expanded (nestjs implies typescript).
-      await installHooks(destDir, ["typescript", "nestjs"], []);
+      await installHooks(lisaDir, destDir, ["typescript", "nestjs"], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).toContain(MIGRATION);
       expect(files).toContain(LINT);
     });
 
     it("ships the rails guards for a rails project", async () => {
-      await installHooks(destDir, ["rails"], []);
+      await installHooks(lisaDir, destDir, ["rails"], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).toEqual([RUBOCOP, SESSION, SGSCAN]);
     });
 
     it("does not ship typescript guards to a rails-only project", async () => {
-      await installHooks(destDir, ["rails"], []);
+      await installHooks(lisaDir, destDir, ["rails"], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).not.toContain(LINT);
       expect(files).not.toContain(SUPPRESS);
     });
 
     it("copies real plugin source (not an empty stub)", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const body = await fs.readFile(
         path.join(
           destDir,
@@ -202,7 +288,7 @@ describe("opencode/hooks-installer", () => {
     });
 
     it("session bootstrap uses strict https?:// URL-scheme check (not loose startsWith)", async () => {
-      await installHooks(destDir, [], []);
+      await installHooks(lisaDir, destDir, [], []);
       const body = await fs.readFile(
         path.join(
           destDir,
@@ -220,7 +306,7 @@ describe("opencode/hooks-installer", () => {
     });
 
     it("reports pluginCount equal to the emitted file count", async () => {
-      const result = await installHooks(destDir, ["typescript"], []);
+      const result = await installHooks(lisaDir, destDir, ["typescript"], []);
       const files = await listInstalledPluginFiles(destDir);
       expect(result.pluginCount).toBe(files.length);
       expect(result.managedFiles).toHaveLength(files.length);
@@ -230,14 +316,19 @@ describe("opencode/hooks-installer", () => {
   describe("stale plugin cleanup", () => {
     it("deletes a Lisa plugin no longer shipped this run", async () => {
       // First install as a nestjs project (ships the migration guard).
-      await installHooks(destDir, ["typescript", "nestjs"], []);
+      await installHooks(lisaDir, destDir, ["typescript", "nestjs"], []);
       const previous = (await listInstalledPluginFiles(destDir)).map(name =>
         path.join(OPENCODE_PLUGIN_SUBDIR, name)
       );
       expect(previous.some(f => f.endsWith(MIGRATION))).toBe(true);
 
       // Re-install as a plain typescript project — migration guard goes stale.
-      const result = await installHooks(destDir, ["typescript"], previous);
+      const result = await installHooks(
+        lisaDir,
+        destDir,
+        ["typescript"],
+        previous
+      );
       expect(result.deleted).toContain(MIGRATION);
       const files = await listInstalledPluginFiles(destDir);
       expect(files).not.toContain(MIGRATION);
@@ -259,6 +350,7 @@ describe("opencode/hooks-installer", () => {
       // Even if a stale-looking host entry is in the manifest, only `lisa-`
       // files are eligible for deletion.
       await installHooks(
+        lisaDir,
         destDir,
         ["typescript"],
         [path.join(OPENCODE_PLUGIN_SUBDIR, hostPlugin)]

--- a/tests/unit/opencode/skills-installer.test.ts
+++ b/tests/unit/opencode/skills-installer.test.ts
@@ -245,6 +245,19 @@ describe("opencode/skills-installer", () => {
     );
   });
 
+  it("ignores generated cursor variants so OpenCode installs canonical skills", async () => {
+    const canonicalContent = `${SAMPLE_SKILL_MD}\nCanonical skill.\n`;
+    const cursorContent = `${SAMPLE_SKILL_MD}\nCursor copy.\n`;
+    await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: canonicalContent });
+    await seedSkill("lisa-cursor", BUG_TRIAGE, { [SKILL_MD]: cursorContent });
+
+    await installSkills(lisaDir, destDir, []);
+
+    expect(await fs.readFile(installedSkillPath(BUG_TRIAGE), "utf8")).toBe(
+      canonicalContent
+    );
+  });
+
   it("deletes stale skills managed previously but not shipped now", async () => {
     await seedSkill("lisa", BUG_TRIAGE, { [SKILL_MD]: SAMPLE_SKILL_MD });
     const skillsDir = path.join(destDir, OPENCODE_DIR, LISA_SKILLS_SUBDIR);


### PR DESCRIPTION
## Summary
- Skip generated agy/copilot/cursor plugin variants when Codex and OpenCode install bundled skills and command-derived skills
- Add lisa-openclaw to the Codex marketplace list
- Mirror Lisa rules through a shared rule copier and load OpenCode eager rules via opencode.json instructions

Fixes #1412.

## Verification
- bun test tests/unit/codex/skills-installer.test.ts tests/unit/codex/skills-installer-variant-filter.test.ts tests/unit/opencode/skills-installer.test.ts tests/unit/opencode/hooks-installer.test.ts tests/unit/codex/plugin-marketplace-installer.test.ts tests/unit/codex/hooks-installer.test.ts
- bun run format:check
- bun run typecheck
- bun run lint
- bun run build:plugins
- bun run check:plugins
- bun run test
- git push pre-push hook: production audit, slow lint, knip, coverage tests, integration tests