### PR TITLE
feat: Lisa settings console prototype, lisa sync config engine, and lisa ui command

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -4,11 +4,128 @@
   "source": "github",
   "github": {
     "org": "CodySwannGT",
-    "repo": "lisa"
+    "repo": "lisa",
+    "labels": {
+      "build": {
+        "ready": "status:ready",
+        "claimed": "status:in-progress",
+        "blocked": "status:blocked",
+        "human_needed": "human-needed",
+        "done": {
+          "dev": "status:on-dev",
+          "staging": "status:on-stg",
+          "production": "status:done"
+        }
+      },
+      "prd": {
+        "draft": "prd-draft",
+        "ready": "prd-ready",
+        "in_review": "prd-in-review",
+        "blocked": "prd-blocked",
+        "ticketed": "prd-ticketed",
+        "shipped": "prd-shipped",
+        "verified": "prd-verified",
+        "sentinel": "prd-intake-feedback"
+      }
+    }
   },
   "deploy": {
     "branches": {
       "production": "main"
+    }
+  },
+  "quality": {
+    "testCoverage": {
+      "global": {
+        "statements": 74,
+        "branches": 65,
+        "functions": 60,
+        "lines": 75
+      }
+    },
+    "lintBudgets": {
+      "cognitiveComplexity": 10,
+      "maxLines": 300,
+      "maxLinesPerFunction": 75
+    },
+    "mutation": {
+      "gate": {
+        "enabled": false,
+        "since": "main"
+      },
+      "strykerThresholds": {
+        "high": 80,
+        "low": 60,
+        "break": 60
+      }
+    }
+  },
+  "_lisaSync": {
+    "populated": {
+      "quality.mutation.gate": {
+        "enabled": false,
+        "since": "main"
+      },
+      "quality.mutation.strykerThresholds": {
+        "high": 80,
+        "low": 60,
+        "break": 60
+      },
+      "intake.repair": {
+        "staleAfterHours": 2,
+        "maxCandidates": 100
+      },
+      "monitor": {
+        "maxCandidates": 20,
+        "gapTiers": "core",
+        "backoffHours": 24,
+        "thresholds": {
+          "minEvents24h": 1,
+          "errorRateSpikeMultiplier": 2,
+          "p95LatencyMs": 1000,
+          "faultRatePct": 5
+        }
+      },
+      "github.labels": {
+        "build": {
+          "ready": "status:ready",
+          "claimed": "status:in-progress",
+          "blocked": "status:blocked",
+          "human_needed": "human-needed",
+          "done": {
+            "dev": "status:on-dev",
+            "staging": "status:on-stg",
+            "production": "status:done"
+          }
+        },
+        "prd": {
+          "draft": "prd-draft",
+          "ready": "prd-ready",
+          "in_review": "prd-in-review",
+          "blocked": "prd-blocked",
+          "ticketed": "prd-ticketed",
+          "shipped": "prd-shipped",
+          "verified": "prd-verified",
+          "sentinel": "prd-intake-feedback"
+        }
+      }
+    }
+  },
+  "intake": {
+    "repair": {
+      "staleAfterHours": 2,
+      "maxCandidates": 100
+    }
+  },
+  "monitor": {
+    "maxCandidates": 20,
+    "gapTiers": "core",
+    "backoffHours": 24,
+    "thresholds": {
+      "minEvents24h": 1,
+      "errorRateSpikeMultiplier": 2,
+      "p95LatencyMs": 1000,
+      "faultRatePct": 5
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   ],
   "files": [
     "dist",
+    "ui",
     "all",
     "typescript",
     "npm-package",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,8 @@ import { runSetupProject } from "./setup-project.js";
 import { runSetupWiki } from "./setup-wiki.js";
 import { addSharedOptions, type CLIOptions } from "./shared-options.js";
 import { SETUP_TYPES } from "./starters.js";
+import { runSync, type SyncCmdOptions } from "./sync-cmd.js";
+import { runUi, type UiCmdOptions } from "./ui-cmd.js";
 import { runUpdate } from "./update-cmd.js";
 import { runUpdateCheck } from "./update-check.js";
 import { runVersion } from "./version-cmd.js";
@@ -35,6 +37,10 @@ export interface ProgramDependencies {
   runDoctor: typeof runDoctor;
   /** Cross-pollinates locally-authored agent definitions across the fleet. */
   runCrossPollinate: typeof runCrossPollinate;
+  /** Populates and syncs `.lisa.config.json` with its mirrored artifacts. */
+  runSync: typeof runSync;
+  /** Serves the Lisa settings console (after a config sync). */
+  runUi: typeof runUi;
   /** Runs the non-fatal npm update check (defaults to {@link runUpdateCheck}). */
   runUpdateCheck: typeof runUpdateCheck;
   /** Prints the update warning (defaults to {@link printUpdateWarning}). */
@@ -49,9 +55,14 @@ const DEFAULT_DEPENDENCIES: ProgramDependencies = {
   runUpdate,
   runDoctor,
   runCrossPollinate,
+  runSync,
+  runUi,
   runUpdateCheck,
   printUpdateWarning,
 };
+
+/** Shared help text for the optional project-path positional argument. */
+const PATH_ARG_DESCRIPTION = "Project path (default: current directory)";
 
 /**
  * Register CLI maintenance commands that do not run the root update warning.
@@ -94,11 +105,38 @@ function addMaintenanceCommands(
     });
 
   program
+    .command("sync")
+    .description(
+      "Populate .lisa.config.json with every missing setting and sync mirrored files (config wins)"
+    )
+    .argument("[path]", PATH_ARG_DESCRIPTION)
+    .option("--dry-run", "Report what would change without writing")
+    .option("--json", "Emit the report as JSON")
+    .action(async (targetPath: string | undefined, options: SyncCmdOptions) => {
+      const code = await deps.runSync(targetPath, options);
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    });
+
+  program
+    .command("ui")
+    .description(
+      "Serve the Lisa settings console for a project (runs a config sync first)"
+    )
+    .argument("[path]", PATH_ARG_DESCRIPTION)
+    .option("--port <port>", "Port to listen on", "4780")
+    .option("--no-sync", "Skip the config sync on startup")
+    .action(async (targetPath: string | undefined, options: UiCmdOptions) => {
+      await deps.runUi(targetPath, options);
+    });
+
+  program
     .command("cross-pollinate")
     .description(
       "Make locally-authored agent definitions available to the other agents this project supports"
     )
-    .argument("[path]", "Project path (default: current directory)")
+    .argument("[path]", PATH_ARG_DESCRIPTION)
     .option("--write", "Apply emits and update the lockfile (default: dry-run)")
     .action(
       async (
@@ -143,7 +181,11 @@ export function createProgram(
   // Run the npm update-check once per invocation, before the matched action.
   // It is non-fatal: a failed check never blocks the action from running.
   program.hook("preAction", async (_thisCommand, actionCommand) => {
-    if (["doctor", "update", "version"].includes(actionCommand.name())) {
+    if (
+      ["doctor", "sync", "ui", "update", "version"].includes(
+        actionCommand.name()
+      )
+    ) {
       return;
     }
     if (program.opts().updateCheck === false) {
@@ -189,7 +231,7 @@ export function createProgram(
     program
       .command("setup-wiki")
       .description("Prepare an existing project for embedded Lisa wiki setup")
-      .argument("[path]", "Project path (default: current directory)")
+      .argument("[path]", PATH_ARG_DESCRIPTION)
   ).action(async (destination: string | undefined, options: CLIOptions) => {
     await deps.runSetupWiki(destination, options);
   });

--- a/src/cli/sync-cmd.ts
+++ b/src/cli/sync-cmd.ts
@@ -1,0 +1,56 @@
+/**
+ * `lisa sync` — populate `.lisa.config.json` with every missing setting and
+ * push config values back into the artifact files that mirror them.
+ * @module cli/sync-cmd
+ */
+import * as path from "node:path";
+import { runConfigSync, type SyncReport } from "../sync/config-sync.js";
+
+/** CLI options for `lisa sync`. */
+export interface SyncCmdOptions {
+  /** Report what would change without writing */
+  readonly dryRun?: boolean;
+  /** Emit the report as JSON instead of human-readable lines */
+  readonly json?: boolean;
+}
+
+/**
+ * Print a sync report in human-readable form.
+ * @param report - Report returned by the sync engine
+ */
+export function printSyncReport(report: SyncReport): void {
+  const prefix = report.dryRun ? "[dry-run] " : "";
+  if (report.actions.length === 0) {
+    console.log(`${prefix}Config is in sync — nothing to do.`);
+  }
+  report.actions.forEach(action => {
+    console.log(`${prefix}${action.kind}  ${action.key} — ${action.detail}`);
+  });
+  report.missingRequired.forEach(missing => {
+    console.warn(
+      `${prefix}missing-required  ${missing.key} — cannot be defaulted; run ${missing.setupHint}`
+    );
+  });
+}
+
+/**
+ * Run the `lisa sync` command.
+ * @param targetPath - Project path argument (defaults to the current directory)
+ * @param options - CLI options
+ * @returns Exit code (0 on success, 1 when required keys are missing)
+ */
+export async function runSync(
+  targetPath: string | undefined,
+  options: SyncCmdOptions = {}
+): Promise<number> {
+  const destDir = path.resolve(targetPath ?? ".");
+  const report = await runConfigSync(destDir, {
+    dryRun: options.dryRun === true,
+  });
+  if (options.json === true) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printSyncReport(report);
+  }
+  return report.missingRequired.length > 0 ? 1 : 0;
+}

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -1,0 +1,125 @@
+/**
+ * `lisa ui` — serve the Lisa settings console for a project.
+ *
+ * Runs a config sync first (so the config file is fully populated — the UI's
+ * contract is "no unset configs"), then serves the packaged `ui/index.html`
+ * with the project's merged live config injected as
+ * `window.LISA_LIVE_CONFIG`, which the page uses to hydrate its controls.
+ * @module cli/ui-cmd
+ */
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import * as http from "node:http";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runConfigSync } from "../sync/config-sync.js";
+import { isJsonObject, type JsonObject } from "../sync/json-path.js";
+import { deepMerge, readJsonOrNull } from "../utils/index.js";
+import { printSyncReport } from "./sync-cmd.js";
+
+/** Default port for the settings console. */
+export const DEFAULT_UI_PORT = 4780;
+
+/** CLI options for `lisa ui`. */
+export interface UiCmdOptions {
+  /** Port to listen on (string because Commander passes raw option values) */
+  readonly port?: string;
+  /** Set false (via --no-sync) to skip the config sync on startup */
+  readonly sync?: boolean;
+}
+
+/**
+ * Locate the packaged `ui/index.html` by walking up from this module until a
+ * directory containing `ui/index.html` is found (works from both `src/` and
+ * the compiled `dist/`).
+ * @param startDir - Directory to start searching from
+ * @returns Absolute path to ui/index.html
+ */
+export function findUiHtml(startDir: string): string {
+  const candidate = path.join(startDir, "ui", "index.html");
+  if (existsSync(candidate)) {
+    return candidate;
+  }
+  const parent = path.dirname(startDir);
+  if (parent === startDir) {
+    throw new Error("Unable to locate the packaged ui/index.html");
+  }
+  return findUiHtml(parent);
+}
+
+/**
+ * Read the project's merged config view (local overlay wins per key).
+ * @param destDir - Project root
+ * @returns Merged config object
+ */
+async function readMergedConfig(destDir: string): Promise<JsonObject> {
+  const committed = await readJsonOrNull<unknown>(
+    path.join(destDir, ".lisa.config.json")
+  );
+  const local = await readJsonOrNull<unknown>(
+    path.join(destDir, ".lisa.config.local.json")
+  );
+  const committedObject = isJsonObject(committed) ? committed : {};
+  const localObject = isJsonObject(local) ? local : {};
+  return deepMerge(committedObject, localObject) as JsonObject;
+}
+
+/**
+ * Inject the live config into the console HTML as a script tag. The JSON is
+ * escaped so a value containing `</script>` cannot break out of the tag.
+ * @param html - Packaged console HTML
+ * @param config - Merged live config
+ * @returns HTML with the injected config
+ */
+export function injectLiveConfig(html: string, config: JsonObject): string {
+  const payload = JSON.stringify(config).replace(/<\//g, "<\\/");
+  const tag = `<script>window.LISA_LIVE_CONFIG = ${payload};</script>`;
+  return html.replace("</body>", `${tag}\n</body>`);
+}
+
+/**
+ * Run the `lisa ui` command: sync, then serve the console until interrupted.
+ * @param targetPath - Project path argument (defaults to the current directory)
+ * @param options - CLI options
+ * @returns The listening server (callers/tests are responsible for closing it)
+ */
+export async function runUi(
+  targetPath: string | undefined,
+  options: UiCmdOptions = {}
+): Promise<http.Server> {
+  const destDir = path.resolve(targetPath ?? ".");
+  const port = Number.parseInt(options.port ?? `${DEFAULT_UI_PORT}`, 10);
+  if (Number.isNaN(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid --port value: ${options.port}`);
+  }
+  if (options.sync !== false) {
+    const report = await runConfigSync(destDir);
+    printSyncReport(report);
+  }
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const htmlPath = findUiHtml(moduleDir);
+  const html = await readFile(htmlPath, "utf8");
+  const config = await readMergedConfig(destDir);
+  const page = injectLiveConfig(html, config);
+
+  const server = http.createServer((request, response) => {
+    const url = request.url ?? "/";
+    if (url === "/" || url.startsWith("/index.html") || url.startsWith("/#")) {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(page);
+      return;
+    }
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("Not found");
+  });
+  await new Promise<void>(resolve => {
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const boundPort =
+    typeof address === "object" && address !== null ? address.port : port;
+  console.log(`Lisa console for ${destDir}`);
+  console.log(`  → http://127.0.0.1:${boundPort}`);
+  console.log("Press Ctrl+C to stop.");
+  return server;
+}

--- a/src/sync/config-sync.ts
+++ b/src/sync/config-sync.ts
@@ -1,0 +1,403 @@
+/**
+ * Config-sync engine: makes `.lisa.config.json` (plus the per-developer
+ * `.lisa.config.local.json` overlay) the source of truth for every registry
+ * setting.
+ *
+ * Populate direction (only when a config value is completely missing):
+ * absorb the value from an existing artifact file if one holds it, otherwise
+ * fall back to the built-in default. Pure-default populations are recorded in
+ * the config's `_lisaSync.populated` block so a later Lisa version that ships
+ * a changed default can distinguish "still the default" (safe to update) from
+ * "the project chose this value" (never touched).
+ *
+ * Sync direction (always): the effective config value is written into every
+ * artifact file that exists on disk — config wins.
+ * @module sync/config-sync
+ */
+import * as fse from "fs-extra";
+import * as path from "node:path";
+import { deepMerge, readJsonOrNull, writeJson } from "../utils/index.js";
+import {
+  fillMissing,
+  getAtPath,
+  isJsonObject,
+  jsonEquals,
+  setAtPath,
+  type JsonObject,
+  type JsonValue,
+} from "./json-path.js";
+import {
+  REQUIRED_KEYS,
+  SYNC_REGISTRY,
+  type SyncedSetting,
+} from "./registry.js";
+
+/** Key holding sync provenance metadata inside `.lisa.config.json`. */
+export const SYNC_METADATA_KEY = "_lisaSync";
+
+/** What sync did (or would do, in dry-run) for one setting. */
+export type SyncActionKind =
+  | "absorbed-artifact"
+  | "populated-default"
+  | "filled-missing"
+  | "default-evolved"
+  | "artifact-synced"
+  | "unchanged";
+
+/** One reportable sync action. */
+export interface SyncAction {
+  /** Config key the action applies to */
+  readonly key: string;
+  /** What happened */
+  readonly kind: SyncActionKind;
+  /** Human-readable detail (e.g. which artifact file was involved) */
+  readonly detail: string;
+}
+
+/** Result of one sync run. */
+export interface SyncReport {
+  /** Actions taken (or planned, when dryRun) — excludes unchanged entries */
+  readonly actions: readonly SyncAction[];
+  /** Required keys that are missing and cannot be defaulted */
+  readonly missingRequired: readonly { key: string; setupHint: string }[];
+  /** True when the run was a dry run (nothing written) */
+  readonly dryRun: boolean;
+}
+
+/** Options for {@link runConfigSync}. */
+export interface SyncOptions {
+  /** Report without writing anything */
+  readonly dryRun?: boolean;
+}
+
+/** Accumulated state threaded through the sync pass. */
+interface SyncState {
+  readonly committed: JsonObject;
+  readonly actions: readonly SyncAction[];
+  readonly artifactWrites: ReadonlyMap<string, JsonObject>;
+}
+
+/**
+ * Check whether a registry relevance condition matches the merged config.
+ * @param merged - Merged (committed + local) config view
+ * @param condition - `"section"` (path exists) or `"path=value"` (equality)
+ * @returns True when the condition matches
+ */
+function conditionMatches(merged: JsonObject, condition: string): boolean {
+  const eqIndex = condition.indexOf("=");
+  if (eqIndex === -1) {
+    return getAtPath(merged, condition) !== undefined;
+  }
+  const value = getAtPath(merged, condition.slice(0, eqIndex));
+  return value === condition.slice(eqIndex + 1);
+}
+
+/**
+ * Whether a registry entry applies to this project's current config.
+ * @param merged - Merged (committed + local) config view
+ * @param relevantWhen - Entry conditions (absent = always relevant)
+ * @returns True when the entry should be synced
+ */
+function isRelevant(
+  merged: JsonObject,
+  relevantWhen: readonly string[] | undefined
+): boolean {
+  if (relevantWhen === undefined) {
+    return true;
+  }
+  return relevantWhen.some(condition => conditionMatches(merged, condition));
+}
+
+/**
+ * Read the first existing artifact's value for a setting.
+ * @param destDir - Project root
+ * @param entry - Registry entry
+ * @returns The artifact value, or undefined when no artifact holds one
+ */
+async function readArtifactValue(
+  destDir: string,
+  entry: SyncedSetting
+): Promise<JsonValue | undefined> {
+  const bindings = entry.artifacts ?? [];
+  const reads = await Promise.all(
+    bindings.map(async binding => {
+      const parsed = await readJsonOrNull(path.join(destDir, binding.file));
+      return parsed === null ? undefined : getAtPath(parsed, binding.pointer);
+    })
+  );
+  return reads.find(value => value !== undefined);
+}
+
+/**
+ * Read the recorded populated-default value for a key, if any. Provenance
+ * keys are stored literally (dots included) inside `_lisaSync.populated`.
+ * @param committed - Committed config object
+ * @param key - Config key
+ * @returns The value recorded at population time, or undefined
+ */
+function recordedPopulation(
+  committed: JsonObject,
+  key: string
+): JsonValue | undefined {
+  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
+  return isJsonObject(populated) ? populated[key] : undefined;
+}
+
+/**
+ * Record that a key was auto-populated with a default value, storing the key
+ * literally (dots included) so later runs can detect default evolution.
+ * @param committed - Committed config object
+ * @param key - Config key
+ * @param value - The default value written
+ * @returns Updated committed config
+ */
+function recordPopulation(
+  committed: JsonObject,
+  key: string,
+  value: JsonValue
+): JsonObject {
+  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
+  const populatedObject = isJsonObject(populated) ? populated : {};
+  return setAtPath(committed, `${SYNC_METADATA_KEY}.populated`, {
+    ...populatedObject,
+    [key]: value,
+  });
+}
+
+/**
+ * Build the next state with an updated committed config and appended action.
+ * @param state - Current sync state
+ * @param committed - Updated committed config
+ * @param action - Action to append to the report
+ * @returns Updated state
+ */
+function withAction(
+  state: SyncState,
+  committed: JsonObject,
+  action: SyncAction
+): SyncState {
+  return { ...state, committed, actions: [...state.actions, action] };
+}
+
+/**
+ * Populate a config key that is completely missing: absorb the artifact
+ * value when one exists, otherwise write the built-in default and record it.
+ * @param state - Current sync state
+ * @param entry - Registry entry
+ * @param artifactValue - Value found in an existing artifact, if any
+ * @returns Updated state
+ */
+function populateMissing(
+  state: SyncState,
+  entry: SyncedSetting,
+  artifactValue: JsonValue | undefined
+): SyncState {
+  if (artifactValue !== undefined) {
+    const absorbed = fillMissing(artifactValue, entry.defaultValue);
+    return withAction(state, setAtPath(state.committed, entry.key, absorbed), {
+      key: entry.key,
+      kind: "absorbed-artifact",
+      detail: `value absorbed from ${entry.artifacts?.[0]?.file ?? "artifact"}`,
+    });
+  }
+  const committed = recordPopulation(
+    setAtPath(state.committed, entry.key, entry.defaultValue),
+    entry.key,
+    entry.defaultValue
+  );
+  return withAction(state, committed, {
+    key: entry.key,
+    kind: "populated-default",
+    detail: "built-in default written to .lisa.config.json",
+  });
+}
+
+/**
+ * Resolve the next committed config for one entry (populate direction).
+ * @param state - Current sync state
+ * @param entry - Registry entry
+ * @param merged - Merged config view (local overlay applied)
+ * @param artifactValue - Value found in an existing artifact, if any
+ * @returns Updated state
+ */
+function populateEntry(
+  state: SyncState,
+  entry: SyncedSetting,
+  merged: JsonObject,
+  artifactValue: JsonValue | undefined
+): SyncState {
+  const configValue = getAtPath(merged, entry.key);
+  if (configValue === undefined) {
+    return populateMissing(state, entry, artifactValue);
+  }
+  const recorded = recordedPopulation(state.committed, entry.key);
+  if (
+    recorded !== undefined &&
+    jsonEquals(configValue, recorded) &&
+    !jsonEquals(configValue, entry.defaultValue)
+  ) {
+    const committed = recordPopulation(
+      setAtPath(state.committed, entry.key, entry.defaultValue),
+      entry.key,
+      entry.defaultValue
+    );
+    return withAction(state, committed, {
+      key: entry.key,
+      kind: "default-evolved",
+      detail: "value still matched the old default; updated to the new one",
+    });
+  }
+  const filled = fillMissing(configValue, entry.defaultValue);
+  if (!jsonEquals(filled, configValue)) {
+    return withAction(state, setAtPath(state.committed, entry.key, filled), {
+      key: entry.key,
+      kind: "filled-missing",
+      detail: "missing sub-keys filled with defaults",
+    });
+  }
+  return state;
+}
+
+/**
+ * Queue artifact writes for one entry (sync direction: config wins). Only
+ * files that already exist on disk are written — sync never scaffolds
+ * artifacts into stacks that do not use them.
+ * @param state - Current sync state
+ * @param entry - Registry entry
+ * @param destDir - Project root
+ * @param local - Local config overlay
+ * @returns Updated state
+ */
+async function syncArtifacts(
+  state: SyncState,
+  entry: SyncedSetting,
+  destDir: string,
+  local: JsonObject
+): Promise<SyncState> {
+  const bindings = entry.artifacts ?? [];
+  if (bindings.length === 0) {
+    return state;
+  }
+  const effective = getAtPath(deepMerge(state.committed, local), entry.key);
+  if (effective === undefined) {
+    return state;
+  }
+  return bindings.reduce<Promise<SyncState>>(async (statePromise, binding) => {
+    const current = await statePromise;
+    const filePath = path.join(destDir, binding.file);
+    const pending = current.artifactWrites.get(binding.file);
+    const parsed =
+      pending ?? (await readJsonOrNull<unknown>(filePath)) ?? undefined;
+    if (parsed === undefined && !(await fse.pathExists(filePath))) {
+      return current;
+    }
+    const fileObject = isJsonObject(parsed) ? parsed : {};
+    if (jsonEquals(getAtPath(fileObject, binding.pointer), effective)) {
+      return current;
+    }
+    const updated = setAtPath(fileObject, binding.pointer, effective);
+    const writes = new Map([
+      ...current.artifactWrites,
+      [binding.file, updated] as const,
+    ]);
+    return {
+      ...current,
+      artifactWrites: writes,
+      actions: [
+        ...current.actions,
+        {
+          key: entry.key,
+          kind: "artifact-synced",
+          detail: `${binding.file} updated from config`,
+        },
+      ],
+    };
+  }, Promise.resolve(state));
+}
+
+/**
+ * Report required keys that are missing from the merged config.
+ * @param merged - Merged config view
+ * @returns Missing required keys with their setup hints
+ */
+function findMissingRequired(
+  merged: JsonObject
+): readonly { key: string; setupHint: string }[] {
+  return REQUIRED_KEYS.filter(
+    required =>
+      isRelevant(merged, required.relevantWhen) &&
+      getAtPath(merged, required.key) === undefined
+  ).map(required => ({ key: required.key, setupHint: required.setupHint }));
+}
+
+/**
+ * Run one populate-and-sync pass over a project.
+ *
+ * Precedence per setting: existing config value → existing artifact value →
+ * built-in default. After population, every existing artifact file is
+ * rewritten from the (local-overlaid) config value.
+ * @param destDir - Absolute path to the project root
+ * @param options - Sync options
+ * @returns Report of every action taken (or planned, when dryRun)
+ */
+export async function runConfigSync(
+  destDir: string,
+  options: SyncOptions = {}
+): Promise<SyncReport> {
+  const committedPath = path.join(destDir, ".lisa.config.json");
+  const localPath = path.join(destDir, ".lisa.config.local.json");
+  const committedRaw = await readJsonOrNull<unknown>(committedPath);
+  const localRaw = await readJsonOrNull<unknown>(localPath);
+  const committed = isJsonObject(committedRaw) ? committedRaw : {};
+  const local = isJsonObject(localRaw) ? localRaw : {};
+
+  const initial: SyncState = {
+    committed,
+    actions: [],
+    artifactWrites: new Map(),
+  };
+  const finalState = await SYNC_REGISTRY.reduce<Promise<SyncState>>(
+    async (statePromise, entry) => {
+      const state = await statePromise;
+      const merged = deepMerge(state.committed, local) as JsonObject;
+      if (!isRelevant(merged, entry.relevantWhen)) {
+        return state;
+      }
+      const artifactValue = await readArtifactValue(destDir, entry);
+      const populated = populateEntry(state, entry, merged, artifactValue);
+      return syncArtifacts(populated, entry, destDir, local);
+    },
+    Promise.resolve(initial)
+  );
+
+  const mergedFinal = deepMerge(finalState.committed, local) as JsonObject;
+  if (options.dryRun !== true) {
+    await persistState(destDir, committed, finalState);
+  }
+  return {
+    actions: finalState.actions,
+    missingRequired: findMissingRequired(mergedFinal),
+    dryRun: options.dryRun === true,
+  };
+}
+
+/**
+ * Write the updated committed config and every queued artifact file.
+ * @param destDir - Project root
+ * @param originalCommitted - Committed config as read at the start of the run
+ * @param state - Final sync state
+ */
+async function persistState(
+  destDir: string,
+  originalCommitted: JsonObject,
+  state: SyncState
+): Promise<void> {
+  if (!jsonEquals(originalCommitted, state.committed)) {
+    await writeJson(path.join(destDir, ".lisa.config.json"), state.committed);
+  }
+  await Promise.all(
+    Array.from(state.artifactWrites.entries()).map(([file, content]) =>
+      writeJson(path.join(destDir, file), content)
+    )
+  );
+}

--- a/src/sync/json-path.ts
+++ b/src/sync/json-path.ts
@@ -1,0 +1,143 @@
+/**
+ * Dot-path helpers for reading and immutably updating nested JSON values.
+ *
+ * Used by the config-sync engine to address settings inside
+ * `.lisa.config.json` (e.g. `quality.testCoverage.global.statements`) and
+ * inside mirrored artifact files (e.g. the `thresholds` key of
+ * `stryker.conf.json`).
+ * @module sync/json-path
+ */
+
+/** Any JSON-compatible value. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+/** A JSON object record (non-array, non-null). */
+export type JsonObject = { readonly [key: string]: JsonValue };
+
+/**
+ * Check whether a value is a plain (non-array) JSON object.
+ * @param value - Candidate value
+ * @returns True when the value is a plain JSON object record
+ */
+export function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Read the value at a dot path inside a JSON object.
+ * @param root - Object to read from
+ * @param dotPath - Dot-separated key path (empty string returns the root)
+ * @returns The value at the path, or undefined when any segment is missing
+ */
+export function getAtPath(
+  root: unknown,
+  dotPath: string
+): JsonValue | undefined {
+  if (dotPath === "") {
+    return root as JsonValue;
+  }
+  const segments = dotPath.split(".");
+  return segments.reduce<unknown>(
+    (node, segment) =>
+      isJsonObject(node)
+        ? (node as Record<string, unknown>)[segment]
+        : undefined,
+    root
+  ) as JsonValue | undefined;
+}
+
+/**
+ * Return a copy of a JSON object with the value at a dot path replaced.
+ * Missing intermediate objects are created; existing siblings are preserved.
+ * The input object is never mutated.
+ * @param root - Object to copy
+ * @param dotPath - Dot-separated key path (empty string replaces the root)
+ * @param value - Value to write at the path
+ * @returns A new object with the update applied
+ */
+export function setAtPath(
+  root: JsonObject,
+  dotPath: string,
+  value: JsonValue
+): JsonObject {
+  if (dotPath === "") {
+    if (!isJsonObject(value)) {
+      throw new Error(
+        "setAtPath: replacing the document root requires an object value"
+      );
+    }
+    return value;
+  }
+  const dotIndex = dotPath.indexOf(".");
+  const head = dotIndex === -1 ? dotPath : dotPath.slice(0, dotIndex);
+  const rest = dotIndex === -1 ? "" : dotPath.slice(dotIndex + 1);
+  if (rest === "") {
+    return { ...root, [head]: value };
+  }
+  const child = root[head];
+  const childObject = isJsonObject(child) ? child : {};
+  return { ...root, [head]: setAtPath(childObject, rest, value) };
+}
+
+/**
+ * Compare two JSON-compatible values for structural equality, independent of
+ * object key insertion order.
+ * @param a - First value
+ * @param b - Second value
+ * @returns True when the values are structurally equal
+ */
+export function jsonEquals(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return (
+      a.length === b.length && a.every((entry, i) => jsonEquals(entry, b[i]))
+    );
+  }
+  if (isJsonObject(a) && isJsonObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every(key => Object.hasOwn(b, key) && jsonEquals(a[key], b[key]))
+    );
+  }
+  return a === b;
+}
+
+/**
+ * Fill missing keys of a JSON value from a fallback, recursively. Present
+ * values always win over the fallback; only absent object keys are filled.
+ * Arrays and scalars are taken wholesale from whichever side is present.
+ * @param value - The preferred value (may be undefined)
+ * @param fallback - Values used only where `value` has gaps
+ * @returns The value with gaps filled from the fallback
+ */
+export function fillMissing(
+  value: JsonValue | undefined,
+  fallback: JsonValue
+): JsonValue {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (isJsonObject(value) && isJsonObject(fallback)) {
+    const keys = new Set([...Object.keys(fallback), ...Object.keys(value)]);
+    const entries = Array.from(keys).map((key): [string, JsonValue] => {
+      const own = Object.hasOwn(value, key) ? value[key] : undefined;
+      const fill = Object.hasOwn(fallback, key) ? fallback[key] : undefined;
+      if (own === undefined) {
+        return [key, fill as JsonValue];
+      }
+      if (fill === undefined) {
+        return [key, own];
+      }
+      return [key, fillMissing(own, fill)];
+    });
+    return Object.fromEntries(entries);
+  }
+  return value;
+}

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -140,11 +140,16 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
       maxCandidates: 20,
       gapTiers: "core",
       backoffHours: 24,
+      // Provider-neutral threshold names: the audit spans Sentry, CloudWatch,
+      // X-Ray, and future providers, so no key is prefixed with a vendor. The
+      // lisa-monitor skill still reads the legacy sentryMinEvents24h /
+      // xrayFaultRatePct keys — renaming those (config-resolution.md + skill)
+      // is a tracked follow-up; see ui/README.md.
       thresholds: {
-        sentryMinEvents24h: 10,
+        minEvents24h: 1,
         errorRateSpikeMultiplier: 2,
         p95LatencyMs: 1000,
-        xrayFaultRatePct: 5,
+        faultRatePct: 5,
       },
     },
     description: "Observability audit caps and alert thresholds",

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -1,0 +1,260 @@
+/**
+ * Registry of synced settings: the single map between `.lisa.config.json`
+ * keys, their built-in defaults, and the project artifact files that mirror
+ * them (test thresholds, lint budgets, mutation gates).
+ *
+ * The registry drives `lisa sync`: every entry is populated into the config
+ * when missing (absorbing an existing artifact value first, falling back to
+ * the built-in default), and afterwards the config value is written back into
+ * each artifact file — config is the source of truth unless a value is
+ * completely missing.
+ * @module sync/registry
+ */
+import type { JsonValue } from "./json-path.js";
+
+/**
+ * A project file that mirrors a synced setting. Artifact files are only ever
+ * written when they already exist on disk — sync never scaffolds an artifact
+ * into a project whose stack does not use it.
+ */
+export interface ArtifactBinding {
+  /** Repo-relative path of the mirrored file */
+  readonly file: string;
+  /** Dot path of the mirrored value inside the file ("" = whole document) */
+  readonly pointer: string;
+}
+
+/** One synced setting: a config key, its default, and optional mirrors. */
+export interface SyncedSetting {
+  /** Dot path of the setting inside `.lisa.config.json` */
+  readonly key: string;
+  /** Built-in default used when neither config nor artifact has a value */
+  readonly defaultValue: JsonValue;
+  /** Files that mirror this value (written from config on every sync) */
+  readonly artifacts?: readonly ArtifactBinding[];
+  /**
+   * Entry applies when ANY condition matches (absent = always applies).
+   * `"github"` means the `github` section exists; `"tracker=jira"` means the
+   * `tracker` key equals `"jira"`.
+   */
+  readonly relevantWhen?: readonly string[];
+  /** One-line human description used in sync reports */
+  readonly description: string;
+}
+
+/** A key sync cannot default and must report when missing. */
+export interface RequiredKey {
+  /** Dot path of the required setting */
+  readonly key: string;
+  /** Applies when ANY condition matches (absent = always required) */
+  readonly relevantWhen?: readonly string[];
+  /** Setup command that provisions the key */
+  readonly setupHint: string;
+}
+
+const WHEN_TRACKER_JIRA = "tracker=jira";
+const WHEN_TRACKER_GITHUB = "tracker=github";
+const WHEN_SOURCE_GITHUB = "source=github";
+const WHEN_TRACKER_LINEAR = "tracker=linear";
+const WHEN_SOURCE_LINEAR = "source=linear";
+const WHEN_SOURCE_NOTION = "source=notion";
+
+const COVERAGE_DEFAULTS: JsonValue = {
+  global: { statements: 70, branches: 70, functions: 70, lines: 70 },
+};
+
+const BUILD_LABEL_DEFAULTS = {
+  ready: "status:ready",
+  claimed: "status:in-progress",
+  blocked: "status:blocked",
+  human_needed: "human-needed",
+  done: {
+    dev: "status:on-dev",
+    staging: "status:on-stg",
+    production: "status:done",
+  },
+} as const;
+
+const PRD_LABEL_DEFAULTS: JsonValue = {
+  draft: "prd-draft",
+  ready: "prd-ready",
+  in_review: "prd-in-review",
+  blocked: "prd-blocked",
+  ticketed: "prd-ticketed",
+  shipped: "prd-shipped",
+  verified: "prd-verified",
+  sentinel: "prd-intake-feedback",
+};
+
+/**
+ * All settings `lisa sync` manages. Local-only keys (`atlassian.email`,
+ * `intake.assignee`, `jira.verified_workflow_hash`, secret paths) are
+ * deliberately absent — sync never populates the committed file with values
+ * that belong in `.lisa.config.local.json`.
+ */
+export const SYNC_REGISTRY: readonly SyncedSetting[] = [
+  {
+    key: "harness",
+    defaultValue: "claude",
+    description: "Target coding-agent harness(es)",
+  },
+  {
+    key: "quality.testCoverage",
+    defaultValue: COVERAGE_DEFAULTS,
+    artifacts: [
+      { file: "vitest.thresholds.json", pointer: "" },
+      { file: "jest.thresholds.json", pointer: "" },
+    ],
+    description: "Test coverage floors (statements/branches/functions/lines)",
+  },
+  {
+    key: "quality.lintBudgets",
+    defaultValue: {
+      cognitiveComplexity: 10,
+      maxLines: 300,
+      maxLinesPerFunction: 75,
+    },
+    artifacts: [{ file: "eslint.thresholds.json", pointer: "" }],
+    description: "Lint complexity and size budgets",
+  },
+  {
+    key: "quality.mutation.gate",
+    defaultValue: { enabled: false, since: "main" },
+    artifacts: [{ file: "mutation.gate.json", pointer: "" }],
+    description: "Diff-only mutation testing gate",
+  },
+  {
+    key: "quality.mutation.strykerThresholds",
+    defaultValue: { high: 80, low: 60, break: 60 },
+    artifacts: [{ file: "stryker.conf.json", pointer: "thresholds" }],
+    description: "Stryker mutation-score thresholds",
+  },
+  {
+    key: "intake.repair",
+    defaultValue: { staleAfterHours: 2, maxCandidates: 100 },
+    description: "Repair-intake stall window and candidate cap",
+  },
+  {
+    key: "monitor",
+    defaultValue: {
+      maxCandidates: 20,
+      gapTiers: "core",
+      backoffHours: 24,
+      thresholds: {
+        sentryMinEvents24h: 10,
+        errorRateSpikeMultiplier: 2,
+        p95LatencyMs: 1000,
+        xrayFaultRatePct: 5,
+      },
+    },
+    description: "Observability audit caps and alert thresholds",
+  },
+  {
+    key: "jira.workflow",
+    defaultValue: {
+      ready: "Ready",
+      claimed: "In Progress",
+      review: "Code Review",
+      blocked: "Blocked",
+      done: { dev: "On Dev", staging: "On Stg", production: "Done" },
+    },
+    relevantWhen: ["jira", WHEN_TRACKER_JIRA],
+    description: "JIRA workflow status names per lifecycle role",
+  },
+  {
+    key: "jira.labels",
+    defaultValue: { human_needed: "Human Needed" },
+    relevantWhen: ["jira", WHEN_TRACKER_JIRA],
+    description: "JIRA marker labels",
+  },
+  {
+    key: "github.labels",
+    defaultValue: { build: BUILD_LABEL_DEFAULTS, prd: PRD_LABEL_DEFAULTS },
+    relevantWhen: ["github", WHEN_TRACKER_GITHUB, WHEN_SOURCE_GITHUB],
+    description: "GitHub build and PRD lifecycle labels",
+  },
+  {
+    key: "linear.labels",
+    defaultValue: {
+      build: { ...BUILD_LABEL_DEFAULTS, review: "status:code-review" },
+      prd: PRD_LABEL_DEFAULTS,
+    },
+    relevantWhen: ["linear", WHEN_TRACKER_LINEAR, WHEN_SOURCE_LINEAR],
+    description: "Linear build and PRD lifecycle labels",
+  },
+  {
+    key: "notion.statusProperty",
+    defaultValue: "Status",
+    relevantWhen: ["notion", WHEN_SOURCE_NOTION],
+    description: "Notion database property that drives the PRD lifecycle",
+  },
+  {
+    key: "notion.values",
+    defaultValue: {
+      draft: "Draft",
+      ready: "Ready",
+      in_review: "In Review",
+      blocked: "Blocked",
+      ticketed: "Ticketed",
+      shipped: "Shipped",
+      verified: "Verified",
+    },
+    relevantWhen: ["notion", WHEN_SOURCE_NOTION],
+    description: "Notion status option names per lifecycle role",
+  },
+  {
+    key: "wiki.ttlSeconds",
+    defaultValue: 300,
+    relevantWhen: ["wiki"],
+    description: "Remote wiki mirror refresh TTL",
+  },
+];
+
+/**
+ * Keys sync can never default: they identify external systems and must come
+ * from a human (via the matching `/lisa:setup:*` skill). Sync reports them
+ * when missing instead of inventing values.
+ */
+export const REQUIRED_KEYS: readonly RequiredKey[] = [
+  { key: "tracker", setupHint: "/lisa:setup:jira | github | linear" },
+  {
+    key: "jira.project",
+    relevantWhen: [WHEN_TRACKER_JIRA],
+    setupHint: "/lisa:setup:jira",
+  },
+  {
+    key: "atlassian.cloudId",
+    relevantWhen: [WHEN_TRACKER_JIRA, "source=confluence"],
+    setupHint: "/lisa:setup:atlassian",
+  },
+  {
+    key: "github.org",
+    relevantWhen: [WHEN_TRACKER_GITHUB, WHEN_SOURCE_GITHUB],
+    setupHint: "/lisa:setup:github",
+  },
+  {
+    key: "github.repo",
+    relevantWhen: [WHEN_TRACKER_GITHUB, WHEN_SOURCE_GITHUB],
+    setupHint: "/lisa:setup:github",
+  },
+  {
+    key: "linear.workspace",
+    relevantWhen: [WHEN_TRACKER_LINEAR, WHEN_SOURCE_LINEAR],
+    setupHint: "/lisa:setup:linear",
+  },
+  {
+    key: "linear.teamKey",
+    relevantWhen: [WHEN_TRACKER_LINEAR],
+    setupHint: "/lisa:setup:linear",
+  },
+  {
+    key: "notion.workspaceId",
+    relevantWhen: [WHEN_SOURCE_NOTION],
+    setupHint: "/lisa:setup:notion",
+  },
+  {
+    key: "notion.prdDatabaseId",
+    relevantWhen: [WHEN_SOURCE_NOTION],
+    setupHint: "/lisa:setup:notion",
+  },
+];

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -308,3 +308,34 @@ export async function countFiles(dir: string): Promise<number> {
 
   return (await fs.pathExists(dir)) ? walk(dir) : 0;
 }
+
+const GIT_HOOK_ENV_VARS = new Set([
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_PREFIX",
+]);
+
+/**
+ * Return a copy of an environment with git's hook-injected variables removed.
+ *
+ * When tests run inside a git hook (pre-push runs the unit suite), git exports
+ * GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_PREFIX pointing at the REAL
+ * repository. Any spawned `git init` / script that inherits them operates on
+ * that repository instead of its temp dir — concurrent test workers then race
+ * against the same gitdir and fail intermittently. Spawn git (and scripts that
+ * call git) with this env instead of the raw process env.
+ * @param base - The environment to sanitize (callers pass process.env)
+ * @param overrides - Optional extra variables layered on top (e.g. PATH shims)
+ * @returns A sanitized environment object safe for spawning git in temp dirs
+ */
+export function cleanGitEnv(
+  base: Record<string, string | undefined>,
+  overrides: Record<string, string> = {}
+): Record<string, string | undefined> {
+  return Object.fromEntries(
+    Object.entries({ ...base, ...overrides }).filter(
+      ([key]) => !GIT_HOOK_ENV_VARS.has(key)
+    )
+  );
+}

--- a/tests/unit/cli/index.test.ts
+++ b/tests/unit/cli/index.test.ts
@@ -1,3 +1,4 @@
+import type { Server } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { createProgram } from "../../../src/cli/index.js";
 import { getPackageVersion } from "../../../src/cli/version.js";
@@ -25,6 +26,8 @@ function createTestProgram(): {
   runVersion: ReturnType<typeof vi.fn>;
   runUpdate: ReturnType<typeof vi.fn>;
   runDoctor: ReturnType<typeof vi.fn>;
+  runSync: ReturnType<typeof vi.fn>;
+  runUi: ReturnType<typeof vi.fn>;
   runUpdateCheck: ReturnType<typeof vi.fn>;
   printUpdateWarning: ReturnType<typeof vi.fn>;
 } {
@@ -34,6 +37,8 @@ function createTestProgram(): {
   const runVersion = vi.fn(async () => undefined);
   const runUpdate = vi.fn(async () => 0);
   const runDoctor = vi.fn(async () => ({ checks: [] }));
+  const runSync = vi.fn(async () => 0);
+  const runUi = vi.fn(async () => ({}) as Server);
   const runUpdateCheck = vi.fn(async () => SKIPPED_RESULT);
   const printUpdateWarning = vi.fn();
   const program = createProgram({
@@ -43,6 +48,8 @@ function createTestProgram(): {
     runVersion,
     runUpdate,
     runDoctor,
+    runSync,
+    runUi,
     runUpdateCheck,
     printUpdateWarning,
   }).exitOverride();
@@ -54,6 +61,8 @@ function createTestProgram(): {
     runVersion,
     runUpdate,
     runDoctor,
+    runSync,
+    runUi,
     runUpdateCheck,
     printUpdateWarning,
   };
@@ -247,5 +256,47 @@ describe("maintenance command invocation", () => {
       DEST,
       expect.objectContaining({ json: true, offline: true })
     );
+  });
+});
+
+describe("sync and ui invocation", () => {
+  it("registers sync and ui subcommands", () => {
+    const { program } = createTestProgram();
+    const subcommandNames = program.commands.map(command => command.name());
+    expect(subcommandNames).toEqual(expect.arrayContaining(["sync", "ui"]));
+  });
+
+  it("routes sync options to the sync action", async () => {
+    const { program, runSync } = createTestProgram();
+
+    await program.parseAsync(["sync", DEST, "--dry-run", "--json"], {
+      from: "user",
+    });
+
+    expect(runSync).toHaveBeenCalledWith(
+      DEST,
+      expect.objectContaining({ dryRun: true, json: true })
+    );
+  });
+
+  it("routes ui options to the ui action, including --no-sync", async () => {
+    const { program, runUi } = createTestProgram();
+
+    await program.parseAsync(["ui", DEST, "--port", "5001", "--no-sync"], {
+      from: "user",
+    });
+
+    expect(runUi).toHaveBeenCalledWith(
+      DEST,
+      expect.objectContaining({ port: "5001", sync: false })
+    );
+  });
+
+  it("does not run the update check for sync or ui", async () => {
+    const { program, runUpdateCheck } = createTestProgram();
+
+    await program.parseAsync(["sync", DEST], { from: "user" });
+
+    expect(runUpdateCheck).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/cli/sync-cmd.test.ts
+++ b/tests/unit/cli/sync-cmd.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runSync } from "../../../src/cli/sync-cmd.js";
+import { readJson, writeJson } from "../../../src/utils/index.js";
+
+const CONFIG = ".lisa.config.json";
+
+/** Holder for the per-test temp project directory. */
+interface TempProject {
+  dir: string;
+}
+
+const project: TempProject = { dir: "" };
+
+beforeEach(async () => {
+  project.dir = await mkdtemp(path.join(tmpdir(), "lisa-sync-cmd-"));
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(project.dir, { recursive: true, force: true });
+});
+
+describe("runSync", () => {
+  it("populates the config and returns 1 while required keys are missing", async () => {
+    const code = await runSync(project.dir);
+
+    const config = await readJson<Record<string, unknown>>(
+      path.join(project.dir, CONFIG)
+    );
+    expect(config.harness).toBe("claude");
+    expect(code).toBe(1);
+  });
+
+  it("returns 0 when every relevant required key is present", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      tracker: "github",
+      github: { org: "acme", repo: "acme-app" },
+    });
+
+    const code = await runSync(project.dir);
+
+    expect(code).toBe(0);
+  });
+
+  it("does not write anything in --dry-run mode", async () => {
+    await runSync(project.dir, { dryRun: true });
+
+    await expect(readJson(path.join(project.dir, CONFIG))).rejects.toThrow();
+  });
+
+  it("emits JSON when --json is passed", async () => {
+    const logSpy = vi.mocked(console.log);
+
+    await runSync(project.dir, { json: true });
+
+    const output = logSpy.mock.calls.map(call => call[0]).join("\n");
+    const parsed = JSON.parse(output) as { actions: unknown[] };
+    expect(Array.isArray(parsed.actions)).toBe(true);
+  });
+});

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findUiHtml,
+  injectLiveConfig,
+  runUi,
+} from "../../../src/cli/ui-cmd.js";
+import { writeJson } from "../../../src/utils/index.js";
+
+/** Holder for per-test temp resources. */
+interface TestResources {
+  dir: string;
+  server: Server | undefined;
+}
+
+const resources: TestResources = { dir: "", server: undefined };
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-cmd-"));
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (resources.server !== undefined) {
+    await new Promise(resolve => resources.server?.close(resolve));
+    resources.server = undefined;
+  }
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+describe("injectLiveConfig", () => {
+  it("injects the config before the closing body tag", () => {
+    const html = "<body><script>run();</script>\n</body>";
+
+    const injected = injectLiveConfig(html, { tracker: "jira" });
+
+    expect(injected).toContain('window.LISA_LIVE_CONFIG = {"tracker":"jira"}');
+    expect(injected.indexOf("LISA_LIVE_CONFIG")).toBeGreaterThan(
+      injected.indexOf("run();")
+    );
+  });
+
+  it("escapes closing script sequences inside config values", () => {
+    const injected = injectLiveConfig("</body>", {
+      note: "</script><script>alert(1)</script>",
+    });
+
+    expect(injected).not.toContain("</script><script>alert(1)");
+    expect(injected).toContain("<\\/script>");
+  });
+});
+
+describe("findUiHtml", () => {
+  it("locates the packaged ui/index.html from the source tree", () => {
+    const htmlPath = findUiHtml(
+      path.dirname(new URL(import.meta.url).pathname)
+    );
+
+    expect(htmlPath.endsWith(path.join("ui", "index.html"))).toBe(true);
+  });
+
+  it("throws when no ui/index.html exists above the start directory", () => {
+    expect(() => findUiHtml(resources.dir)).toThrow(
+      "Unable to locate the packaged ui/index.html"
+    );
+  });
+});
+
+describe("runUi", () => {
+  it("serves the console with the project's live config injected", async () => {
+    await writeJson(path.join(resources.dir, ".lisa.config.json"), {
+      tracker: "linear",
+      linear: { workspace: "acme", teamKey: "ENG" },
+    });
+
+    resources.server = await runUi(resources.dir, { port: "0", sync: false });
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/`);
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(body).toContain('"tracker":"linear"');
+    expect(body).toContain("Lisa Console");
+    const missing = await fetch(`http://127.0.0.1:${port}/nope`);
+    expect(missing.status).toBe(404);
+  });
+
+  it("rejects an invalid port", async () => {
+    await expect(
+      runUi(resources.dir, { port: "not-a-port", sync: false })
+    ).rejects.toThrow("Invalid --port value");
+  });
+});

