### PR TITLE
Fix Lisa postinstall project root detection

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -3,8 +3,32 @@
 # Runs as Lisa's postinstall lifecycle script.
 set -euo pipefail
 
-PROJECT_ROOT="${npm_config_local_prefix:-${INIT_CWD:-}}"
-if [ -z "$PROJECT_ROOT" ]; then exit 0; fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PACKAGE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+case "$PACKAGE_ROOT" in
+  */node_modules/@codyswann/lisa)
+    PROJECT_ROOT="$(cd "$PACKAGE_ROOT/../../.." && pwd -P)"
+    ;;
+  *)
+    PROJECT_ROOT="$PACKAGE_ROOT"
+    ;;
+esac
+
+sanitize_package_manager_env() {
+  local env_name
+  while IFS='=' read -r env_name _; do
+    case "$env_name" in
+      npm_config_*|npm_package_*|npm_lifecycle_*)
+        unset "$env_name"
+        ;;
+    esac
+  done < <(env)
+
+  unset INIT_CWD npm_node_execpath npm_execpath PROJECT_CWD BUN_INSTALL_CACHE_DIR
+}
+
+sanitize_package_manager_env
 
 SETTINGS_FILE="$PROJECT_ROOT/.claude/settings.json"
 

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PACKAGE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 
 case "$PACKAGE_ROOT" in
+  */node_modules/.pnpm/*/node_modules/@codyswann/lisa)
+    PROJECT_ROOT="${PACKAGE_ROOT%%/node_modules/.pnpm/*}"
+    ;;
   */node_modules/@codyswann/lisa)
     PROJECT_ROOT="$(cd "$PACKAGE_ROOT/../../.." && pwd -P)"
     ;;

--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -7,9 +7,11 @@
 import { execFile } from "node:child_process";
 import {
   chmod,
+  cp,
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -19,12 +21,9 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const INSTALL_SCRIPT_NAME = "install-claude-plugins.sh";
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
-const SCRIPT_PATH = path.join(
-  REPO_ROOT,
-  "scripts",
-  "install-claude-plugins.sh"
-);
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", INSTALL_SCRIPT_NAME);
 const COMMAND_LOG = "commands.log";
 
 let tempRoots: string[] = [];
@@ -34,7 +33,9 @@ let tempRoots: string[] = [];
  * @returns Absolute path to the temp directory.
  */
 async function makeTempRoot(): Promise<string> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "lisa-self-postinstall-"));
+  const root = await realpath(
+    await mkdtemp(path.join(os.tmpdir(), "lisa-self-postinstall-"))
+  );
   tempRoots.push(root);
   return root;
 }
