### PR TITLE
feat(harper-fabric): enforce empirically-verified Harper best practices

### DIFF
--- a/ast-grep/rule-tests/__snapshots__/harper-no-early-return-in-search-loop-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/harper-no-early-return-in-search-loop-snapshot.yml
@@ -1,0 +1,30 @@
+id: harper-no-early-return-in-search-loop
+snapshots:
+  'async function bad() { for await (const row of tables.Advisor.search({ conditions: [] })) { if (row.id) return row; } }':
+    labels:
+      - source: return row;
+        style: primary
+        start: 104
+        end: 115
+      - source: 'tables.Advisor.search({ conditions: [] })'
+        style: secondary
+        start: 47
+        end: 88
+      - source: 'for await (const row of tables.Advisor.search({ conditions: [] })) { if (row.id) return row; }'
+        style: secondary
+        start: 23
+        end: 117
+  async function bad() { for await (const row of tables.Advisor.search({})) { if (row.id) break; } }:
+    labels:
+      - source: break;
+        style: primary
+        start: 88
+        end: 94
+      - source: tables.Advisor.search({})
+        style: secondary
+        start: 47
+        end: 72
+      - source: for await (const row of tables.Advisor.search({})) { if (row.id) break; }
+        style: secondary
+        start: 23
+        end: 96

--- a/ast-grep/rule-tests/__snapshots__/harper-no-empty-conditions-with-sort-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/harper-no-empty-conditions-with-sort-snapshot.yml
@@ -1,0 +1,78 @@
+id: harper-no-empty-conditions-with-sort
+snapshots:
+  'tables.Advisor.search({ conditions: [], sort: { attribute: "lastName" } });':
+    labels:
+      - source: '{ conditions: [], sort: { attribute: "lastName" } }'
+        style: primary
+        start: 22
+        end: 73
+      - source: conditions
+        style: secondary
+        start: 24
+        end: 34
+      - source: '[]'
+        style: secondary
+        start: 36
+        end: 38
+      - source: 'conditions: []'
+        style: secondary
+        start: 24
+        end: 38
+      - source: sort
+        style: secondary
+        start: 40
+        end: 44
+      - source: 'sort: { attribute: "lastName" }'
+        style: secondary
+        start: 40
+        end: 71
+      - source: tables.Advisor.search
+        style: secondary
+        start: 0
+        end: 21
+      - source: 'tables.Advisor.search({ conditions: [], sort: { attribute: "lastName" } })'
+        style: secondary
+        start: 0
+        end: 74
+      - source: '({ conditions: [], sort: { attribute: "lastName" } })'
+        style: secondary
+        start: 21
+        end: 74
+  'tables.Advisor.search({ sort: { attribute: "lastName" }, conditions: [] });':
+    labels:
+      - source: '{ sort: { attribute: "lastName" }, conditions: [] }'
+        style: primary
+        start: 22
+        end: 73
+      - source: conditions
+        style: secondary
+        start: 57
+        end: 67
+      - source: '[]'
+        style: secondary
+        start: 69
+        end: 71
+      - source: 'conditions: []'
+        style: secondary
+        start: 57
+        end: 71
+      - source: sort
+        style: secondary
+        start: 24
+        end: 28
+      - source: 'sort: { attribute: "lastName" }'
+        style: secondary
+        start: 24
+        end: 55
+      - source: tables.Advisor.search
+        style: secondary
+        start: 0
+        end: 21
+      - source: 'tables.Advisor.search({ sort: { attribute: "lastName" }, conditions: [] })'
+        style: secondary
+        start: 0
+        end: 74
+      - source: '({ sort: { attribute: "lastName" }, conditions: [] })'
+        style: secondary
+        start: 21
+        end: 74

--- a/ast-grep/rule-tests/__snapshots__/harper-no-full-table-scan-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/harper-no-full-table-scan-snapshot.yml
@@ -1,0 +1,32 @@
+id: harper-no-full-table-scan
+snapshots:
+  allRows(tables.EmploymentHistory):
+    labels:
+      - source: allRows(tables.EmploymentHistory)
+        style: primary
+        start: 0
+        end: 33
+  allRows<AdvisorRow>(tables.Advisor):
+    labels:
+      - source: allRows<AdvisorRow>(tables.Advisor)
+        style: primary
+        start: 0
+        end: 35
+  optionalAll(tables.Advisor):
+    labels:
+      - source: optionalAll(tables.Advisor)
+        style: primary
+        start: 0
+        end: 27
+  tables.Advisor.search():
+    labels:
+      - source: tables.Advisor.search()
+        style: primary
+        start: 0
+        end: 23
+  tables.Advisor.search({}):
+    labels:
+      - source: tables.Advisor.search({})
+        style: primary
+        start: 0
+        end: 25

--- a/ast-grep/rule-tests/__snapshots__/harper-require-statuscode-on-thrown-error-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/harper-require-statuscode-on-thrown-error-snapshot.yml
@@ -1,0 +1,30 @@
+id: harper-require-statuscode-on-thrown-error
+snapshots:
+  'Object.assign(error, { status: 400 });':
+    labels:
+      - source: 'Object.assign(error, { status: 400 })'
+        style: primary
+        start: 0
+        end: 37
+  class StatusError extends Error { constructor(m, s) { super(m); this.status = s; } }:
+    labels:
+      - source: this.status = s
+        style: primary
+        start: 64
+        end: 79
+      - source: Error
+        style: secondary
+        start: 26
+        end: 31
+      - source: extends Error
+        style: secondary
+        start: 18
+        end: 31
+      - source: extends Error
+        style: secondary
+        start: 18
+        end: 31
+      - source: class StatusError extends Error { constructor(m, s) { super(m); this.status = s; } }
+        style: secondary
+        start: 0
+        end: 84

--- a/ast-grep/rule-tests/harper-no-early-return-in-search-loop-test.yml
+++ b/ast-grep/rule-tests/harper-no-early-return-in-search-loop-test.yml
@@ -1,0 +1,7 @@
+id: harper-no-early-return-in-search-loop
+valid:
+  - 'async function ok() { for await (const row of tables.Advisor.search({ conditions: [] })) { doThing(row); } }'
+  - 'async function ok() { for await (const row of otherIterable) { if (row.id) return row; } }'
+invalid:
+  - 'async function bad() { for await (const row of tables.Advisor.search({ conditions: [] })) { if (row.id) return row; } }'
+  - 'async function bad() { for await (const row of tables.Advisor.search({})) { if (row.id) break; } }'

