### PR TITLE
fix(harper-fabric): honor WARN policy and fix duplicate ZAP mount

### DIFF
--- a/harper-fabric/create-only/scripts/zap-baseline.sh
+++ b/harper-fabric/create-only/scripts/zap-baseline.sh
@@ -104,12 +104,26 @@ zap_args="-t $SCAN_TARGET_URL"
 
 if [ -f "$ZAP_RULES_FILE" ]; then
   echo "    Using rules file: $ZAP_RULES_FILE"
-  zap_args="$zap_args -c /zap/wrk/$(basename "$ZAP_RULES_FILE")"
-  mount_rules="-v $(dirname "$(realpath "$ZAP_RULES_FILE")"):/zap/wrk:ro"
+  rules_abs="$(realpath "$ZAP_RULES_FILE")"
+  case "$rules_abs" in
+    "$PROJECT_ROOT"/*)
+      # The project root is already mounted at /zap/wrk — reference the rules
+      # file inside it; a second mount on /zap/wrk collides
+      # (docker: Duplicate mount point).
+      zap_args="$zap_args -c /zap/wrk/${rules_abs#"$PROJECT_ROOT"/}"
+      mount_rules=""
+      ;;
+    *)
+      zap_args="$zap_args -c /zap/rules/$(basename "$rules_abs")"
+      mount_rules="-v $(dirname "$rules_abs"):/zap/rules:ro"
+      ;;
+  esac
 else
   mount_rules=""
 fi
 
+# -I honors .zap/baseline.conf's documented policy: WARN-marked rules are
+# reported but do not fail the scan; rules marked FAIL there still fail it.
 docker run --rm \
   --add-host=host.docker.internal:host-gateway \
   -v "$(pwd)":/zap/wrk/:rw \
@@ -119,6 +133,7 @@ docker run --rm \
   -r "$REPORT_FILE" \
   -J zap-report.json \
   -w zap-report.md \
+  -I \
   -l WARN || zap_exit=$?
 
 if [ -f "$REPORT_FILE" ]; then
@@ -126,7 +141,7 @@ if [ -f "$REPORT_FILE" ]; then
 fi
 
 if [ "${zap_exit:-0}" -ne 0 ]; then
-  echo "ZAP found medium+ severity findings (exit code: $zap_exit)."
+  echo "ZAP found FAIL-level findings or errored (exit code: $zap_exit)."
   exit "$zap_exit"
 fi
 


### PR DESCRIPTION
## Summary

Final two zap-baseline.sh defects surfaced while driving harperstarter #9's ZAP scan to green (follow-up to #1460/#1462/#1463 — the scan is now fully functional; these fixes align exit behavior with committed policy):

1. **Duplicate mount**: the rules-file mount reused `/zap/wrk`, colliding with the project mount (`docker: Duplicate mount point`, exit 125 — misread as scan findings). The project root is already mounted at `/zap/wrk`, so the rules file is referenced inside it; a rules file outside the project mounts at `/zap/rules` instead.
2. **WARN policy**: the committed `.zap/baseline.conf` documents WARN-marked rules (anti-clickjacking, X-Content-Type-Options, CSP, Permissions-Policy, CORP headers) as "report but do not fail", yet the script `exit`ed on any non-zero scan code, hard-failing the job on advisory findings. `-I` makes the scan report WARNs without failing; FAIL-marked rules (debug errors 10023, cookie flags 10010/10011) still fail.

Empirical basis: harperstarter #9's CI run shows the scan completing (5 URLs) with only WARN-level findings after the mount fix; the updater agent verifies the same change project-side.

🤖 Generated with Claude Code