### PR TITLE
feat(github): default branch resolves to lowest-tier environment branch

### DIFF
--- a/plugins/src/base/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-github-repo/SKILL.md
@@ -20,6 +20,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
      (any key under `github.settings` overrides the baseline)
    - Delete head branches after merge (environment branches survive — the rulesets' `deletion` rule means GitHub refuses to delete them)
    - "Always suggest updating pull request branches" on
+   - Default branch set to the lowest-tier environment branch that exists (dev → staging → main); override with `github.settings.default_branch`
    - GitHub wiki tab off (Lisa projects use in-repo `wiki/`)
    - Secret scanning + push protection enabled where the plan supports it
 2. **Rulesets** (`scripts/lisa-github-rulesets.sh`) from Lisa's `<type>/github-rulesets/` templates, matched by project type:

--- a/scripts/lisa-github-repo-settings.sh
+++ b/scripts/lisa-github-repo-settings.sh
@@ -13,8 +13,12 @@
 #   - GitHub wiki tab disabled (Lisa projects use in-repo wiki/)
 #   - secret scanning + push protection enabled where the plan supports it
 #
+#   - default branch set to the lowest-tier environment branch that exists
+#     on the repository (dev > staging > main); repos with none of the
+#     environment branches keep their current default
+#
 # Per-repo overrides come from .lisa.config.json:
-#   { "github": { "settings": { "allow_auto_merge": false } } }
+#   { "github": { "settings": { "allow_auto_merge": false, "default_branch": "main" } } }
 # Any key in github.settings replaces the baseline value for that repo.
 #
 # Usage:
@@ -68,9 +72,23 @@ baseline_settings() {
   }'
 }
 
