### PR TITLE
fix: esbuild $name override for CDK + non-interactive HarperDB in ZAP scan

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -24,6 +24,7 @@
     },
     "devDependencies": {
       "aws-cdk": "^2.1127.0",
+      "esbuild": "^0.28.1",
       "vite": "^8.0.16",
       "vitest": "^4.1.0",
       "@vitest/coverage-v8": "^4.1.0",
@@ -39,10 +40,12 @@
     "private": true,
     "overrides": {
       "aws-cdk-lib": "$aws-cdk-lib",
+      "esbuild": "$esbuild",
       "vite": "$vite"
     },
     "resolutions": {
       "aws-cdk-lib": "$aws-cdk-lib",
+      "esbuild": "$esbuild",
       "vite": "$vite"
     }
   },

--- a/harper-fabric/create-only/scripts/zap-baseline.sh
+++ b/harper-fabric/create-only/scripts/zap-baseline.sh
@@ -57,7 +57,13 @@ if [ "$should_start_local" = true ]; then
   fi
 
   echo "==> Starting Harper app locally..."
-  "$HARPER_BIN" run harper-app &
+  # HarperDB's first run blocks on an interactive Terms & Conditions prompt
+  # and admin-credential setup; supply non-interactive answers (same pattern
+  # as the starter bootstrap script) so CI never hangs waiting for input.
+  TC_AGREEMENT="${TC_AGREEMENT:-yes}" \
+  HDB_ADMIN_USERNAME="${HDB_ADMIN_USERNAME:-admin}" \
+  HDB_ADMIN_PASSWORD="${HDB_ADMIN_PASSWORD:-zap-baseline-local}" \
+    "$HARPER_BIN" run harper-app &
   SERVER_PID=$!
 
   echo "==> Waiting for Harper app..."


### PR DESCRIPTION
## Summary

Two independent template fixes found during the 2026-07-06 fleet update.

### 1. `fix(cdk)`: esbuild EOVERRIDE on npm-based CDK projects

`typescript/package-lisa` sets `force.overrides.esbuild: ">=0.28.1"` (range) for transitive-only consumers, but CDK projects carry esbuild as a direct devDependency for `NodejsFunction` bundling — npm's `assertRootOverrides` rejects a range override on a direct dep (EOVERRIDE, surfaced as the misleading `npm ci needs an existing package-lock.json` EUSAGE; see #1330/#1332 for the identical vite/aws-cdk-lib class). Broke `🏗️ CDK Validation` on propswap-infrastructure.

Fix mirrors the existing vite/aws-cdk-lib handling in the **cdk child template**: force `esbuild: "^0.28.1"` as a direct devDependency and use the `$esbuild` self-reference in overrides/resolutions. Child deep-merge wins; the typescript base keeps its range for transitive-only stacks.

### 2. `fix(harper-fabric)`: ZAP baseline hangs on HarperDB T&C prompt

`scripts/zap-baseline.sh` starts HarperDB bare; first run blocks on the interactive "I agree to the HarperDB Terms and Conditions" prompt, so the app never becomes reachable and the scan fails on every harper-fabric PR (harperstarter #9). Fix supplies the same non-interactive env (`TC_AGREEMENT`, `HDB_ADMIN_USERNAME/PASSWORD`) the starter bootstrap script already uses, respecting caller-provided values. The script is create-only, so existing projects apply the same edit locally (harperstarter is being fixed in its open update PR).

🤖 Generated with Claude Code