### PR TITLE
fix: scrub client project names from distributed skills

### DIFF
--- a/plugins/lisa-agy/commands/lisa/validate-tracker-mapping.md
+++ b/plugins/lisa-agy/commands/lisa/validate-tracker-mapping.md
@@ -9,7 +9,7 @@ Common usage:
 
 - `/lisa:validate-tracker-mapping` — audit the current repo's mapping (read-only).
 - `/lisa:validate-tracker-mapping repair=true` — audit and repair config drift in the current repo.
-- `/lisa:validate-tracker-mapping projects=~/workspace/geminisportsai/projects/*` — sweep every Lisa project under a directory.
-- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=geminisportsai` — sweep the projects in a workspaces file whose paths match a substring.
+- `/lisa:validate-tracker-mapping projects=~/workspace/acme/projects/*` — sweep every Lisa project under a directory.
+- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=acme` — sweep the projects in a workspaces file whose paths match a substring.
 
 Use this when you suspect a JIRA/GitHub/Linear/Notion status, label, or option was renamed or deleted out from under Lisa — the failure mode that leaves builds unable to find their completion transition and items silently stuck. Run it read-only (or on a schedule) to detect drift; run it with `repair=true` to fix the config. Repair only ever edits the config to match the live names — it never renames anything in the tracker.

--- a/plugins/lisa-agy/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-atlassian-access/SKILL.md
@@ -282,7 +282,7 @@ Substrate column meanings:
 - Multiple cells filled means tier ordering applies — try acli, then MCP, then curl, taking the first that has an adapter for the op AND is identity-matched.
 - One cell means only that substrate can perform the op.
 
-`<SITE>` = `.atlassian.site` (e.g. `propswap.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
+`<SITE>` = `.atlassian.site` (e.g. `acme.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
 
 | Operation | acli adapter | MCP adapter | curl adapter |
 |---|---|---|---|

--- a/plugins/lisa-agy/skills/lisa-notion-prd-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-notion-prd-intake/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 `$ARGUMENTS` is a Notion database URL (or bare database ID) — for example:
 
 ```text
-https://www.notion.so/geminisports/28fd00244d7d47c5866876f7de48c0fe?v=34eba63a2800815891a3000c643f0ea8
+https://www.notion.so/acme/<database-id>?v=<view-id>
 ```
 
 Run one intake cycle against that database. The first eligible PRD in the configured `ready` status is claimed, validated, routed to either `blocked` (with clarifying comments) or `ticketed` (with destination tickets created), then the cycle exits. Remaining ready PRDs stay queued for later scheduler invocations.

--- a/plugins/lisa-agy/skills/lisa-validate-tracker-mapping/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-validate-tracker-mapping/SKILL.md
@@ -23,8 +23,8 @@ It is the audit/repair counterpart to `/lisa:setup:jira` (and the other `setup:*
 ## Arguments
 
 - (none) — audit the **current repo** (`./.lisa.config.json`).
-- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/geminisportsai/projects/*`.
-- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=geminisportsai`).
+- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/acme/projects/*`.
+- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=acme`).
 - `repair=true` — enable config repair (see confirmation policy). Default `false`.
 - `lane=build|prd|both` — which mapping family to check. Default `both`. `build` = the destination `tracker` workflow; `prd` = the PRD `source` status/label mapping.
 

--- a/plugins/lisa-copilot/commands/lisa/validate-tracker-mapping.md
+++ b/plugins/lisa-copilot/commands/lisa/validate-tracker-mapping.md
@@ -9,7 +9,7 @@ Common usage:
 
 - `/lisa:validate-tracker-mapping` — audit the current repo's mapping (read-only).
 - `/lisa:validate-tracker-mapping repair=true` — audit and repair config drift in the current repo.
-- `/lisa:validate-tracker-mapping projects=~/workspace/geminisportsai/projects/*` — sweep every Lisa project under a directory.
-- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=geminisportsai` — sweep the projects in a workspaces file whose paths match a substring.
+- `/lisa:validate-tracker-mapping projects=~/workspace/acme/projects/*` — sweep every Lisa project under a directory.
+- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=acme` — sweep the projects in a workspaces file whose paths match a substring.
 
 Use this when you suspect a JIRA/GitHub/Linear/Notion status, label, or option was renamed or deleted out from under Lisa — the failure mode that leaves builds unable to find their completion transition and items silently stuck. Run it read-only (or on a schedule) to detect drift; run it with `repair=true` to fix the config. Repair only ever edits the config to match the live names — it never renames anything in the tracker.

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -248,7 +248,7 @@ Each vendor section is **conditionally required**: required only when that vendo
 | Field | Required when | Where it lives | Notes |
 |-------|---------------|----------------|-------|
 | `atlassian.cloudId` | `tracker = "jira"`, `source = "jira"`, `source = "confluence"`, or any `confluence-*` / `jira-*` skill is invoked | **committed** (`.lisa.config.json`) | Atlassian Cloud site UUID. Same for every developer on the project. Resolve once via `curl https://<site>/_edge/tenant_info` or `getAccessibleAtlassianResources`. Shared between JIRA and Confluence (same Atlassian site). |
-| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `propswap.atlassian.net`). Same for every developer. |
+| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `acme.atlassian.net`). Same for every developer. |
 | `atlassian.email` | when the developer's machine has multiple Atlassian accounts that can access the configured site | **local** (`.lisa.config.local.json`) | Per-developer. `--site` alone cannot disambiguate which acli profile to switch to when two accounts both have access to the same site (e.g., a personal account and a work account both invited to a customer's site). The setup skill writes this to the local override file, NEVER the committed file. |
 
 #### `jira`

--- a/plugins/lisa-copilot/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-atlassian-access/SKILL.md
@@ -282,7 +282,7 @@ Substrate column meanings:
 - Multiple cells filled means tier ordering applies — try acli, then MCP, then curl, taking the first that has an adapter for the op AND is identity-matched.
 - One cell means only that substrate can perform the op.
 
-`<SITE>` = `.atlassian.site` (e.g. `propswap.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
+`<SITE>` = `.atlassian.site` (e.g. `acme.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
 
 | Operation | acli adapter | MCP adapter | curl adapter |
 |---|---|---|---|

--- a/plugins/lisa-copilot/skills/lisa-notion-prd-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-notion-prd-intake/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 `$ARGUMENTS` is a Notion database URL (or bare database ID) — for example:
 
 ```text
-https://www.notion.so/geminisports/28fd00244d7d47c5866876f7de48c0fe?v=34eba63a2800815891a3000c643f0ea8
+https://www.notion.so/acme/<database-id>?v=<view-id>
 ```
 
 Run one intake cycle against that database. The first eligible PRD in the configured `ready` status is claimed, validated, routed to either `blocked` (with clarifying comments) or `ticketed` (with destination tickets created), then the cycle exits. Remaining ready PRDs stay queued for later scheduler invocations.

--- a/plugins/lisa-copilot/skills/lisa-validate-tracker-mapping/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-validate-tracker-mapping/SKILL.md
@@ -23,8 +23,8 @@ It is the audit/repair counterpart to `/lisa:setup:jira` (and the other `setup:*
 ## Arguments
 
 - (none) — audit the **current repo** (`./.lisa.config.json`).
-- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/geminisportsai/projects/*`.
-- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=geminisportsai`).
+- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/acme/projects/*`.
+- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=acme`).
 - `repair=true` — enable config repair (see confirmation policy). Default `false`.
 - `lane=build|prd|both` — which mapping family to check. Default `both`. `build` = the destination `tracker` workflow; `prd` = the PRD `source` status/label mapping.
 

--- a/plugins/lisa-cursor/commands/lisa/validate-tracker-mapping.md
+++ b/plugins/lisa-cursor/commands/lisa/validate-tracker-mapping.md
@@ -9,7 +9,7 @@ Common usage:
 
 - `/lisa:validate-tracker-mapping` — audit the current repo's mapping (read-only).
 - `/lisa:validate-tracker-mapping repair=true` — audit and repair config drift in the current repo.
-- `/lisa:validate-tracker-mapping projects=~/workspace/geminisportsai/projects/*` — sweep every Lisa project under a directory.
-- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=geminisportsai` — sweep the projects in a workspaces file whose paths match a substring.
+- `/lisa:validate-tracker-mapping projects=~/workspace/acme/projects/*` — sweep every Lisa project under a directory.
+- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=acme` — sweep the projects in a workspaces file whose paths match a substring.
 
 Use this when you suspect a JIRA/GitHub/Linear/Notion status, label, or option was renamed or deleted out from under Lisa — the failure mode that leaves builds unable to find their completion transition and items silently stuck. Run it read-only (or on a schedule) to detect drift; run it with `repair=true` to fix the config. Repair only ever edits the config to match the live names — it never renames anything in the tracker.

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -253,7 +253,7 @@ Each vendor section is **conditionally required**: required only when that vendo
 | Field | Required when | Where it lives | Notes |
 |-------|---------------|----------------|-------|
 | `atlassian.cloudId` | `tracker = "jira"`, `source = "jira"`, `source = "confluence"`, or any `confluence-*` / `jira-*` skill is invoked | **committed** (`.lisa.config.json`) | Atlassian Cloud site UUID. Same for every developer on the project. Resolve once via `curl https://<site>/_edge/tenant_info` or `getAccessibleAtlassianResources`. Shared between JIRA and Confluence (same Atlassian site). |
-| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `propswap.atlassian.net`). Same for every developer. |
+| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `acme.atlassian.net`). Same for every developer. |
 | `atlassian.email` | when the developer's machine has multiple Atlassian accounts that can access the configured site | **local** (`.lisa.config.local.json`) | Per-developer. `--site` alone cannot disambiguate which acli profile to switch to when two accounts both have access to the same site (e.g., a personal account and a work account both invited to a customer's site). The setup skill writes this to the local override file, NEVER the committed file. |
 
 #### `jira`

--- a/plugins/lisa-cursor/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-atlassian-access/SKILL.md
@@ -282,7 +282,7 @@ Substrate column meanings:
 - Multiple cells filled means tier ordering applies — try acli, then MCP, then curl, taking the first that has an adapter for the op AND is identity-matched.
 - One cell means only that substrate can perform the op.
 
-`<SITE>` = `.atlassian.site` (e.g. `propswap.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
+`<SITE>` = `.atlassian.site` (e.g. `acme.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
 
 | Operation | acli adapter | MCP adapter | curl adapter |
 |---|---|---|---|

--- a/plugins/lisa-cursor/skills/lisa-notion-prd-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-notion-prd-intake/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 `$ARGUMENTS` is a Notion database URL (or bare database ID) — for example:
 
 ```text
-https://www.notion.so/geminisports/28fd00244d7d47c5866876f7de48c0fe?v=34eba63a2800815891a3000c643f0ea8
+https://www.notion.so/acme/<database-id>?v=<view-id>
 ```
 
 Run one intake cycle against that database. The first eligible PRD in the configured `ready` status is claimed, validated, routed to either `blocked` (with clarifying comments) or `ticketed` (with destination tickets created), then the cycle exits. Remaining ready PRDs stay queued for later scheduler invocations.

--- a/plugins/lisa-cursor/skills/lisa-validate-tracker-mapping/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-validate-tracker-mapping/SKILL.md
@@ -23,8 +23,8 @@ It is the audit/repair counterpart to `/lisa:setup:jira` (and the other `setup:*
 ## Arguments
 
 - (none) — audit the **current repo** (`./.lisa.config.json`).
-- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/geminisportsai/projects/*`.
-- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=geminisportsai`).
+- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/acme/projects/*`.
+- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=acme`).
 - `repair=true` — enable config repair (see confirmation policy). Default `false`.
 - `lane=build|prd|both` — which mapping family to check. Default `both`. `build` = the destination `tracker` workflow; `prd` = the PRD `source` status/label mapping.
 

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/references/folder-structure.md
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/references/folder-structure.md
@@ -3,7 +3,7 @@
 ## Complete Directory Structure
 
 ```
-thumbwar-frontend/
+acme-frontend/
 ├── app/                                    # Expo Router - PAGES live here
 │   ├── (auth)/                            # Auth route group
 │   │   ├── login.tsx                      # Login page

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/references/folder-structure.md
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/references/folder-structure.md
@@ -3,7 +3,7 @@
 ## Complete Directory Structure
 
 ```
-thumbwar-frontend/
+acme-frontend/
 ├── app/                                    # Expo Router - PAGES live here
 │   ├── (auth)/                            # Auth route group
 │   │   ├── login.tsx                      # Login page

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/references/folder-structure.md
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/references/folder-structure.md
@@ -3,7 +3,7 @@
 ## Complete Directory Structure
 
 ```
-thumbwar-frontend/
+acme-frontend/
 ├── app/                                    # Expo Router - PAGES live here
 │   ├── (auth)/                            # Auth route group
 │   │   ├── login.tsx                      # Login page

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/references/folder-structure.md
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/references/folder-structure.md
@@ -3,7 +3,7 @@
 ## Complete Directory Structure
 
 ```
-thumbwar-frontend/
+acme-frontend/
 ├── app/                                    # Expo Router - PAGES live here
 │   ├── (auth)/                            # Auth route group
 │   │   ├── login.tsx                      # Login page

--- a/plugins/lisa-nestjs-agy/skills/typeorm-patterns/references/configuration-patterns.md
+++ b/plugins/lisa-nestjs-agy/skills/typeorm-patterns/references/configuration-patterns.md
@@ -259,9 +259,9 @@ export const configuration = (): Configuration => ({
   database: {
     host: process.env.DATABASE_HOST ?? "localhost",
     port: parseInt(process.env.DATABASE_PORT ?? "5432", 10),
-    username: process.env.DATABASE_USER ?? "thumbwar",
-    password: process.env.DATABASE_PASSWORD ?? "thumbwar_local",
-    name: process.env.DATABASE_NAME ?? "thumbwar",
+    username: process.env.DATABASE_USER ?? "acme",
+    password: process.env.DATABASE_PASSWORD ?? "acme_local",
+    name: process.env.DATABASE_NAME ?? "acme",
     ssl: process.env.DATABASE_SSL === "true",
     sslRejectUnauthorized: process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false",
     proxyHost: process.env.DATABASE_PROXY_HOST,
@@ -400,9 +400,9 @@ export default new DataSource({
 # Database Configuration
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=thumbwar
-DATABASE_PASSWORD=thumbwar_local
-DATABASE_NAME=thumbwar
+DATABASE_USER=acme
+DATABASE_PASSWORD=acme_local
+DATABASE_NAME=acme
 DATABASE_SSL=false
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
@@ -410,8 +410,8 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 IS_OFFLINE=true
 
 # Production Only - RDS Proxy endpoints
-# DATABASE_PROXY_HOST=thumbwar-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
-# DATABASE_PROXY_HOST_READ_1=thumbwar-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST=acme-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST_READ_1=acme-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
 
 # AWS Configuration (production)
 # AWS_REGION=us-east-1

--- a/plugins/lisa-nestjs-copilot/skills/typeorm-patterns/references/configuration-patterns.md
+++ b/plugins/lisa-nestjs-copilot/skills/typeorm-patterns/references/configuration-patterns.md
@@ -259,9 +259,9 @@ export const configuration = (): Configuration => ({
   database: {
     host: process.env.DATABASE_HOST ?? "localhost",
     port: parseInt(process.env.DATABASE_PORT ?? "5432", 10),
-    username: process.env.DATABASE_USER ?? "thumbwar",
-    password: process.env.DATABASE_PASSWORD ?? "thumbwar_local",
-    name: process.env.DATABASE_NAME ?? "thumbwar",
+    username: process.env.DATABASE_USER ?? "acme",
+    password: process.env.DATABASE_PASSWORD ?? "acme_local",
+    name: process.env.DATABASE_NAME ?? "acme",
     ssl: process.env.DATABASE_SSL === "true",
     sslRejectUnauthorized: process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false",
     proxyHost: process.env.DATABASE_PROXY_HOST,
@@ -400,9 +400,9 @@ export default new DataSource({
 # Database Configuration
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=thumbwar
-DATABASE_PASSWORD=thumbwar_local
-DATABASE_NAME=thumbwar
+DATABASE_USER=acme
+DATABASE_PASSWORD=acme_local
+DATABASE_NAME=acme
 DATABASE_SSL=false
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
@@ -410,8 +410,8 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 IS_OFFLINE=true
 
 # Production Only - RDS Proxy endpoints
-# DATABASE_PROXY_HOST=thumbwar-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
-# DATABASE_PROXY_HOST_READ_1=thumbwar-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST=acme-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST_READ_1=acme-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
 
 # AWS Configuration (production)
 # AWS_REGION=us-east-1

--- a/plugins/lisa-nestjs-cursor/skills/typeorm-patterns/references/configuration-patterns.md
+++ b/plugins/lisa-nestjs-cursor/skills/typeorm-patterns/references/configuration-patterns.md
@@ -259,9 +259,9 @@ export const configuration = (): Configuration => ({
   database: {
     host: process.env.DATABASE_HOST ?? "localhost",
     port: parseInt(process.env.DATABASE_PORT ?? "5432", 10),
-    username: process.env.DATABASE_USER ?? "thumbwar",
-    password: process.env.DATABASE_PASSWORD ?? "thumbwar_local",
-    name: process.env.DATABASE_NAME ?? "thumbwar",
+    username: process.env.DATABASE_USER ?? "acme",
+    password: process.env.DATABASE_PASSWORD ?? "acme_local",
+    name: process.env.DATABASE_NAME ?? "acme",
     ssl: process.env.DATABASE_SSL === "true",
     sslRejectUnauthorized: process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false",
     proxyHost: process.env.DATABASE_PROXY_HOST,
@@ -400,9 +400,9 @@ export default new DataSource({
 # Database Configuration
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=thumbwar
-DATABASE_PASSWORD=thumbwar_local
-DATABASE_NAME=thumbwar
+DATABASE_USER=acme
+DATABASE_PASSWORD=acme_local
+DATABASE_NAME=acme
 DATABASE_SSL=false
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
@@ -410,8 +410,8 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 IS_OFFLINE=true
 
 # Production Only - RDS Proxy endpoints
-# DATABASE_PROXY_HOST=thumbwar-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
-# DATABASE_PROXY_HOST_READ_1=thumbwar-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST=acme-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST_READ_1=acme-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
 
 # AWS Configuration (production)
 # AWS_REGION=us-east-1

--- a/plugins/lisa-nestjs/skills/typeorm-patterns/references/configuration-patterns.md
+++ b/plugins/lisa-nestjs/skills/typeorm-patterns/references/configuration-patterns.md
@@ -259,9 +259,9 @@ export const configuration = (): Configuration => ({
   database: {
     host: process.env.DATABASE_HOST ?? "localhost",
     port: parseInt(process.env.DATABASE_PORT ?? "5432", 10),
-    username: process.env.DATABASE_USER ?? "thumbwar",
-    password: process.env.DATABASE_PASSWORD ?? "thumbwar_local",
-    name: process.env.DATABASE_NAME ?? "thumbwar",
+    username: process.env.DATABASE_USER ?? "acme",
+    password: process.env.DATABASE_PASSWORD ?? "acme_local",
+    name: process.env.DATABASE_NAME ?? "acme",
     ssl: process.env.DATABASE_SSL === "true",
     sslRejectUnauthorized: process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false",
     proxyHost: process.env.DATABASE_PROXY_HOST,
@@ -400,9 +400,9 @@ export default new DataSource({
 # Database Configuration
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=thumbwar
-DATABASE_PASSWORD=thumbwar_local
-DATABASE_NAME=thumbwar
+DATABASE_USER=acme
+DATABASE_PASSWORD=acme_local
+DATABASE_NAME=acme
 DATABASE_SSL=false
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
@@ -410,8 +410,8 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 IS_OFFLINE=true
 
 # Production Only - RDS Proxy endpoints
-# DATABASE_PROXY_HOST=thumbwar-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
-# DATABASE_PROXY_HOST_READ_1=thumbwar-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST=acme-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST_READ_1=acme-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
 
 # AWS Configuration (production)
 # AWS_REGION=us-east-1

--- a/plugins/lisa/commands/lisa/validate-tracker-mapping.md
+++ b/plugins/lisa/commands/lisa/validate-tracker-mapping.md
@@ -9,7 +9,7 @@ Common usage:
 
 - `/lisa:validate-tracker-mapping` — audit the current repo's mapping (read-only).
 - `/lisa:validate-tracker-mapping repair=true` — audit and repair config drift in the current repo.
-- `/lisa:validate-tracker-mapping projects=~/workspace/geminisportsai/projects/*` — sweep every Lisa project under a directory.
-- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=geminisportsai` — sweep the projects in a workspaces file whose paths match a substring.
+- `/lisa:validate-tracker-mapping projects=~/workspace/acme/projects/*` — sweep every Lisa project under a directory.
+- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=acme` — sweep the projects in a workspaces file whose paths match a substring.
 
 Use this when you suspect a JIRA/GitHub/Linear/Notion status, label, or option was renamed or deleted out from under Lisa — the failure mode that leaves builds unable to find their completion transition and items silently stuck. Run it read-only (or on a schedule) to detect drift; run it with `repair=true` to fix the config. Repair only ever edits the config to match the live names — it never renames anything in the tracker.

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -248,7 +248,7 @@ Each vendor section is **conditionally required**: required only when that vendo
 | Field | Required when | Where it lives | Notes |
 |-------|---------------|----------------|-------|
 | `atlassian.cloudId` | `tracker = "jira"`, `source = "jira"`, `source = "confluence"`, or any `confluence-*` / `jira-*` skill is invoked | **committed** (`.lisa.config.json`) | Atlassian Cloud site UUID. Same for every developer on the project. Resolve once via `curl https://<site>/_edge/tenant_info` or `getAccessibleAtlassianResources`. Shared between JIRA and Confluence (same Atlassian site). |
-| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `propswap.atlassian.net`). Same for every developer. |
+| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `acme.atlassian.net`). Same for every developer. |
 | `atlassian.email` | when the developer's machine has multiple Atlassian accounts that can access the configured site | **local** (`.lisa.config.local.json`) | Per-developer. `--site` alone cannot disambiguate which acli profile to switch to when two accounts both have access to the same site (e.g., a personal account and a work account both invited to a customer's site). The setup skill writes this to the local override file, NEVER the committed file. |
 
 #### `jira`

--- a/plugins/lisa/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-atlassian-access/SKILL.md
@@ -282,7 +282,7 @@ Substrate column meanings:
 - Multiple cells filled means tier ordering applies — try acli, then MCP, then curl, taking the first that has an adapter for the op AND is identity-matched.
 - One cell means only that substrate can perform the op.
 
-`<SITE>` = `.atlassian.site` (e.g. `propswap.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
+`<SITE>` = `.atlassian.site` (e.g. `acme.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
 
 | Operation | acli adapter | MCP adapter | curl adapter |
 |---|---|---|---|

--- a/plugins/lisa/skills/lisa-notion-prd-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-notion-prd-intake/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 `$ARGUMENTS` is a Notion database URL (or bare database ID) — for example:
 
 ```text
-https://www.notion.so/geminisports/28fd00244d7d47c5866876f7de48c0fe?v=34eba63a2800815891a3000c643f0ea8
+https://www.notion.so/acme/<database-id>?v=<view-id>
 ```
 
 Run one intake cycle against that database. The first eligible PRD in the configured `ready` status is claimed, validated, routed to either `blocked` (with clarifying comments) or `ticketed` (with destination tickets created), then the cycle exits. Remaining ready PRDs stay queued for later scheduler invocations.

--- a/plugins/lisa/skills/lisa-validate-tracker-mapping/SKILL.md
+++ b/plugins/lisa/skills/lisa-validate-tracker-mapping/SKILL.md
@@ -23,8 +23,8 @@ It is the audit/repair counterpart to `/lisa:setup:jira` (and the other `setup:*
 ## Arguments
 
 - (none) — audit the **current repo** (`./.lisa.config.json`).
-- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/geminisportsai/projects/*`.
-- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=geminisportsai`).
+- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/acme/projects/*`.
+- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=acme`).
 - `repair=true` — enable config repair (see confirmation policy). Default `false`.
 - `lane=build|prd|both` — which mapping family to check. Default `both`. `build` = the destination `tracker` workflow; `prd` = the PRD `source` status/label mapping.
 

--- a/plugins/src/base/commands/lisa/validate-tracker-mapping.md
+++ b/plugins/src/base/commands/lisa/validate-tracker-mapping.md
@@ -9,7 +9,7 @@ Common usage:
 
 - `/lisa:validate-tracker-mapping` — audit the current repo's mapping (read-only).
 - `/lisa:validate-tracker-mapping repair=true` — audit and repair config drift in the current repo.
-- `/lisa:validate-tracker-mapping projects=~/workspace/geminisportsai/projects/*` — sweep every Lisa project under a directory.
-- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=geminisportsai` — sweep the projects in a workspaces file whose paths match a substring.
+- `/lisa:validate-tracker-mapping projects=~/workspace/acme/projects/*` — sweep every Lisa project under a directory.
+- `/lisa:validate-tracker-mapping workspaces=~/workspace/lisa/.lisa.workspaces.json filter=acme` — sweep the projects in a workspaces file whose paths match a substring.
 
 Use this when you suspect a JIRA/GitHub/Linear/Notion status, label, or option was renamed or deleted out from under Lisa — the failure mode that leaves builds unable to find their completion transition and items silently stuck. Run it read-only (or on a schedule) to detect drift; run it with `repair=true` to fix the config. Repair only ever edits the config to match the live names — it never renames anything in the tracker.

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -248,7 +248,7 @@ Each vendor section is **conditionally required**: required only when that vendo
 | Field | Required when | Where it lives | Notes |
 |-------|---------------|----------------|-------|
 | `atlassian.cloudId` | `tracker = "jira"`, `source = "jira"`, `source = "confluence"`, or any `confluence-*` / `jira-*` skill is invoked | **committed** (`.lisa.config.json`) | Atlassian Cloud site UUID. Same for every developer on the project. Resolve once via `curl https://<site>/_edge/tenant_info` or `getAccessibleAtlassianResources`. Shared between JIRA and Confluence (same Atlassian site). |
-| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `propswap.atlassian.net`). Same for every developer. |
+| `atlassian.site` | same as above | **committed** | Human-readable site URL (e.g. `acme.atlassian.net`). Same for every developer. |
 | `atlassian.email` | when the developer's machine has multiple Atlassian accounts that can access the configured site | **local** (`.lisa.config.local.json`) | Per-developer. `--site` alone cannot disambiguate which acli profile to switch to when two accounts both have access to the same site (e.g., a personal account and a work account both invited to a customer's site). The setup skill writes this to the local override file, NEVER the committed file. |
 
 #### `jira`

--- a/plugins/src/base/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-atlassian-access/SKILL.md
@@ -282,7 +282,7 @@ Substrate column meanings:
 - Multiple cells filled means tier ordering applies — try acli, then MCP, then curl, taking the first that has an adapter for the op AND is identity-matched.
 - One cell means only that substrate can perform the op.
 
-`<SITE>` = `.atlassian.site` (e.g. `propswap.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
+`<SITE>` = `.atlassian.site` (e.g. `acme.atlassian.net`). `<CLOUDID>` = `.atlassian.cloudId`. `<AUTH>` = `Basic $(printf '%s:%s' "$email" "$ATLASSIAN_API_TOKEN" | base64)`. JIRA curl writes use the cloudId-bound Atlassian gateway `https://api.atlassian.com/ex/jira/<CLOUDID>/rest/api/3/...`; JIRA curl reads may use either that gateway or `https://<SITE>/rest/api/3/...` after the token account check. Confluence uses `/wiki/rest/api/...` (v1) or `/api/v2/...` (v2).
 
 | Operation | acli adapter | MCP adapter | curl adapter |
 |---|---|---|---|

--- a/plugins/src/base/skills/lisa-notion-prd-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-notion-prd-intake/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 `$ARGUMENTS` is a Notion database URL (or bare database ID) — for example:
 
 ```text
-https://www.notion.so/geminisports/28fd00244d7d47c5866876f7de48c0fe?v=34eba63a2800815891a3000c643f0ea8
+https://www.notion.so/acme/<database-id>?v=<view-id>
 ```
 
 Run one intake cycle against that database. The first eligible PRD in the configured `ready` status is claimed, validated, routed to either `blocked` (with clarifying comments) or `ticketed` (with destination tickets created), then the cycle exits. Remaining ready PRDs stay queued for later scheduler invocations.

--- a/plugins/src/base/skills/lisa-validate-tracker-mapping/SKILL.md
+++ b/plugins/src/base/skills/lisa-validate-tracker-mapping/SKILL.md
@@ -23,8 +23,8 @@ It is the audit/repair counterpart to `/lisa:setup:jira` (and the other `setup:*
 ## Arguments
 
 - (none) — audit the **current repo** (`./.lisa.config.json`).
-- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/geminisportsai/projects/*`.
-- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=geminisportsai`).
+- `projects=<glob-or-path>` — batch sweep. Expands to every directory under the glob that contains a `.lisa.config.json`. Example: `projects=~/workspace/acme/projects/*`.
+- `workspaces=<file>` — batch sweep driven by a Lisa workspaces file (the `{ "<project-path>": "<branch>" }` map used by `/lisa:update-projects`). Each key is a project path to audit. Combine with `filter=<substring>` to restrict to matching paths (e.g. `filter=acme`).
 - `repair=true` — enable config repair (see confirmation policy). Default `false`.
 - `lane=build|prd|both` — which mapping family to check. Default `both`. `build` = the destination `tracker` workflow; `prd` = the PRD `source` status/label mapping.
 

--- a/plugins/src/expo/skills/atomic-design-gluestack/references/folder-structure.md
+++ b/plugins/src/expo/skills/atomic-design-gluestack/references/folder-structure.md
@@ -3,7 +3,7 @@
 ## Complete Directory Structure
 
 ```
-thumbwar-frontend/
+acme-frontend/
 ├── app/                                    # Expo Router - PAGES live here
 │   ├── (auth)/                            # Auth route group
 │   │   ├── login.tsx                      # Login page

--- a/plugins/src/nestjs/skills/typeorm-patterns/references/configuration-patterns.md
+++ b/plugins/src/nestjs/skills/typeorm-patterns/references/configuration-patterns.md
@@ -259,9 +259,9 @@ export const configuration = (): Configuration => ({
   database: {
     host: process.env.DATABASE_HOST ?? "localhost",
     port: parseInt(process.env.DATABASE_PORT ?? "5432", 10),
-    username: process.env.DATABASE_USER ?? "thumbwar",
-    password: process.env.DATABASE_PASSWORD ?? "thumbwar_local",
-    name: process.env.DATABASE_NAME ?? "thumbwar",
+    username: process.env.DATABASE_USER ?? "acme",
+    password: process.env.DATABASE_PASSWORD ?? "acme_local",
+    name: process.env.DATABASE_NAME ?? "acme",
     ssl: process.env.DATABASE_SSL === "true",
     sslRejectUnauthorized: process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false",
     proxyHost: process.env.DATABASE_PROXY_HOST,
@@ -400,9 +400,9 @@ export default new DataSource({
 # Database Configuration
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=thumbwar
-DATABASE_PASSWORD=thumbwar_local
-DATABASE_NAME=thumbwar
+DATABASE_USER=acme
+DATABASE_PASSWORD=acme_local
+DATABASE_NAME=acme
 DATABASE_SSL=false
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 
@@ -410,8 +410,8 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 IS_OFFLINE=true
 
 # Production Only - RDS Proxy endpoints
-# DATABASE_PROXY_HOST=thumbwar-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
-# DATABASE_PROXY_HOST_READ_1=thumbwar-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST=acme-proxy.proxy-xxxxx.us-east-1.rds.amazonaws.com
+# DATABASE_PROXY_HOST_READ_1=acme-proxy-read.proxy-xxxxx.us-east-1.rds.amazonaws.com
 
 # AWS Configuration (production)
 # AWS_REGION=us-east-1


### PR DESCRIPTION
Lisa's plugin skills used a real client org (`geminisportsai`, including a real Notion database URL) as documentation examples — shipping one client's name into every other client's repo on `lisa apply`. Examples are now neutral `acme` placeholders; all generated artifacts (codex/opencode/agy/copilot variants) rebuilt from the scrubbed sources. Verified zero occurrences across plugins/.

Surfaced by client-repo hygiene review in gunnertech/tunnl-frontend#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)