### PR TITLE
feat(expo): reusable Maestro native e2e workflow on GitHub runners

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -1,0 +1,430 @@
+# Maestro Native E2E — reusable workflow
+#
+# Native (iOS + Android) e2e suite on GitHub-hosted runners: an Android
+# emulator on ubuntu-latest and an iOS simulator on macos-15. This is the
+# self-hosted sibling of quality.yml's maestro_e2e job, which only supports
+# Maestro Cloud and needs a paid mobile.dev account (MAESTRO_API_KEY). This
+# workflow needs only EXPO_TOKEN: binaries are built by EAS with a dedicated
+# e2e profile (default `dev-e2e` in the project's eas.json — typically a
+# non-dev-client build against the dev backend, analytics capture disabled,
+# and its own update channel so the app never pulls an OTA over the code
+# under test).
+#
+# Cadence lives in the CALLER (schedule in a reusable workflow would fire in
+# the Lisa repo, not the project). Projects get a thin caller template with a
+# nightly cron + workflow_dispatch platform picker; see
+# expo/create-only/.github/workflows/maestro-e2e.yml.
+#
+# Environment contract: every env var named MAESTRO_* that exists after the
+# `maestro_env` input is applied and `setup_command` has run is forwarded to
+# the flows as `-e` variables. Values must not contain whitespace. The
+# platform app id inputs are forwarded as MAESTRO_APP_ID per platform (they
+# may legitimately differ — e.g. `app_dev` on Android vs `app-dev` on iOS).
+#
+# Graceful degradation: when EXPO_TOKEN is not provisioned or the flows
+# directory does not exist, every job skips with a warning instead of
+# failing, so this workflow is safe to install fleet-wide before a project
+# has wired its e2e harness.
+
+name: 📱 Maestro Native E2E
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform(s) to run: all, android, or ios'
+        required: false
+        default: 'all'
+        type: string
+      eas_profile:
+        description: 'EAS build profile for the e2e binaries (must exist in eas.json)'
+        required: false
+        default: 'dev-e2e'
+        type: string
+      flows_dir:
+        description: 'Maestro flows directory'
+        required: false
+        default: '.maestro/flows'
+        type: string
+      android_app_id:
+        description: 'Android application id, forwarded to flows as MAESTRO_APP_ID'
+        required: false
+        default: ''
+        type: string
+      ios_app_id:
+        description: 'iOS bundle identifier, forwarded to flows as MAESTRO_APP_ID'
+        required: false
+        default: ''
+        type: string
+      android_exclude_tags:
+        description: 'Comma-separated flow tags to exclude on Android'
+        required: false
+        default: 'ios-only'
+        type: string
+      ios_exclude_tags:
+        description: 'Comma-separated flow tags to exclude on iOS'
+        required: false
+        default: 'android-only'
+        type: string
+      maestro_env:
+        description: 'Newline-separated KEY=VALUE pairs exported before the run; MAESTRO_* keys are forwarded to flows'
+        required: false
+        default: ''
+        type: string
+      setup_command:
+        description: 'Shell command run in each test job before maestro test (e.g. resolve dynamic seed data); export values for flows by appending MAESTRO_* lines to $GITHUB_ENV'
+        required: false
+        default: ''
+        type: string
+      node_version:
+        description: 'Node.js version for setup_command tooling'
+        required: false
+        default: '22.21.1'
+        type: string
+      package_manager:
+        description: 'Package manager to use (npm, yarn, or bun)'
+        required: false
+        default: 'bun'
+        type: string
+    secrets:
+      EXPO_TOKEN:
+        description: 'Expo token for EAS builds. When absent, the whole suite skips with a warning.'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: 🔍 Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      run_android: ${{ steps.check.outputs.run_android }}
+      run_ios: ${{ steps.check.outputs.run_ios }}
+      platforms: ${{ steps.check.outputs.platforms }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔍 Check prerequisites and compute platform matrix
+        id: check
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          PLATFORM: ${{ inputs.platform }}
+          FLOWS_DIR: ${{ inputs.flows_dir }}
+        run: |
+          should_run=true
+          if [[ -z "${EXPO_TOKEN// }" ]]; then
+            echo "::warning::Maestro native e2e skipped - EXPO_TOKEN not configured"
+            should_run=false
+          fi
+          if [[ ! -d "$FLOWS_DIR" ]]; then
+            echo "::warning::Maestro native e2e skipped - flows directory '$FLOWS_DIR' not found"
+            should_run=false
+          fi
+          case "$PLATFORM" in
+            android) platforms='["android"]' ;;
+            ios) platforms='["ios"]' ;;
+            *) platforms='["android","ios"]' ;;
+          esac
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+          if [[ "$should_run" == "true" && "$platforms" == *'"android"'* ]]; then
+            echo "run_android=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_android=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "$should_run" == "true" && "$platforms" == *'"ios"'* ]]; then
+            echo "run_ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_ios=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: 🏗️ EAS Build (${{ matrix.platform }})
+    needs: preflight
+    if: ${{ needs.preflight.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.preflight.outputs.platforms) }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 🥟 Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 📦 Install dependencies
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+
+      - name: 🔧 Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          packager: ${{ inputs.package_manager }}
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 🏗️ Build with EAS (${{ inputs.eas_profile }} profile)
+        # Deliberately NO `pre-build:eas` here: that script regenerates
+        # .easignore from .gitignore, whose `google-services*.json` line then
+        # excludes the committed google-services JSON from the EAS upload and
+        # the Android build dies with MISSING_GOOGLE_SERVICES_JSON. The
+        # committed .easignore is authoritative and is what the release
+        # pipeline uses.
+        run: |
+          eas build \
+            --platform ${{ matrix.platform }} \
+            --profile ${{ inputs.eas_profile }} \
+            --non-interactive \
+            --wait \
+            --json > build.json
+          BUILD_URL=$(jq -r '.[0].artifacts.buildUrl' build.json)
+          if [[ -z "$BUILD_URL" || "$BUILD_URL" == "null" ]]; then
+            echo "::error::EAS build produced no artifact URL"
+            jq '.' build.json
+            exit 1
+          fi
+          if [[ "${{ matrix.platform }}" == "android" ]]; then
+            curl -fsSL "$BUILD_URL" -o app-android.apk
+          else
+            # iOS simulator builds ship as a tarball containing the .app bundle
+            curl -fsSL "$BUILD_URL" -o app-ios.tar.gz
+          fi
+
+      - name: 📤 Upload app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ matrix.platform }}
+          path: |
+            app-android.apk
+            app-ios.tar.gz
+          if-no-files-found: error
+          retention-days: 3
+
+  android:
+    name: 🤖 Maestro Android
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # !cancelled(): `needs: build` is a matrix job, so one platform's build
+    # failure marks the whole job failed and would skip BOTH test jobs. Run
+    # whenever this platform's artifact might exist — if its own build leg
+    # failed, the download-artifact step fails fast with a clear error.
+    if: ${{ !cancelled() && needs.preflight.outputs.run_android == 'true' }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 📥 Download app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-android
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: ☕ Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: 🧰 Install Maestro
+        run: |
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: 🔓 Enable KVM for emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: 🧩 Apply maestro_env
+        if: inputs.maestro_env != ''
+        env:
+          MAESTRO_ENV_INPUT: ${{ inputs.maestro_env }}
+        run: |
+          while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* ]] && continue
+            echo "$line" >> "$GITHUB_ENV"
+          done <<< "$MAESTRO_ENV_INPUT"
+
+      - name: 🎯 Run setup command
+        # Project-specific dynamic test data (e.g. resolving a seed entity id
+        # from the dev backend). The command exports values for the flows by
+        # appending MAESTRO_*=value lines to $GITHUB_ENV; a failure here fails
+        # the run rather than letting flows interpolate empty values.
+        if: inputs.setup_command != ''
+        run: ${{ inputs.setup_command }}
+
+      - name: 🧮 Assemble Maestro flags
+        env:
+          MAESTRO_APP_ID: ${{ inputs.android_app_id }}
+          EXCLUDE_TAGS: ${{ inputs.android_exclude_tags }}
+        run: |
+          ARGS=""
+          if [[ -n "$EXCLUDE_TAGS" ]]; then
+            ARGS="--exclude-tags=$EXCLUDE_TAGS"
+          fi
+          while IFS='=' read -r key value; do
+            [[ -z "$key" || -z "$value" || "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+            ARGS="$ARGS -e $key=$value"
+          done < <(env | grep '^MAESTRO_' | sort)
+          echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
+
+      - name: 📱 Run Maestro flows on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          disable-animations: true
+          # android-emulator-runner executes each script LINE as a separate
+          # `sh -c` command, so backslash line-continuations do not survive —
+          # a multi-line `maestro test ... \` runs bare and Maestro treats the
+          # trailing `\` as a flow path ("Flow path does not exist"). Keep
+          # each command on ONE line.
+          script: |
+            adb install app-android.apk
+            maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}
+
+      - name: 📤 Upload Maestro debug output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-android-results
+          path: |
+            maestro-android-report.xml
+            maestro-debug
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ios:
+    name: 🍎 Maestro iOS
+    needs: [preflight, build]
+    runs-on: macos-15
+    timeout-minutes: 90
+    # !cancelled(): see the android job — don't let the other platform's
+    # build failure skip this platform's tests.
+    if: ${{ !cancelled() && needs.preflight.outputs.run_ios == 'true' }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 📥 Download app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-ios
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🧰 Install Maestro
+        run: |
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: 📱 Boot simulator and install app
+        run: |
+          mkdir -p ios-app && tar -xzf app-ios.tar.gz -C ios-app
+          APP_PATH=$(find ios-app -maxdepth 2 -name "*.app" -print -quit)
+          if [[ -z "$APP_PATH" ]]; then
+            echo "::error::No .app bundle found in EAS artifact"
+            find ios-app -maxdepth 3 -print
+            exit 1
+          fi
+          # Boot the first available iPhone simulator on the runner's Xcode.
+          UDID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices[] | .[] | select(.name | test("^iPhone"))][0].udid')
+          if [[ -z "$UDID" || "$UDID" == "null" ]]; then
+            echo "::error::No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          xcrun simctl boot "$UDID" || true # already-booted is fine
+          xcrun simctl bootstatus "$UDID"
+          xcrun simctl install "$UDID" "$APP_PATH"
+
+      - name: 🧩 Apply maestro_env
+        if: inputs.maestro_env != ''
+        env:
+          MAESTRO_ENV_INPUT: ${{ inputs.maestro_env }}
+        run: |
+          while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* ]] && continue
+            echo "$line" >> "$GITHUB_ENV"
+          done <<< "$MAESTRO_ENV_INPUT"
+
+      - name: 🎯 Run setup command
+        # See the android job — the command appends MAESTRO_* lines to
+        # $GITHUB_ENV and a failure fails the run.
+        if: inputs.setup_command != ''
+        run: ${{ inputs.setup_command }}
+
+      - name: 🧮 Assemble Maestro flags
+        env:
+          MAESTRO_APP_ID: ${{ inputs.ios_app_id }}
+          EXCLUDE_TAGS: ${{ inputs.ios_exclude_tags }}
+        run: |
+          ARGS=""
+          if [[ -n "$EXCLUDE_TAGS" ]]; then
+            ARGS="--exclude-tags=$EXCLUDE_TAGS"
+          fi
+          while IFS='=' read -r key value; do
+            [[ -z "$key" || -z "$value" || "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+            ARGS="$ARGS -e $key=$value"
+          done < <(env | grep '^MAESTRO_' | sort)
+          echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
+
+      - name: 📱 Run Maestro flows on simulator
+        run: |
+          # MAESTRO_E2E_ARGS is a flag list that needs word splitting.
+          # shellcheck disable=SC2086
+          maestro test ${{ inputs.flows_dir }} \
+            $MAESTRO_E2E_ARGS \
+            --format junit \
+            --output maestro-ios-report.xml \
+            --debug-output maestro-debug
+
+      - name: 📤 Upload Maestro debug output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-ios-results
+          path: |
+            maestro-ios-report.xml
+            maestro-debug
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -15,11 +15,14 @@
 # nightly cron + workflow_dispatch platform picker; see
 # expo/create-only/.github/workflows/maestro-e2e.yml.
 #
-# Environment contract: every env var named MAESTRO_* that exists after the
-# `maestro_env` input is applied and `setup_command` has run is forwarded to
-# the flows as `-e` variables. Values must not contain whitespace. The
-# platform app id inputs are forwarded as MAESTRO_APP_ID per platform (they
-# may legitimately differ — e.g. `app_dev` on Android vs `app-dev` on iOS).
+# Environment contract: forwarded to the flows as `-e` variables are (1)
+# every key declared in the `maestro_env` input, (2) every key declared in
+# the MAESTRO_SECRET_ENV secret (same KEY=VALUE format, for sensitive values
+# like test-account passwords — GitHub masks each line in logs), and (3)
+# every env var named MAESTRO_* after `setup_command` has run. Values must
+# not contain whitespace. The platform app id inputs are forwarded as
+# MAESTRO_APP_ID per platform (they may legitimately differ — e.g. `app_dev`
+# on Android vs `app-dev` on iOS).
 #
 # Graceful degradation: when EXPO_TOKEN is not provisioned or the flows
 # directory does not exist, every job skips with a warning instead of
@@ -89,6 +92,9 @@ on:
     secrets:
       EXPO_TOKEN:
         description: 'Expo token for EAS builds. When absent, the whole suite skips with a warning.'
+        required: false
+      MAESTRO_SECRET_ENV:
+        description: 'Newline-separated KEY=VALUE pairs of sensitive flow variables (e.g. test-account passwords), forwarded like maestro_env. GitHub masks each line in logs.'
         required: false
 
 permissions:
@@ -267,15 +273,17 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: 🧩 Apply maestro_env
-        if: inputs.maestro_env != ''
+      - name: 🧩 Apply maestro env
+        # E2E_* names (not MAESTRO_*) so the multiline inputs never leak into
+        # the MAESTRO_* scan in the assemble step below.
         env:
-          MAESTRO_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
-          while IFS= read -r line; do
-            [[ -z "$line" || "$line" == \#* ]] && continue
+          printf '%s\n%s\n' "$E2E_ENV_INPUT" "$E2E_SECRET_ENV_INPUT" | while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
             echo "$line" >> "$GITHUB_ENV"
-          done <<< "$MAESTRO_ENV_INPUT"
+          done
 
       - name: 🎯 Run setup command
         # Project-specific dynamic test data (e.g. resolving a seed entity id
@@ -289,15 +297,25 @@ jobs:
         env:
           MAESTRO_APP_ID: ${{ inputs.android_app_id }}
           EXCLUDE_TAGS: ${{ inputs.android_exclude_tags }}
+          E2E_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
           ARGS=""
           if [[ -n "$EXCLUDE_TAGS" ]]; then
             ARGS="--exclude-tags=$EXCLUDE_TAGS"
           fi
-          while IFS='=' read -r key value; do
-            [[ -z "$key" || -z "$value" || "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+          KEYS=$(
+            {
+              printf '%s\n%s\n' "$E2E_ENV_INPUT" "$E2E_SECRET_ENV_INPUT" | grep '=' | grep -v '^#' | cut -d= -f1
+              env | grep -o '^MAESTRO_[A-Za-z0-9_]*'
+            } | sort -u
+          )
+          for key in $KEYS; do
+            [[ "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+            value="${!key}"
+            [[ -z "$value" ]] && continue
             ARGS="$ARGS -e $key=$value"
-          done < <(env | grep '^MAESTRO_' | sort)
+          done
           echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
 
       - name: 📱 Run Maestro flows on emulator
@@ -377,15 +395,17 @@ jobs:
           xcrun simctl bootstatus "$UDID"
           xcrun simctl install "$UDID" "$APP_PATH"
 
-      - name: 🧩 Apply maestro_env
-        if: inputs.maestro_env != ''
+      - name: 🧩 Apply maestro env
+        # See the android job — E2E_* names keep the multiline inputs out of
+        # the MAESTRO_* scan.
         env:
-          MAESTRO_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
-          while IFS= read -r line; do
-            [[ -z "$line" || "$line" == \#* ]] && continue
+          printf '%s\n%s\n' "$E2E_ENV_INPUT" "$E2E_SECRET_ENV_INPUT" | while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
             echo "$line" >> "$GITHUB_ENV"
-          done <<< "$MAESTRO_ENV_INPUT"
+          done
 
       - name: 🎯 Run setup command
         # See the android job — the command appends MAESTRO_* lines to
@@ -397,15 +417,25 @@ jobs:
         env:
           MAESTRO_APP_ID: ${{ inputs.ios_app_id }}
           EXCLUDE_TAGS: ${{ inputs.ios_exclude_tags }}
+          E2E_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
           ARGS=""
           if [[ -n "$EXCLUDE_TAGS" ]]; then
             ARGS="--exclude-tags=$EXCLUDE_TAGS"
           fi
-          while IFS='=' read -r key value; do
-            [[ -z "$key" || -z "$value" || "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+          KEYS=$(
+            {
+              printf '%s\n%s\n' "$E2E_ENV_INPUT" "$E2E_SECRET_ENV_INPUT" | grep '=' | grep -v '^#' | cut -d= -f1
+              env | grep -o '^MAESTRO_[A-Za-z0-9_]*'
+            } | sort -u
+          )
+          for key in $KEYS; do
+            [[ "$key" == "MAESTRO_E2E_ARGS" ]] && continue
+            value="${!key}"
+            [[ -z "$value" ]] && continue
             ARGS="$ARGS -e $key=$value"
-          done < <(env | grep '^MAESTRO_' | sort)
+          done
           echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
 
       - name: 📱 Run Maestro flows on simulator

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -18,8 +18,10 @@ name: 📱 Maestro Native E2E
 #   3. Put flows in .maestro/flows. Until 1-3 are done, runs skip with a
 #      warning instead of failing.
 #   4. Set the app id inputs below (they are forwarded to flows as
-#      MAESTRO_APP_ID), plus any MAESTRO_* variables your flows read via
-#      maestro_env, and an optional setup_command for dynamic seed data.
+#      MAESTRO_APP_ID), plus any variables your flows read via maestro_env,
+#      and an optional setup_command for dynamic seed data. Sensitive values
+#      (test-account passwords) go in a MAESTRO_SECRET_ENV repository secret
+#      — same newline-separated KEY=VALUE format — passed through below.
 
 on:
   schedule:
@@ -58,3 +60,4 @@ jobs:
       # setup_command: node scripts/maestro/resolve-seed-data.mjs
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      MAESTRO_SECRET_ENV: ${{ secrets.MAESTRO_SECRET_ENV }}

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -1,0 +1,60 @@
+name: 📱 Maestro Native E2E
+
+# Native (iOS + Android) e2e suite on GitHub-hosted runners — the
+# self-hosted alternative to Maestro Cloud. Playwright in ci.yml covers web;
+# this workflow is the native counterpart. Too heavy to gate PRs: it runs
+# nightly plus on-demand via workflow_dispatch.
+#
+# The heavy lifting lives in Lisa's reusable maestro-native-e2e.yml (EAS
+# build, Android emulator, iOS simulator, JUnit reports, and graceful
+# skipping while prerequisites are missing). This caller owns the cadence
+# and the project-specific values.
+#
+# To wire this project up:
+#   1. Add a `dev-e2e` build profile to eas.json (non-dev-client, dev
+#      backend, its own update channel so an OTA never overwrites the code
+#      under test).
+#   2. Provision the EXPO_TOKEN repository secret.
+#   3. Put flows in .maestro/flows. Until 1-3 are done, runs skip with a
+#      warning instead of failing.
+#   4. Set the app id inputs below (they are forwarded to flows as
+#      MAESTRO_APP_ID), plus any MAESTRO_* variables your flows read via
+#      maestro_env, and an optional setup_command for dynamic seed data.
+
+on:
+  schedule:
+    # Nightly against the default branch. Offset from other nightly suites
+    # (e.g. a Playwright nightly) so backend load doesn't overlap.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform(s) to run'
+        type: choice
+        default: all
+        options:
+          - all
+          - android
+          - ios
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maestro-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  maestro:
+    name: 📱 Maestro Native E2E
+    uses: CodySwannGT/lisa/.github/workflows/maestro-native-e2e.yml@main
+    with:
+      platform: ${{ inputs.platform || 'all' }}
+      # android_app_id: 'com.example.app'
+      # ios_app_id: 'com.example.app'
+      # maestro_env: |
+      #   MAESTRO_TEST_PHONE=0000000000
+      #   MAESTRO_TEST_OTP=555555
+      # setup_command: node scripts/maestro/resolve-seed-data.mjs
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -101,6 +101,12 @@ describe("maestro-native-e2e reusable workflow", () => {
     expect(secrets.EXPO_TOKEN.required ?? false).toBe(false);
   });
 
+  it("accepts sensitive flow variables via an optional MAESTRO_SECRET_ENV secret", () => {
+    const secrets = workflow.on.workflow_call?.secrets ?? {};
+    expect(secrets.MAESTRO_SECRET_ENV).toBeDefined();
+    expect(secrets.MAESTRO_SECRET_ENV.required ?? false).toBe(false);
+  });
+
   it("does not depend on Maestro Cloud", () => {
     // The header comment may NAME the Cloud alternative; the workflow itself
     // must not require its secret or action.
@@ -215,7 +221,7 @@ describe("maestro-native-e2e reusable workflow", () => {
     }
   });
 
-  it("forwards MAESTRO_* env and per-platform app ids as -e flags", () => {
+  it("forwards declared env, secret env, MAESTRO_* vars, and per-platform app ids as -e flags", () => {
     for (const [job, appInput] of [
       [workflow.jobs.android, "android_app_id"],
       [workflow.jobs.ios, "ios_app_id"],
@@ -224,7 +230,11 @@ describe("maestro-native-e2e reusable workflow", () => {
         step.run?.includes("MAESTRO_E2E_ARGS")
       );
       expect(assemble?.env?.MAESTRO_APP_ID).toBe(`\${{ inputs.${appInput} }}`);
-      expect(assemble?.run).toContain("env | grep '^MAESTRO_'");
+      expect(assemble?.env?.E2E_ENV_INPUT).toBe("${{ inputs.maestro_env }}");
+      expect(assemble?.env?.E2E_SECRET_ENV_INPUT).toBe(
+        "${{ secrets.MAESTRO_SECRET_ENV }}"
+      );
+      expect(assemble?.run).toContain("grep -o '^MAESTRO_");
     }
   });
 });
@@ -256,5 +266,8 @@ describe("expo maestro-e2e caller template", () => {
     );
     expect(job.with?.platform).toBe("${{ inputs.platform || 'all' }}");
     expect(job.secrets?.EXPO_TOKEN).toBe("${{ secrets.EXPO_TOKEN }}");
+    expect(job.secrets?.MAESTRO_SECRET_ENV).toBe(
+      "${{ secrets.MAESTRO_SECRET_ENV }}"
+    );
   });
 });

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Contract tests for the Maestro native e2e reusable workflow and its expo
+ * caller template. Locks in the regression-prone details learned in
+ * production (frontend-v2): the one-line maestro command inside
+ * android-emulator-runner, the !cancelled() guards so one platform's build
+ * failure doesn't skip the other's tests, and graceful skipping while a
+ * project hasn't wired its e2e prerequisites yet.
+ */
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+const CALLER_YML = path.join(
+  REPO_ROOT,
+  "expo",
+  "create-only",
+  ".github",
+  "workflows",
+  "maestro-e2e.yml"
+);
+
+/** Shape of a single `workflow_call` input declaration. */
+interface WorkflowInput {
+  description?: string;
+  required?: boolean;
+  default?: unknown;
+  type?: string;
+}
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  if?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+}
+
+/** Shape of a single job inside a workflow's `jobs:` map. */
+interface WorkflowJob {
+  name?: string;
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  needs?: string | string[];
+  if?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  secrets?: Record<string, unknown>;
+  outputs?: Record<string, string>;
+  strategy?: { matrix?: Record<string, unknown>; "fail-fast"?: boolean };
+  steps?: WorkflowStep[];
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, WorkflowInput>;
+      secrets?: Record<string, { required?: boolean }>;
+    };
+  };
+  jobs: Record<string, WorkflowJob>;
+}
+
+/** Root shape of the parsed caller template. */
+interface CallerWorkflow {
+  on: {
+    schedule?: Array<{ cron: string }>;
+    workflow_dispatch?: {
+      inputs?: Record<string, { type?: string; options?: string[] }>;
+    };
+  };
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  jobs: Record<string, WorkflowJob>;
+}
+
+describe("maestro-native-e2e reusable workflow", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  it("is callable with an optional EXPO_TOKEN secret (graceful skip, not hard requirement)", () => {
+    const secrets = workflow.on.workflow_call?.secrets ?? {};
+    expect(secrets.EXPO_TOKEN).toBeDefined();
+    expect(secrets.EXPO_TOKEN.required ?? false).toBe(false);
+  });
+
+  it("does not depend on Maestro Cloud", () => {
+    // The header comment may NAME the Cloud alternative; the workflow itself
+    // must not require its secret or action.
+    expect(workflow.on.workflow_call?.secrets?.MAESTRO_API_KEY).toBeUndefined();
+    const allSteps = Object.values(workflow.jobs).flatMap(
+      job => job.steps ?? []
+    );
+    expect(
+      allSteps.some(step =>
+        step.uses?.startsWith("mobile-dev-inc/action-maestro-cloud")
+      )
+    ).toBe(false);
+  });
+
+  it("exposes the generalized inputs with production defaults", () => {
+    const inputs = workflow.on.workflow_call?.inputs ?? {};
+    expect(inputs.platform?.default).toBe("all");
+    expect(inputs.eas_profile?.default).toBe("dev-e2e");
+    expect(inputs.flows_dir?.default).toBe(".maestro/flows");
+    expect(inputs.android_exclude_tags?.default).toBe("ios-only");
+    expect(inputs.ios_exclude_tags?.default).toBe("android-only");
+    expect(inputs.maestro_env).toBeDefined();
+    expect(inputs.setup_command).toBeDefined();
+    expect(inputs.android_app_id).toBeDefined();
+    expect(inputs.ios_app_id).toBeDefined();
+  });
+
+  it("gates build and test jobs behind the preflight prerequisite check", () => {
+    expect(workflow.jobs.preflight).toBeDefined();
+    expect(workflow.jobs.build.if).toContain(
+      "needs.preflight.outputs.should_run == 'true'"
+    );
+    expect(workflow.jobs.android.if).toContain(
+      "needs.preflight.outputs.run_android == 'true'"
+    );
+    expect(workflow.jobs.ios.if).toContain(
+      "needs.preflight.outputs.run_ios == 'true'"
+    );
+  });
+
+  it("warns instead of failing when prerequisites are missing", () => {
+    const check = (workflow.jobs.preflight.steps ?? []).find(
+      step => step.id === "check"
+    );
+    expect(check?.run).toContain("::warning::");
+    expect(check?.run).toContain("EXPO_TOKEN not configured");
+    expect(check?.run).toContain("not found");
+  });
+
+  it("builds per-platform via an EAS matrix from the preflight platform output", () => {
+    const build = workflow.jobs.build;
+    expect(build.strategy?.["fail-fast"]).toBe(false);
+    expect(build.strategy?.matrix?.platform).toBe(
+      "${{ fromJSON(needs.preflight.outputs.platforms) }}"
+    );
+    const easStep = (build.steps ?? []).find(step =>
+      step.run?.includes("eas build")
+    );
+    expect(easStep?.run).toContain("--profile ${{ inputs.eas_profile }}");
+    expect(easStep?.run).toContain("--non-interactive");
+    // The iOS simulator artifact is a tarball, not an .ipa.
+    expect(easStep?.run).toContain("app-ios.tar.gz");
+  });
+
+  it("does not let one platform's build failure skip the other platform's tests", () => {
+    expect(workflow.jobs.android.if).toContain("!cancelled()");
+    expect(workflow.jobs.ios.if).toContain("!cancelled()");
+  });
+
+  it("runs Android on an emulator with the maestro command on a single line", () => {
+    const android = workflow.jobs.android;
+    expect(android["runs-on"]).toBe("ubuntu-latest");
+    const kvm = (android.steps ?? []).find(step =>
+      step.run?.includes("static_node=kvm")
+    );
+    expect(kvm).toBeDefined();
+    const emulator = (android.steps ?? []).find(step =>
+      step.uses?.startsWith("reactivecircus/android-emulator-runner")
+    );
+    expect(emulator).toBeDefined();
+    const script = String(emulator?.with?.script ?? "");
+    expect(script).toContain("adb install app-android.apk");
+    // android-emulator-runner runs each line as its own `sh -c`; a
+    // backslash-continued maestro command breaks. The whole invocation —
+    // flags, report output, flows dir — must stay on one line.
+    const maestroLines = script
+      .split("\n")
+      .filter(line => line.includes("maestro test"));
+    expect(maestroLines).toHaveLength(1);
+    expect(maestroLines[0]).toContain("$MAESTRO_E2E_ARGS");
+    expect(maestroLines[0]).toContain("--format junit");
+    expect(maestroLines[0]).toContain("${{ inputs.flows_dir }}");
+    expect(maestroLines[0].trimEnd().endsWith("\\")).toBe(false);
+  });
+
+  it("runs iOS on a macos-15 simulator from the tarball artifact", () => {
+    const ios = workflow.jobs.ios;
+    expect(ios["runs-on"]).toBe("macos-15");
+    const boot = (ios.steps ?? []).find(step =>
+      step.run?.includes("xcrun simctl")
+    );
+    expect(boot?.run).toContain("tar -xzf app-ios.tar.gz");
+    expect(boot?.run).toContain("simctl bootstatus");
+  });
+
+  it("uploads JUnit reports and debug output even when flows fail", () => {
+    for (const job of [workflow.jobs.android, workflow.jobs.ios]) {
+      const upload = (job.steps ?? []).find(step =>
+        step.uses?.startsWith("actions/upload-artifact")
+      );
+      expect(upload?.if).toBe("always()");
+    }
+  });
+
+  it("forwards MAESTRO_* env and per-platform app ids as -e flags", () => {
+    for (const [job, appInput] of [
+      [workflow.jobs.android, "android_app_id"],
+      [workflow.jobs.ios, "ios_app_id"],
+    ] as const) {
+      const assemble = (job.steps ?? []).find(step =>
+        step.run?.includes("MAESTRO_E2E_ARGS")
+      );
+      expect(assemble?.env?.MAESTRO_APP_ID).toBe(`\${{ inputs.${appInput} }}`);
+      expect(assemble?.run).toContain("env | grep '^MAESTRO_'");
+    }
+  });
+});
+
+describe("expo maestro-e2e caller template", () => {
+  let workflow: CallerWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(CALLER_YML, "utf-8")
+    ) as CallerWorkflow;
+  });
+
+  it("keeps the production cadence: nightly cron plus on-demand dispatch", () => {
+    expect(workflow.on.schedule).toEqual([{ cron: "0 9 * * *" }]);
+    const platform = workflow.on.workflow_dispatch?.inputs?.platform;
+    expect(platform?.type).toBe("choice");
+    expect(platform?.options).toEqual(["all", "android", "ios"]);
+  });
+
+  it("serializes runs without cancelling in-flight suites", () => {
+    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+  });
+
+  it("delegates to the Lisa reusable workflow and forwards the platform picker", () => {
+    const job = workflow.jobs.maestro;
+    expect(job.uses).toBe(
+      "CodySwannGT/lisa/.github/workflows/maestro-native-e2e.yml@main"
+    );
+    expect(job.with?.platform).toBe("${{ inputs.platform || 'all' }}");
+    expect(job.secrets?.EXPO_TOKEN).toBe("${{ secrets.EXPO_TOKEN }}");
+  });
+});


### PR DESCRIPTION
## Summary

- Upstreams geminisportsai/frontend-v2's battle-tested `maestro-e2e.yml` into Lisa as a reusable workflow (`.github/workflows/maestro-native-e2e.yml`): per-platform EAS builds, Android emulator on `ubuntu-latest` (KVM + reactivecircus runner), iOS simulator on `macos-15`, JUnit + debug artifacts. It is the self-hosted sibling of `quality.yml`'s Maestro Cloud job — needs only `EXPO_TOKEN`, no paid mobile.dev account.
- Preserves every production-learned fix as an explicit contract, with comments: the **one-line maestro command** inside android-emulator-runner (each script line is its own `sh -c`, so continuations break), the **`!cancelled()` guards** so one platform's build failure doesn't skip the other platform's tests, **no `pre-build:eas`** regeneration (MISSING_GOOGLE_SERVICES_JSON), and iOS-simulator-artifact-as-tarball handling.
- Generalizes project specifics into inputs (`eas_profile`, `flows_dir`, per-platform app ids → `MAESTRO_APP_ID`, exclude tags, `maestro_env` KEY=VALUE block, `setup_command` hook for dynamic seed data); every `MAESTRO_*` env var is forwarded to flows as `-e` flags. A preflight job downgrades missing `EXPO_TOKEN`/flows to a warning-skip, making fleet-wide install safe before a project wires its harness.
- Ships an expo create-only caller (`expo/create-only/.github/workflows/maestro-e2e.yml`) that owns the cadence — nightly 09:00 UTC cron + `workflow_dispatch` platform picker (all/android/ios), `cancel-in-progress: false` — since a `schedule` inside a reusable workflow would fire in the Lisa repo rather than the project.

## Test plan

- `tests/integration/maestro-native-workflow.test.ts` (14 tests) locks in the contract: optional-secret graceful skip, no Maestro Cloud dependency, preflight gating, matrix-from-preflight, single-line maestro command, `!cancelled()` guards, `always()` artifact uploads, `MAESTRO_*` env forwarding, caller cadence/pinning.
- `actionlint` + shellcheck clean on both workflows; lint, typecheck, prettier green.
- Downstream verification follows this PR: frontend-v2 migrates onto the thin caller (deleting its 277-line local copy) and tunnlai/gunnertech/expostarter/propswap get wired, each proven in their own CI.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable automation for running native Android and iOS Maestro end-to-end tests.
  * Added configurable platform selection, build profiles, flow directories, environment settings, and setup commands.
  * Added nightly and on-demand native test runs for the Expo template.
  * Test reports and debugging artifacts are preserved even when tests fail.

* **Tests**
  * Added validation to ensure workflow configuration, platform builds, test execution, and artifact handling work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->