### PR TITLE
feat(expo): add e2e route/screen coverage gate for Playwright and Maestro

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,7 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -491,6 +491,46 @@ jobs:
           VERIFY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+
+  e2e_coverage:
+    name: 🧭 E2E Route Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Aggregate e2e surface-coverage gate: % of expo-router routes reached by
+    # at least one Playwright spec / Maestro flow, thresholds from
+    # e2e.thresholds.json (default 80% per runner). Auto-enabled by the
+    # presence of the Lisa-managed script (expo projects); a no-op elsewhere.
+    if: ${{ !contains(inputs.skip_jobs, 'e2e_coverage') }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🔍 Check for e2e coverage script
+        id: check_script
+        run: |
+          if [ -f "scripts/check-e2e-coverage.mjs" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧭 Require e2e route/screen coverage thresholds
+        if: steps.check_script.outputs.exists == 'true'
+        run: node scripts/check-e2e-coverage.mjs
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: ⏭️ Skip e2e coverage (no check-e2e-coverage.mjs script)
+        if: steps.check_script.outputs.exists == 'false'
+        run: echo "Skipping e2e route coverage - scripts/check-e2e-coverage.mjs not found"
 
   test_unit:
     name: 🧪 Run Unit Tests

--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+/**
+ * check-e2e-coverage — aggregate e2e route/screen coverage gate (Expo).
+ *
+ * The e2e counterpart of the unit-test coverage thresholds: where Vitest/Jest
+ * gate on line coverage, this gates on SURFACE coverage — the percentage of
+ * expo-router routes exercised by at least one e2e spec, computed per runner:
+ *
+ *   - Playwright: routes visited via `page.goto("<path>")` in e2e specs
+ *     (top-level `e2e/` or nested `tests/e2e/` trees).
+ *   - Maestro: screens opened via `openLink: <deep link>` in `.maestro/` flows.
+ *
+ * Maestro is black-box (no code-coverage hook exists for a compiled native
+ * app), so route coverage is the shared metric both runners can honor. A spec
+ * or flow that reaches a screen by tapping rather than deep-linking can declare
+ * it with an `e2e-route: /path` comment annotation (JS/TS or YAML comment).
+ *
+ * Thresholds default to 80% per runner and are project-tunable via
+ * `e2e.thresholds.json` (create-only, same convention as vitest.thresholds.json):
+ *   { "playwright": { "routes": 80 }, "maestro": { "routes": 80 } }
+ * A runner threshold of 0 disables that runner's gate (logged, never silent).
+ *
+ * Inputs (env, CI-friendly):
+ *   E2E_COVERAGE_ROOT  project root to scan (default: cwd)
+ *
+ * Exit 0 = every runner meets its threshold (or nothing to gate).
+ * Exit 1 = at least one runner is under threshold; uncovered routes are listed.
+ * @module scripts/check-e2e-coverage
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const defaultThresholds = {
+  playwright: { routes: 80 },
+  maestro: { routes: 80 },
+};
+
+const ROUTE_FILE_PATTERN = /\.(?:tsx|ts|jsx|js)$/;
+const SPEC_FILE_PATTERN = /\.(?:tsx|ts|jsx|js|mjs)$/;
+const FLOW_FILE_PATTERN = /\.(?:yaml|yml)$/;
+// `e2e-route: /path` inside any comment declares a route as covered even when
+// the spec reaches it by tapping/navigating rather than by URL or deep link.
+const ROUTE_ANNOTATION_PATTERN = /e2e-route:\s*(\/[^\s'"`,)]*)/g;
+const GOTO_PATTERN = /\.goto\(\s*(["'`])([^"'`]+)\1/g;
+const OPEN_LINK_PATTERN = /openLink:\s*["']?([^\s"']+)/g;
+
+/**
+ * Derive the expo-router route for one file inside the app directory.
+ * Layouts (`_layout`), private files (`_*`), special files (`+not-found`,
+ * `+html`) and API routes (`*+api`) are not navigable screens and return null.
+ * @param {string} relativePath - Path relative to the app directory
+ * @returns {string | null} Route path (e.g. "/profile/[id]"), or null
+ */
+export function routeFromFile(relativePath) {
+  if (!ROUTE_FILE_PATTERN.test(relativePath)) {
+    return null;
+  }
+  const withoutExtension = relativePath.replace(ROUTE_FILE_PATTERN, "");
+  const rawSegments = withoutExtension.split("/");
+  const basename = rawSegments[rawSegments.length - 1];
+  if (basename.startsWith("+") || basename.endsWith("+api")) {
+    return null;
+  }
+  if (rawSegments.some(segment => segment.startsWith("_"))) {
+    return null;
+  }
+  const segments = rawSegments
+    // Route groups like "(tabs)" organize files without affecting the URL.
+    .filter(segment => !(segment.startsWith("(") && segment.endsWith(")")))
+    .filter(segment => segment !== "index");
+  return `/${segments.join("/")}`.replace(/\/+/g, "/");
+}
+
+/**
+ * Enumerate the unique navigable routes for a set of app-directory files.
+ * @param {string[]} files - Paths relative to the app directory
+ * @returns {string[]} Sorted unique route paths
+ */
+export function enumerateRoutes(files) {
+  const routes = files
+    .map(file => routeFromFile(file))
+    .filter(route => route !== null);
+  return [...new Set(routes)].sort();
+}
+
+/**
+ * Normalize a visited URL or deep link to a route-comparable path.
+ * Handles absolute paths, http(s) URLs, custom-scheme deep links
+ * (`myapp://profile/1` → `/profile/1`), and Expo dev-client URLs
+ * (`exp://host:8081/--/profile` → `/profile`).
+ * @param {string} raw - The literal URL/path from a spec or flow
+ * @returns {string | null} Normalized path, or null when not a navigation
+ */
+export function normalizeVisitedPath(raw) {
+  if (!raw) {
+    return null;
+  }
+  const withoutQuery = raw.split(/[?#]/)[0];
+  const devClientSplit = withoutQuery.split("/--/");
+  if (devClientSplit.length > 1) {
+    return normalizeVisitedPath(`/${devClientSplit[1]}`);
+  }
+  const schemeMatch = withoutQuery.match(/^([a-zA-Z][\w+.-]*):\/\/(.*)$/);
+  const pathPart = schemeMatch
+    ? schemeMatch[1] === "http" || schemeMatch[1] === "https"
+      ? // http(s): the first segment is the host, the rest is the path.
+        `/${schemeMatch[2].split("/").slice(1).join("/")}`
+      : // Custom scheme: everything after :// is the route.
+        `/${schemeMatch[2]}`
+    : withoutQuery.startsWith("/")
+      ? withoutQuery
+      : `/${withoutQuery.replace(/^\.\//, "")}`;
+  const collapsed = pathPart.replace(/\/+/g, "/");
+  const trimmed =
+    collapsed.length > 1 ? collapsed.replace(/\/$/, "") : collapsed;
+  return trimmed || "/";
+}
+
+/**
+ * Extract every route-comparable path a Playwright spec visits.
+ * @param {string} source - Spec file contents
+ * @returns {string[]} Normalized visited paths
+ */
+export function extractPlaywrightPaths(source) {
+  const fromGoto = [...source.matchAll(GOTO_PATTERN)].map(match => match[2]);
+  const fromAnnotations = [...source.matchAll(ROUTE_ANNOTATION_PATTERN)].map(
+    match => match[1]
+  );
+  return [...fromGoto, ...fromAnnotations]
+    .map(visited => normalizeVisitedPath(visited))
+    .filter(visited => visited !== null);
+}
+
+/**
+ * Extract every route-comparable path a Maestro flow opens.
+ * @param {string} source - Flow YAML contents
+ * @returns {string[]} Normalized visited paths
+ */
+export function extractMaestroPaths(source) {
+  const fromOpenLink = [...source.matchAll(OPEN_LINK_PATTERN)].map(
+    match => match[1]
+  );
+  const fromAnnotations = [...source.matchAll(ROUTE_ANNOTATION_PATTERN)].map(
+    match => match[1]
+  );
+  return [...fromOpenLink, ...fromAnnotations]
+    .map(visited => normalizeVisitedPath(visited))
+    .filter(visited => visited !== null);
+}
+
+/**
+ * Does a visited path satisfy a route? Dynamic segments (`[id]`) match any
+ * one segment, catch-alls (`[...rest]`) match one or more, and interpolated
+ * spec segments (template `${...}` holes) match any route segment.
+ * @param {string} route - Enumerated route (e.g. "/profile/[id]")
+ * @param {string} visited - Normalized visited path (e.g. "/profile/42")
+ * @returns {boolean} Whether the visit covers the route
+ */
+export function routeMatchesVisit(route, visited) {
+  const routeSegments = route.split("/").filter(Boolean);
+  const visitedSegments = visited.split("/").filter(Boolean);
+  const isCovered = (routeIndex, visitedIndex) => {
+    if (routeIndex === routeSegments.length) {
+      return visitedIndex === visitedSegments.length;
+    }
+    const segment = routeSegments[routeIndex];
+    if (/^\[\.\.\..*\]$/.test(segment)) {
+      return visitedIndex < visitedSegments.length;
+    }
+    if (visitedIndex === visitedSegments.length) {
+      return false;
+    }
+    const visitedSegment = visitedSegments[visitedIndex];
+    const segmentMatches =
+      /^\[.*\]$/.test(segment) ||
+      visitedSegment.includes("${") ||
+      segment === visitedSegment;
+    return segmentMatches && isCovered(routeIndex + 1, visitedIndex + 1);
+  };
+  return isCovered(0, 0);
+}
+
+/**
+ * Merge project threshold overrides over the defaults, per runner.
+ * @param {typeof defaultThresholds} defaults - Baseline thresholds
+ * @param {object} overrides - Contents of e2e.thresholds.json (may be partial)
+ * @returns {typeof defaultThresholds} Effective thresholds
+ */
+export function mergeThresholds(defaults, overrides) {
+  return {
+    playwright: { ...defaults.playwright, ...overrides?.playwright },
+    maestro: { ...defaults.maestro, ...overrides?.maestro },
+  };
+}
+
+/**
+ * Pure decision: does each runner's route coverage meet its threshold?
+ * @param {object} input - Evaluation input
+ * @param {string[]} input.routes - Enumerated app routes
+ * @param {string[]} input.playwrightVisited - Paths Playwright specs visit
+ * @param {string[]} input.maestroVisited - Paths Maestro flows open
+ * @param {typeof defaultThresholds} input.thresholds - Effective thresholds
+ * @returns {{ok: boolean, runners: Record<string, {threshold: number, total: number, covered: number, percentage: number, missing: string[], ok: boolean}>}} Verdict
+ */
+export function evaluateE2eCoverage({
+  routes,
+  playwrightVisited,
+  maestroVisited,
+  thresholds,
+}) {
+  const evaluateRunner = (visited, threshold) => {
+    const missing = routes.filter(
+      route => !visited.some(visit => routeMatchesVisit(route, visit))
+    );
+    const covered = routes.length - missing.length;
+    const percentage =
+      routes.length === 0 ? 100 : (covered / routes.length) * 100;
+    return {
+      threshold,
+      total: routes.length,
+      covered,
+      percentage,
+      missing,
+      ok: threshold === 0 || percentage >= threshold,
+    };
+  };
+  const runners = {
+    playwright: evaluateRunner(playwrightVisited, thresholds.playwright.routes),
+    maestro: evaluateRunner(maestroVisited, thresholds.maestro.routes),
+  };
+  return { ok: runners.playwright.ok && runners.maestro.ok, runners };
+}
+
+/**
+ * Recursively list files under a directory, relative to it.
+ * @param {string} directory - Absolute directory path
+ * @returns {string[]} Relative file paths (posix separators), or [] if absent
+ */
+function listFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+  return fs
+    .readdirSync(directory, { recursive: true, withFileTypes: true })
+    .filter(entry => entry.isFile())
+    .map(entry =>
+      path
+        .relative(directory, path.join(entry.parentPath, entry.name))
+        .split(path.sep)
+        .join("/")
+    );
+}
+
+/**
+ * Read every matching file under the given directories and extract paths.
+ * @param {object} input - Extraction input
+ * @param {string} input.root - Project root
+ * @param {string[]} input.directories - Candidate directories to scan
+ * @param {RegExp} input.filePattern - Which files to read
+ * @param {(source: string) => string[]} input.extract - Path extractor
+ * @returns {string[]} Every visited path found
+ */
+function collectVisitedPaths({ root, directories, filePattern, extract }) {
+  return directories.flatMap(directory => {
+    const absolute = path.join(root, directory);
+    return listFiles(absolute)
+      .filter(file => filePattern.test(file))
+      .flatMap(file =>
+        extract(fs.readFileSync(path.join(absolute, file), "utf8"))
+      );
+  });
+}
+
+/**
+ * CLI entry: scan the project, evaluate, and exit non-zero when under threshold.
+ * @returns {void}
+ */
+function main() {
+  const root = process.env.E2E_COVERAGE_ROOT || process.cwd();
+  const appDir = ["app", "src/app"]
+    .map(candidate => path.join(root, candidate))
+    .find(candidate => fs.existsSync(candidate));
+  if (!appDir) {
+    console.log(
+      "[e2e-coverage] OK: no expo-router app directory found — nothing to gate."
+    );
+    return;
+  }
+  const routes = enumerateRoutes(listFiles(appDir));
+  if (routes.length === 0) {
+    console.log("[e2e-coverage] OK: no navigable routes — nothing to gate.");
+    return;
+  }
+
+  const thresholdsFile = path.join(root, "e2e.thresholds.json");
+  const overrides = fs.existsSync(thresholdsFile)
+    ? JSON.parse(fs.readFileSync(thresholdsFile, "utf8"))
+    : {};
+  const thresholds = mergeThresholds(defaultThresholds, overrides);
+
+  const result = evaluateE2eCoverage({
+    routes,
+    playwrightVisited: collectVisitedPaths({
+      root,
+      directories: ["e2e", "tests/e2e"],
+      filePattern: SPEC_FILE_PATTERN,
+      extract: extractPlaywrightPaths,
+    }),
+    maestroVisited: collectVisitedPaths({
+      root,
+      directories: [".maestro"],
+      filePattern: FLOW_FILE_PATTERN,
+      extract: extractMaestroPaths,
+    }),
+    thresholds,
+  });
+
+  for (const [runner, verdict] of Object.entries(result.runners)) {
+    const summary = `${verdict.covered}/${verdict.total} routes (${verdict.percentage.toFixed(1)}% vs ${verdict.threshold}% required)`;
+    if (verdict.threshold === 0) {
+      console.log(
+        `[e2e-coverage] ${runner}: gate disabled (threshold 0) — ${summary}`
+      );
+    } else if (verdict.ok) {
+      console.log(`[e2e-coverage] ${runner}: OK — ${summary}`);
+    } else {
+      console.error(`[e2e-coverage] ${runner}: FAIL — ${summary}`);
+      console.error(
+        `[e2e-coverage] ${runner}: screens with no e2e test yet:\n` +
+          verdict.missing.map(route => `  - ${route}`).join("\n")
+      );
+    }
+  }
+  if (!result.ok) {
+    console.error(
+      "[e2e-coverage] FAIL: some screens have no end-to-end test. Add a Playwright spec (page.goto) or Maestro flow (openLink) that reaches each screen listed above, add an `e2e-route: /path` comment to a spec that already reaches it by navigation, or adjust e2e.thresholds.json."
+    );
+    process.exit(1);
+  }
+  console.log("[e2e-coverage] OK");
+}
+
+// Run only when invoked directly — importing for tests must have no side effects.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -233,6 +233,25 @@ export function evaluateE2eCoverage({
 }
 
 /**
+ * Load project threshold overrides from `e2e.thresholds.json`, if present.
+ * Malformed JSON is a readable, operator-facing failure rather than an
+ * uncaught SyntaxError and stack trace.
+ * @param {string} thresholdsFile - Absolute path to the thresholds file
+ * @returns {object} Parsed overrides, or {} when the file is absent
+ * @throws {Error} When the file exists but is not valid JSON
+ */
+export function loadThresholdOverrides(thresholdsFile) {
+  if (!fs.existsSync(thresholdsFile)) {
+    return {};
+  }
+  try {
+    return JSON.parse(fs.readFileSync(thresholdsFile, "utf8"));
+  } catch (error) {
+    throw new Error(`e2e.thresholds.json is not valid JSON — ${error.message}`);
+  }
+}
+
+/**
  * Recursively list files under a directory, relative to it.
  * @param {string} directory - Absolute directory path
  * @returns {string[]} Relative file paths (posix separators), or [] if absent
@@ -294,9 +313,14 @@ function main() {
   }
 
   const thresholdsFile = path.join(root, "e2e.thresholds.json");
-  const overrides = fs.existsSync(thresholdsFile)
-    ? JSON.parse(fs.readFileSync(thresholdsFile, "utf8"))
-    : {};
+  let overrides;
+  try {
+    overrides = loadThresholdOverrides(thresholdsFile);
+  } catch (error) {
+    console.error(`[e2e-coverage] FAIL: ${error.message}`);
+    process.exit(1);
+    return;
+  }
   const thresholds = mergeThresholds(defaultThresholds, overrides);
 
   const result = evaluateE2eCoverage({

--- a/expo/create-only/e2e.thresholds.json
+++ b/expo/create-only/e2e.thresholds.json
@@ -1,0 +1,8 @@
+{
+  "playwright": {
+    "routes": 80
+  },
+  "maestro": {
+    "routes": 80
+  }
+}

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -108,6 +108,13 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
     description: "Test coverage floors (statements/branches/functions/lines)",
   },
   {
+    key: "quality.e2eCoverage",
+    defaultValue: { playwright: { routes: 80 }, maestro: { routes: 80 } },
+    artifacts: [{ file: "e2e.thresholds.json", pointer: "" }],
+    description:
+      "E2E route/screen coverage floors (Playwright web routes, Maestro screens)",
+  },
+  {
     key: "quality.lintBudgets",
     defaultValue: {
       cognitiveComplexity: 10,

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the aggregate e2e route/screen coverage gate and its wiring.
+ * The e2e counterpart of unit-test coverage thresholds: Playwright and
+ * Maestro each must reach a configurable percentage of expo-router routes.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT_REL = "expo/copy-overwrite/scripts/check-e2e-coverage.mjs";
+const THRESHOLDS_REL = "expo/create-only/e2e.thresholds.json";
+const PLAYERS_ROUTE = "/players/[id]";
+const DOCS_ROUTE = "/docs/[...slug]";
+const PLAYERS_VISIT = "/players/42";
+
+/**
+ * Read a repo-relative text file.
+ * @param relativePath - Repo-relative path
+ * @returns File contents
+ */
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+/** Per-runner thresholds accepted by the evaluator. */
+interface E2eThresholds {
+  readonly playwright: { readonly routes: number };
+  readonly maestro: { readonly routes: number };
+}
+/** Per-runner verdict from the evaluator. */
+interface RunnerVerdict {
+  readonly threshold: number;
+  readonly total: number;
+  readonly covered: number;
+  readonly percentage: number;
+  readonly missing: string[];
+  readonly ok: boolean;
+}
+/** Whole-gate verdict from the evaluator. */
+interface E2eCoverageResult {
+  readonly ok: boolean;
+  readonly runners: Record<"playwright" | "maestro", RunnerVerdict>;
+}
+
+describe("check-e2e-coverage", () => {
+  // Dynamic import via a runtime URL keeps this typed as `any` (no .mjs decls).
+  let routeFromFile: (relativePath: string) => string | null;
+  let enumerateRoutes: (files: string[]) => string[];
+  let normalizeVisitedPath: (raw: string) => string | null;
+  let extractPlaywrightPaths: (source: string) => string[];
+  let extractMaestroPaths: (source: string) => string[];
+  let routeMatchesVisit: (route: string, visited: string) => boolean;
+  let mergeThresholds: (
+    defaults: E2eThresholds,
+    overrides: object
+  ) => E2eThresholds;
+  let evaluateE2eCoverage: (input: {
+    routes: string[];
+    playwrightVisited: string[];
+    maestroVisited: string[];
+    thresholds: E2eThresholds;
+  }) => E2eCoverageResult;
+  let defaultThresholds: E2eThresholds;
+
+  beforeAll(async () => {
+    const url = pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href;
+    const mod = await import(url);
+    routeFromFile = mod.routeFromFile;
+    enumerateRoutes = mod.enumerateRoutes;
+    normalizeVisitedPath = mod.normalizeVisitedPath;
+    extractPlaywrightPaths = mod.extractPlaywrightPaths;
+    extractMaestroPaths = mod.extractMaestroPaths;
+    routeMatchesVisit = mod.routeMatchesVisit;
+    mergeThresholds = mod.mergeThresholds;
+    evaluateE2eCoverage = mod.evaluateE2eCoverage;
+    defaultThresholds = mod.defaultThresholds;
+  });
+
+  describe("route enumeration", () => {
+    it("maps index files to their parent path", () => {
+      expect(routeFromFile("index.tsx")).toBe("/");
+      expect(routeFromFile("profile/index.tsx")).toBe("/profile");
+    });
+
+    it("strips route groups from the URL", () => {
+      expect(routeFromFile("(tabs)/home.tsx")).toBe("/home");
+      expect(routeFromFile("(app)/(tabs)/settings/index.tsx")).toBe(
+        "/settings"
+      );
+    });
+
+    it("keeps dynamic and catch-all segments", () => {
+      expect(routeFromFile("players/[id].tsx")).toBe(PLAYERS_ROUTE);
+      expect(routeFromFile("docs/[...slug].tsx")).toBe(DOCS_ROUTE);
+    });
+
+    it("excludes layouts, private files, special files, and API routes", () => {
+      expect(routeFromFile("_layout.tsx")).toBeNull();
+      expect(routeFromFile("(tabs)/_layout.tsx")).toBeNull();
+      expect(routeFromFile("_private/helper.tsx")).toBeNull();
+      expect(routeFromFile("+not-found.tsx")).toBeNull();
+      expect(routeFromFile("+html.tsx")).toBeNull();
+      expect(routeFromFile("api/users+api.ts")).toBeNull();
+      expect(routeFromFile("styles.css")).toBeNull();
+    });
+
+    it("dedupes routes that collapse to the same URL", () => {
+      expect(
+        enumerateRoutes(["(a)/home.tsx", "(b)/home.tsx", "_layout.tsx"])
+      ).toEqual(["/home"]);
+    });
+  });
+
+  describe("visited path normalization", () => {
+    it("passes through absolute paths and strips query/hash and trailing slash", () => {
+      expect(normalizeVisitedPath("/profile?tab=1#top")).toBe("/profile");
+      expect(normalizeVisitedPath("/profile/")).toBe("/profile");
+      expect(normalizeVisitedPath("/")).toBe("/");
+    });
+
+    it("takes the path of http(s) URLs", () => {
+      expect(normalizeVisitedPath("https://example.com/players/42")).toBe(
+        PLAYERS_VISIT
+      );
+      expect(normalizeVisitedPath("https://example.com")).toBe("/");
+    });
+
+    it("treats everything after :// as the route for custom schemes", () => {
+      expect(normalizeVisitedPath("myapp://profile/42")).toBe("/profile/42");
+    });
+
+    it("uses the /--/ suffix of Expo dev-client URLs", () => {
+      expect(normalizeVisitedPath("exp://127.0.0.1:8081/--/settings")).toBe(
+        "/settings"
+      );
+    });
+  });
+
+  describe("extraction", () => {
+    it("extracts page.goto targets and e2e-route annotations from specs", () => {
+      const source = [
+        'await page.goto("/home");',
+        "await page.goto(`/players/${playerId}`);",
+        "// e2e-route: /settings (reached by tapping the gear icon)",
+      ].join("\n");
+      expect(extractPlaywrightPaths(source)).toEqual([
+        "/home",
+        "/players/${playerId}",
+        "/settings",
+      ]);
+    });
+
+    it("extracts openLink targets and e2e-route annotations from flows", () => {
+      const source = [
+        "appId: com.example.app",
+        "---",
+        '- openLink: "myapp://players/42"',
+        "# e2e-route: /settings",
+      ].join("\n");
+      expect(extractMaestroPaths(source)).toEqual([PLAYERS_VISIT, "/settings"]);
+    });
+  });
+
+  describe("route matching", () => {
+    it("matches literal routes exactly", () => {
+      expect(routeMatchesVisit("/home", "/home")).toBe(true);
+      expect(routeMatchesVisit("/home", "/home/extra")).toBe(false);
+      expect(routeMatchesVisit("/home/extra", "/home")).toBe(false);
+    });
+
+    it("matches dynamic segments against any value", () => {
+      expect(routeMatchesVisit(PLAYERS_ROUTE, PLAYERS_VISIT)).toBe(true);
+      expect(routeMatchesVisit(PLAYERS_ROUTE, "/players")).toBe(false);
+    });
+
+    it("matches catch-all segments against one or more segments", () => {
+      expect(routeMatchesVisit(DOCS_ROUTE, "/docs/a/b")).toBe(true);
+      expect(routeMatchesVisit(DOCS_ROUTE, "/docs")).toBe(false);
+    });
+
+    it("treats template-literal holes as wildcards", () => {
+      expect(routeMatchesVisit(PLAYERS_ROUTE, "/players/${playerId}")).toBe(
+        true
+      );
+    });
+  });
+
+  describe("threshold merge", () => {
+    it("defaults both runners to 80% route coverage", () => {
+      expect(defaultThresholds).toEqual({
+        playwright: { routes: 80 },
+        maestro: { routes: 80 },
+      });
+    });
+
+    it("overlays partial project overrides per runner", () => {
+      expect(
+        mergeThresholds(defaultThresholds, { maestro: { routes: 50 } })
+      ).toEqual({ playwright: { routes: 80 }, maestro: { routes: 50 } });
+    });
+  });
+
+  describe("evaluation", () => {
+    it("passes when both runners meet their thresholds", () => {
+      const result = evaluateE2eCoverage({
+        routes: ["/home", PLAYERS_ROUTE],
+        playwrightVisited: ["/home", "/players/1"],
+        maestroVisited: ["/home", "/players/1"],
+        thresholds: defaultThresholds,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.runners.playwright.percentage).toBe(100);
+    });
+
+    it("fails the runner under threshold and lists uncovered routes", () => {
+      const result = evaluateE2eCoverage({
+        routes: ["/home", "/settings"],
+        playwrightVisited: ["/home", "/settings"],
+        maestroVisited: ["/home"],
+        thresholds: defaultThresholds,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.runners.playwright.ok).toBe(true);
+      expect(result.runners.maestro.ok).toBe(false);
+      expect(result.runners.maestro.missing).toEqual(["/settings"]);
+      expect(result.runners.maestro.percentage).toBe(50);
+    });
+
+    it("passes trivially with zero routes", () => {
+      const result = evaluateE2eCoverage({
+        routes: [],
+        playwrightVisited: [],
+        maestroVisited: [],
+        thresholds: defaultThresholds,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.runners.playwright.percentage).toBe(100);
+    });
+
+    it("disables a runner's gate at threshold 0 without hiding its numbers", () => {
+      const result = evaluateE2eCoverage({
+        routes: ["/home"],
+        playwrightVisited: ["/home"],
+        maestroVisited: [],
+        thresholds: { playwright: { routes: 80 }, maestro: { routes: 0 } },
+      });
+      expect(result.ok).toBe(true);
+      expect(result.runners.maestro.percentage).toBe(0);
+      expect(result.runners.maestro.missing).toEqual(["/home"]);
+    });
+  });
+
+  describe("wiring", () => {
+    it("ships the gate script as a managed expo script", () => {
+      expect(fs.existsSync(path.join(REPO_ROOT, SCRIPT_REL))).toBe(true);
+    });
+
+    it("ships the project-tunable thresholds file at the 80% default", () => {
+      const thresholds = JSON.parse(read(THRESHOLDS_REL));
+      expect(thresholds).toEqual({
+        playwright: { routes: 80 },
+        maestro: { routes: 80 },
+      });
+    });
+
+    it("wires the e2e_coverage CI job behind script presence", () => {
+      const workflow = read(".github/workflows/quality.yml");
+      expect(workflow).toContain("e2e_coverage:");
+      expect(workflow).toContain("check-e2e-coverage.mjs");
+      expect(workflow).toContain("!contains(inputs.skip_jobs, 'e2e_coverage')");
+    });
+
+    it("registers the thresholds artifact in the sync registry", () => {
+      const registry = read("src/sync/registry.ts");
+      expect(registry).toContain("quality.e2eCoverage");
+      expect(registry).toContain("e2e.thresholds.json");
+    });
+  });
+});

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -5,12 +5,14 @@
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPT_REL = "expo/copy-overwrite/scripts/check-e2e-coverage.mjs";
-const THRESHOLDS_REL = "expo/create-only/e2e.thresholds.json";
+const THRESHOLDS_FILENAME = "e2e.thresholds.json";
+const THRESHOLDS_REL = `expo/create-only/${THRESHOLDS_FILENAME}`;
 const PLAYERS_ROUTE = "/players/[id]";
 const DOCS_ROUTE = "/docs/[...slug]";
 const PLAYERS_VISIT = "/players/42";
@@ -63,6 +65,7 @@ describe("check-e2e-coverage", () => {
     thresholds: E2eThresholds;
   }) => E2eCoverageResult;
   let defaultThresholds: E2eThresholds;
+  let loadThresholdOverrides: (thresholdsFile: string) => object;
 
   beforeAll(async () => {
     const url = pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href;
@@ -76,6 +79,7 @@ describe("check-e2e-coverage", () => {
     mergeThresholds = mod.mergeThresholds;
     evaluateE2eCoverage = mod.evaluateE2eCoverage;
     defaultThresholds = mod.defaultThresholds;
+    loadThresholdOverrides = mod.loadThresholdOverrides;
   });
 
   describe("route enumeration", () => {
@@ -199,6 +203,34 @@ describe("check-e2e-coverage", () => {
       expect(
         mergeThresholds(defaultThresholds, { maestro: { routes: 50 } })
       ).toEqual({ playwright: { routes: 80 }, maestro: { routes: 50 } });
+    });
+  });
+
+  describe("threshold file loading", () => {
+    it("returns an empty object when the thresholds file is absent", () => {
+      const missingFile = path.join(
+        os.tmpdir(),
+        "e2e-coverage-test-missing-thresholds.json"
+      );
+      expect(loadThresholdOverrides(missingFile)).toEqual({});
+    });
+
+    it("parses valid JSON thresholds", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-coverage-test-"));
+      const file = path.join(dir, THRESHOLDS_FILENAME);
+      fs.writeFileSync(file, JSON.stringify({ maestro: { routes: 50 } }));
+      expect(loadThresholdOverrides(file)).toEqual({
+        maestro: { routes: 50 },
+      });
+    });
+
+    it("throws a readable error instead of an uncaught SyntaxError on malformed JSON", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-coverage-test-"));
+      const file = path.join(dir, THRESHOLDS_FILENAME);
+      fs.writeFileSync(file, "{ not valid json");
+      expect(() => loadThresholdOverrides(file)).toThrow(
+        /e2e\.thresholds\.json is not valid JSON/
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds an aggregate e2e **surface-coverage** gate for the expo stack — the e2e counterpart of the vitest/jest/rspec coverage thresholds. Instead of line coverage (impossible for black-box Maestro), it gates on the percentage of expo-router routes reached by at least one Playwright spec (`page.goto` / `e2e-route:` annotation) and one Maestro flow (`openLink` / `e2e-route:` annotation), **80% per runner by default**.
- Ships the same defaults + project-override convention as the unit-test thresholds: a Lisa-managed gate script (`expo/copy-overwrite/scripts/check-e2e-coverage.mjs`) plus a project-tunable `expo/create-only/e2e.thresholds.json` (a runner threshold of `0` disables that runner's gate, logged rather than silent).
- Wires a new `e2e_coverage` job into `quality.yml` — auto-enabled by script presence, so only expo projects gate and every other stack no-ops; skippable via `skip_jobs: e2e_coverage`. Registers `quality.e2eCoverage` in the `lisa sync` registry mapping to the thresholds artifact.

## Test plan

- `tests/unit/scripts/e2e-coverage.test.ts` (25 tests): route enumeration (groups, dynamic/catch-all segments, layout/private/special/API exclusions, dedupe), URL/deep-link normalization (http(s), custom schemes, Expo dev-client `/--/` URLs), extraction from specs and flows, dynamic-segment matching, threshold merge, evaluator verdicts, and CI/registry wiring.
- Empirically exercised the script against a synthetic expo project: fails at 66.7% Maestro coverage listing the uncovered screen, passes once a flow covers it, and no-ops cleanly when no expo-router app directory exists.
- Full unit suite (3825 tests), lint, typecheck, and prettier all green.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated end-to-end route and screen coverage checks for Playwright and Maestro tests.
  * Coverage thresholds default to 80% and can be customized through configuration.
  * Reports covered and missing routes for each test runner.

* **Quality**
  * Integrated the coverage gate into CI, with support for skipping the check when needed.
  * Added validation to ensure coverage configuration and CI integration remain correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->