### PR TITLE
feat(hooks): add session-end sweep of stale agent worktrees

### DIFF
--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -91,6 +91,19 @@
           }
         ]
       }
+    ],
+    "sessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-stale-worktrees.sh",
+            "async": true,
+            "timeout": 300
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# SessionEnd sweep of abandoned agent worktrees under <repo>/.claude/worktrees.
+#
+# Why: Claude Code's built-in cleanup (cleanupPeriodDays) only removes
+# PRISTINE subagent worktrees — no changes, no untracked files, no unpushed
+# commits. Real agent worktrees almost always carry untracked junk
+# (node_modules, build output), so they survive forever and accumulate;
+# one long-lived repo reached 415 worktrees / 823GB, which also crashes
+# jest-haste-map's find-buffer crawl.
+#
+# Safety model — a worktree is removed only when ALL hold:
+#   * it lives under .claude/worktrees/ (never the primary checkout)
+#   * no modified or staged TRACKED files (real work is never deleted)
+#   * its HEAD commit is reachable from some remote ref (nothing unpushed)
+#   * its directory mtime is older than LISA_WORKTREE_MAX_AGE_DAYS (default 7)
+# Untracked-only dirt does NOT block removal — that junk is exactly what
+# defeats the built-in sweep. Set LISA_WORKTREE_CLEANUP=off to disable.
+
+set -u
+
+[ "${LISA_WORKTREE_CLEANUP:-on}" = "off" ] && exit 0
+
+MAX_AGE_DAYS="${LISA_WORKTREE_MAX_AGE_DAYS:-7}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Never run the sweep from INSIDE an agent worktree — only the primary
+# checkout owns cleanup (a worktree deleting its siblings mid-session
+# would race other live sessions in the same repo).
+case "$repo_root" in
+  */.claude/worktrees/*) exit 0 ;;
+esac
+
+wt_root="$repo_root/.claude/worktrees"
+[ -d "$wt_root" ] || exit 0
+
+now=$(date +%s)
+max_age_secs=$((MAX_AGE_DAYS * 86400))
+removed=0
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+for wt in "$wt_root"/*/; do
+  wt="${wt%/}"
+  [ -d "$wt" ] || continue
+
+  # Age gate: skip anything recently touched (possibly a live session).
+  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  [ $((now - mtime)) -ge "$max_age_secs" ] || continue
+
+  if [ -e "$wt/.git" ]; then
+    # Real work gate: modified/staged tracked files survive.
+    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+
+    # Unpushed gate: HEAD must be reachable from a remote ref.
+    sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue
+    [ -n "$(git -C "$wt" branch -r --contains "$sha" 2>/dev/null | head -1)" ] || continue
+
+    # git worktree lock (held during live agent execution) blocks removal;
+    # --force only clears untracked junk, never the gates above.
+    git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null && removed=$((removed + 1))
+  else
+    # Orphan directory git no longer tracks (post-prune leftover).
+    rm -rf "$wt" && removed=$((removed + 1))
+  fi
+done
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+[ "$removed" -gt 0 ] && echo "Removed $removed stale agent worktree(s) from .claude/worktrees" >&2
+exit 0