@@ -115,6 +116,39 @@ async function writeDownstreamProject(root: string): Promise<void> {
 }
 
 /**
+ * Copy the postinstall script into a fixture as though Lisa were installed from npm.
+ * @param root - Downstream fixture root.
+ * @returns Absolute path to the copied lifecycle script.
+ */
+async function writeInstalledLisaScript(root: string): Promise<string> {
+  const scriptPath = path.join(
+    root,
+    "node_modules",
+    "@codyswann",
+    "lisa",
+    "scripts",
+    INSTALL_SCRIPT_NAME
+  );
+  await mkdir(path.dirname(scriptPath), { recursive: true });
+  await cp(SCRIPT_PATH, scriptPath);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+/**
+ * Copy the postinstall script into a fixture as though it were Lisa's source checkout.
+ * @param root - Self fixture root.
+ * @returns Absolute path to the copied lifecycle script.
+ */
+async function writeSelfLisaScript(root: string): Promise<string> {
+  const scriptPath = path.join(root, "scripts", INSTALL_SCRIPT_NAME);
+  await mkdir(path.dirname(scriptPath), { recursive: true });
+  await cp(SCRIPT_PATH, scriptPath);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+/**
  * Create fake agent CLIs that log invocations and otherwise succeed.
  * @param binDir - Directory to place fake executables in.
  */
@@ -155,13 +189,13 @@ describe("install-claude-plugins self postinstall path", () => {
     const fakeBin = path.join(projectRoot, "bin");
     const commandLog = path.join(projectRoot, COMMAND_LOG);
     await writeSelfProject(projectRoot);
+    const selfScriptPath = await writeSelfLisaScript(projectRoot);
     await writeFakeAgentBins(fakeBin);
 
-    await execFileAsync("bash", [SCRIPT_PATH], {
+    await execFileAsync("bash", [selfScriptPath], {
       env: {
         ...process.env,
         CI: "",
-        npm_config_local_prefix: projectRoot,
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -179,13 +213,13 @@ describe("install-claude-plugins self postinstall path", () => {
     const fakeBin = path.join(projectRoot, "bin");
     const commandLog = path.join(projectRoot, COMMAND_LOG);
     await writeDownstreamProject(projectRoot);
+    const installedScriptPath = await writeInstalledLisaScript(projectRoot);
     await writeFakeAgentBins(fakeBin);
 
-    await execFileAsync("bash", [SCRIPT_PATH], {
+    await execFileAsync("bash", [installedScriptPath], {
       env: {
         ...process.env,
         CI: "",
-        npm_config_local_prefix: projectRoot,
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -198,5 +232,32 @@ describe("install-claude-plugins self postinstall path", () => {
     );
     expect(applyIndex).toBeGreaterThanOrEqual(0);
     expect(codexIndex).toBeGreaterThan(applyIndex);
+  });
+
+  it("ignores leaked package-manager project roots from sibling installs", async () => {
+    const projectRoot = await makeTempRoot();
+    const leakedRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeDownstreamProject(projectRoot);
+    await writeDownstreamProject(leakedRoot);
+    const installedScriptPath = await writeInstalledLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...process.env,
+        CI: "",
+        INIT_CWD: leakedRoot,
+        npm_config_local_prefix: leakedRoot,
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    expect(log).toContain("apply downstream");
+    expect(log).toContain(`codex plugin marketplace add ${projectRoot}`);
+    expect(log).not.toContain(`codex plugin marketplace add ${leakedRoot}`);
   });
 });

--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -21,7 +21,10 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const APPLY_DOWNSTREAM_LOG = "apply downstream";
+const CODYSWANN_SCOPE = "@codyswann";
 const INSTALL_SCRIPT_NAME = "install-claude-plugins.sh";
+const LISA_PACKAGE_DIR_NAME = "lisa";
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", INSTALL_SCRIPT_NAME);
 const COMMAND_LOG = "commands.log";
@@ -103,14 +106,14 @@ async function writeDownstreamProject(root: string): Promise<void> {
   const lisaDist = path.join(
     root,
     "node_modules",
-    "@codyswann",
-    "lisa",
+    CODYSWANN_SCOPE,
+    LISA_PACKAGE_DIR_NAME,
     "dist"
   );
   await mkdir(lisaDist, { recursive: true });
   await writeFile(
     path.join(lisaDist, "index.js"),
-    `require("node:fs").appendFileSync(process.env.LISA_TEST_COMMAND_LOG, "apply downstream\\n");\n`,
+    `require("node:fs").appendFileSync(process.env.LISA_TEST_COMMAND_LOG, "${APPLY_DOWNSTREAM_LOG}\\n");\n`,
     "utf8"
   );
 }
@@ -121,18 +124,31 @@ async function writeDownstreamProject(root: string): Promise<void> {
  * @returns Absolute path to the copied lifecycle script.
  */
 async function writeInstalledLisaScript(root: string): Promise<string> {
-  const scriptPath = path.join(
+  return copyLisaScriptTo(
     root,
     "node_modules",
-    "@codyswann",
-    "lisa",
-    "scripts",
-    INSTALL_SCRIPT_NAME
+    CODYSWANN_SCOPE,
+    LISA_PACKAGE_DIR_NAME,
+    "scripts"
   );
-  await mkdir(path.dirname(scriptPath), { recursive: true });
-  await cp(SCRIPT_PATH, scriptPath);
-  await chmod(scriptPath, 0o755);
-  return scriptPath;
+}
+
+/**
+ * Copy the postinstall script into a pnpm virtual-store fixture path.
+ * @param root - Downstream fixture root.
+ * @returns Absolute path to the copied lifecycle script.
+ */
+async function writePnpmVirtualLisaScript(root: string): Promise<string> {
+  return copyLisaScriptTo(
+    root,
+    "node_modules",
+    ".pnpm",
+    "@codyswann+lisa@2.0.0",
+    "node_modules",
+    CODYSWANN_SCOPE,
+    LISA_PACKAGE_DIR_NAME,
+    "scripts"
+  );
 }
 
 /**
@@ -141,7 +157,20 @@ async function writeInstalledLisaScript(root: string): Promise<string> {
  * @returns Absolute path to the copied lifecycle script.
  */
 async function writeSelfLisaScript(root: string): Promise<string> {
-  const scriptPath = path.join(root, "scripts", INSTALL_SCRIPT_NAME);
+  return copyLisaScriptTo(root, "scripts");
+}
+
+/**
+ * Copy the postinstall script into the requested fixture subdirectory.
+ * @param root - Fixture root.
+ * @param segments - Directory segments below the fixture root.
+ * @returns Absolute path to the copied lifecycle script.
+ */
+async function copyLisaScriptTo(
+  root: string,
+  ...segments: string[]
+): Promise<string> {
+  const scriptPath = path.join(root, ...segments, INSTALL_SCRIPT_NAME);
   await mkdir(path.dirname(scriptPath), { recursive: true });
   await cp(SCRIPT_PATH, scriptPath);
   await chmod(scriptPath, 0o755);
@@ -226,7 +255,7 @@ describe("install-claude-plugins self postinstall path", () => {
     });
 
     const log = await readFile(commandLog, "utf8");
-    const applyIndex = log.indexOf("apply downstream");
+    const applyIndex = log.indexOf(APPLY_DOWNSTREAM_LOG);
     const codexIndex = log.indexOf(
       `codex plugin marketplace add ${projectRoot}`
     );
@@ -256,8 +285,31 @@ describe("install-claude-plugins self postinstall path", () => {
     });
 
     const log = await readFile(commandLog, "utf8");
-    expect(log).toContain("apply downstream");
+    expect(log).toContain(APPLY_DOWNSTREAM_LOG);
     expect(log).toContain(`codex plugin marketplace add ${projectRoot}`);
     expect(log).not.toContain(`codex plugin marketplace add ${leakedRoot}`);
+  });
+
+  it("resolves pnpm virtual-store script paths back to the project root", async () => {
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeDownstreamProject(projectRoot);
+    const pnpmScriptPath = await writePnpmVirtualLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    await execFileAsync("bash", [pnpmScriptPath], {
+      env: {
+        ...process.env,
+        CI: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    expect(log).toContain(APPLY_DOWNSTREAM_LOG);
+    expect(log).toContain(`codex plugin marketplace add ${projectRoot}`);
+    expect(log).not.toContain(`${projectRoot}/node_modules/.pnpm`);
   });
 });


### PR DESCRIPTION
## Summary

- derive Lisa postinstall target roots from the running script location instead of `npm_config_local_prefix` / `INIT_CWD`
- scrub package-manager path/lifecycle env vars before child apply/plugin commands inherit them
- add fixture coverage for installed-package postinstall with leaked sibling-project env vars

Fixes #1405.

## Verification

- `bun test tests/unit/scripts/install-claude-plugins-self.test.ts --runInBand`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:plugins`
- `bun run test`
- `bash .husky/pre-push`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin installation to reliably detect the correct project root in more setup locations, including when installed through package managers.
  * Cleaned up environment handling during installation to avoid interference from leftover npm or working-directory settings.
  * Reduced the chance of plugins being installed into the wrong project when multiple roots or sibling projects are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->