--- a/tests/unit/scripts/lisa-github-environments.test.ts
+++ b/tests/unit/scripts/lisa-github-environments.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
@@ -39,7 +40,11 @@ function writeConfig(projectDir: string, config: object | string): void {
  */
 function createProject(): string {
   const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-environments-"));
-  execFileSync(GIT_BIN, ["init"], { cwd: projectDir, stdio: "ignore" });
+  execFileSync(GIT_BIN, ["init"], {
+    cwd: projectDir,
+    stdio: "ignore",
+    env: cleanGitEnv(process.env),
+  });
   return projectDir;
 }
 
@@ -104,7 +109,7 @@ function runEnvironmentsDryRun(
     [ENVIRONMENTS_SCRIPT, "--dry-run", projectDir],
     {
       cwd: REPO_ROOT,
-      env: { ...process.env, PATH: shimmedPath },
+      env: cleanGitEnv(process.env, { PATH: shimmedPath }),
       encoding: "utf8",
     }
   );

--- a/tests/unit/scripts/lisa-github-rulesets.test.ts
+++ b/tests/unit/scripts/lisa-github-rulesets.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
@@ -28,7 +29,11 @@ const ACTIVE_ENFORCEMENT = "active";
  */
 function createProject(): string {
   const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-rulesets-"));
-  execFileSync(GIT_BIN, ["init"], { cwd: projectDir, stdio: "ignore" });
+  execFileSync(GIT_BIN, ["init"], {
+    cwd: projectDir,
+    stdio: "ignore",
+    env: cleanGitEnv(process.env),
+  });
   writeFileSync(path.join(projectDir, "tsconfig.json"), "{}\n");
   return projectDir;
 }
@@ -103,11 +108,10 @@ describe("lisa-github-rulesets.sh", () => {
         [lisaInstall.scriptPath, "--dry-run", projectDir],
         {
           cwd: REPO_ROOT,
-          env: {
-            ...process.env,
-            // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim injects the mock gh executable.
+          // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim injects the mock gh executable.
+          env: cleanGitEnv(process.env, {
             PATH: `${ghBin}:${process.env.PATH ?? ""}`,
-          },
+          }),
           encoding: "utf8",
         }
       );

--- a/tests/unit/sync/config-sync.test.ts
+++ b/tests/unit/sync/config-sync.test.ts
@@ -1,0 +1,247 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runConfigSync } from "../../../src/sync/config-sync.js";
+import {
+  readJson,
+  readJsonOrNull,
+  writeJson,
+} from "../../../src/utils/index.js";
+
+const CONFIG = ".lisa.config.json";
+const LOCAL_CONFIG = ".lisa.config.local.json";
+const VITEST_THRESHOLDS = "vitest.thresholds.json";
+
+/** Holder for the per-test temp project directory. */
+interface TempProject {
+  dir: string;
+}
+
+const project: TempProject = { dir: "" };
+
+beforeEach(async () => {
+  project.dir = await mkdtemp(path.join(tmpdir(), "lisa-sync-"));
+});
+
+afterEach(async () => {
+  await rm(project.dir, { recursive: true, force: true });
+});
+
+/**
+ * Read the committed config from the temp project.
+ * @returns Parsed config object
+ */
+async function readConfig(): Promise<Record<string, unknown>> {
+  return readJson<Record<string, unknown>>(path.join(project.dir, CONFIG));
+}
+
+describe("runConfigSync — populate direction", () => {
+  it("populates built-in defaults into an empty project and records provenance", async () => {
+    const report = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.harness).toBe("claude");
+    expect(config.quality).toMatchObject({
+      testCoverage: {
+        global: { statements: 70, branches: 70, functions: 70, lines: 70 },
+      },
+      lintBudgets: {
+        cognitiveComplexity: 10,
+        maxLines: 300,
+        maxLinesPerFunction: 75,
+      },
+    });
+    const meta = config._lisaSync as { populated: Record<string, unknown> };
+    expect(meta.populated["quality.testCoverage"]).toBeDefined();
+    expect(
+      report.actions.filter(action => action.kind === "populated-default")
+        .length
+    ).toBeGreaterThan(0);
+  });
+
+  it("absorbs an existing artifact value instead of the default when config is missing it", async () => {
+    await writeJson(path.join(project.dir, VITEST_THRESHOLDS), {
+      global: { statements: 85, branches: 80, functions: 82, lines: 88 },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.quality).toMatchObject({
+      testCoverage: {
+        global: { statements: 85, branches: 80, functions: 82, lines: 88 },
+      },
+    });
+    const meta = config._lisaSync as { populated: Record<string, unknown> };
+    expect(meta.populated["quality.testCoverage"]).toBeUndefined();
+    expect(
+      report.actions.some(action => action.kind === "absorbed-artifact")
+    ).toBe(true);
+  });
+
+  it("does not populate vendor sections the project does not use", async () => {
+    await writeJson(path.join(project.dir, CONFIG), { tracker: "jira" });
+
+    await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.jira).toMatchObject({ workflow: { ready: "Ready" } });
+    expect(config.github).toBeUndefined();
+    expect(config.linear).toBeUndefined();
+    expect(config.notion).toBeUndefined();
+  });
+
+  it("fills only the missing sub-keys of a partially configured object", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: { testCoverage: { global: { statements: 90 } } },
+    });
+
+    await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.quality).toMatchObject({
+      testCoverage: {
+        global: { statements: 90, branches: 70, functions: 70, lines: 70 },
+      },
+    });
+  });
+
+  it("reports required keys it cannot default", async () => {
+    const report = await runConfigSync(project.dir);
+
+    expect(report.missingRequired.map(missing => missing.key)).toContain(
+      "tracker"
+    );
+  });
+});
+
+describe("runConfigSync — sync direction (config wins)", () => {
+  it("overwrites an existing artifact file from the config value", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: {
+        testCoverage: {
+          global: { statements: 92, branches: 91, functions: 90, lines: 93 },
+        },
+      },
+    });
+    await writeJson(path.join(project.dir, VITEST_THRESHOLDS), {
+      global: { statements: 70, branches: 70, functions: 70, lines: 70 },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, VITEST_THRESHOLDS)
+    );
+    expect(artifact).toEqual({
+      global: { statements: 92, branches: 91, functions: 90, lines: 93 },
+    });
+    expect(
+      report.actions.some(action => action.kind === "artifact-synced")
+    ).toBe(true);
+  });
+
+  it("writes a pointered value without disturbing sibling keys", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: {
+        mutation: { strykerThresholds: { high: 90, low: 70, break: 65 } },
+      },
+    });
+    await writeJson(path.join(project.dir, "stryker.conf.json"), {
+      testRunner: "vitest",
+      thresholds: { high: 80, low: 60, break: 60 },
+    });
+
+    await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, "stryker.conf.json")
+    );
+    expect(artifact.testRunner).toBe("vitest");
+    expect(artifact.thresholds).toEqual({ high: 90, low: 70, break: 65 });
+  });
+
+  it("never scaffolds an artifact file that does not exist", async () => {
+    await runConfigSync(project.dir);
+
+    const artifact = await readJsonOrNull(
+      path.join(project.dir, VITEST_THRESHOLDS)
+    );
+    expect(artifact).toBeNull();
+  });
+
+  it("prefers the local overlay value when writing artifacts", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: { lintBudgets: { cognitiveComplexity: 10 } },
+    });
+    await writeJson(path.join(project.dir, LOCAL_CONFIG), {
+      quality: { lintBudgets: { cognitiveComplexity: 25 } },
+    });
+    await writeJson(path.join(project.dir, "eslint.thresholds.json"), {
+      cognitiveComplexity: 10,
+      maxLines: 300,
+      maxLinesPerFunction: 75,
+    });
+
+    await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, "eslint.thresholds.json")
+    );
+    expect(artifact.cognitiveComplexity).toBe(25);
+  });
+});
+
+describe("runConfigSync — default evolution and idempotency", () => {
+  it("is idempotent: a second run reports no actions", async () => {
+    await runConfigSync(project.dir);
+
+    const second = await runConfigSync(project.dir);
+
+    expect(second.actions).toEqual([]);
+  });
+
+  it("leaves a user-chosen value alone even when it differs from the default", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: {
+        lintBudgets: {
+          cognitiveComplexity: 20,
+          maxLines: 400,
+          maxLinesPerFunction: 100,
+        },
+      },
+    });
+
+    await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.quality).toMatchObject({
+      lintBudgets: { cognitiveComplexity: 20, maxLines: 400 },
+    });
+  });
+
+  it("updates an auto-populated value when the recorded default evolves", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      wiki: { source: { path: "wiki" }, ttlSeconds: 120 },
+      _lisaSync: { populated: { "wiki.ttlSeconds": 120 } },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect((config.wiki as Record<string, unknown>).ttlSeconds).toBe(300);
+    expect(
+      report.actions.some(action => action.kind === "default-evolved")
+    ).toBe(true);
+  });
+
+  it("dry-run reports actions without writing anything", async () => {
+    const report = await runConfigSync(project.dir, { dryRun: true });
+
+    expect(report.dryRun).toBe(true);
+    expect(report.actions.length).toBeGreaterThan(0);
+    const config = await readJsonOrNull(path.join(project.dir, CONFIG));
+    expect(config).toBeNull();
+  });
+});

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,133 @@
+# Lisa Console (UI prototype)
+
+A self-contained, zero-build prototype of the Lisa settings console. It catalogs
+every configuration surface Lisa exposes to host projects and presents it as a
+navigable, editable-looking settings UI.
+
+**Prototype scope:** every control is interactive (toggles, selects, inputs,
+tabs, dirty-state tracking, save bar), but edits are not persisted — "Save"
+only clears the in-memory dirty state. Reading real values IS wired up: see
+`lisa ui` below.
+
+## Run it
+
+The real entrypoint is the CLI, which populates and syncs the project's
+`.lisa.config.json` first (see `lisa sync`), then serves the console with the
+merged live config injected — controls whose config key exists show the
+project's actual values:
+
+```bash
+lisa ui [path] [--port 4780] [--no-sync]
+```
+
+The page is also fully standalone (no build step, no dependencies) — without
+live config it falls back to Lisa's shipped defaults:
+
+```bash
+open ui/index.html
+```
+
+## Config sync (`lisa sync`)
+
+`lisa sync [path] [--dry-run] [--json]` makes `.lisa.config.json` (with the
+gitignored `.lisa.config.local.json` overlay) the source of truth for every
+setting in `src/sync/registry.ts`:
+
+- **Populate** — a completely missing config value is absorbed from its
+  mirrored artifact file when one exists (e.g. `vitest.thresholds.json`),
+  otherwise filled with Lisa's built-in default. Vendor sections are only
+  populated when the project uses that vendor.
+- **Sync** — config values are written back into every mirrored artifact file
+  that exists on disk (config wins). Sync never scaffolds an artifact file
+  into a stack that doesn't use it.
+- **Provenance** — pure-default populations are recorded under
+  `_lisaSync.populated`, so when a later Lisa version changes a default, sync
+  can update values that are *still the default* while never touching values
+  a human chose.
+- **Required keys** (`tracker`, `jira.project`, `github.org`, …) can't be
+  invented; sync reports them (exit code 1) and points at the setup skill.
+
+Mirrored artifacts today: `vitest.thresholds.json` / `jest.thresholds.json`
+(`quality.testCoverage`), `eslint.thresholds.json` (`quality.lintBudgets`),
+`mutation.gate.json` (`quality.mutation.gate`), and the `thresholds` key of
+`stryker.conf.json` (`quality.mutation.strykerThresholds`).
+
+## Starter provenance & sync (planned — documented, not wired)
+
+The **Starter templates** section of the console documents this contract; no
+engine exists yet. A project records which starter repo(s) it was generated
+from (`lisa setup-project` already knows them — `src/cli/starters.ts`) and
+stays connected to them in both directions:
+
+```jsonc
+"starter": {
+  "templates": [
+    {
+      "repo": "CodySwannGT/expostarter",   // origin starter
+      "ref": "main",                        // ref compared on each sync
+      "lastSync": { "sha": "8c1f2ab", "at": "2026-07-01" },
+      "paths": ["**"]                       // optional glob scope
+    }
+  ],
+  "sync": {
+    "auto": false,                          // scheduled sync via a lisa-auto cron
+    "strategy": "pull-request",             // or "direct-when-clean"
+    "upstreamProposals": true,              // open issues in the starter repo
+    "proposalLabel": "starter-upstream-proposal"
+  }
+}
+```
+
+**Downstream sync (starter → project).** A sync diffs the starter's tracked
+ref since `lastSync.sha` and applies the changes to the host project,
+respecting Lisa template semantics (create-only files the project now owns
+are never clobbered; a `paths` scope limits what applies). Clean applications
+land per `strategy`; conflicts always open a PR. `lastSync` is updated after
+every successful run. Multiple templates are supported — e.g. an app starter
+plus an infrastructure starter, each with its own path scope.
+
+**Upstreaming (project → starter).** During a sync (or a standalone scan),
+Lisa looks for *generic* additions the host project made — shared utilities,
+dependency/security bumps, CI workflow fixes, config hardening with no
+project-specific identifiers — and opens an issue in the starter repo,
+labeled `proposalLabel`, containing detailed instructions on what was changed
+and how to apply it to the starter. Anything referencing project names,
+product features, secrets, or business logic is never proposed.
+
+When the engine lands, `starter.*` should join the `lisa sync` registry so
+the section above governs it like every other setting.
+
+## What it catalogs
+
+| Section | Source of truth in this repo |
+| --- | --- |
+| General (`harness`, `tracker`, `source`, `repo`) | `src/core/config.ts`, `plugins/src/base/rules/reference/config-resolution.md` |
+| Project types (8 stacks + template strategies) | `src/detection/`, `src/strategies/`, `<stack>/` template dirs |
+| Coding agents (claude/codex/cursor/agy/copilot/opencode/fleet) | `src/core/lisa.ts`, `scripts/generate-*-plugin-artifacts.mjs` |
+| Work tracker (JIRA / GitHub Issues / Linear) | `config-resolution.md`, `lisa-setup-*` skills |
+| PRD source (Notion / Confluence / Linear / GitHub) | `config-resolution.md`, `lisa-setup-*` skills |
+| Deploy & environments (`deploy.*`, `github.environments`) | `scripts/lisa-github-environments.sh` |
+| Automations (intake/repair/exploratory crons) | `lisa-setup-automations` skill |
+| Intake & monitoring thresholds | `.lisa.config.json` `intake.*` / `monitor.*` |
+| Linting (custom plugins, budgets, oxlint, ast-grep) | `eslint-plugin-*/`, `src/configs/eslint/`, `sgconfig.yml` |
+| Testing & coverage (runners, floors, mutation gates) | `src/configs/{vitest,jest}/`, `*.thresholds.json` |
+| Git hooks (Husky / Lefthook) | `typescript/copy-contents/.husky/`, `rails/copy-overwrite/lefthook.yml` |
+| CI quality gates (quality.yml jobs + inputs) | `.github/workflows/quality.yml` |
+| Verification & QA (exploration mutation policy, ZAP) | `lisa-use-the-product` skill |
+| GitHub repository (settings, rulesets, labels, secrets) | `scripts/lisa-github-repo-setup.sh`, `all/github-rulesets/` |
+| Plugins & MCP (Lisa + curated third-party + servers) | `.claude/settings.json`, `plugins/src/` |
+| Advanced (wiki source, usage pricing, Play Store) | `config-resolution.md` |
+
+Values shown are Lisa's real defaults (as of the version in the top bar), with
+a fictional demo project (`acme/acme-app`, typescript + expo, JIRA + Notion)
+supplying example identifiers.
+
+## Implementation notes
+
+- Single `index.html`: inline CSS (token-based light/dark theming with a
+  manual toggle) and vanilla JS. The catalog lives in a declarative `DATA`
+  structure at the top of the script; rendering is generic per block type
+  (`card`/`rows`, `table`, `tabs`, `stacks`, `hooks`, `flow`, `tiles`,
+  `callout`), so adding a setting is a data edit, not a DOM edit.
+- Search box filters rows/cards within the active section.
+- URL hash routes to a section (e.g. `ui/index.html#linting`).