--- a/plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh
@@ -48,12 +48,19 @@ for wt in "$wt_root"/*/; do
   [ -d "$wt" ] || continue
 
   # Age gate: skip anything recently touched (possibly a live session).
-  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  # GNU `stat -c` is tried first: GNU's `-f` means "filesystem status" (not
+  # BSD's "format"), so `stat -f %m` on Linux silently misparses instead of
+  # failing cleanly, defeating the fallback. Try the GNU form first — it
+  # fails cleanly with no stdout on BSD/macOS, letting `-f %m` take over.
+  mtime=$(stat -c %Y "$wt" 2>/dev/null || stat -f %m "$wt" 2>/dev/null) || continue
   [ $((now - mtime)) -ge "$max_age_secs" ] || continue
 
   if [ -e "$wt/.git" ]; then
-    # Real work gate: modified/staged tracked files survive.
-    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+    # Real work gate: modified/staged tracked files survive. A failed
+    # `git status` (corrupted index, permission issue, etc.) must NOT be
+    # treated as clean — capture its exit status too and skip on failure.
+    status_output=$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null) || continue
+    [ -z "$status_output" ] || continue
 
     # Unpushed gate: HEAD must be reachable from a remote ref.
     sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue

--- a/plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# SessionEnd sweep of abandoned agent worktrees under <repo>/.claude/worktrees.
+#
+# Why: Claude Code's built-in cleanup (cleanupPeriodDays) only removes
+# PRISTINE subagent worktrees — no changes, no untracked files, no unpushed
+# commits. Real agent worktrees almost always carry untracked junk
+# (node_modules, build output), so they survive forever and accumulate;
+# one long-lived repo reached 415 worktrees / 823GB, which also crashes
+# jest-haste-map's find-buffer crawl.
+#
+# Safety model — a worktree is removed only when ALL hold:
+#   * it lives under .claude/worktrees/ (never the primary checkout)
+#   * no modified or staged TRACKED files (real work is never deleted)
+#   * its HEAD commit is reachable from some remote ref (nothing unpushed)
+#   * its directory mtime is older than LISA_WORKTREE_MAX_AGE_DAYS (default 7)
+# Untracked-only dirt does NOT block removal — that junk is exactly what
+# defeats the built-in sweep. Set LISA_WORKTREE_CLEANUP=off to disable.
+
+set -u
+
+[ "${LISA_WORKTREE_CLEANUP:-on}" = "off" ] && exit 0
+
+MAX_AGE_DAYS="${LISA_WORKTREE_MAX_AGE_DAYS:-7}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Never run the sweep from INSIDE an agent worktree — only the primary
+# checkout owns cleanup (a worktree deleting its siblings mid-session
+# would race other live sessions in the same repo).
+case "$repo_root" in
+  */.claude/worktrees/*) exit 0 ;;
+esac
+
+wt_root="$repo_root/.claude/worktrees"
+[ -d "$wt_root" ] || exit 0
+
+now=$(date +%s)
+max_age_secs=$((MAX_AGE_DAYS * 86400))
+removed=0
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+for wt in "$wt_root"/*/; do
+  wt="${wt%/}"
+  [ -d "$wt" ] || continue
+
+  # Age gate: skip anything recently touched (possibly a live session).
+  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  [ $((now - mtime)) -ge "$max_age_secs" ] || continue
+
+  if [ -e "$wt/.git" ]; then
+    # Real work gate: modified/staged tracked files survive.
+    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+
+    # Unpushed gate: HEAD must be reachable from a remote ref.
+    sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue
+    [ -n "$(git -C "$wt" branch -r --contains "$sha" 2>/dev/null | head -1)" ] || continue
+
+    # git worktree lock (held during live agent execution) blocks removal;
+    # --force only clears untracked junk, never the gates above.
+    git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null && removed=$((removed + 1))
+  else
+    # Orphan directory git no longer tracks (post-prune leftover).
+    rm -rf "$wt" && removed=$((removed + 1))
+  fi
+done
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+[ "$removed" -gt 0 ] && echo "Removed $removed stale agent worktree(s) from .claude/worktrees" >&2
+exit 0

