### PR TITLE
fix(expo): remove always-on Maestro MCP server from the expo plugin

### DIFF
--- a/plugins/lisa-expo-agy/THIRD-PARTY-NOTICES.md
+++ b/plugins/lisa-expo-agy/THIRD-PARTY-NOTICES.md
@@ -30,12 +30,20 @@ The accompanying `expo` MCP server in `.mcp.json` points at Expo's official
 remote server (`https://mcp.expo.dev/mcp`), replacing the previously bundled
 third-party `expo-local-docs-mcp` stdio server.
 
-The `maestro` MCP server in `.mcp.json` runs the official Maestro CLI's
-built-in MCP server (`maestro mcp`, STDIO) — nothing is bundled; it requires
-the host machine's own Maestro CLI (with a Java runtime) and exposes device
-automation tools (list_devices, inspect_screen, take_screenshot, run flows,
-cheat_sheet, and Maestro Cloud variants) to coding agents. Servers whose CLI
-is absent simply fail to start without affecting the rest of the plugin.
+The Maestro CLI's built-in MCP server (`maestro mcp`, STDIO) is intentionally
+NOT registered in `.mcp.json`. Coding agents spawn stdio servers with a
+non-login PATH, so an always-on entry fails visibly (Claude Code shows a
+"Failed to reconnect … -32000" error every session) on any machine missing the
+Maestro CLI or a resolvable Java runtime — which is most of the fleet. Opt in
+per machine instead, e.g.:
+
+```
+claude mcp add --scope local maestro -- maestro mcp
+```
+
+ensuring `maestro` and a Java runtime are on the non-interactive PATH (mise
+users: `claude mcp add --scope local maestro -- mise exec java -- maestro mcp`
+from a directory where Java is active).
 
 ### MIT License
 

--- a/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
@@ -12,12 +12,6 @@
     "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
-    },
-    "maestro": {
-      "command": "maestro",
-      "args": [
-        "mcp"
-      ]
     }
   }
 }

--- a/plugins/lisa-expo-copilot/.mcp.json
+++ b/plugins/lisa-expo-copilot/.mcp.json
@@ -3,10 +3,6 @@
     "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
-    },
-    "maestro": {
-      "command": "maestro",
-      "args": ["mcp"]
     }
   }
 }

--- a/plugins/lisa-expo-copilot/THIRD-PARTY-NOTICES.md
+++ b/plugins/lisa-expo-copilot/THIRD-PARTY-NOTICES.md
@@ -30,12 +30,20 @@ The accompanying `expo` MCP server in `.mcp.json` points at Expo's official
 remote server (`https://mcp.expo.dev/mcp`), replacing the previously bundled
 third-party `expo-local-docs-mcp` stdio server.
 
-The `maestro` MCP server in `.mcp.json` runs the official Maestro CLI's
-built-in MCP server (`maestro mcp`, STDIO) — nothing is bundled; it requires
-the host machine's own Maestro CLI (with a Java runtime) and exposes device
-automation tools (list_devices, inspect_screen, take_screenshot, run flows,
-cheat_sheet, and Maestro Cloud variants) to coding agents. Servers whose CLI
-is absent simply fail to start without affecting the rest of the plugin.
+The Maestro CLI's built-in MCP server (`maestro mcp`, STDIO) is intentionally
+NOT registered in `.mcp.json`. Coding agents spawn stdio servers with a
+non-login PATH, so an always-on entry fails visibly (Claude Code shows a
+"Failed to reconnect … -32000" error every session) on any machine missing the
+Maestro CLI or a resolvable Java runtime — which is most of the fleet. Opt in
+per machine instead, e.g.:
+
+```
+claude mcp add --scope local maestro -- maestro mcp
+```
+
+ensuring `maestro` and a Java runtime are on the non-interactive PATH (mise
+users: `claude mcp add --scope local maestro -- mise exec java -- maestro mcp`
+from a directory where Java is active).
 
 ### MIT License
 

--- a/plugins/lisa-expo-cursor/THIRD-PARTY-NOTICES.md
+++ b/plugins/lisa-expo-cursor/THIRD-PARTY-NOTICES.md
@@ -30,12 +30,20 @@ The accompanying `expo` MCP server in `.mcp.json` points at Expo's official
 remote server (`https://mcp.expo.dev/mcp`), replacing the previously bundled
 third-party `expo-local-docs-mcp` stdio server.
 
-The `maestro` MCP server in `.mcp.json` runs the official Maestro CLI's
-built-in MCP server (`maestro mcp`, STDIO) — nothing is bundled; it requires
-the host machine's own Maestro CLI (with a Java runtime) and exposes device
-automation tools (list_devices, inspect_screen, take_screenshot, run flows,
-cheat_sheet, and Maestro Cloud variants) to coding agents. Servers whose CLI
-is absent simply fail to start without affecting the rest of the plugin.
+The Maestro CLI's built-in MCP server (`maestro mcp`, STDIO) is intentionally
+NOT registered in `.mcp.json`. Coding agents spawn stdio servers with a
+non-login PATH, so an always-on entry fails visibly (Claude Code shows a
+"Failed to reconnect … -32000" error every session) on any machine missing the
+Maestro CLI or a resolvable Java runtime — which is most of the fleet. Opt in
+per machine instead, e.g.:
+
+```
+claude mcp add --scope local maestro -- maestro mcp
+```
+
+ensuring `maestro` and a Java runtime are on the non-interactive PATH (mise
+users: `claude mcp add --scope local maestro -- mise exec java -- maestro mcp`
+from a directory where Java is active).
 
 ### MIT License
 

