### PR TITLE
fix(expo): ship copy-overwrite tsconfig so the typescript template stops clobbering expo projects

### DIFF
--- a/cdk/copy-overwrite/tsconfig.json
+++ b/cdk/copy-overwrite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/cdk", "./tsconfig.local.json"],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   }
 }

--- a/expo/copy-overwrite/tsconfig.json
+++ b/expo/copy-overwrite/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@codyswann/lisa/tsconfig/expo", "./tsconfig.local.json"],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/harper-fabric/copy-overwrite/tsconfig.json
+++ b/harper-fabric/copy-overwrite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/harper-fabric", "./tsconfig.local.json"],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   }
 }

--- a/phaser/copy-overwrite/tsconfig.json
+++ b/phaser/copy-overwrite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@codyswann/lisa/tsconfig/phaser", "./tsconfig.local.json"],
   "compilerOptions": {
-    "baseUrl": "./",
     "ignoreDeprecations": "6.0"
   }
 }

--- a/tests/unit/templates/stack-tsconfig-shadowing.test.ts
+++ b/tests/unit/templates/stack-tsconfig-shadowing.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+/** Child stacks that extend the typescript base and detect alongside it. */
+const CHILD_STACKS = ["expo", "cdk", "nestjs", "phaser", "harper-fabric"];
+
+/**
+ * Read one stack's copy-overwrite tsconfig.json template.
+ * @param stack - Stack template directory name.
+ * @returns Parsed tsconfig template.
+ */
+function readStackTsconfig(stack: string): {
+  extends: string[];
+  compilerOptions?: Record<string, unknown>;
+} {
+  return fs.readJsonSync(
+    path.join(ROOT, stack, "copy-overwrite", "tsconfig.json")
+  );
+}
+
+describe("stack tsconfig.json copy-overwrite shadowing", () => {
+  // Regression: copy-overwrite resolves same-path collisions child-over-
+  // parent via per-type ordering, so every child stack MUST ship its own
+  // copy-overwrite tsconfig.json. Expo didn't — the typescript parent's
+  // template ran unopposed and stamped `extends .../typescript` over expo
+  // projects on every apply/postinstall, dropping jsx and failing typecheck
+  // (hit TunnlAI/frontend and expostarter).
+  it.each(CHILD_STACKS)(
+    "%s ships a copy-overwrite tsconfig extending its own base",
+    stack => {
+      const template = readStackTsconfig(stack);
+      expect(template.extends[0]).toBe(`@codyswann/lisa/tsconfig/${stack}`);
+    }
+  );
+
+  // TypeScript 7 (native preview) removed baseUrl entirely (TS5102); it has
+  // been the effective default since TS 4.1. No template may reintroduce it.
+  it.each([...CHILD_STACKS, "typescript"])(
+    "%s copy-overwrite tsconfig carries no baseUrl",
+    stack => {
+      const template = readStackTsconfig(stack);
+      expect(template.compilerOptions?.["baseUrl"]).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
## Summary
`copy-overwrite` resolves same-path collisions **child-over-parent** via per-type ordering — so every child stack must ship its own `copy-overwrite/tsconfig.json` to shadow the typescript parent's. Expo only had a `create-only` tsconfig, so the typescript template ran unopposed on every apply/postinstall and stamped `extends "@codyswann/lisa/tsconfig/typescript"` over expo projects, dropping `jsx` and failing typecheck.

This is the root cause of the tsconfig clobber observed in TunnlAI/frontend (2026-07-14) and reproduced in expostarter during the legacy-overlay retirement sweep: even after hand-fixing, the postinstall trampoline re-clobbered the file on the next install.

## Change
- Add `expo/copy-overwrite/tsconfig.json` (`extends: .../expo`, no `baseUrl`) — expo now wins the collision like cdk/nestjs/phaser/harper-fabric already do.
- Finish what #1638 started: remove the TS7-removed `baseUrl` from the **cdk, phaser, harper-fabric** copy-overwrite tsconfigs it missed.
- New `stack-tsconfig-shadowing` test suite pins both invariants for every child stack (11 tests).

## Testing
- 60/60 across the template suites.
- Fixture-verified end-to-end: an expo project (`all typescript expo` detected) keeps `extends .../expo` through a full `lisa apply` built from this branch.

🤖 Generated with Claude Code
