### PR TITLE
fix: skip agent emits during postinstall apply

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -165,6 +165,17 @@ export class Lisa {
   ) {}
 
   /**
+   * Postinstall applies are intentionally narrow: they refresh governance
+   * templates that must track dependency updates, but they must not regenerate
+   * project-scoped agent surfaces. Agent trees are large, committed outputs and
+   * are updated through an explicit `lisa apply` or cross-pollinate run.
+   * @returns True when the current apply should avoid agent-surface writes.
+   */
+  private shouldSkipAgentEmitDuringPostinstall(): boolean {
+    return this.config.skipGitCheck;
+  }
+
+  /**
    * Initialize services
    */
   private async initServices(): Promise<void> {
@@ -753,6 +764,12 @@ export class Lisa {
     if (!harnessIncludesAgent(harness, "codex")) {
       return;
     }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
+      this.deps.logger.info(
+        pc.gray("Codex emit: skipped during postinstall-safe apply")
+      );
+      return;
+    }
     if (this.config.dryRun) {
       this.deps.logger.info(pc.gray("Codex emit: skipped (dry-run mode)"));
       return;
@@ -790,6 +807,12 @@ export class Lisa {
   private async processClaudeEmit(): Promise<void> {
     const { harness } = this.config;
     if (!harnessIncludesAgent(harness, "claude")) {
+      return;
+    }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
+      this.deps.logger.info(
+        pc.gray("Claude emit: skipped during postinstall-safe apply")
+      );
       return;
     }
     if (this.config.dryRun) {
@@ -837,6 +860,12 @@ export class Lisa {
   private async processAgyEmit(): Promise<void> {
     const { harness } = this.config;
     if (!harnessIncludesAgent(harness, "agy")) {
+      return;
+    }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
+      this.deps.logger.info(
+        pc.gray("agy emit: skipped during postinstall-safe apply")
+      );
       return;
     }
     if (this.config.dryRun) {
@@ -935,6 +964,12 @@ export class Lisa {
     if (!harnessIncludesAgent(harness, "copilot")) {
       return;
     }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
+      this.deps.logger.info(
+        pc.gray("Copilot emit: skipped during postinstall-safe apply")
+      );
+      return;
+    }
     if (this.config.dryRun) {
       this.deps.logger.info(pc.gray("Copilot emit: skipped (dry-run mode)"));
       return;
@@ -994,6 +1029,12 @@ export class Lisa {
   private async processOpencodeEmit(): Promise<void> {
     const { harness } = this.config;
     if (!harnessIncludesAgent(harness, "opencode")) {
+      return;
+    }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
+      this.deps.logger.info(
+        pc.gray("OpenCode emit: skipped during postinstall-safe apply")
+      );
       return;
     }
     if (this.config.dryRun) {
@@ -1106,6 +1147,9 @@ export class Lisa {
    */
   private async processInstructionFilesMigration(): Promise<void> {
     if (this.config.dryRun) {
+      return;
+    }
+    if (this.shouldSkipAgentEmitDuringPostinstall()) {
       return;
     }
     const result = await migrateInstructionFiles(this.config.destDir, {

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -174,6 +174,69 @@ describe("Lisa Integration Tests", () => {
       );
     });
 
+    it("does not regenerate committed agent trees during postinstall-safe apply", async () => {
+      await createTypeScriptProject(destDir);
+      const codexManagedPath = path.join(
+        destDir,
+        ".codex",
+        ".lisa-managed.json"
+      );
+      const codexAgentPath = path.join(
+        destDir,
+        ".codex",
+        "agents",
+        "lisa",
+        "bug-fixer.toml"
+      );
+      const opencodeManagedPath = path.join(
+        destDir,
+        ".opencode",
+        ".lisa-managed.json"
+      );
+      const opencodeSkillPath = path.join(
+        destDir,
+        ".opencode",
+        "skills",
+        "lisa",
+        "build",
+        "SKILL.md"
+      );
+      await fs.outputJson(codexManagedPath, {
+        files: ["agents/lisa/bug-fixer.toml", "agents/lisa/stale.toml"],
+      });
+      await fs.outputFile(codexAgentPath, 'name = "bug-fixer"\n');
+      await fs.outputJson(opencodeManagedPath, {
+        files: ["skills/lisa/build/SKILL.md", "skills/lisa/stale/SKILL.md"],
+      });
+      await fs.outputFile(opencodeSkillPath, "# Build\n");
+
+      const beforeCodexManifest = await fs.readFile(codexManagedPath, "utf8");
+      const beforeCodexAgent = await fs.readFile(codexAgentPath, "utf8");
+      const beforeOpencodeManifest = await fs.readFile(
+        opencodeManagedPath,
+        "utf8"
+      );
+      const beforeOpencodeSkill = await fs.readFile(opencodeSkillPath, "utf8");
+
+      const result = await createLisa({
+        harness: "fleet",
+        skipGitCheck: true,
+      }).apply();
+
+      expect(result.success).toBe(true);
+      expect(await fs.readFile(codexManagedPath, "utf8")).toBe(
+        beforeCodexManifest
+      );
+      expect(await fs.readFile(codexAgentPath, "utf8")).toBe(beforeCodexAgent);
+      expect(await fs.readFile(opencodeManagedPath, "utf8")).toBe(
+        beforeOpencodeManifest
+      );
+      expect(await fs.readFile(opencodeSkillPath, "utf8")).toBe(
+        beforeOpencodeSkill
+      );
+      expect(await fs.pathExists(path.join(destDir, "AGENTS.md"))).toBe(false);
+    });
+
     it("is a no-op on the second apply to an unchanged managed tree", async () => {
       await createTypeScriptProject(destDir);
 


### PR DESCRIPTION
## Summary
- skip project-scoped agent emission during postinstall-safe `--skip-git-check` applies
- preserve explicit `lisa apply` / cross-pollinate as the regeneration path for committed agent trees
- add a regression covering committed `.codex` and `.opencode` outputs staying untouched during postinstall-safe apply

Closes #1609

## Verification
- `bun run typecheck`
- `bun run build:dist`
- `bun run build:plugins`
- `bun test tests/integration/lisa.test.ts`
- `bun test`
- `bun run check:plugins`
- pre-push: slow lint, knip, coverage unit suite, integration suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Postinstall-safe apply operations no longer regenerate or modify existing agent configurations and instruction files.
  * Existing committed agent and skill files remain unchanged during protected apply operations.
  * Prevented unintended creation of `AGENTS.md` in postinstall-safe mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->