### PR TITLE
fix: pass package manager through claude templates

### DIFF
--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -40,6 +40,15 @@ const SAFETY_NET_JSON = ".safety-net.json";
 const HARPER_FABRIC_TYPE = "harper-fabric";
 const HARPER_FABRIC_TXT = "harper-fabric.txt";
 const JEST_CONFIG_LOCAL = "jest.config.local.ts";
+const WORKFLOWS_DIR = path.join(".github", "workflows");
+const CLAUDE_PACKAGE_MANAGER_WORKFLOWS = [
+  "claude-ci-auto-fix.yml",
+  "claude-code-review-response.yml",
+  "claude-deploy-auto-fix.yml",
+  "claude-nightly-code-complexity.yml",
+  "claude-nightly-test-coverage.yml",
+  "claude-nightly-test-improvement.yml",
+] as const;
 
 describe("Lisa Integration Tests", () => {
   let tempDir: string;
@@ -117,6 +126,36 @@ describe("Lisa Integration Tests", () => {
       // Check that files were copied
       expect(await fs.pathExists(path.join(destDir, TEST_TXT))).toBe(true);
       expect(await fs.pathExists(path.join(destDir, TSCONFIG_BASE))).toBe(true);
+    });
+
+    it("scaffolds TypeScript Claude callers with the bun package manager", async () => {
+      await createTypeScriptProject(destDir);
+      await fs.copy(
+        path.join(process.cwd(), "typescript", CREATE_ONLY, WORKFLOWS_DIR),
+        path.join(lisaDir, "typescript", CREATE_ONLY, WORKFLOWS_DIR)
+      );
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      for (const workflow of CLAUDE_PACKAGE_MANAGER_WORKFLOWS) {
+        const content = await fs.readFile(
+          path.join(destDir, WORKFLOWS_DIR, workflow),
+          "utf-8"
+        );
+        expect(content).toContain("package_manager: 'bun'");
+      }
+
+      const syncDownBranches = await fs.readFile(
+        path.join(destDir, WORKFLOWS_DIR, "claude-sync-down-branches.yml"),
+        "utf-8"
+      );
+      const claude = await fs.readFile(
+        path.join(destDir, WORKFLOWS_DIR, "claude.yml"),
+        "utf-8"
+      );
+      expect(syncDownBranches).not.toContain("package_manager:");
+      expect(claude).not.toContain("package_manager:");
     });
 
     it("preserves host-owned config during postinstall-safe apply", async () => {

--- a/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-ci-auto-fix.yml
@@ -24,5 +24,6 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-code-review-response.yml
+++ b/typescript/create-only/.github/workflows/claude-code-review-response.yml
@@ -25,5 +25,6 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       repo_owner: ${{ github.repository_owner }}
       repo_name: ${{ github.event.repository.name }}
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
+++ b/typescript/create-only/.github/workflows/claude-deploy-auto-fix.yml
@@ -24,5 +24,6 @@ jobs:
       repo_full_name: ${{ github.repository }}
       head_branch: ${{ github.event.workflow_run.head_branch }}
       run_id: ${{ github.event.workflow_run.id }}
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-code-complexity.yml
@@ -17,5 +17,7 @@ permissions:
 jobs:
   reduce-complexity:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-code-complexity.yml@main
+    with:
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-coverage.yml
@@ -25,5 +25,6 @@ jobs:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-coverage.yml@main
     with:
       coverage_increment: ${{ github.event.inputs.coverage_increment || 5 }}
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
+++ b/typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml
@@ -28,5 +28,6 @@ jobs:
     uses: CodySwannGT/lisa/.github/workflows/reusable-claude-nightly-test-improvement.yml@main
     with:
       mode: ${{ github.event.inputs.mode || 'nightly' }}
+      package_manager: 'bun'
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- add `package_manager: 'bun'` to the six TypeScript first-setup Claude workflow callers whose reusables accept it
- leave `claude-sync-down-branches.yml` and `claude.yml` untouched to avoid undeclared/deprecated input regressions
- add an integration regression that applies the TypeScript workflow templates and verifies the scaffolded callers

Closes #1612

## Verification
- `bun run check:workflow-inputs`
- `bun test tests/integration/lisa.test.ts -t "scaffolds TypeScript Claude callers"`
- `bun run typecheck`
- `bun run build:dist`
- `bun run format:check`
- `bun run build:plugins`
- `bun run check:plugins`
- `bun run lint`
- `bun test tests/integration/lisa.test.ts`
- `bun test tests/unit/scripts/detect-stale-workflow-inputs.test.ts`
- pre-push hook: security audit, slow lint, knip, coverage unit suite, integration suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated Claude workflow configurations now support Bun as the package manager.
  * Automated fixes, code reviews, deployments, complexity checks, coverage checks, and test-improvement workflows consistently use Bun when configured.

* **Tests**
  * Added integration coverage to verify Bun settings are applied to the expected workflows while remaining absent from workflows that do not require package-manager configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->