### PR TITLE
fix(nestjs,expo): demote split-major pins from force to defaults

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -75,10 +75,6 @@
     "devDependencies": {
       "@babel/core": "^7.20.0",
       "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-      "@graphql-codegen/cli": "^6.1.0",
-      "@graphql-codegen/typescript": "^4.1.6",
-      "@graphql-codegen/typescript-operations": "^4.4.2",
-      "@graphql-codegen/typescript-react-apollo": "^4.3.4",
       "@lhci/cli": "^0.15.1",
       "@playwright/test": "^1.57.0",
       "@types/base-64": "^1.0.2",
@@ -163,6 +159,10 @@
     },
     "devDependencies": {
       "@codyswann/lisa": "^2.106.0",
+      "@graphql-codegen/cli": "^6.1.0",
+      "@graphql-codegen/typescript": "^4.1.6",
+      "@graphql-codegen/typescript-operations": "^4.4.2",
+      "@graphql-codegen/typescript-react-apollo": "^4.3.4",
       "@react-native-community/cli": "^20.0.2",
       "@react-native-community/cli-platform-android": "^20.0.2",
       "@react-native-community/cli-platform-ios": "^20.0.2",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -1,7 +1,10 @@
 {
   "defaults": {
     "devDependencies": {
-      "@codyswann/lisa": "^2.106.0"
+      "@codyswann/lisa": "^2.106.0",
+      "@graphql-codegen/cli": "^6.1.0",
+      "@graphql-codegen/typescript": "^4.1.6",
+      "@graphql-codegen/typescript-operations": "^4.4.2"
     },
     "scripts": {
       "migration:generate": "tsx ./node_modules/typeorm/cli.js migration:generate -d typeorm.config.ts src/database/migrations/$npm_config_name",
@@ -9,6 +12,7 @@
       "migration:revert": "tsx ./node_modules/typeorm/cli.js migration:revert -d typeorm.config.ts"
     },
     "dependencies": {
+      "class-validator": "^0.14.3",
       "graphql": "15.10.1"
     }
   },
@@ -63,7 +67,6 @@
       "aws-jwt-verify": "^5.1.1",
       "aws-xray-sdk-core": "^3.12.0",
       "class-transformer": "^0.5.1",
-      "class-validator": "^0.14.3",
       "dataloader": "^2.2.3",
       "graphql-query-complexity": "^1.1.0",
       "graphql-subscriptions": "^3.0.0",
@@ -76,9 +79,6 @@
       "typeorm-naming-strategies": "^4.1.0"
     },
     "devDependencies": {
-      "@graphql-codegen/cli": "^6.1.0",
-      "@graphql-codegen/typescript": "^4.1.6",
-      "@graphql-codegen/typescript-operations": "^4.4.2",
       "@nestjs/cli": "^11.0.14",
       "@nestjs/schematics": "^11.0.9",
       "@nestjs/testing": "^11.1.11",

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1152,6 +1152,21 @@ describe("PackageLisaStrategy", () => {
       // lockfile in CI.
       expect(template.force.dependencies["tailwindcss"]).toBeUndefined();
       expect(template.defaults.dependencies["tailwindcss"]).toBeDefined();
+      // @graphql-codegen/* must stay in defaults, NEVER force: the fleet is
+      // split across codegen generations (backend-v2 on cli 6/typescript 4,
+      // tunnl/gunnertech/nestjsstarter on cli 7/typescript 6), and a forced
+      // pin downgrades whichever side the template doesn't match. Frontends
+      // can drift the same way, so the expo template gets the same treatment
+      // as the nestjs one.
+      for (const pkg of [
+        "@graphql-codegen/cli",
+        "@graphql-codegen/typescript",
+        "@graphql-codegen/typescript-operations",
+        "@graphql-codegen/typescript-react-apollo",
+      ]) {
+        expect(template.force.devDependencies[pkg]).toBeUndefined();
+        expect(template.defaults.devDependencies[pkg]).toBeDefined();
+      }
       expect(template.force.devDependencies["jest"]).toBeDefined();
       expect(template.force.devDependencies["oxlint"]).toBeDefined();
       expect(template.force.devDependencies["@playwright/test"]).toBeDefined();
@@ -1268,6 +1283,68 @@ describe("PackageLisaStrategy", () => {
       expect(content.devDependencies["@stryker-mutator/jest-runner"]).toBe(
         "^9.0.0"
       );
+    });
+  });
+
+  describe("NestJS real template: split-major pins stay in defaults", () => {
+    // Regression: class-validator and the @graphql-codegen/* toolchain used
+    // to sit in `force`, but the fleet is legitimately split across their
+    // majors (geminisportsai/backend-v2 on codegen cli 6/typescript 4 +
+    // class-validator 0.14; tunnl-backend, gunnertech/backend and
+    // nestjsstarter on codegen cli 7/typescript 6 + class-validator 0.15).
+    // Because force REPLACES project values, whichever side the template
+    // didn't match got a silent major downgrade/upgrade on every apply, plus
+    // a frozen-lockfile CI break. These packages live in `defaults` (project
+    // value wins); the convergent framework core (@nestjs/*, typeorm, pg)
+    // legitimately stays in force.
+    const repoRoot = process.cwd();
+    const nestSource = path.join(
+      repoRoot,
+      "nestjs",
+      "package-lisa",
+      "package.lisa.json"
+    );
+
+    /**
+     * Read and parse the real shipped NestJS package.lisa.json template.
+     * @returns The parsed template with force/defaults sections.
+     */
+    function readNestTemplate(): {
+      force: {
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+      };
+      defaults: {
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+      };
+    } {
+      return fs.readJsonSync(nestSource);
+    }
+
+    it("keeps class-validator in defaults, not force", () => {
+      const template = readNestTemplate();
+      expect(template.force.dependencies["class-validator"]).toBeUndefined();
+      expect(template.defaults.dependencies["class-validator"]).toBeDefined();
+    });
+
+    it("keeps @graphql-codegen/* in defaults, not force", () => {
+      const template = readNestTemplate();
+      for (const pkg of [
+        "@graphql-codegen/cli",
+        "@graphql-codegen/typescript",
+        "@graphql-codegen/typescript-operations",
+      ]) {
+        expect(template.force.devDependencies[pkg]).toBeUndefined();
+        expect(template.defaults.devDependencies[pkg]).toBeDefined();
+      }
+    });
+
+    it("keeps the convergent NestJS framework core in force", () => {
+      const template = readNestTemplate();
+      for (const pkg of ["@nestjs/common", "@nestjs/core", "typeorm", "pg"]) {
+        expect(template.force.dependencies[pkg]).toBeDefined();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #1633 (tailwindcss force→defaults). A fleet audit found the same footgun in the nestjs template: the fleet is **legitimately split across majors** for these packages, so any force value downgrades one side or force-upgrades the other on the next `lisa apply` — plus a frozen-lockfile CI break either way.

| Package | geminisportsai/backend-v2 | tunnl-backend / gunnertech/backend / nestjsstarter | Template forced |
|---|---|---|---|
| `@graphql-codegen/cli` | `^6.3.1` | `^7.2.0` | `^6.1.0` |
| `@graphql-codegen/typescript` | `^4.1.6` | `^6.1.0` | `^4.1.6` |
| `@graphql-codegen/typescript-operations` | `^4.6.1` | `^6.1.0` | `^4.4.2` |
| `class-validator` | `^0.14.4` | `^0.15.1` | `^0.14.3` (0.x caret = effectively a major pin) |

## Change
- **nestjs**: move `class-validator` (dependencies) and `@graphql-codegen/cli|typescript|typescript-operations` (devDependencies) from `force` to `defaults`.
- **expo**: move the `@graphql-codegen/*` set (incl. `typescript-react-apollo`) to `defaults` for the same reason — frontends can drift across codegen generations the same way.
- The convergent framework core (`@nestjs/*`, `typeorm`, `pg`, apollo server/client couplings) deliberately **stays in force**.
- New "NestJS real template" regression tests + extended expo assertions pin the placement so these can't drift back into force.

## Testing
- `tests/unit/strategies/package-lisa.test.ts`: 47/47 pass (3 new tests).

🤖 Generated with Claude Code