--- a/ast-grep/rule-tests/harper-no-empty-conditions-with-sort-test.yml
+++ b/ast-grep/rule-tests/harper-no-empty-conditions-with-sort-test.yml
@@ -1,0 +1,8 @@
+id: harper-no-empty-conditions-with-sort
+valid:
+  - 'tables.Advisor.search({ conditions: [{ attribute: "lastName", value: "A" }], sort: { attribute: "lastName" } });'
+  - 'tables.Advisor.search({ conditions: [] });'
+  - 'tables.Advisor.search({ sort: { attribute: "lastName" } });'
+invalid:
+  - 'tables.Advisor.search({ conditions: [], sort: { attribute: "lastName" } });'
+  - 'tables.Advisor.search({ sort: { attribute: "lastName" }, conditions: [] });'

--- a/ast-grep/rule-tests/harper-no-full-table-scan-test.yml
+++ b/ast-grep/rule-tests/harper-no-full-table-scan-test.yml
@@ -1,0 +1,11 @@
+id: harper-no-full-table-scan
+valid:
+  - 'rowsByAttribute(tables.Advisor, "advisorId", value)'
+  - 'tables.Advisor.search({ conditions: [{ attribute: "id", value: 1 }] })'
+  - 'searchPageAndCount(tables.Advisor, query)'
+invalid:
+  - 'allRows(tables.EmploymentHistory)'
+  - 'optionalAll(tables.Advisor)'
+  - 'allRows<AdvisorRow>(tables.Advisor)'
+  - 'tables.Advisor.search({})'
+  - 'tables.Advisor.search()'

--- a/ast-grep/rule-tests/harper-require-statuscode-on-thrown-error-test.yml
+++ b/ast-grep/rule-tests/harper-require-statuscode-on-thrown-error-test.yml
@@ -1,0 +1,9 @@
+id: harper-require-statuscode-on-thrown-error
+valid:
+  - 'Object.assign(error, { status, statusCode: status });'
+  - 'Object.assign(error, { statusCode: status });'
+  - 'class StatusError extends Error { constructor(m, s) { super(m); this.status = s; this.statusCode = s; } }'
+  - 'class Widget extends Base { constructor(s) { this.status = s; } }'
+invalid:
+  - 'Object.assign(error, { status: 400 });'
+  - 'class StatusError extends Error { constructor(m, s) { super(m); this.status = s; } }'

--- a/ast-grep/rules/harper/no-early-return-in-search-loop.yml
+++ b/ast-grep/rules/harper/no-early-return-in-search-loop.yml
@@ -1,0 +1,27 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-early-return-in-search-loop
+language: typescript
+severity: warning
+message: |
+  Early `return`/`break` out of a `for await (... of tables.X.search(...))` loop
+  leaves Harper's read transaction open — the iterator is abandoned before the
+  scan completes and the transaction is not released, leaking a read handle.
+note: >-
+  Drain or explicitly close the iterator on early exit. Prefer bounding the query
+  so the loop finishes naturally (`search({ ..., limit: 1 })` when you only need
+  the first row), or drive the iterator manually and call `iterator.return?.()`
+  in a `finally` block so Harper releases the read transaction. This is a
+  heuristic — a `break` that belongs to an inner `switch` or a `return` inside a
+  nested callback is a false positive; suppress those with an inline
+  `// ast-grep-ignore: harper-no-early-return-in-search-loop`.
+rule:
+  any:
+    - kind: return_statement
+    - kind: break_statement
+  inside:
+    kind: for_in_statement
+    stopBy: end
+    has:
+      field: right
+      pattern: $ITER.search($$$ARGS)

--- a/ast-grep/rules/harper/no-empty-conditions-with-sort.yml
+++ b/ast-grep/rules/harper/no-empty-conditions-with-sort.yml
@@ -1,0 +1,45 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-empty-conditions-with-sort
+language: typescript
+severity: error
+message: |
+  A Harper `search()` with `sort` but an empty `conditions: []` array crashes
+  the query planner — it cannot seed the btree scan from the sort attribute and
+  throws at runtime (a latent 500 the first time an unfiltered, sorted page is
+  requested).
+note: >-
+  Seed a floor/sentinel condition on the sort attribute so the planner has an
+  index range to walk, e.g. `{ attribute: "lastName", comparator:
+  "greater_than_equal", value: "" }` (or `not_equal: null`), then apply the sort.
+  Centralize this in the page helper (`searchPageAndCount`) rather than
+  duplicating a sentinel at each call site. If a sort-only scan is genuinely
+  intended and the attribute is guaranteed present, suppress with an inline
+  `// ast-grep-ignore: harper-no-empty-conditions-with-sort` and a comment.
+rule:
+  kind: object
+  all:
+    - has:
+        kind: pair
+        all:
+          - has:
+              field: key
+              regex: ^conditions$
+          - has:
+              field: value
+              kind: array
+              regex: "^\\[\\s*\\]$"
+    - has:
+        kind: pair
+        has:
+          field: key
+          regex: ^sort$
+  inside:
+    kind: arguments
+    stopBy: end
+    inside:
+      kind: call_expression
+      stopBy: end
+      has:
+        field: function
+        regex: search$

--- a/ast-grep/rules/harper/no-full-table-scan.yml
+++ b/ast-grep/rules/harper/no-full-table-scan.yml
@@ -1,0 +1,33 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-full-table-scan
+language: typescript
+severity: warning
+message: |
+  Possible full table scan in a Harper resource. Loading a whole table on every
+  request does not scale — one large table (e.g. an employment/event history) was
+  the root cause of multi-second `/Search` and directory responses and a day-long
+  red deploy gate in production.
+note: >-
+  Fetch only the rows you need through an indexed attribute
+  (`rowsByAttribute(tables.$TABLE, "someIndexedId", value)`), or page with
+  `searchPageAndCount` / `search({ conditions, limit, offset })`. A conditionless
+  `tables.$TABLE.search({})` / `search()` and the `allRows` / `optionalAll`
+  helpers read every row. Small lookup tables can be legitimate to scan — this is
+  a warning; if a full scan is genuinely intended (a one-off offline script, never
+  a Resource handler), suppress with an inline
+  `// ast-grep-ignore: harper-no-full-table-scan` and a comment saying why.
+rule:
+  any:
+    # Non-generic full-table reads via common directory helpers.
+    - pattern: allRows(tables.$TABLE)
+    - pattern: optionalAll(tables.$TABLE)
+    # Generic form, e.g. allRows<AdvisorRow>(tables.Advisor): the type argument
+    # nests the callee in an instantiation_expression, so the plain patterns
+    # above miss it. Any single-arg generic call passing the whole table is a
+    # full scan regardless of helper name (the scoped rowsByAttribute helper
+    # takes 3 args and is not matched).
+    - pattern: $FN<$TYPE>(tables.$TABLE)
+    # Raw unconditional table scans.
+    - pattern: tables.$TABLE.search({})
+    - pattern: tables.$TABLE.search()

