### PR TITLE
fix(harper-fabric): make the ZAP report dir writable by the container user

### DIFF
--- a/harper-fabric/create-only/scripts/zap-baseline.sh
+++ b/harper-fabric/create-only/scripts/zap-baseline.sh
@@ -122,6 +122,12 @@ else
   mount_rules=""
 fi
 
+# The zaproxy image runs as the unprivileged `zap` user (uid 1000); CI
+# checkouts are owned by a different uid (e.g. 1001 on GitHub runners), so
+# without this the report writes fail with PermissionError and the scan
+# aborts with exit 3.
+chmod o+w "$(pwd)"
+
 # -I honors .zap/baseline.conf's documented policy: WARN-marked rules are
 # reported but do not fail the scan; rules marked FAIL there still fail it.
 docker run --rm \


### PR DESCRIPTION
## Summary

Final piece of the harper-fabric ZAP chain (#1460 → #1462 → #1463 → #1465 → this). With startup and mounts fixed, the scan still exited 3 on CI: the zaproxy image runs as the unprivileged `zap` user (uid 1000) while GitHub runner checkouts are owned by uid 1001 (mode 755), so `zap-baseline.py` aborts with `PermissionError: [Errno 13] Permission denied: '/zap/wrk/zap-report.html'` — masked in logs because WARN findings print immediately before the traceback. This was the actual cause of the exit-3 previously attributed to WARN accounting (a local run of the same image/conf with `-I` exits 0 with `PASS: 60`; macOS Docker masks the uid mismatch, which is why it only reproduced on CI).

## Fix

`chmod o+w "$(pwd)"` (single directory, non-recursive) before the `docker run` so the container can create its report files. Preferred over `--user` remapping, which breaks ZAP's own writes to `/home/zap` (add-on auto-update).

## Verification

The identical change is green in harperstarter PR #9's CI — ZAP scans 5 URLs, writes all three reports, and exits 0 with WARN-only findings.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of security scan reporting in CI by preventing write-permission failures when generating scan output.
  * Reduced the chance of baseline scan jobs failing due to repository ownership or access differences in containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->