### PR TITLE
fix(expo): move tailwindcss pin from force to defaults

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -67,7 +67,6 @@
       "i18n-js": "^4.5.1",
       "patch-package": "^8.0.0",
       "react-hook-form": "^7.70.0",
-      "tailwindcss": "^3.4.7",
       "tar": ">=7.5.11",
       "text-encoding-polyfill": "^0.6.7",
       "usehooks-ts": "^3.1.1",
@@ -159,7 +158,8 @@
       "react-native-screens": "4.25.2",
       "react-native-svg": "15.15.4",
       "react-native-web": "^0.21.2",
-      "react-native-worklets": "0.10.0"
+      "react-native-worklets": "0.10.0",
+      "tailwindcss": "^3.4.7"
     },
     "devDependencies": {
       "@codyswann/lisa": "^2.106.0",

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1143,7 +1143,15 @@ describe("PackageLisaStrategy", () => {
       expect(template.force.dependencies["@apollo/client"]).toMatch(/^\^?3\./);
       expect(template.force.dependencies["apollo-link-sentry"]).toBe("4.4.0");
       expect(template.force.dependencies["zod"]).toBeDefined();
-      expect(template.force.dependencies["tailwindcss"]).toBeDefined();
+      // tailwindcss must stay in defaults, NEVER force: the tailwind major is
+      // coupled to the project's gluestack-ui generation (v3/v4 → tailwind ^3 +
+      // nativewind 4; v5 → tailwind ^4.2 + nativewind 5 per
+      // https://gluestack.io/ui/docs/guides/more/upgrade-to-v5), and the fleet
+      // runs both generations. A forced pin silently downgraded a tailwind-4
+      // project (TunnlAI/frontend) on every apply and broke its frozen
+      // lockfile in CI.
+      expect(template.force.dependencies["tailwindcss"]).toBeUndefined();
+      expect(template.defaults.dependencies["tailwindcss"]).toBeDefined();
       expect(template.force.devDependencies["jest"]).toBeDefined();
       expect(template.force.devDependencies["oxlint"]).toBeDefined();
       expect(template.force.devDependencies["@playwright/test"]).toBeDefined();


### PR DESCRIPTION
## Summary
The expo template force-pinned `tailwindcss: ^3.4.7`, but the tailwind major is coupled to each project's gluestack-ui generation:

| gluestack-ui | tailwindcss | nativewind |
|---|---|---|
| v3 / v4 | `^3.x` | `^4.x` |
| v5 | `^4.2.0` | `^5.x` (or uniwind) |

(per the [upgrade-to-v5 guide](https://gluestack.io/ui/docs/guides/more/upgrade-to-v5))

The fleet runs both generations, so the forced pin silently downgraded tailwind-4 projects back to v3 on every `lisa apply` — and because apply doesn't regenerate lockfiles, it also invalidated `bun install --frozen-lockfile` in CI. Observed for real on TunnlAI/frontend (tailwind `^4.2.0`) during the overlay-retirement apply on 2026-07-14.

## Change
- Move `tailwindcss` from `force.dependencies` to `defaults.dependencies` — projects keep their own major; new projects still start on `^3.4.7` from the template. This matches how `nativewind` and `@gluestack-ui/*` are already handled, and follows the Expo SDK pin precedent (force→defaults in 2.132.6).
- Update the package-lisa template test to assert tailwindcss is defaults-only, with the coupling rationale inline.

## Testing
- `tests/unit/strategies/package-lisa.test.ts`: 44/44 pass.

🤖 Generated with Claude Code