--- a/ast-grep/rules/harper/require-statuscode-on-thrown-error.yml
+++ b/ast-grep/rules/harper/require-statuscode-on-thrown-error.yml
@@ -1,0 +1,41 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-require-statuscode-on-thrown-error
+language: typescript
+severity: error
+message: |
+  This error carries `status` but not `statusCode`. Harper's thrown-error HTTP
+  response writer reads `error.statusCode` (falling back to 500); a plain
+  `status` is ignored, so every intended 4xx becomes a 500 on the wire.
+note: >-
+  Set `statusCode` (keep `status` too if callers/tests rely on it):
+  `Object.assign(error, { status, statusCode: status })`, or in an Error
+  subclass assign `this.statusCode = status` alongside `this.status`. Verified
+  live on harperdb 4.7.32 — a 401/403/404 thrown with only `status` was served
+  as 500. Direct `err.status = code` assignments are not auto-detected; when you
+  attach an HTTP code to a thrown error, always set `statusCode`.
+rule:
+  any:
+    # `Object.assign(error, { status })` with only a `status` property — the
+    # exact object match excludes the correct `{ status, statusCode }` form.
+    - pattern: 'Object.assign($E, { status: $S })'
+    # Error subclass that assigns `this.status` but never mentions `statusCode`
+    # anywhere in the class body.
+    - pattern: this.status = $S
+      inside:
+        kind: class_declaration
+        stopBy: end
+        all:
+          - has:
+              kind: class_heritage
+              stopBy: end
+              has:
+                kind: extends_clause
+                has:
+                  field: value
+                  regex: Error$
+          - not:
+              has:
+                kind: property_identifier
+                regex: ^statusCode$
+                stopBy: end

--- a/harper-fabric/copy-overwrite/.github/dependabot.yml
+++ b/harper-fabric/copy-overwrite/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+
+# Harper/Fabric override of the TypeScript dependabot template.
+# A fresh Harper/Fabric repo ships with only a `main` branch, so this file
+# omits `target-branch` — Dependabot then opens PRs against the repository's
+# default branch instead of a `dev` branch that does not exist. If a project
+# adopts a long-lived integration branch, set `target-branch` back per updater.
+
+version: 2
+updates:
+  # JavaScript/Node.js dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: 'ci(deps)'

--- a/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-early-return-in-search-loop.yml
+++ b/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-early-return-in-search-loop.yml
@@ -1,0 +1,27 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-early-return-in-search-loop
+language: typescript
+severity: warning
+message: |
+  Early `return`/`break` out of a `for await (... of tables.X.search(...))` loop
+  leaves Harper's read transaction open — the iterator is abandoned before the
+  scan completes and the transaction is not released, leaking a read handle.
+note: >-
+  Drain or explicitly close the iterator on early exit. Prefer bounding the query
+  so the loop finishes naturally (`search({ ..., limit: 1 })` when you only need
+  the first row), or drive the iterator manually and call `iterator.return?.()`
+  in a `finally` block so Harper releases the read transaction. This is a
+  heuristic — a `break` that belongs to an inner `switch` or a `return` inside a
+  nested callback is a false positive; suppress those with an inline
+  `// ast-grep-ignore: harper-no-early-return-in-search-loop`.
+rule:
+  any:
+    - kind: return_statement
+    - kind: break_statement
+  inside:
+    kind: for_in_statement
+    stopBy: end
+    has:
+      field: right
+      pattern: $ITER.search($$$ARGS)

--- a/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-empty-conditions-with-sort.yml
+++ b/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-empty-conditions-with-sort.yml
@@ -1,0 +1,45 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-empty-conditions-with-sort
+language: typescript
+severity: error
+message: |
+  A Harper `search()` with `sort` but an empty `conditions: []` array crashes
+  the query planner — it cannot seed the btree scan from the sort attribute and
+  throws at runtime (a latent 500 the first time an unfiltered, sorted page is
+  requested).
+note: >-
+  Seed a floor/sentinel condition on the sort attribute so the planner has an
+  index range to walk, e.g. `{ attribute: "lastName", comparator:
+  "greater_than_equal", value: "" }` (or `not_equal: null`), then apply the sort.
+  Centralize this in the page helper (`searchPageAndCount`) rather than
+  duplicating a sentinel at each call site. If a sort-only scan is genuinely
+  intended and the attribute is guaranteed present, suppress with an inline
+  `// ast-grep-ignore: harper-no-empty-conditions-with-sort` and a comment.
+rule:
+  kind: object
+  all:
+    - has:
+        kind: pair
+        all:
+          - has:
+              field: key
+              regex: ^conditions$
+          - has:
+              field: value
+              kind: array
+              regex: "^\\[\\s*\\]$"
+    - has:
+        kind: pair
+        has:
+          field: key
+          regex: ^sort$
+  inside:
+    kind: arguments
+    stopBy: end
+    inside:
+      kind: call_expression
+      stopBy: end
+      has:
+        field: function
+        regex: search$

--- a/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-full-table-scan.yml
+++ b/harper-fabric/copy-overwrite/ast-grep/rules/harper/no-full-table-scan.yml
@@ -1,0 +1,33 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-no-full-table-scan
+language: typescript
+severity: warning
+message: |
+  Possible full table scan in a Harper resource. Loading a whole table on every
+  request does not scale — one large table (e.g. an employment/event history) was
+  the root cause of multi-second `/Search` and directory responses and a day-long
+  red deploy gate in production.
+note: >-
+  Fetch only the rows you need through an indexed attribute
+  (`rowsByAttribute(tables.$TABLE, "someIndexedId", value)`), or page with
+  `searchPageAndCount` / `search({ conditions, limit, offset })`. A conditionless
+  `tables.$TABLE.search({})` / `search()` and the `allRows` / `optionalAll`
+  helpers read every row. Small lookup tables can be legitimate to scan — this is
+  a warning; if a full scan is genuinely intended (a one-off offline script, never
+  a Resource handler), suppress with an inline
+  `// ast-grep-ignore: harper-no-full-table-scan` and a comment saying why.
+rule:
+  any:
+    # Non-generic full-table reads via common directory helpers.
+    - pattern: allRows(tables.$TABLE)
+    - pattern: optionalAll(tables.$TABLE)
+    # Generic form, e.g. allRows<AdvisorRow>(tables.Advisor): the type argument
+    # nests the callee in an instantiation_expression, so the plain patterns
+    # above miss it. Any single-arg generic call passing the whole table is a
+    # full scan regardless of helper name (the scoped rowsByAttribute helper
+    # takes 3 args and is not matched).
+    - pattern: $FN<$TYPE>(tables.$TABLE)
+    # Raw unconditional table scans.
+    - pattern: tables.$TABLE.search({})
+    - pattern: tables.$TABLE.search()

