### PR TITLE
feat(nestjs): add optional deploy env and health smoke

### DIFF
--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -249,12 +249,81 @@ jobs:
           bun-version: '1.3.8'
       - name: Install dependencies
         run: bun install
+      - name: Materialize dotenv env file
+        if: ${{ vars.DOTENV_ENV_MATERIALIZATION_KEYS != '' }}
+        shell: bash
+        env:
+          DOTENV_ENV_MATERIALIZATION_KEYS: ${{ vars.DOTENV_ENV_MATERIALIZATION_KEYS }}
+          DOTENV_ENV_FILE: ${{ vars.DOTENV_ENV_FILE || '.env.local' }}
+          # Optional project mapping for serverless-dotenv-plugin projects:
+          # DOTENV_ENV_MATERIALIZATION_KEYS="API_URL JWT_SECRET"
+          # API_URL: ${{ vars.API_URL }}
+          # JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        run: |
+          set -euo pipefail
+          : > "$DOTENV_ENV_FILE"
+          wrote_any=false
+
+          for key in $DOTENV_ENV_MATERIALIZATION_KEYS; do
+            value="${!key:-}"
+            if [ -z "$value" ]; then
+              echo "::notice::Skipping empty dotenv key: $key"
+              continue
+            fi
+            printf '%s=%s\n' "$key" "$value" >> "$DOTENV_ENV_FILE"
+            wrote_any=true
+          done
+
+          if [ "$wrote_any" != "true" ]; then
+            rm -f "$DOTENV_ENV_FILE"
+            echo "::notice::No dotenv values were materialized"
+          fi
       - name: serverless deploy
         run: |
           bun run serverless deploy --stage ${{ github.ref_name != 'main' && github.ref_name || 'production' }}
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
           AWS_PROFILE: '' # Override serverless.yml profile with empty string for CI
+      - name: Post-deploy health smoke
+        if: ${{ vars.POST_DEPLOY_HEALTH_CHECK_ENABLED == 'true' }}
+        shell: bash
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          AWS_PROFILE: ''
+          HEALTH_OUTPUT_KEY: ${{ vars.POST_DEPLOY_HEALTH_OUTPUT_KEY || 'HttpApiUrl' }}
+          HEALTH_PATH: ${{ vars.POST_DEPLOY_HEALTH_PATH || '/health' }}
+          HEALTH_EXPECTED_BODY: ${{ vars.POST_DEPLOY_HEALTH_EXPECTED_BODY }}
+          SERVERLESS_STACK_NAME: ${{ vars.SERVERLESS_STACK_NAME }}
+          STAGE: ${{ github.ref_name != 'main' && github.ref_name || 'production' }}
+        run: |
+          set -euo pipefail
+
+          stack_name="$SERVERLESS_STACK_NAME"
+          if [ -z "$stack_name" ]; then
+            service_name=$(bun run serverless print --stage "$STAGE" --format json | jq -r '.service // empty')
+            if [ -z "$service_name" ]; then
+              echo "::error::Set SERVERLESS_STACK_NAME or make serverless print expose .service"
+              exit 1
+            fi
+            stack_name="${service_name}-${STAGE}"
+          fi
+
+          base_url=$(aws cloudformation describe-stacks \
+            --stack-name "$stack_name" \
+            --query "Stacks[0].Outputs[?OutputKey=='${HEALTH_OUTPUT_KEY}'].OutputValue | [0]" \
+            --output text)
+          if [ -z "$base_url" ] || [ "$base_url" = "None" ]; then
+            echo "::error::CloudFormation output ${HEALTH_OUTPUT_KEY} was not found on ${stack_name}"
+            exit 1
+          fi
+
+          health_url="${base_url%/}/${HEALTH_PATH#/}"
+          body=$(curl --fail --silent --show-error --max-time 20 "$health_url")
+          if [ -n "$HEALTH_EXPECTED_BODY" ] && ! grep -Fq "$HEALTH_EXPECTED_BODY" <<< "$body"; then
+            echo "::error::Health check response did not contain expected body"
+            exit 1
+          fi
+          echo "Health check passed: $health_url"
 
       - name: 📢 Notify on success
         run: echo "Successfully deployed version ${{ needs.release.outputs.version }} to ${{ needs.determine_environment.outputs.environment }}"

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- workflow contract coverage intentionally exercises several reusable templates in one parse pass */
 import * as fs from "fs-extra";
 import yaml from "js-yaml";
 import * as path from "node:path";
@@ -16,6 +17,14 @@ const QUALITY_RAILS_YML = path.join(
 );
 const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
 const DEPLOY_YML = path.join(REPO_ROOT, ".github", "workflows", "deploy.yml");