--- a/ui/README.md
+++ b/ui/README.md
@@ -144,7 +144,11 @@ visible in the section.
 
 | Section | Source of truth in this repo |
 | --- | --- |
-| General (`harness`, `tracker`, `source`, `repo`) | `src/core/config.ts`, `plugins/src/base/rules/reference/config-resolution.md` |
+| Setup checklist (install → sync → tracker/PRD → repo governance → secrets → automations) | `lisa apply`, `lisa sync`, `/lisa:setup:*` skills |
+| Health (version status + planned in-band scan) | `lisa doctor`, `lisa sync --dry-run`, planned `/lisa:health` skill |
+| Core workflow (the delivery-loop slash commands and their automations) | `plugins/src/base/commands/lisa/`, `plugins/src/base/skills/` |
+| Starter templates (provenance + planned two-way sync) | `src/cli/starters.ts`, planned `starter.*` config |
+| General (`harness`, `tracker`, `source`, `repo`, package manager) | `src/core/config.ts`, `plugins/src/base/rules/reference/config-resolution.md` |
 | Project types (8 stacks + template strategies) | `src/detection/`, `src/strategies/`, `<stack>/` template dirs |
 | Coding agents (claude/codex/cursor/agy/copilot/opencode/fleet) | `src/core/lisa.ts`, `scripts/generate-*-plugin-artifacts.mjs` |
 | Work tracker (JIRA / GitHub Issues / Linear) | `config-resolution.md`, `lisa-setup-*` skills |

--- a/ui/README.md
+++ b/ui/README.md
@@ -97,6 +97,39 @@ product features, secrets, or business logic is never proposed.
 When the engine lands, `starter.*` should join the `lisa sync` registry so
 the section above governs it like every other setting.
 
+## Health (planned — documented, not wired)
+
+The **Health** section answers two questions with different lifecycles:
+
+**Is Lisa on the latest version?** — always-on status. Lisa's CLI already
+checks npm on every invocation; the console surfaces the result permanently
+as the top-bar chip (green dot `up to date`, amber when behind) and in the
+Health section's version card. When behind, `lisa update` prints (or runs
+with `--yes`) the package-manager update command.
+
+**Is the project completely in band?** — on-demand scan behind the
+"Run health check" button (plus an optional scheduled cadence via
+`health.schedule` that files a ticket when drift is found). "In band" means
+every Lisa-managed surface matches what the installed Lisa version would
+emit. The check is a mix of deterministic and agentic verification,
+packaged as one skill (working name `/lisa:health`) so the console button,
+the cron, and the CLI share a single implementation:
+
+- **Deterministic layer** (fast, exact — reuses what exists today):
+  `lisa doctor`, template diffing for copy-overwrite/managed-block files,
+  `package.json` governance (force/defaults/merge conformance),
+  `lisa sync --dry-run` (config fully populated, artifacts in sync), git
+  hooks installed and unmodified, plugins enabled and version-current, CI
+  workflow drift vs the stack template, rulesets present.
+- **Agentic layer** (judges what a diff can't): whether local overrides
+  (`eslint.config.local.ts`, grandfathered globs) still serve their original
+  purpose, whether detected drift looks intentional or accidental, whether
+  skipped CI jobs and disabled gates have a recorded justification.
+
+Results render as a per-check table (pass / warn / fail, with the layer that
+produced each finding), and the last full check's date + verdict stays
+visible in the section.
+
 ## What it catalogs
 
 | Section | Source of truth in this repo |

--- a/ui/README.md
+++ b/ui/README.md
@@ -52,6 +52,16 @@ Mirrored artifacts today: `vitest.thresholds.json` / `jest.thresholds.json`
 `mutation.gate.json` (`quality.mutation.gate`), and the `thresholds` key of
 `stryker.conf.json` (`quality.mutation.strykerThresholds`).
 
+**Provider-neutral monitoring keys.** The observability audit spans Sentry,
+AWS CloudWatch Alarms, AWS X-Ray, and future providers, so
+`monitor.thresholds` uses vendor-free names: `minEvents24h` (default **1**)
+and `faultRatePct` replace the legacy `sentryMinEvents24h` /
+`xrayFaultRatePct`. The Monitoring section shows which providers are
+connected (detected from credentials and instrumentation, not configured by
+hand). The runtime `lisa-monitor` skill still reads the legacy keys —
+renaming them in `config-resolution.md` and the skill is a tracked
+follow-up.
+
 ## Starter provenance & sync (planned — documented, not wired)
 
 The **Starter templates** section of the console documents this contract; no

--- a/ui/index.html
+++ b/ui/index.html
@@ -244,6 +244,44 @@
         border-radius: 99px;
         padding: 3px 10px;
       }
