### PR TITLE
fix(harper-fabric): protect all root-level compiled harper-app modules

### DIFF
--- a/harper-fabric/copy-contents/.prettierignore
+++ b/harper-fabric/copy-contents/.prettierignore
@@ -4,6 +4,7 @@
 # source formatting inputs.
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**
 research/articles/

--- a/harper-fabric/copy-contents/gitignore
+++ b/harper-fabric/copy-contents/gitignore
@@ -1,6 +1,13 @@
 # BEGIN: AI GUARDRAILS HARPER-FABRIC
+# Compiled Harper modules are emitted straight into harper-app/ from src/. The
+# root-level `harper-app/*.js` rule covers resources.js, resource-*.js, and any
+# other build output (e.g. detail-shell-negotiation.js) without matching
+# hand-written shims nested one level down (harper-app/<route>/index.js). If you
+# keep a hand-written .js at the harper-app root (e.g. an SEO shell), re-include
+# it with a `!harper-app/<file>.js` line placed BELOW this managed block.
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**
 .lisabak/

--- a/harper-fabric/copy-overwrite/knip.json
+++ b/harper-fabric/copy-overwrite/knip.json
@@ -15,6 +15,7 @@
     "**/node_modules/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
+    "harper-app/*.js",
     "harper-app/web/**",
     "harper-app/lib/**"
   ],

--- a/harper-fabric/copy-overwrite/tsconfig.eslint.json
+++ b/harper-fabric/copy-overwrite/tsconfig.eslint.json
@@ -22,6 +22,7 @@
     "coverage",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
+    "harper-app/*.js",
     "harper-app/web/**",
     "harper-app/lib/**"
   ]

--- a/harper-fabric/merge/.oxlintrc.json
+++ b/harper-fabric/merge/.oxlintrc.json
@@ -12,6 +12,7 @@
     "**/generated/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
+    "harper-app/*.js",
     "harper-app/web/**",
     "harper-app/lib/**"
   ]

--- a/oxlint/harper-fabric.json
+++ b/oxlint/harper-fabric.json
@@ -7,6 +7,7 @@
     "node_modules/**",
     "harper-app/resources.js",
     "harper-app/resource-*.js",
+    "harper-app/*.js",
     "harper-app/web/**",
     "harper-app/lib/**"
   ]

--- a/plugins/lisa-harper-fabric-agy/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-agy/generated-artifact-globs.txt
@@ -1,4 +1,5 @@
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**

--- a/plugins/lisa-harper-fabric-agy/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-agy/skills/harper-build-and-deploy/SKILL.md
@@ -50,15 +50,30 @@ What the build actually does:
 
 Generated Harper deploy artifacts usually include:
 
-- `harper-app/resources.js`
-- `harper-app/resource-*.js`
+- `harper-app/*.js` — every compiled module the build emits to the harper-app
+  root (`resources.js`, `resource-*.js`, and any other output such as a route
+  negotiation module). The single-star does **not** cross a directory separator,
+  so it does not match hand-written shims one level down.
 - `harper-app/web/**`
 - `harper-app/lib/**`
 
+The guard surfaces (`generated-artifact-globs.txt` for the PreToolUse block hook,
+`.gitignore`, `.prettierignore`, the ESLint/oxlint/knip ignores, and
+`tsconfig.eslint.json`) all key off `harper-app/*.js` so a newly-named compiled
+module is protected automatically. **Name compiled resource modules
+`resource-*.ts`** so their JS output is unambiguously generated.
+
+If you keep a *hand-written* `.js` at the harper-app root (e.g. an SEO shell),
+the root-level rule would otherwise treat it as generated: re-include it with a
+`!harper-app/<file>.js` line below the managed gitignore block, and add it to
+`.lisa/harper-generated-artifact-allowlist.txt` so the block hook lets you edit
+it. Hand-written shims nested under `harper-app/<route>/index.js` need no
+exemption — the root-level rule never matches them.
+
 Every lint, format, dead-code, search, or generated-artifact guard must ignore
