### PR TITLE
fix: guard auto-merge against stale PR heads

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -38,8 +38,28 @@ Use plain `gh` + `git` so Claude and Codex execute identically.
 
 ## 1. Enable auto-merge
 
+Before enabling auto-merge, capture the live PR head and compare it to
+`verify_commit`:
+
+```bash
+head_sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+test "$head_sha" = "<verify_commit>"
+```
+
+If they differ, reset `verify_commit` to the live head only after confirming the
+new head contains the intended fix, or stop and report the mismatch. Never enable
+auto-merge against a stale head you have not verified.
+
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
+
+If any later step will push commits, temporarily remove the auto-merge latch
+before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
+or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
+reset `verify_commit` to the pushed head, wait until that head's checks have
+started, then re-enable auto-merge. Do not leave auto-merge armed while a
+required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
+still in flight.
 
 - **Capability fallback**: if the repo disallows auto-merge, do not fail. Keep
   watching; once checks are green, the review gate is clear, and `mergeable == MERGEABLE`,
@@ -99,17 +119,23 @@ surface the file list and merge state.
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Commit, push, resume. When the root cause is an upstream
-Lisa template/postinstall bug rather than this project's code, fix it upstream and
-propagate down rather than patching only here.
+checks** to force green. Before pushing the fix, disarm auto-merge or classify the
+run as race-prone, then after the push re-read the PR head, update `verify_commit`
+to that exact SHA, wait for checks on that head to start, and only then resume
+auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+rather than this project's code, fix it upstream and propagate down rather than
+patching only here.
 
 ### d. Review comments — human and bot (CodeRabbit, etc.)
 Delegate to the `pull-request-review` skill with the PR number. It owns the whole
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. Do not re-implement that here — it is the single
-source of truth for review-thread handling. When it returns, re-poll and continue.
+thread-resolution gate clears. If that skill needs to push a commit, auto-merge
+must be disabled first when possible; when it returns, re-read `headRefOid`, reset
+`verify_commit` to the returned/pushed head, wait for that head's checks to start,
+then re-enable auto-merge and continue. Do not re-implement review handling here
+— it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
 After the requested changes are addressed and threads resolved, the prior
@@ -138,7 +164,8 @@ git merge-base --is-ancestor <verify_commit> origin/<baseRefName>   # exit 0 = s
 Also confirm the merge commit's parent is your fixed head, not a stale one. If a
 late commit (CI auto-fix, CodeRabbit follow-up) raced past the merge, it did **not**
 ship — fix forward with a new commit/PR and re-drive. Re-confirm after any commit
-that lands while auto-merge is enabled.
+that lands while auto-merge is enabled; a successful merge of an older head is a
+failed drive-to-merge outcome, not a successful closeout.
 
 ## 4. Terminal states
 

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -38,8 +38,28 @@ Use plain `gh` + `git` so Claude and Codex execute identically.
 
 ## 1. Enable auto-merge
 
+Before enabling auto-merge, capture the live PR head and compare it to
+`verify_commit`:
+
+```bash
+head_sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+test "$head_sha" = "<verify_commit>"
+```
+
+If they differ, reset `verify_commit` to the live head only after confirming the
+new head contains the intended fix, or stop and report the mismatch. Never enable
+auto-merge against a stale head you have not verified.
+
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
+
+If any later step will push commits, temporarily remove the auto-merge latch
+before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
+or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
+reset `verify_commit` to the pushed head, wait until that head's checks have
+started, then re-enable auto-merge. Do not leave auto-merge armed while a
+required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
+still in flight.
 
 - **Capability fallback**: if the repo disallows auto-merge, do not fail. Keep
   watching; once checks are green, the review gate is clear, and `mergeable == MERGEABLE`,
