### PR TITLE
fix(nestjs): keep typescript7/bin/tsc in knip ignoreBinaries

### DIFF
--- a/nestjs/copy-overwrite/knip.json
+++ b/nestjs/copy-overwrite/knip.json
@@ -1,7 +1,16 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/**/*.ts", "lambdas/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts"],
-  "project": ["src/**/*.ts", "lambdas/**/*.ts", "lib/**/*.ts"],
+  "entry": [
+    "src/**/*.ts",
+    "lambdas/**/*.ts",
+    "lib/**/*.ts",
+    "scripts/**/*.ts"
+  ],
+  "project": [
+    "src/**/*.ts",
+    "lambdas/**/*.ts",
+    "lib/**/*.ts"
+  ],
   "ignore": [
     "**/*.test.ts",
     "**/*.spec.ts",
@@ -75,6 +84,7 @@
     "sentry-cli",
     "sls",
     "tsc",
+    "typescript7/bin/tsc",
     "tsx",
     "vitest"
   ],


### PR DESCRIPTION
## Summary
The nestjs fleet (nestjsstarter, tunnl-backend, gunnertech/backend) aliases the TypeScript 7 native preview as `typescript7` and calls `./node_modules/typescript7/bin/tsc` from its `build`/`typecheck` scripts. The copy-overwrite `knip.json` template lacked the matching `ignoreBinaries` entry, so every `lisa apply` reintroduced a knip **"Unlisted binaries: typescript7/bin/tsc"** failure that blocks the pre-push dead-code gate.

Found live while retiring nestjsstarter's legacy Codex overlay (CodySwannGT/nestjsstarter#20): the apply refreshed knip.json, dropping the entry the repo had carried, and `git push` failed on the knip gate.

## Change
Add `typescript7/bin/tsc` to `ignoreBinaries` in `nestjs/copy-overwrite/knip.json` (right after `tsc`). Array formatting expanded by the JSON writer; content change is the single entry.

🤖 Generated with Claude Code
