### PR TITLE
fix(tsconfig): drop baseUrl from project tsconfig templates

### DIFF
--- a/expo/create-only/tsconfig.json
+++ b/expo/create-only/tsconfig.json
@@ -4,7 +4,6 @@
     "./tsconfig.local.json"
   ],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   },
   "include": [

--- a/nestjs/copy-overwrite/tsconfig.json
+++ b/nestjs/copy-overwrite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/nestjs", "./tsconfig.local.json"],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   }
 }

--- a/typescript/copy-overwrite/tsconfig.json
+++ b/typescript/copy-overwrite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/typescript", "./tsconfig.local.json"],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
## Summary
TypeScript 6 removed `baseUrl` entirely — `tsc` fails with **TS5102 "Option 'baseUrl' has been removed"**. The copy-overwrite tsconfig templates (`nestjs`, `typescript`) stamp `"baseUrl": "./"` into every project on every apply, and the postinstall trampoline re-stamps it after every install, so a TS6 project can't even hand-fix its tsconfig — the pre-commit typecheck gate fails immediately and permanently.

Found live in nestjsstarter (TS6) while retiring its legacy Codex overlay: apply → commit → typecheck gate red with TS5102 → remove line → next `bun install` re-stamps it.

## Change
Remove `"baseUrl": "./"` from:
- `nestjs/copy-overwrite/tsconfig.json`
- `typescript/copy-overwrite/tsconfig.json`
- `expo/create-only/tsconfig.json` (TS6-readiness for new expo projects)

Safe because `baseUrl: "./"` was already the effective default here: since TS 4.1, `paths` mappings resolve relative to the tsconfig file when `baseUrl` is absent, and the shipped base tsconfigs (`tsconfig/*.json`) never set or rely on it.

## Testing
- All three templates remain valid JSON; no tests or shipped base configs reference `baseUrl`.
- Empirically hit and verified in nestjsstarter (typecheck goes green with the line removed).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to remove deprecated base URL settings.
  * Preserved existing TypeScript configuration and project behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->