### PR TITLE
fix(workflows): harden deploy template contracts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,14 @@ on:
         type: string
     secrets:
       EXPO_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:
     name: Install and build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/create-github-issue-on-failure.yml
+++ b/.github/workflows/create-github-issue-on-failure.yml
@@ -62,6 +62,9 @@ jobs:
     name: 📝 Create GitHub Issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/create-issue-on-failure.yml
+++ b/.github/workflows/create-issue-on-failure.yml
@@ -90,6 +90,8 @@ jobs:
     name: 🧭 Determine Issue Tracking System
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       use_sentry: ${{ steps.check.outputs.sentry }}
       use_jira: ${{ steps.check.outputs.jira }}
@@ -166,6 +168,9 @@ jobs:
     needs: [dispatch]
     if: ${{ needs.dispatch.outputs.use_github == 'true' }}
     uses: ./.github/workflows/create-github-issue-on-failure.yml
+    permissions:
+      contents: read
+      issues: write
     with:
       workflow_name: ${{ inputs.workflow_name }}
       failed_job: ${{ inputs.failed_job }}

--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -47,6 +47,8 @@ jobs:
     name: 🌍 Determine Environment
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       approval_environment: ${{ steps.approval.outputs.approval_environment }}
@@ -88,6 +90,9 @@ jobs:
     # Reference to the quality checks workflow
     uses: CodySwannGT/lisa/.github/workflows/release.yml@main
     needs: [determine_environment]
+    permissions:
+      contents: write
+      pull-requests: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'
@@ -114,6 +119,8 @@ jobs:
     name: Check EAS Setup
     runs-on: ubuntu-latest
     needs: [determine_environment]
+    permissions:
+      contents: read
     outputs:
       has_eas_setup: ${{ steps.check.outputs.has_eas_setup }}
     steps:
@@ -132,6 +139,8 @@ jobs:
     name: Check App Config Changes
     runs-on: ubuntu-latest
     needs: [determine_environment]
+    permissions:
+      contents: read
     outputs:
       app_config_changed: ${{ steps.check_changes.outputs.app_config_changed }}
     steps:
@@ -157,6 +166,8 @@ jobs:
     needs: [determine_environment, check_eas_setup, check_app_config_changes]
     if: needs.check_eas_setup.outputs.has_eas_setup == 'true' && (needs.check_app_config_changes.outputs.app_config_changed == 'true' || inputs.force_build == true)
     uses: CodySwannGT/lisa/.github/workflows/build.yml@main
+    permissions:
+      contents: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
     secrets:
@@ -178,6 +189,8 @@ jobs:
       always() && 
       needs.check_eas_setup.outputs.has_eas_setup == 'true' &&
       needs.release.result == 'success'
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -237,6 +237,7 @@ jobs:
     if: |
       always() &&
       needs.verify_aws_credentials.outputs.has_aws_credentials == 'true' &&
+      needs.check_migration_required.result == 'success' &&
       (
         needs.migrate.result == 'success' ||
         (needs.check_migration_required.outputs.requires_migration != 'true' && needs.migrate.result == 'skipped')

--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
     name: 🌍 Determine Environment
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       approval_environment: ${{ steps.approval.outputs.approval_environment }}
@@ -81,6 +83,9 @@ jobs:
     name: 📦 Release
     uses: CodySwannGT/lisa/.github/workflows/release.yml@main
     needs: [determine_environment]
+    permissions:
+      contents: write
+      pull-requests: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'
@@ -105,6 +110,8 @@ jobs:
     name: Verify AWS Credentials
     runs-on: ubuntu-latest
     needs: [release]
+    permissions:
+      contents: read
     outputs:
       has_aws_credentials: ${{ steps.check.outputs.has_aws_credentials }}
     steps:
@@ -129,6 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release, verify_aws_credentials]
     if: needs.verify_aws_credentials.outputs.has_aws_credentials == 'true'
+    permissions:
+      contents: read
     outputs:
       requires_migration: ${{ steps.check.outputs.requires_migration }}
     steps:
