### PR TITLE
fix(monitor): preserve legacy threshold keys

### DIFF
--- a/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/plugins/lisa/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/plugins/src/base/skills/lisa-monitor/SKILL.md
+++ b/plugins/src/base/skills/lisa-monitor/SKILL.md
@@ -15,6 +15,15 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
+## Threshold compatibility
+
+Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+
+- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
+- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+
+A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+
 ## Orchestration: agent team
 
 You are "inside an agent team" only if you are yourself a spawned teammate or subagent — you were spawned into a team context, or your context names a team lead you report to. A lead/root session that has previously spawned subagents is still the lead and retains full authority to create this flow's team.

--- a/src/cli/doctor-monitor-thresholds.ts
+++ b/src/cli/doctor-monitor-thresholds.ts
@@ -1,0 +1,111 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import type { DoctorCheck } from "./doctor.js";
+
+const CHECK_NAME = "Monitor threshold keys current?";
+const COMMITTED_CONFIG = ".lisa.config.json";
+const LOCAL_CONFIG = ".lisa.config.local.json";
+const MONITOR_THRESHOLDS_PREFIX = "monitor.thresholds.";
+const LEGACY_MONITOR_THRESHOLD_KEYS = [
+  {
+    legacy: `${MONITOR_THRESHOLDS_PREFIX}sentryMinEvents24h`,
+    replacement: `${MONITOR_THRESHOLDS_PREFIX}minEvents24h`,
+  },
+  {
+    legacy: `${MONITOR_THRESHOLDS_PREFIX}xrayFaultRatePct`,
+    replacement: `${MONITOR_THRESHOLDS_PREFIX}faultRatePct`,
+  },
+] as const;
+
+/**
+ * Safely parse a Lisa config file for non-blocking advisory checks.
+ * @param configPath - Config path to parse
+ * @returns Parsed config or undefined when unavailable/malformed
+ */
+async function readConfigForAdvisoryCheck(
+  configPath: string
+): Promise<unknown | undefined> {
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(await readFile(configPath, "utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Determine whether an object owns a dotted config path.
+ * @param value - Object to inspect
+ * @param segments - Config key path segments
+ * @returns True when every segment exists as an own property
+ */
+function hasConfigPathSegments(value: unknown, segments: string[]): boolean {
+  if (segments.length === 0) {
+    return true;
+  }
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const segment = segments[0];
+  const remaining = segments.slice(1);
+  if (segment === undefined) {
+    return true;
+  }
+  if (!Object.prototype.hasOwnProperty.call(value, segment)) {
+    return false;
+  }
+  return hasConfigPathSegments(
+    (value as Record<string, unknown>)[segment],
+    remaining
+  );
+}
+
+/**
+ * Determine whether an object owns a dotted config path.
+ * @param value - Object to inspect
+ * @param dottedPath - Dot-separated config key path
+ * @returns True when every segment exists as an own property
+ */
+function hasConfigPath(value: unknown, dottedPath: string): boolean {
+  return hasConfigPathSegments(value, dottedPath.split("."));
+}
+
+/**
+ * Warn when projects still carry deprecated monitor threshold keys.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+export async function checkLegacyMonitorThresholds(
+  targetPath: string
+): Promise<DoctorCheck> {
+  const configs = await Promise.all(
+    [COMMITTED_CONFIG, LOCAL_CONFIG].map(async fileName => ({
+      fileName,
+      config: await readConfigForAdvisoryCheck(path.join(targetPath, fileName)),
+    }))
+  );
+  const findings = configs.flatMap(({ fileName, config }) =>
+    LEGACY_MONITOR_THRESHOLD_KEYS.filter(({ legacy }) =>
+      hasConfigPath(config, legacy)
+    ).map(
+      ({ legacy, replacement }) => `${fileName}: ${legacy} -> ${replacement}`
+    )
+  );
+
+  if (findings.length === 0) {
+    return {
+      name: CHECK_NAME,
+      status: "ok",
+      detail: "No legacy monitor threshold keys present",
+    };
+  }
+
+  return {
+    name: CHECK_NAME,
+    status: "warn",
+    detail: `Legacy monitor threshold keys found; migrate ${findings.join(", ")}`,
+  };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,6 +10,7 @@ import { AGENTS_MD_FILENAME } from "../codex/agents-md-installer.js";
 import { CLAUDE_MD_FILENAME } from "../claude/claude-md-installer.js";
 import { migrateInstructionFiles } from "../core/instruction-files-migration.js";
 import { createDetectorRegistry } from "../detection/index.js";
+import { checkLegacyMonitorThresholds } from "./doctor-monitor-thresholds.js";
 import { STARTERS } from "./starters.js";
 import { runUpdateCheck } from "./update-check.js";
 
@@ -363,6 +364,7 @@ export async function runDoctor(
   const checks = [
     await checkVersion(deps, options.offline === true),
     await checkProjectConfig(resolvedTarget),
+    await checkLegacyMonitorThresholds(resolvedTarget),
     await checkProjectType(resolvedTarget),
     await checkInstructionFiles(resolvedTarget),
     checkLegacyCodexOverlay(resolvedTarget),

--- a/tests/unit/cli/doctor.test.ts
+++ b/tests/unit/cli/doctor.test.ts
@@ -9,6 +9,7 @@ const LISA_CONFIG_FILE = ".lisa.config.json";
 
 /** Doctor check name for the legacy Codex overlay detection. */
 const CODEX_OVERLAY_CHECK = "Codex overlay current?";
+const MONITOR_THRESHOLD_KEYS_CHECK = "Monitor threshold keys current?";
 
 let tempDir: string | undefined;
 
@@ -73,6 +74,103 @@ describe("runDoctor", () => {
     );
 
     expect(setExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it("warns when legacy monitor threshold keys are present", async () => {
+    const cwd = await getTempDir();
+    await writeFile(
+      path.join(cwd, LISA_CONFIG_FILE),
+      JSON.stringify({
+        monitor: {
+          thresholds: {
+            sentryMinEvents24h: 50,
+            xrayFaultRatePct: 12,
+          },
+        },
+      })
+    );
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: MONITOR_THRESHOLD_KEYS_CHECK,
+        status: "warn",
+        detail: expect.stringContaining(
+          "monitor.thresholds.sentryMinEvents24h -> monitor.thresholds.minEvents24h"
+        ),
+      })
+    );
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        detail: expect.stringContaining(
+          "monitor.thresholds.xrayFaultRatePct -> monitor.thresholds.faultRatePct"
+        ),
+      })
+    );
+  });
+
+  it("does not warn when only current monitor threshold keys are present", async () => {
+    const cwd = await getTempDir();
+    await writeFile(
+      path.join(cwd, LISA_CONFIG_FILE),
+      JSON.stringify({
+        monitor: {
+          thresholds: {
+            minEvents24h: 50,
+            faultRatePct: 12,
+          },
+        },
+      })
+    );
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: MONITOR_THRESHOLD_KEYS_CHECK,
+        status: "ok",
+      })
+    );
+  });
+
+  it("warns on legacy leftovers even when current monitor keys are present", async () => {
+    const cwd = await getTempDir();
+    await writeFile(
+      path.join(cwd, LISA_CONFIG_FILE),
+      JSON.stringify({
+        monitor: {
+          thresholds: {
+            minEvents24h: 5,
+            sentryMinEvents24h: 50,
+          },
+        },
+      })
+    );
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: MONITOR_THRESHOLD_KEYS_CHECK,
+        status: "warn",
+        detail: expect.stringContaining(
+          "monitor.thresholds.sentryMinEvents24h -> monitor.thresholds.minEvents24h"
+        ),
+      })
+    );
   });
 
   it("warns when the legacy pre-2.198 Codex overlay is still present", async () => {


### PR DESCRIPTION
## Summary

Closes #1527.

- Add a `lisa doctor` advisory check that warns when `.lisa.config.json` or `.lisa.config.local.json` still carries legacy monitor threshold keys, naming the exact provider-neutral replacement key.
- Preserve `lisa-monitor` backward compatibility in the canonical skill contract: current key wins, legacy key falls back, then documented default.
- Regenerate the monitor skill copies for Claude/Codex, Cursor, Copilot, and Agy from the canonical source.

## Verification

- `bunx vitest run tests/unit/cli/doctor.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build:dist`
- real built CLI smoke: legacy-only WARN, current-only OK, both-key WARN
- `bun run test:unit`
- `bun run check:plugins`
- push hook: security audit, slow lint, knip, coverage unit suite, integration suite

