### PR TITLE
fix(eslint): enforce the jsdoc rules deferred to oxlint

### DIFF
--- a/oxlint/base.json
+++ b/oxlint/base.json
@@ -19,7 +19,17 @@
     "no-unused-vars": "off",
     "max-lines": "off",
     "max-lines-per-function": "off",
-    "jsdoc/check-tag-names": "off"
+    "jsdoc/check-tag-names": "off",
+    "jsdoc/check-access": "error",
+    "jsdoc/check-property-names": "error",
+    "jsdoc/empty-tags": "error",
+    "jsdoc/implements-on-classes": "error",
+    "jsdoc/no-defaults": "error",
+    "jsdoc/require-param-name": "error",
+    "jsdoc/require-property": "error",
+    "jsdoc/require-property-name": "error",
+    "jsdoc/require-yields": "error",
+    "jsdoc/require-property-type": "off"
   },
   "ignorePatterns": [
     "build/**",

--- a/tests/unit/config/oxlint-jsdoc-parity.test.ts
+++ b/tests/unit/config/oxlint-jsdoc-parity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests that pin jsdoc rule parity between the ESLint hybrid pipeline
+ * and the shipped oxlint preset.
+ *
+ * Background: `src/configs/eslint/base.ts` spreads
+ * `oxlint.configs["flat/jsdoc"]`, which turns OFF every ESLint-side jsdoc
+ * rule that oxlint's jsdoc plugin implements. Each of those rules must then
+ * be enforced somewhere in the fast pipeline (`oxlint && eslint . --quiet`):
+ * either re-enabled ESLint-side in `getSharedRules`, set to "error" in
+ * `oxlint/base.json`, or intentionally off (JSDoc type annotations are
+ * redundant under TypeScript). Before this guard existed, nine rules —
+ * check-access, check-property-names, empty-tags, implements-on-classes,
+ * no-defaults, require-param-name, require-property, require-property-name,
+ * require-yields — were enforced NOWHERE: oxlint's `correctness` category
+ * runs at "warn" (non-gating, oxlint exits 0 on warnings) and two of the
+ * rules live in the off-by-default `restriction`/`pedantic` categories.
+ */
+import oxlint from "eslint-plugin-oxlint";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultThresholds,
+  getSharedRules,
+} from "../../../src/configs/eslint/base.js";
+
+/**
+ * Shape of the oxlint JSON preset relevant to this test.
+ */
+interface OxlintConfig {
+  readonly plugins?: readonly string[];
+  readonly rules?: Record<string, unknown>;
+}
+
+/**
+ * JSDoc rules whose absence from both linters is intentional: JSDoc type
+ * annotations ({type} braces) are redundant in TypeScript sources, matching
+ * the explicit "off" entries in getSharedRules.
+ */
+const intentionallyUnenforced = new Set([
+  "jsdoc/require-param-type",
+  "jsdoc/require-returns-type",
+  "jsdoc/require-property-type",
+]);
+
+const oxlintBasePath = join(process.cwd(), "oxlint", "base.json");
+const oxlintBase = JSON.parse(
+  readFileSync(oxlintBasePath, "utf8")
+) as OxlintConfig;
+
+const sharedRules = getSharedRules(defaultThresholds) as Record<
+  string,
+  unknown
+>;
+
+/**
+ * Extracts the severity from an ESLint rule entry ("error" or ["error", ...]).
+ * @param entry - The rule configuration entry
+ * @returns The severity string
+ */
+const severityOf = (entry: unknown): unknown =>
+  Array.isArray(entry) ? entry[0] : entry;
+
+const flatJsdocDisabledRules = oxlint.configs["flat/jsdoc"].flatMap(config =>
+  Object.keys(config.rules ?? {})
+);
+
+describe("jsdoc rule parity between eslint-plugin-oxlint disables and enforcement", () => {
+  it("disables at least one jsdoc rule via flat/jsdoc (premise check)", () => {
+    expect(flatJsdocDisabledRules.length).toBeGreaterThan(0);
+  });
+
+  it("enables the jsdoc plugin in oxlint/base.json", () => {
+    expect(oxlintBase.plugins).toContain("jsdoc");
+  });
+
+  it.each(flatJsdocDisabledRules)(
+    "%s is enforced by ESLint, enforced by oxlint, or intentionally off",
+    rule => {
+      const reEnabledInEslint =
+        rule in sharedRules && severityOf(sharedRules[rule]) !== "off";
+      const enforcedInOxlint = severityOf(oxlintBase.rules?.[rule]) === "error";
+      const intentional = intentionallyUnenforced.has(rule);
+
+      expect(reEnabledInEslint || enforcedInOxlint || intentional).toBe(true);
+    }
+  );
+
+  it("does not leave an intentionally-off rule active at warn in oxlint (noise guard)", () => {
+    const activeIntentional = [...intentionallyUnenforced].filter(rule => {
+      const severity = severityOf(oxlintBase.rules?.[rule]);
+      return severity !== undefined && severity !== "off";
+    });
+    expect(activeIntentional).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The shared ESLint base config (`src/configs/eslint/base.ts`) spreads `oxlint.configs["flat/jsdoc"]`, which turns OFF every ESLint-side jsdoc rule that oxlint's jsdoc plugin implements — on the assumption that oxlint enforces them in the fast pass of the hybrid `oxlint && eslint . --quiet` pipeline. It didn't. Nine jsdoc hygiene rules were enforced **nowhere** in any downstream project:

| Rule | oxlint category | Before |
|---|---|---|
| `jsdoc/check-property-names` | correctness | warn only (non-gating) |
| `jsdoc/implements-on-classes` | correctness | warn only (non-gating) |
| `jsdoc/no-defaults` | correctness | warn only (non-gating) |
| `jsdoc/require-property` | correctness | warn only (non-gating) |
| `jsdoc/require-property-name` | correctness | warn only (non-gating) |
| `jsdoc/require-yields` | correctness | warn only (non-gating) |
| `jsdoc/check-access` | restriction | not enabled at all |
| `jsdoc/empty-tags` | restriction | not enabled at all |
| `jsdoc/require-param-name` | pedantic | not enabled at all |

Two mechanisms hid the gap: `oxlint/base.json` runs `categories.correctness` at `"warn"`, and oxlint exits 0 on warnings, so warn-level findings never fail `bun run lint`; the restriction/pedantic rules are off-by-default categories and had no explicit entries. The heavyweight rules (`require-jsdoc`, `require-description`, `require-param`, `require-returns`, the `-description` variants, `check-tag-names`) were never affected — `getSharedRules` re-enables them ESLint-side after the disable spread.

## Fix

- Pin the nine deferred rules to `"error"` in `oxlint/base.json` — the single source every stack preset (`typescript.json`, `expo.json`, `nestjs.json`, `cdk.json`, …) and the downstream `.oxlintrc.json` template extend, so parity lands in the fast oxlint pass fleet-wide on the next lisa update. Chosen over dropping the `flat/jsdoc` spread from `base.ts` because oxlint 1.62.0 implements all 18 disabled rules (verified by run, see below) and keeps them out of the slower ESLint pass.
- Set `jsdoc/require-property-type` to `"off"` for parity with the explicit ESLint-side off (JSDoc `{type}` braces are redundant under TypeScript); it previously produced contradictory warn-level noise.
- Add `tests/unit/config/oxlint-jsdoc-parity.test.ts`: walks the actual `flat/jsdoc` disable list from `eslint-plugin-oxlint` and asserts every rule is re-enabled ESLint-side in `getSharedRules`, enforced at `"error"` in `oxlint/base.json`, or on the intentional type-rule allowlist — the gap cannot silently reopen. Run against the old config it fails on exactly the nine rules above.

## Empirical proof

Scratch file with `@access foobar` (check-access), `@internal some stray content` (empty-tags), and `@param [a=1]` (no-defaults):

- **Before**: `oxlint` → 1 warning, 0 errors, exit 0; `eslint --quiet` → exit 0. Full pipeline green despite three violations.
- **After**: `oxlint` → 3 errors, exit 1. Also verified `require-param-name` (bare `@param`) and `check-property-names` (duplicate `@property`) now hard-fail.

## Blast radius

- Lisa's own source: `oxlint` repo-wide → 0 warnings, 0 errors with the new config (no source fixes needed).
- `bun run lint`, `bun run test` (3881 passed), `bun run check:plugins` all green.
- No plugin artifacts reference the oxlint presets; `oxlint/` ships via the npm `files` list unchanged.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Linting**
  * Added stricter JSDoc validation rules to improve documentation consistency and completeness.
  * Clarified which JSDoc checks are intentionally disabled.

* **Tests**
  * Added automated coverage to verify parity between ESLint and Oxlint JSDoc rules.
  * Added checks confirming the JSDoc plugin and intentional rule exceptions are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->