--- a/plugins/lisa-expo-cursor/mcp.json
+++ b/plugins/lisa-expo-cursor/mcp.json
@@ -3,10 +3,6 @@
     "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
-    },
-    "maestro": {
-      "command": "maestro",
-      "args": ["mcp"]
     }
   }
 }

--- a/plugins/lisa-expo/.mcp.json
+++ b/plugins/lisa-expo/.mcp.json
@@ -3,10 +3,6 @@
     "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
-    },
-    "maestro": {
-      "command": "maestro",
-      "args": ["mcp"]
     }
   }
 }

--- a/plugins/lisa-expo/THIRD-PARTY-NOTICES.md
+++ b/plugins/lisa-expo/THIRD-PARTY-NOTICES.md
@@ -30,12 +30,20 @@ The accompanying `expo` MCP server in `.mcp.json` points at Expo's official
 remote server (`https://mcp.expo.dev/mcp`), replacing the previously bundled
 third-party `expo-local-docs-mcp` stdio server.
 
-The `maestro` MCP server in `.mcp.json` runs the official Maestro CLI's
-built-in MCP server (`maestro mcp`, STDIO) — nothing is bundled; it requires
-the host machine's own Maestro CLI (with a Java runtime) and exposes device
-automation tools (list_devices, inspect_screen, take_screenshot, run flows,
-cheat_sheet, and Maestro Cloud variants) to coding agents. Servers whose CLI
-is absent simply fail to start without affecting the rest of the plugin.
+The Maestro CLI's built-in MCP server (`maestro mcp`, STDIO) is intentionally
+NOT registered in `.mcp.json`. Coding agents spawn stdio servers with a
+non-login PATH, so an always-on entry fails visibly (Claude Code shows a
+"Failed to reconnect … -32000" error every session) on any machine missing the
+Maestro CLI or a resolvable Java runtime — which is most of the fleet. Opt in
+per machine instead, e.g.:
+
+```
+claude mcp add --scope local maestro -- maestro mcp
+```
+
+ensuring `maestro` and a Java runtime are on the non-interactive PATH (mise
+users: `claude mcp add --scope local maestro -- mise exec java -- maestro mcp`
+from a directory where Java is active).
 
 ### MIT License
 

--- a/plugins/src/expo/.mcp.json
+++ b/plugins/src/expo/.mcp.json
@@ -3,10 +3,6 @@
     "expo": {
       "type": "http",
       "url": "https://mcp.expo.dev/mcp"
-    },
-    "maestro": {
-      "command": "maestro",
-      "args": ["mcp"]
     }
   }
 }

--- a/plugins/src/expo/THIRD-PARTY-NOTICES.md
+++ b/plugins/src/expo/THIRD-PARTY-NOTICES.md
@@ -30,12 +30,20 @@ The accompanying `expo` MCP server in `.mcp.json` points at Expo's official
 remote server (`https://mcp.expo.dev/mcp`), replacing the previously bundled
 third-party `expo-local-docs-mcp` stdio server.
 
-The `maestro` MCP server in `.mcp.json` runs the official Maestro CLI's
-built-in MCP server (`maestro mcp`, STDIO) — nothing is bundled; it requires
-the host machine's own Maestro CLI (with a Java runtime) and exposes device
-automation tools (list_devices, inspect_screen, take_screenshot, run flows,
-cheat_sheet, and Maestro Cloud variants) to coding agents. Servers whose CLI
-is absent simply fail to start without affecting the rest of the plugin.
+The Maestro CLI's built-in MCP server (`maestro mcp`, STDIO) is intentionally
+NOT registered in `.mcp.json`. Coding agents spawn stdio servers with a
+non-login PATH, so an always-on entry fails visibly (Claude Code shows a
+"Failed to reconnect … -32000" error every session) on any machine missing the
+Maestro CLI or a resolvable Java runtime — which is most of the fleet. Opt in
+per machine instead, e.g.:
+
+```
+claude mcp add --scope local maestro -- maestro mcp
+```
+
+ensuring `maestro` and a Java runtime are on the non-interactive PATH (mise
+users: `claude mcp add --scope local maestro -- mise exec java -- maestro mcp`
+from a directory where Java is active).
 
 ### MIT License
 


### PR DESCRIPTION
## Summary

- Removes the `maestro` stdio MCP server from the expo plugin's `.mcp.json` (source `plugins/src/expo` + regenerated `lisa-expo`, `-copilot`, `-cursor`, `-agy` variants).
- The always-on entry made every Claude Code session on a Lisa-enabled Expo project show `Failed to reconnect to plugin:lisa-expo:maestro: -32000`: coding agents spawn stdio servers with a non-login PATH, so the server dies on any machine missing the Maestro CLI — and even on machines that have it, Maestro can't find a Java runtime managed by mise/sdkman.
- Nothing in the plugin depends on the server (no skills, agents, or tests reference it). THIRD-PARTY-NOTICES now documents per-machine opt-in via `claude mcp add --scope local maestro -- maestro mcp` instead.

## Test plan

- `bun run check:plugins` — artifacts in sync with `plugins/src`, marketplace registers every built plugin.
- Full pre-push suite (unit + integration, 71 integration tests) passed on push.
- After release, `/plugin` in a Lisa-enabled Expo project no longer lists a failed `lisa-expo:maestro` server.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the always-on Maestro MCP entry from bundled configurations, reducing connection and reconnect errors on machines without Maestro or a usable Java runtime.
  * Kept the Expo MCP server available as the default integration.

* **Documentation**
  * Updated third-party notices to explain the new opt-in setup for Maestro on a per-machine basis, with clearer setup guidance for environments using non-login paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->