### PR TITLE
fix: install husky after successful prepare build

### DIFF
--- a/npm-package/package-lisa/package.lisa.json
+++ b/npm-package/package-lisa/package.lisa.json
@@ -3,7 +3,7 @@
     "scripts": {
       "prepublishOnly": "$npm_execpath run build",
       "setup:deploy-key": "setup-deploy-key",
-      "prepare": "$npm_execpath run build || husky install || true"
+      "prepare": "$npm_execpath run build && husky install || true"
     },
     "devDependencies": {
       "vite": "^8.0.16",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -11,7 +11,7 @@
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "build": "tsc",
-      "prepare": "$npm_execpath run build || husky install || true",
+      "prepare": "$npm_execpath run build && husky install || true",
       "lisa:update": "npx @codyswann/lisa@latest ."
     },
     "devDependencies": {

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -108,6 +108,19 @@ describe("package.lisa.json templates never force-pin Lisa's own version", () =>
   );
 });
 
+describe("package.lisa.json prepare scripts install hooks after successful builds", () => {
+  it.each([
+    ["package.lisa.json"],
+    ["npm-package/package-lisa/package.lisa.json"],
+  ])("%s runs husky install only after a successful build", relPath => {
+    const template = readTemplateJson(relPath) as PackageLisaShape;
+    const prepare = template.force?.scripts?.prepare;
+
+    expect(prepare).toBe("$npm_execpath run build && husky install || true");
+    expect(prepare).not.toContain("run build || husky install");
+  });
+});
+
 describe("EnsureLisaPostinstallMigration injects CI-guarded invocation", () => {
   it("the migration's LISA_INVOCATION constant starts with the CI guard", async () => {
     // Read the compiled source verbatim — we want to guard the literal


### PR DESCRIPTION
## Summary

- Fix the shared and npm-package `prepare` templates so successful builds continue into `husky install`.
- Add a regression covering the two build-backed prepare templates so `build || husky install` cannot return.

## Verification

- `bun test tests/unit/config/postinstall-ci-guard.test.ts`
- Real temp npm-package apply via `LISA_BOOTSTRAP=1 bun src/index.ts apply ... --yes --no-update-check --harness=claude`, read back `scripts.prepare = "$npm_execpath run build && husky install || true"`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:plugins`
- `bun run build`
- `bun run test` (227 files / 3744 tests)
- pre-push: production audit, slow lint, knip, coverage tests, integration tests

Closes #1402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the package preparation step so the build runs first, and Husky installation is only attempted after a successful build.
  * The preparation process now completes without failing the overall install step if Husky setup is unavailable.

* **Tests**
  * Added coverage to ensure the package configuration keeps the build-before-install behavior and avoids the unsupported command order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->