### PR TITLE
fix(monitor): preserve legacy threshold behavior

### DIFF
--- a/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/plugins/lisa/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/plugins/src/base/skills/lisa-monitor/SKILL.md
+++ b/plugins/src/base/skills/lisa-monitor/SKILL.md
@@ -15,14 +15,69 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Threshold compatibility
+## Monitor threshold compatibility
 
-Resolve monitor thresholds from `.lisa.config.local.json` first and `.lisa.config.json` second, using the local-overrides-global semantics from the `config-resolution` rule. For renamed thresholds, prefer the provider-neutral key when present, then fall back to the legacy provider-named key, then fall back to the documented default:
+Before resolving anomaly thresholds, inspect the committed
+`.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
+Use a literal, fixed-path projection that returns presence and value for only
+these four exact paths; do not use `Read`, `cat`, interpolation, or a filter
+that emits either entire config into agent context:
 
-- `monitor.thresholds.minEvents24h` falls back to `monitor.thresholds.sentryMinEvents24h`, then default `1`.
-- `monitor.thresholds.faultRatePct` falls back to `monitor.thresholds.xrayFaultRatePct`, then default `5`.
+- `monitor.thresholds.minEvents24h`, then
+  `monitor.thresholds.sentryMinEvents24h`.
+- `monitor.thresholds.faultRatePct`, then
+  `monitor.thresholds.xrayFaultRatePct`.
 
-A project carrying both keys uses the provider-neutral value. A project carrying only the legacy key keeps using that explicit legacy value; never silently substitute the new default just because the new key is absent.
+Run this fixed filter once with literal final argument `.lisa.config.json` and
+once with literal final argument `.lisa.config.local.json` when the respective
+file exists:
+
+```bash
+jq 'def threshold($object; $name):
+    if ($object | has($name)) then
+      ($object[$name] | type) as $type |
+      if $type == "number" then
+        if ($object[$name] | isfinite and (isnan | not)) then
+          {present: true, valid: true, type: "number", value: $object[$name]}
+        else
+          {present: true, valid: false, type: "non-finite-number"}
+        end
+      else
+        {present: true, valid: false, type: $type}
+      end
+    else
+      {present: false, valid: false, type: "missing"}
+    end;
+  (.monitor.thresholds | if type == "object" then . else {} end) as $t |
+  {
+    "monitor.thresholds.minEvents24h": threshold($t; "minEvents24h"),
+    "monitor.thresholds.sentryMinEvents24h": threshold($t; "sentryMinEvents24h"),
+    "monitor.thresholds.faultRatePct": threshold($t; "faultRatePct"),
+    "monitor.thresholds.xrayFaultRatePct": threshold($t; "xrayFaultRatePct")
+  }' .lisa.config.json
+```
+
+A nonzero `jq` result fails threshold collection; do not treat an uninspectable
+present file as if it were absent.
+
+For each exact path, keep the raw `jq` presence/value result from each file;
+do not inject defaults during this merge. Local presence overrides committed
+presence per path. After that merge, resolve the current key before the legacy
+key, then use default `1` for `monitor.thresholds.minEvents24h` or default `5`
+for `monitor.thresholds.faultRatePct`. Current key wins over legacy key even
+when its configured value is invalid.
+
+Every configured threshold must be a finite JSON number. If the selected path
+is null, a string, a boolean, an object, an array, or otherwise non-finite,
+fail threshold collection and report the exact path and source without echoing
+the invalid value; never fall through to a legacy value or default. Never quote
+or report either whole config. The fixed `jq` projection itself must redact
+invalid configured content: it emits only presence, validity, and a fixed type
+classification, and includes the numeric `value` field only for a finite number.
+For a valid resolution, the monitor report must include the resolved value and
+source. Report only a validated numeric resolved value and one fixed source enum:
+`local-current`, `committed-current`, `local-legacy`, `committed-legacy`, or
+`default`.
 
 ## Orchestration: agent team
 

--- a/src/cli/doctor-monitor-thresholds.ts
+++ b/src/cli/doctor-monitor-thresholds.ts
@@ -1,111 +1,110 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
-import type { DoctorCheck } from "./doctor.js";
 
-const CHECK_NAME = "Monitor threshold keys current?";
-const COMMITTED_CONFIG = ".lisa.config.json";
-const LOCAL_CONFIG = ".lisa.config.local.json";
-const MONITOR_THRESHOLDS_PREFIX = "monitor.thresholds.";
-const LEGACY_MONITOR_THRESHOLD_KEYS = [
+const MONITOR_THRESHOLD_CONFIG_CHECK_NAME = "Monitor threshold keys current?";
+
+const CONFIG_FILES = [".lisa.config.json", ".lisa.config.local.json"] as const;
+
+const LEGACY_MONITOR_THRESHOLDS = [
   {
-    legacy: `${MONITOR_THRESHOLDS_PREFIX}sentryMinEvents24h`,
-    replacement: `${MONITOR_THRESHOLDS_PREFIX}minEvents24h`,
+    legacy: "monitor.thresholds.sentryMinEvents24h",
+    current: "monitor.thresholds.minEvents24h",
+    property: "sentryMinEvents24h",
   },
   {
-    legacy: `${MONITOR_THRESHOLDS_PREFIX}xrayFaultRatePct`,
-    replacement: `${MONITOR_THRESHOLDS_PREFIX}faultRatePct`,
+    legacy: "monitor.thresholds.xrayFaultRatePct",
+    current: "monitor.thresholds.faultRatePct",
+    property: "xrayFaultRatePct",
   },
 ] as const;
 
-/**
- * Safely parse a Lisa config file for non-blocking advisory checks.
- * @param configPath - Config path to parse
- * @returns Parsed config or undefined when unavailable/malformed
- */
-async function readConfigForAdvisoryCheck(
-  configPath: string
-): Promise<unknown | undefined> {
-  if (!existsSync(configPath)) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(await readFile(configPath, "utf8")) as unknown;
-  } catch {
-    return undefined;
-  }
+/** Result of inspecting one optional config file. */
+interface ConfigInspection {
+  findings: string[];
+  uninspectable?: string;
 }
 
 /**
- * Determine whether an object owns a dotted config path.
- * @param value - Object to inspect
- * @param segments - Config key path segments
- * @returns True when every segment exists as an own property
+ * Return an object-shaped value as a string-keyed record.
+ * @param value - Value to narrow
+ * @returns Record for objects, otherwise undefined
  */
-function hasConfigPathSegments(value: unknown, segments: string[]): boolean {
-  if (segments.length === 0) {
-    return true;
-  }
-  if (value === null || typeof value !== "object") {
-    return false;
-  }
-  const segment = segments[0];
-  const remaining = segments.slice(1);
-  if (segment === undefined) {
-    return true;
-  }
-  if (!Object.prototype.hasOwnProperty.call(value, segment)) {
-    return false;
-  }
-  return hasConfigPathSegments(
-    (value as Record<string, unknown>)[segment],
-    remaining
-  );
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 /**
- * Determine whether an object owns a dotted config path.
- * @param value - Object to inspect
- * @param dottedPath - Dot-separated config key path
- * @returns True when every segment exists as an own property
- */
-function hasConfigPath(value: unknown, dottedPath: string): boolean {
-  return hasConfigPathSegments(value, dottedPath.split("."));
-}
-
-/**
- * Warn when projects still carry deprecated monitor threshold keys.
+ * Find legacy monitor threshold keys in one raw config file.
+ * Parse failures are reported by doctor's existing project-config check.
  * @param targetPath - Project path to inspect
- * @returns Doctor check result
+ * @param fileName - Raw config file to inspect
+ * @returns Legacy-path migration findings
+ */
+async function legacyFindingsForFile(
+  targetPath: string,
+  fileName: (typeof CONFIG_FILES)[number]
+): Promise<ConfigInspection> {
+  const configPath = path.join(targetPath, fileName);
+  if (!existsSync(configPath)) return { findings: [] };
+
+  try {
+    const config = asRecord(JSON.parse(await readFile(configPath, "utf8")));
+    const monitor = asRecord(config?.["monitor"]);
+    const thresholds = asRecord(monitor?.["thresholds"]);
+
+    return {
+      findings: LEGACY_MONITOR_THRESHOLDS.filter(threshold =>
+        Object.hasOwn(thresholds ?? {}, threshold.property)
+      ).map(
+        threshold => `${fileName}: ${threshold.legacy} -> ${threshold.current}`
+      ),
+    };
+  } catch {
+    return { findings: [], uninspectable: fileName };
+  }
+}
+
+/**
+ * Find legacy monitor keys in committed and local config independently.
+ * @param targetPath - Project path to inspect
+ * @returns One named doctor check result
  */
 export async function checkLegacyMonitorThresholds(
   targetPath: string
-): Promise<DoctorCheck> {
-  const configs = await Promise.all(
-    [COMMITTED_CONFIG, LOCAL_CONFIG].map(async fileName => ({
-      fileName,
-      config: await readConfigForAdvisoryCheck(path.join(targetPath, fileName)),
-    }))
+): Promise<{
+  name: string;
+  status: "ok" | "warn";
+  detail: string;
+}> {
+  const inspections = await Promise.all(
+    CONFIG_FILES.map(fileName => legacyFindingsForFile(targetPath, fileName))
   );
-  const findings = configs.flatMap(({ fileName, config }) =>
-    LEGACY_MONITOR_THRESHOLD_KEYS.filter(({ legacy }) =>
-      hasConfigPath(config, legacy)
-    ).map(
-      ({ legacy, replacement }) => `${fileName}: ${legacy} -> ${replacement}`
-    )
+  const findings = inspections.flatMap(inspection => inspection.findings);
+  const uninspectable = inspections.flatMap(inspection =>
+    inspection.uninspectable ? [inspection.uninspectable] : []
   );
 
-  if (findings.length === 0) {
-    return {
-      name: CHECK_NAME,
-      status: "ok",
-      detail: "No legacy monitor threshold keys present",
-    };
-  }
-
-  return {
-    name: CHECK_NAME,
-    status: "warn",
-    detail: `Legacy monitor threshold keys found; migrate ${findings.join(", ")}`,
-  };
+  return findings.length === 0 && uninspectable.length === 0
+    ? {
+        name: MONITOR_THRESHOLD_CONFIG_CHECK_NAME,
+        status: "ok",
+        detail: "No legacy monitor threshold keys found",
+      }
+    : {
+        name: MONITOR_THRESHOLD_CONFIG_CHECK_NAME,
+        status: "warn",
+        detail: [
+          findings.length > 0
+            ? `Replace legacy monitor threshold keys: ${findings.join(", ")}`
+            : undefined,
+          uninspectable.length > 0
+            ? `Could not inspect monitor threshold keys in: ${uninspectable.join(", ")}`
+            : undefined,
+        ]
+          .filter((message): message is string => message !== undefined)
+          .join(". "),
+      };
 }

--- a/tests/unit/cli/doctor-monitor-thresholds.test.ts
+++ b/tests/unit/cli/doctor-monitor-thresholds.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Runtime regression coverage for legacy monitor threshold diagnostics.
+ *
+ * Issue #1527 keeps legacy threshold configuration actionable while projects
+ * migrate to provider-neutral key names. These tests exercise `runDoctor`
+ * against real config files rather than checking implementation text.
+ * @module tests/unit/cli/doctor-monitor-thresholds
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runDoctor } from "../../../src/cli/doctor.js";
+
+const COMMITTED_CONFIG = ".lisa.config.json";
+const LOCAL_CONFIG = ".lisa.config.local.json";
+const LEGACY_MIN_EVENTS = "monitor.thresholds.sentryMinEvents24h";
+const CURRENT_MIN_EVENTS = "monitor.thresholds.minEvents24h";
+const LEGACY_FAULT_RATE = "monitor.thresholds.xrayFaultRatePct";
+const CURRENT_FAULT_RATE = "monitor.thresholds.faultRatePct";
+const MONITOR_THRESHOLD_CHECK = "Monitor threshold keys current?";
+
+let tempDir: string | undefined;
+
+/**
+ * Create one isolated project fixture.
+ * @returns Temporary fixture path
+ */
+async function fixtureDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-doctor-monitor-"));
+  return tempDir;
+}
+
+/**
+ * Write JSON to a project configuration file.
+ * @param fileName - Config file to write
+ * @param value - JSON-compatible fixture value
+ */
+async function writeConfig(
+  fileName: typeof COMMITTED_CONFIG | typeof LOCAL_CONFIG,
+  value: unknown
+): Promise<void> {
+  const cwd = await fixtureDir();
+  await writeFile(path.join(cwd, fileName), `${JSON.stringify(value)}\n`);
+}
+
+/**
+ * Run doctor without network access or console output.
+ * @returns Machine-readable doctor result
+ */
+async function doctor() {
+  return runDoctor(
+    await fixtureDir(),
+    { offline: true },
+    { runUpdateCheck: vi.fn(), setExitCode: vi.fn(), write: vi.fn() }
+  );
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("doctor legacy monitor threshold diagnostics (#1527)", () => {
+  it("warns for legacy-only keys and names each exact replacement path", async () => {
+    await writeConfig(COMMITTED_CONFIG, {
+      monitor: {
+        thresholds: {
+          sentryMinEvents24h: 50,
+          xrayFaultRatePct: 17,
+        },
+      },
+    });
+
+    const result = await doctor();
+    const monitorKeyCheck = result.checks.find(check =>
+      /monitor threshold/i.test(`${check.name} ${check.detail}`)
+    );
+
+    expect(monitorKeyCheck?.status).toBe("warn");
+    expect(monitorKeyCheck?.detail).toContain(LEGACY_MIN_EVENTS);
+    expect(monitorKeyCheck?.detail).toContain(CURRENT_MIN_EVENTS);
+    expect(monitorKeyCheck?.detail).toContain(LEGACY_FAULT_RATE);
+    expect(monitorKeyCheck?.detail).toContain(CURRENT_FAULT_RATE);
+  });
+
+  it("reports an OK monitor-key check for current-only keys", async () => {
+    await writeConfig(COMMITTED_CONFIG, {
+      monitor: {
+        thresholds: { minEvents24h: 50, faultRatePct: 17 },
+      },
+    });
+
+    const result = await doctor();
+    const monitorKeyChecks = result.checks.filter(check =>
+      /monitor threshold/i.test(`${check.name} ${check.detail}`)
+    );
+
+    expect(monitorKeyChecks).toContainEqual(
+      expect.objectContaining({ status: "ok" })
+    );
+    expect(monitorKeyChecks).not.toContainEqual(
+      expect.objectContaining({ status: "warn" })
+    );
+  });
+
+  it("still warns when current and legacy keys coexist", async () => {
+    await writeConfig(COMMITTED_CONFIG, {
+      monitor: {
+        thresholds: {
+          minEvents24h: 3,
+          sentryMinEvents24h: 50,
+          faultRatePct: 4,
+          xrayFaultRatePct: 17,
+        },
+      },
+    });
+
+    const result = await doctor();
+    const warningText = result.checks
+      .filter(check => check.status === "warn")
+      .map(check => check.detail)
+      .join("\n");
+
+    expect(warningText).toContain(LEGACY_MIN_EVENTS);
+    expect(warningText).toContain(CURRENT_MIN_EVENTS);
+    expect(warningText).toContain(LEGACY_FAULT_RATE);
+    expect(warningText).toContain(CURRENT_FAULT_RATE);
+  });
+
+  it("detects a legacy key that exists only in local configuration", async () => {
+    await writeConfig(COMMITTED_CONFIG, {
+      monitor: { thresholds: { minEvents24h: 3 } },
+    });
+    await writeConfig(LOCAL_CONFIG, {
+      monitor: { thresholds: { xrayFaultRatePct: 17 } },
+    });
+
+    const result = await doctor();
+    const warningText = result.checks
+      .filter(check => check.status === "warn")
+      .map(check => check.detail)
+      .join("\n");
+
+    expect(warningText).toContain(LEGACY_FAULT_RATE);
+    expect(warningText).toContain(CURRENT_FAULT_RATE);
+  });
+
+  it("treats null-valued legacy keys as present own properties", async () => {
+    await writeConfig(LOCAL_CONFIG, {
+      monitor: { thresholds: { sentryMinEvents24h: null } },
+    });
+
+    const result = await doctor();
+    const monitorKeyCheck = result.checks.find(
+      check => check.name === MONITOR_THRESHOLD_CHECK
+    );
+
+    expect(monitorKeyCheck?.status).toBe("warn");
+    expect(monitorKeyCheck?.detail).toContain(LEGACY_MIN_EVENTS);
+    expect(monitorKeyCheck?.detail).toContain(CURRENT_MIN_EVENTS);
+  });
+
+  it("does not crash the added check when either config file is malformed", async () => {
+    const cwd = await fixtureDir();
+    await writeFile(path.join(cwd, COMMITTED_CONFIG), "{\n");
+    await writeFile(path.join(cwd, LOCAL_CONFIG), "[\n");
+
+    const result = await doctor();
+    const monitorChecks = result.checks.filter(
+      check => check.name === MONITOR_THRESHOLD_CHECK
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: "Project Lisa config present?",
+        status: "fail",
+      })
+    );
+    expect(monitorChecks).toHaveLength(1);
+    expect(monitorChecks).toContainEqual(
+      expect.objectContaining({
+        name: MONITOR_THRESHOLD_CHECK,
+        status: "warn",
+        detail: expect.stringContaining(COMMITTED_CONFIG),
+      })
+    );
+    expect(monitorChecks[0]?.detail).toContain(LOCAL_CONFIG);
+    expect(monitorChecks).not.toContainEqual(
+      expect.objectContaining({
+        name: MONITOR_THRESHOLD_CHECK,
+        status: "ok",
+      })
+    );
+  });
+});

--- a/tests/unit/strategies/monitor-threshold-compatibility.test.ts
+++ b/tests/unit/strategies/monitor-threshold-compatibility.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Prompt-as-code regression coverage for monitor threshold compatibility.
+ *
+ * `lisa-monitor` is an agent-executed skill, so its operational contract must
+ * explicitly define scoped config extraction, alias precedence, defaults, and
+ * observable reporting that an independent verifier can inspect.
+ * @module tests/unit/strategies/monitor-threshold-compatibility
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SOURCE_SKILL = "plugins/src/base/skills/lisa-monitor/SKILL.md";
+const JQ_PROJECTION = /```bash\njq '(.*?)' \.lisa\.config\.json\n```/s;
+/** Four byte-identical copies; Codex is the fifth copy with transformed metadata. */
+const BYTE_IDENTICAL_GENERATED_SKILLS = [
+  "plugins/lisa/skills/lisa-monitor/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-monitor/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-monitor/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-monitor/SKILL.md",
+] as const;
+
+const read = (filePath: string): string =>
+  readFileSync(path.resolve(filePath), "utf8");
+
+const source = read(SOURCE_SKILL);
+
+describe("monitor threshold compatibility contract (#1527)", () => {
+  it("requires four-key-only jq extraction from committed and local config", () => {
+    expect(source).toMatch(/`\.lisa\.config\.json`.*`jq`/is);
+    expect(source).toContain(".lisa.config.local.json");
+    expect(source).toMatch(/fixed-path.*only.*four exact paths/is);
+    expect(source).toMatch(/do not use `Read`, `cat`/i);
+    expect(source).toMatch(/local.*override.*committed.*per path/is);
+    expect(source).toMatch(/presence\/value.*do not inject defaults/is);
+  });
+
+  it("defines current, legacy, and default precedence for event counts", () => {
+    expect(source).toMatch(
+      /`monitor\.thresholds\.minEvents24h`[\s\S]*`monitor\.thresholds\.sentryMinEvents24h`[\s\S]*default[^\n]*`?1`?/i
+    );
+    expect(source).toMatch(/(?:current|new) key wins over (?:the )?legacy/i);
+  });
+
+  it("defines current, legacy, and default precedence for fault rates", () => {
+    expect(source).toMatch(
+      /`monitor\.thresholds\.faultRatePct`[\s\S]*`monitor\.thresholds\.xrayFaultRatePct`[\s\S]*default[^\n]*`?5`?/i
+    );
+    expect(source).toMatch(/(?:current|new) key wins over (?:the )?legacy/i);
+  });
+
+  it("requires observable resolved value and source reporting for both pairs", () => {
+    expect(source).toMatch(/report.*resolved value.*source/is);
+    expect(source).toContain("monitor.thresholds.minEvents24h");
+    expect(source).toContain("monitor.thresholds.faultRatePct");
+    expect(source).toMatch(/committed|local|legacy|default/i);
+    for (const sourceName of [
+      "local-current",
+      "committed-current",
+      "local-legacy",
+      "committed-legacy",
+      "default",
+    ]) {
+      expect(source).toContain(`\`${sourceName}\``);
+    }
+  });
+
+  it("rejects invalid configured values without leaking config or falling back", () => {
+    expect(source).toMatch(/finite JSON number/i);
+    expect(source).toMatch(/fail threshold collection/i);
+    expect(source).toMatch(/never fall through.*legacy value or default/is);
+    expect(source).toMatch(/never quote.*whole config/is);
+    expect(source).toMatch(/report only.*validated numeric resolved value/is);
+    expect(source).toContain("isfinite");
+    expect(source).toContain("isfinite and (isnan | not)");
+    expect(source).toMatch(/projection itself must redact.*invalid/is);
+    expect(source).toMatch(/numeric `value` field only for a finite number/is);
+  });
+
+  it("executes the canonical jq projection without exposing NaN", () => {
+    const projection = JQ_PROJECTION.exec(source)?.[1];
+    expect(projection).toBeDefined();
+    if (!projection) throw new Error("Canonical jq projection is missing");
+
+    const jqPath = [
+      "/opt/homebrew/bin/jq",
+      "/usr/local/bin/jq",
+      "/usr/bin/jq",
+    ].find(candidate => existsSync(candidate));
+    expect(jqPath).toBeDefined();
+    if (!jqPath) throw new Error("jq executable is unavailable");
+
+    const output = execFileSync(jqPath, [projection], {
+      encoding: "utf8",
+      input: '{"monitor":{"thresholds":{"minEvents24h":NaN}}}',
+    });
+    const projected = JSON.parse(output) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const nanResult = projected["monitor.thresholds.minEvents24h"];
+
+    expect(nanResult).toEqual({
+      present: true,
+      type: "non-finite-number",
+      valid: false,
+    });
+    expect(nanResult).not.toHaveProperty("value");
+  });
+
+  it.each(BYTE_IDENTICAL_GENERATED_SKILLS)(
+    "keeps generated skill content in lockstep at %s",
+    generatedPath => {
+      expect(read(generatedPath)).toBe(source);
+    }
+  );
+
+  it("keeps the Codex skill body aligned after its generated description override", () => {
+    const codex = read(
+      "plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md"
+    );
+    const bodyStart = source.indexOf("\n---\n") + "\n---\n".length;
+    const codexBodyStart = codex.indexOf("\n---\n") + "\n---\n".length;
+
+    expect(codex.slice(codexBodyStart)).toBe(source.slice(bodyStart));
+  });
+});