--- a/plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh
@@ -48,12 +48,19 @@ for wt in "$wt_root"/*/; do
   [ -d "$wt" ] || continue
 
   # Age gate: skip anything recently touched (possibly a live session).
-  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  # GNU `stat -c` is tried first: GNU's `-f` means "filesystem status" (not
+  # BSD's "format"), so `stat -f %m` on Linux silently misparses instead of
+  # failing cleanly, defeating the fallback. Try the GNU form first — it
+  # fails cleanly with no stdout on BSD/macOS, letting `-f %m` take over.
+  mtime=$(stat -c %Y "$wt" 2>/dev/null || stat -f %m "$wt" 2>/dev/null) || continue
   [ $((now - mtime)) -ge "$max_age_secs" ] || continue
 
   if [ -e "$wt/.git" ]; then
-    # Real work gate: modified/staged tracked files survive.
-    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+    # Real work gate: modified/staged tracked files survive. A failed
+    # `git status` (corrupted index, permission issue, etc.) must NOT be
+    # treated as clean — capture its exit status too and skip on failure.
+    status_output=$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null) || continue
+    [ -z "$status_output" ] || continue
 
     # Unpushed gate: HEAD must be reachable from a remote ref.
     sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue

--- a/plugins/lisa-cursor/hooks/hooks.json
+++ b/plugins/lisa-cursor/hooks/hooks.json
@@ -43,6 +43,11 @@
       {
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
       }
+    ],
+    "sessionEnd": [
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/cleanup-stale-worktrees.sh"
+      }
     ]
   }
 }

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -220,6 +220,17 @@
             "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-end || true"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-stale-worktrees.sh",
+            "async": true,
+            "timeout": 300
+          }
+        ]
       }
     ]
   }

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -114,6 +114,19 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/cleanup-stale-worktrees.sh",
+            "async": true,
+            "timeout": 300
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/lisa/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa/hooks/cleanup-stale-worktrees.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# SessionEnd sweep of abandoned agent worktrees under <repo>/.claude/worktrees.
+#
+# Why: Claude Code's built-in cleanup (cleanupPeriodDays) only removes
+# PRISTINE subagent worktrees — no changes, no untracked files, no unpushed
+# commits. Real agent worktrees almost always carry untracked junk
+# (node_modules, build output), so they survive forever and accumulate;
+# one long-lived repo reached 415 worktrees / 823GB, which also crashes
+# jest-haste-map's find-buffer crawl.
+#
+# Safety model — a worktree is removed only when ALL hold:
+#   * it lives under .claude/worktrees/ (never the primary checkout)
+#   * no modified or staged TRACKED files (real work is never deleted)
+#   * its HEAD commit is reachable from some remote ref (nothing unpushed)
+#   * its directory mtime is older than LISA_WORKTREE_MAX_AGE_DAYS (default 7)
+# Untracked-only dirt does NOT block removal — that junk is exactly what
+# defeats the built-in sweep. Set LISA_WORKTREE_CLEANUP=off to disable.
+
+set -u
+
+[ "${LISA_WORKTREE_CLEANUP:-on}" = "off" ] && exit 0
+
+MAX_AGE_DAYS="${LISA_WORKTREE_MAX_AGE_DAYS:-7}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Never run the sweep from INSIDE an agent worktree — only the primary
+# checkout owns cleanup (a worktree deleting its siblings mid-session
+# would race other live sessions in the same repo).
+case "$repo_root" in
+  */.claude/worktrees/*) exit 0 ;;
+esac
+
+wt_root="$repo_root/.claude/worktrees"
+[ -d "$wt_root" ] || exit 0
+
+now=$(date +%s)
+max_age_secs=$((MAX_AGE_DAYS * 86400))
+removed=0
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+for wt in "$wt_root"/*/; do
+  wt="${wt%/}"
+  [ -d "$wt" ] || continue
+
+  # Age gate: skip anything recently touched (possibly a live session).
+  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  [ $((now - mtime)) -ge "$max_age_secs" ] || continue
+
+  if [ -e "$wt/.git" ]; then
+    # Real work gate: modified/staged tracked files survive.
+    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+
+    # Unpushed gate: HEAD must be reachable from a remote ref.
+    sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue
+    [ -n "$(git -C "$wt" branch -r --contains "$sha" 2>/dev/null | head -1)" ] || continue
+
+    # git worktree lock (held during live agent execution) blocks removal;
+    # --force only clears untracked junk, never the gates above.
+    git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null && removed=$((removed + 1))
+  else
+    # Orphan directory git no longer tracks (post-prune leftover).
+    rm -rf "$wt" && removed=$((removed + 1))
+  fi
+done
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+[ "$removed" -gt 0 ] && echo "Removed $removed stale agent worktree(s) from .claude/worktrees" >&2
+exit 0