--- a/harper-fabric/copy-overwrite/ast-grep/rules/harper/require-statuscode-on-thrown-error.yml
+++ b/harper-fabric/copy-overwrite/ast-grep/rules/harper/require-statuscode-on-thrown-error.yml
@@ -1,0 +1,41 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+id: harper-require-statuscode-on-thrown-error
+language: typescript
+severity: error
+message: |
+  This error carries `status` but not `statusCode`. Harper's thrown-error HTTP
+  response writer reads `error.statusCode` (falling back to 500); a plain
+  `status` is ignored, so every intended 4xx becomes a 500 on the wire.
+note: >-
+  Set `statusCode` (keep `status` too if callers/tests rely on it):
+  `Object.assign(error, { status, statusCode: status })`, or in an Error
+  subclass assign `this.statusCode = status` alongside `this.status`. Verified
+  live on harperdb 4.7.32 — a 401/403/404 thrown with only `status` was served
+  as 500. Direct `err.status = code` assignments are not auto-detected; when you
+  attach an HTTP code to a thrown error, always set `statusCode`.
+rule:
+  any:
+    # `Object.assign(error, { status })` with only a `status` property — the
+    # exact object match excludes the correct `{ status, statusCode }` form.
+    - pattern: 'Object.assign($E, { status: $S })'
+    # Error subclass that assigns `this.status` but never mentions `statusCode`
+    # anywhere in the class body.
+    - pattern: this.status = $S
+      inside:
+        kind: class_declaration
+        stopBy: end
+        all:
+          - has:
+              kind: class_heritage
+              stopBy: end
+              has:
+                kind: extends_clause
+                has:
+                  field: value
+                  regex: Error$
+          - not:
+              has:
+                kind: property_identifier
+                regex: ^statusCode$
+                stopBy: end

--- a/plugins/lisa-harper-fabric-agy/skills/harper-auth/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-auth/SKILL.md
@@ -260,6 +260,54 @@ Guidance:
   webhook must bypass Harper auth, verify its signature first and keep its table
   writes narrowly scoped.
 
+## Session cookies are `SameSite=None` — guard state-changing POSTs
+
+Harper hardcodes the session cookie's `SameSite=None` attribute on HTTPS. The
+browser therefore attaches the session cookie to **cross-site** requests, so a
+same-origin app cannot rely on `SameSite` to block CSRF on cookie-authenticated,
+state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`).
+
+Add an app-side origin check in the resource before mutating. Reject requests
+whose `Origin` (or `Referer` fallback) is not an allowed origin:
+
+```javascript
+const ALLOWED_ORIGINS = new Set([
+  'https://app.example.com',
+]);
+
+function requireSameOrigin(context) {
+  const headers = context.requestContext?.headers ?? context.headers;
+  const origin =
+    headers?.get?.('origin') ??
+    headers?.get?.('referer');
+  const ok =
+    typeof origin === 'string' &&
+    [...ALLOWED_ORIGINS].some((allowed) => origin.startsWith(allowed));
+  if (!ok) {
+    const error = new Error('Cross-origin request rejected');
+    error.statusCode = 403; // Harper reads statusCode, not status
+    throw error;
+  }
+}
+
+export class Watchlists extends tables.Watchlists {
+  static async post(target, data, context) {
+    requireSameOrigin(context);
+    // ...authorization and write
+    return super.post(target, await data, context);
+  }
+}
+```
+
+Guidance:
+
+- Call the check on every cookie-authenticated state-changing route. Read-only
+  `GET` handlers and token/`Authorization: Bearer` APIs (not cookie-driven) do
+  not need it.
+- Prefer an allowlist of exact origins over substring matching that a lookalike
+  host could satisfy.
+- This is defense the app owns; Harper will not add it for you.
+
 ## Verification matrix
 
 Run the local app, create the test users, and check unauthenticated, reader, and

--- a/plugins/lisa-harper-fabric-agy/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-resources/SKILL.md
@@ -74,6 +74,41 @@ See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] f
 how the schema defines the tables resources extend, and [[harper-realtime]] when
 `subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
+## Throwing HTTP status errors
+
+Harper's thrown-error response writer reads **`error.statusCode`** (falling back
+to `500`). A plain `error.status` is **ignored** — throw an error with only
+`status` set and every intended `4xx` is served as a `500`. Verified on
+harperdb 4.7.32.
+
+Always set `statusCode` (keep `status` too only if callers or tests read it):
+
+```javascript
+static async post(target, data, context) {
+  if (!context.user) {
+    const error = new Error('Authentication required');
+    error.statusCode = 401; // NOT `error.status` — Harper reads statusCode
+    throw error;
+  }
+  // ...
+}
+```
+
+A shared helper keeps every throw site correct:
+
+```javascript
+function throwStatus(message, status) {
+  // Set both: `statusCode` is what Harper serves; `status` is kept for
+  // returned-response symmetry and any caller/test that reads it.
+  throw Object.assign(new Error(message), { status, statusCode: status });
+}
+```
+
+The `harper-require-statuscode-on-thrown-error` ast-grep rule flags errors that
+carry `status` without `statusCode`. Pass `context` through to `super` and nested
+table calls so authorization and the request transaction stay aligned — see
+[[harper-rest-queries]] for context propagation and iterator draining.
+
 ## Project conventions (TS is source)
 
 - **Write resources in TypeScript under `src/`. `harper-app/resources.js` is a