+      .health-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--surface2);
+        cursor: pointer;
+      }
+      .health-link:hover {
+        border-color: var(--line-strong);
+        color: var(--ink);
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex: none;
+      }
+      .dot.ok {
+        background: var(--good);
+      }
+      .dot.warn {
+        background: var(--warn);
+      }
+      .dot.fail {
+        background: var(--crit);
+      }
+      .badge.pass {
+        background: var(--good-soft);
+        color: var(--good);
+      }
+      .badge.warn {
+        background: var(--warn-soft);
+        color: var(--warn);
+      }
+      .badge.fail {
+        background: var(--crit-soft);
+        color: var(--crit);
+      }
 
       .app {
         display: grid;
@@ -1071,7 +1109,15 @@
           aria-label="Filter settings"
         />
       </div>
-      <span class="version-chip">@codyswann/lisa 2.199.0</span>
+      <button
+        class="version-chip health-link"
+        id="healthChip"
+        type="button"
+        title="Lisa health — click for details"
+      >
+        <span class="dot ok" aria-hidden="true"></span> @codyswann/lisa 2.199.0
+        · up to date
+      </button>
       <button
         class="icon-btn"
         id="themeToggle"
@@ -1130,7 +1176,14 @@
         groups: [
           {
             label: "Project",
-            sections: ["overview", "general", "stacks", "starters", "agents"],
+            sections: [
+              "overview",
+              "health",
+              "general",
+              "stacks",
+              "starters",
+              "agents",
+            ],
           },
           {
             label: "Delivery",
@@ -1223,6 +1276,152 @@
       };
 
       /* ---------------------------------- General ---------------------------------- */
+      /* ---------------------------------- Health ---------------------------------- */
+      DATA.sections.health = {
+        title: "Health",
+        desc: "Whether this project is on the latest Lisa and completely in band — every Lisa-managed surface matching what the installed version would emit. Version status is always visible (top bar); the in-band scan runs on demand.",
+        src: "lisa doctor · lisa sync --dry-run · planned /lisa:health skill",
+        blocks: [
+          {
+            type: "callout",
+            variant: "warn",
+            text: "<b>Planned feature.</b> The version status is real today (lisa's npm update check). The in-band scan below documents the contract for a health-check skill that mixes deterministic checks with agentic review — not wired up yet.",
+          },
+          {
+            card: "Lisa version",
+            note: "Checked automatically on every lisa invocation",
+            rows: [
+              {
+                key: "",
+                label: "Installed",
+                desc: "",
+                control: stat("@codyswann/lisa 2.199.0", "mono"),
+              },
+              {
+                key: "",
+                label: "Latest published",
+                desc: "From the npm registry.",
+                control: stat("2.199.0 · up to date", "mono"),
+              },
+              {
+                key: "",
+                label: "Update",
+                desc: "When behind, lisa update prints (or runs with --yes) the package-manager update command.",
+                control: {
+                  type: "button",
+                  label: "Check for updates",
+                  toast: "Up to date — @codyswann/lisa 2.199.0 is the latest",
+                },
+              },
+            ],
+          },
+          {
+            card: "In-band scan",
+            note: "Deterministic checks + agentic review, packaged as a skill",
+            rows: [
+              {
+                key: "",
+                label: "Run health check",
+                desc: "Scans every Lisa-managed surface and reports drift: managed files vs templates, package.json governance, config population, hooks, plugins, CI workflows, rulesets — then an agentic pass reviews what a diff can't judge.",
+                control: {
+                  type: "button",
+                  label: "Run health check",
+                  toast:
+                    "Prototype — the health-check skill is not wired up yet",
+                },
+              },
+              {
+                key: "health.schedule",
+                label: "Scheduled scan",
+                desc: "Optionally run the health check on a cadence (a lisa-auto cron) and file a ticket when drift is found.",
+                control: sel("off", ["off", "daily", "weekly"]),
+              },
+              {
+                key: "",
+                label: "Last full check",
+                desc: "",
+                control: stat("2026-07-10 · in band (1 advisory)", "mono"),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Latest results",
+            note: "Sample output — what a health check reports",
+            cols: ["Check", "Layer", "Status"],
+            rows: [
+              [
+                {
+                  t: "text",
+                  v: "Managed files match templates (copy-overwrite)",
+                },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                {
+                  t: "text",
+                  v: "package.json governance (force/defaults/merge)",
+                },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                {
+                  t: "text",
+                  v: ".lisa.config.json fully populated (sync clean)",
+                },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                { t: "text", v: "Git hooks installed and unmodified" },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                { t: "text", v: "Plugins enabled and version-current" },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                { t: "text", v: "CI workflows drifted from stack template" },
+                { t: "mono", v: "deterministic" },
+                { t: "badge", v: "warn", cls: "warn" },
+              ],
+              [
+                {
+                  t: "text",
+                  v: "Local overrides still justified (eslint.config.local.ts)",
+                },
+                { t: "mono", v: "agentic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                {
+                  t: "text",
+                  v: "Skipped CI jobs have a recorded reason",
+                },
+                { t: "mono", v: "agentic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+              [
+                {
+                  t: "text",
+                  v: "Grandfathered lint globs still needed",
+                },
+                { t: "mono", v: "agentic" },
+                { t: "badge", v: "pass", cls: "pass" },
+              ],
+            ],
+          },
+          {
+            type: "callout",
+            text: "<b>How it will work.</b> The deterministic layer reuses what already exists — lisa doctor, template diffing, lisa sync --dry-run, plugin reconciliation — and is fast and exact. The agentic layer reviews what a diff can't: whether local overrides still serve their original purpose, whether drift is intentional, whether skipped gates have justification. Both are packaged as one skill so the button, the cron, and the CLI share a single implementation.",
+          },
+        ],
+      };
+
       DATA.sections.general = {
         title: "General",
         desc: "Top-level project identity: which coding agents Lisa installs into, where tickets are written, and where PRDs come from.",
@@ -4522,6 +4721,10 @@
         clearDirty();
         renderAll();
         showSection(activeSection);
+      });
+
+      document.getElementById("healthChip").addEventListener("click", () => {
+        showSection("health");
       });
 
       document.getElementById("themeToggle").addEventListener("click", () => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,4541 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lisa Console — Project Settings</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230e6272'/%3E%3Ctext x='16' y='23' font-family='monospace' font-size='19' font-weight='bold' fill='white' text-anchor='middle'%3EL%3C/text%3E%3C/svg%3E"
+    />
+    <style>
+      :root {
+        --bg: #f4f7f7;
+        --surface: #ffffff;
+        --surface2: #ecf1f1;
+        --ink: #162326;
+        --muted: #5b6d72;
+        --faint: #8ba0a5;
+        --line: #dce4e5;
+        --line-strong: #c3cfd1;
+        --accent: #0e6272;
+        --accent-ink: #ffffff;
+        --accent-soft: #e1eef1;
+        --good: #22773c;
+        --good-soft: #e2f0e6;
+        --warn: #93610a;
+        --warn-soft: #f6ecd6;
+        --crit: #b3372c;
+        --crit-soft: #f8e5e2;
+        --chip-bg: #eef3f3;
+        --shadow:
+          0 1px 2px rgba(22, 35, 38, 0.06), 0 4px 16px rgba(22, 35, 38, 0.05);
+        --mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+        --sans:
+          system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+          sans-serif;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0e1618;
+          --surface: #151f22;
+          --surface2: #1b282c;
+          --ink: #e6edee;
+          --muted: #94a7ab;
+          --faint: #6c8085;
+          --line: #243438;
+          --line-strong: #35494e;
+          --accent: #5cb9ca;
+          --accent-ink: #06282e;
+          --accent-soft: #10373f;
+          --good: #63c184;
+          --good-soft: #12301c;
+          --warn: #d9a441;
+          --warn-soft: #33270e;
+          --crit: #e07862;
+          --crit-soft: #3a1712;
+          --chip-bg: #1d2b2f;
+          --shadow:
+            0 1px 2px rgba(0, 0, 0, 0.3), 0 6px 20px rgba(0, 0, 0, 0.25);
+        }
+      }
+      :root[data-theme="light"] {
+        --bg: #f4f7f7;
+        --surface: #ffffff;
+        --surface2: #ecf1f1;
+        --ink: #162326;
+        --muted: #5b6d72;
+        --faint: #8ba0a5;
+        --line: #dce4e5;
+        --line-strong: #c3cfd1;
+        --accent: #0e6272;
+        --accent-ink: #ffffff;
+        --accent-soft: #e1eef1;
+        --good: #22773c;
+        --good-soft: #e2f0e6;
+        --warn: #93610a;
+        --warn-soft: #f6ecd6;
+        --crit: #b3372c;
+        --crit-soft: #f8e5e2;
+        --chip-bg: #eef3f3;
+        --shadow:
+          0 1px 2px rgba(22, 35, 38, 0.06), 0 4px 16px rgba(22, 35, 38, 0.05);
+      }
+      :root[data-theme="dark"] {
+        --bg: #0e1618;
+        --surface: #151f22;
+        --surface2: #1b282c;
+        --ink: #e6edee;
+        --muted: #94a7ab;
+        --faint: #6c8085;
+        --line: #243438;
+        --line-strong: #35494e;
+        --accent: #5cb9ca;
+        --accent-ink: #06282e;
+        --accent-soft: #10373f;
+        --good: #63c184;
+        --good-soft: #12301c;
+        --warn: #d9a441;
+        --warn-soft: #33270e;
+        --crit: #e07862;
+        --crit-soft: #3a1712;
+        --chip-bg: #1d2b2f;
+        --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 6px 20px rgba(0, 0, 0, 0.25);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: var(--sans);
+        font-size: 14px;
+        line-height: 1.55;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      button,
+      input,
+      select,
+      textarea {
+        font: inherit;
+        color: inherit;
+      }
+      ::placeholder {
+        color: var(--faint);
+      }
+
+      .proto-strip {
+        background: var(--accent);
+        color: var(--accent-ink);
+        text-align: center;
+        font-size: 12px;
+        letter-spacing: 0.02em;
+        padding: 5px 12px;
+      }
+      .proto-strip strong {
+        font-weight: 650;
+      }
+
+      .topbar {
+        position: sticky;
+        top: 0;
+        z-index: 40;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        height: 56px;
+        padding: 0 20px;
+        background: var(--surface);
+        border-bottom: 1px solid var(--line);
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        font-size: 15px;
+      }
+      .brand-mark {
+        width: 26px;
+        height: 26px;
+        border-radius: 7px;
+        background: var(--accent);
+        color: var(--accent-ink);
+        display: grid;
+        place-items: center;
+        font-weight: 800;
+        font-size: 14px;
+        font-family: var(--mono);
+      }
+      .brand .console-tag {
+        color: var(--muted);
+        font-weight: 450;
+      }
+      .project-switch {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 5px 10px;
+        background: var(--surface2);
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .project-switch .repo {
+        font-family: var(--mono);
+        font-size: 12.5px;
+      }
+      .project-switch .caret {
+        color: var(--faint);
+        font-size: 10px;
+      }
+      .topbar .spacer {
+        flex: 1;
+      }
+      .search-wrap {
+        position: relative;
+      }
+      .search-wrap input {
+        width: 260px;
+        padding: 7px 12px 7px 32px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--bg);
+        outline: none;
+      }
+      .search-wrap input:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      .search-wrap .icon {
+        position: absolute;
+        left: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--faint);
+        font-size: 13px;
+      }
+      .icon-btn {
+        border: 1px solid var(--line);
+        background: var(--surface2);
+        border-radius: 8px;
+        width: 34px;
+        height: 34px;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        font-size: 15px;
+      }
+      .icon-btn:hover {
+        border-color: var(--line-strong);
+      }
+      .version-chip {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        color: var(--muted);
+        border: 1px solid var(--line);
+        border-radius: 99px;
+        padding: 3px 10px;
+      }
+
+      .app {
+        display: grid;
+        grid-template-columns: 250px 1fr;
+        min-height: calc(100vh - 90px);
+      }
+      .sidebar {
+        border-right: 1px solid var(--line);
+        padding: 18px 12px 120px;
+        background: var(--surface);
+        position: sticky;
+        top: 56px;
+        height: calc(100vh - 56px);
+        overflow-y: auto;
+      }
+      .nav-group {
+        margin-bottom: 18px;
+      }
+      .nav-eyebrow {
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        color: var(--faint);
+        font-weight: 650;
+        padding: 0 10px 6px;
+      }
+      .nav-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        text-align: left;
+        padding: 7px 10px;
+        border: 0;
+        background: none;
+        border-radius: 7px;
+        cursor: pointer;
+        color: var(--ink);
+        font-size: 13.5px;
+      }
+      .nav-item:hover {
+        background: var(--surface2);
+      }
+      .nav-item.active {
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .nav-item .count {
+        font-size: 11px;
+        color: var(--faint);
+        font-family: var(--mono);
+      }
+      .nav-item.active .count {
+        color: var(--accent);
+      }
+
+      .main {
+        padding: 28px 36px 160px;
+        min-width: 0;
+      }
+      .section {
+        max-width: 880px;
+        display: none;
+      }
+      .section.visible {
+        display: block;
+      }
+      .section-head {
+        margin-bottom: 20px;
+      }
+      .section-head h1 {
+        margin: 0 0 6px;
+        font-size: 21px;
+        font-weight: 700;
+        letter-spacing: -0.015em;
+        text-wrap: balance;
+      }
+      .section-head p {
+        margin: 0;
+        color: var(--muted);
+        max-width: 68ch;
+      }
+      .src-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin-top: 10px;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--muted);
+        background: var(--chip-bg);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 3px 8px;
+      }
+
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        box-shadow: var(--shadow);
+        margin-bottom: 18px;
+        overflow: hidden;
+      }
+      .card-head {
+        padding: 13px 18px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .card-head h2 {
+        margin: 0;
+        font-size: 14.5px;
+        font-weight: 650;
+      }
+      .card-head .note {
+        color: var(--muted);
+        font-size: 12.5px;
+      }
+      .card-body {
+        padding: 4px 0;
+      }
+      .card-body.padded {
+        padding: 16px 18px;
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px 24px;
+        align-items: center;
+        padding: 12px 18px;
+        border-bottom: 1px solid var(--line);
+      }
+      .row:last-child {
+        border-bottom: 0;
+      }
+      .row.modified {
+        box-shadow: inset 3px 0 0 var(--accent);
+      }
+      .row .label {
+        font-weight: 550;
+        font-size: 13.5px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .row .desc {
+        color: var(--muted);
+        font-size: 12.5px;
+        margin-top: 2px;
+        max-width: 62ch;
+      }
+      .row .keychip {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--muted);
+        background: var(--chip-bg);
+        border-radius: 5px;
+        padding: 1px 6px;
+      }
+      .row .control {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        justify-content: flex-end;
+      }
+
+      .badge {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 650;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-radius: 99px;
+        padding: 2px 8px;
+      }
+      .badge.required {
+        background: var(--crit-soft);
+        color: var(--crit);
+      }
+      .badge.local {
+        background: var(--warn-soft);
+        color: var(--warn);
+      }
+      .badge.default {
+        background: var(--chip-bg);
+        color: var(--muted);
+      }
+      .badge.on {
+        background: var(--good-soft);
+        color: var(--good);
+      }
+      .badge.off {
+        background: var(--chip-bg);
+        color: var(--muted);
+      }
+      .badge.accent {
+        background: var(--accent-soft);
+        color: var(--accent);
+      }
+
+      .switch {
+        position: relative;
+        width: 36px;
+        height: 20px;
+        flex: none;
+        cursor: pointer;
+      }
+      .switch input {
+        position: absolute;
+        opacity: 0;
+        inset: 0;
+        margin: 0;
+        cursor: pointer;
+      }
+      .switch .trk {
+        position: absolute;
+        inset: 0;
+        border-radius: 99px;
+        background: var(--line-strong);
+        transition: background 0.15s;
+      }
+      .switch .trk::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+        transition: transform 0.15s;
+      }
+      .switch input:checked + .trk {
+        background: var(--accent);
+      }
+      .switch input:checked + .trk::after {
+        transform: translateX(16px);
+      }
+      .switch input:focus-visible + .trk {
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+
+      select.ctl,
+      input.ctl {
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        background: var(--surface);
+        padding: 6px 10px;
+        min-width: 120px;
+        outline: none;
+        font-size: 13px;
+      }
+      select.ctl:focus,
+      input.ctl:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+      }
+      input.ctl.num {
+        width: 86px;
+        min-width: 0;
+        text-align: right;
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+      }
+      input.ctl.mono,
+      select.ctl.mono {
+        font-family: var(--mono);
+        font-size: 12.5px;
+      }
+      input.ctl.wide {
+        width: 260px;
+      }
+      .unit {
+        color: var(--faint);
+        font-size: 12px;
+      }
+
+      .tagbox {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        justify-content: flex-end;
+        max-width: 340px;
+      }
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        background: var(--chip-bg);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 3px 7px;
+      }
+      .tag button {
+        border: 0;
+        background: none;
+        color: var(--faint);
+        cursor: pointer;
+        padding: 0;
+        font-size: 12px;
+        line-height: 1;
+      }
+      .tag button:hover {
+        color: var(--crit);
+      }
+      .tag-add {
+        border: 1px dashed var(--line-strong);
+        background: none;
+        border-radius: 6px;
+        padding: 3px 8px;
+        font-size: 11.5px;
+        color: var(--muted);
+        cursor: pointer;
+      }
+      .tag-add:hover {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+
+      .action-btn {
+        border: 1px solid var(--accent);
+        color: var(--accent);
+        background: none;
+        border-radius: 7px;
+        padding: 6px 14px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .action-btn:hover {
+        background: var(--accent-soft);
+      }
+
+      .envmap {
+        display: grid;
+        grid-template-columns: repeat(3, auto);
+        gap: 8px;
+      }
+      .envmap .cell {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+      }
+      .envmap .cell span {
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--faint);
+        font-weight: 600;
+      }
+      .envmap input {
+        width: 110px;
+      }
+
+      .tabs {
+        display: flex;
+        gap: 4px;
+        padding: 10px 18px 0;
+        border-bottom: 1px solid var(--line);
+        background: var(--surface);
+      }
+      .tab {
+        border: 0;
+        background: none;
+        cursor: pointer;
+        padding: 8px 14px 10px;
+        font-size: 13.5px;
+        color: var(--muted);
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+      }
+      .tab:hover {
+        color: var(--ink);
+      }
+      .tab.active {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+        font-weight: 600;
+      }
+      .tab .mini {
+        font-size: 10px;
+        margin-left: 6px;
+        vertical-align: 1px;
+      }
+
+      table.grid {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      table.grid th {
+        text-align: left;
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--faint);
+        font-weight: 650;
+        padding: 10px 18px 8px;
+        border-bottom: 1px solid var(--line);
+      }
+      table.grid td {
+        padding: 9px 18px;
+        border-bottom: 1px solid var(--line);
+        vertical-align: middle;
+      }
+      table.grid tr:last-child td {
+        border-bottom: 0;
+      }
+      table.grid td.mono,
+      .mono {
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      .table-scroll {
+        overflow-x: auto;
+      }
+
+      .stack-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+      @media (max-width: 1100px) {
+        .stack-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .stack-card {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--surface);
+        overflow: hidden;
+      }
+      .stack-card.on {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 1px var(--accent);
+      }
+      .stack-card .head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 14px;
+      }
+      .stack-card .glyph {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+        flex: none;
+        display: grid;
+        place-items: center;
+        font-family: var(--mono);
+        font-weight: 700;
+        font-size: 12px;
+        background: var(--surface2);
+        color: var(--muted);
+        border: 1px solid var(--line);
+      }
+      .stack-card.on .glyph {
+        background: var(--accent-soft);
+        color: var(--accent);
+        border-color: transparent;
+      }
+      .stack-card .head .t {
+        flex: 1;
+        min-width: 0;
+      }
+      .stack-card .head .t b {
+        display: block;
+        font-size: 13.5px;
+      }
+      .stack-card .head .t i {
+        display: block;
+        font-style: normal;
+        color: var(--muted);
+        font-size: 11.5px;
+      }
+      .stack-card .meta {
+        padding: 0 14px 10px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+      }
+      .stack-card .detect {
+        padding: 8px 14px;
+        border-top: 1px dashed var(--line);
+        color: var(--muted);
+        font-size: 11.5px;
+      }
+      .stack-card .detect code {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        background: var(--chip-bg);
+        border-radius: 4px;
+        padding: 1px 4px;
+      }
+      details.stack-more {
+        border-top: 1px solid var(--line);
+      }
+      details.stack-more summary {
+        cursor: pointer;
+        padding: 8px 14px;
+        font-size: 12px;
+        color: var(--accent);
+        list-style: none;
+      }
+      details.stack-more summary::before {
+        content: "▸ ";
+      }
+      details.stack-more[open] summary::before {
+        content: "▾ ";
+      }
+      details.stack-more ul {
+        margin: 0;
+        padding: 0 14px 12px 28px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      details.stack-more li {
+        margin-bottom: 3px;
+      }
+
+      .tile-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 14px;
+        margin-bottom: 18px;
+      }
+      @media (max-width: 1100px) {
+        .tile-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .tile {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 14px 16px;
+        box-shadow: var(--shadow);
+      }
+      .tile .k {
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--faint);
+        font-weight: 650;
+      }
+      .tile .v {
+        font-size: 19px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        margin-top: 2px;
+        font-variant-numeric: tabular-nums;
+      }
+      .tile .s {
+        font-size: 11.5px;
+        color: var(--muted);
+        margin-top: 2px;
+      }
+      .tile .v .dim {
+        color: var(--faint);
+        font-weight: 450;
+        font-size: 14px;
+      }
+
+      .flow {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 6px;
+        padding: 14px 18px;
+      }
+      .flow .state {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        border: 1px solid var(--line);
+        background: var(--chip-bg);
+        border-radius: 99px;
+        padding: 3px 10px;
+      }
+      .flow .state.terminal {
+        border-color: var(--good);
+        color: var(--good);
+        background: var(--good-soft);
+      }
+      .flow .arr {
+        color: var(--faint);
+        font-size: 11px;
+      }
+
+      .colorchip {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+      }
+      .colorchip .swatch {
+        width: 12px;
+        height: 12px;
+        border-radius: 4px;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        flex: none;
+      }
+
+      .callout {
+        display: flex;
+        gap: 10px;
+        padding: 12px 16px;
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        background: var(--surface2);
+        font-size: 12.5px;
+        color: var(--muted);
+        margin-bottom: 18px;
+      }
+      .callout.warn {
+        background: var(--warn-soft);
+        border-color: transparent;
+        color: var(--warn);
+      }
+      .callout b {
+        color: inherit;
+      }
+
+      .savebar {
+        position: fixed;
+        left: 50%;
+        bottom: 22px;
+        transform: translate(-50%, 90px);
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: var(--ink);
+        color: var(--bg);
+        border-radius: 12px;
+        padding: 10px 12px 10px 18px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+        transition:
+          transform 0.25s cubic-bezier(0.2, 0.9, 0.3, 1.2),
+          visibility 0.25s;
+        visibility: hidden;
+        z-index: 60;
+      }
+      .savebar.show {
+        transform: translate(-50%, 0);
+        visibility: visible;
+      }
+      .savebar .msg {
+        font-size: 13px;
+      }
+      .savebar .msg b {
+        font-variant-numeric: tabular-nums;
+      }
+      .savebar button {
+        border: 0;
+        border-radius: 8px;
+        padding: 8px 16px;
+        cursor: pointer;
+        font-weight: 600;
+        font-size: 13px;
+      }
+      .savebar .discard {
+        background: transparent;
+        color: var(--bg);
+        opacity: 0.75;
+      }
+      .savebar .discard:hover {
+        opacity: 1;
+      }
+      .savebar .save {
+        background: var(--accent);
+        color: var(--accent-ink);
+      }
+
+      .toast {
+        position: fixed;
+        bottom: 90px;
+        left: 50%;
+        transform: translate(-50%, 20px);
+        background: var(--good);
+        color: #fff;
+        border-radius: 10px;
+        padding: 10px 18px;
+        font-size: 13px;
+        font-weight: 550;
+        opacity: 0;
+        pointer-events: none;
+        transition: all 0.25s;
+        z-index: 70;
+      }
+      .toast.show {
+        opacity: 1;
+        transform: translate(-50%, 0);
+      }
+
+      .hooks-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+      @media (max-width: 1100px) {
+        .hooks-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .hook-card {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--surface);
+      }
+      .hook-card .hd {
+        padding: 11px 14px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .hook-card .hd .nm {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        font-weight: 650;
+      }
+      .hook-card .steps {
+        padding: 6px 0;
+      }
+      .hook-step {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 14px;
+        font-size: 12.5px;
+      }
+      .hook-step .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--good);
+        flex: none;
+      }
+      .hook-step.optional .dot {
+        background: var(--faint);
+      }
+      .hook-step .what {
+        flex: 1;
+      }
+      .hook-step .how {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--faint);
+      }
+
+      @media (max-width: 900px) {
+        .app {
+          grid-template-columns: 1fr;
+        }
+        .sidebar {
+          position: static;
+          height: auto;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 4px;
+          border-right: 0;
+          border-bottom: 1px solid var(--line);
+        }
+        .nav-group {
+          margin: 0 12px 6px 0;
+        }
+        .search-wrap input {
+          width: 140px;
+        }
+        .main {
+          padding: 20px 16px 160px;
+        }
+        .row {
+          grid-template-columns: 1fr;
+        }
+        .row .control {
+          justify-content: flex-start;
+        }
+        .envmap {
+          grid-template-columns: 1fr;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition: none !important;
+          animation: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="proto-strip">
+      <strong>Prototype</strong> — every setting below is editable in the UI,
+      but nothing is persisted yet. Values shown reflect Lisa's real defaults.
+    </div>
+    <header class="topbar">
+      <div class="brand">
+        <span class="brand-mark">L</span> Lisa
+        <span class="console-tag">Console</span>
+      </div>
+      <button
+        class="project-switch"
+        type="button"
+        title="Project switcher (prototype)"
+      >
+        <span class="repo">acme/acme-app</span> <span class="caret">▼</span>
+      </button>
+      <div class="spacer"></div>
+      <div class="search-wrap">
+        <span class="icon">⌕</span>
+        <input
+          id="search"
+          type="search"
+          placeholder="Filter settings in this section…"
+          aria-label="Filter settings"
+        />
+      </div>
+      <span class="version-chip">@codyswann/lisa 2.199.0</span>
+      <button
+        class="icon-btn"
+        id="themeToggle"
+        type="button"
+        title="Toggle theme"
+        aria-label="Toggle theme"
+      >
+        ◐
+      </button>
+    </header>
+    <div class="app">
+      <nav class="sidebar" id="nav" aria-label="Settings sections"></nav>
+      <main class="main" id="main"></main>
+    </div>
+    <div class="savebar" id="savebar" role="status">
+      <span class="msg"
+        ><b id="dirtyCount">0</b> unsaved change<span id="dirtyPlural"
+          >s</span
+        ></span
+      >
+      <button class="discard" id="discardBtn" type="button">Discard</button>
+      <button class="save" id="saveBtn" type="button">Save changes</button>
+    </div>
+    <div class="toast" id="toast">
+      Saved — prototype only, nothing was written
+    </div>
+    <script>
+      "use strict";
+      document.title = "Lisa Console — Project Settings";
+
+      /* ------------------------------------------------------------------ *
+       * Catalog data. Shapes:
+       *  section: { id, group, title, desc, src, blocks: [block] }
+       *  block:   { card, note?, rows } | { type: 'tabs'|'table'|'tiles'|'stacks'|'flow'|'hooks'|'callout', ... }
+       *  row:     { key, label, desc, badges?, control }
+       *  control: { type: 'toggle'|'select'|'text'|'number'|'tags'|'envmap'|'static', ... }
+       * ------------------------------------------------------------------ */
+
+      const sel = (value, options) => ({ type: "select", value, options });
+      const tog = value => ({ type: "toggle", value });
+      const txt = (value, opts) =>
+        Object.assign({ type: "text", value }, opts || {});
+      const num = (value, unit) => ({ type: "number", value, unit });
+      const tags = values => ({ type: "tags", values });
+      const envmap = (dev, staging, production) => ({
+        type: "envmap",
+        dev,
+        staging,
+        production,
+      });
+      const stat = (value, cls) => ({ type: "static", value, cls });
+
+      const SEVERITIES = ["error", "warn", "off"];
+
+      const DATA = {
+        groups: [
+          {
+            label: "Project",
+            sections: ["overview", "general", "stacks", "starters", "agents"],
+          },
+          {
+            label: "Delivery",
+            sections: ["tracker", "prd", "deploy", "automations", "intake"],
+          },
+          {
+            label: "Quality",
+            sections: ["linting", "testing", "hooks", "ci", "qa"],
+          },
+          { label: "Distribution", sections: ["github", "plugins"] },
+          { label: "Advanced", sections: ["advanced"] },
+        ],
+        sections: {},
+      };
+
+      /* ---------------------------------- Overview ---------------------------------- */
+      DATA.sections.overview = {
+        title: "Overview",
+        desc: "Everything Lisa governs for this project at a glance. Values come from .lisa.config.json, the detected stack templates, and shipped defaults.",
+        src: ".lisa.config.json · .lisa.config.local.json",
+        blocks: [
+          {
+            type: "tiles",
+            tiles: [
+              { k: "Project types", v: "2", s: "typescript · expo" },
+              { k: "Work tracker", v: "JIRA", s: "project ACME" },
+              { k: "PRD source", v: "Notion", s: "PRD queue database" },
+              { k: "Harness", v: "fleet", s: "all 6 coding agents" },
+              { k: "Plugins enabled", v: "11", s: "4 Lisa + 7 curated" },
+              {
+                k: "Coverage floor",
+                v: "70%",
+                s: "statements · branches · functions · lines",
+              },
+              {
+                k: "Required CI checks",
+                v: "9",
+                s: "incl. CodeRabbit + GitGuardian",
+              },
+              { k: "Automations", v: "5", s: "intake, repair, exploratory" },
+            ],
+          },
+          {
+            type: "flow",
+            title:
+              "Build lifecycle (fixed — only the status names are configurable)",
+            states: [
+              { name: "ready" },
+              { name: "claimed" },
+              { name: "review?", opt: true },
+              { name: "done", terminal: true },
+            ],
+          },
+          {
+            type: "flow",
+            title: "PRD lifecycle (fixed)",
+            states: [
+              { name: "draft" },
+              { name: "ready" },
+              { name: "in_review" },
+              { name: "blocked | ticketed" },
+              { name: "shipped" },
+              { name: "verified", terminal: true },
+            ],
+          },
+          {
+            card: "How configuration resolves",
+            rows: [
+              {
+                key: "",
+                label: "Resolution order",
+                desc: "Skill arguments always win, then the per-developer local file, then the committed file, then Lisa’s built-in default.",
+                control: stat(
+                  "$ARGUMENTS → .lisa.config.local.json → .lisa.config.json → default",
+                  "mono"
+                ),
+              },
+              {
+                key: "",
+                label: "Secrets",
+                desc: "Tokens never live in config — only IDs, keys and slugs. Secrets stay in env vars or the OS keychain.",
+                control: stat(
+                  "ATLASSIAN_API_TOKEN · NOTION_API_TOKEN · LINEAR_API_KEY · GH_TOKEN",
+                  "mono"
+                ),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- General ---------------------------------- */
+      DATA.sections.general = {
+        title: "General",
+        desc: "Top-level project identity: which coding agents Lisa installs into, where tickets are written, and where PRDs come from.",
+        src: ".lisa.config.json · src/core/config.ts",
+        blocks: [
+          {
+            card: "Core selections",
+            rows: [
+              {
+                key: "harness",
+                label: "Coding-agent harness",
+                desc: "Which agent(s) Lisa emits artifacts for. fleet targets all six; a single value targets only that agent. Default: claude.",
+                badges: ["default: claude"],
+                control: sel("fleet", [
+                  "claude",
+                  "codex",
+                  "cursor",
+                  "agy",
+                  "copilot",
+                  "opencode",
+                  "fleet",
+                ]),
+              },
+              {
+                key: "tracker",
+                label: "Work tracker",
+                desc: "Destination for every ticket write. Required — skills hard-fail without it and point to /lisa:setup:*.",
+                badges: ["required"],
+                control: sel("jira", ["jira", "github", "linear"]),
+              },
+              {
+                key: "source",
+                label: "PRD source",
+                desc: "Default product-requirements system for batch intake skills. Explicit URLs passed to a skill always win.",
+                control: sel("notion", [
+                  "(none)",
+                  "notion",
+                  "confluence",
+                  "linear",
+                  "github",
+                  "jira",
+                ]),
+              },
+              {
+                key: "repo",
+                label: "Repository name",
+                desc: "Explicit current-repo override for multi-repo trackers. Falls back to github.repo, then the git remote basename.",
+                control: txt("acme-app", {
+                  mono: true,
+                  placeholder: "derived from git remote",
+                }),
+              },
+            ],
+          },
+          {
+            type: "callout",
+            text: "<b>Two config files.</b> .lisa.config.json is committed and shared; .lisa.config.local.json is gitignored and overrides it per-key. Keys flagged <i>local-only</i> below belong in the local file — lisa doctor warns when they are committed.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Stacks ---------------------------------- */
+      DATA.sections.stacks = {
+        title: "Project types",
+        desc: "Lisa auto-detects the stacks in a repository and applies each stack’s templates in hierarchy order (parents before children, so children override). Toggling a stack here previews what it would install.",
+        src: "src/detection/detectors/*.ts · src/core/config.ts",
+        blocks: [
+          {
+            type: "stacks",
+            items: [
+              {
+                id: "typescript",
+                glyph: "TS",
+                name: "TypeScript",
+                tagline: "Root stack for every JS/TS project",
+                on: true,
+                detect:
+                  "Detected by <code>tsconfig.json</code> or a <code>typescript</code> dependency",
+                badges: ["Vitest", "oxlint + ESLint", "Husky", "bun"],
+                more: [
+                  "Enforced configs: eslint.config.ts, tsconfig.json, vitest.config.ts, knip.json, commitlint, Prettier, ast-grep",
+                  "Seeded once: ci.yml, claude*.yml, nightly improvement workflows, eslint.config.local.ts, thresholds files",
+                  "package.json governance: lint/test/typecheck scripts forced, security overrides forced, engines bun 1.3.8 / node 22.21.1 defaulted",
+                ],
+              },
+              {
+                id: "expo",
+                glyph: "EX",
+                name: "Expo",
+                tagline: "React Native mobile + web apps",
+                on: true,
+                detect:
+                  "Detected by <code>app.json</code>, <code>eas.json</code>, or an <code>expo</code> dependency",
+                badges: [
+                  "Jest (jest-expo)",
+                  "Playwright",
+                  "Maestro",
+                  "Lighthouse",
+                  "ZAP",
+                ],
+                more: [
+                  "Jest replaces Vitest; integration tests split by filename regex",
+                  "EAS build/update scripts per environment; GraphQL codegen",
+                  "Playwright required check on staging via ruleset",
+                  "Forces RN/GraphQL toolchain (@apollo/client, zod, nativewind); defaults full Expo SDK set",
+                ],
+              },
+              {
+                id: "nestjs",
+                glyph: "NJ",
+                name: "NestJS",
+                tagline: "Serverless GraphQL APIs",
+                on: false,
+                detect:
+                  "Detected by <code>nest-cli.json</code> or any <code>@nestjs/*</code> dependency",
+                badges: [
+                  "Vitest",
+                  "Serverless",
+                  "k6 load tests",
+                  "TypeORM",
+                  "ZAP",
+                ],
+                more: [
+                  "Full k6 scenario kit (smoke/load/stress/spike/soak)",
+                  "deploy:dev/staging/production via Serverless Framework",
+                  "Forces @nestjs/*, @apollo/server, typeorm, pg, ioredis, class-validator",
+                  "max-lines-per-function raised to 100",
+                ],
+              },
+              {
+                id: "cdk",
+                glyph: "CD",
+                name: "AWS CDK",
+                tagline: "Infrastructure as code",
+                on: false,
+                detect:
+                  "Detected by <code>cdk.json</code> or any <code>aws-cdk*</code> dependency",
+                badges: ["Vitest", "npm (not bun)", "cdk CLI"],
+                more: [
+                  "Forces aws-cdk-lib 2.246.0, constructs, OIDC deploy helper",
+                  "Per-env AWS account IDs via secrets (AWS_ACCOUNT_ID_*)",
+                  "cognitive-complexity threshold relaxed to 15",
+                ],
+              },
+              {
+                id: "harper-fabric",
+                glyph: "HF",
+                name: "Harper Fabric",
+                tagline: "HarperDB Fabric components",
+                on: false,
+                detect:
+                  "Detected by <code>harper-app/config.yaml</code> + schema + harperdb markers",
+                badges: [
+                  "Vitest",
+                  "Playwright",
+                  "ZAP",
+                  "ast-grep Harper rules",
+                ],
+                more: [
+                  "Harper lifecycle scripts (start/stop/status/reset)",
+                  "ast-grep guards: no-full-table-scan, no-empty-conditions-with-sort, require-statusCode",
+                  "Strictest functional immutability rules of any stack",
+                ],
+              },
+              {
+                id: "phaser",
+                glyph: "PH",
+                name: "Phaser",
+                tagline: "Phaser 4 browser games",
+                on: false,
+                detect: "Detected by a <code>phaser</code> dependency",
+                badges: ["Vite + PWA", "Vitest", "Playwright", "size-limit"],
+                more: [
+                  "20 game-dev agents (designer, playtester, producer, publisher…)",
+                  "Determinism lint bans: Math.random, Date.now, performance.now in src",
+                  "14 Phaser v3→v4 API bans; scene-lifecycle ESLint rules",
+                  "verify_enforced CI gate on; wiki plugin enabled by default",
+                ],
+              },
+              {
+                id: "npm-package",
+                glyph: "NP",
+                name: "npm package",
+                tagline: "Publishable libraries",
+                on: false,
+                detect:
+                  "Detected when package.json is public with <code>main</code>/<code>bin</code>/<code>exports</code>/<code>files</code>",
+                badges: ["inherits TypeScript", "publish-to-npm.yml"],
+                more: [
+                  "Rides the TypeScript layer with library publishing conventions",
+                ],
+              },
+              {
+                id: "rails",
+                glyph: "RB",
+                name: "Rails",
+                tagline: "Ruby on Rails apps (non-JS root)",
+                on: false,
+                detect:
+                  "Detected by <code>bin/rails</code> or <code>config/application.rb</code>",
+                badges: [
+                  "RSpec + SimpleCov",
+                  "RuboCop",
+                  "Lefthook",
+                  "Mutant",
+                  "mise",
+                ],
+                more: [
+                  "Gemfile governed via managed block-merge (no package.lisa.json)",
+                  "pre-push: rspec, brakeman, reek, flog, flay, mutation gate",
+                  "ast-grep Ruby security rules (SQLi, strong params, unsafe send)",
+                  "SimpleCov floors: line 80 / branch 70",
+                ],
+              },
+            ],
+          },
+          {
+            card: "Template strategies",
+            note: "How Lisa writes each file class into a project",
+            rows: [
+              {
+                key: "copy-overwrite",
+                label: "Enforced",
+                desc: "Lisa owns the file. Created if missing, overwritten on drift (with backup). Example: eslint.config.ts.",
+                control: stat("Lisa wins", ""),
+              },
+              {
+                key: "create-only",
+                label: "Seed once",
+                desc: "Created if missing, never touched again. The project owns it. Example: ci.yml, eslint.config.local.ts.",
+                control: stat("project wins", ""),
+              },
+              {
+                key: "copy-contents",
+                label: "Managed block",
+                desc: "Only the content between AI GUARDRAILS markers is replaced. Example: .gitignore, Husky hooks.",
+                control: stat("shared", ""),
+              },
+              {
+                key: "merge",
+                label: "Deep merge",
+                desc: "JSON deep merge where Lisa’s values win on conflict. Example: .claude/settings.json, .oxlintrc.json.",
+                control: stat("Lisa wins on conflict", ""),
+              },
+              {
+                key: "package-lisa",
+                label: "package.json governance",
+                desc: "Sidecar package.lisa.json with force (Lisa replaces), defaults (project preserved), merge (arrays deduped), remove (keys stripped).",
+                control: stat("force · defaults · merge · remove", "mono"),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- Starters ---------------------------------- */
+      DATA.sections.starters = {
+        title: "Starter templates",
+        desc: "Which starter repo(s) this project was generated from, and how it stays connected to them — pulling upstream starter improvements down into the project, and proposing generic project additions back up to the starter.",
+        src: ".lisa.config.json starter.* · src/cli/starters.ts",
+        blocks: [
+          {
+            type: "callout",
+            variant: "warn",
+            text: "<b>Planned feature.</b> This page documents the starter-sync contract and its settings; the sync engine and upstream-proposal flow are not wired up yet. Controls here preview the intended behavior.",
+          },
+          {
+            type: "flow",
+            title: "Sync cycle",
+            states: [
+              { name: "upstream commits" },
+              { name: "diff since lastSync.sha" },
+              { name: "apply to project" },
+              { name: "detect generic additions" },
+              { name: "open starter issue", terminal: true },
+            ],
+          },
+          {
+            card: "Template: expostarter",
+            note: "starter.templates[0]",
+            rows: [
+              {
+                key: "starter.templates.0.repo",
+                label: "Starter repository",
+                desc: "The repo this project was generated from by lisa setup-project.",
+                control: txt("CodySwannGT/expostarter", {
+                  mono: true,
+                  wide: true,
+                }),
+              },
+              {
+                key: "starter.templates.0.ref",
+                label: "Tracked ref",
+                desc: "Branch or tag whose history is compared on each sync.",
+                control: txt("main", { mono: true }),
+              },
+              {
+                key: "starter.templates.0.lastSync",
+                label: "Last synced",
+                desc: "Recorded automatically after every successful sync; the next sync diffs the starter from this commit forward.",
+                control: stat(
+                  "8c1f2ab · 2026-07-01 · 12 upstream commits since",
+                  "mono"
+                ),
+              },
+              {
+                key: "starter.templates.0.paths",
+                label: "Path scope",
+                desc: "Optional glob scope — only starter changes under these paths are applied.",
+                control: tags(["**"]),
+              },
+            ],
+          },
+          {
+            card: "Template: cdkstarter",
+            note: "starter.templates[1] — a project can descend from more than one starter",
+            rows: [
+              {
+                key: "starter.templates.1.repo",
+                label: "Starter repository",
+                desc: "",
+                control: txt("CodySwannGT/cdkstarter", {
+                  mono: true,
+                  wide: true,
+                }),
+              },
+              {
+                key: "starter.templates.1.ref",
+                label: "Tracked ref",
+                desc: "",
+                control: txt("main", { mono: true }),
+              },
+              {
+                key: "starter.templates.1.lastSync",
+                label: "Last synced",
+                desc: "",
+                control: stat("412de90 · 2026-06-18 · up to date", "mono"),
+              },
+              {
+                key: "starter.templates.1.paths",
+                label: "Path scope",
+                desc: "",
+                control: tags(["infrastructure/**"]),
+              },
+            ],
+          },
+          {
+            card: "Sync behavior (starter → project)",
+            rows: [
+              {
+                key: "starter.sync.auto",
+                label: "Automatic sync",
+                desc: "On: check the upstream starter on a schedule (a lisa-auto cron) and apply new changes without being asked. Off: sync only runs manually.",
+                control: tog(false),
+              },
+              {
+                key: "starter.sync.strategy",
+                label: "Conflict handling",
+                desc: "How changes land: direct commits when clean, or always through a reviewable PR.",
+                control: sel("pull-request", [
+                  "pull-request",
+                  "direct-when-clean",
+                ]),
+              },
+              {
+                key: "",
+                label: "Check for upstream changes",
+                desc: "Diffs the starter since the last synced commit and applies the changes to this project, respecting Lisa template semantics (create-only files the project now owns are never clobbered).",
+                control: {
+                  type: "button",
+                  label: "Sync now",
+                  toast: "Prototype — starter sync is not wired up yet",
+                },
+              },
+            ],
+          },
+          {
+            card: "Upstreaming (project → starter)",
+            rows: [
+              {
+                key: "starter.sync.upstreamProposals",
+                label: "Propose upstream contributions",
+                desc: "During a sync, Lisa looks for generic additions this project made — utilities, config hardening, CI fixes with no project-specific values — and opens an issue in the starter repo with detailed instructions on what changed and how to apply it to the starter.",
+                control: tog(true),
+              },
+              {
+                key: "starter.sync.proposalLabel",
+                label: "Proposal issue label",
+                desc: "Label applied to the issues Lisa opens in the starter repo.",
+                control: txt("starter-upstream-proposal", { mono: true }),
+              },
+              {
+                key: "",
+                label: "Scan for upstreamable changes",
+                desc: "One-off scan without a full sync.",
+                control: {
+                  type: "button",
+                  label: "Scan & propose",
+                  toast: "Prototype — upstream proposals are not wired up yet",
+                },
+              },
+            ],
+          },
+          {
+            card: "What counts as generic",
+            rows: [
+              {
+                key: "",
+                label: "Upstreamable",
+                desc: "New shared utilities or hooks, dependency/security bumps, CI workflow fixes, lint-rule or config improvements with no project-specific identifiers.",
+                control: stat("proposed as starter issue", ""),
+              },
+              {
+                key: "",
+                label: "Not upstreamable",
+                desc: "Anything referencing project names, product features, secrets/IDs, tracker keys, or business logic.",
+                control: stat("stays in the project", ""),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- Agents ---------------------------------- */
+      DATA.sections.agents = {
+        title: "Coding agents",
+        desc: "The harness setting picks which coding-agent CLIs Lisa installs governance into. fleet (this project) targets all of them; each agent gets an equivalent surface generated from the same source.",
+        src: "src/core/lisa.ts · scripts/generate-*-plugin-artifacts.mjs",
+        blocks: [
+          {
+            type: "table",
+            card: "Fleet targets",
+            cols: ["Agent", "What Lisa installs", "Enabled"],
+            rows: [
+              [
+                { t: "mono", v: "claude" },
+                {
+                  t: "text",
+                  v: ".claude/, .claude-plugin/, CLAUDE.md; plugins installed from the lisa marketplace at project scope",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "codex" },
+                {
+                  t: "text",
+                  v: ".codex/, .codex-plugin/, .agents/, AGENTS.md; hooks merged into ~/.codex/hooks.json",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "cursor" },
+                {
+                  t: "text",
+                  v: "No per-project writes — Cursor natively reads the .claude-plugin loader via lisa-cursor variants",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "agy" },
+                {
+                  t: "text",
+                  v: "Antigravity: lisa-agy plugin variants; MCP mirrored user-globally; rules baked into AGENTS.md",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "copilot" },
+                {
+                  t: "text",
+                  v: ".github/copilot-instructions.md; agents emitted as *.agent.md with camelCase hook events",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "opencode" },
+                {
+                  t: "text",
+                  v: ".opencode/skills/lisa/ + AGENTS.md, read natively; project plugin hooks",
+                },
+                { t: "toggle", v: true },
+              ],
+            ],
+          },
+          {
+            type: "callout",
+            text: "<b>Parity guarantee.</b> Claude is the reference harness. Every other agent receives an equivalent generated surface; where a capability cannot be represented, the gap is documented rather than silently dropped.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Tracker ---------------------------------- */
+      DATA.sections.tracker = {
+        title: "Work tracker",
+        desc: "Where tickets live and how their lifecycle states map to your workflow. Role semantics are fixed — only the status and label names are configurable.",
+        src: "plugins/src/base/rules/reference/config-resolution.md",
+        blocks: [
+          {
+            type: "tabs",
+            active: 0,
+            tabs: [
+              {
+                label: "JIRA",
+                badge: "active",
+                blocks: [
+                  {
+                    card: "Atlassian site",
+                    note: "Shared by JIRA and Confluence",
+                    rows: [
+                      {
+                        key: "atlassian.cloudId",
+                        label: "Cloud ID",
+                        desc: "Atlassian Cloud site UUID, resolved once at setup.",
+                        badges: ["required"],
+                        control: txt("8f2a01c4-6b7e-4d1a-9c3e-2f5b8d7a4e91", {
+                          mono: true,
+                          wide: true,
+                        }),
+                      },
+                      {
+                        key: "atlassian.site",
+                        label: "Site",
+                        desc: "Human-readable site URL.",
+                        control: txt("acme.atlassian.net", { mono: true }),
+                      },
+                      {
+                        key: "atlassian.email",
+                        label: "Account email",
+                        desc: "Per-developer disambiguator when multiple accounts access the site.",
+                        badges: ["local-only"],
+                        control: txt("you@acme.com", { mono: true }),
+                      },
+                    ],
+                  },
+                  {
+                    card: "Project & workflow statuses",
+                    note: "Map Lisa’s fixed roles to your JIRA workflow status names",
+                    rows: [
+                      {
+                        key: "jira.project",
+                        label: "Project key",
+                        desc: "The JIRA project Lisa writes tickets into.",
+                        badges: ["required"],
+                        control: txt("ACME", { mono: true }),
+                      },
+                      {
+                        key: "jira.workflow.ready",
+                        label: "Ready",
+                        desc: "Human signal that a ticket is buildable and an agent may claim it.",
+                        control: txt("Ready"),
+                      },
+                      {
+                        key: "jira.workflow.claimed",
+                        label: "Claimed",
+                        desc: "An agent has picked the ticket up.",
+                        control: txt("In Progress"),
+                      },
+                      {
+                        key: "jira.workflow.review",
+                        label: "Review (optional)",
+                        desc: "Post-build review hold. Leave empty to skip the transition.",
+                        control: txt("Code Review"),
+                      },
+                      {
+                        key: "jira.workflow.blocked",
+                        label: "Blocked",
+                        desc: "Human attention required.",
+                        control: txt("Blocked"),
+                      },
+                      {
+                        key: "jira.workflow.done",
+                        label: "Done",
+                        desc: "Terminal state, keyed per environment. The production value is the only true terminal that triggers native closure.",
+                        control: envmap("On Dev", "On Stg", "Done"),
+                      },
+                      {
+                        key: "jira.labels.human_needed",
+                        label: "Human-needed label",
+                        desc: "Additive marker label applied alongside Blocked.",
+                        control: txt("Human Needed"),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "GitHub Issues",
+                blocks: [
+                  {
+                    card: "Repository",
+                    rows: [
+                      {
+                        key: "github.org",
+                        label: "Organization",
+                        desc: "GitHub organization or user.",
+                        badges: ["required"],
+                        control: txt("acme", { mono: true }),
+                      },
+                      {
+                        key: "github.repo",
+                        label: "Repository",
+                        desc: "Repository name.",
+                        badges: ["required"],
+                        control: txt("acme-app", { mono: true }),
+                      },
+                    ],
+                  },
+                  {
+                    card: "Build lifecycle labels",
+                    rows: [
+                      {
+                        key: "github.labels.build.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("status:ready", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.build.claimed",
+                        label: "Claimed",
+                        desc: "",
+                        control: txt("status:in-progress", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.build.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("status:blocked", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.build.human_needed",
+                        label: "Human needed",
+                        desc: "Additive marker next to Blocked.",
+                        control: txt("human-needed", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.build.done",
+                        label: "Done",
+                        desc: "Env-keyed terminal labels. GitHub build intake has no review hold — claimed moves straight to done.",
+                        control: envmap(
+                          "status:on-dev",
+                          "status:on-stg",
+                          "status:done"
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    card: "ProjectV2 coordination",
+                    note: "Optional — Issues remain the source of truth",
+                    rows: [
+                      {
+                        key: "github.projects.v2.owner.kind",
+                        label: "Owner kind",
+                        desc: "",
+                        control: sel("organization", ["organization", "user"]),
+                      },
+                      {
+                        key: "github.projects.v2.owner.slug",
+                        label: "Owner slug",
+                        desc: "Must match github.org — cross-namespace projects are rejected.",
+                        control: txt("acme", { mono: true }),
+                      },
+                      {
+                        key: "github.projects.v2.number",
+                        label: "Project number",
+                        desc: "Human-facing number from the project URL.",
+                        control: num(7),
+                      },
+                      {
+                        key: "github.projects.v2.required",
+                        label: "Membership required",
+                        desc: "On: membership failures block the write. Off: best-effort with warnings.",
+                        control: tog(false),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "Linear",
+                blocks: [
+                  {
+                    card: "Workspace",
+                    rows: [
+                      {
+                        key: "linear.workspace",
+                        label: "Workspace slug",
+                        desc: "",
+                        badges: ["required"],
+                        control: txt("acme", { mono: true }),
+                      },
+                      {
+                        key: "linear.teamKey",
+                        label: "Team key",
+                        desc: "Team that owns destination issues.",
+                        badges: ["required"],
+                        control: txt("ENG", { mono: true }),
+                      },
+                    ],
+                  },
+                  {
+                    card: "Build lifecycle labels",
+                    rows: [
+                      {
+                        key: "linear.labels.build.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("status:ready", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.build.claimed",
+                        label: "Claimed",
+                        desc: "",
+                        control: txt("status:in-progress", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.build.review",
+                        label: "Review (optional)",
+                        desc: "Linear ships a default review hold; GitHub does not.",
+                        control: txt("status:code-review", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.build.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("status:blocked", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.build.done",
+                        label: "Done",
+                        desc: "Env-keyed terminal labels.",
+                        control: envmap(
+                          "status:on-dev",
+                          "status:on-stg",
+                          "status:done"
+                        ),
+                      },
+                    ],
+                  },
+                  {
+                    type: "callout",
+                    text: 'Fixed native mappings: priority 0=None…4=Low, native estimates, components via a <span class="mono">component:</span> label prefix. Epics map to Projects, Stories to Issues, Sub-tasks to Sub-issues.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- PRD ---------------------------------- */
+      DATA.sections.prd = {
+        title: "PRD source",
+        desc: "Where product requirements live and how their lifecycle maps onto that system. Notion uses a status property, Confluence uses parent pages, Linear and GitHub use labels.",
+        src: "plugins/src/base/skills/lisa-setup-{notion,confluence,linear,github}",
+        blocks: [
+          {
+            type: "flow",
+            title: "PRD lifecycle (fixed semantics, configurable names)",
+            states: [
+              { name: "draft" },
+              { name: "ready" },
+              { name: "in_review" },
+              { name: "blocked | ticketed" },
+              { name: "shipped" },
+              { name: "verified", terminal: true },
+            ],
+          },
+          {
+            type: "tabs",
+            active: 0,
+            tabs: [
+              {
+                label: "Notion",
+                badge: "active",
+                blocks: [
+                  {
+                    card: "Connection",
+                    rows: [
+                      {
+                        key: "notion.workspaceId",
+                        label: "Workspace",
+                        desc: "Connection-match key; also the keychain account for the integration token.",
+                        badges: ["required"],
+                        control: txt("acme-product", { mono: true }),
+                      },
+                      {
+                        key: "notion.prdDatabaseId",
+                        label: "PRD database",
+                        desc: "The database that is the PRD queue. Must be shared with the integration.",
+                        badges: ["required"],
+                        control: txt("f3d9a1b2-4c5e-6789-abcd-ef0123456789", {
+                          mono: true,
+                          wide: true,
+                        }),
+                      },
+                      {
+                        key: "notion.statusProperty",
+                        label: "Status property",
+                        desc: "The database property that drives the lifecycle.",
+                        control: txt("Status"),
+                      },
+                    ],
+                  },
+                  {
+                    card: "Status values",
+                    note: "Override only where your database uses non-default option names",
+                    rows: [
+                      {
+                        key: "notion.values.draft",
+                        label: "Draft",
+                        desc: "",
+                        control: txt("Draft"),
+                      },
+                      {
+                        key: "notion.values.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("Ready"),
+                      },
+                      {
+                        key: "notion.values.in_review",
+                        label: "In review",
+                        desc: "",
+                        control: txt("In Review"),
+                      },
+                      {
+                        key: "notion.values.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("Blocked"),
+                      },
+                      {
+                        key: "notion.values.ticketed",
+                        label: "Ticketed",
+                        desc: "",
+                        control: txt("Ticketed"),
+                      },
+                      {
+                        key: "notion.values.shipped",
+                        label: "Shipped",
+                        desc: "",
+                        control: txt("Shipped"),
+                      },
+                      {
+                        key: "notion.values.verified",
+                        label: "Verified",
+                        desc: "",
+                        control: txt("Verified"),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "Confluence",
+                blocks: [
+                  {
+                    type: "callout",
+                    text: "<b>Lifecycle via parent pages.</b> A PRD’s state is which parent page it sits under; transitions re-parent the page. This works with scoped tokens that cannot write Confluence labels.",
+                  },
+                  {
+                    card: "Scope",
+                    rows: [
+                      {
+                        key: "confluence.spaceKey",
+                        label: "Space key",
+                        desc: "Required when no parent page is set.",
+                        control: txt("PROD", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parentPageId",
+                        label: "Parent page ID",
+                        desc: "Required when no space key is set. Both together narrow the scope.",
+                        control: txt("98304412", { mono: true }),
+                      },
+                    ],
+                  },
+                  {
+                    card: "Role parent pages",
+                    rows: [
+                      {
+                        key: "confluence.parents.draft",
+                        label: "Draft",
+                        desc: "",
+                        control: txt("98304413", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("98304414", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.in_review",
+                        label: "In review",
+                        desc: "",
+                        control: txt("98304415", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("98304416", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.ticketed",
+                        label: "Ticketed",
+                        desc: "",
+                        control: txt("98304417", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.shipped",
+                        label: "Shipped",
+                        desc: "",
+                        control: txt("98304418", { mono: true }),
+                      },
+                      {
+                        key: "confluence.parents.verified",
+                        label: "Verified",
+                        desc: "",
+                        control: txt("98304419", { mono: true }),
+                      },
+                      {
+                        key: "confluence.dashboardPageId",
+                        label: "Dashboard page",
+                        desc: "Children-Display macro aggregation page.",
+                        control: txt("98304420", { mono: true }),
+                      },
+                      {
+                        key: "confluence.feedbackPageId",
+                        label: "Feedback page",
+                        desc: "Where PRD-intake posts clarifying questions.",
+                        control: txt("98304421", { mono: true }),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "Linear",
+                blocks: [
+                  {
+                    card: "PRD project labels",
+                    rows: [
+                      {
+                        key: "linear.labels.prd.draft",
+                        label: "Draft",
+                        desc: "",
+                        control: txt("prd-draft", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("prd-ready", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.in_review",
+                        label: "In review",
+                        desc: "",
+                        control: txt("prd-in-review", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("prd-blocked", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.ticketed",
+                        label: "Ticketed",
+                        desc: "",
+                        control: txt("prd-ticketed", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.shipped",
+                        label: "Shipped",
+                        desc: "",
+                        control: txt("prd-shipped", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.verified",
+                        label: "Verified",
+                        desc: "",
+                        control: txt("prd-verified", { mono: true }),
+                      },
+                      {
+                        key: "linear.labels.prd.sentinel",
+                        label: "Feedback sentinel",
+                        desc: "Marks the intake feedback issue when Linear hosts both PRDs and builds.",
+                        control: txt("prd-intake-feedback", { mono: true }),
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "GitHub Issues",
+                blocks: [
+                  {
+                    card: "PRD issue labels",
+                    rows: [
+                      {
+                        key: "github.labels.prd.draft",
+                        label: "Draft",
+                        desc: "",
+                        control: txt("prd-draft", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.ready",
+                        label: "Ready",
+                        desc: "",
+                        control: txt("prd-ready", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.in_review",
+                        label: "In review",
+                        desc: "",
+                        control: txt("prd-in-review", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.blocked",
+                        label: "Blocked",
+                        desc: "",
+                        control: txt("prd-blocked", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.ticketed",
+                        label: "Ticketed",
+                        desc: "",
+                        control: txt("prd-ticketed", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.shipped",
+                        label: "Shipped",
+                        desc: "",
+                        control: txt("prd-shipped", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.verified",
+                        label: "Verified",
+                        desc: "",
+                        control: txt("prd-verified", { mono: true }),
+                      },
+                      {
+                        key: "github.labels.prd.sentinel",
+                        label: "Feedback sentinel",
+                        desc: "Self-host feedback-issue marker when GitHub is both tracker and PRD source.",
+                        control: txt("prd-intake-feedback", { mono: true }),
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- Deploy ---------------------------------- */
+      DATA.sections.deploy = {
+        title: "Deploy & environments",
+        desc: "The environment-to-branch map that drives PR base branches, env-keyed done states, the back-sync chain, and GitHub deployment approval gates.",
+        src: ".lisa.config.json deploy.* · scripts/lisa-github-environments.sh",
+        blocks: [
+          {
+            card: "Branch map",
+            rows: [
+              {
+                key: "deploy.branches",
+                label: "Environment branches",
+                desc: "Forward: a work item’s target env picks the PR base branch. Reverse: a PR’s base branch resolves the env-keyed done status.",
+                control: envmap("dev", "staging", "main"),
+              },
+              {
+                key: "deploy.order",
+                label: "Promotion order",
+                desc: "Lowest environment first. Required when more than one distinct branch exists; drives the sync-down chain.",
+                control: tags(["dev", "staging", "production"]),
+              },
+            ],
+          },
+          {
+            card: "GitHub environment: production",
+            note: "github.environments.production",
+            rows: [
+              {
+                key: "github.environments.production.branch",
+                label: "Deploy branch",
+                desc: "Falls back to deploy.branches[production], then the environment name itself.",
+                control: txt("main", { mono: true }),
+              },
+              {
+                key: "github.environments.production.require_approval",
+                label: "Require approval",
+                desc: "Provisions required reviewers and pauses release.yml at the release_approval job.",
+                control: tog(true),
+              },
+              {
+                key: "github.environments.production.reviewers",
+                label: "Reviewers",
+                desc: "Usernames or org/team-slug, max 6. A gate nobody can approve is refused at provision time.",
+                control: tags(["acme/platform-leads", "cody"]),
+              },
+              {
+                key: "github.environments.production.prevent_self_review",
+                label: "Prevent self-review",
+                desc: "Blocks the deployer from approving their own deployment.",
+                control: tog(true),
+              },
+              {
+                key: "github.environments.production.wait_timer",
+                label: "Wait timer",
+                desc: "Delay after approval before the deploy proceeds.",
+                control: num(0, "min"),
+              },
+            ],
+          },
+          {
+            card: "GitHub environment: staging",
+            note: "github.environments.staging",
+            rows: [
+              {
+                key: "github.environments.staging.branch",
+                label: "Deploy branch",
+                desc: "",
+                control: txt("staging", { mono: true }),
+              },
+              {
+                key: "github.environments.staging.require_approval",
+                label: "Require approval",
+                desc: "",
+                control: tog(false),
+              },
+            ],
+          },
+          {
+            type: "callout",
+            text: "GitHub silently auto-creates an unprotected environment the first time a workflow references it — Lisa provisions these explicitly so an approval gate always gates on something. Deployment branch policy is always pinned to the environment’s branch.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Automations ---------------------------------- */
+      DATA.sections.automations = {
+        title: "Automations",
+        desc: "Recurring agents Lisa schedules on the harness’s native scheduler (Claude /schedule, Codex automations). Names carry a stable lisa-auto-<project>- prefix so teardown is precise.",
+        src: "plugins/src/base/skills/lisa-setup-automations",
+        blocks: [
+          {
+            type: "table",
+            card: "Scheduled jobs",
+            cols: ["Automation", "Command", "Cadence", "Enabled"],
+            rows: [
+              [
+                { t: "mono", v: "intake-tickets" },
+                { t: "mono", v: "/lisa:intake <build queue>" },
+                {
+                  t: "select",
+                  v: "every 10 min",
+                  options: ["every 10 min", "every 30 min", "every 60 min"],
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "intake-prd" },
+                { t: "mono", v: "/lisa:intake <PRD queue>" },
+                {
+                  t: "select",
+                  v: "every 60 min",
+                  options: ["every 10 min", "every 30 min", "every 60 min"],
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "intake-repair" },
+                { t: "mono", v: "/lisa:repair-intake <queue>" },
+                {
+                  t: "select",
+                  v: "every 60 min",
+                  options: ["every 30 min", "every 60 min", "every 3 h"],
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "exploratory-bugs" },
+                { t: "mono", v: "/lisa-<stack>:exploratory-qa" },
+                { t: "select", v: "daily", options: ["daily", "weekly"] },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "exploratory-prds" },
+                { t: "mono", v: "/lisa:project-ideation" },
+                { t: "select", v: "daily", options: ["daily", "weekly"] },
+                { t: "toggle", v: true },
+              ],
+            ],
+          },
+          {
+            card: "Autonomy flags",
+            rows: [
+              {
+                key: "auto-start-tickets",
+                label: "Auto-start exploratory bug tickets",
+                desc: "On: bugs found by exploratory QA are filed build-ready and picked up automatically. Off: they land in the backlog for human triage.",
+                control: tog(false),
+              },
+              {
+                key: "auto-start-prds",
+                label: "Auto-start ideated PRDs",
+                desc: "On: ideated PRDs are created prd-ready and flow straight into intake. Off: they stay drafts for human review.",
+                control: tog(false),
+              },
+            ],
+          },
+          {
+            type: "callout",
+            text: "exploratory-bugs is only created for stacks that ship exploratory QA (expo, rails, harper-fabric).",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Intake & Monitoring ---------------------------------- */
+      DATA.sections.intake = {
+        title: "Intake & monitoring",
+        desc: "Tuning for the queue scanners that claim ready work, the repair scanner that unsticks stalled items, and the observability audit that files regression tickets.",
+        src: ".lisa.config.json intake.* / monitor.*",
+        blocks: [
+          {
+            card: "Intake",
+            rows: [
+              {
+                key: "intake.assignee",
+                label: "Assignee filter",
+                desc: "Narrows ready-item selection to items already assigned to this user. Never assigns.",
+                badges: ["local-only"],
+                control: txt("", { mono: true, placeholder: "no filter" }),
+              },
+              {
+                key: "intake.repair.staleAfterHours",
+                label: "Stale after",
+                desc: "How long an in-progress item may sit before repair-intake treats it as stalled.",
+                control: num(2, "hours"),
+              },
+              {
+                key: "intake.repair.maxCandidates",
+                label: "Max repair candidates",
+                desc: "Cap on stuck items enumerated per repair run.",
+                control: num(100),
+              },
+            ],
+          },
+          {
+            card: "Monitor audit",
+            rows: [
+              {
+                key: "monitor.maxCandidates",
+                label: "Max tickets per run",
+                desc: "",
+                control: num(20),
+              },
+              {
+                key: "monitor.gapTiers",
+                label: "Gap tier",
+                desc: "Which observability-gap tier files tickets.",
+                control: sel("core", ["core", "all"]),
+              },
+              {
+                key: "monitor.backoffHours",
+                label: "Re-file backoff",
+                desc: "Suppression window after a finding’s ticket is resolved.",
+                control: num(24, "hours"),
+              },
+            ],
+          },
+          {
+            card: "Alert thresholds",
+            rows: [
+              {
+                key: "monitor.thresholds.sentryMinEvents24h",
+                label: "Sentry minimum events",
+                desc: "Minimum 24-hour event count before a Sentry error is fileable.",
+                control: num(10, "/24 h"),
+              },
+              {
+                key: "monitor.thresholds.errorRateSpikeMultiplier",
+                label: "Error-rate spike",
+                desc: "Error rate must reach this multiple of baseline to file.",
+                control: num(2, "× baseline"),
+              },
+              {
+                key: "monitor.thresholds.p95LatencyMs",
+                label: "p95 latency",
+                desc: "At or above this (or +50% vs prior) is a fileable regression.",
+                control: num(1000, "ms"),
+              },
+              {
+                key: "monitor.thresholds.xrayFaultRatePct",
+                label: "X-Ray fault rate",
+                desc: "Fault-trace percentage above this is fileable.",
+                control: num(5, "%"),
+              },
+            ],
+          },
+        ],
+      };
+      /* ---------------------------------- Linting ---------------------------------- */
+      DATA.sections.linting = {
+        title: "Linting",
+        desc: "Two-phase linting — oxlint first for speed, then ESLint with Lisa’s four custom plugins, sonarjs, functional and jsdoc. Slow import rules are deferred to lint:slow. Formatting is checked by Prettier separately.",
+        src: "src/configs/eslint/*.ts · eslint-plugin-*/",
+        blocks: [
+          {
+            card: "Complexity budgets",
+            note: "eslint.thresholds.json",
+            rows: [
+              {
+                key: "quality.lintBudgets.cognitiveComplexity",
+                label: "Cognitive complexity",
+                desc: "Maximum sonarjs cognitive complexity per function (CDK stacks relax this to 15).",
+                control: num(10),
+              },
+              {
+                key: "quality.lintBudgets.maxLines",
+                label: "Max lines per file",
+                desc: "Blank lines and comments excluded.",
+                control: num(300),
+              },
+              {
+                key: "quality.lintBudgets.maxLinesPerFunction",
+                label: "Max lines per function",
+                desc: "Blank lines and comments excluded (NestJS raises this to 100).",
+                control: num(75),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Custom rules — code organization",
+            note: "eslint-plugin-code-organization",
+            cols: ["Rule", "Enforces", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "enforce-statement-order" },
+                {
+                  t: "text",
+                  v: "Definitions → side effects → return inside function bodies; if-statement guard clauses are exempt",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            card: "Statement-order options",
+            rows: [
+              {
+                key: "checkAllFunctionBodies",
+                label: "Check all function bodies",
+                desc: "Off limits the rule to declarations and assigned arrow functions — the opt-out Lisa’s own repo uses.",
+                control: tog(true),
+              },
+              {
+                key: "checkAwaitedCalls",
+                label: "Count awaited calls as side effects",
+                desc: "",
+                control: tog(true),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Custom rules — component structure",
+            note: "eslint-plugin-component-structure",
+            cols: ["Rule", "Enforces", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "enforce-component-structure" },
+                {
+                  t: "text",
+                  v: "Container/View directory pattern: each component dir needs {Name}Container, {Name}View and index",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-return-in-view" },
+                {
+                  t: "text",
+                  v: "View components must be arrow shorthand — no block bodies or early returns",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "require-memo-in-view" },
+                {
+                  t: "text",
+                  v: "Views must export default memo(…) and set displayName",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "single-component-per-file" },
+                {
+                  t: "text",
+                  v: "Exactly one React component per View/Container file",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            card: "Component-structure options",
+            rows: [
+              {
+                key: "checkRequiredComponentFiles",
+                label: "Require Container/View/index trio",
+                desc: "Off keeps naming and index-export checks but skips the directory-shape requirement — the grandfather opt-out for older projects.",
+                control: tog(true),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Custom rules — UI standards",
+            note: "eslint-plugin-ui-standards · shipped off by default in the Expo config",
+            cols: ["Rule", "Enforces", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "no-classname-outside-ui" },
+                {
+                  t: "text",
+                  v: "JSX className only inside /components/ui/ and /components/custom/ui/",
+                },
+                { t: "select", v: "off", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-direct-rn-imports" },
+                {
+                  t: "text",
+                  v: "Ban react-native primitives (View, Text, Pressable…) in favor of @/components/ui equivalents",
+                },
+                { t: "select", v: "off", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            type: "table",
+            card: "Custom rules — Phaser scenes",
+            note: "eslint-plugin-phaser · applies to the phaser stack",
+            cols: ["Rule", "Enforces", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "no-create-in-update" },
+                {
+                  t: "text",
+                  v: "No object creation (add/make/tweens/anims/new Phaser.*) inside a Scene update()",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-allocation-in-update" },
+                {
+                  t: "text",
+                  v: "No heap allocations in update(): literals, map/filter/reduce, new collections",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "require-shutdown-cleanup" },
+                {
+                  t: "text",
+                  v: "Scenes registering external listeners must clean up on shutdown",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            type: "table",
+            card: "Notable base-config severities",
+            note: "src/configs/eslint/base.ts — a selection of the shared rule set",
+            cols: ["Rule", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "sonarjs/cognitive-complexity" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "sonarjs/no-identical-functions" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "sonarjs/no-duplicate-string" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "@typescript-eslint/no-explicit-any" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "functional/no-let" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "functional/immutable-data" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "eslint-comments/require-description" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                {
+                  t: "mono",
+                  v: "jsdoc/require-jsdoc (+ param/returns descriptions)",
+                },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-restricted-syntax: process.env access" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-restricted-imports: @/features/*/*" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "sonarjs/no-commented-code" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "sonarjs/todo-tag" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            card: "oxlint (phase 1)",
+            rows: [
+              {
+                key: "oxlint",
+                label: "Run oxlint before ESLint",
+                desc: "oxlint covers the fast rules; eslint-plugin-oxlint then disables ESLint’s duplicates (unicorn runs via oxlint only).",
+                control: tog(true),
+              },
+              {
+                key: "oxlint.plugins",
+                label: "oxlint plugins",
+                desc: "",
+                control: tags([
+                  "typescript",
+                  "unicorn",
+                  "oxc",
+                  "import",
+                  "jsdoc",
+                  "promise",
+                  "node",
+                ]),
+              },
+              {
+                key: "oxlint.categories.correctness",
+                label: "Correctness category",
+                desc: "",
+                control: sel("warn", SEVERITIES),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "ast-grep structural rules",
+            note: "sgconfig.yml · ast-grep/rules/",
+            cols: ["Rule", "Language", "Severity"],
+            rows: [
+              [
+                { t: "mono", v: "no-inline-component-in-container" },
+                { t: "text", v: "tsx" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-inline-component-in-view" },
+                { t: "text", v: "tsx" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "phaser-no-canvas-renderer" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "phaser-no-raw-webgl-context" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "harper-no-full-table-scan" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "harper-no-empty-conditions-with-sort" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "harper-no-early-return-in-search-loop" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "harper-require-statuscode-on-thrown-error" },
+                { t: "text", v: "ts" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-raw-sql-in-where" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-find-by-sql-without-params" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-unsafe-send" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "error", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-params-without-permit" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-skip-before-action-without-scope" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+              [
+                { t: "mono", v: "no-update-columns" },
+                { t: "text", v: "ruby" },
+                { t: "select", v: "warn", options: SEVERITIES },
+              ],
+            ],
+          },
+          {
+            card: "Other quality gates",
+            rows: [
+              {
+                key: "commitlint",
+                label: "Conventional commits",
+                desc: "commitlint with config-conventional; body lines capped, loud subject cases banned.",
+                control: tog(true),
+              },
+              {
+                key: "body-max-line-length",
+                label: "Commit body line length",
+                desc: "",
+                control: num(300, "chars"),
+              },
+              {
+                key: "knip",
+                label: "Dead-code detection (knip)",
+                desc: "Unused files, exports and dependencies fail the pre-push gate and CI.",
+                control: tog(true),
+              },
+              {
+                key: "audit.exclusions",
+                label: "Dependency-audit exclusions",
+                desc: "Accepted advisories, each with a GHSA id and a written justification.",
+                control: stat("~40 exclusions", ""),
+              },
+            ],
+          },
+          {
+            type: "callout",
+            text: "<b>Project overrides live in eslint.config.local.ts</b> (seeded once, never overwritten, spread after the factory so it wins). Two sanctioned patterns: re-declare a rule with looser <i>options</i> globally, or grandfather a path with a files-scoped block. Hand-refactoring to chase a tightened rule is the anti-pattern.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Testing ---------------------------------- */
+      DATA.sections.testing = {
+        title: "Testing & coverage",
+        desc: "Runner per stack, coverage floors, and the opt-in diff-only mutation gate. Managed config entrypoints merge a project-owned *.config.local.ts and *.thresholds.json over Lisa’s factory.",
+        src: "src/configs/{vitest,jest}/*.ts · *.thresholds.json",
+        blocks: [
+          {
+            type: "table",
+            card: "Runner per stack",
+            cols: ["Stack", "Runner", "Test command"],
+            rows: [
+              [
+                { t: "mono", v: "typescript" },
+                { t: "text", v: "Vitest" },
+                { t: "mono", v: "vitest run" },
+              ],
+              [
+                { t: "mono", v: "expo" },
+                { t: "text", v: "Jest (jest-expo)" },
+                { t: "mono", v: "NODE_ENV=test jest" },
+              ],
+              [
+                { t: "mono", v: "nestjs" },
+                { t: "text", v: "Vitest" },
+                { t: "mono", v: "vitest run" },
+              ],
+              [
+                { t: "mono", v: "cdk" },
+                { t: "text", v: "Vitest" },
+                { t: "mono", v: "vitest run" },
+              ],
+              [
+                { t: "mono", v: "harper-fabric" },
+                { t: "text", v: "Vitest" },
+                { t: "mono", v: "vitest run" },
+              ],
+              [
+                { t: "mono", v: "phaser" },
+                { t: "text", v: "Vitest + Playwright e2e" },
+                { t: "mono", v: "vitest run · playwright test" },
+              ],
+              [
+                { t: "mono", v: "rails" },
+                { t: "text", v: "RSpec + SimpleCov" },
+                { t: "mono", v: "bundle exec rspec" },
+              ],
+            ],
+          },
+          {
+            card: "Coverage floors",
+            note: "vitest.thresholds.json / jest.thresholds.json — Jest-style global shape shared by both runners",
+            rows: [
+              {
+                key: "quality.testCoverage.global.statements",
+                label: "Statements",
+                desc: "",
+                control: num(70, "%"),
+              },
+              {
+                key: "quality.testCoverage.global.branches",
+                label: "Branches",
+                desc: "",
+                control: num(70, "%"),
+              },
+              {
+                key: "quality.testCoverage.global.functions",
+                label: "Functions",
+                desc: "",
+                control: num(70, "%"),
+              },
+              {
+                key: "quality.testCoverage.global.lines",
+                label: "Lines",
+                desc: "",
+                control: num(70, "%"),
+              },
+              {
+                key: "simplecov",
+                label: "Rails (SimpleCov)",
+                desc: "Rails ships its own floors.",
+                control: stat("line 80 · branch 70", "mono"),
+              },
+              {
+                key: "coverage.exclude",
+                label: "Excluded from coverage",
+                desc: "",
+                control: tags([
+                  "*.d.ts",
+                  "index.ts",
+                  "*.test.*",
+                  "*.mock.*",
+                  "__tests__/",
+                  "components/ui/**",
+                ]),
+              },
+            ],
+          },
+          {
+            card: "Mutation testing",
+            note: "StrykerJS for JS/TS, mutant for Rails — both opt-in and diff-only",
+            rows: [
+              {
+                key: "quality.mutation.gate.enabled",
+                label: "Mutation gate",
+                desc: "Off costs nothing — the gate script exits immediately. On, only files changed vs the base ref are mutated.",
+                control: tog(false),
+              },
+              {
+                key: "quality.mutation.gate.since",
+                label: "Diff base",
+                desc: "",
+                control: txt("main", { mono: true }),
+              },
+              {
+                key: "quality.mutation.strykerThresholds.high",
+                label: "Score: high",
+                desc: "",
+                control: num(80, "%"),
+              },
+              {
+                key: "quality.mutation.strykerThresholds.low",
+                label: "Score: low",
+                desc: "",
+                control: num(60, "%"),
+              },
+              {
+                key: "quality.mutation.strykerThresholds.break",
+                label: "Score: break",
+                desc: "Below this the gate fails CI.",
+                control: num(60, "%"),
+              },
+            ],
+          },
+          {
+            card: "Test scripts installed",
+            rows: [
+              {
+                key: "scripts",
+                label: "Standard suite",
+                desc: "Forced into every project’s package.json.",
+                control: tags([
+                  "test",
+                  "test:unit",
+                  "test:integration",
+                  "test:cov",
+                  "test:e2e",
+                  "test:mutation",
+                  "test:watch",
+                ]),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- Hooks ---------------------------------- */
+      DATA.sections.hooks = {
+        title: "Git hooks",
+        desc: "Local gates installed into every project — Husky for JS/TS stacks, Lefthook for Rails. Managed inside AI GUARDRAILS blocks; a pre-push.local extension slot stays project-owned. Bypassing with --no-verify is prohibited.",
+        src: "typescript/copy-contents/.husky/ · rails/copy-overwrite/lefthook.yml",
+        blocks: [
+          {
+            type: "hooks",
+            items: [
+              {
+                name: "commit-msg",
+                runner: "Husky",
+                steps: [
+                  {
+                    what: "Auto-append JIRA key from branch name",
+                    how: "JIRA_PROJECT_KEY",
+                  },
+                  {
+                    what: "Conventional-commit check",
+                    how: "commitlint --edit",
+                  },
+                  {
+                    what: "Require AI co-authorship trailer",
+                    how: "Claude | Codex | OpenCode",
+                  },
+                ],
+              },
+              {
+                name: "pre-commit",
+                runner: "Husky",
+                steps: [
+                  {
+                    what: "Block direct commits to env branches",
+                    how: "dev · staging · main",
+                  },
+                  {
+                    what: "Secret scan on staged files",
+                    how: "gitleaks protect --staged",
+                  },
+                  { what: "Whole-project type check", how: "tsc --noEmit" },
+                  { what: "Incremental lint + format", how: "lint-staged" },
+                ],
+              },
+              {
+                name: "pre-push",
+                runner: "Husky",
+                steps: [
+                  {
+                    what: "Dependency audit (high + critical, prod deps)",
+                    how: "audit.ignore.config.json exclusions",
+                  },
+                  {
+                    what: "Slow lint rules",
+                    how: "lint:slow (import/no-cycle…)",
+                  },
+                  { what: "Dead-code detection", how: "knip" },
+                  { what: "Unit tests with coverage floors", how: "test:cov" },
+                  { what: "Integration tests", how: "test:integration" },
+                  {
+                    what: "Project extension slot",
+                    how: ".husky/pre-push.local",
+                    optional: true,
+                  },
+                ],
+              },
+              {
+                name: "pre-push (Rails)",
+                runner: "Lefthook",
+                steps: [
+                  { what: "Full spec suite", how: "rspec" },
+                  { what: "Static security analysis", how: "brakeman" },
+                  { what: "Code smell detection", how: "reek · flog · flay" },
+                  {
+                    what: "Mutation gate (when enabled)",
+                    how: "scripts/lisa-mutation.sh",
+                    optional: true,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "callout",
+            variant: "warn",
+            text: "<b>Never --no-verify.</b> When a gate fails, the root cause gets fixed or a specific documented ignore is added with human sign-off. Blanket bypasses are blocked by a harness hook as well.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- CI ---------------------------------- */
+      DATA.sections.ci = {
+        title: "CI quality gates",
+        desc: "Every project’s ci.yml is a thin caller of Lisa’s reusable quality workflow. Job names double as the required-check contexts that rulesets enforce. Toggling a job off adds it to skip_jobs.",
+        src: ".github/workflows/quality.yml · <stack>/create-only/.github/workflows/ci.yml",
+        blocks: [
+          {
+            card: "Workflow inputs",
+            rows: [
+              {
+                key: "node_version",
+                label: "Node version",
+                desc: "",
+                control: txt("22.21.1", { mono: true }),
+              },
+              {
+                key: "package_manager",
+                label: "Package manager",
+                desc: "CDK stacks use npm; everything else defaults to bun.",
+                control: sel("bun", ["bun", "npm", "yarn"]),
+              },
+              {
+                key: "verify_enforced",
+                label: "Verification coverage gate",
+                desc: "On: every feat/fix PR must add or extend an e2e verification spec unless labeled verification-exempt. Phaser opts in by default.",
+                control: tog(false),
+              },
+              {
+                key: "playwright_shards",
+                label: "Playwright shards",
+                desc: "2 or more enables a sharded matrix.",
+                control: num(1),
+              },
+              {
+                key: "compliance_framework",
+                label: "Compliance framework",
+                desc: "Adds a compliance validation job.",
+                control: sel("(none)", [
+                  "(none)",
+                  "SOC2",
+                  "ISO27001",
+                  "HIPAA",
+                  "PCI-DSS",
+                ]),
+              },
+              {
+                key: "audit_retention_days",
+                label: "Audit log retention",
+                desc: "",
+                control: num(90, "days"),
+              },
+              {
+                key: "concurrency_group",
+                label: "Concurrency group",
+                desc: "Opt-in cross-run serialization; default is unique per run.",
+                control: txt("", { mono: true, placeholder: "unique per run" }),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Quality jobs",
+            note: "Job name = required-check context",
+            cols: ["Job", "Gated by", "Run"],
+            rows: [
+              [
+                { t: "mono", v: "🧹 Lint" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🐢 Slow Lint Rules" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🔍 Type Check" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run Unit Tests" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run Integration Tests" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run E2E Tests" },
+                { t: "text", v: "auto-detects playwright.config + test:e2e" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🧬 Mutation Testing Gate" },
+                { t: "text", v: "test:mutation script + gate enabled" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "✅ Verification Coverage" },
+                { t: "text", v: "verify_enforced on PRs" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "📱 Maestro Cloud E2E" },
+                { t: "text", v: "MAESTRO_API_KEY + project id + app file" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🎭 Playwright E2E Tests" },
+                { t: "text", v: "expo web export; required on staging" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "📐 Check Formatting" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🏗️ Build" },
+                { t: "text", v: "always" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🗑️ Dead Code Detection" },
+                { t: "text", v: "knip" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🔎 AST Grep Scan" },
+                { t: "text", v: "sgconfig.yml" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🔒 Security Scan" },
+                { t: "text", v: "always (npm audit)" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🔍 SonarCloud SAST" },
+                { t: "text", v: "SONAR_TOKEN" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🛡️ Snyk" },
+                { t: "text", v: "SNYK_TOKEN" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "🔐 GitGuardian" },
+                { t: "text", v: "GITGUARDIAN_API_KEY" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "📜 FOSSA" },
+                { t: "text", v: "FOSSA_API_KEY" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "🕷️ OWASP ZAP Baseline" },
+                { t: "text", v: "zap_target_url" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "🚦 Approval Gate" },
+                { t: "text", v: "require_approval + environment" },
+                { t: "toggle", v: true },
+              ],
+            ],
+          },
+          {
+            type: "callout",
+            text: "Rails calls quality-rails.yml instead: rubocop lint, brakeman security, rspec on Postgres and MySQL, reek code quality, mutation, secret scanning, ast-grep, license compliance and ZAP.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- QA / Verification ---------------------------------- */
+      DATA.sections.qa = {
+        title: "Verification & QA",
+        desc: "How agents empirically use the product — exploratory QA, product walkthroughs, and the per-environment mutation policy that keeps production data safe.",
+        src: "plugins/src/base/skills/lisa-use-the-product · .lisa.config.json exploration.*",
+        blocks: [
+          {
+            card: "Exploration defaults",
+            rows: [
+              {
+                key: "exploration.default",
+                label: "Default environment",
+                desc: "Which environment to drive when a skill is invoked without one.",
+                control: sel("dev", ["dev", "staging", "production"]),
+              },
+            ],
+          },
+          {
+            card: "Environment: dev",
+            note: "exploration.environments.dev",
+            rows: [
+              {
+                key: "exploration.environments.dev.url",
+                label: "Target URL",
+                desc: "Omit for local CLI or game targets.",
+                control: txt("https://dev.acme-app.io", {
+                  mono: true,
+                  wide: true,
+                }),
+              },
+              {
+                key: "exploration.environments.dev.mutation",
+                label: "Mutation policy",
+                desc: "full allows create/edit/delete as the test identity, with cleanup discipline.",
+                control: sel("full", ["forbidden", "read-only", "full"]),
+              },
+              {
+                key: "exploration.environments.dev.identity",
+                label: "Test identity",
+                desc: "Test-account login used for mutations. Never a real or admin user.",
+                control: txt("QA_TEST_ACCOUNT", { mono: true }),
+              },
+              {
+                key: "exploration.environments.dev.provision",
+                label: "Ephemeral provision",
+                desc: "IaC targets: stand up before, tear down after.",
+                control: tog(false),
+              },
+            ],
+          },
+          {
+            card: "Environment: production",
+            note: "exploration.environments.production",
+            rows: [
+              {
+                key: "exploration.environments.production.url",
+                label: "Target URL",
+                desc: "",
+                control: txt("https://acme-app.io", { mono: true, wide: true }),
+              },
+              {
+                key: "exploration.environments.production.mutation",
+                label: "Mutation policy",
+                desc: "Production-named environments default to forbidden. full requires a written acknowledgment below.",
+                control: sel("forbidden", ["forbidden", "read-only", "full"]),
+              },
+              {
+                key: "exploration.environments.production.prodMutationAck",
+                label: "Production mutation acknowledgment",
+                desc: "One-sentence justification required to allow full mutation on a production environment.",
+                control: txt("", { wide: true, placeholder: "not granted" }),
+              },
+            ],
+          },
+          {
+            card: "Personas",
+            rows: [
+              {
+                key: "personas",
+                label: "Persona-driven exploration",
+                desc: "When the project defines personas (wiki/personas/**, persona subagents), exploratory QA drives the product through each archetype’s constraints.",
+                control: stat("soft-detected", ""),
+              },
+            ],
+          },
+          {
+            card: "DAST (OWASP ZAP)",
+            rows: [
+              {
+                key: "zap_target_url",
+                label: "ZAP target URL",
+                desc: "",
+                control: txt("https://staging.acme-app.io", {
+                  mono: true,
+                  wide: true,
+                }),
+              },
+              {
+                key: "zap_rules_file",
+                label: "Rules file",
+                desc: "Per-rule IGNORE / WARN / FAIL decisions.",
+                control: txt(".zap/baseline.conf", { mono: true }),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- GitHub repo ---------------------------------- */
+      DATA.sections.github = {
+        title: "GitHub repository",
+        desc: "Repo-level governance provisioned by lisa-github-repo-setup: merge policy, rulesets with required checks, lifecycle labels, deploy key and expected secrets.",
+        src: "scripts/lisa-github-repo-setup.sh · all/github-rulesets/",
+        blocks: [
+          {
+            card: "Repository settings",
+            note: "github.settings.* overrides the baseline per key",
+            rows: [
+              {
+                key: "allow_merge_commit",
+                label: "Allow merge commits",
+                desc: "The fleet is merge-only — squash and rebase are disabled because squashing flattens release commits and breaks promotion.",
+                control: tog(true),
+              },
+              {
+                key: "allow_squash_merge",
+                label: "Allow squash merge",
+                desc: "",
+                control: tog(false),
+              },
+              {
+                key: "allow_rebase_merge",
+                label: "Allow rebase merge",
+                desc: "",
+                control: tog(false),
+              },
+              {
+                key: "allow_auto_merge",
+                label: "Auto-merge",
+                desc: "Lisa PRs enable auto-merge and drive themselves to green.",
+                control: tog(true),
+              },
+              {
+                key: "allow_update_branch",
+                label: "Suggest updating PR branches",
+                desc: "",
+                control: tog(true),
+              },
+              {
+                key: "delete_branch_on_merge",
+                label: "Delete head branch on merge",
+                desc: "Environment branches survive via the prevent-delete ruleset.",
+                control: tog(true),
+              },
+              {
+                key: "merge_commit_title",
+                label: "Merge commit title",
+                desc: "",
+                control: sel("MERGE_MESSAGE", ["MERGE_MESSAGE", "PR_TITLE"]),
+              },
+              {
+                key: "has_issues",
+                label: "Issues tab",
+                desc: "",
+                control: tog(true),
+              },
+              {
+                key: "has_wiki",
+                label: "Wiki tab",
+                desc: "Off — Lisa uses the in-repo wiki/ directory instead.",
+                control: tog(false),
+              },
+              {
+                key: "secret_scanning",
+                label: "Secret scanning + push protection",
+                desc: "Best-effort; skipped when the plan lacks GitHub Advanced Security.",
+                control: tog(true),
+              },
+              {
+                key: "github.settings.default_branch",
+                label: "Default branch",
+                desc: "Lowest-tier existing environment branch wins: dev, then staging, then main.",
+                control: txt("dev", { mono: true }),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Rulesets",
+            note: "Bypass: deploy key + repo admins (prevent-delete has no bypass)",
+            cols: ["Ruleset", "Applies to", "Enforces", "Active"],
+            rows: [
+              [
+                { t: "mono", v: "base" },
+                { t: "text", v: "dev · staging · main" },
+                {
+                  t: "text",
+                  v: "No deletion/force-push; PRs with thread resolution; CodeRabbit + GitGuardian required",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "quality checks" },
+                { t: "text", v: "dev · staging · main" },
+                {
+                  t: "text",
+                  v: "Lint, Type Check, Build, Formatting, Security Scan, Unit + Integration Tests",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "playwright" },
+                { t: "text", v: "staging" },
+                { t: "text", v: "Playwright E2E required (expo stacks)" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "prevent delete" },
+                { t: "text", v: "dev · staging · main" },
+                { t: "text", v: "Deletion + force-push blocked, no bypass" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "protect tags" },
+                { t: "text", v: "refs/tags/v*" },
+                { t: "text", v: "Tag deletion + moves blocked" },
+                { t: "toggle", v: true },
+              ],
+            ],
+          },
+          {
+            card: "Ruleset adjustments",
+            rows: [
+              {
+                key: "github.rulesets.dropRequiredChecks",
+                label: "Dropped required checks",
+                desc: "Contexts removed from required checks for this repo — e.g. an app integration not installed here.",
+                control: tags([]),
+              },
+              {
+                key: "pull_request.required_review_thread_resolution",
+                label: "Require review-thread resolution",
+                desc: "PRs stay blocked until every conversation (including CodeRabbit’s) is resolved.",
+                control: tog(true),
+              },
+              {
+                key: "pull_request.required_approving_review_count",
+                label: "Required approvals",
+                desc: "Zero — quality is enforced by checks and reviews-by-agents rather than human approval count.",
+                control: num(0),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Lifecycle labels",
+            note: "Created idempotently by /lisa:setup:github",
+            cols: ["Label", "Role", "Color"],
+            rows: [
+              [
+                { t: "mono", v: "status:ready" },
+                { t: "text", v: "build · ready" },
+                { t: "color", v: "#FBCA04" },
+              ],
+              [
+                { t: "mono", v: "status:in-progress" },
+                { t: "text", v: "build · claimed" },
+                { t: "color", v: "#0E8A16" },
+              ],
+              [
+                { t: "mono", v: "status:blocked" },
+                { t: "text", v: "build · blocked" },
+                { t: "color", v: "#D93F0B" },
+              ],
+              [
+                { t: "mono", v: "status:on-dev / status:on-stg" },
+                { t: "text", v: "build · done (dev/staging)" },
+                { t: "color", v: "#1D76DB" },
+              ],
+              [
+                { t: "mono", v: "status:done" },
+                { t: "text", v: "build · done (production)" },
+                { t: "color", v: "#0E8A16" },
+              ],
+              [
+                { t: "mono", v: "prd-draft → prd-verified" },
+                { t: "text", v: "PRD lifecycle (8 labels)" },
+                { t: "color", v: "#5319E7" },
+              ],
+            ],
+          },
+          {
+            type: "table",
+            card: "Secrets",
+            note: "DEPLOY_KEY is the only secret Lisa creates; the rest are expected by workflows",
+            cols: ["Secret", "Purpose", "Status"],
+            rows: [
+              [
+                { t: "mono", v: "DEPLOY_KEY" },
+                {
+                  t: "text",
+                  v: "Write deploy key so CI can push version bumps through ruleset bypass",
+                },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "CLAUDE_CODE_OAUTH_TOKEN" },
+                {
+                  t: "text",
+                  v: "Claude Code Action workflows (nightly, review response, auto-fix)",
+                },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "AWS_ACCOUNT_ID_DEV / _STAGING / _PRODUCTION" },
+                { t: "text", v: "Per-environment AWS accounts for deploys" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "GITGUARDIAN_API_KEY" },
+                { t: "text", v: "Secret scanning check" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "SONAR_TOKEN" },
+                { t: "text", v: "SonarCloud SAST" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "SNYK_TOKEN" },
+                { t: "text", v: "Snyk dependency scan" },
+                { t: "badge", v: "missing", cls: "off" },
+              ],
+              [
+                { t: "mono", v: "FOSSA_API_KEY" },
+                { t: "text", v: "License compliance" },
+                { t: "badge", v: "missing", cls: "off" },
+              ],
+              [
+                { t: "mono", v: "SENTRY_AUTH_TOKEN / ORG / PROJECT" },
+                { t: "text", v: "Sentry releases and sourcemaps" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "EXPO_TOKEN" },
+                { t: "text", v: "EAS builds" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+              [
+                { t: "mono", v: "MAESTRO_API_KEY" },
+                { t: "text", v: "Maestro Cloud mobile E2E" },
+                { t: "badge", v: "set", cls: "on" },
+              ],
+            ],
+          },
+        ],
+      };
+
+      /* ---------------------------------- Plugins ---------------------------------- */
+      DATA.sections.plugins = {
+        title: "Plugins & MCP",
+        desc: "Lisa’s own plugin set (base + one per detected stack), curated third-party plugins, and the MCP servers each one carries. Non-Claude agents receive generated equivalents of everything here.",
+        src: ".claude/settings.json enabledPlugins · plugins/src/",
+        blocks: [
+          {
+            type: "table",
+            card: "Lisa plugins",
+            cols: ["Plugin", "Bundles", "Enabled"],
+            rows: [
+              [
+                { t: "mono", v: "lisa@lisa" },
+                {
+                  t: "text",
+                  v: "Base governance: ~145 skills, 26 agents, 12 hooks, /lisa:* commands, rules, Sentry MCP",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "lisa-typescript@lisa" },
+                {
+                  t: "text",
+                  v: "format-on-edit, lint-on-edit, ast-grep-on-edit, suppress-directive blocking",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "lisa-expo@lisa" },
+                {
+                  t: "text",
+                  v: "~40 skills (EAS, expo-router, gluestack), ops-specialist agent, Expo MCP",
+                },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "lisa-nestjs@lisa" },
+                {
+                  t: "text",
+                  v: "GraphQL/TypeORM skills, migration-edit blocking",
+                },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "lisa-phaser@lisa" },
+                { t: "text", v: "8 skills, 20 game-dev agents, Phaser rules" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "lisa-rails@lisa" },
+                {
+                  t: "text",
+                  v: "20 skills, rubocop-on-edit, Rails conventions",
+                },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "lisa-harper-fabric@lisa" },
+                { t: "text", v: "12 skills, generated-artifact protection" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "lisa-wiki@lisa" },
+                {
+                  t: "text",
+                  v: "In-repo LLM wiki: 22 skills, ingestion connectors (default-on for phaser only)",
+                },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "lisa-openclaw@lisa" },
+                {
+                  t: "text",
+                  v: "Telegram/Slack routing via OpenClaw (opt-in)",
+                },
+                { t: "toggle", v: false },
+              ],
+            ],
+          },
+          {
+            type: "table",
+            card: "Curated third-party plugins",
+            note: "Flip an entry to enable or disable; Lisa never touches third-party keys on re-apply",
+            cols: ["Plugin", "Purpose", "Enabled"],
+            rows: [
+              [
+                { t: "mono", v: "code-review@claude-plugins-official" },
+                { t: "text", v: "Pre-ship diff defect hunt" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "code-simplifier@claude-plugins-official" },
+                { t: "text", v: "Behavior-preserving cleanup" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "coderabbit@claude-plugins-official" },
+                { t: "text", v: "AI PR review (also a required check)" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "sentry@claude-plugins-official" },
+                { t: "text", v: "Issue debugging, Seer, instrumentation" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "safety-net@cc-marketplace" },
+                { t: "text", v: "Guardrail rulebooks" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "typescript-lsp@claude-plugins-official" },
+                { t: "text", v: "TypeScript language server" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "playwright@claude-plugins-official" },
+                { t: "text", v: "Browser automation MCP" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "posthog@claude-plugins-official" },
+                { t: "text", v: "Product analytics" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "impeccable@impeccable" },
+                { t: "text", v: "UI design polish" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "skill-creator@claude-plugins-official" },
+                { t: "text", v: "Author and optimize skills" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "ruby-lsp@claude-plugins-official" },
+                { t: "text", v: "Ruby language server (rails stacks)" },
+                { t: "toggle", v: false },
+              ],
+            ],
+          },
+          {
+            type: "table",
+            card: "MCP servers",
+            cols: ["Server", "Transport", "Enablement", "Enabled"],
+            rows: [
+              [
+                { t: "mono", v: "sentry" },
+                { t: "mono", v: "http" },
+                { t: "text", v: "always-on via base plugin" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "expo" },
+                { t: "mono", v: "http" },
+                { t: "text", v: "on when the expo stack is detected" },
+                { t: "toggle", v: true },
+              ],
+              [
+                { t: "mono", v: "linear-server" },
+                { t: "mono", v: "http" },
+                { t: "text", v: "project-level .mcp.json" },
+                { t: "toggle", v: false },
+              ],
+              [
+                { t: "mono", v: "phaser-editor" },
+                { t: "mono", v: "stdio" },
+                { t: "text", v: "shipped disabled (disabledMcpjsonServers)" },
+                { t: "toggle", v: false },
+              ],
+            ],
+          },
+          {
+            type: "callout",
+            text: "<b>Parity reimplementations.</b> For non-Claude agents, curated plugin behavior is reimplemented as version-pinned Lisa skills: code-review, code-simplifier, coderabbit, safety-net rules, sentry SDK setup, sentry Seer, skill-creator. A drift detector fails CI when an upstream plugin moves ahead of its pin.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Advanced ---------------------------------- */
+      DATA.sections.advanced = {
+        title: "Advanced",
+        desc: "Less-traveled configuration: the LLM wiki source, token-cost accounting, and Play Store access for Expo Android projects.",
+        src: ".lisa.config.json wiki.* / usage.* / playStore.*",
+        blocks: [
+          {
+            card: "LLM wiki source",
+            rows: [
+              {
+                key: "wiki.source.path",
+                label: "Local wiki path",
+                desc: "Repo-relative wiki root. Mutually exclusive with a remote URL.",
+                control: txt("wiki", { mono: true }),
+              },
+              {
+                key: "wiki.source.url",
+                label: "Remote wiki URL",
+                desc: "Presence selects remote mode: the wiki is mirrored into the repo.",
+                control: txt("", {
+                  mono: true,
+                  wide: true,
+                  placeholder: "local mode",
+                }),
+              },
+              {
+                key: "wiki.source.mirrorPath",
+                label: "Mirror path",
+                desc: "Where the gitignored mirror materializes (remote mode).",
+                control: txt(".lisa/wiki", { mono: true }),
+              },
+              {
+                key: "wiki.ttlSeconds",
+                label: "Refresh TTL",
+                desc: "Skip the refresh fetch when the mirror synced more recently than this.",
+                control: num(300, "s"),
+              },
+            ],
+          },
+          {
+            card: "Usage accounting",
+            note: "usage.pricing — optional per-model token rates",
+            rows: [
+              {
+                key: "usage.pricing.currency",
+                label: "Currency",
+                desc: "",
+                control: sel("USD", ["USD", "EUR", "GBP"]),
+              },
+              {
+                key: "usage.pricing.models",
+                label: "Model rates",
+                desc: "Per-million-token input / cached-input / output / reasoning rates, keyed by provider/model.",
+                control: stat("2 models configured", ""),
+              },
+            ],
+          },
+          {
+            card: "Play Store (Expo Android)",
+            rows: [
+              {
+                key: "playStore.packageName",
+                label: "Package name",
+                desc: "Falls back to expo.android.package.",
+                control: txt("io.acme.app", { mono: true }),
+              },
+              {
+                key: "playStore.track",
+                label: "Release track",
+                desc: "",
+                control: sel("production", [
+                  "production",
+                  "beta",
+                  "alpha",
+                  "internal",
+                ]),
+              },
+              {
+                key: "playStore.serviceAccountKeyPath",
+                label: "Service-account key path",
+                desc: "Path to the Play service-account JSON key.",
+                badges: ["local-only"],
+                control: txt("~/keys/play-sa.json", { mono: true, wide: true }),
+              },
+            ],
+          },
+        ],
+      };
+
+      /* ------------------------------------------------------------------ *
+       * Rendering + interactions (prototype: state is in-memory only)
+       * ------------------------------------------------------------------ */
+
+      const $nav = document.getElementById("nav");
+      const $main = document.getElementById("main");
+      const $savebar = document.getElementById("savebar");
+      const $toast = document.getElementById("toast");
+      const dirty = new Set();
+
+      function el(tag, cls, html) {
+        const node = document.createElement(tag);
+        if (cls) node.className = cls;
+        if (html !== undefined) node.innerHTML = html;
+        return node;
+      }
+      function esc(s) {
+        return String(s)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;");
+      }
+
+      function markDirty(id, rowEl) {
+        dirty.add(id);
+        if (rowEl) rowEl.classList.add("modified");
+        updateSavebar();
+      }
+      function updateSavebar() {
+        const n = dirty.size;
+        document.getElementById("dirtyCount").textContent = n;
+        document.getElementById("dirtyPlural").textContent = n === 1 ? "" : "s";
+        $savebar.classList.toggle("show", n > 0);
+      }
+      const toastState = { timer: 0 };
+      function showToast(message) {
+        $toast.textContent = message;
+        $toast.classList.add("show");
+        clearTimeout(toastState.timer);
+        toastState.timer = setTimeout(
+          () => $toast.classList.remove("show"),
+          2600
+        );
+      }
+      function clearDirty() {
+        dirty.clear();
+        updateSavebar();
+      }
+
+      let ctlSeq = 0;
+      function buildControl(control, dirtyId) {
+        const id = dirtyId || "ctl-" + ++ctlSeq;
+        const wrap = el("div", "control");
+        const bind = (input, rowFinder) => {
+          input.addEventListener("change", () =>
+            markDirty(
+              id + "·" + ++ctlSeq,
+              rowFinder ? rowFinder(input) : input.closest(".row")
+            )
+          );
+        };
+        if (!control) return wrap;
+        if (control.type === "toggle") {
+          const label = el("label", "switch");
+          const input = document.createElement("input");
+          input.type = "checkbox";
+          input.checked = !!control.value;
+          label.appendChild(input);
+          label.appendChild(el("span", "trk"));
+          bind(input, i => i.closest(".row") || i.closest("tr"));
+          wrap.appendChild(label);
+        } else if (control.type === "select") {
+          const s = document.createElement("select");
+          s.className = "ctl" + (control.mono ? " mono" : "");
+          (control.options || []).forEach(o => {
+            const opt = document.createElement("option");
+            opt.value = o;
+            opt.textContent = o;
+            if (o === control.value) opt.selected = true;
+            s.appendChild(opt);
+          });
+          bind(s, i => i.closest(".row") || i.closest("tr"));
+          wrap.appendChild(s);
+        } else if (control.type === "text") {
+          const i = document.createElement("input");
+          i.type = "text";
+          i.className =
+            "ctl" +
+            (control.mono ? " mono" : "") +
+            (control.wide ? " wide" : "");
+          i.value = control.value || "";
+          if (control.placeholder) i.placeholder = control.placeholder;
+          bind(i);
+          wrap.appendChild(i);
+        } else if (control.type === "number") {
+          const i = document.createElement("input");
+          i.type = "number";
+          i.className = "ctl num";
+          i.value = control.value;
+          bind(i);
+          wrap.appendChild(i);
+          if (control.unit)
+            wrap.appendChild(el("span", "unit", esc(control.unit)));
+        } else if (control.type === "tags") {
+          const box = el("div", "tagbox");
+          (control.values || []).forEach(v => {
+            const t = el("span", "tag", esc(v) + " ");
+            const x = el("button", "", "×");
+            x.type = "button";
+            x.title = "Remove (prototype)";
+            x.addEventListener("click", () => {
+              t.remove();
+              markDirty(id + "·" + v, box.closest(".row"));
+            });
+            t.appendChild(x);
+            box.appendChild(t);
+          });
+          const add = el("button", "tag-add", "+ add");
+          add.type = "button";
+          add.addEventListener("click", () => {
+            const v = prompt("Add value (prototype only):");
+            if (!v) return;
+            const t = el("span", "tag", esc(v) + " ");
+            const x = el("button", "", "×");
+            x.type = "button";
+            x.addEventListener("click", () => {
+              t.remove();
+              markDirty(id + "·rm·" + v, box.closest(".row"));
+            });
+            t.appendChild(x);
+            box.insertBefore(t, add);
+            markDirty(id + "·add·" + v, box.closest(".row"));
+          });
+          box.appendChild(add);
+          wrap.appendChild(box);
+        } else if (control.type === "envmap") {
+          const box = el("div", "envmap");
+          ["dev", "staging", "production"].forEach(envName => {
+            const cell = el("div", "cell");
+            cell.appendChild(el("span", "", envName));
+            const i = document.createElement("input");
+            i.type = "text";
+            i.className = "ctl mono";
+            i.value = control[envName] || "";
+            bind(i, inp => inp.closest(".row"));
+            cell.appendChild(i);
+            box.appendChild(cell);
+          });
+          wrap.appendChild(box);
+        } else if (control.type === "button") {
+          const b = el("button", "action-btn", esc(control.label));
+          b.type = "button";
+          b.addEventListener("click", () =>
+            showToast(control.toast || "Prototype action")
+          );
+          wrap.appendChild(b);
+        } else if (control.type === "static") {
+          wrap.appendChild(
+            el("span", control.cls === "mono" ? "mono" : "", esc(control.value))
+          );
+        }
+        return wrap;
+      }
+
+      function buildRow(row) {
+        const r = el("div", "row");
+        const left = el("div");
+        const label = el("div", "label");
+        label.appendChild(el("span", "", esc(row.label)));
+        (row.badges || []).forEach(b => {
+          const cls =
+            b === "required"
+              ? "required"
+              : b === "local-only"
+                ? "local"
+                : "default";
+          label.appendChild(el("span", "badge " + cls, esc(b)));
+        });
+        left.appendChild(label);
+        if (row.desc) left.appendChild(el("div", "desc", row.desc));
+        if (row.key) left.appendChild(el("span", "keychip", esc(row.key)));
+        r.appendChild(left);
+        r.appendChild(buildControl(row.control, row.key));
+        return r;
+      }
+
+      function buildCard(block) {
+        const card = el("div", "card");
+        if (block.card) {
+          const head = el("div", "card-head");
+          head.appendChild(el("h2", "", esc(block.card)));
+          if (block.note) head.appendChild(el("span", "note", esc(block.note)));
+          card.appendChild(head);
+        }
+        const body = el("div", "card-body");
+        (block.rows || []).forEach(row => body.appendChild(buildRow(row)));
+        card.appendChild(body);
+        return card;
+      }
+
+      function buildTable(block) {
+        const card = el("div", "card");
+        if (block.card) {
+          const head = el("div", "card-head");
+          head.appendChild(el("h2", "", esc(block.card)));
+          if (block.note) head.appendChild(el("span", "note", esc(block.note)));
+          card.appendChild(head);
+        }
+        const scroll = el("div", "table-scroll");
+        const table = el("table", "grid");
+        const thead = el("thead");
+        const trh = el("tr");
+        block.cols.forEach(c => trh.appendChild(el("th", "", esc(c))));
+        thead.appendChild(trh);
+        table.appendChild(thead);
+        const tbody = el("tbody");
+        block.rows.forEach(cells => {
+          const tr = el("tr");
+          cells.forEach(cell => {
+            const td = el("td");
+            if (cell.t === "mono") td.className = "mono";
+            if (cell.t === "text" || cell.t === "mono") {
+              td.textContent = cell.v;
+            } else if (cell.t === "badge") {
+              td.appendChild(
+                el("span", "badge " + (cell.cls || "default"), esc(cell.v))
+              );
+            } else if (cell.t === "color") {
+              const chip = el("span", "colorchip");
+              const sw = el("span", "swatch");
+              sw.style.background = cell.v;
+              chip.appendChild(sw);
+              chip.appendChild(el("span", "", esc(cell.v)));
+              td.appendChild(chip);
+            } else if (cell.t === "toggle" || cell.t === "select") {
+              td.appendChild(buildControl(cell, null));
+            }
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        scroll.appendChild(table);
+        card.appendChild(scroll);
+        return card;
+      }
+
+      function buildTiles(block) {
+        const grid = el("div", "tile-grid");
+        block.tiles.forEach(t => {
+          const tile = el("div", "tile");
+          tile.appendChild(el("div", "k", esc(t.k)));
+          tile.appendChild(el("div", "v", esc(t.v)));
+          if (t.s) tile.appendChild(el("div", "s", esc(t.s)));
+          grid.appendChild(tile);
+        });
+        return grid;
+      }
+
+      function buildFlow(block) {
+        const card = el("div", "card");
+        const head = el("div", "card-head");
+        head.appendChild(el("h2", "", esc(block.title)));
+        card.appendChild(head);
+        const flow = el("div", "flow");
+        block.states.forEach((s, i) => {
+          if (i > 0) flow.appendChild(el("span", "arr", "→"));
+          flow.appendChild(
+            el("span", "state" + (s.terminal ? " terminal" : ""), esc(s.name))
+          );
+        });
+        card.appendChild(flow);
+        return card;
+      }
+
+      function buildStacks(block) {
+        const grid = el("div", "stack-grid");
+        block.items.forEach(s => {
+          const card = el("div", "stack-card" + (s.on ? " on" : ""));
+          const head = el("div", "head");
+          head.appendChild(el("span", "glyph", esc(s.glyph)));
+          const t = el("div", "t");
+          t.appendChild(el("b", "", esc(s.name)));
+          t.appendChild(el("i", "", esc(s.tagline)));
+          head.appendChild(t);
+          const toggleWrap = buildControl(
+            { type: "toggle", value: s.on },
+            "stack." + s.id
+          );
+          toggleWrap.querySelector("input").addEventListener("change", e => {
+            card.classList.toggle("on", e.target.checked);
+            markDirty("stack." + s.id, null);
+          });
+          head.appendChild(toggleWrap);
+          card.appendChild(head);
+          const meta = el("div", "meta");
+          s.badges.forEach(b => meta.appendChild(el("span", "tag", esc(b))));
+          card.appendChild(meta);
+          card.appendChild(el("div", "detect", s.detect));
+          if (s.more && s.more.length) {
+            const det = el("details", "stack-more");
+            det.appendChild(el("summary", "", "What this stack installs"));
+            const ul = el("ul");
+            s.more.forEach(m => ul.appendChild(el("li", "", esc(m))));
+            det.appendChild(ul);
+            card.appendChild(det);
+          }
+          grid.appendChild(card);
+        });
+        const wrap = el("div");
+        wrap.appendChild(grid);
+        wrap.appendChild(el("div", "", "&nbsp;"));
+        return wrap;
+      }
+
+      function buildHooks(block) {
+        const grid = el("div", "hooks-grid");
+        block.items.forEach(h => {
+          const card = el("div", "hook-card");
+          const hd = el("div", "hd");
+          hd.appendChild(el("span", "nm", esc(h.name)));
+          hd.appendChild(el("span", "badge accent", esc(h.runner)));
+          card.appendChild(hd);
+          const steps = el("div", "steps");
+          h.steps.forEach(s => {
+            const st = el("div", "hook-step" + (s.optional ? " optional" : ""));
+            st.appendChild(el("span", "dot"));
+            st.appendChild(el("span", "what", esc(s.what)));
+            st.appendChild(el("span", "how", esc(s.how)));
+            steps.appendChild(st);
+          });
+          card.appendChild(steps);
+          grid.appendChild(card);
+        });
+        const wrap = el("div");
+        wrap.appendChild(grid);
+        wrap.appendChild(el("div", "", "&nbsp;"));
+        return wrap;
+      }
+
+      function buildCallout(block) {
+        return el(
+          "div",
+          "callout" + (block.variant === "warn" ? " warn" : ""),
+          block.text
+        );
+      }
+
+      function buildTabs(block) {
+        const card = el("div", "card");
+        const bar = el("div", "tabs");
+        const bodies = [];
+        block.tabs.forEach((tab, i) => {
+          const btn = el(
+            "button",
+            "tab" + (i === (block.active || 0) ? " active" : "")
+          );
+          btn.type = "button";
+          btn.innerHTML =
+            esc(tab.label) +
+            (tab.badge
+              ? ' <span class="mini badge on">' + esc(tab.badge) + "</span>"
+              : "");
+          btn.addEventListener("click", () => {
+            bar
+              .querySelectorAll(".tab")
+              .forEach(b => b.classList.remove("active"));
+            btn.classList.add("active");
+            bodies.forEach((b, j) => {
+              b.style.display = j === i ? "" : "none";
+            });
+          });
+          bar.appendChild(btn);
+        });
+        card.appendChild(bar);
+        block.tabs.forEach((tab, i) => {
+          const body = el("div", "card-body padded");
+          body.style.padding = "14px 14px 6px";
+          tab.blocks.forEach(b => body.appendChild(buildBlock(b)));
+          if (i !== (block.active || 0)) body.style.display = "none";
+          bodies.push(body);
+          card.appendChild(body);
+        });
+        return card;
+      }
+
+      function buildBlock(block) {
+        if (block.type === "tiles") return buildTiles(block);
+        if (block.type === "flow") return buildFlow(block);
+        if (block.type === "stacks") return buildStacks(block);
+        if (block.type === "hooks") return buildHooks(block);
+        if (block.type === "callout") return buildCallout(block);
+        if (block.type === "table") return buildTable(block);
+        if (block.type === "tabs") return buildTabs(block);
+        return buildCard(block);
+      }
+
+      function renderAll() {
+        $main.innerHTML = "";
+        $nav.innerHTML = "";
+        ctlSeq = 0;
+        DATA.groups.forEach(group => {
+          const g = el("div", "nav-group");
+          g.appendChild(el("div", "nav-eyebrow", esc(group.label)));
+          group.sections.forEach(sid => {
+            const section = DATA.sections[sid];
+            const btn = el("button", "nav-item");
+            btn.type = "button";
+            btn.dataset.section = sid;
+            btn.innerHTML = "<span>" + esc(section.title) + "</span>";
+            btn.addEventListener("click", () => showSection(sid));
+            g.appendChild(btn);
+          });
+          $nav.appendChild(g);
+        });
+        Object.entries(DATA.sections).forEach(([sid, section]) => {
+          const sec = el("section", "section");
+          sec.id = "section-" + sid;
+          const head = el("div", "section-head");
+          head.appendChild(el("h1", "", esc(section.title)));
+          head.appendChild(el("p", "", esc(section.desc)));
+          if (section.src)
+            head.appendChild(el("span", "src-chip", "⚙ " + esc(section.src)));
+          sec.appendChild(head);
+          section.blocks.forEach(b => sec.appendChild(buildBlock(b)));
+          $main.appendChild(sec);
+        });
+      }
+
+      let activeSection = "overview";
+      function showSection(sid) {
+        activeSection = sid;
+        document
+          .querySelectorAll(".section")
+          .forEach(s => s.classList.remove("visible"));
+        const sec = document.getElementById("section-" + sid);
+        if (sec) sec.classList.add("visible");
+        document
+          .querySelectorAll(".nav-item")
+          .forEach(b =>
+            b.classList.toggle("active", b.dataset.section === sid)
+          );
+        if (location.hash !== "#" + sid)
+          history.replaceState(null, "", "#" + sid);
+        applyFilter(document.getElementById("search").value);
+        window.scrollTo({ top: 0 });
+      }
+
+      function applyFilter(query) {
+        const q = (query || "").trim().toLowerCase();
+        const sec = document.getElementById("section-" + activeSection);
+        if (!sec) return;
+        sec
+          .querySelectorAll(".row, tbody tr, .stack-card, .hook-card")
+          .forEach(node => {
+            node.style.display =
+              !q || node.textContent.toLowerCase().includes(q) ? "" : "none";
+          });
+      }
+
+      /* --- live-config hydration (lisa ui injects window.LISA_LIVE_CONFIG) --- */
+      function walkRows(blocks, fn) {
+        (blocks || []).forEach(block => {
+          (block.rows || []).forEach(fn);
+          (block.tabs || []).forEach(tab => walkRows(tab.blocks, fn));
+        });
+      }
+      function liveGet(obj, dotPath) {
+        return dotPath
+          .split(".")
+          .reduce(
+            (node, seg) =>
+              node && typeof node === "object" && !Array.isArray(node)
+                ? node[seg]
+                : undefined,
+            obj
+          );
+      }
+      function hydrateControl(control, value) {
+        if (control.type === "toggle") {
+          control.value = !!value;
+          return;
+        }
+        if (control.type === "number" && typeof value === "number") {
+          control.value = value;
+          return;
+        }
+        if (control.type === "text" || control.type === "select") {
+          control.value = String(value);
+          return;
+        }
+        if (control.type === "tags" && Array.isArray(value)) {
+          control.values = value.map(String);
+          return;
+        }
+        if (control.type === "envmap") {
+          if (typeof value === "string") {
+            control.production = value;
+            return;
+          }
+          if (value && typeof value === "object") {
+            ["dev", "staging", "production"].forEach(envName => {
+              if (value[envName] !== undefined)
+                control[envName] = String(value[envName]);
+            });
+          }
+          return;
+        }
+        if (control.type === "static" && typeof value === "string")
+          control.value = value;
+      }
+      function hydrateFromLiveConfig() {
+        const cfg = window.LISA_LIVE_CONFIG;
+        if (!cfg) return;
+        Object.values(DATA.sections).forEach(section => {
+          walkRows(section.blocks, row => {
+            if (!row.key || !row.control) return;
+            const value = liveGet(cfg, row.key);
+            if (value !== undefined) hydrateControl(row.control, value);
+          });
+        });
+        const repoEl = document.querySelector(".project-switch .repo");
+        if (repoEl && cfg.github && cfg.github.org && cfg.github.repo) {
+          repoEl.textContent = cfg.github.org + "/" + cfg.github.repo;
+        }
+      }
+
+      /* --- boot (deferred so an injected live-config tag after this script is seen) --- */
+      function boot() {
+        hydrateFromLiveConfig();
+        renderAll();
+        showSection(location.hash ? location.hash.slice(1) : "overview");
+        if (!document.getElementById("section-" + activeSection))
+          showSection("overview");
+      }
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", boot);
+      } else {
+        boot();
+      }
+
+      window.addEventListener("hashchange", () => {
+        const sid = location.hash.slice(1);
+        if (DATA.sections[sid]) showSection(sid);
+      });
+
+      document
+        .getElementById("search")
+        .addEventListener("input", e => applyFilter(e.target.value));
+      document.getElementById("search").addEventListener("keydown", e => {
+        if (e.key === "Escape") {
+          e.target.value = "";
+          applyFilter("");
+        }
+      });
+
+      document.getElementById("saveBtn").addEventListener("click", () => {
+        clearDirty();
+        document
+          .querySelectorAll(".row.modified")
+          .forEach(r => r.classList.remove("modified"));
+        showToast("Saved — prototype only, nothing was written");
+      });
+      document.getElementById("discardBtn").addEventListener("click", () => {
+        clearDirty();
+        renderAll();
+        showSection(activeSection);
+      });
+
+      document.getElementById("themeToggle").addEventListener("click", () => {
+        const root = document.documentElement;
+        const current = root.getAttribute("data-theme");
+        const preferDark = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+        const effective = current || (preferDark ? "dark" : "light");
+        root.setAttribute(
+          "data-theme",
+          effective === "dark" ? "light" : "dark"
+        );
+      });
+    </script>
+  </body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -290,6 +290,69 @@
         max-width: 26ch;
       }
 
+      .check-item {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        padding: 13px 18px;
+        border-bottom: 1px solid var(--line);
+      }
+      .check-item:last-child {
+        border-bottom: 0;
+      }
+      .ck {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        border: 2px solid var(--line-strong);
+        background: none;
+        color: transparent;
+        cursor: pointer;
+        flex: none;
+        margin-top: 1px;
+        padding: 0;
+        display: grid;
+        place-items: center;
+        font-size: 12px;
+        line-height: 1;
+      }
+      .ck::after {
+        content: "✓";
+      }
+      .ck:hover {
+        border-color: var(--good);
+      }
+      .check-item.done .ck {
+        background: var(--good);
+        border-color: var(--good);
+        color: #fff;
+      }
+      .check-content {
+        flex: 1;
+        min-width: 0;
+      }
+      .check-label {
+        font-weight: 550;
+        font-size: 13.5px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .check-content .desc {
+        color: var(--muted);
+        font-size: 12.5px;
+        margin: 2px 0 5px;
+        max-width: 62ch;
+      }
+      .check-right {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 3px;
+        flex: none;
+      }
+
       .app {
         display: grid;
         grid-template-columns: 250px 1fr;
@@ -446,7 +509,7 @@
         margin-top: 2px;
         max-width: 62ch;
       }
-      .row .keychip {
+      .keychip {
         font-family: var(--mono);
         font-size: 10.5px;
         color: var(--muted);
@@ -1185,6 +1248,7 @@
             label: "Project",
             sections: [
               "overview",
+              "setup",
               "health",
               "general",
               "stacks",
@@ -1194,7 +1258,14 @@
           },
           {
             label: "Delivery",
-            sections: ["tracker", "prd", "deploy", "automations", "monitor"],
+            sections: [
+              "workflow",
+              "tracker",
+              "prd",
+              "deploy",
+              "automations",
+              "monitor",
+            ],
           },
           {
             label: "Quality",
@@ -1284,6 +1355,263 @@
 
       /* ---------------------------------- General ---------------------------------- */
       /* ---------------------------------- Health ---------------------------------- */
+      /* ---------------------------------- Setup checklist ---------------------------------- */
+      DATA.sections.setup = {
+        title: "Setup checklist",
+        desc: "Everything a host project needs to be fully governed, in the order it usually happens. Each step is idempotent — re-running it is always safe.",
+        src: "lisa apply · lisa sync · /lisa:setup:* skills",
+        blocks: [
+          {
+            type: "checklist",
+            card: "Required",
+            items: [
+              {
+                label: "Install Lisa and apply templates",
+                desc: "Detects the project’s stacks, applies their templates, installs plugins and git hooks.",
+                command: "bun add -d @codyswann/lisa && bunx lisa",
+                done: true,
+              },
+              {
+                label: "Populate configuration",
+                desc: "Fills every missing .lisa.config.json setting (absorbing existing artifact values first) and syncs mirrored files. No unset configs.",
+                command: "lisa sync",
+                done: true,
+              },
+              {
+                label: "Connect the work tracker",
+                desc: "Verifies the workflow status names and writes the tracker section. This project: JIRA, project ACME.",
+                command: "/lisa:setup:jira | github | linear",
+                done: true,
+              },
+              {
+                label: "Connect the PRD source",
+                desc: "Wires the product-requirements queue and its lifecycle vocabulary. This project: Notion.",
+                command: "/lisa:setup:notion | confluence | linear | github",
+                done: true,
+              },
+              {
+                label: "Apply GitHub repository governance",
+                desc: "Repo settings (merge-only), rulesets with required checks, write deploy key, deployment environments with approval gates.",
+                command: "/lisa:setup:github-repo",
+                done: true,
+              },
+              {
+                label: "Provision CI secrets",
+                desc: "CLAUDE_CODE_OAUTH_TOKEN, GITGUARDIAN_API_KEY, SONAR_TOKEN, per-environment AWS accounts, and the optional scanners.",
+                command: "gh secret set …",
+                done: false,
+                why: "2 missing: SNYK_TOKEN, FOSSA_API_KEY",
+              },
+              {
+                label: "Schedule the automations",
+                desc: "Creates the intake, repair, and exploratory crons on the harness’s native scheduler.",
+                command: "/lisa:setup-automations",
+                done: false,
+              },
+              {
+                label: "Configure exploration environments",
+                desc: "Per-environment mutation policy and test identity so agents can use the product safely (production defaults to forbidden).",
+                command: ".lisa.config.json exploration.*",
+                done: false,
+              },
+            ],
+          },
+          {
+            type: "checklist",
+            card: "Optional",
+            items: [
+              {
+                label: "Install the LLM wiki",
+                desc: "In-repo knowledge base agents read and maintain.",
+                command: "/lisa:wiki:install",
+                done: false,
+                optional: true,
+              },
+              {
+                label: "Record starter provenance",
+                desc: "Which starter repo(s) this project descends from, enabling starter sync (planned).",
+                command: ".lisa.config.json starter.*",
+                done: false,
+                optional: true,
+              },
+            ],
+          },
+          {
+            type: "callout",
+            text: "The Health section’s in-band scan re-verifies most of these continuously once setup is complete; lisa doctor diagnoses any step that went sideways.",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Core workflow ---------------------------------- */
+      DATA.sections.workflow = {
+        title: "Core workflow",
+        desc: "The slash commands that run the delivery loop — what each one does, when to reach for it yourself, and which scheduled automation already runs it for you.",
+        src: "plugins/src/base/commands/lisa/ · plugins/src/base/skills/",
+        blocks: [
+          {
+            type: "flow",
+            title: "The delivery loop these commands drive",
+            states: [
+              { name: "PRD ready" },
+              { name: "intake → plan" },
+              { name: "tickets ready" },
+              { name: "intake → implement" },
+              { name: "PR merged + deployed" },
+              { name: "verify-prd" },
+              { name: "verified", terminal: true },
+            ],
+          },
+          {
+            type: "table",
+            card: "Core commands",
+            note: "Commands marked with an automation run on a schedule — invoke them manually to force a cycle",
+            cols: ["Command", "What it does", "When to use it", "Automation"],
+            rows: [
+              [
+                { t: "mono", v: "/lisa:intake" },
+                {
+                  t: "text",
+                  v: "Scans the ready queues and processes one eligible item: a ready PRD is validated and ticketed; a ready ticket is built end-to-end; shipped PRDs roll forward to verification",
+                },
+                {
+                  t: "text",
+                  v: "Rarely by hand — the crons run it; invoke to force an immediate cycle",
+                },
+                { t: "mono", v: "intake-prd · intake-tickets" },
+              ],
+              [
+                { t: "mono", v: "/lisa:repair-intake" },
+                {
+                  t: "text",
+                  v: "Finds stuck or half-closed work — stalled builds, missed transitions, unreconciled rollups — and repairs each one",
+                },
+                {
+                  t: "text",
+                  v: "When something looks wedged; the hourly cron usually gets there first",
+                },
+                { t: "mono", v: "intake-repair" },
+              ],
+              [
+                { t: "mono", v: "/lisa:plan" },
+                {
+                  t: "text",
+                  v: "Turns a PRD or epic into a reviewed implementation plan and build-ready tickets",
+                },
+                {
+                  t: "text",
+                  v: "Plan one specific PRD now instead of waiting for intake",
+                },
+                { t: "mono", v: "via intake" },
+              ],
+              [
+                { t: "mono", v: "/lisa:implement" },
+                {
+                  t: "text",
+                  v: "Builds one ticket end-to-end: TDD implementation, parallel reviews, empirical verification, PR driven to merge",
+                },
+                { t: "text", v: "Build one specific ticket now" },
+                { t: "mono", v: "via intake" },
+              ],
+              [
+                { t: "mono", v: "/lisa:verify" },
+                {
+                  t: "text",
+                  v: "Empirically proves a change works by driving the real product — not just tests and typecheck",
+                },
+                {
+                  t: "text",
+                  v: "Before shipping anything nontrivial; build flows call it automatically",
+                },
+                { t: "mono", v: "via implement" },
+              ],
+              [
+                { t: "mono", v: "/lisa:verify-prd" },
+                {
+                  t: "text",
+                  v: "Checks a shipped PRD end-to-end and rolls it to verified — or reopens it with build-ready fix tickets",
+                },
+                { t: "text", v: "Close the loop on a shipped PRD" },
+                { t: "mono", v: "via intake" },
+              ],
+              [
+                { t: "mono", v: "/lisa:git:commit" },
+                {
+                  t: "text",
+                  v: "Groups current changes into conventional commits, all quality hooks enforced",
+                },
+                { t: "text", v: "Any time work needs committing" },
+                { t: "mono", v: "—" },
+              ],
+              [
+                { t: "mono", v: "/lisa:git:submit-pr" },
+                {
+                  t: "text",
+                  v: "Pushes, opens or updates the PR, enables auto-merge, and drives it all the way to merged — resolving reviews and fixing checks",
+                },
+                { t: "text", v: "When a branch is ready to ship" },
+                { t: "mono", v: "—" },
+              ],
+              [
+                { t: "mono", v: "/lisa:exploratory-qa" },
+                {
+                  t: "text",
+                  v: "Explores the product like a first-time user (respecting the mutation policy) and files bugs",
+                },
+                {
+                  t: "text",
+                  v: "After notable UX changes, or let the daily cron handle it",
+                },
+                { t: "mono", v: "exploratory-bugs" },
+              ],
+              [
+                { t: "mono", v: "/lisa:project-ideation" },
+                {
+                  t: "text",
+                  v: "Ideates product improvements and drafts PRDs",
+                },
+                { t: "text", v: "Fill the product pipeline" },
+                { t: "mono", v: "exploratory-prds" },
+              ],
+              [
+                { t: "mono", v: "/lisa:monitor" },
+                {
+                  t: "text",
+                  v: "Audits the connected observability providers against the alert thresholds and files regression tickets",
+                },
+                { t: "text", v: "On demand between scheduled runs" },
+                { t: "mono", v: "—" },
+              ],
+              [
+                { t: "mono", v: "/lisa:debrief" },
+                {
+                  t: "text",
+                  v: "Mines a shipped initiative — tickets, PRs, review threads — for learnings to triage",
+                },
+                { t: "text", v: "After an initiative ships" },
+                { t: "mono", v: "—" },
+              ],
+              [
+                { t: "mono", v: "/lisa:doctor" },
+                {
+                  t: "text",
+                  v: "Diagnoses Lisa, project, starter, and wiki health",
+                },
+                {
+                  t: "text",
+                  v: "When something seems off; also feeds the planned health check",
+                },
+                { t: "mono", v: "—" },
+              ],
+            ],
+          },
+          {
+            type: "callout",
+            text: "Setup commands (/lisa:setup:*) live in the Setup checklist; quality one-offs (/lisa:improve:*, /lisa:security:*, mutation testing) are stack tools rather than core workflow.",
+          },
+        ],
+      };
+
       DATA.sections.health = {
         title: "Health",
         desc: "Whether this project is on the latest Lisa and completely in band — every Lisa-managed surface matching what the installed version would emit. Version status is always visible (top bar); the in-band scan runs on demand.",
@@ -4800,6 +5128,69 @@
         return card;
       }
 
+      function buildChecklist(block) {
+        const card = el("div", "card");
+        const head = el("div", "card-head");
+        const note = el("span", "note");
+        const countDone = () =>
+          card.querySelectorAll(".check-item.done").length;
+        const refreshNote = () => {
+          note.textContent =
+            countDone() + " of " + block.items.length + " complete";
+        };
+        head.appendChild(el("h2", "", esc(block.card)));
+        head.appendChild(note);
+        card.appendChild(head);
+        const body = el("div", "card-body");
+        block.items.forEach(item => {
+          const row = el("div", "check-item" + (item.done ? " done" : ""));
+          const right = el("div", "check-right");
+          const refreshRight = () => {
+            const isDone = row.classList.contains("done");
+            right.innerHTML = "";
+            right.appendChild(
+              el(
+                "span",
+                "badge " +
+                  (isDone ? "pass" : item.optional ? "default" : "warn"),
+                isDone ? "done" : item.optional ? "not set up" : "pending"
+              )
+            );
+            if (!isDone && item.why) {
+              right.appendChild(el("span", "status-why", esc(item.why)));
+            }
+          };
+          const ck = el("button", "ck");
+          ck.type = "button";
+          ck.title = "Toggle (prototype)";
+          ck.setAttribute("aria-label", "Toggle " + item.label);
+          ck.addEventListener("click", () => {
+            row.classList.toggle("done");
+            refreshRight();
+            refreshNote();
+            markDirty("setup·" + item.label, null);
+          });
+          row.appendChild(ck);
+          const content = el("div", "check-content");
+          const lab = el("div", "check-label", esc(item.label));
+          if (item.optional) {
+            lab.appendChild(el("span", "badge default", "optional"));
+          }
+          content.appendChild(lab);
+          if (item.desc) content.appendChild(el("div", "desc", esc(item.desc)));
+          if (item.command) {
+            content.appendChild(el("span", "keychip", esc(item.command)));
+          }
+          row.appendChild(content);
+          refreshRight();
+          row.appendChild(right);
+          body.appendChild(row);
+        });
+        card.appendChild(body);
+        refreshNote();
+        return card;
+      }
+
       function buildBlock(block) {
         if (block.type === "tiles") return buildTiles(block);
         if (block.type === "flow") return buildFlow(block);
@@ -4808,6 +5199,7 @@
         if (block.type === "callout") return buildCallout(block);
         if (block.type === "table") return buildTable(block);
         if (block.type === "tabs") return buildTabs(block);
+        if (block.type === "checklist") return buildChecklist(block);
         return buildCard(block);
       }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -282,6 +282,13 @@
         background: var(--crit-soft);
         color: var(--crit);
       }
+      .status-why {
+        display: block;
+        font-size: 11px;
+        color: var(--muted);
+        margin-top: 3px;
+        max-width: 26ch;
+      }
 
       .app {
         display: grid;
@@ -1187,7 +1194,7 @@
           },
           {
             label: "Delivery",
-            sections: ["tracker", "prd", "deploy", "automations", "intake"],
+            sections: ["tracker", "prd", "deploy", "automations", "monitor"],
           },
           {
             label: "Quality",
@@ -1473,6 +1480,12 @@
                   mono: true,
                   placeholder: "derived from git remote",
                 }),
+              },
+              {
+                key: "packageManager",
+                label: "Package manager",
+                desc: "Used for installs, scripts, and git hooks — locally and in CI alike. CDK stacks pin npm; every other stack defaults to bun.",
+                control: sel("bun", ["bun", "npm", "yarn"]),
               },
             ],
           },
@@ -2563,6 +2576,100 @@
             type: "callout",
             text: "GitHub silently auto-creates an unprotected environment the first time a workflow references it — Lisa provisions these explicitly so an approval gate always gates on something. Deployment branch policy is always pinned to the environment’s branch.",
           },
+          {
+            card: "Pipeline",
+            note: "create-only deploy.yml calling Lisa’s reusable release workflow",
+            rows: [
+              {
+                key: "",
+                label: "CI/CD provider",
+                desc: "Where the deploy pipeline runs. GitHub Actions is the only supported runner today; the template model leaves room for more.",
+                control: sel("GitHub Actions", ["GitHub Actions"]),
+              },
+              {
+                key: "",
+                label: "Workflows",
+                desc: "deploy.yml is seeded once and project-owned; it calls Lisa’s reusable release workflow.",
+                control: stat("deploy.yml → release.yml@main", "mono"),
+              },
+            ],
+          },
+          {
+            type: "table",
+            card: "Deploy pipeline stages",
+            note: "Runs when an environment branch (dev / staging / main) receives a merge",
+            cols: ["Stage", "What it does", "Active"],
+            rows: [
+              [
+                { t: "mono", v: "🏗️ Build & package" },
+                {
+                  t: "text",
+                  v: "Builds the artifacts for the environment mapped to the pushed branch",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🚦 Release approval — production" },
+                {
+                  t: "text",
+                  v: "Pauses at the release_approval job until a configured reviewer approves the GitHub environment",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🚦 Release approval — staging" },
+                {
+                  t: "text",
+                  v: "Approval hold before staging deploys",
+                },
+                {
+                  t: "status",
+                  v: false,
+                  reason: "require_approval is off for staging",
+                },
+              ],
+              [
+                { t: "mono", v: "🚀 Deploy" },
+                {
+                  t: "text",
+                  v: "Runs the stack’s deploy (EAS / Serverless / CDK / Fabric) against the target environment",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "📝 Version bump & changelog" },
+                {
+                  t: "text",
+                  v: "standard-version tags the release and pushes the chore(release) commit through the deploy key’s ruleset bypass",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🔄 Sync-down branches" },
+                {
+                  t: "text",
+                  v: "After a promotion merges, back-merges higher environment branches into lower ones",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧯 Deploy auto-fix" },
+                {
+                  t: "text",
+                  v: "On a failed deploy, a Claude workflow investigates and opens a fix PR",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🎫 Issue on failure" },
+                {
+                  t: "text",
+                  v: "Files a tracker issue when a deploy run fails",
+                },
+                { t: "status", v: true },
+              ],
+            ],
+          },
         ],
       };
 
@@ -2575,10 +2682,20 @@
           {
             type: "table",
             card: "Scheduled jobs",
-            cols: ["Automation", "Command", "Cadence", "Enabled"],
+            cols: [
+              "Automation",
+              "What it does",
+              "Command",
+              "Cadence",
+              "Enabled",
+            ],
             rows: [
               [
                 { t: "mono", v: "intake-tickets" },
+                {
+                  t: "text",
+                  v: "Claims the next build-ready ticket from the tracker and runs the full build flow on it — one item per cycle",
+                },
                 { t: "mono", v: "/lisa:intake <build queue>" },
                 {
                   t: "select",
@@ -2589,6 +2706,10 @@
               ],
               [
                 { t: "mono", v: "intake-prd" },
+                {
+                  t: "text",
+                  v: "Validates the next ready PRD and either creates its destination tickets or blocks it with clarifying questions; also rolls shipped PRDs forward to verified",
+                },
                 { t: "mono", v: "/lisa:intake <PRD queue>" },
                 {
                   t: "select",
@@ -2599,6 +2720,10 @@
               ],
               [
                 { t: "mono", v: "intake-repair" },
+                {
+                  t: "text",
+                  v: "Finds stuck work — stalled builds, half-closed items, unreconciled parent rollups — and repairs or resumes each one",
+                },
                 { t: "mono", v: "/lisa:repair-intake <queue>" },
                 {
                   t: "select",
@@ -2609,12 +2734,20 @@
               ],
               [
                 { t: "mono", v: "exploratory-bugs" },
+                {
+                  t: "text",
+                  v: "Explores the product like a first-time user (respecting the per-environment mutation policy) and files any bugs it finds",
+                },
                 { t: "mono", v: "/lisa-<stack>:exploratory-qa" },
                 { t: "select", v: "daily", options: ["daily", "weekly"] },
                 { t: "toggle", v: true },
               ],
               [
                 { t: "mono", v: "exploratory-prds" },
+                {
+                  t: "text",
+                  v: "Ideates product improvements from usage and codebase context and drafts PRDs for review",
+                },
                 { t: "mono", v: "/lisa:project-ideation" },
                 { t: "select", v: "daily", options: ["daily", "weekly"] },
                 { t: "toggle", v: true },
@@ -2639,20 +2772,8 @@
             ],
           },
           {
-            type: "callout",
-            text: "exploratory-bugs is only created for stacks that ship exploratory QA (expo, rails, harper-fabric).",
-          },
-        ],
-      };
-
-      /* ---------------------------------- Intake & Monitoring ---------------------------------- */
-      DATA.sections.intake = {
-        title: "Intake & monitoring",
-        desc: "Tuning for the queue scanners that claim ready work, the repair scanner that unsticks stalled items, and the observability audit that files regression tickets.",
-        src: ".lisa.config.json intake.* / monitor.*",
-        blocks: [
-          {
-            card: "Intake",
+            card: "Intake tuning",
+            note: "How the intake and repair automations select and treat work",
             rows: [
               {
                 key: "intake.assignee",
@@ -2664,15 +2785,61 @@
               {
                 key: "intake.repair.staleAfterHours",
                 label: "Stale after",
-                desc: "How long an in-progress item may sit before repair-intake treats it as stalled.",
+                desc: "How long an in-progress item may sit before intake-repair treats it as stalled.",
                 control: num(2, "hours"),
               },
               {
                 key: "intake.repair.maxCandidates",
                 label: "Max repair candidates",
-                desc: "Cap on stuck items enumerated per repair run.",
+                desc: "Cap on stuck items enumerated per intake-repair run.",
                 control: num(100),
               },
+            ],
+          },
+          {
+            type: "callout",
+            text: "exploratory-bugs is only created for stacks that ship exploratory QA (expo, rails, harper-fabric).",
+          },
+        ],
+      };
+
+      /* ---------------------------------- Monitoring ---------------------------------- */
+      DATA.sections.monitor = {
+        title: "Monitoring",
+        desc: "The observability audit: scans errors, latency, and fault rates across every connected provider on a cadence and files regression tickets when thresholds are crossed. Thresholds are provider-neutral — the same limits apply whichever tools are connected.",
+        src: ".lisa.config.json monitor.*",
+        blocks: [
+          {
+            type: "table",
+            card: "Connected providers",
+            note: "Detected from credentials and instrumentation — not configured by hand",
+            cols: ["Provider", "Supplies", "Status"],
+            rows: [
+              [
+                { t: "mono", v: "Sentry" },
+                {
+                  t: "text",
+                  v: "Error events, issue volume, release health",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "AWS CloudWatch (Alarms)" },
+                {
+                  t: "text",
+                  v: "Alarm states, error-rate and latency metrics",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "AWS X-Ray" },
+                { t: "text", v: "Trace fault rates, latency percentiles" },
+                {
+                  t: "status",
+                  v: false,
+                  reason: "no traces found — X-Ray is not instrumented",
+                },
+              ],
             ],
           },
           {
@@ -2700,12 +2867,13 @@
           },
           {
             card: "Alert thresholds",
+            note: "Provider-neutral — evaluated against every connected source",
             rows: [
               {
-                key: "monitor.thresholds.sentryMinEvents24h",
-                label: "Sentry minimum events",
-                desc: "Minimum 24-hour event count before a Sentry error is fileable.",
-                control: num(10, "/24 h"),
+                key: "monitor.thresholds.minEvents24h",
+                label: "Minimum error events",
+                desc: "Minimum 24-hour event count, from any connected error provider, before an error is fileable.",
+                control: num(1, "/24 h"),
               },
               {
                 key: "monitor.thresholds.errorRateSpikeMultiplier",
@@ -2720,12 +2888,16 @@
                 control: num(1000, "ms"),
               },
               {
-                key: "monitor.thresholds.xrayFaultRatePct",
-                label: "X-Ray fault rate",
-                desc: "Fault-trace percentage above this is fileable.",
+                key: "monitor.thresholds.faultRatePct",
+                label: "Fault rate",
+                desc: "Trace or request fault percentage above this is fileable, from whichever tracing provider is connected.",
                 control: num(5, "%"),
               },
             ],
+          },
+          {
+            type: "callout",
+            text: "The runtime monitor skill still reads the legacy provider-prefixed keys (sentryMinEvents24h, xrayFaultRatePct) — renaming them to these provider-neutral keys in config-resolution.md and the lisa-monitor skill is a tracked follow-up.",
           },
         ],
       };
@@ -3350,9 +3522,27 @@
       /* ---------------------------------- CI ---------------------------------- */
       DATA.sections.ci = {
         title: "CI quality gates",
-        desc: "Every project’s ci.yml is a thin caller of Lisa’s reusable quality workflow. Job names double as the required-check contexts that rulesets enforce. Toggling a job off adds it to skip_jobs.",
+        desc: "Every project’s ci.yml is a thin caller of Lisa’s reusable quality workflow. Each job below reports a status check on the PR; branch rulesets require the critical ones to pass before merge.",
         src: ".github/workflows/quality.yml · <stack>/create-only/.github/workflows/ci.yml",
         blocks: [
+          {
+            card: "Pipeline",
+            note: "create-only ci.yml calling Lisa’s reusable quality workflow",
+            rows: [
+              {
+                key: "",
+                label: "CI provider",
+                desc: "Where quality checks run. GitHub Actions is the only supported runner today; the template model leaves room for more.",
+                control: sel("GitHub Actions", ["GitHub Actions"]),
+              },
+              {
+                key: "",
+                label: "Workflows",
+                desc: "ci.yml is seeded once and project-owned; it calls Lisa’s reusable quality workflow on every pull request.",
+                control: stat("ci.yml → quality.yml@main", "mono"),
+              },
+            ],
+          },
           {
             card: "Workflow inputs",
             rows: [
@@ -3361,12 +3551,6 @@
                 label: "Node version",
                 desc: "",
                 control: txt("22.21.1", { mono: true }),
-              },
-              {
-                key: "package_manager",
-                label: "Package manager",
-                desc: "CDK stacks use npm; everything else defaults to bun.",
-                control: sel("bun", ["bun", "npm", "yarn"]),
               },
               {
                 key: "verify_enforced",
@@ -3409,113 +3593,180 @@
           {
             type: "table",
             card: "Quality jobs",
-            note: "Job name = required-check context",
-            cols: ["Job", "Gated by", "Run"],
+            note: "A job’s name is the status check branch rulesets require — renaming one breaks the protection that references it",
+            cols: ["Job", "What it does", "Active"],
             rows: [
               [
                 { t: "mono", v: "🧹 Lint" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "oxlint then ESLint over the whole repo — the fast rule set",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🐢 Slow Lint Rules" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "The expensive rules deferred from local lint (import cycles, namespace checks)",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🔍 Type Check" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "🧪 Run Unit Tests" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "🧪 Run Integration Tests" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "🧪 Run E2E Tests" },
-                { t: "text", v: "auto-detects playwright.config + test:e2e" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "🧬 Mutation Testing Gate" },
-                { t: "text", v: "test:mutation script + gate enabled" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "✅ Verification Coverage" },
-                { t: "text", v: "verify_enforced on PRs" },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "📱 Maestro Cloud E2E" },
-                { t: "text", v: "MAESTRO_API_KEY + project id + app file" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "🎭 Playwright E2E Tests" },
-                { t: "text", v: "expo web export; required on staging" },
-                { t: "toggle", v: true },
+                { t: "text", v: "tsc --noEmit across the project" },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "📐 Check Formatting" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
+                { t: "text", v: "Prettier in check mode — no writes" },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🏗️ Build" },
-                { t: "text", v: "always" },
-                { t: "toggle", v: true },
+                { t: "text", v: "Compiles the project to catch build breaks" },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run Unit Tests" },
+                {
+                  t: "text",
+                  v: "Unit suite with the coverage floors from Testing & coverage enforced",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run Integration Tests" },
+                { t: "text", v: "Integration suite (30-minute timeout)" },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧪 Run E2E Tests" },
+                {
+                  t: "text",
+                  v: "Playwright end-to-end tests, auto-detected from playwright.config + a test:e2e script",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🎭 Playwright E2E Tests" },
+                {
+                  t: "text",
+                  v: "Web-export e2e run — a required check on staging via ruleset",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "📱 Maestro Cloud E2E" },
+                {
+                  t: "text",
+                  v: "Mobile end-to-end flows on Maestro Cloud",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧬 Mutation Testing Gate" },
+                {
+                  t: "text",
+                  v: "Diff-only Stryker run over changed files; fails below the break score",
+                },
+                {
+                  t: "status",
+                  v: false,
+                  reason:
+                    "mutation gate is disabled (quality.mutation.gate.enabled)",
+                },
+              ],
+              [
+                { t: "mono", v: "✅ Verification Coverage" },
+                {
+                  t: "text",
+                  v: "Requires feat/fix PRs to add or extend an e2e verification spec",
+                },
+                { t: "status", v: false, reason: "verify_enforced is off" },
               ],
               [
                 { t: "mono", v: "🗑️ Dead Code Detection" },
-                { t: "text", v: "knip" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "knip — unused files, exports, and dependencies",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🔎 AST Grep Scan" },
-                { t: "text", v: "sgconfig.yml" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "Structural code rules from sgconfig.yml",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🔒 Security Scan" },
-                { t: "text", v: "always (npm audit)" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "Dependency audit — high and critical advisories in production dependencies",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🔍 SonarCloud SAST" },
-                { t: "text", v: "SONAR_TOKEN" },
-                { t: "toggle", v: true },
+                { t: "text", v: "Static analysis via SonarCloud" },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "🛡️ Snyk" },
-                { t: "text", v: "SNYK_TOKEN" },
-                { t: "toggle", v: false },
+                { t: "text", v: "Snyk dependency vulnerability scan" },
+                {
+                  t: "status",
+                  v: false,
+                  reason: "SNYK_TOKEN secret is not set",
+                },
               ],
               [
                 { t: "mono", v: "🔐 GitGuardian" },
-                { t: "text", v: "GITGUARDIAN_API_KEY" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "Secret scanning — also a required check via the base ruleset",
+                },
+                { t: "status", v: true },
               ],
               [
                 { t: "mono", v: "📜 FOSSA" },
-                { t: "text", v: "FOSSA_API_KEY" },
-                { t: "toggle", v: false },
+                { t: "text", v: "License compliance check" },
+                {
+                  t: "status",
+                  v: false,
+                  reason: "FOSSA_API_KEY secret is not set",
+                },
               ],
               [
                 { t: "mono", v: "🕷️ OWASP ZAP Baseline" },
-                { t: "text", v: "zap_target_url" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "DAST baseline scan against zap_target_url with per-rule IGNORE/WARN/FAIL decisions",
+                },
+                { t: "status", v: true },
+              ],
+              [
+                { t: "mono", v: "🧾 Compliance Validation" },
+                {
+                  t: "text",
+                  v: "SOC2 / ISO27001 / HIPAA / PCI-DSS control checks",
+                },
+                {
+                  t: "status",
+                  v: false,
+                  reason: "no compliance_framework configured",
+                },
               ],
               [
                 { t: "mono", v: "🚦 Approval Gate" },
-                { t: "text", v: "require_approval + environment" },
-                { t: "toggle", v: true },
+                {
+                  t: "text",
+                  v: "Pauses the run until the target GitHub environment’s reviewers approve",
+                },
+                { t: "status", v: true },
               ],
             ],
           },
@@ -4388,6 +4639,15 @@
               chip.appendChild(sw);
               chip.appendChild(el("span", "", esc(cell.v)));
               td.appendChild(chip);
+            } else if (cell.t === "status") {
+              if (cell.v) {
+                td.appendChild(el("span", "badge pass", "✓ active"));
+              } else {
+                td.appendChild(el("span", "badge fail", "✗ off"));
+                if (cell.reason) {
+                  td.appendChild(el("span", "status-why", esc(cell.reason)));
+                }
+              }
             } else if (cell.t === "toggle" || cell.t === "select") {
               td.appendChild(buildControl(cell, null));
             }


### PR DESCRIPTION
## Summary

- **Lisa Console prototype** (`ui/index.html` + `ui/README.md`): a self-contained, zero-build settings console cataloging every configuration surface Lisa offers host projects — 19 sections covering general selections, project types, coding agents, trackers, PRD sources, deploy environments, automations, monitoring (provider-neutral thresholds + connected-providers view), linting, testing, git hooks, CI quality gates (per-job active status with reasons), verification/QA, GitHub governance, plugins/MCP, plus documented-contract sections for Setup checklist, Core workflow, Health, and Starter templates. Controls are interactive; only the config read-path is wired (see #1492 for the wire-up plan).
- **`lisa sync`** (`src/sync/`): makes `.lisa.config.json` (+ local overlay) the source of truth for every registry setting — populates missing values (absorbing existing artifact values first, built-in defaults otherwise), writes config back into existing artifact files (config wins, never scaffolds), records pure-default populations under `_lisaSync.populated` so default evolution updates still-default values without touching human choices, and reports required identity keys it can never invent.
- **`lisa ui`** (`src/cli/ui-cmd.ts`): runs a sync, then serves the console on loopback with the project's merged config injected as `window.LISA_LIVE_CONFIG` for control hydration.
- **Test-infra fix**: `cleanGitEnv` strips git's hook-injected env vars (`GIT_DIR` etc.) in the two script tests that spawn `git init` — they intermittently raced against the real repo when the unit suite ran inside the pre-push hook.

Refs CodySwannGT/lisa#1492

## Test plan

- `bun run test:unit` — 3,853 tests green (44 new for the sync engine + CLI wiring, plus the hook-env fix verified by injecting `GIT_DIR`/`GIT_WORK_TREE`)
- `bun run typecheck`, `bun run lint`, `bun run knip:check` — clean
- Empirical: `node dist/index.js sync <demo>` absorbed real thresholds, populated vendor-gated defaults, flagged missing required keys, evolved an auto-populated legacy monitor block to the renamed keys; `node dist/index.js ui <demo>` served the console with live values verified in a real browser (Playwright) in both themes
- This repo's own `.lisa.config.json` was populated by running the tool against itself (committed here)

🤖 Generated with Claude Code