-those generated paths unless it is explicitly validating the build output itself.
-When a new generated path appears, add it to every relevant ignore surface in the
-same change; partial ignores fail later gates in non-obvious ways.
+generated paths unless it is explicitly validating the build output itself. When
+a new generated *directory* appears, add it to every relevant ignore surface in
+the same change; partial ignores fail later gates in non-obvious ways.
 
 - **TypeScript under `src/` is source.** `bun run build` produces the deployable
   Harper assets from it.

--- a/plugins/lisa-harper-fabric-copilot/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-copilot/generated-artifact-globs.txt
@@ -1,4 +1,5 @@
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**

--- a/plugins/lisa-harper-fabric-copilot/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric-copilot/hooks/block-generated-artifact-edits.sh
@@ -33,6 +33,7 @@ matches_glob() {
   local file="$1"
   local glob="$2"
 
+  # Recursive directory globs: "dir/**" matches everything under dir.
   if [ "${glob: -3}" = "/**" ]; then
     local dir="${glob%/**}"
     case "$file" in
@@ -41,6 +42,38 @@ matches_glob() {
     return 1
   fi
 
+  # Single-star globs like "harper-app/*.js": the star must not cross a
+  # directory separator, so a broadened root-level pattern protects compiled
+  # modules emitted straight into harper-app/ (resources.js, resource-*.js, and
+  # any other build output such as detail-shell-negotiation.js) WITHOUT matching
+  # hand-written files nested one level down (e.g. harper-app/<route>/index.js).
+  case "$glob" in
+    */\** | \**)
+      local base_glob="${glob##*/}"
+      local dir_glob=""
+      case "$glob" in
+        */*) dir_glob="${glob%/*}" ;;
+      esac
+      local file_base="${file##*/}"
+      local file_dir=""
+      case "$file" in
+        */*) file_dir="${file%/*}" ;;
+      esac
+      case "$file_base" in
+        $base_glob) ;;
+        *) return 1 ;;
+      esac
+      [ -z "$dir_glob" ] && return 0
+      # Match the directory exactly, or as a suffix so absolute/prefixed paths
+      # (e.g. /repo/harper-app/foo.js) still resolve.
+      case "$file_dir" in
+        $dir_glob | */"$dir_glob") return 0 ;;
+      esac
+      return 1
+      ;;
+  esac
+
+  # Literal (wildcard-free) globs.
   case "$file" in
     $glob | */$glob) return 0 ;;
   esac
@@ -49,6 +82,24 @@ matches_glob() {
 }
 
 NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+# Project-owned allowlist of hand-written files that live under harper-app/ and
+# must NOT be treated as generated (e.g. a hand-authored SEO shell, or route
+# index.js shims kept at the harper-app root). The broadened root-level
+# `harper-app/*.js` protection would otherwise block editing them. One glob per
+# line (same syntax as the globs file); blank lines and `#` comments ignored.
+# Prefer naming compiled resource modules `resource-*.ts` so their JS output is
+# unambiguously generated and never needs allowlisting.
+ALLOWLIST_FILE="${CLAUDE_PROJECT_DIR:-.}/.lisa/harper-generated-artifact-allowlist.txt"
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r allow || [ -n "$allow" ]; do
+    [ -n "$allow" ] || continue
+    case "$allow" in \#*) continue ;; esac
+    if matches_glob "$NORMALIZED_FILE" "$allow"; then
+      exit 0
+    fi
+  done <"$ALLOWLIST_FILE"
+fi
 
 while IFS= read -r glob || [ -n "$glob" ]; do
   [ -n "$glob" ] || continue