+# The default branch is the lowest-tier environment branch the repo has.
+resolve_default_branch() {
+  local repo="$1"
+  local branch
+  for branch in dev staging main; do
+    if gh api "repos/$repo/branches/$branch" > /dev/null 2>&1; then
+      echo "$branch"
+      return 0
+    fi
+  done
+  echo ""
+}
+
 # Merge .lisa.config.json github.settings overrides on top of the baseline.
 resolved_settings() {
   local project_path="$1"
+  local repo="$2"
   local overrides="{}"
 
   if [[ -f "$project_path/.lisa.config.json" ]]; then
@@ -80,7 +98,16 @@ resolved_settings() {
     fi
   fi
 
-  jq -n --argjson base "$(baseline_settings)" --argjson over "$overrides" '$base * $over'
+  local base
+  base=$(baseline_settings)
+
+  local default_branch
+  default_branch=$(resolve_default_branch "$repo")
+  if [[ -n "$default_branch" ]]; then
+    base=$(echo "$base" | jq --arg b "$default_branch" '. + {default_branch: $b}')
+  fi
+
+  jq -n --argjson base "$base" --argjson over "$overrides" '$base * $over'
 }
 
 main() {
@@ -115,7 +142,7 @@ main() {
   log_info "Repository: $repo"
 
   local settings
-  settings=$(resolved_settings "$PROJECT_PATH")
+  settings=$(resolved_settings "$PROJECT_PATH" "$repo")
   log_verbose "Settings payload: $(echo "$settings" | jq -c .)"
 
   if [[ "$DRY_RUN" == "true" ]]; then

--- a/tests/unit/scripts/github-governance.test.ts
+++ b/tests/unit/scripts/github-governance.test.ts
@@ -1,26 +1,10 @@
-import { execFileSync, spawnSync } from "node:child_process";
-import {
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
-const SETTINGS_SCRIPT = path.join(
-  REPO_ROOT,
-  "scripts",
-  "lisa-github-repo-settings.sh"
-);
-const BASH_BIN = "/bin/bash";
-const GIT_BIN = "/usr/bin/git";
-const REPO_NAME = "CodySwannGT/lisa";
 const CODERABBIT_INTEGRATION_ID = 347564;
 const ACTIONS_INTEGRATION_ID = 15368;
 const RULESETS_DIR = "github-rulesets";
@@ -80,68 +64,6 @@ function collectTemplates(): readonly { file: string; type: string }[] {
     }
   }
   return templates;
-}
-
-/**
- * Creates a git project directory for the settings script to inspect.
- *
- * @returns Temporary project directory path.
- */
-function createProject(): string {
-  const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-settings-"));
-  execFileSync(GIT_BIN, ["init"], { cwd: projectDir, stdio: "ignore" });
-  return projectDir;
-}
-
-/**
- * Creates a mock gh executable for the settings script.
- *
- * @returns Temporary bin directory containing the mock gh executable.
- */
-function createMockGhBin(): string {
-  const binDir = mkdtempSync(path.join(tmpdir(), "lisa-gh-bin-"));
-  const ghPath = path.join(binDir, "gh");
-  writeFileSync(
-    ghPath,
-    [
-      "#!/usr/bin/env bash",
-      "set -euo pipefail",
-      'if [[ "$1 $2" == "auth status" ]]; then',
-      "  exit 0",
-      "fi",
-      'if [[ "$1 $2" == "repo view" ]]; then',
-      `  echo "${REPO_NAME}"`,
-      "  exit 0",
-      "fi",
-      'echo "unexpected gh invocation: $*" >&2',
-      "exit 1",
-      "",
-    ].join("\n"),
-    { mode: 0o755 }
-  );
-  return binDir;
-}
-
-/**
- * Runs the settings script in dry-run mode with a mock gh on PATH.
- *
- * @param projectDir - Project directory to point the script at.
- * @param ghBin - Directory containing the mock gh executable.
- * @returns Captured stdout from the script.
- */
-function runSettingsDryRun(projectDir: string, ghBin: string): string {
-  const shimmedPath = [ghBin, process.env.PATH ?? ""].join(":");
-  const result = spawnSync(
-    BASH_BIN,
-    [SETTINGS_SCRIPT, "--dry-run", projectDir],
-    {
-      cwd: REPO_ROOT,
-      env: { ...process.env, PATH: shimmedPath },
-      encoding: "utf8",
-    }
-  );
-  expect(result.status).toBe(0);
-  return result.stdout;
 }
 
 /**
@@ -259,43 +181,6 @@ describe("github-rulesets templates", () => {
     );
     const stripped = stripActionsChecks(quality);
     expect(stripped.rules).toHaveLength(0);
-  });
-});
-
-describe("lisa-github-repo-settings.sh", () => {
-  it("applies the merge-only baseline in dry-run", () => {
-    const projectDir = createProject();
-    const ghBin = createMockGhBin();
-
-    try {
-      const stdout = runSettingsDryRun(projectDir, ghBin);
-      expect(stdout).toContain('"allow_squash_merge": false');
-      expect(stdout).toContain('"allow_rebase_merge": false');
-      expect(stdout).toContain('"allow_auto_merge": true');
-      expect(stdout).toContain('"delete_branch_on_merge": true');
-      expect(stdout).toContain('"allow_update_branch": true');
-    } finally {
-      rmSync(projectDir, { recursive: true, force: true });
-      rmSync(ghBin, { recursive: true, force: true });
-    }
-  });
-
-  it("honors per-repo overrides from .lisa.config.json github.settings", () => {
-    const projectDir = createProject();
-    const ghBin = createMockGhBin();
-
-    try {
-      writeFileSync(
-        path.join(projectDir, ".lisa.config.json"),
-        JSON.stringify({ github: { settings: { allow_auto_merge: false } } })
-      );
-      const stdout = runSettingsDryRun(projectDir, ghBin);
-      expect(stdout).toContain('"allow_auto_merge": false');
-      expect(stdout).toContain('"allow_squash_merge": false');
-    } finally {
-      rmSync(projectDir, { recursive: true, force: true });
-      rmSync(ghBin, { recursive: true, force: true });
-    }
   });
 });
 

--- a/tests/unit/scripts/lisa-github-repo-settings.test.ts
+++ b/tests/unit/scripts/lisa-github-repo-settings.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SETTINGS_SCRIPT = path.join(
+  REPO_ROOT,
+  "scripts",
+  "lisa-github-repo-settings.sh"
+);
+const BASH_BIN = "/bin/bash";
+const GIT_BIN = "/usr/bin/git";
+const REPO_NAME = "CodySwannGT/lisa";
+
+/**
+ * Creates a git project directory for the settings script to inspect.
+ *
+ * @returns Temporary project directory path.
+ */
+function createProject(): string {
+  const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-settings-"));
+  execFileSync(GIT_BIN, ["init"], { cwd: projectDir, stdio: "ignore" });
+  return projectDir;
+}
+
+/**
+ * Creates a mock gh executable for the settings script.
+ *
+ * @param existingBranches - Branch names the mock reports as existing.
+ * @returns Temporary bin directory containing the mock gh executable.
+ */
+function createMockGhBin(
+  existingBranches: readonly string[] = ["main"]
+): string {
+  const binDir = mkdtempSync(path.join(tmpdir(), "lisa-gh-bin-"));
+  const ghPath = path.join(binDir, "gh");
+  writeFileSync(
+    ghPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [[ "$1 $2" == "auth status" ]]; then',
+      "  exit 0",
+      "fi",
+      'if [[ "$1 $2" == "repo view" ]]; then',
+      `  echo "${REPO_NAME}"`,
+      "  exit 0",
+      "fi",
+      'if [[ "$1" == "api" && "$2" == repos/*/branches/* ]]; then',
+      '  branch="${2##*/}"',
+      `  case "$branch" in ${existingBranches.join("|")}) exit 0 ;; esac`,
+      "  exit 1",
+      "fi",
+      'echo "unexpected gh invocation: $*" >&2',
+      "exit 1",
+      "",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+  return binDir;
+}
+
+/**
+ * Runs the settings script in dry-run mode with a mock gh on PATH.
+ *
+ * @param projectDir - Project directory to point the script at.
+ * @param ghBin - Directory containing the mock gh executable.
+ * @returns Captured stdout from the script.
+ */
+function runSettingsDryRun(projectDir: string, ghBin: string): string {
+  const shimmedPath = [ghBin, process.env.PATH ?? ""].join(":");
+  const result = spawnSync(
+    BASH_BIN,
+    [SETTINGS_SCRIPT, "--dry-run", projectDir],
+    {
+      cwd: REPO_ROOT,
+      env: { ...process.env, PATH: shimmedPath },
+      encoding: "utf8",
+    }
+  );
+  expect(result.status).toBe(0);
+  return result.stdout;
+}
+
+describe("lisa-github-repo-settings.sh", () => {
+  it("applies the merge-only baseline in dry-run", () => {
+    const projectDir = createProject();
+    const ghBin = createMockGhBin();
+
+    try {
+      const stdout = runSettingsDryRun(projectDir, ghBin);
+      expect(stdout).toContain('"allow_squash_merge": false');
+      expect(stdout).toContain('"allow_rebase_merge": false');
+      expect(stdout).toContain('"allow_auto_merge": true');
+      expect(stdout).toContain('"delete_branch_on_merge": true');
+      expect(stdout).toContain('"allow_update_branch": true');
+      expect(stdout).toContain('"default_branch": "main"');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(ghBin, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults the default branch to the lowest-tier environment branch", () => {
+    const projectDir = createProject();
+    const ghBin = createMockGhBin(["dev", "staging", "main"]);
+
+    try {
+      const stdout = runSettingsDryRun(projectDir, ghBin);
+      expect(stdout).toContain('"default_branch": "dev"');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(ghBin, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers staging when dev does not exist", () => {
+    const projectDir = createProject();
+    const ghBin = createMockGhBin(["staging", "main"]);
+
+    try {
+      const stdout = runSettingsDryRun(projectDir, ghBin);
+      expect(stdout).toContain('"default_branch": "staging"');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(ghBin, { recursive: true, force: true });
+    }
+  });
+
+  it("lets .lisa.config.json override the resolved default branch", () => {
+    const projectDir = createProject();
+    const ghBin = createMockGhBin(["dev", "staging", "main"]);
+
+    try {
+      writeFileSync(
+        path.join(projectDir, ".lisa.config.json"),
+        JSON.stringify({ github: { settings: { default_branch: "main" } } })
+      );
+      const stdout = runSettingsDryRun(projectDir, ghBin);
+      expect(stdout).toContain('"default_branch": "main"');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(ghBin, { recursive: true, force: true });
+    }
+  });
+
+  it("honors per-repo overrides from .lisa.config.json github.settings", () => {
+    const projectDir = createProject();
+    const ghBin = createMockGhBin();
+
+    try {
+      writeFileSync(
+        path.join(projectDir, ".lisa.config.json"),
+        JSON.stringify({ github: { settings: { allow_auto_merge: false } } })
+      );
+      const stdout = runSettingsDryRun(projectDir, ghBin);
+      expect(stdout).toContain('"allow_auto_merge": false');
+      expect(stdout).toContain('"allow_squash_merge": false');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(ghBin, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The repo-settings baseline now sets `default_branch` to the lowest-tier environment branch that exists on the repository (dev → staging → main). Repos with none of the environment branches keep their current default. Per-repo override: `.lisa.config.json` → `github.settings.default_branch`.

## Test plan

- `bunx vitest run tests/unit/scripts/` — 221 tests pass, including new coverage: dev preferred when present, staging when dev absent, main fallback, and config override beating the resolved value (settings tests split into their own file to stay under max-lines).

🤖 Generated with Claude Code