### PR TITLE
Fix packaged wiki resolver path

### DIFF
--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: Answer a question from the LLM Wiki with citations. Reads the index
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: Answer a question from the LLM Wiki with citations. Reads the index
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: Answer a question from the LLM Wiki with citations. Reads the index
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: "Answer a question from the LLM…"
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/lisa-wiki/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: Answer a question from the LLM Wiki with citations. Reads the index
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-ingest/SKILL.md
@@ -21,8 +21,15 @@ performs the shared, ordered pipeline.
 
 ## Step 0 — resolve the wiki root (once per run)
 
-Before anything else, run `node scripts/ensure-wiki.mjs --json` and use the returned `wikiRoot` as the
-base for the whole pipeline — never hardcode `wiki/`. This is mode-agnostic by design:
+Before anything else, run the bundled resolver from the installed Lisa wiki plugin, not from the
+consumer repository's `scripts/` directory:
+
+```bash
+node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+```
+
+Use the returned `wikiRoot` as the base for the whole pipeline — never hardcode `wiki/`. This is
+mode-agnostic by design:
 
 - **Local wiki** (no `wiki.source` in `.lisa.config.json`) — resolves the in-repo wiki root instantly;
   the branch sync below proceeds against **this** repo's remote, exactly as before.

--- a/plugins/src/wiki/skills/lisa-wiki-query/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-query/SKILL.md
@@ -8,12 +8,16 @@ description: Answer a question from the LLM Wiki with citations. Reads the index
 Answer from the wiki, with citations, without changing it (by default).
 
 ## Workflow