--- a/plugins/lisa-harper-fabric-copilot/rules/harper-fabric.md
+++ b/plugins/lisa-harper-fabric-copilot/rules/harper-fabric.md
@@ -13,7 +13,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
 - `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
-- `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
+- Every `.js` at the harper-app root (`harper-app/*.js` — `resources.js`, `resource-*.js`, and any other compiled module) plus `harper-app/web/**/*.js` and `harper-app/lib/**` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`. Name compiled resource modules `resource-*.ts` so their output is unambiguously generated; a hand-written `.js` kept at the harper-app root must be re-included in `.gitignore` and listed in `.lisa/harper-generated-artifact-allowlist.txt` so the block hook allows editing it.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 
 ## Harper/Fabric Deploy Surface

--- a/plugins/lisa-harper-fabric-copilot/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-copilot/skills/harper-build-and-deploy/SKILL.md
@@ -50,15 +50,30 @@ What the build actually does:
 
 Generated Harper deploy artifacts usually include:
 
-- `harper-app/resources.js`
-- `harper-app/resource-*.js`
+- `harper-app/*.js` — every compiled module the build emits to the harper-app
+  root (`resources.js`, `resource-*.js`, and any other output such as a route
+  negotiation module). The single-star does **not** cross a directory separator,
+  so it does not match hand-written shims one level down.
 - `harper-app/web/**`
 - `harper-app/lib/**`
 
+The guard surfaces (`generated-artifact-globs.txt` for the PreToolUse block hook,
+`.gitignore`, `.prettierignore`, the ESLint/oxlint/knip ignores, and
+`tsconfig.eslint.json`) all key off `harper-app/*.js` so a newly-named compiled
+module is protected automatically. **Name compiled resource modules
+`resource-*.ts`** so their JS output is unambiguously generated.
+
+If you keep a *hand-written* `.js` at the harper-app root (e.g. an SEO shell),
+the root-level rule would otherwise treat it as generated: re-include it with a
+`!harper-app/<file>.js` line below the managed gitignore block, and add it to
+`.lisa/harper-generated-artifact-allowlist.txt` so the block hook lets you edit
+it. Hand-written shims nested under `harper-app/<route>/index.js` need no
+exemption — the root-level rule never matches them.
+
 Every lint, format, dead-code, search, or generated-artifact guard must ignore
-those generated paths unless it is explicitly validating the build output itself.
-When a new generated path appears, add it to every relevant ignore surface in the
-same change; partial ignores fail later gates in non-obvious ways.
+generated paths unless it is explicitly validating the build output itself. When
+a new generated *directory* appears, add it to every relevant ignore surface in
+the same change; partial ignores fail later gates in non-obvious ways.
 
 - **TypeScript under `src/` is source.** `bun run build` produces the deployable
   Harper assets from it.

--- a/plugins/lisa-harper-fabric-cursor/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric-cursor/generated-artifact-globs.txt
@@ -1,4 +1,5 @@
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**

--- a/plugins/lisa-harper-fabric-cursor/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric-cursor/hooks/block-generated-artifact-edits.sh
@@ -33,6 +33,7 @@ matches_glob() {
   local file="$1"
   local glob="$2"
 
+  # Recursive directory globs: "dir/**" matches everything under dir.
   if [ "${glob: -3}" = "/**" ]; then
     local dir="${glob%/**}"
     case "$file" in
@@ -41,6 +42,38 @@ matches_glob() {
     return 1
   fi
 
+  # Single-star globs like "harper-app/*.js": the star must not cross a
+  # directory separator, so a broadened root-level pattern protects compiled
+  # modules emitted straight into harper-app/ (resources.js, resource-*.js, and
+  # any other build output such as detail-shell-negotiation.js) WITHOUT matching
+  # hand-written files nested one level down (e.g. harper-app/<route>/index.js).
+  case "$glob" in
+    */\** | \**)
+      local base_glob="${glob##*/}"
+      local dir_glob=""
+      case "$glob" in
+        */*) dir_glob="${glob%/*}" ;;
+      esac
+      local file_base="${file##*/}"
+      local file_dir=""
+      case "$file" in
+        */*) file_dir="${file%/*}" ;;
+      esac
+      case "$file_base" in
+        $base_glob) ;;
+        *) return 1 ;;
+      esac
+      [ -z "$dir_glob" ] && return 0
+      # Match the directory exactly, or as a suffix so absolute/prefixed paths
+      # (e.g. /repo/harper-app/foo.js) still resolve.
+      case "$file_dir" in
+        $dir_glob | */"$dir_glob") return 0 ;;
+      esac
+      return 1
+      ;;
+  esac
+
+  # Literal (wildcard-free) globs.
   case "$file" in
     $glob | */$glob) return 0 ;;
   esac