--- a/plugins/lisa/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/lisa/hooks/cleanup-stale-worktrees.sh
@@ -48,12 +48,19 @@ for wt in "$wt_root"/*/; do
   [ -d "$wt" ] || continue
 
   # Age gate: skip anything recently touched (possibly a live session).
-  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  # GNU `stat -c` is tried first: GNU's `-f` means "filesystem status" (not
+  # BSD's "format"), so `stat -f %m` on Linux silently misparses instead of
+  # failing cleanly, defeating the fallback. Try the GNU form first — it
+  # fails cleanly with no stdout on BSD/macOS, letting `-f %m` take over.
+  mtime=$(stat -c %Y "$wt" 2>/dev/null || stat -f %m "$wt" 2>/dev/null) || continue
   [ $((now - mtime)) -ge "$max_age_secs" ] || continue
 
   if [ -e "$wt/.git" ]; then
-    # Real work gate: modified/staged tracked files survive.
-    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+    # Real work gate: modified/staged tracked files survive. A failed
+    # `git status` (corrupted index, permission issue, etc.) must NOT be
+    # treated as clean — capture its exit status too and skip on failure.
+    status_output=$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null) || continue
+    [ -z "$status_output" ] || continue
 
     # Unpushed gate: HEAD must be reachable from a remote ref.
     sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -1,8 +1,10 @@
 {
   "name": "lisa",
   "version": "1.0.0",
-  "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
-  "author": { "name": "Cody Swann" },
+  "description": "Universal governance \u2014 agents, skills, commands, hooks, and rules for all projects",
+  "author": {
+    "name": "Cody Swann"
+  },
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -17,13 +19,19 @@
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
         ]
       },
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
+          }
         ]
       }
     ],
@@ -31,25 +39,37 @@
       {
         "matcher": "Task",
         "hooks": [
-          { "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-task || true" }
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-task || true"
+          }
         ]
       },
       {
         "matcher": "TodoWrite",
         "hooks": [
-          { "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-todo || true" }
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code post-todo || true"
+          }
         ]
       },
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
+          }
         ]
       },
       {
         "matcher": "TeamCreate|Agent",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
         ]
       }
     ],
@@ -57,47 +77,161 @@
       {
         "matcher": "Task",
         "hooks": [
-          { "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code pre-task || true" }
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code pre-task || true"
+          }
         ]
       },
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-no-verify.sh" },
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-no-verify.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh"
+          }
         ]
       },
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
         ]
       },
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh" }
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
+          }
         ]
       }
     ],
     "Stop": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code stop || true" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh" }] }
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code stop || true"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
+          }
+        ]
+      }
     ],
     "SessionStart": [
-      { "matcher": "startup", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/install-pkgs.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/setup-jira-cli.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-start || true" }] }
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/install-pkgs.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/setup-jira-cli.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-start || true"
+          }
+        ]
+      }
     ],
     "SubagentStart": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-flow-context.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh" }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh" }] }
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-rules.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-flow-context.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-team-first.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
+          }
+        ]
+      }
     ],
     "SessionEnd": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-end || true" }] }
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v entire >/dev/null 2>&1 && entire hooks claude-code session-end || true"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-stale-worktrees.sh",
+            "async": true,
+            "timeout": 300
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/src/base/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/src/base/hooks/cleanup-stale-worktrees.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# SessionEnd sweep of abandoned agent worktrees under <repo>/.claude/worktrees.
+#
+# Why: Claude Code's built-in cleanup (cleanupPeriodDays) only removes
+# PRISTINE subagent worktrees — no changes, no untracked files, no unpushed
+# commits. Real agent worktrees almost always carry untracked junk
+# (node_modules, build output), so they survive forever and accumulate;
+# one long-lived repo reached 415 worktrees / 823GB, which also crashes
+# jest-haste-map's find-buffer crawl.
+#
+# Safety model — a worktree is removed only when ALL hold:
+#   * it lives under .claude/worktrees/ (never the primary checkout)
+#   * no modified or staged TRACKED files (real work is never deleted)
+#   * its HEAD commit is reachable from some remote ref (nothing unpushed)
+#   * its directory mtime is older than LISA_WORKTREE_MAX_AGE_DAYS (default 7)
+# Untracked-only dirt does NOT block removal — that junk is exactly what
+# defeats the built-in sweep. Set LISA_WORKTREE_CLEANUP=off to disable.
+
+set -u
+
+[ "${LISA_WORKTREE_CLEANUP:-on}" = "off" ] && exit 0
+
+MAX_AGE_DAYS="${LISA_WORKTREE_MAX_AGE_DAYS:-7}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Never run the sweep from INSIDE an agent worktree — only the primary
+# checkout owns cleanup (a worktree deleting its siblings mid-session
+# would race other live sessions in the same repo).
+case "$repo_root" in
+  */.claude/worktrees/*) exit 0 ;;
+esac
+
+wt_root="$repo_root/.claude/worktrees"
+[ -d "$wt_root" ] || exit 0
+
+now=$(date +%s)
+max_age_secs=$((MAX_AGE_DAYS * 86400))
+removed=0
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+for wt in "$wt_root"/*/; do
+  wt="${wt%/}"
+  [ -d "$wt" ] || continue
+
+  # Age gate: skip anything recently touched (possibly a live session).
+  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  [ $((now - mtime)) -ge "$max_age_secs" ] || continue
+
+  if [ -e "$wt/.git" ]; then
+    # Real work gate: modified/staged tracked files survive.
+    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+
+    # Unpushed gate: HEAD must be reachable from a remote ref.
+    sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue
+    [ -n "$(git -C "$wt" branch -r --contains "$sha" 2>/dev/null | head -1)" ] || continue
+
+    # git worktree lock (held during live agent execution) blocks removal;
+    # --force only clears untracked junk, never the gates above.
+    git -C "$repo_root" worktree remove --force "$wt" 2>/dev/null && removed=$((removed + 1))
+  else
+    # Orphan directory git no longer tracks (post-prune leftover).
+    rm -rf "$wt" && removed=$((removed + 1))
+  fi
+done
+
+git -C "$repo_root" worktree prune 2>/dev/null
+
+[ "$removed" -gt 0 ] && echo "Removed $removed stale agent worktree(s) from .claude/worktrees" >&2
+exit 0