### PR DESCRIPTION
## Summary

This hardens the basic #1527 implementation merged in PR #1655:

- restrict `lisa-monitor` threshold reads to a literal four-path `jq` projection
- redact invalid project-controlled values before they can enter agent context
- reject NaN/non-finite and other invalid selected values without silently falling back
- report validated resolved values with fixed source enums
- make `lisa doctor` WARN on malformed/unreadable config instead of falsely reporting threshold config current
- add focused runtime, prompt-contract, executable jq, and five-agent parity regressions

Closes #1527

## Why this follow-up is required

The concurrent PR #1655 landed while this implementation was being independently verified. Its basic current → legacy → default behavior is correct, but review found two enterprise-grade gaps: whole/unchecked config values could enter monitor context, and parse/read failure produced a contradictory threshold OK. This nine-file delta preserves #1655's public doctor check name and existing tests while closing those gaps.

## Validation

- `bun run test` — 257 files, 4,069 tests passed
- integration tests — 8 files, 121 tests passed
- `bun run lint` and `bun run lint:slow`
- `bun run typecheck`
- `bun run format:check`
- `bun run check:plugins`
- `bun run check:rules-pairing`
- pre-push security audit, dead-code detection, coverage, and integration gates
- independent post-rebase verification: 6/6 criteria PASS at `85b0f5fba862620c4f58a66c6a4f8f927ae86249`