@@ -49,6 +82,24 @@ matches_glob() {
 }
 
 NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+# Project-owned allowlist of hand-written files that live under harper-app/ and
+# must NOT be treated as generated (e.g. a hand-authored SEO shell, or route
+# index.js shims kept at the harper-app root). The broadened root-level
+# `harper-app/*.js` protection would otherwise block editing them. One glob per
+# line (same syntax as the globs file); blank lines and `#` comments ignored.
+# Prefer naming compiled resource modules `resource-*.ts` so their JS output is
+# unambiguously generated and never needs allowlisting.
+ALLOWLIST_FILE="${CLAUDE_PROJECT_DIR:-.}/.lisa/harper-generated-artifact-allowlist.txt"
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r allow || [ -n "$allow" ]; do
+    [ -n "$allow" ] || continue
+    case "$allow" in \#*) continue ;; esac
+    if matches_glob "$NORMALIZED_FILE" "$allow"; then
+      exit 0
+    fi
+  done <"$ALLOWLIST_FILE"
+fi
 
 while IFS= read -r glob || [ -n "$glob" ]; do
   [ -n "$glob" ] || continue

--- a/plugins/lisa-harper-fabric-cursor/rules/harper-fabric.mdc
+++ b/plugins/lisa-harper-fabric-cursor/rules/harper-fabric.mdc
@@ -18,7 +18,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
 - `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
-- `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
+- Every `.js` at the harper-app root (`harper-app/*.js` — `resources.js`, `resource-*.js`, and any other compiled module) plus `harper-app/web/**/*.js` and `harper-app/lib/**` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`. Name compiled resource modules `resource-*.ts` so their output is unambiguously generated; a hand-written `.js` kept at the harper-app root must be re-included in `.gitignore` and listed in `.lisa/harper-generated-artifact-allowlist.txt` so the block hook allows editing it.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 
 ## Harper/Fabric Deploy Surface

--- a/plugins/lisa-harper-fabric-cursor/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric-cursor/skills/harper-build-and-deploy/SKILL.md
@@ -50,15 +50,30 @@ What the build actually does:
 
 Generated Harper deploy artifacts usually include:
 
-- `harper-app/resources.js`
-- `harper-app/resource-*.js`
+- `harper-app/*.js` — every compiled module the build emits to the harper-app
+  root (`resources.js`, `resource-*.js`, and any other output such as a route
+  negotiation module). The single-star does **not** cross a directory separator,
+  so it does not match hand-written shims one level down.
 - `harper-app/web/**`
 - `harper-app/lib/**`
 
+The guard surfaces (`generated-artifact-globs.txt` for the PreToolUse block hook,
+`.gitignore`, `.prettierignore`, the ESLint/oxlint/knip ignores, and
+`tsconfig.eslint.json`) all key off `harper-app/*.js` so a newly-named compiled
+module is protected automatically. **Name compiled resource modules
+`resource-*.ts`** so their JS output is unambiguously generated.
+
+If you keep a *hand-written* `.js` at the harper-app root (e.g. an SEO shell),
+the root-level rule would otherwise treat it as generated: re-include it with a
+`!harper-app/<file>.js` line below the managed gitignore block, and add it to
+`.lisa/harper-generated-artifact-allowlist.txt` so the block hook lets you edit
+it. Hand-written shims nested under `harper-app/<route>/index.js` need no
+exemption — the root-level rule never matches them.
+
 Every lint, format, dead-code, search, or generated-artifact guard must ignore
-those generated paths unless it is explicitly validating the build output itself.
-When a new generated path appears, add it to every relevant ignore surface in the
-same change; partial ignores fail later gates in non-obvious ways.
+generated paths unless it is explicitly validating the build output itself. When
+a new generated *directory* appears, add it to every relevant ignore surface in
+the same change; partial ignores fail later gates in non-obvious ways.
 
 - **TypeScript under `src/` is source.** `bun run build` produces the deployable
   Harper assets from it.

--- a/plugins/lisa-harper-fabric/generated-artifact-globs.txt
+++ b/plugins/lisa-harper-fabric/generated-artifact-globs.txt
@@ -1,4 +1,5 @@
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**

--- a/plugins/lisa-harper-fabric/hooks/block-generated-artifact-edits.sh
+++ b/plugins/lisa-harper-fabric/hooks/block-generated-artifact-edits.sh
@@ -33,6 +33,7 @@ matches_glob() {
   local file="$1"
   local glob="$2"
 
+  # Recursive directory globs: "dir/**" matches everything under dir.
   if [ "${glob: -3}" = "/**" ]; then
     local dir="${glob%/**}"
     case "$file" in
@@ -41,6 +42,38 @@ matches_glob() {
     return 1
   fi
 
+  # Single-star globs like "harper-app/*.js": the star must not cross a
+  # directory separator, so a broadened root-level pattern protects compiled
+  # modules emitted straight into harper-app/ (resources.js, resource-*.js, and
+  # any other build output such as detail-shell-negotiation.js) WITHOUT matching
+  # hand-written files nested one level down (e.g. harper-app/<route>/index.js).
+  case "$glob" in
+    */\** | \**)
+      local base_glob="${glob##*/}"
+      local dir_glob=""
+      case "$glob" in
+        */*) dir_glob="${glob%/*}" ;;
+      esac
+      local file_base="${file##*/}"
+      local file_dir=""
+      case "$file" in
+        */*) file_dir="${file%/*}" ;;
+      esac
+      case "$file_base" in
+        $base_glob) ;;
+        *) return 1 ;;
+      esac
+      [ -z "$dir_glob" ] && return 0
+      # Match the directory exactly, or as a suffix so absolute/prefixed paths
+      # (e.g. /repo/harper-app/foo.js) still resolve.
+      case "$file_dir" in
+        $dir_glob | */"$dir_glob") return 0 ;;
+      esac
+      return 1
+      ;;
+  esac
+
+  # Literal (wildcard-free) globs.
   case "$file" in
     $glob | */$glob) return 0 ;;
   esac
