### PR TITLE
fix: preserve arrays in merge strategy

### DIFF
--- a/src/strategies/merge.ts
+++ b/src/strategies/merge.ts
@@ -3,7 +3,11 @@ import { copyFile } from "node:fs/promises";
 import type { FileOperationResult } from "../core/config.js";
 import type { ICopyStrategy, StrategyContext } from "./strategy.interface.js";
 import { ensureParentDir } from "../utils/file-operations.js";
-import { readJson, writeJson, deepMerge } from "../utils/json-utils.js";
+import {
+  readJson,
+  writeJson,
+  deepMergeWithArrayUnion,
+} from "../utils/json-utils.js";
 import { JsonMergeError } from "../errors/index.js";
 
 /**
@@ -58,8 +62,9 @@ export class MergeStrategy implements ICopyStrategy {
       );
     });
 
-    // Deep merge: Lisa (source) takes precedence, project (dest) provides defaults
-    const merged = deepMerge(destJson, sourceJson);
+    // Deep merge: Lisa (source) takes precedence, project (dest) provides defaults.
+    // Arrays are unioned so Lisa templates add guardrails without removing host ones.
+    const merged = deepMergeWithArrayUnion(destJson, sourceJson);
 
     // Normalize for comparison (parse and re-stringify both)
     const normalizedDest = JSON.stringify(destJson, null, 2);

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -133,19 +133,47 @@ function mergeJsonObjects(
 
 /**
  * Remove duplicate JSON array entries while preserving first occurrence order.
+ * Uses structural equality so key order does not affect deduplication.
  * @param items Array entries to deduplicate
  * @returns Deduplicated array
  */
 function dedupeArray(items: unknown[]): unknown[] {
   return items.reduce<unknown[]>(
     (deduped, item) =>
-      deduped.some(
-        existing => JSON.stringify(existing) === JSON.stringify(item)
-      )
+      deduped.some(existing => isDeepEqualJsonValue(existing, item))
         ? deduped
         : [...deduped, cloneJsonValue(item)],
     []
   );
+}
+
+/**
+ * Compare two JSON-compatible values for structural equality, independent of
+ * object key insertion order.
+ * @param a First value
+ * @param b Second value
+ * @returns True when the values are structurally equal
+ */
+function isDeepEqualJsonValue(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return (
+      a.length === b.length &&
+      a.every((entry, index) => isDeepEqualJsonValue(entry, b[index]))
+    );
+  }
+
+  if (isJsonObject(a) && isJsonObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every(
+        key => Object.hasOwn(b, key) && isDeepEqualJsonValue(a[key], b[key])
+      )
+    );
+  }
+
+  return a === b;
 }
 
 /**

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -74,3 +74,104 @@ export function deepMerge<T extends object>(base: T, override: T): T {
   // Create a new object to avoid mutating inputs
   return merge({}, base, override) as T;
 }
+
+/**
+ * Deep merge two JSON objects while preserving array entries from both sides.
+ * Scalar conflicts still use override-wins semantics.
+ * @param base Base object (project values)
+ * @param override Override object with precedence (Lisa values)
+ * @returns Merged object with arrays concatenated and deduplicated
+ */
+export function deepMergeWithArrayUnion<T extends object>(
+  base: T,
+  override: T
+): T {
+  return mergeJsonValues(base, override) as T;
+}
+
+/**
+ * Merge two JSON-compatible values.
+ * @param base Lower-precedence value
+ * @param override Higher-precedence value
+ * @returns Merged JSON-compatible value
+ */
+function mergeJsonValues(base: unknown, override: unknown): unknown {
+  if (Array.isArray(base) && Array.isArray(override)) {
+    return dedupeArray([...base, ...override]);
+  }
+
+  if (isJsonObject(base) && isJsonObject(override)) {
+    return mergeJsonObjects(base, override);
+  }
+
+  return cloneJsonValue(override);
+}
+
+/**
+ * Merge two JSON object records without mutating either input.
+ * @param base Lower-precedence object
+ * @param override Higher-precedence object
+ * @returns Merged object
+ */
+function mergeJsonObjects(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> {
+  const keys = new Set([...Object.keys(base), ...Object.keys(override)]);
+
+  return Object.fromEntries(
+    Array.from(keys).map(key => {
+      const value = Object.hasOwn(override, key)
+        ? Object.hasOwn(base, key)
+          ? mergeJsonValues(base[key], override[key])
+          : cloneJsonValue(override[key])
+        : cloneJsonValue(base[key]);
+      return [key, value];
+    })
+  );
+}
+
+/**
+ * Remove duplicate JSON array entries while preserving first occurrence order.
+ * @param items Array entries to deduplicate
+ * @returns Deduplicated array
+ */
+function dedupeArray(items: unknown[]): unknown[] {
+  return items.reduce<unknown[]>(
+    (deduped, item) =>
+      deduped.some(
+        existing => JSON.stringify(existing) === JSON.stringify(item)
+      )
+        ? deduped
+        : [...deduped, cloneJsonValue(item)],
+    []
+  );
+}
+
+/**
+ * Check whether a value is a non-array JSON object.
+ * @param value Candidate value
+ * @returns True when the value is a plain JSON object record
+ */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Clone JSON-compatible values so merge results do not retain input references.
+ * @param value JSON-compatible value
+ * @returns Cloned JSON-compatible value
+ */
+function cloneJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(cloneJsonValue);
+  }
+
+  if (isJsonObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneJsonValue(entry)])
+    );
+  }
+
+  return value;
+}

