### PR TITLE
fix(release): pin npm compatible with Node 22.21

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -100,7 +100,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        # npm 12 requires a newer Node release than this project currently pins.
+        run: npm install -g npm@11.7.0
 
       - name: Get OIDC Token for npm
         id: npm-oidc

--- a/npm-package/create-only/.github/workflows/publish-to-npm.yml
+++ b/npm-package/create-only/.github/workflows/publish-to-npm.yml
@@ -101,7 +101,8 @@ jobs:
           cache: ${{ inputs.package_manager != 'bun' && inputs.package_manager || '' }}
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        # npm 12 requires a newer Node release than the generated project may pin.
+        run: npm install -g npm@11.7.0
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- pin the release publisher to npm 11.7.0, which supports OIDC and Node 22.21.1
- update the npm-package template so Lisa apply preserves the fix

## Root cause
The v2.195.5 GitHub release succeeded, but npm publishing failed because `npm@latest` resolved to npm 12.0.0, whose Node engine excludes the project's pinned Node 22.21.1.

## Validation
- `git diff --check`
- `bunx prettier --check .github/workflows/publish-to-npm.yml npm-package/create-only/.github/workflows/publish-to-npm.yml`
- `bun run check:plugins`
- pre-push: typecheck, slow lint, knip, 3,802 unit tests with coverage, 71 integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing process to use a compatible, pinned npm version.
  * Improved publishing reliability with the current Node.js setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->