### PR TITLE
fix(expo): add force_build dispatch input to recover skipped EAS builds

### DIFF
--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -31,6 +31,11 @@ on:
           - main
           - staging
           - dev
+      force_build:
+        description: 'Queue an EAS build even if app config did not change in the last commit (recovers builds lost to cancelled runs)'
+        required: false
+        default: false
+        type: boolean
 
 # Prevent concurrent runs of the same workflow on the same ref
 concurrency:
@@ -126,7 +131,7 @@ jobs:
   trigger_eas_build:
     name: Trigger EAS Build
     needs: [determine_environment, check_eas_setup, check_app_config_changes]
-    if: needs.check_eas_setup.outputs.has_eas_setup == 'true' && needs.check_app_config_changes.outputs.app_config_changed == 'true'
+    if: needs.check_eas_setup.outputs.has_eas_setup == 'true' && (needs.check_app_config_changes.outputs.app_config_changed == 'true' || inputs.force_build == true)
     uses: CodySwannGT/lisa/.github/workflows/build.yml@main
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}


### PR DESCRIPTION
## Summary

- Companion to the earlier gate-pattern fix (#1483): the EAS build gate diffs only `HEAD^..HEAD`, so a config-changing merge whose deploy run gets cancelled by a concurrent push loses its build permanently — the newer commit's diff has no config change and re-runs can't recover it. Observed on PropSwapLLC/frontend when a dev→staging promotion cancelled the splash-fix deploy run 12 seconds after merge.
- Adds a `force_build` boolean `workflow_dispatch` input ORed into the trigger condition, making recovery a single manual dispatch.

## Test plan

- Template-only change (create-only overlay). Consumer copy live in PropSwapLLC/frontend#822.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to manually force an EAS build through the deployment workflow.
  * Builds can now run even when no app configuration changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->