### PR TITLE
fix(expo): trigger EAS build when app.json or eas.json changes

### DIFF
--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
-  # Check if app.config.ts has changed
+  # Check if native app config has changed
   check_app_config_changes:
     name: Check App Config Changes
     runs-on: ubuntu-latest
@@ -111,18 +111,18 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check if app.config.ts changed
+      - name: Check if app config changed
         id: check_changes
         run: |
-          if git diff --name-only HEAD^ HEAD | grep -q "app.config.ts"; then
+          if git diff --name-only HEAD^ HEAD | grep -qE "^(app\.config\.ts|app\.json|eas\.json)$"; then
             echo "app_config_changed=true" >> $GITHUB_OUTPUT
-            echo "app.config.ts has been modified"
+            echo "app config (app.config.ts / app.json / eas.json) has been modified"
           else
             echo "app_config_changed=false" >> $GITHUB_OUTPUT
-            echo "app.config.ts has not been modified"
+            echo "app config has not been modified"
           fi
 
-  # Trigger EAS Build if needed (only runs if app.config.ts changed)
+  # Trigger EAS Build if needed (only runs if app config changed)
   trigger_eas_build:
     name: Trigger EAS Build
     needs: [determine_environment, check_eas_setup, check_app_config_changes]


### PR DESCRIPTION
## Summary

- The expo deploy template's build gate (`expo/create-only/.github/workflows/deploy.yml`) only greps the merge diff for `app.config.ts`, so native config changes made in `app.json` (permission strings, plugin config) or `eas.json` (profiles, channels) skip the EAS build and ship OTA-only when a new binary is required.
- Gate now matches `app.config.ts`, `app.json`, or `eas.json` (exact root paths).

Observed in the wild: PropSwapLLC/frontend 1.76.1 revised iOS location-permission strings in `app.json` for an App Store rejection fix; the staging release skipped "Trigger EAS Build" and only published an `eas update`, which cannot carry Info.plist changes. The consumer repo was patched directly in PropSwapLLC/frontend#813; this PR fixes the template at the source.

## Test plan

- Template-only change (create-only overlay); no lisa code paths affected.
- Verified the new grep matches `app.json` in the 1.76.1 merge diff and does not match JS-only diffs.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated native app configuration change detection to include `app.config.ts`, `app.json`, and `eas.json`.
  * EAS builds now trigger reliably when any supported native app configuration file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->