### PR TITLE
fix: harden failure workflow inputs

### DIFF
--- a/.github/workflows/create-jira-issue-on-failure.yml
+++ b/.github/workflows/create-jira-issue-on-failure.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: 🔖 Create Jira Issue
         id: create_jira_issue
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'N/A' }}
         run: |
           cd "${{ inputs.working_directory || '.' }}"
 
@@ -103,9 +105,8 @@ jobs:
           ISSUE_TYPE="${{ inputs.issue_type }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # Get commit message, handling special characters properly
-          # Remove leading/trailing whitespace and escape for shell
-          COMMIT_MESSAGE="${{ github.event.head_commit.message || 'N/A' }}"
+          # Get commit message from env so GitHub expressions are never expanded inside shell.
+          COMMIT_MESSAGE="${COMMIT_MESSAGE:-N/A}"
 
           # Create summary with failure details
           if [ "$FAILED_JOB" != "Unknown" ]; then

--- a/.github/workflows/create-sentry-issue-on-failure.yml
+++ b/.github/workflows/create-sentry-issue-on-failure.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: 🔴 Create Sentry Issue
         id: create_sentry_issue
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'N/A' }}
         run: |
           cd "${{ inputs.working_directory || '.' }}"
 
@@ -104,8 +106,8 @@ jobs:
           LEVEL="${{ inputs.level }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # Get commit message, handling special characters properly
-          COMMIT_MESSAGE="${{ github.event.head_commit.message || 'N/A' }}"
+          # Get commit message from env so GitHub expressions are never expanded inside shell.
+          COMMIT_MESSAGE="${COMMIT_MESSAGE:-N/A}"
 
           # Create error message
           if [ "$FAILED_JOB" != "Unknown" ]; then

--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -285,7 +285,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
 
           set +e
-          ggshield secret scan ci --show-secrets 2>&1 | tee ggshield.log
+          ggshield secret scan ci 2>&1 | tee ggshield.log
           scan_status=${PIPESTATUS[0]}
           set -e
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1742,7 +1742,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
 
           set +e
-          ggshield secret scan ci --show-secrets 2>&1 | tee ggshield.log
+          ggshield secret scan ci 2>&1 | tee ggshield.log
           scan_status=${PIPESTATUS[0]}
           set -e
 

--- a/tests/integration/failure-issue-workflows.test.ts
+++ b/tests/integration/failure-issue-workflows.test.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const CREATE_JIRA_ISSUE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "create-jira-issue-on-failure.yml"
+);
+const CREATE_SENTRY_ISSUE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "create-sentry-issue-on-failure.yml"
+);
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  env?: Record<string, unknown>;
+}
+
+/** Shape of a single job inside a workflow's `jobs:` map. */
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+/** Root shape of the parsed failure issue workflows. */
+interface FailureIssueWorkflow {
+  jobs: Record<string, WorkflowJob>;
+}
+
+describe("failure issue workflows", () => {
+  it.each([
+    ["Jira", CREATE_JIRA_ISSUE_YML, "create_jira_issue"],
+    ["Sentry", CREATE_SENTRY_ISSUE_YML, "create_sentry_issue"],
+  ])(
+    "%s passes commit messages through env instead of shell interpolation",
+    (_label, workflowPath, stepId) => {
+      const workflow = yaml.load(
+        fs.readFileSync(workflowPath, "utf8")
+      ) as FailureIssueWorkflow;
+      const steps = Object.values(workflow.jobs).flatMap(
+        job => job.steps ?? []
+      );
+      const createIssue = steps.find(step => step.id === stepId);
+      const run = createIssue?.run ?? "";
+
+      expect(createIssue).toBeDefined();
+      expect(createIssue?.env?.COMMIT_MESSAGE).toBe(
+        "${{ github.event.head_commit.message || 'N/A' }}"
+      );
+      expect(run).toContain('COMMIT_MESSAGE="${COMMIT_MESSAGE:-N/A}"');
+      expect(run).toContain('--arg commit_message "${COMMIT_MESSAGE}"');
+      expect(run).not.toContain("github.event.head_commit.message");
+    }
+  );
+
+  it("keeps head_commit.message out of workflow shell scripts", () => {
+    for (const workflowPath of [
+      CREATE_JIRA_ISSUE_YML,
+      CREATE_SENTRY_ISSUE_YML,
+    ]) {
+      const workflow = yaml.load(
+        fs.readFileSync(workflowPath, "utf8")
+      ) as FailureIssueWorkflow;
+
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        for (const step of job.steps ?? []) {
+          expect(
+            step.run ?? "",
+            `${path.basename(workflowPath)} ${jobName}: ${step.name ?? step.id}`
+          ).not.toContain("github.event.head_commit.message");
+        }
+      }
+    }
+  });
+});

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -280,7 +280,8 @@ describe("quality.yml reusable workflow", () => {
 
       expect(scan).toBeDefined();
       expect(scan?.uses).toBeUndefined();
-      expect(scan?.run).toContain("ggshield secret scan ci --show-secrets");
+      expect(scan?.run).toContain("ggshield secret scan ci");
+      expect(scan?.run).not.toContain("--show-secrets");
       expect(scan?.run).not.toContain("--all-policies");
       expect(scan?.run).toContain("no more API calls available");
       expect(scan?.run).toContain('exit "$scan_status"');


### PR DESCRIPTION
## Summary

- move Jira/Sentry failure workflow commit messages into step env before shell execution
- keep shell scripts reading `COMMIT_MESSAGE` as data and passing it through `jq --arg`
- remove GitGuardian `--show-secrets` from standard and Rails quality workflows
- add parser-based regressions for failure workflow shell interpolation and GitGuardian redaction

## Verification

- `bun test tests/integration/quality-workflow.test.ts tests/integration/failure-issue-workflows.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:plugins`
- `bun run test`
- pre-push: production audit, slow lint, knip, coverage tests, integration tests

Fixes #1406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure-issue workflows so commit messages are handled more reliably, even when they contain special characters.
  * Reduced the chance of sensitive scan results appearing directly in logs.

* **Tests**
  * Added coverage for workflow handling of commit messages and secret-scanning behavior.
  * Updated existing workflow checks to match the new log-safe scan output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->