### PR TITLE
Fix blocking hook exits for Claude feedback

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -61,7 +61,7 @@ When upstreaming a governance pattern discovered in a downstream project (e.g., 
 
 Never parse JSON in shell scripts using grep/sed/cut/awk - always use jq for robust JSON handling.
 
-When creating Claude Code hooks for enforcement (linting, code quality, static analysis), always use blocking behavior (exit 1 on failures) so Claude receives feedback and can fix the errors. Notification-only hooks (like ntfy.sh) should exit 0 since they don't require Claude to take action.
+When creating Claude Code hooks for enforcement (linting, code quality, static analysis), always use blocking behavior (exit 2 on failures) so Claude receives feedback and can fix the errors. Notification-only hooks (like ntfy.sh) should exit 0 since they don't require Claude to take action.
 
 ## Skills and Commands
 

--- a/plugins/lisa-rails-copilot/hooks/rubocop-on-edit.sh
+++ b/plugins/lisa-rails-copilot/hooks/rubocop-on-edit.sh
@@ -10,7 +10,7 @@
 #
 # Behavior:
 #   - Exit 0: RuboCop passes or auto-fix resolved all errors
-#   - Exit 1: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -75,4 +75,4 @@ fi
 # Unfixable errors remain — block with feedback
 echo "RuboCop found unfixable errors in: $FILE_PATH" >&2
 echo "$OUTPUT" >&2
-exit 1
+exit 2

--- a/plugins/lisa-rails-copilot/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-rails-copilot/hooks/sg-scan-on-edit.sh
@@ -9,7 +9,7 @@
 #
 # Behavior:
 #   - Exit 0: no issues found or ast-grep not configured
-#   - Exit 1: issues found — blocks Claude so it fixes them immediately
+#   - Exit 2: issues found — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -70,5 +70,5 @@ if OUTPUT=$($SG_CMD scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/lisa-rails-cursor/hooks/rubocop-on-edit.sh
+++ b/plugins/lisa-rails-cursor/hooks/rubocop-on-edit.sh
@@ -10,7 +10,7 @@
 #
 # Behavior:
 #   - Exit 0: RuboCop passes or auto-fix resolved all errors
-#   - Exit 1: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -75,4 +75,4 @@ fi
 # Unfixable errors remain — block with feedback
 echo "RuboCop found unfixable errors in: $FILE_PATH" >&2
 echo "$OUTPUT" >&2
-exit 1
+exit 2

--- a/plugins/lisa-rails-cursor/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-rails-cursor/hooks/sg-scan-on-edit.sh
@@ -9,7 +9,7 @@
 #
 # Behavior:
 #   - Exit 0: no issues found or ast-grep not configured
-#   - Exit 1: issues found — blocks Claude so it fixes them immediately
+#   - Exit 2: issues found — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -70,5 +70,5 @@ if OUTPUT=$($SG_CMD scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/lisa-rails/hooks/rubocop-on-edit.sh
+++ b/plugins/lisa-rails/hooks/rubocop-on-edit.sh
@@ -10,7 +10,7 @@
 #
 # Behavior:
 #   - Exit 0: RuboCop passes or auto-fix resolved all errors
-#   - Exit 1: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -75,4 +75,4 @@ fi
 # Unfixable errors remain — block with feedback
 echo "RuboCop found unfixable errors in: $FILE_PATH" >&2
 echo "$OUTPUT" >&2
-exit 1
+exit 2

--- a/plugins/lisa-rails/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-rails/hooks/sg-scan-on-edit.sh
@@ -9,7 +9,7 @@
 #
 # Behavior:
 #   - Exit 0: no issues found or ast-grep not configured
-#   - Exit 1: issues found — blocks Claude so it fixes them immediately
+#   - Exit 2: issues found — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -70,5 +70,5 @@ if OUTPUT=$($SG_CMD scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/lisa-typescript-copilot/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript-copilot/hooks/sg-scan-on-edit.sh
@@ -67,5 +67,5 @@ if OUTPUT=$($PKG_MANAGER run sg:scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/lisa-typescript-cursor/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript-cursor/hooks/sg-scan-on-edit.sh
@@ -67,5 +67,5 @@ if OUTPUT=$($PKG_MANAGER run sg:scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/lisa-typescript/hooks/sg-scan-on-edit.sh
+++ b/plugins/lisa-typescript/hooks/sg-scan-on-edit.sh
@@ -67,5 +67,5 @@ if OUTPUT=$($PKG_MANAGER run sg:scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/src/rails/hooks/rubocop-on-edit.sh
+++ b/plugins/src/rails/hooks/rubocop-on-edit.sh
@@ -10,7 +10,7 @@
 #
 # Behavior:
 #   - Exit 0: RuboCop passes or auto-fix resolved all errors
-#   - Exit 1: unfixable errors remain — blocks Claude so it fixes them immediately
+#   - Exit 2: unfixable errors remain — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -75,4 +75,4 @@ fi
 # Unfixable errors remain — block with feedback
 echo "RuboCop found unfixable errors in: $FILE_PATH" >&2
 echo "$OUTPUT" >&2
-exit 1
+exit 2

--- a/plugins/src/rails/hooks/sg-scan-on-edit.sh
+++ b/plugins/src/rails/hooks/sg-scan-on-edit.sh
@@ -9,7 +9,7 @@
 #
 # Behavior:
 #   - Exit 0: no issues found or ast-grep not configured
-#   - Exit 1: issues found — blocks Claude so it fixes them immediately
+#   - Exit 2: issues found — blocks Claude so it fixes them immediately
 #
 # @see .claude/rules/verification.md "Self-Correction Loop" section
 # =============================================================================
@@ -70,5 +70,5 @@ if OUTPUT=$($SG_CMD scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/plugins/src/typescript/hooks/sg-scan-on-edit.sh
+++ b/plugins/src/typescript/hooks/sg-scan-on-edit.sh
@@ -67,5 +67,5 @@ if OUTPUT=$($PKG_MANAGER run sg:scan "$FILE_PATH" 2>&1); then
 else
     echo "ast-grep found issues in: $FILE_PATH" >&2
     echo "$OUTPUT" >&2
-    exit 1
+    exit 2
 fi

--- a/tests/unit/hooks/blocking-hook-exit.test.ts
+++ b/tests/unit/hooks/blocking-hook-exit.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const BLOCKING_HOOKS = [
+  "plugins/src/typescript/hooks/sg-scan-on-edit.sh",
+  "plugins/src/rails/hooks/sg-scan-on-edit.sh",
+  "plugins/src/rails/hooks/rubocop-on-edit.sh",
+] as const;
+
+describe("blocking Claude hooks", () => {
+  it.each(BLOCKING_HOOKS)(
+    "%s exits 2 when findings must be fed back to Claude",
+    hookPath => {
+      const content = readFileSync(path.resolve(hookPath), "utf8");
+
+      expect(content).toMatch(/\bexit 2\b/);
+      expect(content).not.toMatch(
+        /(?:issues found|unfixable errors remain|RuboCop found unfixable errors|ast-grep found issues)[\s\S]{0,240}\bexit 1\b/
+      );
+    }
+  );
+
+  it("documents exit 2 for blocking hook authoring", () => {
+    const projectRules = readFileSync(
+      path.resolve(".claude/rules/PROJECT_RULES.md"),
+      "utf8"
+    );
+
+    expect(projectRules).toContain(
+      "always use blocking behavior (exit 2 on failures)"
+    );
+    expect(projectRules).not.toContain(
+      "always use blocking behavior (exit 1 on failures)"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- change TypeScript and Rails Claude edit-time blocking hook failures from `exit 1` to `exit 2`
- update `PROJECT_RULES.md` so new Claude enforcement hooks use the blocking-feedback exit code
- regenerate plugin artifacts for Claude/Cursor/Copilot variants and add regression coverage for the convention

Closes #1400

## Verification
- `bun test tests/unit/hooks/blocking-hook-exit.test.ts tests/unit/hooks/lint-on-edit.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build:plugins`
- `bun run check:plugins`
- pre-push hook: production audit, slow lint, knip, coverage tests, integration tests
