### PR TITLE
chore(config): persist sync-populated e2e coverage defaults

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -58,6 +58,14 @@
         "low": 60,
         "break": 60
       }
+    },
+    "e2eCoverage": {
+      "playwright": {
+        "routes": 80
+      },
+      "maestro": {
+        "routes": 80
+      }
     }
   },
   "_lisaSync": {
@@ -107,6 +115,14 @@
           "shipped": "prd-shipped",
           "verified": "prd-verified",
           "sentinel": "prd-intake-feedback"
+        }
+      },
+      "quality.e2eCoverage": {
+        "playwright": {
+          "routes": 80
+        },
+        "maestro": {
+          "routes": 80
         }
       }
     }


### PR DESCRIPTION
## Why

`.lisa.config.json` has been showing up dirty in the working tree with a `quality.e2eCoverage` block that nobody hand-wrote.

It's a `lisa sync` artifact. `quality.e2eCoverage` is a registry entry (`src/sync/registry.ts:111`) whose `defaultValue` is exactly `{ playwright: { routes: 80 }, maestro: { routes: 80 } }` — byte-for-byte what sync wrote — and sync stamped it into `_lisaSync.populated` to record that it's a built-in default rather than a human choice.

So it is neither redundant (merged `main` does not define it) nor discardable (the next `lisa sync` / `lisa ui` run recreates it identically). Committing it is what stops it reappearing dirty every session, and it's what the config-as-source-of-truth design intends: no unset configs, with `populated` provenance so future changes to the default still flow through rather than being frozen as a user override.

## What changed

- `quality.e2eCoverage` — the populated default.
- `_lisaSync.populated["quality.e2eCoverage"]` — the provenance marker that keeps it treated as a default.

No behavior change; values are identical to the registry default.

🤖 Generated with Claude Code