@@ -144,13 +153,14 @@ jobs:
         shell: bash
         env:
           SKIP_MIGRATIONS: ${{ vars.SKIP_MIGRATIONS }}
-          GITHUB_OUTPUT: ${{ github.output }}
 
   verify_vpn:
     name: Verify VPN
     runs-on: ubuntu-latest
     needs: [check_migration_required]
     if: always() && needs.check_migration_required.outputs.requires_migration == 'true'
+    permissions:
+      contents: read
     outputs:
       has_vpn_setup: ${{ steps.check.outputs.has_vpn_setup }}
     steps:
@@ -168,7 +178,6 @@ jobs:
           fi
         env:
           OVPN_CONFIG: ${{ secrets[env.OVPN_CONFIG_NAME] }}
-          GITHUB_OUTPUT: ${{ github.output }}
   migrate:
     name: Schema Migrations
     runs-on: ubuntu-latest
@@ -217,13 +226,26 @@ jobs:
           SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
           AWS_PROFILE: '' # Override serverless.yml profile with empty string for CI
   deploy:
-    needs: [migrate, verify_aws_credentials]
+    needs:
+      [
+        determine_environment,
+        release,
+        check_migration_required,
+        migrate,
+        verify_aws_credentials,
+      ]
     if: |
       always() &&
       needs.verify_aws_credentials.outputs.has_aws_credentials == 'true' &&
-      (needs.migrate.result == 'success' || needs.migrate.result == 'skipped')
+      (
+        needs.migrate.result == 'success' ||
+        (needs.check_migration_required.outputs.requires_migration != 'true' && needs.migrate.result == 'skipped')
+      )
     name: Deploy
     runs-on: ubuntu-latest
+    outputs:
+      environment_url: ${{ steps.deployment_outputs.outputs.environment_url }}
+      deployment_status: ${{ steps.deployment_outputs.outputs.deployment_status }}
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint
       contents: read
@@ -324,6 +346,43 @@ jobs:
             exit 1
           fi
           echo "Health check passed: $health_url"
+
+      - name: Resolve deployment outputs
+        id: deployment_outputs
+        shell: bash
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          AWS_PROFILE: ''
+          DEPLOYMENT_URL: ${{ vars.DEPLOYMENT_URL }}
+          HEALTH_OUTPUT_KEY: ${{ vars.POST_DEPLOY_HEALTH_OUTPUT_KEY || 'HttpApiUrl' }}
+          SERVERLESS_STACK_NAME: ${{ vars.SERVERLESS_STACK_NAME }}
+          STAGE: ${{ github.ref_name != 'main' && github.ref_name || 'production' }}
+        run: |
+          set -euo pipefail
+          environment_url="$DEPLOYMENT_URL"
+
+          if [ -z "$environment_url" ]; then
+            stack_name="$SERVERLESS_STACK_NAME"
+            if [ -z "$stack_name" ]; then
+              service_name=$(bun run serverless print --stage "$STAGE" --format json | jq -r '.service // empty' 2>/dev/null || true)
+              if [ -n "$service_name" ]; then
+                stack_name="${service_name}-${STAGE}"
+              fi
+            fi
+
+            if [ -n "$stack_name" ]; then
+              environment_url=$(aws cloudformation describe-stacks \
+                --stack-name "$stack_name" \
+                --query "Stacks[0].Outputs[?OutputKey=='${HEALTH_OUTPUT_KEY}'].OutputValue | [0]" \
+                --output text 2>/dev/null || true)
+              if [ "$environment_url" = "None" ]; then
+                environment_url=""
+              fi
+            fi
+          fi
+
+          echo "environment_url=$environment_url" >> "$GITHUB_OUTPUT"
+          echo "deployment_status=success" >> "$GITHUB_OUTPUT"
 
       - name: 📢 Notify on success
         run: echo "Successfully deployed version ${{ needs.release.outputs.version }} to ${{ needs.determine_environment.outputs.environment }}"

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -8,22 +8,36 @@ import { fileURLToPath } from "node:url";
 // portable across worktrees and CI working directories.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