--- a/plugins/src/base/hooks/cleanup-stale-worktrees.sh
+++ b/plugins/src/base/hooks/cleanup-stale-worktrees.sh
@@ -48,12 +48,19 @@ for wt in "$wt_root"/*/; do
   [ -d "$wt" ] || continue
 
   # Age gate: skip anything recently touched (possibly a live session).
-  mtime=$(stat -f %m "$wt" 2>/dev/null || stat -c %Y "$wt" 2>/dev/null) || continue
+  # GNU `stat -c` is tried first: GNU's `-f` means "filesystem status" (not
+  # BSD's "format"), so `stat -f %m` on Linux silently misparses instead of
+  # failing cleanly, defeating the fallback. Try the GNU form first — it
+  # fails cleanly with no stdout on BSD/macOS, letting `-f %m` take over.
+  mtime=$(stat -c %Y "$wt" 2>/dev/null || stat -f %m "$wt" 2>/dev/null) || continue
   [ $((now - mtime)) -ge "$max_age_secs" ] || continue
 
   if [ -e "$wt/.git" ]; then
-    # Real work gate: modified/staged tracked files survive.
-    [ -z "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ] || continue
+    # Real work gate: modified/staged tracked files survive. A failed
+    # `git status` (corrupted index, permission issue, etc.) must NOT be
+    # treated as clean — capture its exit status too and skip on failure.
+    status_output=$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null) || continue
+    [ -z "$status_output" ] || continue
 
     # Unpushed gate: HEAD must be reachable from a remote ref.
     sha=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue

--- a/tests/unit/hooks/cleanup-stale-worktrees.test.ts
+++ b/tests/unit/hooks/cleanup-stale-worktrees.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the SessionEnd cleanup-stale-worktrees.sh hook.
+ *
+ * The hook sweeps abandoned agent worktrees under `<repo>/.claude/worktrees`,
+ * but only removes a worktree when ALL safety gates hold: no modified/staged
+ * tracked files, HEAD reachable from a remote ref, and old enough. A failed
+ * `git status` (corrupted index, permission issue, etc.) must NOT be treated
+ * as "clean" — an unreadable worktree state must never be swept.
+ * @module tests/unit/hooks/cleanup-stale-worktrees
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const HOOK_PATH = path.resolve(
+  "plugins/src/base/hooks/cleanup-stale-worktrees.sh"
+);
+const BASH_PATH = "/bin/bash";
+const GIT_PATH = "/usr/bin/git";
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+/**
+ * Return process env without outer git hook state for nested temp repos.
+ * @returns Environment safe for fixture git commands
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await cleanupTempDir(dir);
+  }
+  tempDirs = [];
+});
+
+/**
+ * Build a primary repo (with a pushable remote) plus one pushed worktree
+ * under `.claude/worktrees/<name>` that is old enough to be swept.
+ * @returns The primary repo root and the worktree path
+ */
+async function createRepoWithPushedWorktree(): Promise<{
+  root: string;
+  worktree: string;
+}> {
+  const tempDir = await createTempDir();
+  const remote = path.join(tempDir, "remote.git");
+  const root = path.join(tempDir, "primary");
+  const env = cleanGitEnv();
+  const worktree = path.join(root, ".claude", "worktrees", "stale");
+
+  tempDirs.push(tempDir);
+
+  spawnSync(GIT_PATH, ["init", "-q", "--bare", remote], { env });
+  spawnSync(GIT_PATH, ["init", "-q", root], { env });
+  spawnSync(GIT_PATH, ["commit", "-q", "--allow-empty", "-m", "init"], {
+    cwd: root,
+    env: { ...env, ...GIT_IDENTITY },
+  });
+  spawnSync(GIT_PATH, ["remote", "add", "origin", remote], {
+    cwd: root,
+    env,
+  });
+  spawnSync(GIT_PATH, ["push", "-q", "origin", "HEAD:refs/heads/main"], {
+    cwd: root,
+    env: { ...env, ...GIT_IDENTITY },
+  });
+  spawnSync(
+    GIT_PATH,
+    ["worktree", "add", "-q", worktree, "-b", "stale-branch"],
+    { cwd: root, env: { ...env, ...GIT_IDENTITY } }
+  );
+  spawnSync(
+    GIT_PATH,
+    ["push", "-q", "origin", "stale-branch:refs/heads/stale-branch"],
+    { cwd: worktree, env: { ...env, ...GIT_IDENTITY } }
+  );
+
+  return { root, worktree };
+}
+
+/**
+ * Locate the admin index file for a linked worktree so it can be corrupted
+ * to force `git status` to fail there while other git plumbing still works.
+ * @param worktree - Path to the linked worktree
+ * @returns Absolute path to that worktree's index file
+ */
+function worktreeIndexPath(worktree: string): string {
+  const gitDir = spawnSync(GIT_PATH, ["rev-parse", "--git-dir"], {
+    cwd: worktree,
+    env: cleanGitEnv(),
+    encoding: "utf-8",
+  }).stdout.trim();
+  return path.isAbsolute(gitDir)
+    ? path.join(gitDir, "index")
+    : path.join(worktree, gitDir, "index");
+}
+
+/**
+ * Run the hook against a primary repo root.
+ * @param root - Primary repo root (hook's cwd)
+ * @param extraEnv - Extra environment overrides for the hook run
+ * @returns The hook's exit status
+ */
+function runHook(
+  root: string,
+  extraEnv: NodeJS.ProcessEnv = {}
+): { status: number | null } {
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    cwd: root,
+    env: {
+      ...cleanGitEnv(),
+      LISA_WORKTREE_MAX_AGE_DAYS: "0",
+      ...extraEnv,
+    },
+    encoding: "utf-8",
+  });
+  return { status: result.status };
+}
+
+describe("cleanup-stale-worktrees.sh", () => {
+  it("removes a pushed, clean, old-enough worktree", async () => {
+    const { root, worktree } = await createRepoWithPushedWorktree();
+
+    const { status } = runHook(root);
+
+    expect(status).toBe(0);
+    expect(existsSync(worktree)).toBe(false);
+  });
+
+  it("does NOT remove a worktree when git status fails (corrupted index)", async () => {
+    const { root, worktree } = await createRepoWithPushedWorktree();
+
+    // Corrupt the worktree's index so `git status` fails there while
+    // `git rev-parse HEAD` and `git branch -r --contains` still succeed.
+    const indexPath = worktreeIndexPath(worktree);
+    await import("node:fs/promises").then(({ writeFile }) =>
+      writeFile(indexPath, "not a git index")
+    );
+
+    const { status } = runHook(root);
+
+    expect(status).toBe(0);
+    expect(existsSync(worktree)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a base-plugin `SessionEnd` hook that sweeps abandoned agent worktrees from `<repo>/.claude/worktrees/`.

**Why**: Claude Code's built-in cleanup (`cleanupPeriodDays`) only removes *pristine* subagent worktrees — no changes, no untracked files, no unpushed commits. Real agent worktrees almost always carry untracked junk (node_modules, build output), so they survive forever. One long-lived Lisa-managed repo (PropSwapLLC/frontend) accumulated **415 worktrees / 823 GB**, which also crashed jest-haste-map's find-buffer crawl (#1472).

**Safety model** — removal requires ALL of:
- lives under `.claude/worktrees/` (the hook exits immediately when run *from* an agent worktree; only the primary checkout sweeps)
- no modified/staged tracked files
- HEAD reachable from a remote ref (nothing unpushed)
- older than `LISA_WORKTREE_MAX_AGE_DAYS` (default 7) by dir mtime

Untracked-only dirt deliberately does **not** block removal — it's exactly what defeats the built-in sweep. `git worktree lock` (held during live agent execution) still blocks removal. Opt out with `LISA_WORKTREE_CLEANUP=off`. Runs `async` with a 5-minute timeout so session close is never blocked.

## Verification
Synthetic repo test: stale worktree with untracked junk + pushed HEAD → removed; orphan unregistered dir → removed; worktree with unpushed commit → kept. `bash -n` clean; `build:plugins` regenerated all variants.

Related: #1472 (jest haste crawl fix for the same accumulation).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-end cleanup of stale agent worktrees across multiple plugins.
  * Cleanup runs asynchronously with a timeout, includes age-based thresholds, and can be disabled or tuned via environment settings.
  * Removed worktrees only when multiple safety checks pass.

* **Bug Fixes**
  * Improved protection against deleting recent, modified, or potentially unpushed worktrees.
  * Handles orphaned leftovers after pruning and skips safely when detection fails.

* **Tests**
  * Added unit tests covering successful cleanup and guarded behavior on failure cases.

* **Documentation / Style**
  * Reformatted plugin hook configuration for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->