### PR TITLE
fix(apply): preserve expo tsconfig ownership

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -1289,7 +1289,10 @@ export class Lisa {
    *    (avoids the create-then-delete ENOENT race)
    * 3. Create-only ownership conflicts (parent stack ships a path that a
    *    child stack also ships under create-only — child wins)
-   * 4. Copy-overwrite ownership conflicts (parent and child both ship a path
+   * 4. Cross-strategy ownership conflicts (a child stack ships a create-only
+   *    path that a parent stack ships under copy-overwrite — child wins before
+   *    the parent can overwrite a host-owned or soon-to-be-created child file)
+   * 5. Copy-overwrite ownership conflicts (parent and child both ship a path
    *    under copy-overwrite — only the most-specific stack writes it, so there
    *    is no parent-then-child overwrite window; see copyOverwriteOwnership)
    * @param relativePath - Path relative to the strategy's source directory
@@ -1326,15 +1329,53 @@ export class Lisa {
       }
     }
     if (strategyName === "copy-overwrite") {
-      const owner = this.copyOverwriteOwnership.get(relativePath);
-      if (owner !== undefined && owner !== currentType) {
-        this.counters.skipped++;
-        const reason = `overridden by ${owner}/copy-overwrite`;
-        this.logSkip(reason, relativePath, `Skipped (${reason})`);
-        return false;
-      }
+      return this.shouldProcessCopyOverwrite(relativePath, currentType);
     }
     return true;
+  }
+
+  /**
+   * Apply copy-overwrite-specific ownership rules.
+   * @param relativePath - Path relative to the strategy source directory
+   * @param currentType - Project type currently being processed
+   * @returns True if copy-overwrite should apply the file, false to skip
+   */
+  private shouldProcessCopyOverwrite(
+    relativePath: string,
+    currentType: string
+  ): boolean {
+    const createOnlyOwner = this.createOnlyOwnership.get(relativePath);
+    if (
+      createOnlyOwner !== undefined &&
+      createOnlyOwner !== currentType &&
+      this.isMoreSpecificType(createOnlyOwner, currentType)
+    ) {
+      this.counters.skipped++;
+      const reason = `owned by ${createOnlyOwner}/create-only`;
+      this.logSkip(reason, relativePath, `Skipped (${reason})`);
+      return false;
+    }
+    const owner = this.copyOverwriteOwnership.get(relativePath);
+    if (owner !== undefined && owner !== currentType) {
+      this.counters.skipped++;
+      const reason = `overridden by ${owner}/copy-overwrite`;
+      this.logSkip(reason, relativePath, `Skipped (${reason})`);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Determine whether one detected stack is more specific than another.
+   * `expandAndOrderTypes` orders parents before children, matching the strategy
+   * processing order, so a higher index means a more-specific owner.
+   * @param candidate - Potential child stack
+   * @param currentType - Current stack being processed
+   * @returns True when candidate is ordered after currentType
+   */
+  private isMoreSpecificType(candidate: string, currentType: string): boolean {
+    const orderedTypes = ["all", ...this.detectedTypes];
+    return orderedTypes.indexOf(candidate) > orderedTypes.indexOf(currentType);
   }
 
   /**

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -493,6 +493,41 @@ describe("Lisa Integration Tests", () => {
       expect(finalCi).not.toBe(TS_CI);
     });
 
+    it("child stack create-only suppresses parent copy-overwrite for the same path", async () => {
+      const TSCONFIG_JSON = "tsconfig.json";
+      const TS_CONFIG = `${JSON.stringify({
+        extends: [
+          "@codyswann/lisa/tsconfig/typescript",
+          "./tsconfig.local.json",
+        ],
+      })}\n`;
+      const EXPO_CONFIG = `${JSON.stringify({
+        extends: ["@codyswann/lisa/tsconfig/expo", "./tsconfig.local.json"],
+        compilerOptions: { jsx: "react-jsx" },
+      })}\n`;
+
+      await createExpoProject(destDir);
+
+      const tsCopyOverwrite = path.join(lisaDir, "typescript", COPY_OVERWRITE);
+      await fs.ensureDir(tsCopyOverwrite);
+      await fs.writeFile(path.join(tsCopyOverwrite, TSCONFIG_JSON), TS_CONFIG);
+
+      const expoCreateOnly = path.join(lisaDir, "expo", CREATE_ONLY);
+      await fs.ensureDir(expoCreateOnly);
+      await fs.writeFile(path.join(expoCreateOnly, TSCONFIG_JSON), EXPO_CONFIG);
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      const finalConfig = await fs.readFile(
+        path.join(destDir, TSCONFIG_JSON),
+        "utf-8"
+      );
+      expect(finalConfig).toBe(EXPO_CONFIG);
+      expect(finalConfig).not.toBe(TS_CONFIG);
+      expect(result.counters.overwritten).toBe(0);
+    });
+
     it("Harper/Fabric child stack overrides TypeScript parent templates", async () => {
       const SHARED_CONFIG = "shared-stack-config.txt";
       const TS_CONFIG = "typescript parent\n";


### PR DESCRIPTION
## Summary
- Prevent parent `copy-overwrite` templates from writing a path owned by a more-specific child stack's `create-only` template.
- Add an Expo regression proving `expo/create-only/tsconfig.json` beats `typescript/copy-overwrite/tsconfig.json` without an overwrite window.

Closes #1598.

## Verification
- `bun run typecheck`
- `bun run build:dist`
- `bun run build:plugins`
- `bun run check:plugins`
- `bun run format:check`
- `bun run lint`
- `bun run knip:check`
- `bun test tests/integration/lisa.test.ts`
- `bun test` (serial; 3966 pass)
- pre-push: security audit, `lint:slow`, `knip`, coverage unit suite, integration suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file ownership handling when parent and child stacks provide conflicting content strategies.
  * Ensured the more specific stack’s `create-only` content takes precedence over a parent stack’s `copy-overwrite` content.
  * Prevented files from being incorrectly reported as overwritten in this scenario.

* **Tests**
  * Added coverage for conflicting ownership between nested stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->