--- a/plugins/lisa-harper-fabric-agy/skills/harper-rest-queries/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-rest-queries/SKILL.md
@@ -121,6 +121,38 @@ const products = await tables.Products.search({
 });
 ```
 
+## Sort with no conditions crashes the planner
+
+A `search()` that carries a `sort` but an **empty `conditions: []`** array throws
+at runtime — the planner cannot seed the btree scan from the sort attribute. This
+is a latent `500` the first time an unfiltered, sorted collection page is
+requested (verified on harperdb 4.7.32).
+
+```javascript
+// ✗ crashes: sort with nothing to seed the scan
+tables.Advisor.search({
+  conditions: [],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Seed a floor/sentinel condition on the sort attribute so the planner has an index
+range to walk, then apply the sort:
+
+```javascript
+// ✓ floor condition on the sort attribute seeds the scan
+tables.Advisor.search({
+  conditions: [
+    { attribute: 'lastName', comparator: 'greater_than_equal', value: '' },
+  ],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Centralize this in the page helper (`searchPageAndCount`) rather than duplicating
+a sentinel at each call site. The `harper-no-empty-conditions-with-sort` ast-grep
+rule flags the crashing shape.
+
 ## Relationship queries
 
 Relationship attributes can be queried with dot syntax when the relationship is
@@ -200,9 +232,14 @@ Useful query keys:
 | `select` | Projection list. Keep admin-only fields out of public responses. |
 | `explain` | Debug execution order and index usage while tuning. |
 
-`search()` can return an `AsyncIterable`. When iterating manually or stopping
-early, drain it or call the iterator's `return()` in `finally` so Harper can
-release the read transaction:
+`search()` can return an `AsyncIterable`. An early `return`/`break` out of a
+`for await (... of tables.X.search(...))` loop abandons the iterator before the
+scan completes and **leaks the open read transaction** (verified on
+harperdb 4.7.32). When iterating manually or stopping early, drain it or call the
+iterator's `return()` in `finally` so Harper releases the read transaction — or
+bound the query (`search({ ..., limit: 1 })`) when you only need the first row.
+The `harper-no-early-return-in-search-loop` ast-grep rule flags early exits from
+these loops:
 
 ```javascript
 const iterator = tables.Products

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-auth/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-auth/SKILL.md
@@ -260,6 +260,54 @@ Guidance:
   webhook must bypass Harper auth, verify its signature first and keep its table
   writes narrowly scoped.
 
+## Session cookies are `SameSite=None` — guard state-changing POSTs
+
+Harper hardcodes the session cookie's `SameSite=None` attribute on HTTPS. The
+browser therefore attaches the session cookie to **cross-site** requests, so a
+same-origin app cannot rely on `SameSite` to block CSRF on cookie-authenticated,
+state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`).
+
+Add an app-side origin check in the resource before mutating. Reject requests
+whose `Origin` (or `Referer` fallback) is not an allowed origin:
+
+```javascript
+const ALLOWED_ORIGINS = new Set([
+  'https://app.example.com',
+]);
+
+function requireSameOrigin(context) {
+  const headers = context.requestContext?.headers ?? context.headers;
+  const origin =
+    headers?.get?.('origin') ??
+    headers?.get?.('referer');
+  const ok =
+    typeof origin === 'string' &&
+    [...ALLOWED_ORIGINS].some((allowed) => origin.startsWith(allowed));
+  if (!ok) {
+    const error = new Error('Cross-origin request rejected');
+    error.statusCode = 403; // Harper reads statusCode, not status
+    throw error;
+  }
+}
+
+export class Watchlists extends tables.Watchlists {
+  static async post(target, data, context) {
+    requireSameOrigin(context);
+    // ...authorization and write
+    return super.post(target, await data, context);
+  }
+}
+```
+
+Guidance:
+
+- Call the check on every cookie-authenticated state-changing route. Read-only
+  `GET` handlers and token/`Authorization: Bearer` APIs (not cookie-driven) do
+  not need it.
+- Prefer an allowlist of exact origins over substring matching that a lookalike
+  host could satisfy.
+- This is defense the app owns; Harper will not add it for you.
+
 ## Verification matrix
 
 Run the local app, create the test users, and check unauthenticated, reader, and

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-resources/SKILL.md
@@ -74,6 +74,41 @@ See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] f
 how the schema defines the tables resources extend, and [[harper-realtime]] when
 `subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
+## Throwing HTTP status errors
+
+Harper's thrown-error response writer reads **`error.statusCode`** (falling back
+to `500`). A plain `error.status` is **ignored** — throw an error with only
+`status` set and every intended `4xx` is served as a `500`. Verified on
+harperdb 4.7.32.
+
+Always set `statusCode` (keep `status` too only if callers or tests read it):
+
+```javascript
+static async post(target, data, context) {
+  if (!context.user) {
+    const error = new Error('Authentication required');
+    error.statusCode = 401; // NOT `error.status` — Harper reads statusCode
+    throw error;
+  }
+  // ...
+}
+```
+
+A shared helper keeps every throw site correct:
+
+```javascript
+function throwStatus(message, status) {
+  // Set both: `statusCode` is what Harper serves; `status` is kept for
+  // returned-response symmetry and any caller/test that reads it.
+  throw Object.assign(new Error(message), { status, statusCode: status });
+}
+```
+
+The `harper-require-statuscode-on-thrown-error` ast-grep rule flags errors that
+carry `status` without `statusCode`. Pass `context` through to `super` and nested
+table calls so authorization and the request transaction stay aligned — see
+[[harper-rest-queries]] for context propagation and iterator draining.
+
 ## Project conventions (TS is source)
 
 - **Write resources in TypeScript under `src/`. `harper-app/resources.js` is a

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-rest-queries/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-rest-queries/SKILL.md
@@ -121,6 +121,38 @@ const products = await tables.Products.search({
 });
 ```
 
+## Sort with no conditions crashes the planner
+
+A `search()` that carries a `sort` but an **empty `conditions: []`** array throws
+at runtime — the planner cannot seed the btree scan from the sort attribute. This
+is a latent `500` the first time an unfiltered, sorted collection page is
+requested (verified on harperdb 4.7.32).
+
+```javascript
+// ✗ crashes: sort with nothing to seed the scan
+tables.Advisor.search({
+  conditions: [],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Seed a floor/sentinel condition on the sort attribute so the planner has an index
+range to walk, then apply the sort:
+
+```javascript
+// ✓ floor condition on the sort attribute seeds the scan
+tables.Advisor.search({
+  conditions: [
+    { attribute: 'lastName', comparator: 'greater_than_equal', value: '' },
+  ],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Centralize this in the page helper (`searchPageAndCount`) rather than duplicating
+a sentinel at each call site. The `harper-no-empty-conditions-with-sort` ast-grep
+rule flags the crashing shape.
+
 ## Relationship queries
 
 Relationship attributes can be queried with dot syntax when the relationship is
@@ -200,9 +232,14 @@ Useful query keys:
 | `select` | Projection list. Keep admin-only fields out of public responses. |
 | `explain` | Debug execution order and index usage while tuning. |
 
-`search()` can return an `AsyncIterable`. When iterating manually or stopping
-early, drain it or call the iterator's `return()` in `finally` so Harper can
-release the read transaction:
+`search()` can return an `AsyncIterable`. An early `return`/`break` out of a
+`for await (... of tables.X.search(...))` loop abandons the iterator before the
+scan completes and **leaks the open read transaction** (verified on
+harperdb 4.7.32). When iterating manually or stopping early, drain it or call the
+iterator's `return()` in `finally` so Harper releases the read transaction — or
+bound the query (`search({ ..., limit: 1 })`) when you only need the first row.
+The `harper-no-early-return-in-search-loop` ast-grep rule flags early exits from
+these loops:
 
 ```javascript
 const iterator = tables.Products

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-auth/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-auth/SKILL.md
@@ -260,6 +260,54 @@ Guidance:
   webhook must bypass Harper auth, verify its signature first and keep its table
   writes narrowly scoped.
 
+## Session cookies are `SameSite=None` — guard state-changing POSTs
+
+Harper hardcodes the session cookie's `SameSite=None` attribute on HTTPS. The
+browser therefore attaches the session cookie to **cross-site** requests, so a
+same-origin app cannot rely on `SameSite` to block CSRF on cookie-authenticated,
+state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`).
+
+Add an app-side origin check in the resource before mutating. Reject requests
+whose `Origin` (or `Referer` fallback) is not an allowed origin:
+
+```javascript
+const ALLOWED_ORIGINS = new Set([
+  'https://app.example.com',
+]);
+
+function requireSameOrigin(context) {
+  const headers = context.requestContext?.headers ?? context.headers;
+  const origin =
+    headers?.get?.('origin') ??
+    headers?.get?.('referer');
+  const ok =
+    typeof origin === 'string' &&
+    [...ALLOWED_ORIGINS].some((allowed) => origin.startsWith(allowed));
+  if (!ok) {
+    const error = new Error('Cross-origin request rejected');
+    error.statusCode = 403; // Harper reads statusCode, not status
+    throw error;
+  }
+}
+
+export class Watchlists extends tables.Watchlists {
+  static async post(target, data, context) {
+    requireSameOrigin(context);
+    // ...authorization and write
+    return super.post(target, await data, context);
+  }
+}
+```
+
+Guidance:
+
+- Call the check on every cookie-authenticated state-changing route. Read-only
+  `GET` handlers and token/`Authorization: Bearer` APIs (not cookie-driven) do
+  not need it.
+- Prefer an allowlist of exact origins over substring matching that a lookalike
+  host could satisfy.
+- This is defense the app owns; Harper will not add it for you.
+
 ## Verification matrix
 
 Run the local app, create the test users, and check unauthenticated, reader, and

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-resources/SKILL.md
@@ -74,6 +74,41 @@ See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] f
 how the schema defines the tables resources extend, and [[harper-realtime]] when
 `subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
+## Throwing HTTP status errors
+
+Harper's thrown-error response writer reads **`error.statusCode`** (falling back
+to `500`). A plain `error.status` is **ignored** — throw an error with only
+`status` set and every intended `4xx` is served as a `500`. Verified on
+harperdb 4.7.32.
+
+Always set `statusCode` (keep `status` too only if callers or tests read it):
+
+```javascript
+static async post(target, data, context) {
+  if (!context.user) {
+    const error = new Error('Authentication required');
+    error.statusCode = 401; // NOT `error.status` — Harper reads statusCode
+    throw error;
+  }
+  // ...
+}
+```
+
+A shared helper keeps every throw site correct:
+
+```javascript
+function throwStatus(message, status) {
+  // Set both: `statusCode` is what Harper serves; `status` is kept for
+  // returned-response symmetry and any caller/test that reads it.
+  throw Object.assign(new Error(message), { status, statusCode: status });
+}
+```
+
+The `harper-require-statuscode-on-thrown-error` ast-grep rule flags errors that
+carry `status` without `statusCode`. Pass `context` through to `super` and nested
+table calls so authorization and the request transaction stay aligned — see
+[[harper-rest-queries]] for context propagation and iterator draining.
+
 ## Project conventions (TS is source)
 
 - **Write resources in TypeScript under `src/`. `harper-app/resources.js` is a

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-rest-queries/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-rest-queries/SKILL.md
@@ -121,6 +121,38 @@ const products = await tables.Products.search({
 });
 ```
 
+## Sort with no conditions crashes the planner
+
+A `search()` that carries a `sort` but an **empty `conditions: []`** array throws
+at runtime — the planner cannot seed the btree scan from the sort attribute. This
+is a latent `500` the first time an unfiltered, sorted collection page is
+requested (verified on harperdb 4.7.32).
+
+```javascript
+// ✗ crashes: sort with nothing to seed the scan
+tables.Advisor.search({
+  conditions: [],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Seed a floor/sentinel condition on the sort attribute so the planner has an index
+range to walk, then apply the sort:
+
+```javascript
+// ✓ floor condition on the sort attribute seeds the scan
+tables.Advisor.search({
+  conditions: [
+    { attribute: 'lastName', comparator: 'greater_than_equal', value: '' },
+  ],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Centralize this in the page helper (`searchPageAndCount`) rather than duplicating
+a sentinel at each call site. The `harper-no-empty-conditions-with-sort` ast-grep
+rule flags the crashing shape.
+
 ## Relationship queries
 
 Relationship attributes can be queried with dot syntax when the relationship is
@@ -200,9 +232,14 @@ Useful query keys:
 | `select` | Projection list. Keep admin-only fields out of public responses. |
 | `explain` | Debug execution order and index usage while tuning. |
 
-`search()` can return an `AsyncIterable`. When iterating manually or stopping
-early, drain it or call the iterator's `return()` in `finally` so Harper can
-release the read transaction:
+`search()` can return an `AsyncIterable`. An early `return`/`break` out of a
+`for await (... of tables.X.search(...))` loop abandons the iterator before the
+scan completes and **leaks the open read transaction** (verified on
+harperdb 4.7.32). When iterating manually or stopping early, drain it or call the
+iterator's `return()` in `finally` so Harper releases the read transaction — or
+bound the query (`search({ ..., limit: 1 })`) when you only need the first row.
+The `harper-no-early-return-in-search-loop` ast-grep rule flags early exits from
+these loops:
 
 ```javascript
 const iterator = tables.Products

--- a/plugins/lisa-harper-fabric/skills/harper-auth/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-auth/SKILL.md
@@ -260,6 +260,54 @@ Guidance:
   webhook must bypass Harper auth, verify its signature first and keep its table
   writes narrowly scoped.
 
+## Session cookies are `SameSite=None` — guard state-changing POSTs
+
+Harper hardcodes the session cookie's `SameSite=None` attribute on HTTPS. The
+browser therefore attaches the session cookie to **cross-site** requests, so a
+same-origin app cannot rely on `SameSite` to block CSRF on cookie-authenticated,
+state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`).
+
+Add an app-side origin check in the resource before mutating. Reject requests
+whose `Origin` (or `Referer` fallback) is not an allowed origin:
+
+```javascript
+const ALLOWED_ORIGINS = new Set([
+  'https://app.example.com',
+]);
+
+function requireSameOrigin(context) {
+  const headers = context.requestContext?.headers ?? context.headers;
+  const origin =
+    headers?.get?.('origin') ??
+    headers?.get?.('referer');
+  const ok =
+    typeof origin === 'string' &&
+    [...ALLOWED_ORIGINS].some((allowed) => origin.startsWith(allowed));
+  if (!ok) {
+    const error = new Error('Cross-origin request rejected');
+    error.statusCode = 403; // Harper reads statusCode, not status
+    throw error;
+  }
+}
+
+export class Watchlists extends tables.Watchlists {
+  static async post(target, data, context) {
+    requireSameOrigin(context);
+    // ...authorization and write
+    return super.post(target, await data, context);
+  }
+}
+```
+
+Guidance:
+
+- Call the check on every cookie-authenticated state-changing route. Read-only
+  `GET` handlers and token/`Authorization: Bearer` APIs (not cookie-driven) do
+  not need it.
+- Prefer an allowlist of exact origins over substring matching that a lookalike
+  host could satisfy.
+- This is defense the app owns; Harper will not add it for you.
+
 ## Verification matrix
 
 Run the local app, create the test users, and check unauthenticated, reader, and

--- a/plugins/lisa-harper-fabric/skills/harper-resources/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-resources/SKILL.md
@@ -74,6 +74,41 @@ See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] f
 how the schema defines the tables resources extend, and [[harper-realtime]] when
 `subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
+## Throwing HTTP status errors
+
+Harper's thrown-error response writer reads **`error.statusCode`** (falling back
+to `500`). A plain `error.status` is **ignored** — throw an error with only
+`status` set and every intended `4xx` is served as a `500`. Verified on
+harperdb 4.7.32.
+
+Always set `statusCode` (keep `status` too only if callers or tests read it):
+
+```javascript
+static async post(target, data, context) {
+  if (!context.user) {
+    const error = new Error('Authentication required');
+    error.statusCode = 401; // NOT `error.status` — Harper reads statusCode
+    throw error;
+  }
+  // ...
+}
+```
+
+A shared helper keeps every throw site correct:
+
+```javascript
+function throwStatus(message, status) {
+  // Set both: `statusCode` is what Harper serves; `status` is kept for
+  // returned-response symmetry and any caller/test that reads it.
+  throw Object.assign(new Error(message), { status, statusCode: status });
+}
+```
+
+The `harper-require-statuscode-on-thrown-error` ast-grep rule flags errors that
+carry `status` without `statusCode`. Pass `context` through to `super` and nested
+table calls so authorization and the request transaction stay aligned — see
+[[harper-rest-queries]] for context propagation and iterator draining.
+
 ## Project conventions (TS is source)
 
 - **Write resources in TypeScript under `src/`. `harper-app/resources.js` is a

--- a/plugins/lisa-harper-fabric/skills/harper-rest-queries/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-rest-queries/SKILL.md
@@ -121,6 +121,38 @@ const products = await tables.Products.search({
 });
 ```
 
+## Sort with no conditions crashes the planner
+
+A `search()` that carries a `sort` but an **empty `conditions: []`** array throws
+at runtime — the planner cannot seed the btree scan from the sort attribute. This
+is a latent `500` the first time an unfiltered, sorted collection page is
+requested (verified on harperdb 4.7.32).
+
+```javascript
+// ✗ crashes: sort with nothing to seed the scan
+tables.Advisor.search({
+  conditions: [],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Seed a floor/sentinel condition on the sort attribute so the planner has an index
+range to walk, then apply the sort:
+
+```javascript
+// ✓ floor condition on the sort attribute seeds the scan
+tables.Advisor.search({
+  conditions: [
+    { attribute: 'lastName', comparator: 'greater_than_equal', value: '' },
+  ],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Centralize this in the page helper (`searchPageAndCount`) rather than duplicating
+a sentinel at each call site. The `harper-no-empty-conditions-with-sort` ast-grep
+rule flags the crashing shape.
+
 ## Relationship queries
 
 Relationship attributes can be queried with dot syntax when the relationship is
@@ -200,9 +232,14 @@ Useful query keys:
 | `select` | Projection list. Keep admin-only fields out of public responses. |
 | `explain` | Debug execution order and index usage while tuning. |
 
-`search()` can return an `AsyncIterable`. When iterating manually or stopping
-early, drain it or call the iterator's `return()` in `finally` so Harper can
-release the read transaction:
+`search()` can return an `AsyncIterable`. An early `return`/`break` out of a
+`for await (... of tables.X.search(...))` loop abandons the iterator before the
+scan completes and **leaks the open read transaction** (verified on
+harperdb 4.7.32). When iterating manually or stopping early, drain it or call the
+iterator's `return()` in `finally` so Harper releases the read transaction — or
+bound the query (`search({ ..., limit: 1 })`) when you only need the first row.
+The `harper-no-early-return-in-search-loop` ast-grep rule flags early exits from
+these loops:
 
 ```javascript
 const iterator = tables.Products

--- a/plugins/src/harper-fabric/skills/harper-auth/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-auth/SKILL.md
@@ -260,6 +260,54 @@ Guidance:
   webhook must bypass Harper auth, verify its signature first and keep its table
   writes narrowly scoped.
 
+## Session cookies are `SameSite=None` — guard state-changing POSTs
+
+Harper hardcodes the session cookie's `SameSite=None` attribute on HTTPS. The
+browser therefore attaches the session cookie to **cross-site** requests, so a
+same-origin app cannot rely on `SameSite` to block CSRF on cookie-authenticated,
+state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`).
+
+Add an app-side origin check in the resource before mutating. Reject requests
+whose `Origin` (or `Referer` fallback) is not an allowed origin:
+
+```javascript
+const ALLOWED_ORIGINS = new Set([
+  'https://app.example.com',
+]);
+
+function requireSameOrigin(context) {
+  const headers = context.requestContext?.headers ?? context.headers;
+  const origin =
+    headers?.get?.('origin') ??
+    headers?.get?.('referer');
+  const ok =
+    typeof origin === 'string' &&
+    [...ALLOWED_ORIGINS].some((allowed) => origin.startsWith(allowed));
+  if (!ok) {
+    const error = new Error('Cross-origin request rejected');
+    error.statusCode = 403; // Harper reads statusCode, not status
+    throw error;
+  }
+}
+
+export class Watchlists extends tables.Watchlists {
+  static async post(target, data, context) {
+    requireSameOrigin(context);
+    // ...authorization and write
+    return super.post(target, await data, context);
+  }
+}
+```
+
+Guidance:
+
+- Call the check on every cookie-authenticated state-changing route. Read-only
+  `GET` handlers and token/`Authorization: Bearer` APIs (not cookie-driven) do
+  not need it.
+- Prefer an allowlist of exact origins over substring matching that a lookalike
+  host could satisfy.
+- This is defense the app owns; Harper will not add it for you.
+
 ## Verification matrix
 
 Run the local app, create the test users, and check unauthenticated, reader, and

--- a/plugins/src/harper-fabric/skills/harper-resources/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-resources/SKILL.md
@@ -74,6 +74,41 @@ See [[harper-config-yaml]] for the extension wiring, [[harper-schema-graphql]] f
 how the schema defines the tables resources extend, and [[harper-realtime]] when
 `subscribe`, `publish`, or WebSocket behavior is part of the feature.
 
+## Throwing HTTP status errors
+
+Harper's thrown-error response writer reads **`error.statusCode`** (falling back
+to `500`). A plain `error.status` is **ignored** — throw an error with only
+`status` set and every intended `4xx` is served as a `500`. Verified on
+harperdb 4.7.32.
+
+Always set `statusCode` (keep `status` too only if callers or tests read it):
+
+```javascript
+static async post(target, data, context) {
+  if (!context.user) {
+    const error = new Error('Authentication required');
+    error.statusCode = 401; // NOT `error.status` — Harper reads statusCode
+    throw error;
+  }
+  // ...
+}
+```
+
+A shared helper keeps every throw site correct:
+
+```javascript
+function throwStatus(message, status) {
+  // Set both: `statusCode` is what Harper serves; `status` is kept for
+  // returned-response symmetry and any caller/test that reads it.
+  throw Object.assign(new Error(message), { status, statusCode: status });
+}
+```
+
+The `harper-require-statuscode-on-thrown-error` ast-grep rule flags errors that
+carry `status` without `statusCode`. Pass `context` through to `super` and nested
+table calls so authorization and the request transaction stay aligned — see
+[[harper-rest-queries]] for context propagation and iterator draining.
+
 ## Project conventions (TS is source)
 
 - **Write resources in TypeScript under `src/`. `harper-app/resources.js` is a

--- a/plugins/src/harper-fabric/skills/harper-rest-queries/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-rest-queries/SKILL.md
@@ -121,6 +121,38 @@ const products = await tables.Products.search({
 });
 ```
 
+## Sort with no conditions crashes the planner
+
+A `search()` that carries a `sort` but an **empty `conditions: []`** array throws
+at runtime — the planner cannot seed the btree scan from the sort attribute. This
+is a latent `500` the first time an unfiltered, sorted collection page is
+requested (verified on harperdb 4.7.32).
+
+```javascript
+// ✗ crashes: sort with nothing to seed the scan
+tables.Advisor.search({
+  conditions: [],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Seed a floor/sentinel condition on the sort attribute so the planner has an index
+range to walk, then apply the sort:
+
+```javascript
+// ✓ floor condition on the sort attribute seeds the scan
+tables.Advisor.search({
+  conditions: [
+    { attribute: 'lastName', comparator: 'greater_than_equal', value: '' },
+  ],
+  sort: { attribute: 'lastName' },
+});
+```
+
+Centralize this in the page helper (`searchPageAndCount`) rather than duplicating
+a sentinel at each call site. The `harper-no-empty-conditions-with-sort` ast-grep
+rule flags the crashing shape.
+
 ## Relationship queries
 
 Relationship attributes can be queried with dot syntax when the relationship is
@@ -200,9 +232,14 @@ Useful query keys:
 | `select` | Projection list. Keep admin-only fields out of public responses. |
 | `explain` | Debug execution order and index usage while tuning. |
 
-`search()` can return an `AsyncIterable`. When iterating manually or stopping
-early, drain it or call the iterator's `return()` in `finally` so Harper can
-release the read transaction:
+`search()` can return an `AsyncIterable`. An early `return`/`break` out of a
+`for await (... of tables.X.search(...))` loop abandons the iterator before the
+scan completes and **leaks the open read transaction** (verified on
+harperdb 4.7.32). When iterating manually or stopping early, drain it or call the
+iterator's `return()` in `finally` so Harper releases the read transaction — or
+bound the query (`search({ ..., limit: 1 })`) when you only need the first row.
+The `harper-no-early-return-in-search-loop` ast-grep rule flags early exits from
+these loops:
 
 ```javascript
 const iterator = tables.Products


### PR DESCRIPTION
## What & why

Upstreams four production defects (verified live on **harperdb 4.7.32** in the `advisory-rankings` consuming project) into the Lisa `harper-fabric` project type — as enforced ast-grep rules, shipped templates, and documented skill gotchas. Track B of the Harper best-practices review.

## ast-grep rules

New `ast-grep/rules/harper/` (mirrored into `harper-fabric/copy-overwrite/` so consuming projects inherit them), each with rule-tests + snapshots under `ast-grep/rule-tests/`:

| Rule | Severity | Defect it encodes |
|---|---|---|
| `harper-no-full-table-scan` | warning | Generalizes the project `no-full-scan` rule from a hardcoded table to `tables.$TABLE`. Flags `allRows`/`optionalAll`/generic single-arg table reads and conditionless `.search({})`/`.search()`. A large table scanned per request caused multi-second `/Search` responses. Warning, since small-table scans can be legitimate. |
| `harper-require-statuscode-on-thrown-error` | error | Harper's thrown-error HTTP writer reads `error.statusCode` (falls back to 500). An error carrying only `status` turns every intended 4xx into a 500. Flags `Object.assign(e, { status })` (single-prop) and `Error` subclasses that set `this.status` with no `statusCode` in the class body. |
| `harper-no-empty-conditions-with-sort` | error | `search({ conditions: [], sort })` crashes the query planner — it cannot seed the btree scan from the sort attribute. A latent 500 the first time an unfiltered, sorted page is requested. |
| `harper-no-early-return-in-search-loop` | warning | An early `return`/`break` out of `for await (... of tables.X.search(...))` abandons the iterator and leaks the open read transaction. Warning, since the rule cannot see a `finally` drain (suppress documented). |

All rules verified to produce **zero matches against Lisa's own `src/`** (`sg:scan` exits 0); false-positive surfaces (generic helper calls, switch-`break`, nested-callback `return`) are documented with inline-suppression guidance in each rule's `note`.

## Template + skills

- **`harper-fabric/copy-overwrite/.github/dependabot.yml`** — scoped override of the TypeScript template that **omits `target-branch: dev`**. A fresh Harper repo has only `main`, so Dependabot now targets the default branch instead of a nonexistent `dev`. (Scoped to `harper-fabric` — the shared TypeScript template is untouched.)
- **Skills** (`plugins/src/harper-fabric/skills/`):
  - `harper-resources` — new "Throwing HTTP status errors" section (statusCode-not-status, shared `throwStatus` helper, context propagation).
  - `harper-rest-queries` — documents the empty-conditions+sort crash and the sentinel/floor-condition fix; expands the iterator-drain note to call out the read-transaction leak on early loop exit.
  - `harper-auth` — documents Harper's hardcoded `SameSite=None` session cookie and the app-side origin check required on cookie-authenticated state-changing POSTs.
- Rebuilt plugin variants (claude/agy/copilot/cursor).

## Gates

- `bunx ast-grep test` — 6 passed / 0 failed
- `bun run sg:scan` — exit 0 (no matches in Lisa's own src)
- `bun run check:plugins` — artifacts in sync, marketplace registered
- `bun run check:rules-pairing` — all eager rules paired
- pre-commit typecheck + prettier — clean

## Not in this PR (parallel tracks)

Impl templates (deploy libs, offset-cursor, seo_shell, smoke retry) are going to `harperstarter`, not Lisa. No package version bump (standard-version handles it at release).

🤖 Generated with Claude Code