@@ -99,17 +119,23 @@ surface the file list and merge state.
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Commit, push, resume. When the root cause is an upstream
-Lisa template/postinstall bug rather than this project's code, fix it upstream and
-propagate down rather than patching only here.
+checks** to force green. Before pushing the fix, disarm auto-merge or classify the
+run as race-prone, then after the push re-read the PR head, update `verify_commit`
+to that exact SHA, wait for checks on that head to start, and only then resume
+auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+rather than this project's code, fix it upstream and propagate down rather than
+patching only here.
 
 ### d. Review comments — human and bot (CodeRabbit, etc.)
 Delegate to the `pull-request-review` skill with the PR number. It owns the whole
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. Do not re-implement that here — it is the single
-source of truth for review-thread handling. When it returns, re-poll and continue.
+thread-resolution gate clears. If that skill needs to push a commit, auto-merge
+must be disabled first when possible; when it returns, re-read `headRefOid`, reset
+`verify_commit` to the returned/pushed head, wait for that head's checks to start,
+then re-enable auto-merge and continue. Do not re-implement review handling here
+— it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
 After the requested changes are addressed and threads resolved, the prior
@@ -138,7 +164,8 @@ git merge-base --is-ancestor <verify_commit> origin/<baseRefName>   # exit 0 = s
 Also confirm the merge commit's parent is your fixed head, not a stale one. If a
 late commit (CI auto-fix, CodeRabbit follow-up) raced past the merge, it did **not**
 ship — fix forward with a new commit/PR and re-drive. Re-confirm after any commit
-that lands while auto-merge is enabled.
+that lands while auto-merge is enabled; a successful merge of an older head is a
+failed drive-to-merge outcome, not a successful closeout.
 
 ## 4. Terminal states
 

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -38,8 +38,28 @@ Use plain `gh` + `git` so Claude and Codex execute identically.
 
 ## 1. Enable auto-merge
 
+Before enabling auto-merge, capture the live PR head and compare it to
+`verify_commit`:
+
+```bash
+head_sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+test "$head_sha" = "<verify_commit>"
+```
+
+If they differ, reset `verify_commit` to the live head only after confirming the
+new head contains the intended fix, or stop and report the mismatch. Never enable
+auto-merge against a stale head you have not verified.
+
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
+
+If any later step will push commits, temporarily remove the auto-merge latch
+before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
+or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
+reset `verify_commit` to the pushed head, wait until that head's checks have
+started, then re-enable auto-merge. Do not leave auto-merge armed while a
+required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
+still in flight.
 
 - **Capability fallback**: if the repo disallows auto-merge, do not fail. Keep
   watching; once checks are green, the review gate is clear, and `mergeable == MERGEABLE`,
@@ -99,17 +119,23 @@ surface the file list and merge state.
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Commit, push, resume. When the root cause is an upstream
-Lisa template/postinstall bug rather than this project's code, fix it upstream and
-propagate down rather than patching only here.
+checks** to force green. Before pushing the fix, disarm auto-merge or classify the
+run as race-prone, then after the push re-read the PR head, update `verify_commit`
+to that exact SHA, wait for checks on that head to start, and only then resume
+auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+rather than this project's code, fix it upstream and propagate down rather than
+patching only here.
 
 ### d. Review comments — human and bot (CodeRabbit, etc.)
 Delegate to the `pull-request-review` skill with the PR number. It owns the whole
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. Do not re-implement that here — it is the single
-source of truth for review-thread handling. When it returns, re-poll and continue.
+thread-resolution gate clears. If that skill needs to push a commit, auto-merge
+must be disabled first when possible; when it returns, re-read `headRefOid`, reset
+`verify_commit` to the returned/pushed head, wait for that head's checks to start,
+then re-enable auto-merge and continue. Do not re-implement review handling here
+— it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
 After the requested changes are addressed and threads resolved, the prior
@@ -138,7 +164,8 @@ git merge-base --is-ancestor <verify_commit> origin/<baseRefName>   # exit 0 = s
 Also confirm the merge commit's parent is your fixed head, not a stale one. If a
 late commit (CI auto-fix, CodeRabbit follow-up) raced past the merge, it did **not**
 ship — fix forward with a new commit/PR and re-drive. Re-confirm after any commit