@@ -49,6 +82,24 @@ matches_glob() {
 }
 
 NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+# Project-owned allowlist of hand-written files that live under harper-app/ and
+# must NOT be treated as generated (e.g. a hand-authored SEO shell, or route
+# index.js shims kept at the harper-app root). The broadened root-level
+# `harper-app/*.js` protection would otherwise block editing them. One glob per
+# line (same syntax as the globs file); blank lines and `#` comments ignored.
+# Prefer naming compiled resource modules `resource-*.ts` so their JS output is
+# unambiguously generated and never needs allowlisting.
+ALLOWLIST_FILE="${CLAUDE_PROJECT_DIR:-.}/.lisa/harper-generated-artifact-allowlist.txt"
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r allow || [ -n "$allow" ]; do
+    [ -n "$allow" ] || continue
+    case "$allow" in \#*) continue ;; esac
+    if matches_glob "$NORMALIZED_FILE" "$allow"; then
+      exit 0
+    fi
+  done <"$ALLOWLIST_FILE"
+fi
 
 while IFS= read -r glob || [ -n "$glob" ]; do
   [ -n "$glob" ] || continue

--- a/plugins/lisa-harper-fabric/rules/harper-fabric.md
+++ b/plugins/lisa-harper-fabric/rules/harper-fabric.md
@@ -13,7 +13,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
 - `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
-- `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
+- Every `.js` at the harper-app root (`harper-app/*.js` — `resources.js`, `resource-*.js`, and any other compiled module) plus `harper-app/web/**/*.js` and `harper-app/lib/**` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`. Name compiled resource modules `resource-*.ts` so their output is unambiguously generated; a hand-written `.js` kept at the harper-app root must be re-included in `.gitignore` and listed in `.lisa/harper-generated-artifact-allowlist.txt` so the block hook allows editing it.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 
 ## Harper/Fabric Deploy Surface

--- a/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/lisa-harper-fabric/skills/harper-build-and-deploy/SKILL.md
@@ -50,15 +50,30 @@ What the build actually does:
 
 Generated Harper deploy artifacts usually include:
 
-- `harper-app/resources.js`
-- `harper-app/resource-*.js`
+- `harper-app/*.js` — every compiled module the build emits to the harper-app
+  root (`resources.js`, `resource-*.js`, and any other output such as a route
+  negotiation module). The single-star does **not** cross a directory separator,
+  so it does not match hand-written shims one level down.
 - `harper-app/web/**`
 - `harper-app/lib/**`
 
+The guard surfaces (`generated-artifact-globs.txt` for the PreToolUse block hook,
+`.gitignore`, `.prettierignore`, the ESLint/oxlint/knip ignores, and
+`tsconfig.eslint.json`) all key off `harper-app/*.js` so a newly-named compiled
+module is protected automatically. **Name compiled resource modules
+`resource-*.ts`** so their JS output is unambiguously generated.
+
+If you keep a *hand-written* `.js` at the harper-app root (e.g. an SEO shell),
+the root-level rule would otherwise treat it as generated: re-include it with a
+`!harper-app/<file>.js` line below the managed gitignore block, and add it to
+`.lisa/harper-generated-artifact-allowlist.txt` so the block hook lets you edit
+it. Hand-written shims nested under `harper-app/<route>/index.js` need no
+exemption — the root-level rule never matches them.
+
 Every lint, format, dead-code, search, or generated-artifact guard must ignore
-those generated paths unless it is explicitly validating the build output itself.
-When a new generated path appears, add it to every relevant ignore surface in the
-same change; partial ignores fail later gates in non-obvious ways.
+generated paths unless it is explicitly validating the build output itself. When
+a new generated *directory* appears, add it to every relevant ignore surface in
+the same change; partial ignores fail later gates in non-obvious ways.
 
 - **TypeScript under `src/` is source.** `bun run build` produces the deployable
   Harper assets from it.

--- a/plugins/src/harper-fabric/generated-artifact-globs.txt
+++ b/plugins/src/harper-fabric/generated-artifact-globs.txt
@@ -1,4 +1,5 @@
 harper-app/resources.js
 harper-app/resource-*.js
+harper-app/*.js
 harper-app/web/**
 harper-app/lib/**

--- a/plugins/src/harper-fabric/hooks/block-generated-artifact-edits.sh
+++ b/plugins/src/harper-fabric/hooks/block-generated-artifact-edits.sh
@@ -33,6 +33,7 @@ matches_glob() {
   local file="$1"
   local glob="$2"
 
+  # Recursive directory globs: "dir/**" matches everything under dir.
   if [ "${glob: -3}" = "/**" ]; then
     local dir="${glob%/**}"
     case "$file" in
@@ -41,6 +42,38 @@ matches_glob() {
     return 1
   fi
 
+  # Single-star globs like "harper-app/*.js": the star must not cross a
+  # directory separator, so a broadened root-level pattern protects compiled
+  # modules emitted straight into harper-app/ (resources.js, resource-*.js, and
+  # any other build output such as detail-shell-negotiation.js) WITHOUT matching
+  # hand-written files nested one level down (e.g. harper-app/<route>/index.js).
+  case "$glob" in
+    */\** | \**)
+      local base_glob="${glob##*/}"
+      local dir_glob=""
+      case "$glob" in
+        */*) dir_glob="${glob%/*}" ;;
+      esac
+      local file_base="${file##*/}"
+      local file_dir=""
+      case "$file" in
+        */*) file_dir="${file%/*}" ;;
+      esac
+      case "$file_base" in
+        $base_glob) ;;
+        *) return 1 ;;
+      esac
+      [ -z "$dir_glob" ] && return 0
+      # Match the directory exactly, or as a suffix so absolute/prefixed paths
+      # (e.g. /repo/harper-app/foo.js) still resolve.
+      case "$file_dir" in
+        $dir_glob | */"$dir_glob") return 0 ;;
+      esac
+      return 1
+      ;;
+  esac
+
+  # Literal (wildcard-free) globs.
   case "$file" in
     $glob | */$glob) return 0 ;;
   esac
