### PR TITLE
fix(security): triage historical gitleaks findings as $SONAR_TOKEN false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -32,3 +32,10 @@ firebase-web-prod.json:gcp-api-key:2
 
 # Quality workflow curl uses $SONAR_TOKEN variable reference, not a real secret
 .github/workflows/quality.yml:curl-auth-user:1093
+
+# Historical full-history scan findings (issue #1418): the flagged lines pass
+# the SONAR_TOKEN environment variable to curl's basic-auth flag as a shell
+# variable reference, not a literal credential, so nothing was exposed and no
+# rotation or history rewrite is needed.
+0215799854477c30dd3bf947f4cc65fe9a78fe13:.github/workflows/quality.yml:curl-auth-user:1083
+0215799854477c30dd3bf947f4cc65fe9a78fe13:typescript/copy-overwrite/.github/workflows/quality.yml:curl-auth-user:1083

--- a/tests/unit/scripts/plugin-sync-scripts.test.ts
+++ b/tests/unit/scripts/plugin-sync-scripts.test.ts
@@ -213,11 +213,17 @@ function run(
   args: readonly string[],
   cwd: string
 ): ReturnType<typeof spawnSync> {
+  // Git hooks export GIT_DIR/GIT_INDEX_FILE pointing at the parent repo, which
+  // would redirect the fixture repo's git commands there; strip them so the
+  // fixture stays hermetic when this suite runs under pre-push.
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
   return spawnSync(args[0] as string, args.slice(1), {
     cwd,
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...env,
       HUSKY: "0",
     },
   });


### PR DESCRIPTION
## Summary

- Triage of the two historical `curl-auth-user` gitleaks findings from commit `0215799` (issue #1418): the flagged line passes the `SONAR_TOKEN` environment variable to curl's basic-auth flag as a shell variable reference — no literal credential was ever committed, so no rotation and no history rewrite are needed.
- Adds both commit-scoped fingerprints to `.gitleaksignore` with the triage rationale so `gitleaks detect --log-opts='--all'` runs clean (verified locally: 2661 commits scanned, no leaks found).
- Fixes the `plugin-sync-scripts` test suite to strip `GIT_*` env vars from its spawned git commands; under a git pre-push hook the leaked `GIT_DIR` made the fixture repo's git commands target the real repository (failing the suite and even committing fixture content onto the pushing branch).

Closes #1418

## Test plan

- `gitleaks detect --source . --redact --log-opts='--all'` → no leaks found
- `GIT_DIR=$(git rev-parse --absolute-git-dir) npx vitest run tests/unit/scripts/plugin-sync-scripts.test.ts` → passes (reproduced the hook failure before the fix)
- Full pre-push gates (typecheck, slow lint, test:cov, integration) passed on push

🤖 Generated with Claude Code