### PR TITLE
feat(expo): add include-tags inputs to the Maestro native e2e workflow

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -69,6 +69,16 @@ on:
         required: false
         default: 'android-only'
         type: string
+      android_include_tags:
+        description: 'Comma-separated flow tags to include on Android (empty = all flows)'
+        required: false
+        default: ''
+        type: string
+      ios_include_tags:
+        description: 'Comma-separated flow tags to include on iOS (empty = all flows)'
+        required: false
+        default: ''
+        type: string
       maestro_env:
         description: 'Newline-separated KEY=VALUE pairs exported before the run; MAESTRO_* keys are forwarded to flows'
         required: false
@@ -297,12 +307,16 @@ jobs:
         env:
           MAESTRO_APP_ID: ${{ inputs.android_app_id }}
           EXCLUDE_TAGS: ${{ inputs.android_exclude_tags }}
+          INCLUDE_TAGS: ${{ inputs.android_include_tags }}
           E2E_ENV_INPUT: ${{ inputs.maestro_env }}
           E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
           ARGS=""
           if [[ -n "$EXCLUDE_TAGS" ]]; then
             ARGS="--exclude-tags=$EXCLUDE_TAGS"
+          fi
+          if [[ -n "$INCLUDE_TAGS" ]]; then
+            ARGS="$ARGS --include-tags=$INCLUDE_TAGS"
           fi
           KEYS=$(
             {
@@ -417,12 +431,16 @@ jobs:
         env:
           MAESTRO_APP_ID: ${{ inputs.ios_app_id }}
           EXCLUDE_TAGS: ${{ inputs.ios_exclude_tags }}
+          INCLUDE_TAGS: ${{ inputs.ios_include_tags }}
           E2E_ENV_INPUT: ${{ inputs.maestro_env }}
           E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
         run: |
           ARGS=""
           if [[ -n "$EXCLUDE_TAGS" ]]; then
             ARGS="--exclude-tags=$EXCLUDE_TAGS"
+          fi
+          if [[ -n "$INCLUDE_TAGS" ]]; then
+            ARGS="$ARGS --include-tags=$INCLUDE_TAGS"
           fi
           KEYS=$(
             {

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -128,6 +128,8 @@ describe("maestro-native-e2e reusable workflow", () => {
     expect(inputs.flows_dir?.default).toBe(".maestro/flows");
     expect(inputs.android_exclude_tags?.default).toBe("ios-only");
     expect(inputs.ios_exclude_tags?.default).toBe("android-only");
+    expect(inputs.android_include_tags?.default).toBe("");
+    expect(inputs.ios_include_tags?.default).toBe("");
     expect(inputs.maestro_env).toBeDefined();
     expect(inputs.setup_command).toBeDefined();
     expect(inputs.android_app_id).toBeDefined();
@@ -235,6 +237,7 @@ describe("maestro-native-e2e reusable workflow", () => {
         "${{ secrets.MAESTRO_SECRET_ENV }}"
       );
       expect(assemble?.run).toContain("grep -o '^MAESTRO_");
+      expect(assemble?.run).toContain("--include-tags=$INCLUDE_TAGS");
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `android_include_tags` / `ios_include_tags` inputs to `maestro-native-e2e.yml` (empty default = all flows), passed as `--include-tags`. Parity with `quality.yml`'s Maestro Cloud `maestro_include_tags` input.
- First consumer: PropSwapLLC/frontend, whose full flow suite exceeds the 90-minute iOS job timeout — its nightly will run the 7-flow `smoke` tier while the full suite stays dispatchable per flow.

## Test plan

- Contract test extended: input defaults + `--include-tags=$INCLUDE_TAGS` present in both platform assemble steps; actionlint + prettier clean.

🤖 Generated with Claude Code