### PR TITLE
fix(release): prevent cross-branch tag collisions and make release creation rerun-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -542,6 +542,21 @@ jobs:
           # Normalize any leading "v" regardless of strategy so "tag=v$VERSION" never yields "vv"
           VERSION="${VERSION#v}"
 
+          # Guard against tag collisions. Version counters are branch-local
+          # (standard-version reads package.json; semantic reads the nearest
+          # reachable tag) but tags are repo-global, so two long-lived release
+          # branches (e.g. dev and staging) can compute the same next version
+          # and the Create GitHub Release step would 422 (already_exists) and
+          # skip deployment. Bump patch until the tag is free. Skipped for the
+          # "custom" strategy — an explicitly pinned version must not be
+          # silently changed (a collision there fails loudly at release time).
+          if [ "${{ inputs.release_strategy }}" != "custom" ]; then
+            while git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; do
+              echo "::warning::Tag v$VERSION already exists (released from another branch); bumping patch"
+              VERSION=$(npx semver -i patch "$VERSION")
+            done
+          fi
+
           # Add prerelease suffix if specified
           if [ -n "${{ inputs.prerelease }}" ] && [ "${{ inputs.release_strategy }}" != "calendar" ]; then
             VERSION="${VERSION}-${{ inputs.prerelease }}.$(date +%s)"
@@ -1115,12 +1130,33 @@ jobs:
               draft: $draft
             }')
 
-          # Create release
-          RESPONSE=$(curl --fail-with-body -sS -X POST \
+          # Create release. Idempotent: a rerun after a partial failure finds
+          # the release already created for this commit — reuse it instead of
+          # dying on 422 already_exists (which would skip deployment).
+          HTTP_CODE=$(curl -sS -o response.json -w "%{http_code}" -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             -d "$RELEASE_DATA" \
             "https://api.github.com/repos/${{ github.repository }}/releases")
+
+          if [ "$HTTP_CODE" = "422" ] && jq -e '.errors[]? | select(.code == "already_exists")' response.json >/dev/null; then
+            echo "Release ${{ needs.version.outputs.tag }} already exists; fetching it"
+            curl --fail-with-body -sS \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.version.outputs.tag }}" > response.json
+            TARGET=$(jq -r '.target_commitish' response.json)
+            if [ "$TARGET" != "${{ github.sha }}" ]; then
+              echo "::error::Tag ${{ needs.version.outputs.tag }} was already released from a different commit ($TARGET). This branch's version counter has fallen behind the repo's tags — align the version in package.json past the latest existing tag."
+              exit 1
+            fi
+          elif [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Create release failed with HTTP $HTTP_CODE"
+            cat response.json
+            exit 1
+          fi
+
+          RESPONSE=$(cat response.json)
 
           # Extract release information
           echo "$RESPONSE" | jq -e -r '.html_url' > .release_url

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -335,31 +335,37 @@ describe("release and deploy workflows", () => {
     );
   });
 
-  it("normalizes standard-version output before composing release tags", () => {
+  it("normalizes versions and bumps past existing tags before composing release tags", () => {
+    // Version counters are branch-local but tags are repo-global (dev and
+    // staging can compute the same next version); custom pins never bump.
     const steps = releaseWorkflow.jobs.version.steps ?? [];
-    const determineVersion = steps.find(s => s.name === "Determine Version");
-    const run = determineVersion?.run ?? "";
+    const run = steps.find(s => s.name === "Determine Version")?.run ?? "";
 
-    expect(determineVersion).toBeDefined();
     expect(run).toContain("awk '{print $4}'");
+    expect(run).toContain('npx semver -i patch "$VERSION"');
+    expect(run).toContain('!= "custom"');
+
     expect(run).toContain('VERSION="${VERSION#v}"');
-
-    const stripPrefixIndex = run.indexOf('VERSION="${VERSION#v}"');
-    const versionOutputIndex = run.indexOf('echo "version=$VERSION"');
-    const tagOutputIndex = run.indexOf('echo "tag=v$VERSION"');
-
-    expect(stripPrefixIndex).toBeGreaterThan(-1);
-    expect(versionOutputIndex).toBeGreaterThan(stripPrefixIndex);
-    expect(tagOutputIndex).toBeGreaterThan(stripPrefixIndex);
+    const guardIndex = run.indexOf("git rev-parse -q --verify");
+    expect(guardIndex).toBeGreaterThan(run.indexOf('VERSION="${VERSION#v}"'));
+    expect(run.indexOf('echo "version=$VERSION"')).toBeGreaterThan(guardIndex);
+    expect(run.indexOf('echo "tag=v$VERSION"')).toBeGreaterThan(guardIndex);
   });
 
-  it("fails the job when GitHub release creation returns an API error", () => {
+  it("fails release creation on API errors but reuses an existing release on rerun", () => {
     const steps = releaseWorkflow.jobs.github_release.steps ?? [];
     const createRelease = steps.find(s => s.name === "Create GitHub Release");
     const run = createRelease?.run ?? "";
 
     expect(createRelease).toBeDefined();
-    expect(run).toContain("curl --fail-with-body -sS -X POST");
+    expect(run).toContain('-w "%{http_code}"');
+    expect(run).toContain(
+      '[ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]'
+    );
+    expect(run).toContain("exit 1");
+    expect(run).toContain('select(.code == "already_exists")');
+    expect(run).toContain("releases/tags/${{ needs.version.outputs.tag }}");
+    expect(run).toContain('[ "$TARGET" != "${{ github.sha }}" ]');
     expect(run).toContain("jq -e -r '.html_url'");
     expect(run).toContain("jq -e -r '.id'");
     expect(run).toContain("jq -e -r '.upload_url'");


### PR DESCRIPTION
## Summary
Two defects in `release.yml` surfaced today when a consumer repo (geminisportsai/backend-v2) released from two long-lived branches (dev + staging) sharing one tag namespace:

- **Determine Version computes a branch-local next version but tags are repo-global.** `standard-version` reads the branch's package.json (and `semantic` reads the nearest reachable tag), so dev and staging can compute the same tag — staging computed `0.130.603`, which dev had already released. Fix: after normalization, bump patch (`npx semver -i patch`) until `git rev-parse` finds no existing tag (`fetch-depth: 0` checkout has all tags). Skipped for the `custom` strategy — an explicitly pinned version must not be silently changed.
- **Create GitHub Release was not rerun-safe.** A bare `curl --fail-with-body` POST dies on 422 `already_exists` — whether from a collision or from `gh run rerun --failed` after a partial failure — failing the job and causing deploy.yml to skip the Deploy job entirely. Fix: capture the HTTP code; on 422 already_exists, GET the release by tag and reuse it when it targets this run's commit (rerun case), or fail with an actionable message when the tag belongs to a different commit; any other non-2xx still fails loudly.

Either fix alone would have prevented today's skipped staging deploy; together they cover both the collision and the recovery path.

## Test plan
- [x] `bun test tests/integration/quality-workflow.test.ts` — 24 pass; assertions updated to pin the collision guard (placement between prefix-strip and outputs, custom-strategy exemption) and the idempotent create-release behavior (http_code capture, already_exists reuse, foreign-commit rejection, non-2xx exit 1)
- [x] YAML validated

🤖 Generated with Claude Code