### PR TITLE
fix(eslint): add checkRequiredComponentFiles opt-out to enforce-component-structure

### DIFF
--- a/eslint-plugin-component-structure/__tests__/enforce-component-structure.test.js
+++ b/eslint-plugin-component-structure/__tests__/enforce-component-structure.test.js
@@ -50,12 +50,30 @@ function createComponentIndexFixture(componentName) {
 }
 
 ruleTester.run("enforce-component-structure", rule, {
-  valid: [],
+  valid: [
+    // Opt-out for projects predating the Container/View pairing requirement:
+    // the directory-shape check is skipped while the index-export check stays
+    // active (the export below still matches the required pattern).
+    {
+      code: `export { default } from "./LegacyShapeView";`,
+      filename: createComponentIndexFixture("LegacyShape"),
+      options: [{ checkRequiredComponentFiles: false }],
+    },
+  ],
   invalid: [
     {
       code: `export { default } from "./MissingSiblingsView";`,
       filename: createComponentIndexFixture("MissingSiblings"),
       errors: [{ messageId: "missingContainer" }, { messageId: "missingView" }],
+    },
+
+    // The opt-out disables only the directory-shape check — the index-export
+    // check still reports when index.tsx does not export Container/View.
+    {
+      code: `export const unrelated = true;`,
+      filename: createComponentIndexFixture("LegacyExport"),
+      options: [{ checkRequiredComponentFiles: false }],
+      errors: [{ messageId: "incorrectIndexExport" }],
     },
   ],
 });

--- a/eslint-plugin-component-structure/rules/enforce-component-structure.js
+++ b/eslint-plugin-component-structure/rules/enforce-component-structure.js
@@ -16,7 +16,17 @@ module.exports = {
       recommended: true,
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          checkRequiredComponentFiles: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       missingContainer:
         'Component directory "{{componentName}}" is missing {{componentName}}Container.tsx file',
@@ -196,11 +206,18 @@ module.exports = {
       }
     };
 
-    // Only check once per file
+    // Only check once per file. Projects predating the Container/View pairing
+    // requirement can opt out of the directory-shape check while keeping the
+    // naming and index-export checks active.
+    const options = context.options[0] || {};
+    const checkRequiredComponentFiles =
+      options.checkRequiredComponentFiles !== false;
+
     if (
-      fileName === "index.ts" ||
-      fileName === "index.tsx" ||
-      fileName === "index.jsx"
+      checkRequiredComponentFiles &&
+      (fileName === "index.ts" ||
+        fileName === "index.tsx" ||
+        fileName === "index.jsx")
     ) {
       checkRequiredFiles();
     }


### PR DESCRIPTION
## Summary

Commit 667d83bdb (2.189.18) activated the previously-dormant Container/View directory-shape check for index barrels. Unlike the `enforce-statement-order` tightening **in the same commit** — which shipped `checkAwaitedCalls`/`checkAllFunctionBodies` opt-outs the Lisa repo itself uses — this rule kept `schema: []`, leaving projects with legacy component layouts (geminisports frontend-v2: **155 errors**, all new-scope, green on 2.176.x) no sanctioned migration path short of blanket-disabling the rule or enumerating every legacy directory.

## Fix

Mirror the statement-order pattern: an options object with `checkRequiredComponentFiles` (default **true** — the published default stays strict). Opting out skips only the directory-shape check (`missingContainer`/`missingView`/`missingIndex`); the index-export and file-naming checks stay active.

Downstream usage (project-owned `eslint.config.local.ts`, deferral comment per the fleet-update playbook):

```ts
"component-structure/enforce-component-structure": ["error", { checkRequiredComponentFiles: false }]
```

## Tests

RuleTester cases for both sides: opt-out + legacy shape → clean; opt-out + wrong index export → still reports `incorrectIndexExport`. Existing default-strict case unchanged. Suite passes.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new rule option to let you skip required component file checks when needed.

* **Bug Fixes**
  * The component structure rule now only enforces required file and export checks when that option is enabled.
  * Improved handling for index files so validation is applied more predictably.

* **Tests**
  * Expanded coverage for both valid and invalid component structure scenarios, including the new option behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->