### PR TITLE
fix(harper-fabric): answer the HarperDB destination prompt in zap-baseline.sh

### DIFF
--- a/harper-fabric/create-only/scripts/zap-baseline.sh
+++ b/harper-fabric/create-only/scripts/zap-baseline.sh
@@ -57,12 +57,19 @@ if [ "$should_start_local" = true ]; then
   fi
 
   echo "==> Starting Harper app locally..."
-  # HarperDB's first run blocks on an interactive Terms & Conditions prompt
-  # and admin-credential setup; supply non-interactive answers (same pattern
-  # as the starter bootstrap script) so CI never hangs waiting for input.
+  # HarperDB's first run blocks on interactive prompts: Terms & Conditions,
+  # admin credentials, AND the install destination (rootPath). Supply the full
+  # non-interactive answer set (same pattern as the starter bootstrap script)
+  # so CI never hangs waiting for input. HTTP_PORT must stay 9926 to match
+  # the scan target URL above.
   TC_AGREEMENT="${TC_AGREEMENT:-yes}" \
+  HDB_ROOT="${HDB_ROOT:-$HOME/.harperdb}" \
   HDB_ADMIN_USERNAME="${HDB_ADMIN_USERNAME:-admin}" \
   HDB_ADMIN_PASSWORD="${HDB_ADMIN_PASSWORD:-zap-baseline-local}" \
+  OPERATIONSAPI_NETWORK_PORT="${OPERATIONSAPI_NETWORK_PORT:-9925}" \
+  HTTP_PORT="${HTTP_PORT:-9926}" \
+  ANALYTICS_ENABLED="${ANALYTICS_ENABLED:-false}" \
+  LOGGING_LEVEL="${LOGGING_LEVEL:-warn}" \
     "$HARPER_BIN" run harper-app &
   SERVER_PID=$!
 


### PR DESCRIPTION
## Summary

Follow-up to #1460: the T&C/admin-credential env answered HarperDB's first three prompts, but the first run then blocks on a **fourth** interactive prompt — `Please enter a destination for HarperDB` (rootPath) — so the ZAP baseline job still hangs and times out (verified in harperstarter #9's CI log, which shows the first three prompts answered and the destination prompt hanging).

## Fix

Complete the non-interactive env set to match `harperstarter/scripts/bootstrap.sh` (the proven pattern): `HDB_ROOT` answers the destination prompt; `OPERATIONSAPI_NETWORK_PORT`/`HTTP_PORT` pin the app to the scan target URL (`localhost:9926`); `ANALYTICS_ENABLED=false` / `LOGGING_LEVEL=warn` keep CI quiet. All values respect caller overrides via `${VAR:-default}`.

Note: the script is create-only — existing projects sync the edit locally (updater agent is applying the same change to harperstarter's open PR; this template fix covers future projects).

🤖 Generated with Claude Code