## Scope

Exactly nine files: canonical monitor skill + five generated agent copies, the existing doctor helper, and two focused test files. No registry, sync, reference-rule, eager-rule, UI, doctor wiring, or roster changes.

## Evidence

Post-rebase verification at `85b0f5fba862620c4f58a66c6a4f8f927ae86249` passed every issue marker:

- [state-dump: legacy-only-project-config](https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1656-01-legacy-only-project-config.json)
- [cli-output: doctor-warns-on-legacy-keys](https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1656-02-doctor-warns-on-legacy-keys.txt)
- [cli-output: monitor-uses-legacy-value](https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1656-03-monitor-uses-legacy-value.json)
- [cli-output: doctor-clean-after-migration](https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1656-04-doctor-clean-after-migration.txt)
- [cli-output: both-keys-prefers-new-and-warns](https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1656-05-both-keys-prefers-new-and-warns.txt)

This nine-file hardening delta builds on merged PR #1655. It preserves that public doctor contract while making malformed/unreadable configs WARN instead of false-OK, restricting monitor reads to four literal paths, redacting hostile/NaN values before output, and proving source/value resolution across all five generated agent surfaces.

Full post-rebase verification passed 4,069 tests, 121 integration tests, plugin parity, rules pairing, lint, slow lint, typecheck, formatting, security, coverage, and dead-code gates.

## Lisa Usage

_This section is managed by Lisa. Rewrites update matching usage entries in place and preserve older rows._

| Flow | Source | Model | Tokens | Cost |
| --- | --- | --- | ---: | ---: |
| lisa-verify | unavailable | openai/gpt-5 | null | null | <!-- lisa:usage-entry entry_id=verify-github-lisa-1527-019f6bfd flow=lisa-verify run_id=019f6bfd-ed31-7b62-8743-f5262e5da11c provider=openai model=gpt-5 source=unavailable input_tokens=null cached_input_tokens=null output_tokens=null reasoning_tokens=null total_tokens=null cost=null currency=null pricing_status=unavailable pricing_source=null artifact_ref=github-pr-comment%3ACodySwannGT%2Flisa%231656%2Fevidence parent_artifact_ref=github%3ACodySwannGT%2Flisa%231527 -->

<!-- lisa:usage-rollup direct_entry_ids=verify-github-lisa-1527-019f6bfd child_entry_ids= child_refs= direct_tokens=null child_tokens=null total_tokens=null direct_cost=null child_cost=null total_cost=null currency=null child_currency=null -->