-that lands while auto-merge is enabled.
+that lands while auto-merge is enabled; a successful merge of an older head is a
+failed drive-to-merge outcome, not a successful closeout.
 
 ## 4. Terminal states
 

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -38,8 +38,28 @@ Use plain `gh` + `git` so Claude and Codex execute identically.
 
 ## 1. Enable auto-merge
 
+Before enabling auto-merge, capture the live PR head and compare it to
+`verify_commit`:
+
+```bash
+head_sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+test "$head_sha" = "<verify_commit>"
+```
+
+If they differ, reset `verify_commit` to the live head only after confirming the
+new head contains the intended fix, or stop and report the mismatch. Never enable
+auto-merge against a stale head you have not verified.
+
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
+
+If any later step will push commits, temporarily remove the auto-merge latch
+before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
+or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
+reset `verify_commit` to the pushed head, wait until that head's checks have
+started, then re-enable auto-merge. Do not leave auto-merge armed while a
+required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
+still in flight.
 
 - **Capability fallback**: if the repo disallows auto-merge, do not fail. Keep
   watching; once checks are green, the review gate is clear, and `mergeable == MERGEABLE`,
@@ -99,17 +119,23 @@ surface the file list and merge state.
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Commit, push, resume. When the root cause is an upstream
-Lisa template/postinstall bug rather than this project's code, fix it upstream and
-propagate down rather than patching only here.
+checks** to force green. Before pushing the fix, disarm auto-merge or classify the
+run as race-prone, then after the push re-read the PR head, update `verify_commit`
+to that exact SHA, wait for checks on that head to start, and only then resume
+auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+rather than this project's code, fix it upstream and propagate down rather than
+patching only here.
 
 ### d. Review comments — human and bot (CodeRabbit, etc.)
 Delegate to the `pull-request-review` skill with the PR number. It owns the whole
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. Do not re-implement that here — it is the single
-source of truth for review-thread handling. When it returns, re-poll and continue.
+thread-resolution gate clears. If that skill needs to push a commit, auto-merge
+must be disabled first when possible; when it returns, re-read `headRefOid`, reset
+`verify_commit` to the returned/pushed head, wait for that head's checks to start,
+then re-enable auto-merge and continue. Do not re-implement review handling here
+— it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
 After the requested changes are addressed and threads resolved, the prior
@@ -138,7 +164,8 @@ git merge-base --is-ancestor <verify_commit> origin/<baseRefName>   # exit 0 = s
 Also confirm the merge commit's parent is your fixed head, not a stale one. If a
 late commit (CI auto-fix, CodeRabbit follow-up) raced past the merge, it did **not**
 ship — fix forward with a new commit/PR and re-drive. Re-confirm after any commit
-that lands while auto-merge is enabled.
+that lands while auto-merge is enabled; a successful merge of an older head is a
+failed drive-to-merge outcome, not a successful closeout.
 
 ## 4. Terminal states
 

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -38,8 +38,28 @@ Use plain `gh` + `git` so Claude and Codex execute identically.
 
 ## 1. Enable auto-merge
 
+Before enabling auto-merge, capture the live PR head and compare it to
+`verify_commit`:
+
+```bash
+head_sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+test "$head_sha" = "<verify_commit>"
+```
+
+If they differ, reset `verify_commit` to the live head only after confirming the
+new head contains the intended fix, or stop and report the mismatch. Never enable
+auto-merge against a stale head you have not verified.
+
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
+
+If any later step will push commits, temporarily remove the auto-merge latch
+before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
+or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
+reset `verify_commit` to the pushed head, wait until that head's checks have
+started, then re-enable auto-merge. Do not leave auto-merge armed while a
+required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
+still in flight.
 
 - **Capability fallback**: if the repo disallows auto-merge, do not fail. Keep
   watching; once checks are green, the review gate is clear, and `mergeable == MERGEABLE`,
