### PR TITLE
fix: emit Claude hook context envelope for eager rules

### DIFF
--- a/plugins/lisa-copilot/hooks/inject-rules.sh
+++ b/plugins/lisa-copilot/hooks/inject-rules.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/eager/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 #
 # The split between eager and reference rules is documented in
@@ -8,6 +8,13 @@
 # under rules/reference/ are installed alongside but loaded only when the
 # eager breadcrumb points to them.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules/eager"
 
@@ -30,4 +37,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/plugins/lisa-rails-copilot/hooks/inject-rules.sh
+++ b/plugins/lisa-rails-copilot/hooks/inject-rules.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules"
 
@@ -19,4 +26,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/plugins/lisa-rails/hooks/inject-rules.sh
+++ b/plugins/lisa-rails/hooks/inject-rules.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules"
 
@@ -19,4 +26,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/plugins/lisa/hooks/inject-rules.sh
+++ b/plugins/lisa/hooks/inject-rules.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/eager/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 #
 # The split between eager and reference rules is documented in
@@ -8,6 +8,13 @@
 # under rules/reference/ are installed alongside but loaded only when the
 # eager breadcrumb points to them.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules/eager"
 
@@ -30,4 +37,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/plugins/src/base/hooks/inject-rules.sh
+++ b/plugins/src/base/hooks/inject-rules.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/eager/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 #
 # The split between eager and reference rules is documented in
@@ -8,6 +8,13 @@
 # under rules/reference/ are installed alongside but loaded only when the
 # eager breadcrumb points to them.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules/eager"
 
@@ -30,4 +37,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/plugins/src/rails/hooks/inject-rules.sh
+++ b/plugins/src/rails/hooks/inject-rules.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # Reads all .md files from the plugin's rules/ directory and injects them
-# into the session context via additionalContext.
+# into the session context via hookSpecificOutput.additionalContext.
 # Used by SessionStart and SubagentStart hooks.
 set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -n "$INPUT" ]; then
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "SessionStart"' 2>/dev/null || echo "SessionStart")
+else
+  HOOK_EVENT="SessionStart"
+fi
 
 RULES_DIR="${CLAUDE_PLUGIN_ROOT}/rules"
 
@@ -19,4 +26,4 @@ done
 [ -n "$CONTEXT" ] || exit 0
 
 # Output as JSON — jq handles escaping
-jq -n --arg ctx "$CONTEXT" '{"additionalContext": $ctx}'
+jq -n --arg event "$HOOK_EVENT" --arg ctx "$CONTEXT" '{"hookSpecificOutput": {"hookEventName": $event, "additionalContext": $ctx}}'

--- a/tests/unit/hooks/inject-rules.test.ts
+++ b/tests/unit/hooks/inject-rules.test.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const BASH = "/bin/bash";
+const BASE_INJECT_RULES_HOOK = "plugins/src/base/hooks/inject-rules.sh";
+const RULE_SENTINEL = "EAGER-RULE-REACHED-SESSION";
+
+/** Parsed JSON emitted by Claude context-injection hooks. */
+type HookOutput = {
+  additionalContext?: string;
+  hookSpecificOutput?: {
+    hookEventName?: string;
+    additionalContext?: string;
+  };
+};
+
+const runHook = (
+  hookPath: string,
+  pluginRoot: string,
+  input?: Record<string, unknown>
+): HookOutput => {
+  const result = spawnSync(BASH, [path.resolve(hookPath)], {
+    encoding: "utf8",
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: pluginRoot },
+    input: input ? JSON.stringify(input) : undefined,
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe("");
+  return JSON.parse(result.stdout) as HookOutput;
+};
+
+const createPluginRoot = (rulesSubdir: "rules" | "rules/eager"): string => {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-inject-rules-"));
+  const rulesDir = path.join(root, rulesSubdir);
+  mkdirSync(rulesDir, { recursive: true });
+  writeFileSync(
+    path.join(rulesDir, "delivery.md"),
+    `${RULE_SENTINEL}\n`,
+    "utf8"
+  );
+  return root;
+};
+
+const expectClaudeContextEnvelope = (
+  output: HookOutput,
+  eventName = "SessionStart"
+): void => {
+  expect(output.additionalContext).toBeUndefined();
+  expect(output.hookSpecificOutput?.hookEventName).toBe(eventName);
+  expect(output.hookSpecificOutput?.additionalContext).toContain(RULE_SENTINEL);
+};
+
+describe("Claude inject-rules hooks", () => {
+  it("emits the Claude-recognized context envelope for base eager rules", () => {
+    const output = runHook(
+      BASE_INJECT_RULES_HOOK,
+      createPluginRoot("rules/eager")
+    );
+
+    expectClaudeContextEnvelope(output);
+  });
+
+  it("keeps base backward compatibility for flat rule directories", () => {
+    const output = runHook(BASE_INJECT_RULES_HOOK, createPluginRoot("rules"));
+
+    expectClaudeContextEnvelope(output);
+  });
+
+  it("preserves the SubagentStart event name for base rule injection", () => {
+    const output = runHook(
+      BASE_INJECT_RULES_HOOK,
+      createPluginRoot("rules/eager"),
+      { hook_event_name: "SubagentStart" }
+    );
+
+    expectClaudeContextEnvelope(output, "SubagentStart");
+  });
+
+  it("emits the Claude-recognized context envelope for Rails rules", () => {
+    const output = runHook(
+      "plugins/src/rails/hooks/inject-rules.sh",
+      createPluginRoot("rules")
+    );
+
+    expectClaudeContextEnvelope(output);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Claude `inject-rules.sh` hooks to emit `hookSpecificOutput.additionalContext` instead of ignored top-level `additionalContext`.
- Preserve the actual `hook_event_name` for dual SessionStart/SubagentStart registration, with SessionStart as the direct-execution fallback.
- Rebuild generated Lisa and Rails Claude/Copilot hook artifacts and add regression coverage for eager/fallback rule injection.

Closes #1399

## Verification
- `bun test tests/unit/hooks/inject-rules.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:plugins`
- pre-push: production audit, slow lint, knip, coverage tests, integration tests
- empirical probe: generated `plugins/lisa/hooks/inject-rules.sh` with `hook_event_name=SubagentStart` returned `SubagentStart true false` for `[hookSpecificOutput.hookEventName, context contains eager rule, has top-level additionalContext]`
