### PR TITLE
fix: normalize release tag version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,6 +511,7 @@ jobs:
           case "${{ inputs.release_strategy }}" in
             "standard-version")
               VERSION=$(npx standard-version --dry-run | grep "tagging release" | awk '{print $4}')
+              VERSION="${VERSION#v}"
               ;;
             "semantic")
               if git log --format=%B -n 50 --no-merges | grep -qE "^(BREAKING CHANGE:|.*!:)"; then

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -334,6 +334,24 @@ describe("release and deploy workflows", () => {
     );
   });
 
+  it("normalizes standard-version output before composing release tags", () => {
+    const steps = releaseWorkflow.jobs.version.steps ?? [];
+    const determineVersion = steps.find(s => s.name === "Determine Version");
+    const run = determineVersion?.run ?? "";
+
+    expect(determineVersion).toBeDefined();
+    expect(run).toContain("awk '{print $4}'");
+    expect(run).toContain('VERSION="${VERSION#v}"');
+
+    const stripPrefixIndex = run.indexOf('VERSION="${VERSION#v}"');
+    const versionOutputIndex = run.indexOf('echo "version=$VERSION"');
+    const tagOutputIndex = run.indexOf('echo "tag=v$VERSION"');
+
+    expect(stripPrefixIndex).toBeGreaterThan(-1);
+    expect(versionOutputIndex).toBeGreaterThan(stripPrefixIndex);
+    expect(tagOutputIndex).toBeGreaterThan(stripPrefixIndex);
+  });
+
   it("fails the job when GitHub release creation returns an API error", () => {
     const steps = releaseWorkflow.jobs.github_release.steps ?? [];
     const createRelease = steps.find(s => s.name === "Create GitHub Release");


### PR DESCRIPTION
## Summary
- Strip a leading `v` from `standard-version --dry-run` output before writing release workflow outputs
- Add workflow regression coverage proving `version` is bare semver before `tag=v$VERSION` is composed

Closes #1407

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:plugins`
- `bun run test`
- `bash -lc 'VERSION=v2.190.0; VERSION="${VERSION#v}"; printf "version=%s\\ntag=v%s\\n" "$VERSION" "$VERSION"'` => `version=2.190.0`, `tag=v2.190.0`\n- pre-push: production audit, slow lint, knip, coverage tests, integration tests\n