@@ -99,17 +119,23 @@ surface the file list and merge state.
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Commit, push, resume. When the root cause is an upstream
-Lisa template/postinstall bug rather than this project's code, fix it upstream and
-propagate down rather than patching only here.
+checks** to force green. Before pushing the fix, disarm auto-merge or classify the
+run as race-prone, then after the push re-read the PR head, update `verify_commit`
+to that exact SHA, wait for checks on that head to start, and only then resume
+auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+rather than this project's code, fix it upstream and propagate down rather than
+patching only here.
 
 ### d. Review comments — human and bot (CodeRabbit, etc.)
 Delegate to the `pull-request-review` skill with the PR number. It owns the whole
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. Do not re-implement that here — it is the single
-source of truth for review-thread handling. When it returns, re-poll and continue.
+thread-resolution gate clears. If that skill needs to push a commit, auto-merge
+must be disabled first when possible; when it returns, re-read `headRefOid`, reset
+`verify_commit` to the returned/pushed head, wait for that head's checks to start,
+then re-enable auto-merge and continue. Do not re-implement review handling here
+— it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
 After the requested changes are addressed and threads resolved, the prior
@@ -138,7 +164,8 @@ git merge-base --is-ancestor <verify_commit> origin/<baseRefName>   # exit 0 = s
 Also confirm the merge commit's parent is your fixed head, not a stale one. If a
 late commit (CI auto-fix, CodeRabbit follow-up) raced past the merge, it did **not**
 ship — fix forward with a new commit/PR and re-drive. Re-confirm after any commit
-that lands while auto-merge is enabled.
+that lands while auto-merge is enabled; a successful merge of an older head is a
+failed drive-to-merge outcome, not a successful closeout.
 
 ## 4. Terminal states
 

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression tests for issue #1395: auto-merge must not stay armed while a
+ * later fix commit is still being pushed or queued for checks.
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails the suite.
+ * @module tests/unit/strategies/drive-pr-auto-merge-race
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+  "plugins/lisa-cursor/skills",
+] as const;
+
+const readSkill = (root: string, slug: string): string =>
+  readFileSync(path.resolve(root, slug, "SKILL.md"), "utf8");
+
+describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
+  const content = readSkill(root, "lisa-drive-pr-to-merge");
+
+  it("checks the live PR head before enabling auto-merge", () => {
+    expect(content).toMatch(/headRefOid/);
+    expect(content).toMatch(/Never enable\s+auto-merge against a stale head/i);
+  });
+
+  it("requires auto-merge to be disarmed or treated as race-prone before fix pushes", () => {
+    expect(content).toMatch(/disablePullRequestAutoMerge/);
+    expect(content).toMatch(/Do not leave auto-merge armed/i);
+    expect(content).toMatch(/required fix, CodeRabbit follow-up/i);
+  });
+
+  it("resets verify_commit to the pushed head before re-enabling auto-merge", () => {
+    expect(content).toMatch(
+      /reset\s+`verify_commit` to the returned\/pushed head/i
+    );
+    expect(content).toMatch(/wait for that head's checks to start/i);
+    expect(content).toMatch(/failed drive-to-merge outcome/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Harden `lisa-drive-pr-to-merge` so it checks the live PR `headRefOid` before enabling auto-merge.
- Require auto-merge to be disabled or treated as race-prone before fix-producing pushes, then reset `verify_commit` to the pushed head and wait for checks on that head before re-enabling.
- Add regression coverage across source and generated Lisa plugin variants.

Closes #1395

## Test plan
- `bun test tests/unit/strategies/drive-pr-auto-merge-race.test.ts`
- `bun test tests/unit/strategies/drive-pr-auto-merge-race.test.ts tests/unit/strategies/github-linked-pr-project-membership.test.ts tests/unit/strategies/two-way-pr-ticket-linking.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run check:plugins`
- `bun run test`
- `git push` pre-push gates: production audit, slow lint, knip, coverage tests, integration tests
- Live ruleset readback: `required_review_thread_resolution=true`, `required_approving_review_count=0`, CodeRabbit required status check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened guidance for auto-merge safety, including verifying the current PR head before enabling it.
  * Clarified how to handle new commits during review or fix pushes so checks run on the correct head.
  * Updated shipped/ancestry guidance to treat older-head merges as failed closeouts.

* **Tests**
  * Added regression coverage to ensure the updated merge-safety guidance is present across supported skill docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->