--- a/tests/unit/strategies/merge.test.ts
+++ b/tests/unit/strategies/merge.test.ts
@@ -196,7 +196,7 @@ describe("MergeStrategy", () => {
     expect(content.editor.formatOnSave).toBe(true); // Lisa value added
   });
 
-  it("handles arrays (merges by index)", async () => {
+  it("unions arrays instead of merging them by index", async () => {
     const srcFile = path.join(srcDir, CONFIG_JSON);
     const destFile = path.join(destDir, CONFIG_JSON);
 
@@ -206,8 +206,73 @@ describe("MergeStrategy", () => {
     await strategy.apply(srcFile, destFile, CONFIG_JSON, createContext());
 
     const content = await fs.readJson(destFile);
-    // lodash.merge merges arrays by index - src[0]='a' overwrites dest[0]='c', src[1]='b' is kept
-    expect(content.plugins).toEqual(["a", "b"]);
+    expect(content.plugins).toEqual(["c", "a", "b"]);
+  });
+
+  it("preserves host Claude deny rules when merging settings", async () => {
+    const srcFile = path.join(srcDir, SETTINGS_JSON);
+    const destFile = path.join(destDir, SETTINGS_JSON);
+
+    await fs.writeJson(srcFile, {
+      permissions: {
+        deny: ["Bash(git push --force*)", "Bash(git commit --no-verify*)"],
+      },
+    });
+    await fs.writeJson(destFile, {
+      permissions: {
+        deny: ["Bash(rm -rf*)", "Bash(git reset --hard*)"],
+      },
+    });
+
+    await strategy.apply(srcFile, destFile, SETTINGS_JSON, createContext());
+
+    const content = await fs.readJson(destFile);
+    expect(content.permissions.deny).toEqual([
+      "Bash(rm -rf*)",
+      "Bash(git reset --hard*)",
+      "Bash(git push --force*)",
+      "Bash(git commit --no-verify*)",
+    ]);
+  });
+
+  it("preserves host Claude hooks when merging settings", async () => {
+    const srcFile = path.join(srcDir, SETTINGS_JSON);
+    const destFile = path.join(destDir, SETTINGS_JSON);
+
+    await fs.writeJson(srcFile, {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Edit|Write",
+            hooks: [{ type: "command", command: "bash .claude/hooks/lisa.sh" }],
+          },
+        ],
+      },
+    });
+    await fs.writeJson(destFile, {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Edit",
+            hooks: [{ type: "command", command: "bash .claude/hooks/host.sh" }],
+          },
+        ],
+      },
+    });
+
+    await strategy.apply(srcFile, destFile, SETTINGS_JSON, createContext());
+
+    const content = await fs.readJson(destFile);
+    expect(content.hooks.PostToolUse).toEqual([
+      {
+        matcher: "Edit",
+        hooks: [{ type: "command", command: "bash .claude/hooks/host.sh" }],
+      },
+      {
+        matcher: "Edit|Write",
+        hooks: [{ type: "command", command: "bash .claude/hooks/lisa.sh" }],
+      },
+    ]);
   });
 
   it("does not modify files in dry run mode", async () => {

--- a/tests/unit/utils/json-utils.test.ts
+++ b/tests/unit/utils/json-utils.test.ts
@@ -1,0 +1,60 @@
+import { deepMergeWithArrayUnion } from "../../../src/utils/json-utils.js";
+
+describe("deepMergeWithArrayUnion", () => {
+  it("concatenates and deduplicates identical array entries", () => {
+    const base = { items: [{ x: 1, y: 2 }] };
+    const override = { items: [{ x: 1, y: 2 }] };
+
+    const result = deepMergeWithArrayUnion(base, override);
+
+    expect(result.items).toEqual([{ x: 1, y: 2 }]);
+  });
+
+  it("dedupes structurally identical objects regardless of key order", () => {
+    const base = { items: [{ x: 1, y: 2 }] };
+    const override = { items: [{ y: 2, x: 1 }] };
+
+    const result = deepMergeWithArrayUnion(base, override);
+
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("stays idempotent across repeated merges with reordered keys", () => {
+    const base = { items: [{ x: 1, y: 2 }] };
+    const override = { items: [{ y: 2, x: 1 }] };
+
+    const first = deepMergeWithArrayUnion(base, override);
+    const second = deepMergeWithArrayUnion(first, override);
+    const third = deepMergeWithArrayUnion(second, override);
+
+    expect(third.items).toHaveLength(1);
+  });
+
+  it("preserves distinct array entries that are not duplicates", () => {
+    const base = { items: [{ x: 1 }] };
+    const override = { items: [{ x: 2 }] };
+
+    const result = deepMergeWithArrayUnion(base, override);
+
+    expect(result.items).toEqual([{ x: 1 }, { x: 2 }]);
+  });
+
+  it("does not mutate the input objects", () => {
+    const base = { items: [{ x: 1 }] };
+    const override = { items: [{ x: 2 }] };
+
+    deepMergeWithArrayUnion(base, override);
+
+    expect(base).toEqual({ items: [{ x: 1 }] });
+    expect(override).toEqual({ items: [{ x: 2 }] });
+  });
+
+  it("lets override scalars win over base scalars", () => {
+    const base = { name: "base" };
+    const override = { name: "override" };
+
+    const result = deepMergeWithArrayUnion(base, override);
+
+    expect(result.name).toBe("override");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a merge helper for `MergeStrategy` that unions JSON arrays while keeping override-wins scalar/object behavior.
- Use the helper for `all/merge` JSON applies so Lisa settings add guardrails without dropping host entries.
- Add regression coverage for array union behavior, `.claude/settings.json` `permissions.deny`, and `hooks.PostToolUse` preservation.

Fixes #1404

## Validation

- `bunx vitest run tests/unit/strategies/merge.test.ts`
- `bunx vitest run tests/unit/strategies/merge.test.ts tests/unit/strategies/package-lisa.test.ts tests/unit/strategies/tagged-merge.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`
- pre-push hook: security audit, slow lint, `knip`, coverage test suite, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON merge behavior now unions arrays by combining elements and removing duplicates (preserving first-occurrence order).
  * In merged settings, existing host entries are retained and new incoming entries are appended after them.

* **Bug Fixes**
  * Configuration updates no longer overwrite/replace array items; array contents are preserved via union.

* **Tests**
  * Updated merge strategy tests for array-union ordering and host entry preservation.
  * Added unit tests for the new deep merge helper, including immutability and deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->