-0. **Resolve the wiki root.** Run `node scripts/ensure-wiki.mjs --json` and use the returned
-   `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki resolves
-   instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is mirrored and
-   refreshed transparently first. The script is offline-tolerant (it proceeds with the existing
-   mirror and warns rather than blocking), so freshness is guaranteed here and the caller never has
-   to think about it.
+0. **Resolve the wiki root.** Run the bundled resolver from the installed Lisa wiki plugin, not from
+   the consumer repository's `scripts/` directory:
+   ```bash
+   node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json
+   ```
+   Use the returned `wikiRoot` as the base for every read below — never assume `wiki/`. A local wiki
+   resolves instantly (no-op); a wiki whose `.lisa.config.json` declares `wiki.source.url` is
+   mirrored and refreshed transparently first. The script is offline-tolerant (it proceeds with the
+   existing mirror and warns rather than blocking), so freshness is guaranteed here and the caller
+   never has to think about it.
 1. Read `<wikiRoot>/index.md` to locate candidate pages; consult `<wikiRoot>/start-here.md` for orientation.
 2. Drill into the relevant synthesis pages and their cited source notes.
 3. Synthesize an answer. **Every claim cites its wiki page and/or source note.** If the wiki does not

--- a/tests/unit/strategies/wiki-ensure-wiki.test.ts
+++ b/tests/unit/strategies/wiki-ensure-wiki.test.ts
@@ -38,6 +38,23 @@ const SCRIPT_PATH = path.resolve(
   __dirname,
   "../../../plugins/src/wiki/scripts/ensure-wiki.mjs"
 );
+/** Package-relative resolver command documented in the distributed wiki skills. */
+const PACKAGED_RESOLVER_COMMAND =
+  'node "${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(npm root)/@codyswann/lisa/plugins/lisa-wiki}}}/scripts/ensure-wiki.mjs" --json';
+/** Wiki plugin roots whose query/ingest skills must carry the portable command. */
+const WIKI_PLUGIN_ROOTS = [
+  "plugins/src/wiki",
+  "plugins/lisa-wiki",
+  "plugins/lisa-wiki/.codex-plugin",
+  "plugins/lisa-wiki-agy",
+  "plugins/lisa-wiki-copilot",
+  "plugins/lisa-wiki-cursor",
+] as const;
+/** Wiki skills that resolve the root before doing work. */
+const RESOLVER_SKILLS = [
+  "skills/lisa-wiki-query/SKILL.md",
+  "skills/lisa-wiki-ingest/SKILL.md",
+] as const;
 
 /**
  * Git env with no system/global config bleed-through.
@@ -165,6 +182,44 @@ describe("lisa-wiki ensure-wiki.mjs", () => {
     expect(fs.existsSync(path.join(tmp, ".lisa"))).toBe(false);
   });
 
+  it("LOCAL: packaged plugin command resolves from a consumer root without a consumer scripts dir", () => {
+    const consumer = path.join(tmp, "consumer");
+    const pluginScripts = path.join(
+      consumer,
+      "node_modules",
+      "@codyswann",
+      "lisa",
+      "plugins",
+      "lisa-wiki",
+      "scripts"
+    );
+    fs.mkdirSync(path.join(consumer, CUSTOM_WIKI), { recursive: true });
+    fs.mkdirSync(pluginScripts, { recursive: true });
+    fs.writeFileSync(
+      path.join(consumer, CUSTOM_WIKI, INDEX_MD),
+      "# Packaged Wiki\n"
+    );
+    fs.writeFileSync(
+      path.join(consumer, LISA_CONFIG),
+      JSON.stringify({ wiki: { source: { path: CUSTOM_WIKI } } })
+    );
+    fs.copyFileSync(SCRIPT_PATH, path.join(pluginScripts, "ensure-wiki.mjs"));
+
+    expect(
+      fs.existsSync(path.join(consumer, "scripts", "ensure-wiki.mjs"))
+    ).toBe(false);
+    const out = execFileSync("/bin/sh", ["-lc", PACKAGED_RESOLVER_COMMAND], {
+      cwd: consumer,
+      encoding: "utf8",
+      env: CLEAN_GIT_ENV,
+    });
+    const res = JSON.parse(out.trim().split("\n").pop() as string);
+    expect(res.mode).toBe("local");
+    expect(fs.realpathSync(res.wikiRoot)).toBe(
+      fs.realpathSync(path.join(consumer, CUSTOM_WIKI))
+    );
+  });
+
   it("LOCAL: wiki.source.path wins over a lisa-wiki.config.json wikiRoot", () => {
     fs.mkdirSync(path.join(tmp, "wiki"), { recursive: true });
     fs.writeFileSync(
@@ -217,5 +272,20 @@ describe("lisa-wiki ensure-wiki.mjs", () => {
   it("REMOTE: fails when offline with no mirror yet on disk", () => {
     const { consumer } = setupRemoteConsumer(tmp);
     expect(() => run(consumer, ["--offline"])).toThrow();
+  });
+});
+
+describe("lisa-wiki packaged resolver command", () => {
+  it.each(
+    WIKI_PLUGIN_ROOTS.flatMap(root =>
+      RESOLVER_SKILLS.map(skill => [root, skill])
+    )
+  )("%s/%s uses the package/runtime plugin-root resolver", (root, skill) => {
+    const content = fs.readFileSync(
+      path.join(String(root), String(skill)),
+      "utf8"
+    );
+    expect(content).toContain(PACKAGED_RESOLVER_COMMAND);
+    expect(content).not.toContain("node scripts/ensure-wiki.mjs");
   });
 });


### PR DESCRIPTION
## Summary
- update lisa-wiki query and ingest step-zero commands to resolve the bundled ensure-wiki script through runtime plugin roots or the installed @codyswann/lisa package
- regenerate wiki plugin variants for Codex, Claude, Cursor, AGY, and Copilot surfaces
- add downstream-shaped coverage that runs the documented packaged command from a consumer root without scripts/ensure-wiki.mjs

Closes #1629

## Validation
- bun test tests/unit/strategies/wiki-ensure-wiki.test.ts
- bun run format:check
- bun run typecheck
- bun run build:dist
- bun run lint
- bun run check:plugins
- pre-push: security audit, slow lint, knip, unit coverage, integration tests