### PR TITLE
fix: scope Phaser shutdown cleanup rule to scenes

### DIFF
--- a/eslint-plugin-phaser/rules/require-shutdown-cleanup.js
+++ b/eslint-plugin-phaser/rules/require-shutdown-cleanup.js
@@ -125,6 +125,23 @@ function hasShutdownMember(classNode) {
   );
 }
 
+/**
+ * Whether a class extends a Phaser Scene (superclass name ends in "Scene", e.g.
+ * Phaser.Scene, Scene, BaseScene). Keeps this lifecycle rule from firing on
+ * unrelated classes that use their own cleanup conventions.
+ * @param {object} classNode - A ClassDeclaration/ClassExpression node
+ * @returns {boolean} True if the class extends a Scene-like superclass
+ */
+function extendsScene(classNode) {
+  const sc = classNode.superClass;
+  if (!sc) return false;
+  if (sc.type === "Identifier") return /Scene$/.test(sc.name);
+  if (sc.type === "MemberExpression" && sc.property.type === "Identifier") {
+    return /Scene$/.test(sc.property.name);
+  }
+  return false;
+}
+
 module.exports = {
   meta: {
     type: "problem",
@@ -153,6 +170,7 @@ module.exports = {
     const enterClass = node =>
       classStack.push({
         node,
+        isScene: extendsScene(node),
         leaky: [],
         hasShutdown: hasShutdownMember(node),
       });
@@ -163,7 +181,7 @@ module.exports = {
      */
     const exitClass = () => {
       const frame = classStack.pop();
-      if (!frame.hasShutdown && frame.leaky.length > 0) {
+      if (frame.isScene && !frame.hasShutdown && frame.leaky.length > 0) {
         for (const leakyNode of frame.leaky) {
           context.report({ node: leakyNode, messageId: "requireShutdown" });
         }
@@ -178,6 +196,7 @@ module.exports = {
       CallExpression(node) {
         if (classStack.length === 0) return;
         const frame = classStack[classStack.length - 1];
+        if (!frame.isScene) return;
         if (isShutdownHandler(node)) {
           frame.hasShutdown = true;
           return;

--- a/tests/unit/config/eslint-plugin-phaser.test.ts
+++ b/tests/unit/config/eslint-plugin-phaser.test.ts
@@ -99,29 +99,31 @@ ruleTester.run("no-allocation-in-update", noAllocationInUpdate, {
 ruleTester.run("require-shutdown-cleanup", requireShutdownCleanup, {
   valid: [
     // Persistent listener WITH a shutdown method.
-    "class S { create() { this.input.on('pointerdown', this.h); } shutdown() { this.input.off('pointerdown', this.h); } }",
+    "class S extends Phaser.Scene { create() { this.input.on('pointerdown', this.h); } shutdown() { this.input.off('pointerdown', this.h); } }",
     // Persistent listener WITH an in-place shutdown handler.
-    "class S { create() { this.input.on('pointerdown', this.h); this.events.once('shutdown', this.cleanup, this); } }",
+    "class S extends Phaser.Scene { create() { this.input.on('pointerdown', this.h); this.events.once('shutdown', this.cleanup, this); } }",
     // this.events listeners auto-clean — not leaky.
-    "class S { create() { this.events.on('update', this.h); } }",
+    "class S extends Phaser.Scene { create() { this.events.on('update', this.h); } }",
     // No external listeners at all.
-    "class S { create() { this.add.sprite(0, 0, 'k'); } }",
+    "class S extends Phaser.Scene { create() { this.add.sprite(0, 0, 'k'); } }",
+    // Not a Scene — out of scope even if it owns a different cleanup lifecycle.
+    "class Widget { mount() { window.addEventListener('resize', this.h); } dispose() { window.removeEventListener('resize', this.h); } }",
   ],
   invalid: [
     {
-      code: "class S { create() { this.input.on('pointerdown', this.h); } }",
+      code: "class S extends Phaser.Scene { create() { this.input.on('pointerdown', this.h); } }",
       errors: [{ messageId: "requireShutdown" }],
     },
     {
-      code: "class S { create() { this.scale.on('resize', this.h); } }",
+      code: "class S extends Phaser.Scene { create() { this.scale.on('resize', this.h); } }",
       errors: [{ messageId: "requireShutdown" }],
     },
     {
-      code: "class S { create() { this.game.events.on('blur', this.h); } }",
+      code: "class S extends Phaser.Scene { create() { this.game.events.on('blur', this.h); } }",
       errors: [{ messageId: "requireShutdown" }],
     },
     {
-      code: "class S { create() { window.addEventListener('resize', this.h); } }",
+      code: "class S extends Phaser.Scene { create() { window.addEventListener('resize', this.h); } }",
       errors: [{ messageId: "requireShutdown" }],
     },
   ],


### PR DESCRIPTION
## Summary
- Scope `require-shutdown-cleanup` to Phaser Scene subclasses, matching sibling Phaser ESLint rules.
- Add RuleTester coverage proving non-Scene classes are ignored while Scenes missing cleanup still report.

Fixes #1410

## Verification
- `bun test tests/unit/config/eslint-plugin-phaser.test.ts --runInBand` (38 pass)
- `bun run format:check && bun run typecheck && bun run lint && bun run check:plugins && bun run test` (223 files / 3724 tests)
- pre-push hook: production audit, slow lint, knip, coverage tests, integration tests

## Lisa Usage
- implement: source=automation, issue=CodySwannGT/lisa#1410, result=pr-ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup checks so they only run for Phaser Scene classes, reducing false warnings on non-Scene classes.
  * Listener-leak detection now applies more accurately to Scene-based code.
* **Tests**
  * Updated rule coverage to use Scene-based examples for both passing and failing cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->