### PR TITLE
feat(doctor): flag committed legacy pre-2.198 Codex overlay

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,6 +1,11 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
+import {
+  LISA_HOOKS_SUBDIR,
+  LISA_RULES_SUBDIR,
+} from "../codex/hooks-installer.js";
+import { LISA_SKILLS_SUBDIR } from "../codex/skills-installer.js";
 import { AGENTS_MD_FILENAME } from "../codex/agents-md-installer.js";
 import { CLAUDE_MD_FILENAME } from "../claude/claude-md-installer.js";
 import { migrateInstructionFiles } from "../core/instruction-files-migration.js";
@@ -235,6 +240,58 @@ function checkWiki(targetPath: string): DoctorCheck {
   };
 }
 
+const LEGACY_CODEX_OVERLAY_CHECK_NAME = "Codex overlay current?";
+
+/**
+ * Detect the retired pre-2.198 project-level Codex overlay. Lisa now delivers
+ * Codex hooks and skills through the repository plugin marketplace
+ * (`.agents/plugins/marketplace.json` → `node_modules`), and postinstall
+ * applies deliberately skip agent emits — so a committed legacy overlay is
+ * never cleaned up automatically. Fresh clones/worktrees then load stale
+ * hooks/skills from it, and a later explicit apply retires them out from
+ * under whatever session is running (exit-127 hooks, vanished skills — the
+ * incident behind CodySwannGT/lisa#1632).
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+function checkLegacyCodexOverlay(targetPath: string): DoctorCheck {
+  const codexDir = path.join(targetPath, ".codex");
+  if (!existsSync(codexDir)) {
+    return {
+      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+      status: "ok",
+      detail: "No .codex directory present",
+    };
+  }
+
+  const legacyPaths = [
+    LISA_HOOKS_SUBDIR,
+    LISA_RULES_SUBDIR,
+    LISA_SKILLS_SUBDIR,
+  ].filter(subdir => existsSync(path.join(codexDir, subdir)));
+
+  if (legacyPaths.length === 0) {
+    return {
+      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+      status: "ok",
+      detail: "No legacy project-level Codex overlay present",
+    };
+  }
+
+  const listed = legacyPaths
+    .map(subdir => path.join(".codex", subdir))
+    .join(", ");
+  return {
+    name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+    status: "warn",
+    detail:
+      `Legacy pre-2.198 Codex overlay present (${listed}). ` +
+      "Run `lisa apply` in the primary checkout and commit the removals — " +
+      "fresh clones/worktrees otherwise load stale hooks/skills that a later " +
+      "apply deletes mid-session (CodySwannGT/lisa#1632)",
+  };
+}
+
 /**
  * Determine whether a path looks like an agent-governed project, i.e. one that
  * should carry the canonical `AGENTS.md` / `CLAUDE.md` pointer pattern. True
@@ -308,6 +365,7 @@ export async function runDoctor(
     await checkProjectConfig(resolvedTarget),
     await checkProjectType(resolvedTarget),
     await checkInstructionFiles(resolvedTarget),
+    checkLegacyCodexOverlay(resolvedTarget),
     await checkStarterHealth(deps, options.offline === true),
     checkWiki(resolvedTarget),
   ];

--- a/tests/unit/cli/doctor.test.ts
+++ b/tests/unit/cli/doctor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +6,9 @@ import { runDoctor } from "../../../src/cli/doctor.js";
 
 /** Lisa project marker file written into doctor test fixtures. */
 const LISA_CONFIG_FILE = ".lisa.config.json";
+
+/** Doctor check name for the legacy Codex overlay detection. */
+const CODEX_OVERLAY_CHECK = "Codex overlay current?";
 
 let tempDir: string | undefined;
 
@@ -70,6 +73,70 @@ describe("runDoctor", () => {
     );
 
     expect(setExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it("warns when the legacy pre-2.198 Codex overlay is still present", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, LISA_CONFIG_FILE), "{}\n");
+    await mkdir(path.join(cwd, ".codex", "hooks", "lisa"), {
+      recursive: true,
+    });
+    await mkdir(path.join(cwd, ".codex", "skills", "lisa"), {
+      recursive: true,
+    });
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: CODEX_OVERLAY_CHECK,
+        status: "warn",
+        detail: expect.stringContaining(".codex/hooks/lisa"),
+      })
+    );
+  });
+
+  it("passes the Codex overlay check when .codex has no legacy directories", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, LISA_CONFIG_FILE), "{}\n");
+    await mkdir(path.join(cwd, ".codex", "agents"), { recursive: true });
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: CODEX_OVERLAY_CHECK,
+        status: "ok",
+        detail: "No legacy project-level Codex overlay present",
+      })
+    );
+  });
+
+  it("passes the Codex overlay check when .codex is absent", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, LISA_CONFIG_FILE), "{}\n");
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: CODEX_OVERLAY_CHECK,
+        status: "ok",
+        detail: "No .codex directory present",
+      })
+    );
   });
 
   it("repairs instruction files in a Lisa project (AGENTS.md canonical + CLAUDE.md pointer)", async () => {


### PR DESCRIPTION
## Summary
Closes #1632.

Investigation found the **mid-session race itself was already fixed** in v2.204.6 ("skip agent emits during postinstall apply"): host postinstall runs `--yes --skip-git-check`, and `shouldSkipAgentEmitDuringPostinstall()` now skips the entire Codex emit — including `retireProjectHooks` — so a dependency install can no longer delete `.codex` hooks/skills out from under a live session. The 2026-07-14 incident host was on 2.198.1, which predates that fix.

What remained from #1632 is the flip side: because postinstall never touches the overlay anymore, a repo with the **pre-2.198 overlay still committed** (~660 files of `.codex/hooks/lisa` + `.codex/lisa-rules` + `.codex/skills/lisa`) keeps it indefinitely. Fresh clones/worktrees load stale hooks/skills from it, double-deliver skills alongside the marketplace plugin (blowing Codex's 2% skills-context budget), and whenever an *explicit* apply finally runs, the retirement lands mid-session anyway.

## Change
`lisa doctor` gains a **"Codex overlay current?"** check: warns when any legacy directory is present, with the exact remediation ("run `lisa apply` in the primary checkout and commit the removals") and a pointer to #1632. Uses the installer-exported `LISA_HOOKS_SUBDIR` / `LISA_RULES_SUBDIR` / `LISA_SKILLS_SUBDIR` constants so the definition of "legacy" stays single-sourced.

## Testing
- 3 new unit tests (legacy present → warn; modern `.codex` → ok; no `.codex` → ok); doctor suite 9/9.
- End-to-end against a real legacy repo: `node dist/index.js doctor ~/workspace/nestjsstarter --offline` emits the WARN with all three paths listed. Fleet check found nestjsstarter, expostarter, geminisportsai/backend-v2 and tunnl-backend still carrying the overlay.

🤖 Generated with Claude Code
