### PR TITLE
fix: remove rails tired boss prompt hook

### DIFF
--- a/rails/merge/.claude/settings.json
+++ b/rails/merge/.claude/settings.json
@@ -75,10 +75,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'REMINDER: Start your response with \"I'\\''m tired boss\" as required by CLAUDE.md.'"
-          },
-          {
-            "type": "command",
             "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code user-prompt-submit || true"
           }
         ]

--- a/tests/unit/config/rails-template.test.ts
+++ b/tests/unit/config/rails-template.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression guards for Rails stack templates.
+ */
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const RAILS_MERGE_SETTINGS = "rails/merge/.claude/settings.json";
+
+/**
+ * Read a JSON template from the Lisa repository.
+ * @param relativePath - Repo-relative JSON path
+ * @returns Parsed template content
+ */
+function readJson(relativePath: string): unknown {
+  return JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8")
+  );
+}
+
+/**
+ * Read a text template from the Lisa repository.
+ * @param relativePath - Repo-relative text path
+ * @returns Template content
+ */
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+describe("Rails templates", () => {
+  it("does not ship the retired tired-boss prompt hook", () => {
+    const settingsText = readText(RAILS_MERGE_SETTINGS);
+    const settings = readJson(RAILS_MERGE_SETTINGS) as {
+      readonly hooks?: {
+        readonly UserPromptSubmit?: readonly {
+          readonly hooks?: readonly { readonly command?: string }[];
+        }[];
+      };
+    };
+
+    expect(settingsText).not.toContain("tired boss");
+    expect(settingsText).not.toContain("Start your response");
+    expect(settings.hooks?.UserPromptSubmit?.[0]?.hooks).toEqual([
+      {
+        type: "command",
+        command:
+          "command -v entire >/dev/null 2>&1 && entire hooks claude-code user-prompt-submit || true",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the retired tired-boss UserPromptSubmit reminder from the Rails merge settings template
- keep the legitimate entire UserPromptSubmit hook intact
- add a Rails template regression that prevents the retired prompt text from returning

## Verification
- bun test tests/unit/config/rails-template.test.ts
- rg -n "tired boss|Start your response" rails plugins/src plugins/lisa-rails plugins/lisa-rails-copilot plugins/lisa-rails-cursor plugins/lisa-rails-agy --glob "!node_modules/**"
- bun run format:check
- bun run typecheck
- bun run lint
- bun run check:plugins
- bun run test
- bun run build
- LISA_BOOTSTRAP=1 node dist/index.js apply /tmp/lisa-rails-apply-* --yes --skip-git-check --no-update-check --harness claude, then verified downstream .claude/settings.json has no retired prompt text and still has the entire UserPromptSubmit hook

Closes #1403