### PR TITLE
fix(cdk): move aws-cdk-lib pin from force to defaults

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -16,9 +16,7 @@
       "lint:fix": "oxlint --fix && eslint . --fix"
     },
     "dependencies": {
-      "@aws-cdk/aws-amplify-alpha": "^2.246.0-alpha.0",
       "aws-cdk-github-oidc": "^2.4.1",
-      "aws-cdk-lib": "2.246.0",
       "constructs": "^10.4.5",
       "source-map-support": "^0.5.21"
     },
@@ -50,6 +48,10 @@
     }
   },
   "defaults": {
+    "dependencies": {
+      "@aws-cdk/aws-amplify-alpha": "^2.246.0-alpha.0",
+      "aws-cdk-lib": "2.246.0"
+    },
     "devDependencies": {
       "@codyswann/lisa": "^2.106.0"
     },

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1388,14 +1388,19 @@ describe("PackageLisaStrategy", () => {
       const template = readCdkTemplate();
       for (const pkg of ["aws-cdk-lib", "@aws-cdk/aws-amplify-alpha"]) {
         expect(template.force.dependencies[pkg]).toBeUndefined();
-        expect(template.defaults.dependencies[pkg]).toBeDefined();
       }
+      // Exact pins (not just "is defined") so an accidental version bump in
+      // the template is caught by this regression test.
+      expect(template.defaults.dependencies["aws-cdk-lib"]).toBe("2.246.0");
+      expect(template.defaults.dependencies["@aws-cdk/aws-amplify-alpha"]).toBe(
+        "^2.246.0-alpha.0"
+      );
     });
 
     it("keeps the aws-cdk CLI floor and $name overrides in force", () => {
       const template = readCdkTemplate();
       // A caret floor can only pull projects forward, never downgrade.
-      expect(template.force.devDependencies["aws-cdk"]).toMatch(/^\^/);
+      expect(template.force.devDependencies["aws-cdk"]).toBe("^2.1127.0");
       expect(template.force.overrides["aws-cdk-lib"]).toBe("$aws-cdk-lib");
       expect(template.force.resolutions["aws-cdk-lib"]).toBe("$aws-cdk-lib");
     });

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1348,6 +1348,59 @@ describe("PackageLisaStrategy", () => {
     });
   });
 
+  describe("CDK real template: aws-cdk-lib stays in defaults", () => {
+    // Regression: aws-cdk-lib was force-pinned EXACTLY (2.246.0), so a
+    // project that had moved ahead (qualis/infrastructure on 2.259.0) got a
+    // 13-minor downgrade on the next apply — which can break synth for
+    // stacks using newer constructs. Projects own their aws-cdk-lib pace;
+    // CVE-driven bumps go through per-repo security gates instead. The
+    // paired @aws-cdk/aws-amplify-alpha must live in the same section since
+    // its version tracks aws-cdk-lib. The $name overrides/resolutions
+    // entries stay in force and resolve against the project's own direct
+    // dep, so they remain valid with the pin in defaults.
+    const repoRoot = process.cwd();
+    const cdkSource = path.join(
+      repoRoot,
+      "cdk",
+      "package-lisa",
+      "package.lisa.json"
+    );
+
+    /**
+     * Read and parse the real shipped CDK package.lisa.json template.
+     * @returns The parsed template with force/defaults sections.
+     */
+    function readCdkTemplate(): {
+      force: {
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+        overrides: Record<string, string>;
+        resolutions: Record<string, string>;
+      };
+      defaults: {
+        dependencies: Record<string, string>;
+      };
+    } {
+      return fs.readJsonSync(cdkSource);
+    }
+
+    it("keeps aws-cdk-lib and its alpha companion in defaults, not force", () => {
+      const template = readCdkTemplate();
+      for (const pkg of ["aws-cdk-lib", "@aws-cdk/aws-amplify-alpha"]) {
+        expect(template.force.dependencies[pkg]).toBeUndefined();
+        expect(template.defaults.dependencies[pkg]).toBeDefined();
+      }
+    });
+
+    it("keeps the aws-cdk CLI floor and $name overrides in force", () => {
+      const template = readCdkTemplate();
+      // A caret floor can only pull projects forward, never downgrade.
+      expect(template.force.devDependencies["aws-cdk"]).toMatch(/^\^/);
+      expect(template.force.overrides["aws-cdk-lib"]).toBe("$aws-cdk-lib");
+      expect(template.force.resolutions["aws-cdk-lib"]).toBe("$aws-cdk-lib");
+    });
+  });
+
   describe("empty sections", () => {
     it("handles template with empty force section", async () => {
       await createPackageLisaTemplate("all", {


### PR DESCRIPTION
## Summary
Third in the force→defaults series (#1633 tailwindcss, #1635 class-validator/@graphql-codegen). A CDK fleet audit (cdkstarter, geminisportsai/infrastructure-v2, tunnl-infrastructure, gunnertech/infrastructure, propswap/infrastructure, thumbwar/infrastructure, qualis/infrastructure) found `aws-cdk-lib` force-pinned **exactly** at `2.246.0` while qualis/infrastructure has legitimately moved ahead to `2.259.0` — so its next `lisa apply` would deliver a 13-minor downgrade, which can break synth for stacks using newer constructs, plus the usual frozen-lockfile CI break.

## Change
- Move `aws-cdk-lib` and its version-tracking companion `@aws-cdk/aws-amplify-alpha` from `force.dependencies` to `defaults.dependencies` — each project owns its CDK pace; new projects still scaffold on `2.246.0`. CVE remediation flows through the per-repo security gates (pre-push audit + CI Security Scan) rather than template force-bumps.
- The `aws-cdk` CLI **caret floor stays in force** — a floor can only pull projects forward, never downgrade.
- The `$name` overrides/resolutions entries stay in force and remain valid: they resolve against the project's own direct dependency.
- New "CDK real template" regression tests pin the placement.

## Testing
- `tests/unit/strategies/package-lisa.test.ts`: 49/49 pass (2 new tests).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CDK dependency configuration to apply standard version defaults correctly while preserving required tooling constraints.
  * Ensured Amplify and CDK library dependencies resolve consistently from the shipped package template.

* **Tests**
  * Added coverage validating dependency placement and version-resolution rules in the CDK package template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->