### PR TITLE
fix(workflows): skip Claude automation jobs cleanly when CLAUDE_CODE_OAUTH_TOKEN is absent

### DIFF
--- a/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
+++ b/.github/workflows/reusable-auto-update-pr-branches-dispatch.yml
@@ -35,9 +35,30 @@ permissions:
   id-token: write
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   update-all-prs:
+    needs: [check_claude_setup]
     name: Update open PRs targeting ${{ inputs.ref_name }}
-    if: inputs.action == 'auto-update-pr-branches'
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (inputs.action == 'auto-update-pr-branches')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,8 +114,11 @@ jobs:
             --max-turns 3
 
   update-single-pr:
+    needs: [check_claude_setup]
     name: Update PR #${{ inputs.pr_number }}
-    if: inputs.action == 'auto-update-pr-branch'
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (inputs.action == 'auto-update-pr-branch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -41,14 +41,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   auto-fix:
+    needs: [check_claude_setup]
     if: |
-      inputs.workflow_run_conclusion == 'failure' &&
-      inputs.head_repo_full_name == inputs.repo_full_name &&
-      !startsWith(inputs.head_branch, 'claude-auto-fix-') &&
-      inputs.head_branch != 'main' &&
-      inputs.head_branch != 'staging' &&
-      inputs.head_branch != 'dev'
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (inputs.workflow_run_conclusion == 'failure' && inputs.head_repo_full_name == inputs.repo_full_name && !startsWith(inputs.head_branch, 'claude-auto-fix-') && inputs.head_branch != 'main' && inputs.head_branch != 'staging' && inputs.head_branch != 'dev')
     runs-on: ubuntu-latest
     outputs:
       fixed: ${{ steps.check-fix.outputs.fixed }}

--- a/.github/workflows/reusable-claude-code-review-response.yml
+++ b/.github/workflows/reusable-claude-code-review-response.yml
@@ -45,12 +45,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   respond-to-review:
+    needs: [check_claude_setup]
     if: |
-      vars.ENABLE_CLAUDE_CODE_REVIEW_RESPONSE == 'true' &&
-      inputs.review_user_login == 'coderabbitai[bot]' &&
-      inputs.pr_user_login != 'coderabbitai[bot]' &&
-      inputs.pr_user_login != 'dependabot[bot]'
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_CODE_REVIEW_RESPONSE == 'true' && inputs.review_user_login == 'coderabbitai[bot]' && inputs.pr_user_login != 'coderabbitai[bot]' && inputs.pr_user_login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-deploy-auto-fix.yml
+++ b/.github/workflows/reusable-claude-deploy-auto-fix.yml
@@ -43,11 +43,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   auto-fix:
+    needs: [check_claude_setup]
     if: |
-      inputs.workflow_run_conclusion == 'failure' &&
-      inputs.head_repo_full_name == inputs.repo_full_name &&
-      !startsWith(inputs.head_branch, 'claude/deploy-fix-')
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (inputs.workflow_run_conclusion == 'failure' && inputs.head_repo_full_name == inputs.repo_full_name && !startsWith(inputs.head_branch, 'claude/deploy-fix-'))
     runs-on: ubuntu-latest
     outputs:
       fixed: ${{ steps.check-fix.outputs.fixed }}
@@ -259,11 +277,10 @@ jobs:
   # of dead-ending in a bare, never-picked-up bug issue.
   escalate-to-ticket:
     name: File a build-ready ticket for the unfixed deploy failure
-    needs: [auto-fix]
+    needs: [auto-fix, check_claude_setup]
     if: |
-      always() &&
-      needs.auto-fix.result != 'skipped' &&
-      needs.auto-fix.outputs.fixed != 'true'
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (always() && needs.auto-fix.result != 'skipped' && needs.auto-fix.outputs.fixed != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity-rails.yml
@@ -21,8 +21,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   reduce-complexity:
-    if: vars.ENABLE_CLAUDE_NIGHTLY == 'true'
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-nightly-code-complexity.yml
+++ b/.github/workflows/reusable-claude-nightly-code-complexity.yml
@@ -26,8 +26,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   reduce-complexity:
-    if: vars.ENABLE_CLAUDE_NIGHTLY == 'true'
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-nightly-jira-triage.yml
+++ b/.github/workflows/reusable-claude-nightly-jira-triage.yml
@@ -28,11 +28,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   triage:
-    if: >-
-      vars.JIRA_BASE_URL != '' &&
-      vars.JIRA_USER_EMAIL != '' &&
-      vars.JIRA_PROJECT_KEY != ''
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.JIRA_BASE_URL != '' && vars.JIRA_USER_EMAIL != '' && vars.JIRA_PROJECT_KEY != '')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage-rails.yml
@@ -36,9 +36,30 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   improve-coverage-postgres:
+    needs: [check_claude_setup]
     name: improve-coverage
-    if: ${{ vars.ENABLE_CLAUDE_NIGHTLY == 'true' && inputs.database_type == 'postgres' }}
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true' && inputs.database_type == 'postgres')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -262,8 +283,11 @@ jobs:
           fi
 
   improve-coverage-mysql:
+    needs: [check_claude_setup]
     name: improve-coverage
-    if: ${{ vars.ENABLE_CLAUDE_NIGHTLY == 'true' && inputs.database_type == 'mysql' }}
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true' && inputs.database_type == 'mysql')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-nightly-test-coverage.yml
+++ b/.github/workflows/reusable-claude-nightly-test-coverage.yml
@@ -31,8 +31,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   improve-coverage:
-    if: vars.ENABLE_CLAUDE_NIGHTLY == 'true'
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement-rails.yml
@@ -26,8 +26,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   improve-tests:
-    if: vars.ENABLE_CLAUDE_NIGHTLY == 'true'
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-nightly-test-improvement.yml
+++ b/.github/workflows/reusable-claude-nightly-test-improvement.yml
@@ -31,8 +31,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   improve-tests:
-    if: vars.ENABLE_CLAUDE_NIGHTLY == 'true'
+    needs: [check_claude_setup]
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (vars.ENABLE_CLAUDE_NIGHTLY == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude-sync-down-branches.yml
+++ b/.github/workflows/reusable-claude-sync-down-branches.yml
@@ -25,8 +25,33 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   sync:
-    if: github.event.pull_request.merged == true
+    needs: [check_claude_setup]
+    # Skip cleanly when CLAUDE_CODE_OAUTH_TOKEN is absent. The sync PR must be
+    # authored by claude[bot] for CI to trigger on it, so a tokenless sync would
+    # either hard-fail (when there is something to sync) or produce un-CI'd PRs.
+    # Skipping is the ratified behavior (Cody, 2026-07-13).
+    if: |
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -45,15 +45,29 @@ on:
         required: false
 
 jobs:
+  check_claude_setup:
+    name: 🔑 Check Claude Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_claude_token: ${{ steps.check.outputs.has_claude_token }}
+    steps:
+      - name: Check for CLAUDE_CODE_OAUTH_TOKEN
+        id: check
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "has_claude_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_claude_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set - Claude automation will be skipped. Provision the secret to enable it."
+          fi
+
   claude:
+    needs: [check_claude_setup]
     if: |
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), inputs.author_association) &&
-      (
-        (inputs.event_name == 'issue_comment' && contains(inputs.comment_body, '@claude')) ||
-        (inputs.event_name == 'pull_request_review_comment' && contains(inputs.comment_body, '@claude')) ||
-        (inputs.event_name == 'pull_request_review' && contains(inputs.review_body, '@claude')) ||
-        (inputs.event_name == 'issues' && (contains(inputs.issue_body, '@claude') || contains(inputs.issue_title, '@claude')))
-      )
+      needs.check_claude_setup.outputs.has_claude_token == 'true' &&
+      (contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), inputs.author_association) && ( (inputs.event_name == 'issue_comment' && contains(inputs.comment_body, '@claude')) || (inputs.event_name == 'pull_request_review_comment' && contains(inputs.comment_body, '@claude')) || (inputs.event_name == 'pull_request_review' && contains(inputs.review_body, '@claude')) || (inputs.event_name == 'issues' && (contains(inputs.issue_body, '@claude') || contains(inputs.issue_title, '@claude'))) ))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Adds a `check_claude_setup` gate job (same pattern as the expo template's `check_eas_setup`; `secrets` context is not available in job-level `if:`) to 13 reusable workflows and gates all 16 Claude-payload jobs on it — consumers without `CLAUDE_CODE_OAUTH_TOKEN` now get a clean **skip** with a `::notice`, instead of today's behavior:
  - auto-fix workflows **run, fail, and file '🚨 manual intervention' issues** on every CI/deploy failure (observed: TunnlAI/frontend issues #13–16, #21);
  - the auto-update-PR dispatch jobs report **fake success** (`continue-on-error: true` masking a failed Claude step that did nothing);
  - sync-down hard-fails whenever there is actually something to sync.
- Original job conditions are preserved verbatim, parenthesized under the gate. Downstream dependents audited for skip-tolerance (`ci-auto-fix::create-issue` already skip-tolerant; `deploy-auto-fix::escalate-to-ticket` gated itself since it also runs Claude).
- The gate step reads the secret via `env:` (no secret interpolation into the shell line) and deliberately carries **no `permissions:` block** — a called job requesting more than its caller grants invalidates the whole workflow at queue time (see the second bug in #1601's latest comment).
- `reusable-auto-update-pr-branches.yml` untouched: it declares the secret but never uses it (dispatch runs on `GITHUB_TOKEN`).
- sync-down's gate carries a comment documenting why skipping (not a `GITHUB_TOKEN` fallback) is correct: sync PRs must be authored by claude[bot] or downstream `pull_request` CI never fires, and an un-CI'd auto-merging PR is worse than no PR.

Known pre-existing issue, out of scope: `reusable-auto-update-pr-branches-dispatch.yml`'s `update-single-pr` job references `steps.plugins.outputs.*` but has no `plugins` step (actionlint flags it on main today) — those action inputs resolve to empty.

## Test plan

- `yaml.safe_load`: 13/13 parse; `actionlint -shellcheck=`: clean on 12/13 (the 13th has only the pre-existing error above, verified identical on main).
- Programmatic audit: every job referencing `CLAUDE_CODE_OAUTH_TOKEN`/`claude-code-action` across all reusable workflows is gated (16/16), zero violations.
- Behavior with the token present is unchanged: gate evaluates true and every original condition applies as before.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude-powered automation now checks for the required authentication setup before running.
  * Workflows skip cleanly and provide a notice when the required credential is unavailable.
  * Existing triggers and feature controls remain enforced alongside the new setup check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->