### PR TITLE
fix(hooks): derive primary checkout via git-common-dir in install-pkgs

### DIFF
--- a/plugins/lisa-copilot/hooks/install-pkgs.sh
+++ b/plugins/lisa-copilot/hooks/install-pkgs.sh
@@ -11,14 +11,23 @@ link_primary_worktree_node_modules() {
   [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  case "$repo_root" in
-    */.claude/worktrees/*)
-      primary_root="${repo_root%%/.claude/worktrees/*}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  # A linked worktree's --git-common-dir is <primary>/.git no matter where the
+  # worktree lives (.claude/worktrees, ~/.codex/worktrees, plain
+  # `git worktree add`), so derive the primary checkout from it. Fall back to
+  # the legacy .claude path parse on git <2.31 (no --path-format support).
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common_dir" ]; then
+    primary_root="$(dirname "$git_common_dir")"
+  else
+    case "$repo_root" in
+      */.claude/worktrees/*)
+        primary_root="${repo_root%%/.claude/worktrees/*}"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
 
   [ "$primary_root" != "$repo_root" ] || return 1
   [ -d "$primary_root/node_modules" ] || return 1

--- a/plugins/lisa-cursor/hooks/install-pkgs.sh
+++ b/plugins/lisa-cursor/hooks/install-pkgs.sh
@@ -11,14 +11,23 @@ link_primary_worktree_node_modules() {
   [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  case "$repo_root" in
-    */.claude/worktrees/*)
-      primary_root="${repo_root%%/.claude/worktrees/*}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  # A linked worktree's --git-common-dir is <primary>/.git no matter where the
+  # worktree lives (.claude/worktrees, ~/.codex/worktrees, plain
+  # `git worktree add`), so derive the primary checkout from it. Fall back to
+  # the legacy .claude path parse on git <2.31 (no --path-format support).
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common_dir" ]; then
+    primary_root="$(dirname "$git_common_dir")"
+  else
+    case "$repo_root" in
+      */.claude/worktrees/*)
+        primary_root="${repo_root%%/.claude/worktrees/*}"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
 
   [ "$primary_root" != "$repo_root" ] || return 1
   [ -d "$primary_root/node_modules" ] || return 1

--- a/plugins/lisa/hooks/install-pkgs.sh
+++ b/plugins/lisa/hooks/install-pkgs.sh
@@ -11,14 +11,23 @@ link_primary_worktree_node_modules() {
   [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  case "$repo_root" in
-    */.claude/worktrees/*)
-      primary_root="${repo_root%%/.claude/worktrees/*}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  # A linked worktree's --git-common-dir is <primary>/.git no matter where the
+  # worktree lives (.claude/worktrees, ~/.codex/worktrees, plain
+  # `git worktree add`), so derive the primary checkout from it. Fall back to
+  # the legacy .claude path parse on git <2.31 (no --path-format support).
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common_dir" ]; then
+    primary_root="$(dirname "$git_common_dir")"
+  else
+    case "$repo_root" in
+      */.claude/worktrees/*)
+        primary_root="${repo_root%%/.claude/worktrees/*}"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
 
   [ "$primary_root" != "$repo_root" ] || return 1
   [ -d "$primary_root/node_modules" ] || return 1

--- a/plugins/src/base/hooks/install-pkgs.sh
+++ b/plugins/src/base/hooks/install-pkgs.sh
@@ -11,14 +11,23 @@ link_primary_worktree_node_modules() {
   [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  case "$repo_root" in
-    */.claude/worktrees/*)
-      primary_root="${repo_root%%/.claude/worktrees/*}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  # A linked worktree's --git-common-dir is <primary>/.git no matter where the
+  # worktree lives (.claude/worktrees, ~/.codex/worktrees, plain
+  # `git worktree add`), so derive the primary checkout from it. Fall back to
+  # the legacy .claude path parse on git <2.31 (no --path-format support).
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common_dir" ]; then
+    primary_root="$(dirname "$git_common_dir")"
+  else
+    case "$repo_root" in
+      */.claude/worktrees/*)
+        primary_root="${repo_root%%/.claude/worktrees/*}"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
 
   [ "$primary_root" != "$repo_root" ] || return 1
   [ -d "$primary_root/node_modules" ] || return 1

--- a/src/codex/scripts/install-pkgs.sh
+++ b/src/codex/scripts/install-pkgs.sh
@@ -18,14 +18,23 @@ fi
 link_primary_worktree_node_modules() {
   [ ! -e "node_modules" ] && [ ! -L "node_modules" ] || return 1
 
-  case "$repo_root" in
-    */.claude/worktrees/*)
-      primary_root="${repo_root%%/.claude/worktrees/*}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  # A linked worktree's --git-common-dir is <primary>/.git no matter where the
+  # worktree lives (.claude/worktrees, ~/.codex/worktrees, plain
+  # `git worktree add`), so derive the primary checkout from it. Fall back to
+  # the legacy .claude path parse on git <2.31 (no --path-format support).
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$git_common_dir" ]; then
+    primary_root="$(dirname "$git_common_dir")"
+  else
+    case "$repo_root" in
+      */.claude/worktrees/*)
+        primary_root="${repo_root%%/.claude/worktrees/*}"
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
 
   [ "$primary_root" != "$repo_root" ] || return 1
   [ -d "$primary_root/node_modules" ] || return 1

--- a/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
+++ b/tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts
@@ -10,6 +10,11 @@ const CLAUDE_INSTALL_PKGS = path.join(
   "plugins/src/base/hooks/install-pkgs.sh"
 );
 const CODEX_INSTALL_PKGS = path.join(ROOT, "src/codex/scripts/install-pkgs.sh");
+const PACKAGE_JSON = "package.json";
+const HOOK_SCRIPTS: ReadonlyArray<readonly [string, string]> = [
+  ["Claude/plugin", CLAUDE_INSTALL_PKGS],
+  ["Codex", CODEX_INSTALL_PKGS],
+];
 
 describe("install-pkgs worktree node_modules handoff", () => {
   let tempDir: string;
@@ -28,7 +33,7 @@ describe("install-pkgs worktree node_modules handoff", () => {
     await fs.ensureDir(path.join(primaryRoot, "node_modules", ".bin"));
     await fs.ensureDir(worktreeRoot);
     await fs.writeFile(
-      path.join(worktreeRoot, "package.json"),
+      path.join(worktreeRoot, PACKAGE_JSON),
       '{"name":"fixture"}\n',
       "utf8"
     );
@@ -54,10 +59,7 @@ describe("install-pkgs worktree node_modules handoff", () => {
     await cleanupTempDir(tempDir);
   });
 
-  it.each([
-    ["Claude/plugin", CLAUDE_INSTALL_PKGS],
-    ["Codex", CODEX_INSTALL_PKGS],
-  ])(
+  it.each(HOOK_SCRIPTS)(
     "%s hook links primary node_modules before installing",
     (_name, script) => {
       // eslint-disable-next-line sonarjs/no-os-command-from-path -- Test-only PATH shim fakes git and package managers.
@@ -75,16 +77,50 @@ describe("install-pkgs worktree node_modules handoff", () => {
     }
   );
 
-  it.each([
-    ["Claude/plugin", CLAUDE_INSTALL_PKGS],
-    ["Codex", CODEX_INSTALL_PKGS],
-  ])(
+  it.each(HOOK_SCRIPTS)(
+    "%s hook links primary node_modules for worktrees outside .claude via --git-common-dir",
+    async (_name, script) => {
+      const codexWorktree = path.join(
+        tempDir,
+        "codex-worktrees",
+        "ticket",
+        "project"
+      );
+      await fs.ensureDir(codexWorktree);
+      await fs.writeFile(
+        path.join(codexWorktree, PACKAGE_JSON),
+        '{"name":"fixture"}\n',
+        "utf8"
+      );
+      await writeExecutable(
+        path.join(fakeBin, "git"),
+        "#!/usr/bin/env bash\n" +
+          'if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then pwd; exit 0; fi\n' +
+          `if [ "$1" = "rev-parse" ] && [ "$2" = "--path-format=absolute" ] && [ "$3" = "--git-common-dir" ]; then echo "${primaryRoot}/.git"; exit 0; fi\n` +
+          "exit 1\n"
+      );
+
+      const output = execFileSync("/bin/bash", [script], {
+        cwd: codexWorktree,
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+        stdio: "pipe",
+      });
+
+      expect(output.toString("utf8")).toBe("");
+      expect(fs.realpathSync(path.join(codexWorktree, "node_modules"))).toBe(
+        fs.realpathSync(path.join(primaryRoot, "node_modules"))
+      );
+      expect(fs.existsSync(installMarker)).toBe(false);
+    }
+  );
+
+  it.each(HOOK_SCRIPTS)(
     "%s hook keeps package-manager output off stdout",
     async (_name, script) => {
       const projectRoot = path.join(tempDir, `install-${_name}`);
       fs.ensureDirSync(projectRoot);
       fs.writeFileSync(
-        path.join(projectRoot, "package.json"),
+        path.join(projectRoot, PACKAGE_JSON),
         '{"name":"fixture","engines":{"npm":"please-use-npm"}}\n',
         "utf8"
       );


### PR DESCRIPTION
## Summary
The `install-pkgs` SessionStart hook symlinks the primary checkout's `node_modules` into a fresh worktree instead of running a cold install — but only recognized worktrees under `.claude/worktrees/` via string-parsing the path. Worktrees created anywhere else (notably Codex's `~/.codex/worktrees/<ticket>/<repo>` layout) always fell through to a full `npm`/`bun install`, blocking session start for 3+ minutes.

This derives the primary checkout for **any** linked worktree via `git rev-parse --path-format=absolute --git-common-dir` (a linked worktree's common dir is always `<primary>/.git`), keeping the legacy `.claude/worktrees` path parse as a fallback for git <2.31 which lacks `--path-format`.

Applied to both the Claude plugin hook (`plugins/src/base/hooks/install-pkgs.sh`) and the Codex bundled script (`src/codex/scripts/install-pkgs.sh`); artifacts regenerated via `bun run build:plugins`.

## Context
Diagnosed from a real failure: a Codex session in `~/.codex/worktrees/frontend-queue/frontend` spent 3m30s+ in a cold `npm install` at SessionStart because the primary checkout's `node_modules` wasn't linked. (The same incident also surfaced the 2.198 legacy-overlay retirement racing a live session — tracked separately.)

## Testing
- Extended `tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts` with a worktree **outside** `.claude/worktrees` resolved via `--git-common-dir` (both Claude and Codex variants); existing tests keep covering the git<2.31 fallback since their git shim rejects `--path-format`.
- All 6 tests pass.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `node_modules` linking for Git worktrees located outside the repository’s legacy worktree directory.
  * Added compatibility fallback for older Git versions and unsupported repository layouts.
  * Preserved quiet hook behavior without triggering unnecessary package installation.

* **Tests**
  * Added coverage for external worktrees and Git common-directory detection across supported hooks.
  * Standardized test fixtures and hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->