### PR TITLE
fix: ship npm package template

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dist",
     "all",
     "typescript",
+    "npm-package",
     "expo",
     "nestjs",
     "cdk",

--- a/tests/unit/detection/detectors.test.ts
+++ b/tests/unit/detection/detectors.test.ts
@@ -8,6 +8,7 @@ import { CDKDetector } from "../../../src/detection/detectors/cdk.js";
 import { HarperFabricDetector } from "../../../src/detection/detectors/harper-fabric.js";
 import { PhaserDetector } from "../../../src/detection/detectors/phaser.js";
 import { RailsDetector } from "../../../src/detection/detectors/rails.js";
+import { PROJECT_TYPE_ORDER } from "../../../src/core/config.js";
 import { DetectorRegistry } from "../../../src/detection/index.js";
 import { createTempDir, cleanupTempDir } from "../../helpers/test-utils.js";
 
@@ -472,6 +473,22 @@ describe("DetectorRegistry", () => {
     const types = await registry.detectAll(tempDir);
 
     expect(types).toContain(RAILS_TYPE);
+  });
+});
+
+describe("published project type templates", () => {
+  it("includes every supported project type template directory in package files", async () => {
+    const packageJson = await fs.readJson(
+      path.join(process.cwd(), PACKAGE_JSON)
+    );
+    const packageFiles = new Set(packageJson.files);
+
+    for (const projectType of PROJECT_TYPE_ORDER) {
+      expect(await fs.pathExists(path.join(process.cwd(), projectType))).toBe(
+        true
+      );
+      expect(packageFiles.has(projectType)).toBe(true);
+    }
   });
 });
 /* eslint-enable max-lines -- Re-enable after detector matrix */


### PR DESCRIPTION
## Summary
- Add `npm-package` to the published package `files[]` allowlist so the governance template ships in the npm tarball.
- Add a regression that every supported project type template directory is present in the package allowlist.

Closes #1408

## Test plan
- `bun test tests/unit/detection/detectors.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit`
- `npm pack --dry-run --json` output includes `npm-package/create-only/.github/workflows/publish-to-npm.yml` and `npm-package/package-lisa/package.lisa.json`
- Pre-push hook: security audit, `bun run lint:slow`, `knip`, `vitest run --coverage`, and `vitest run tests/integration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The published npm package now includes the `npm-package` artifact in its distributed contents.
* **Tests**
  * Added coverage to verify published package contents match the expected project templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->