+const NESTJS_DEPLOY_YML = path.join(
+  REPO_ROOT,
+  "nestjs",
+  "create-only",
+  ".github",
+  "workflows",
+  "deploy.yml"
+);
 
 /** Shape of a single `workflow_call` input declaration. */
 interface WorkflowInput {
@@ -68,6 +77,7 @@ interface ReleaseWorkflow {
 /** Root shape of the parsed `deploy.yml` workflow. */
 interface DeployWorkflow {
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  jobs?: Record<string, WorkflowJob>;
 }
 
 describe("quality.yml reusable workflow", () => {
@@ -313,6 +323,8 @@ describe("quality.yml reusable workflow", () => {
 describe("release and deploy workflows", () => {
   let releaseWorkflow: ReleaseWorkflow;
   let deployWorkflow: DeployWorkflow;
+  let nestjsDeployRaw: string;
+  let nestjsDeployWorkflow: DeployWorkflow;
 
   beforeAll(() => {
     releaseWorkflow = yaml.load(
@@ -321,6 +333,8 @@ describe("release and deploy workflows", () => {
     deployWorkflow = yaml.load(
       fs.readFileSync(DEPLOY_YML, "utf8")
     ) as DeployWorkflow;
+    nestjsDeployRaw = fs.readFileSync(NESTJS_DEPLOY_YML, "utf8");
+    nestjsDeployWorkflow = yaml.load(nestjsDeployRaw) as DeployWorkflow;
   });
 
   it("pushes signed release tags after creating them", () => {
@@ -375,4 +389,43 @@ describe("release and deploy workflows", () => {
     expect(deployWorkflow.concurrency).toBeDefined();
     expect(deployWorkflow.concurrency?.["cancel-in-progress"]).toBe(false);
   });
+
+  it("keeps NestJS dotenv materialization opt-in and env-driven", () => {
+    const deploySteps = nestjsDeployWorkflow.jobs?.deploy.steps ?? [];
+    const dotenvStep = deploySteps.find(
+      step => step.name === "Materialize dotenv env file"
+    );
+
+    expect(dotenvStep).toBeDefined();
+    expect(dotenvStep?.if).toBe(
+      "${{ vars.DOTENV_ENV_MATERIALIZATION_KEYS != '' }}"
+    );
+    expect(dotenvStep?.env?.DOTENV_ENV_MATERIALIZATION_KEYS).toBe(
+      "${{ vars.DOTENV_ENV_MATERIALIZATION_KEYS }}"
+    );
+    expect(dotenvStep?.run).toContain('printf \'%s=%s\\n\' "$key" "$value"');
+    expect(dotenvStep?.run).toContain("Skipping empty dotenv key");
+    expect(nestjsDeployRaw).toContain(
+      "Optional project mapping for serverless-dotenv-plugin projects"
+    );
+  });
+
+  it("keeps NestJS post-deploy health smoke opt-in and CloudFormation-backed", () => {
+    const deploySteps = nestjsDeployWorkflow.jobs?.deploy.steps ?? [];
+    const smokeStep = deploySteps.find(
+      step => step.name === "Post-deploy health smoke"
+    );
+
+    expect(smokeStep).toBeDefined();
+    expect(smokeStep?.if).toBe(
+      "${{ vars.POST_DEPLOY_HEALTH_CHECK_ENABLED == 'true' }}"
+    );
+    expect(smokeStep?.env?.HEALTH_OUTPUT_KEY).toContain("HttpApiUrl");
+    expect(smokeStep?.env?.HEALTH_PATH).toContain("/health");
+    expect(smokeStep?.run).toContain("aws cloudformation describe-stacks");
+    expect(smokeStep?.run).toContain("curl --fail --silent --show-error");
+    expect(smokeStep?.run).toContain("HEALTH_EXPECTED_BODY");
+  });
 });
+
+/* eslint-enable max-lines -- end scoped waiver for workflow contract coverage */

--- a/tests/unit/cli/apply.test.ts
+++ b/tests/unit/cli/apply.test.ts
@@ -6,13 +6,19 @@ import { BOOTSTRAP_SKIP_NOTICE } from "../../../src/core/bootstrap-environment.j
 import { runApply } from "../../../src/cli/apply.js";
 
 describe("runApply bootstrap guard", () => {
+  const originalCi = process.env.CI;
+
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllEnvs();
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
   });
 
   it("exits successfully without writing in a build context", async () => {
-    vi.stubEnv("CI", "1");
+    process.env.CI = "1";
     const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
     const packageJson = join(projectDir, "package.json");
     await writeFile(packageJson, '{"name":"guard-fixture"}\n', "utf8");
@@ -30,7 +36,7 @@ describe("runApply bootstrap guard", () => {
   });
 
   it("skips before parsing project config in a build context", async () => {
-    vi.stubEnv("CI", "1");
+    process.env.CI = "1";
     const projectDir = await mkdtemp(join(tmpdir(), "lisa-apply-guard-"));
     const configPath = join(projectDir, ".lisa.config.json");
     await writeFile(configPath, "{not-json", "utf8");

--- a/tests/unit/cli/sync-cmd.test.ts
+++ b/tests/unit/cli/sync-cmd.test.ts
@@ -54,7 +54,7 @@ describe("runSync", () => {
   });
 
   it("emits JSON when --json is passed", async () => {
-    const logSpy = vi.mocked(console.log);
+    const logSpy = vi.spyOn(console, "log");
 
     await runSync(project.dir, { json: true });
 


### PR DESCRIPTION
## Summary
- add opt-in dotenv `.env.local` materialization to the NestJS deploy workflow for serverless-dotenv-plugin projects
- add opt-in post-deploy CloudFormation `HttpApiUrl` health smoke verification
- cover the NestJS deploy template with workflow contract tests and make two CLI tests Bun-compatible

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check:workflow-inputs`
- `bun run build`
- `bun run check:plugins`
- `git diff --check`
- `bun test`
- pre-push hook: security audit, slow lint, knip, vitest coverage, integration tests

Closes #1597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployments can optionally generate environment configuration files from configured variables before deployment.
  - Added an optional post-deployment health check that verifies the service endpoint and expected response content.
  - Health check failures now provide clear deployment error messages and stop the workflow.

- **Tests**
  - Added coverage to validate the new deployment configuration and health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->