-const QUALITY_YML = path.join(REPO_ROOT, ".github", "workflows", "quality.yml");
-const QUALITY_RAILS_YML = path.join(
-  REPO_ROOT,
-  ".github",
-  "workflows",
-  "quality-rails.yml"
-);
-const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
-const DEPLOY_YML = path.join(REPO_ROOT, ".github", "workflows", "deploy.yml");
+const WORKFLOWS_DIR = path.join(REPO_ROOT, ".github", "workflows");
+const DEPLOY_WORKFLOW_FILE = "deploy.yml";
+const QUALITY_YML = path.join(WORKFLOWS_DIR, "quality.yml");
+const QUALITY_RAILS_YML = path.join(WORKFLOWS_DIR, "quality-rails.yml");
+const RELEASE_YML = path.join(WORKFLOWS_DIR, "release.yml");
+const DEPLOY_YML = path.join(WORKFLOWS_DIR, DEPLOY_WORKFLOW_FILE);
 const NESTJS_DEPLOY_YML = path.join(
   REPO_ROOT,
   "nestjs",
   "create-only",
   ".github",
   "workflows",
-  "deploy.yml"
+  DEPLOY_WORKFLOW_FILE
+);
+const EXPO_DEPLOY_YML = path.join(
+  REPO_ROOT,
+  "expo",
+  "create-only",
+  ".github",
+  "workflows",
+  DEPLOY_WORKFLOW_FILE
+);
+const EAS_BUILD_YML = path.join(WORKFLOWS_DIR, "build.yml");
+const CREATE_ISSUE_ON_FAILURE_YML = path.join(
+  WORKFLOWS_DIR,
+  "create-issue-on-failure.yml"
+);
+const CREATE_GITHUB_ISSUE_ON_FAILURE_YML = path.join(
+  WORKFLOWS_DIR,
+  "create-github-issue-on-failure.yml"
 );
 
 /** Shape of a single `workflow_call` input declaration. */
