### PR TITLE
feat(doctor): diagnose findings against upstream Lisa git history

### DIFF
--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -307,9 +307,14 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
-     --paginate
+     --paginate --slurp \
+     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
    ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
+   per page instead of one merged result. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -291,6 +291,45 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Upstream Lisa change-history diagnosis
+
+A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
+upstream** since this project last updated. Doctor must distinguish them instead of blaming the
+project by default. Whenever findings need explanation — and always before proposing repairs —
+pull Lisa's own git history and read what actually changed:
+
+1. **Resolve the version window.** Determine the project's installed Lisa version (the
+   `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
+   runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
+   check's cached result).
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
+   available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+   ```
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
+   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
+   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
+   note — never fail the audit because history was unavailable.
+3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
+   commits, not the whole log.
+4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
+   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
+   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
+   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
+   files. When history shows no relevant upstream change, the project drifted — remediate on the
+   project side.
+
+This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
+to it, and repair suggestions stay suggestions.
+
 ## Output contract
 
 The final report must:

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -307,14 +307,26 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}'
+     --jq '{total_commits, files: [.files[].filename], commits: [.commits[].commit.message | split("\n")[0]]}' \
+     --paginate
    ```
 
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   still can't be established, say so in the finding and mark it `WARN` rather than attributing
+   drift with unverified confidence.
+
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view; a shallow clone (`git clone --filter=blob:none --no-checkout` then
-   `git log v<installed>..v<latest> -- <paths>`); or the local marketplace/plugin cache checkout
-   when the runtime has one. If none are reachable, report the gap as a `WARN`-level observability
-   note — never fail the audit because history was unavailable.
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
+   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
+   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
+   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
+   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
+   observability note — never fail the audit because history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/tests/unit/scripts/lisa-github-repo-settings.test.ts
+++ b/tests/unit/scripts/lisa-github-repo-settings.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
@@ -23,7 +24,11 @@ const REPO_NAME = "CodySwannGT/lisa";
  */
 function createProject(): string {
   const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-settings-"));
-  execFileSync(GIT_BIN, ["init"], { cwd: projectDir, stdio: "ignore" });
+  execFileSync(GIT_BIN, ["init"], {
+    cwd: projectDir,
+    stdio: "ignore",
+    env: cleanGitEnv(process.env),
+  });
   return projectDir;
 }
 
@@ -78,7 +83,7 @@ function runSettingsDryRun(projectDir: string, ghBin: string): string {
     [SETTINGS_SCRIPT, "--dry-run", projectDir],
     {
       cwd: REPO_ROOT,
-      env: { ...process.env, PATH: shimmedPath },
+      env: cleanGitEnv(process.env, { PATH: shimmedPath }),
       encoding: "utf8",
     }
   );


### PR DESCRIPTION
## Summary

- The doctor skill now instructs the agent to pull **Lisa's own git history** when diagnosing and repairing a project: resolve the installed-vs-latest version window, read the upstream compare (gh API, with path-scoped / shallow-clone / plugin-cache fallbacks), scope commits to the paths behind each finding, and attribute findings as *upstream contract change* (remediate via the sanctioned adoption path) vs *project drift* (remediate project-side). History unavailability is a WARN-level note; the pull is strictly read-only.
- Source change in `plugins/src/base/skills/lisa-doctor/SKILL.md` with regenerated artifacts for all agent variants (`bun run check:plugins` green).
- Also fixes the third instance of the git-hook-env test race (repo-settings script test) using the shared `cleanGitEnv` helper.

## Test plan

- `bash scripts/check-plugins-sync.sh` — artifacts in sync
- Repo-settings test verified with `GIT_DIR`/`GIT_WORK_TREE` injected to simulate the pre-push hook
- Full pre-push gate (audit, slow lint, knip, coverage, integration) passed on push

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the `lisa-doctor` audit contract with an “Upstream Lisa change-history diagnosis” step to separate upstream contract changes from project drift for `WARN`/`FAIL` findings.
  - Added read-only upstream history retrieval guidance (including completeness/truncation handling) and requirement to scope history to relevant areas for accurate `Observed` vs `Remediation` attribution.
  - Clarified that when upstream history can’t be verified, the audit records a `WARN` observability note rather than failing, with repairs remaining suggestions.

- **Tests**
  - Improved test subprocess environment sanitization for GitHub repository settings checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->