@@ -49,6 +82,24 @@ matches_glob() {
 }
 
 NORMALIZED_FILE=$(normalize_path "$FILE_PATH")
+
+# Project-owned allowlist of hand-written files that live under harper-app/ and
+# must NOT be treated as generated (e.g. a hand-authored SEO shell, or route
+# index.js shims kept at the harper-app root). The broadened root-level
+# `harper-app/*.js` protection would otherwise block editing them. One glob per
+# line (same syntax as the globs file); blank lines and `#` comments ignored.
+# Prefer naming compiled resource modules `resource-*.ts` so their JS output is
+# unambiguously generated and never needs allowlisting.
+ALLOWLIST_FILE="${CLAUDE_PROJECT_DIR:-.}/.lisa/harper-generated-artifact-allowlist.txt"
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r allow || [ -n "$allow" ]; do
+    [ -n "$allow" ] || continue
+    case "$allow" in \#*) continue ;; esac
+    if matches_glob "$NORMALIZED_FILE" "$allow"; then
+      exit 0
+    fi
+  done <"$ALLOWLIST_FILE"
+fi
 
 while IFS= read -r glob || [ -n "$glob" ]; do
   [ -n "$glob" ] || continue

--- a/plugins/src/harper-fabric/rules/harper-fabric.md
+++ b/plugins/src/harper-fabric/rules/harper-fabric.md
@@ -13,7 +13,7 @@ These rules apply to Harper/Fabric component apps managed by Lisa.
 - TypeScript under `src/` is the source of truth for Harper resources, browser modules, shared libraries, and operational scripts.
 - `harper-app/config.yaml`, `harper-app/schema.graphql`, HTML, CSS, docs, and research fixtures are source assets.
 - `harper-app/config.yaml` does not merge with Harper defaults. Keep every required top-level extension declared when editing it; the Harper Fabric hook blocks accidental extension drops unless the removal is documented in `.lisa/harper-config-extension-allowlist.json`.