@@ -53,6 +67,7 @@ interface WorkflowJob {
   needs?: string | string[];
   if?: string;
   environment?: unknown;
+  outputs?: Record<string, string>;
   permissions?: Record<string, unknown>;
   strategy?: { matrix?: Record<string, unknown>; "fail-fast"?: boolean };
   steps?: WorkflowStep[];
@@ -78,6 +93,30 @@ interface ReleaseWorkflow {
 interface DeployWorkflow {
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
   jobs?: Record<string, WorkflowJob>;
+}
+
+/** Root shape for lightweight reusable workflow contract checks. */
+interface ReusableWorkflow {
+  on?: {
+    workflow_call?: {
+      secrets?: Record<string, { required?: boolean }>;
+    };
+  };
+  jobs?: Record<string, WorkflowJob>;
+}
+
+/**
+ * Normalize GitHub Actions' scalar-or-list `needs` value for assertions.
+ *
+ * @param job Parsed workflow job.
+ * @returns Job dependency names.
+ */
+function needsList(job: WorkflowJob | undefined): string[] {
+  if (!job?.needs) {
+    return [];
+  }
+
+  return Array.isArray(job.needs) ? job.needs : [job.needs];
 }
 
 describe("quality.yml reusable workflow", () => {
@@ -325,6 +364,10 @@ describe("release and deploy workflows", () => {
   let deployWorkflow: DeployWorkflow;
   let nestjsDeployRaw: string;
   let nestjsDeployWorkflow: DeployWorkflow;
+  let expoDeployWorkflow: DeployWorkflow;
+  let easBuildWorkflow: ReusableWorkflow;
+  let createIssueOnFailureWorkflow: ReusableWorkflow;
+  let createGithubIssueOnFailureWorkflow: ReusableWorkflow;
 
   beforeAll(() => {
     releaseWorkflow = yaml.load(
@@ -335,6 +378,18 @@ describe("release and deploy workflows", () => {
     ) as DeployWorkflow;
     nestjsDeployRaw = fs.readFileSync(NESTJS_DEPLOY_YML, "utf8");
     nestjsDeployWorkflow = yaml.load(nestjsDeployRaw) as DeployWorkflow;
+    expoDeployWorkflow = yaml.load(
+      fs.readFileSync(EXPO_DEPLOY_YML, "utf8")
+    ) as DeployWorkflow;
+    easBuildWorkflow = yaml.load(
+      fs.readFileSync(EAS_BUILD_YML, "utf8")
+    ) as ReusableWorkflow;
+    createIssueOnFailureWorkflow = yaml.load(
+      fs.readFileSync(CREATE_ISSUE_ON_FAILURE_YML, "utf8")
+    ) as ReusableWorkflow;
+    createGithubIssueOnFailureWorkflow = yaml.load(
+      fs.readFileSync(CREATE_GITHUB_ISSUE_ON_FAILURE_YML, "utf8")
+    ) as ReusableWorkflow;
   });
 
   it("pushes signed release tags after creating them", () => {
@@ -425,6 +480,122 @@ describe("release and deploy workflows", () => {
     expect(smokeStep?.run).toContain("aws cloudformation describe-stacks");
     expect(smokeStep?.run).toContain("curl --fail --silent --show-error");
     expect(smokeStep?.run).toContain("HEALTH_EXPECTED_BODY");
+  });
+
+  it("keeps NestJS deploy output plumbing and migration skip gate valid", () => {
+    const deployJob = nestjsDeployWorkflow.jobs?.deploy;
+    const deployNeeds = needsList(deployJob);
+
+    expect(deployNeeds).toEqual(
+      expect.arrayContaining([
+        "determine_environment",
+        "release",
+        "check_migration_required",
+        "migrate",
+        "verify_aws_credentials",
+      ])
+    );
+    expect(deployJob?.outputs?.environment_url).toContain(
+      "steps.deployment_outputs.outputs.environment_url"
+    );
+    expect(deployJob?.outputs?.deployment_status).toContain(
+      "steps.deployment_outputs.outputs.deployment_status"
+    );
+    expect(deployJob?.if).toContain(
+      "needs.check_migration_required.outputs.requires_migration != 'true'"
+    );
+    expect(deployJob?.if).toContain("needs.migrate.result == 'success'");
+    expect(deployJob?.if).not.toContain(
+      "needs.migrate.result == 'success' || needs.migrate.result == 'skipped'"
+    );
+
+    const outputStep = deployJob?.steps?.find(
+      step => step.id === "deployment_outputs"
+    );
+    expect(outputStep).toBeDefined();
+    expect(outputStep?.run).toContain("deployment_status=success");
+  });
+
+  it("does not clobber runner-provided GITHUB_OUTPUT in NestJS helper jobs", () => {
+    for (const jobName of ["check_migration_required", "verify_vpn"]) {
+      const job = nestjsDeployWorkflow.jobs?.[jobName];
+      for (const step of job?.steps ?? []) {
+        const envKeys = Object.keys(step.env ?? {});
+        expect(envKeys, `${jobName}: ${step.name ?? step.id}`).not.toContain(
+          "GITHUB_OUTPUT"
+        );
+      }
+    }
+  });
+
+  it("uses explicit least-privilege permissions for read-only NestJS jobs and release caller", () => {
+    expect(
+      nestjsDeployWorkflow.jobs?.determine_environment.permissions
+    ).toEqual({ contents: "read" });
+    expect(
+      nestjsDeployWorkflow.jobs?.verify_aws_credentials.permissions
+    ).toEqual({ contents: "read" });
+    expect(
+      nestjsDeployWorkflow.jobs?.check_migration_required.permissions
+    ).toEqual({ contents: "read" });
+    expect(nestjsDeployWorkflow.jobs?.verify_vpn.permissions).toEqual({
+      contents: "read",
+    });
+    expect(nestjsDeployWorkflow.jobs?.release.permissions).toEqual({
+      contents: "write",
+      "pull-requests": "read",
+    });
+  });
+
+  it("lets Expo deploy skip EAS build cleanly when EXPO_TOKEN is absent", () => {
+    const tokenSecret = easBuildWorkflow.on?.workflow_call?.secrets?.EXPO_TOKEN;
+    expect(tokenSecret).toBeDefined();
+    expect(tokenSecret?.required).toBe(false);
+
+    const check = expoDeployWorkflow.jobs?.check_eas_setup;
+    expect(check?.outputs?.has_eas_setup).toContain(
+      "steps.check.outputs.has_eas_setup"
+    );
+
+    const trigger = expoDeployWorkflow.jobs?.trigger_eas_build;
+    expect(trigger?.if).toContain(
+      "needs.check_eas_setup.outputs.has_eas_setup == 'true'"
+    );
+    expect(trigger?.permissions).toEqual({ contents: "read" });
+  });
+
+  it("grants reusable Expo release and deploy jobs the permissions they request", () => {
+    expect(expoDeployWorkflow.jobs?.release.permissions).toEqual({
+      contents: "write",
+      "pull-requests": "read",
+    });
+    expect(expoDeployWorkflow.jobs?.determine_environment.permissions).toEqual({
+      contents: "read",
+    });
+    expect(expoDeployWorkflow.jobs?.check_eas_setup.permissions).toEqual({
+      contents: "read",
+    });
+    expect(
+      expoDeployWorkflow.jobs?.check_app_config_changes.permissions
+    ).toEqual({ contents: "read" });
+    expect(expoDeployWorkflow.jobs?.deploy.permissions).toEqual({
+      contents: "read",
+    });
+  });
+
+  it("grants GitHub issue fallback workflows enough token scope for read-only repos", () => {
+    expect(
+      createIssueOnFailureWorkflow.jobs?.create_github_issue.permissions
+    ).toEqual({
+      contents: "read",
+      issues: "write",
+    });
+    expect(
+      createGithubIssueOnFailureWorkflow.jobs?.create_issue.permissions
+    ).toEqual({
+      contents: "read",
+      issues: "write",
+    });
   });
 });
 

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -508,6 +508,12 @@ describe("release and deploy workflows", () => {
     expect(deployJob?.if).not.toContain(
       "needs.migrate.result == 'success' || needs.migrate.result == 'skipped'"
     );
+    // A failed check_migration_required job leaves requires_migration empty
+    // (which is != 'true') and its downstream jobs skipped, so without this
+    // gate deploy would run despite the migration check itself failing.
+    expect(deployJob?.if).toContain(
+      "needs.check_migration_required.result == 'success'"
+    );
 
     const outputStep = deployJob?.steps?.find(
       step => step.id === "deployment_outputs"


### PR DESCRIPTION
## Summary
- Fixes NestJS deploy template output handling, deploy dependencies, exported deploy outputs, and skipped-migration gating.
- Makes Expo EAS build token optional behind the existing setup gate and adds least-privilege caller permissions for reusable release/build/deploy jobs.
- Grants GitHub issue fallback workflows explicit issue-write permissions and adds workflow contract regression coverage.

Closes #1601.

## Verification
- bun test tests/integration/quality-workflow.test.ts
- bunx vitest run tests/integration/quality-workflow.test.ts
- bun run typecheck
- bun run lint
- bun run check:workflow-inputs
- bun run build
- bun run check:plugins
- git diff --check
- bun test
- pre-push hook: security audit, slow lint, knip, vitest coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployments now surface a deployment status and an environment URL when available.
- **Bug Fixes**
  - Improved environment URL resolution, including reliable fallback behavior when no configured URL is set.
- **Security**
  - CI/CD workflows now use explicit, least-privilege permissions.
  - Expo build/deploy behavior adjusts so an Expo token is optional when not required.
- **Changes**
  - Deployment execution is tightened to only run when credentials are available and migration outcomes are acceptable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->