### PR TITLE
fix(eslint): disable enforce-statement-order in shared test-file override

### DIFF
--- a/src/configs/eslint/base.ts
+++ b/src/configs/eslint/base.ts
@@ -379,6 +379,9 @@ export const getTestFilesOverride = (additionalPatterns: string[] = []) => ({
     "no-restricted-syntax": "off",
     // Tests can be longer than typical functions
     "max-lines-per-function": "off",
+    // Arrange-act-assert tests interleave mock-setup side effects with
+    // consts that read the resulting state, so definition-order cannot apply
+    "code-organization/enforce-statement-order": "off",
   },
 });
 

--- a/tests/unit/config/eslint-test-files-override.test.ts
+++ b/tests/unit/config/eslint-test-files-override.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests that pin the rule relaxations in Lisa's shared test-file
+ * ESLint override (`getTestFilesOverride`).
+ *
+ * Background: every stack config (typescript, expo, nestjs, cdk) enables
+ * strict rules like `code-organization/enforce-statement-order` globally and
+ * relies on `getTestFilesOverride` — appended later in the flat-config
+ * array — to switch off the rules that arrange-act-assert tests cannot
+ * satisfy. Lisa 2.191.x shipped without the statement-order relaxation,
+ * which broke CI lint in every downstream project whose tests interleave
+ * mock-setup side effects with consts that read the resulting state. This
+ * guard test keeps each required relaxation in place.
+ */
+import { describe, expect, it } from "vitest";
+
+import { getTestFilesOverride } from "../../../src/configs/eslint/base.js";
+
+describe("getTestFilesOverride rule relaxations", () => {
+  const override = getTestFilesOverride();
+  const rules = override.rules as Record<string, unknown>;
+
+  it("targets test file patterns", () => {
+    expect(override.files).toContain("**/*.test.ts");
+    expect(override.files).toContain("**/__tests__/*");
+  });
+
+  it("appends additional patterns when provided", () => {
+    const extended = getTestFilesOverride(["**/*.integration.ts"]);
+    expect(extended.files).toContain("**/*.integration.ts");
+  });
+
+  it("disables statement-order enforcement for arrange-act-assert tests", () => {
+    expect(rules["code-organization/enforce-statement-order"]).toBe("off");
+  });
+
+  it("disables immutability rules that block mock mutation", () => {
+    expect(rules["functional/immutable-data"]).toBe("off");
+    expect(rules["functional/no-let"]).toBe("off");
+  });
+
+  it("disables process.env and length restrictions for test setup", () => {
+    expect(rules["no-restricted-syntax"]).toBe("off");
+    expect(rules["max-lines-per-function"]).toBe("off");
+  });
+});


### PR DESCRIPTION
## Summary

Lisa 2.191.x turned on `code-organization/enforce-statement-order` ("error") for all files, but the shared test-file override (`getTestFilesOverride` in `src/configs/eslint/base.ts`) never relaxed it. Arrange-act-assert tests legitimately interleave mock-setup side effects with `const`s that read the resulting state, so the rule is unsatisfiable in tests. Found during the 2026-07-06 fleet update: nestjsstarter CI lint red with 177 errors, expostarter 48 errors; hits every TS/expo/nestjs/cdk project with tests. Projects were green under 2.176.x.

## Fix

Add `"code-organization/enforce-statement-order": "off"` to `getTestFilesOverride`, joining the existing test-hostile relaxations (`functional/no-let`, `functional/immutable-data`, `no-restricted-syntax`, `max-lines-per-function`). The override is appended after each stack's main rules block in every config factory, so the relaxation wins for test files across all stacks.

## Tests

New guard test `tests/unit/config/eslint-test-files-override.test.ts` pins every test-file relaxation (5 assertions, passing).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed certain linting restrictions for test files so arrange-act-assert style tests can use a more natural statement order and setup flow.
  * Improved test-file lint coverage to better match expected patterns and allow caller-provided glob additions.

* **Tests**
  * Added unit tests to verify test-file lint overrides target the right files and apply the intended rule relaxations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->