### PR TITLE
fix(workflows): populate the GitHub release changelog for standard-version releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,6 +589,24 @@ jobs:
           # Generate changelog based on strategy
           if [ "${{ inputs.release_strategy }}" == "standard-version" ]; then
             npx standard-version --release-as ${{ steps.version.outputs.version }} --skip.tag --releaseCommitMessageFormat "chore(release): {{currentTag}} [skip ci]"
+
+            # standard-version rewrites the full CHANGELOG.md but the GitHub
+            # release body is built from CHANGELOG_ENTRY.md, so extract this
+            # version's section (from its heading to the next version heading).
+            # Version headings are "## [x.y.z](...)" or "### [x.y.z](...)"
+            # (patch entries share the ### level with "### Bug Fixes" sections,
+            # so match on the version token, not the heading depth).
+            awk -v ver="${{ steps.version.outputs.version }}" '
+              /^#+ \[?[0-9]+\.[0-9]+\.[0-9]+/ {
+                if (index($0, "[" ver "]") > 0 || $2 == ver) { found=1; print; next }
+                if (found) { exit }
+              }
+              found { print }
+            ' CHANGELOG.md > CHANGELOG_ENTRY.md
+
+            if [ ! -s CHANGELOG_ENTRY.md ]; then
+              echo "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md) for this release's changes." > CHANGELOG_ENTRY.md
+            fi
           else
             # Custom changelog generation
             LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -1074,9 +1092,12 @@ jobs:
           ## 📝 Changelog
           EOF
 
-          # Include changelog content
-          if [ -f "version-artifacts-${{ github.run_id }}/CHANGELOG_ENTRY.md" ]; then
+          # Include changelog content. Fall back to a pointer at the full
+          # changelog rather than publishing an empty section.
+          if [ -s "version-artifacts-${{ github.run_id }}/CHANGELOG_ENTRY.md" ]; then
             cat "version-artifacts-${{ github.run_id }}/CHANGELOG_ENTRY.md" >> RELEASE_NOTES.md
+          else
+            echo "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md) for this release's changes." >> RELEASE_NOTES.md
           fi
 
           # Add verification instructions if signed

