### PR TITLE
fix(typescript): group regex alternatives in check-verification-coverage

### DIFF
--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -31,7 +31,8 @@ const EXEMPT_LABEL = "verification-exempt";
 // A verification spec lives in a top-level e2e/ dir, a nested tests/e2e/ tree,
 // or a tests/verification/ tree — NOT an arbitrary path that merely contains an
 // "e2e" segment (e.g. src/e2e/helpers.ts must not satisfy the gate).
-const VERIFICATION_PATH = /^e2e\/|(^|\/)tests\/(e2e|verification)\//;
+const VERIFICATION_PATH =
+  /(?:^e2e\/)|(?:(?:^|\/)tests\/(?:e2e|verification)\/)/;
 
 /**
  * Parse a comma-delimited label list.


### PR DESCRIPTION
## Summary

SonarCloud flags `VERIFICATION_PATH` in the template script `scripts/check-verification-coverage.mjs` with **S5850 (anchor-precedence)** — a BUG-type/Major rule: the `^` anchor in the first alternative of an ungrouped alternation reads as ambiguous operator precedence. One new-code bug drops the Reliability rating on new code to C, failing downstream SonarCloud quality gates whenever a lisa update delivers this copy-overwrite script (propswap-infrastructure PR #259 during the 2026-07-06 fleet update).

## Fix

Group each alternative explicitly with non-capturing groups. Reproduced the finding locally via `eslint-plugin-sonarjs` (`sonarjs/anchor-precedence`) — clean after the fix.

## Verification

Behavior proven identical: 12 representative matching and non-matching paths (top-level `e2e/`, nested `tests/e2e|verification/`, and the documented non-matches like `src/e2e/helpers.ts`, `xtests/e2e/…`, `e2e-helpers/…`) produce byte-identical results under old and new regex.

🤖 Generated with Claude Code