### PR TITLE
fix(eslint): treat super() as constructor prologue in enforce-statement-order

### DIFF
--- a/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
+++ b/eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js
@@ -242,6 +242,34 @@ ruleTester.run("enforce-statement-order", rule, {
       `,
       options: [{ checkAllFunctionBodies: false }],
     },
+
+    // super() is a language-mandated prologue, not a side effect: definitions
+    // after it must not be flagged (derived constructors cannot avoid this)
+    {
+      code: `
+        class NetworkStage extends Stage {
+          constructor(scope, id, props) {
+            super(scope, id, props);
+            const environment = props.environment;
+            const natGatewayCount = environment === "production" ? 3 : 1;
+            configureNetwork(environment, natGatewayCount);
+          }
+        }
+      `,
+    },
+
+    // super() alone with only definitions after it
+    {
+      code: `
+        class Widget extends Base {
+          constructor(options) {
+            super(options);
+            const name = options.name;
+            this.name = name;
+          }
+        }
+      `,
+    },
   ],
 
   invalid: [
@@ -509,6 +537,30 @@ ruleTester.run("enforce-statement-order", rule, {
             initialize();
             const config = getConfig();
             return config;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            current: DEFINITIONS,
+            previous: SIDE_EFFECTS,
+          },
+        },
+      ],
+    },
+
+    // super() neutrality must not mask real violations: a definition after a
+    // genuine side effect inside a derived constructor is still flagged
+    {
+      code: `
+        class NetworkStage extends Stage {
+          constructor(scope, id, props) {
+            super(scope, id, props);
+            configureNetwork(props);
+            const environment = props.environment;
+            this.environment = environment;
           }
         }
       `,

--- a/eslint-plugin-code-organization/rules/enforce-statement-order.js
+++ b/eslint-plugin-code-organization/rules/enforce-statement-order.js
@@ -122,6 +122,21 @@ module.exports = {
         return ORDER.DEFINITION;
       }
 
+      // super(...) is a language-mandated constructor prologue: it must run
+      // before any `this` access, so definitions that follow it are
+      // unavoidable. Treat it as order-neutral rather than a side effect.
+      if (statement.type === "ExpressionStatement") {
+        const expression = unwrapExpression(statement.expression);
+
+        if (
+          expression &&
+          expression.type === "CallExpression" &&
+          expression.callee.type === "Super"
+        ) {
+          return null;
+        }
+      }
+
       // Expression statements with function calls are side effects
       if (isFunctionCallExpression(statement)) {
         return ORDER.SIDE_EFFECT;


### PR DESCRIPTION
## Summary

The `checkAllFunctionBodies` tightening (2.189.18) made `code-organization/enforce-statement-order` count the mandatory `super(...)` call as a side effect, flagging every subsequent `const` in a derived-class constructor as "definition after side effect". Since `super()` must be the first statement before any `this` access, the strict default was **unsatisfiable** for any subclass constructor that declares locals — not legacy debt, but a rule defect: even freshly-written compliant code cannot pass. Hit by every CDK stack/stage constructor (cdkstarter: 32 errors across 17 files) and NestJS subclass services during the 2026-07-06 fleet update.

## Fix

Treat a `super(...)` expression statement as order-neutral in `getStatementOrder` (same treatment as guard-clause `if` statements): it no longer sets the side-effect boundary. Definitions following *genuine* side effects inside constructors are still flagged.

## Tests

- Valid: derived constructor with `super()` → consts → side effects under **default (strict) options**; `super()` + definitions only.
- Invalid: definition after a genuine side effect inside a derived constructor still reports `wrongOrder`.
- Full rule suite passes (`node eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js`).

Note: projects that applied the per-project `{ checkAllFunctionBodies: false }` deferral are unaffected by this change; it makes the strict default adoptable going forward.

🤖 Generated with Claude Code