--- a/tests/integration/release-changelog-entry.test.ts
+++ b/tests/integration/release-changelog-entry.test.ts
@@ -1,0 +1,127 @@
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Derive the repo root from this test file's location so the test is
+// portable across worktrees and CI working directories.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
+
+/** Minimal shape of the parsed release workflow needed by these tests. */
+interface ReleaseWorkflow {
+  jobs: Record<
+    string,
+    { steps?: ReadonlyArray<{ name?: string; run?: string }> }
+  >;
+}
+
+const loadWorkflow = async (): Promise<ReleaseWorkflow> => {
+  const contents = await fs.readFile(RELEASE_YML, "utf8");
+  return yaml.load(contents) as ReleaseWorkflow;
+};
+
+describe("release changelog entry generation", () => {
+  let releaseWorkflow: ReleaseWorkflow;
+
+  beforeAll(async () => {
+    releaseWorkflow = await loadWorkflow();
+  });
+
+  // Host projects call release.yml with release_strategy: 'standard-version'.
+  // standard-version rewrites CHANGELOG.md but never wrote CHANGELOG_ENTRY.md,
+  // so every host release shipped with an empty "## 📝 Changelog" section.
+  it("writes CHANGELOG_ENTRY.md in the standard-version branch", () => {
+    const steps = releaseWorkflow.jobs.version.steps ?? [];
+    const changelog = steps.find(s => s.name === "Generate Changelog");
+    const run = changelog?.run ?? "";
+
+    const standardVersionBranch = run.slice(
+      run.indexOf("npx standard-version"),
+      run.indexOf("else")
+    );
+    expect(standardVersionBranch).toContain("> CHANGELOG_ENTRY.md");
+  });
+
+  it("falls back to a CHANGELOG.md link when the entry is missing or empty", () => {
+    const steps = releaseWorkflow.jobs.github_release.steps ?? [];
+    const notes = steps.find(s => s.name === "Generate Release Notes");
+    const run = notes?.run ?? "";
+
+    // -s (non-empty), not -f (exists): an empty extraction must also fall back.
+    expect(run).toContain('if [ -s "version-artifacts-');
+    expect(run).toContain("See [CHANGELOG.md]");
+  });
+});
+
+describe("changelog entry extraction (awk)", () => {
+  let awkProgram: string;
+  let fixturePath: string;
+
+  const CHANGELOG = [
+    "# Changelog",
+    "",
+    "### [2.204.4](https://github.com/o/r/compare/v2.204.3...v2.204.4) (2026-07-13)",
+    "",
+    "### Bug Fixes",
+    "",
+    "* **eslint:** enforce jsdoc rules ([881147d](https://github.com/o/r/commit/881147d))",
+    "",
+    "## [2.204.0](https://github.com/o/r/compare/v2.203.0...v2.204.0) (2026-07-12)",
+    "",
+    "### Features",
+    "",
+    "* **nestjs:** add optional deploy env ([a468e4e](https://github.com/o/r/commit/a468e4e))",
+    "",
+  ].join("\n");
+
+  beforeAll(async () => {
+    // Run the exact awk program embedded in the Generate Changelog step, so
+    // the test cannot drift from what the workflow actually executes.
+    const releaseWorkflow = await loadWorkflow();
+    const steps = releaseWorkflow.jobs.version.steps ?? [];
+    const run = steps.find(s => s.name === "Generate Changelog")?.run ?? "";
+    const match = /awk -v ver="[^"]*" '([\s\S]*?)' CHANGELOG\.md/.exec(run);
+    if (!match?.[1]) {
+      throw new Error("awk extraction program not found in Generate Changelog");
+    }
+    awkProgram = match[1];
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "changelog-entry-"));
+    fixturePath = path.join(dir, "CHANGELOG.md");
+    await fs.writeFile(fixturePath, CHANGELOG);
+  });
+
+  // Fixed path so the command can't be hijacked via PATH; present on both
+  // macOS and the ubuntu CI runners.
+  const AWK = "/usr/bin/awk";
+
+  const extractEntry = (version: string): string =>
+    execFileSync(AWK, ["-v", `ver=${version}`, awkProgram, fixturePath], {
+      encoding: "utf8",
+    });
+
+  // Patch entries use "### [x.y.z]" — the same heading level as the
+  // "### Bug Fixes" section inside them, so extraction must key on the
+  // version token, not the heading depth.
+  it("extracts a patch entry including its ###-level sections", () => {
+    const entry = extractEntry("2.204.4");
+    expect(entry).toContain("### [2.204.4]");
+    expect(entry).toContain("enforce jsdoc rules");
+    expect(entry).not.toContain("2.204.0");
+  });
+
+  it("extracts a minor entry and stops at the end of the file", () => {
+    const entry = extractEntry("2.204.0");
+    expect(entry).toContain("## [2.204.0]");
+    expect(entry).toContain("add optional deploy env");
+    expect(entry).not.toContain("2.204.4");
+  });
+
+  it("returns empty when the version heading is absent", () => {
+    expect(extractEntry("9.9.9").trim()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Host projects call the reusable `release.yml` with `release_strategy: 'standard-version'`, but that branch of the **Generate Changelog** step never produced `CHANGELOG_ENTRY.md` — only the non-standard-version branch did. The **Generate Release Notes** step silently skipped the missing file, so every host-project GitHub release shipped with an empty "📝 Changelog" section (verified on real releases, e.g. geminisportsai/backend-v2 v0.130.614).
- After `standard-version` runs, extract the current version's entry from `CHANGELOG.md` into `CHANGELOG_ENTRY.md`. Extraction keys on the version token rather than heading depth, because patch entries (`### [x.y.z]`) share the `###` level with their `### Bug Fixes` / `### Features` sections.
- Harden the release-notes step: check `-s` (non-empty) instead of `-f`, and fall back to a link to the full `CHANGELOG.md` so the section is never blank.

## Test plan
- `tests/integration/release-changelog-entry.test.ts`:
  - Asserts the standard-version branch of **Generate Changelog** writes `CHANGELOG_ENTRY.md` and the release-notes step has the non-empty check + fallback.
  - Extracts the *actual* awk program from `release.yml` and executes it against a standard-version-format changelog fixture — verifying patch-entry extraction (including its `###`-level sections), minor-entry extraction, boundary handling between adjacent entries, and empty output for an unknown version.
- `bun run typecheck`, ESLint, and the full pre-commit/pre-push gates pass.
- Empirical follow-up: the next release cut by any host project (all reference `release.yml@main`) should carry the version's changelog entry in the release body.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated release-note generation for standard-version releases.
  - Release notes now extract the correct version section, including nested subsections.
  - Added clearer fallback behavior linking to the full changelog when a version-specific entry is unavailable or empty.
  - GitHub release notes now include generated changelog content only when valid content exists, preventing incomplete or misleading release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->