-- `harper-app/resources.js` and `harper-app/web/**/*.js` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`.
+- Every `.js` at the harper-app root (`harper-app/*.js` — `resources.js`, `resource-*.js`, and any other compiled module) plus `harper-app/web/**/*.js` and `harper-app/lib/**` are generated deploy artifacts. Never edit them directly; change the matching TypeScript and run `bun run build`. Name compiled resource modules `resource-*.ts` so their output is unambiguously generated; a hand-written `.js` kept at the harper-app root must be re-included in `.gitignore` and listed in `.lisa/harper-generated-artifact-allowlist.txt` so the block hook allows editing it.
 - Deployment, bootstrap, smoke, seed, verify, preview, token, crawl, ingest, and extraction commands must run from compiled JavaScript or generated Harper assets, not stale checked-in JavaScript.
 
 ## Harper/Fabric Deploy Surface

--- a/plugins/src/harper-fabric/skills/harper-build-and-deploy/SKILL.md
+++ b/plugins/src/harper-fabric/skills/harper-build-and-deploy/SKILL.md
@@ -50,15 +50,30 @@ What the build actually does:
 
 Generated Harper deploy artifacts usually include:
 
-- `harper-app/resources.js`
-- `harper-app/resource-*.js`
+- `harper-app/*.js` — every compiled module the build emits to the harper-app
+  root (`resources.js`, `resource-*.js`, and any other output such as a route
+  negotiation module). The single-star does **not** cross a directory separator,
+  so it does not match hand-written shims one level down.
 - `harper-app/web/**`
 - `harper-app/lib/**`
 
+The guard surfaces (`generated-artifact-globs.txt` for the PreToolUse block hook,
+`.gitignore`, `.prettierignore`, the ESLint/oxlint/knip ignores, and
+`tsconfig.eslint.json`) all key off `harper-app/*.js` so a newly-named compiled
+module is protected automatically. **Name compiled resource modules
+`resource-*.ts`** so their JS output is unambiguously generated.
+
+If you keep a *hand-written* `.js` at the harper-app root (e.g. an SEO shell),
+the root-level rule would otherwise treat it as generated: re-include it with a
+`!harper-app/<file>.js` line below the managed gitignore block, and add it to
+`.lisa/harper-generated-artifact-allowlist.txt` so the block hook lets you edit
+it. Hand-written shims nested under `harper-app/<route>/index.js` need no
+exemption — the root-level rule never matches them.
+
 Every lint, format, dead-code, search, or generated-artifact guard must ignore
-those generated paths unless it is explicitly validating the build output itself.
-When a new generated path appears, add it to every relevant ignore surface in the
-same change; partial ignores fail later gates in non-obvious ways.
+generated paths unless it is explicitly validating the build output itself. When
+a new generated *directory* appears, add it to every relevant ignore surface in
+the same change; partial ignores fail later gates in non-obvious ways.
 
 - **TypeScript under `src/` is source.** `bun run build` produces the deployable
   Harper assets from it.

--- a/src/configs/eslint/harper-fabric.ts
+++ b/src/configs/eslint/harper-fabric.ts
@@ -25,6 +25,11 @@ export const defaultHarperFabricIgnores = [
   "*.config.local.ts",
   "harper-app/resources.js",
   "harper-app/resource-*.js",
+  // Root-level compiled Harper modules (resources.js, resource-*.js, and any
+  // other build output emitted straight into harper-app/). The single-star does
+  // not cross a directory separator, so hand-written shims one level down
+  // (harper-app/<route>/index.js) are still linted.
+  "harper-app/*.js",
   "harper-app/web/**",
   "harper-app/lib/**",
 ];


### PR DESCRIPTION
## Problem

The harper-fabric generated-artifact guards assumed every compiled Harper module is named `resources.js` or `resource-*.js`. A project that compiled `src/harper/detail-shell-negotiation.ts` → `harper-app/detail-shell-negotiation.js` matched **no** guard glob: it was committed by accident, and the PreToolUse block hook would not have stopped a direct edit to it (the edit would then be silently overwritten by the next build).

Follow-up to #1468 (Track B of the Harper best-practices review).

## Fix

Broaden the protected pattern to root-level **`harper-app/*.js`** across every guard surface:

| Surface | File |
|---|---|
| PreToolUse block hook | `plugins/src/harper-fabric/generated-artifact-globs.txt` |
| gitignore | `harper-fabric/copy-contents/gitignore` |
| prettierignore | `harper-fabric/copy-contents/.prettierignore` |
| knip | `harper-fabric/copy-overwrite/knip.json` |
| tsconfig.eslint | `harper-fabric/copy-overwrite/tsconfig.eslint.json` |
| oxlint (merge template) | `harper-fabric/merge/.oxlintrc.json` |
| ESLint factory | `src/configs/eslint/harper-fabric.ts` |
| oxlint preset | `oxlint/harper-fabric.json` |

The single-star **does not cross a directory separator**, so `harper-app/*.js` is root-level only — hand-written shims nested one level down (`harper-app/<route>/index.js`) are unaffected across all these tools.

### Block hook changes

- **Rewrote `matches_glob`** so a single `*` no longer crosses `/`. Bash `case` globbing otherwise over-matches nested paths; the new matcher gives root-level-only semantics consistent with gitignore/minimatch. Existing `resources.js` / `resource-*.js` / `web/**` / `lib/**` patterns are unchanged (verified).
- **Added an optional project allowlist** — `.lisa/harper-generated-artifact-allowlist.txt` (mirrors the existing `.lisa/harper-config-extension-allowlist.json` pattern). A hand-written `.js` kept at the harper-app root (e.g. an SEO shell) can be exempted without editing the Lisa-managed globs.

### Docs

Documented the naming assumption in the harper-fabric rules doc and the `harper-build-and-deploy` skill: name compiled resource modules `resource-*.ts`; allowlist hand-written root files.

## Verification

Block hook tested end-to-end via JSON stdin:
- `harper-app/detail-shell-negotiation.js` → **blocked** (exit 2) — the bug fix
- `harper-app/resources.js`, `harper-app/web/app.js` → blocked (exit 2)
- `harper-app/<route>/index.js` (subdir shim) → allowed (exit 0)
- `src/harper/foo.ts` (source) → allowed (exit 0)
- `harper-app/seo_shell.js` → blocked without allowlist, **allowed** when listed in `.lisa/harper-generated-artifact-allowlist.txt`

Gates: `check:plugins` in-sync · `check:rules-pairing` pass · `ast-grep test` 6/6 · typecheck clean · all edited JSON valid · `bash -n` hook clean.

🤖 Generated with Claude Code