### PR TITLE
fix(sync): preserve human legacy monitor values

### DIFF
--- a/src/sync/config-sync.ts
+++ b/src/sync/config-sync.ts
@@ -31,6 +31,7 @@ import {
   SYNC_REGISTRY,
   type SyncedSetting,
 } from "./registry.js";
+import { aliasCompatibleDefault, hasLegacyAlias } from "./legacy-aliases.js";
 
 /** Key holding sync provenance metadata inside `.lisa.config.json`. */
 export const SYNC_METADATA_KEY = "_lisaSync";
@@ -217,6 +218,7 @@ function populateMissing(
  * @param state - Current sync state
  * @param entry - Registry entry
  * @param merged - Merged config view (local overlay applied)
+ * @param local - Local config overlay
  * @param artifactValue - Value found in an existing artifact, if any
  * @returns Updated state
  */
@@ -224,17 +226,23 @@ function populateEntry(
   state: SyncState,
   entry: SyncedSetting,
   merged: JsonObject,
+  local: JsonObject,
   artifactValue: JsonValue | undefined
 ): SyncState {
   const configValue = getAtPath(merged, entry.key);
   if (configValue === undefined) {
     return populateMissing(state, entry, artifactValue);
   }
+  const committedValue = getAtPath(state.committed, entry.key);
+  const localValue = getAtPath(local, entry.key);
   const recorded = recordedPopulation(state.committed, entry.key);
+  const evolutionValue =
+    entry.legacyAliases === undefined ? configValue : committedValue;
   if (
     recorded !== undefined &&
-    jsonEquals(configValue, recorded) &&
-    !jsonEquals(configValue, entry.defaultValue)
+    jsonEquals(evolutionValue, recorded) &&
+    !jsonEquals(evolutionValue, entry.defaultValue) &&
+    !hasLegacyAlias(localValue, entry.legacyAliases)
   ) {
     const committed = recordPopulation(
       setAtPath(state.committed, entry.key, entry.defaultValue),
@@ -247,8 +255,22 @@ function populateEntry(
       detail: "value still matched the old default; updated to the new one",
     });
   }
-  const filled = fillMissing(configValue, entry.defaultValue);
-  if (!jsonEquals(filled, configValue)) {
+  const hasEffectiveAlias = hasLegacyAlias(configValue, entry.legacyAliases);
+  if (hasEffectiveAlias && committedValue === undefined) {
+    return state;
+  }
+  // Compatibility fills are based only on committed state. Each present alias
+  // prunes its own mapped current default while unrelated defaults still fill.
+  const fillSource = hasEffectiveAlias ? committedValue : configValue;
+  const fallback = hasEffectiveAlias
+    ? aliasCompatibleDefault(
+        configValue,
+        entry.defaultValue,
+        entry.legacyAliases
+      )
+    : entry.defaultValue;
+  const filled = fillMissing(fillSource, fallback);
+  if (!jsonEquals(filled, fillSource)) {
     return withAction(state, setAtPath(state.committed, entry.key, filled), {
       key: entry.key,
       kind: "filled-missing",
@@ -364,7 +386,13 @@ export async function runConfigSync(
         return state;
       }
       const artifactValue = await readArtifactValue(destDir, entry);
-      const populated = populateEntry(state, entry, merged, artifactValue);
+      const populated = populateEntry(
+        state,
+        entry,
+        merged,
+        local,
+        artifactValue
+      );
       return syncArtifacts(populated, entry, destDir, local);
     },
     Promise.resolve(initial)

--- a/src/sync/legacy-aliases.ts
+++ b/src/sync/legacy-aliases.ts
@@ -1,0 +1,78 @@
+/**
+ * Compatibility helpers for registry settings with deprecated relative paths.
+ * @module sync/legacy-aliases
+ */
+import { getAtPath, isJsonObject, type JsonValue } from "./json-path.js";
+
+/** One deprecated relative path and the current path that replaces it. */
+export interface LegacyAliasMapping {
+  readonly currentPath: string;
+  readonly legacyPath: string;
+}
+
+/**
+ * Whether a value contains any declared deprecated alias. Presence is checked
+ * against `undefined` so explicit `0` and `null` values remain human-owned.
+ * @param value - Setting value to inspect
+ * @param aliases - Relative-path alias mappings
+ * @returns True when at least one legacy path is present
+ */
+export function hasLegacyAlias(
+  value: JsonValue | undefined,
+  aliases: readonly LegacyAliasMapping[] | undefined
+): boolean {
+  return (
+    aliases?.some(alias => getAtPath(value, alias.legacyPath) !== undefined) ??
+    false
+  );
+}
+
+/**
+ * Return a JSON value without one nested object path.
+ * @param value - Value to copy
+ * @param dotPath - Relative dot path to omit
+ * @returns Copied value with the addressed property omitted
+ */
+function omitAtPath(value: JsonValue, dotPath: string): JsonValue {
+  if (!isJsonObject(value)) {
+    return value;
+  }
+  const dotIndex = dotPath.indexOf(".");
+  const head = dotIndex === -1 ? dotPath : dotPath.slice(0, dotIndex);
+  if (dotIndex === -1) {
+    return Object.fromEntries(
+      Object.entries(value).filter(([key]) => key !== head)
+    );
+  }
+  const child = value[head];
+  if (child === undefined) {
+    return value;
+  }
+  return {
+    ...value,
+    [head]: omitAtPath(child, dotPath.slice(dotIndex + 1)),
+  };
+}
+
+/**
+ * Remove only current defaults whose legacy counterpart is present.
+ * @param value - Effective entry value used to detect aliases
+ * @param defaultValue - Registry default to prune
+ * @param aliases - Relative-path alias mappings
+ * @returns Default value safe to fill beside the effective aliases
+ */
+export function aliasCompatibleDefault(
+  value: JsonValue,
+  defaultValue: JsonValue,
+  aliases: readonly LegacyAliasMapping[] | undefined
+): JsonValue {
+  return (
+    aliases?.reduce(
+      (fallback, alias) =>
+        getAtPath(value, alias.legacyPath) === undefined
+          ? fallback
+          : omitAtPath(fallback, alias.currentPath),
+      defaultValue
+    ) ?? defaultValue
+  );
+}

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -11,6 +11,7 @@
  * @module sync/registry
  */
 import type { JsonValue } from "./json-path.js";
+import type { LegacyAliasMapping } from "./legacy-aliases.js";
 
 /**
  * A project file that mirrors a synced setting. Artifact files are only ever
@@ -30,6 +31,11 @@ export interface SyncedSetting {
   readonly key: string;
   /** Built-in default used when neither config nor artifact has a value */
   readonly defaultValue: JsonValue;
+  /**
+   * Internal relative-path mappings for deprecated keys that remain readable.
+   * Sync uses these to avoid filling a new default beside a human-owned alias.
+   */
+  readonly legacyAliases?: readonly LegacyAliasMapping[];
   /** Files that mirror this value (written from config on every sync) */
   readonly artifacts?: readonly ArtifactBinding[];
   /**
@@ -148,10 +154,7 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
       gapTiers: "core",
       backoffHours: 24,
       // Provider-neutral threshold names: the audit spans Sentry, CloudWatch,
-      // X-Ray, and future providers, so no key is prefixed with a vendor. The
-      // lisa-monitor skill still reads the legacy sentryMinEvents24h /
-      // xrayFaultRatePct keys — renaming those (config-resolution.md + skill)
-      // is a tracked follow-up; see ui/README.md.
+      // X-Ray, and future providers, so no key is prefixed with a vendor.
       thresholds: {
         minEvents24h: 1,
         errorRateSpikeMultiplier: 2,
@@ -159,6 +162,16 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
         faultRatePct: 5,
       },
     },
+    legacyAliases: [
+      {
+        currentPath: "thresholds.minEvents24h",
+        legacyPath: "thresholds.sentryMinEvents24h",
+      },
+      {
+        currentPath: "thresholds.faultRatePct",
+        legacyPath: "thresholds.xrayFaultRatePct",
+      },
+    ],
     description: "Observability audit caps and alert thresholds",
   },
   {

--- a/tests/unit/sync/config-sync-artifacts.test.ts
+++ b/tests/unit/sync/config-sync-artifacts.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runConfigSync } from "../../../src/sync/config-sync.js";
+import {
+  readJson,
+  readJsonOrNull,
+  writeJson,
+} from "../../../src/utils/index.js";
+
+const CONFIG = ".lisa.config.json";
+const LOCAL_CONFIG = ".lisa.config.local.json";
+const VITEST_THRESHOLDS = "vitest.thresholds.json";
+const project = { dir: "" };
+
+beforeEach(async () => {
+  project.dir = await mkdtemp(path.join(tmpdir(), "lisa-sync-artifacts-"));
+});
+
+afterEach(async () => {
+  await rm(project.dir, { recursive: true, force: true });
+});
+
+describe("runConfigSync — sync direction (config wins)", () => {
+  it("overwrites an existing artifact file from the config value", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: {
+        testCoverage: {
+          global: { statements: 92, branches: 91, functions: 90, lines: 93 },
+        },
+      },
+    });
+    await writeJson(path.join(project.dir, VITEST_THRESHOLDS), {
+      global: { statements: 70, branches: 70, functions: 70, lines: 70 },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, VITEST_THRESHOLDS)
+    );
+    expect(artifact).toEqual({
+      global: { statements: 92, branches: 91, functions: 90, lines: 93 },
+    });
+    expect(
+      report.actions.some(action => action.kind === "artifact-synced")
+    ).toBe(true);
+  });
+
+  it("writes a pointered value without disturbing sibling keys", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: {
+        mutation: { strykerThresholds: { high: 90, low: 70, break: 65 } },
+      },
+    });
+    await writeJson(path.join(project.dir, "stryker.conf.json"), {
+      testRunner: "vitest",
+      thresholds: { high: 80, low: 60, break: 60 },
+    });
+
+    await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, "stryker.conf.json")
+    );
+    expect(artifact.testRunner).toBe("vitest");
+    expect(artifact.thresholds).toEqual({ high: 90, low: 70, break: 65 });
+  });
+
+  it("never scaffolds an artifact file that does not exist", async () => {
+    await runConfigSync(project.dir);
+
+    const artifact = await readJsonOrNull(
+      path.join(project.dir, VITEST_THRESHOLDS)
+    );
+    expect(artifact).toBeNull();
+  });
+
+  it("prefers the local overlay value when writing artifacts", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      quality: { lintBudgets: { cognitiveComplexity: 10 } },
+    });
+    await writeJson(path.join(project.dir, LOCAL_CONFIG), {
+      quality: { lintBudgets: { cognitiveComplexity: 25 } },
+    });
+    await writeJson(path.join(project.dir, "eslint.thresholds.json"), {
+      cognitiveComplexity: 10,
+      maxLines: 300,
+      maxLinesPerFunction: 75,
+    });
+
+    await runConfigSync(project.dir);
+
+    const artifact = await readJson<Record<string, unknown>>(
+      path.join(project.dir, "eslint.thresholds.json")
+    );
+    expect(artifact.cognitiveComplexity).toBe(25);
+  });
+});

--- a/tests/unit/sync/config-sync.test.ts
+++ b/tests/unit/sync/config-sync.test.ts
@@ -12,6 +12,31 @@ import {
 const CONFIG = ".lisa.config.json";
 const LOCAL_CONFIG = ".lisa.config.local.json";
 const VITEST_THRESHOLDS = "vitest.thresholds.json";
+const DEFAULT_EVOLVED = "default-evolved";
+
+const LEGACY_MONITOR_DEFAULT = {
+  maxCandidates: 20,
+  gapTiers: "core",
+  backoffHours: 24,
+  thresholds: {
+    sentryMinEvents24h: 10,
+    errorRateSpikeMultiplier: 2,
+    p95LatencyMs: 1000,
+    xrayFaultRatePct: 5,
+  },
+};
+
+const PROVIDER_NEUTRAL_MONITOR_DEFAULT = {
+  maxCandidates: 20,
+  gapTiers: "core",
+  backoffHours: 24,
+  thresholds: {
+    minEvents24h: 1,
+    errorRateSpikeMultiplier: 2,
+    p95LatencyMs: 1000,
+    faultRatePct: 5,
+  },
+};
 
 /** Holder for the per-test temp project directory. */
 interface TempProject {
@@ -116,83 +141,6 @@ describe("runConfigSync — populate direction", () => {
   });
 });
 
-describe("runConfigSync — sync direction (config wins)", () => {
-  it("overwrites an existing artifact file from the config value", async () => {
-    await writeJson(path.join(project.dir, CONFIG), {
-      quality: {
-        testCoverage: {
-          global: { statements: 92, branches: 91, functions: 90, lines: 93 },
-        },
-      },
-    });
-    await writeJson(path.join(project.dir, VITEST_THRESHOLDS), {
-      global: { statements: 70, branches: 70, functions: 70, lines: 70 },
-    });
-
-    const report = await runConfigSync(project.dir);
-
-    const artifact = await readJson<Record<string, unknown>>(
-      path.join(project.dir, VITEST_THRESHOLDS)
-    );
-    expect(artifact).toEqual({
-      global: { statements: 92, branches: 91, functions: 90, lines: 93 },
-    });
-    expect(
-      report.actions.some(action => action.kind === "artifact-synced")
-    ).toBe(true);
-  });
-
-  it("writes a pointered value without disturbing sibling keys", async () => {
-    await writeJson(path.join(project.dir, CONFIG), {
-      quality: {
-        mutation: { strykerThresholds: { high: 90, low: 70, break: 65 } },
-      },
-    });
-    await writeJson(path.join(project.dir, "stryker.conf.json"), {
-      testRunner: "vitest",
-      thresholds: { high: 80, low: 60, break: 60 },
-    });
-
-    await runConfigSync(project.dir);
-
-    const artifact = await readJson<Record<string, unknown>>(
-      path.join(project.dir, "stryker.conf.json")
-    );
-    expect(artifact.testRunner).toBe("vitest");
-    expect(artifact.thresholds).toEqual({ high: 90, low: 70, break: 65 });
-  });
-
-  it("never scaffolds an artifact file that does not exist", async () => {
-    await runConfigSync(project.dir);
-
-    const artifact = await readJsonOrNull(
-      path.join(project.dir, VITEST_THRESHOLDS)
-    );
-    expect(artifact).toBeNull();
-  });
-
-  it("prefers the local overlay value when writing artifacts", async () => {
-    await writeJson(path.join(project.dir, CONFIG), {
-      quality: { lintBudgets: { cognitiveComplexity: 10 } },
-    });
-    await writeJson(path.join(project.dir, LOCAL_CONFIG), {
-      quality: { lintBudgets: { cognitiveComplexity: 25 } },
-    });
-    await writeJson(path.join(project.dir, "eslint.thresholds.json"), {
-      cognitiveComplexity: 10,
-      maxLines: 300,
-      maxLinesPerFunction: 75,
-    });
-
-    await runConfigSync(project.dir);
-
-    const artifact = await readJson<Record<string, unknown>>(
-      path.join(project.dir, "eslint.thresholds.json")
-    );
-    expect(artifact.cognitiveComplexity).toBe(25);
-  });
-});
-
 describe("runConfigSync — default evolution and idempotency", () => {
   it("is idempotent: a second run reports no actions", async () => {
     await runConfigSync(project.dir);
@@ -231,9 +179,167 @@ describe("runConfigSync — default evolution and idempotency", () => {
 
     const config = await readConfig();
     expect((config.wiki as Record<string, unknown>).ttlSeconds).toBe(300);
+    expect(report.actions.some(action => action.kind === DEFAULT_EVOLVED)).toBe(
+      true
+    );
+  });
+
+  it("migrates the recorded legacy monitor default to neutral keys exactly once", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      monitor: LEGACY_MONITOR_DEFAULT,
+      _lisaSync: { populated: { monitor: LEGACY_MONITOR_DEFAULT } },
+    });
+
+    const dryRun = await runConfigSync(project.dir, { dryRun: true });
+    expect(dryRun.actions).toContainEqual(
+      expect.objectContaining({ key: "monitor", kind: DEFAULT_EVOLVED })
+    );
+    expect(await readConfig()).toEqual({
+      monitor: LEGACY_MONITOR_DEFAULT,
+      _lisaSync: { populated: { monitor: LEGACY_MONITOR_DEFAULT } },
+    });
+
+    const first = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.monitor).toEqual(PROVIDER_NEUTRAL_MONITOR_DEFAULT);
     expect(
-      report.actions.some(action => action.kind === "default-evolved")
-    ).toBe(true);
+      (config._lisaSync as { populated: Record<string, unknown> }).populated
+        .monitor
+    ).toEqual(PROVIDER_NEUTRAL_MONITOR_DEFAULT);
+    expect(first.actions).toContainEqual(
+      expect.objectContaining({ key: "monitor", kind: DEFAULT_EVOLVED })
+    );
+
+    const second = await runConfigSync(project.dir);
+    expect(second.actions).toEqual([]);
+  });
+
+  it("fills safe monitor defaults without shadowing a partial human legacy value", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      monitor: { thresholds: { sentryMinEvents24h: 50 } },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const monitor = (await readConfig()).monitor as Record<string, unknown>;
+    expect(monitor).toMatchObject({
+      maxCandidates: 20,
+      gapTiers: "core",
+      backoffHours: 24,
+      thresholds: {
+        sentryMinEvents24h: 50,
+        faultRatePct: 5,
+        errorRateSpikeMultiplier: 2,
+        p95LatencyMs: 1000,
+      },
+    });
+    expect(
+      (monitor.thresholds as Record<string, unknown>).minEvents24h
+    ).toBeUndefined();
+    expect(report.actions).toContainEqual(
+      expect.objectContaining({ key: "monitor", kind: "filled-missing" })
+    );
+  });
+
+  it.each([
+    ["has no provenance", undefined],
+    ["differs from its recorded provenance", LEGACY_MONITOR_DEFAULT],
+  ])(
+    "preserves a human-chosen legacy monitor value when it %s",
+    async (_scenario, recordedMonitor) => {
+      const humanMonitor = {
+        ...LEGACY_MONITOR_DEFAULT,
+        thresholds: {
+          ...LEGACY_MONITOR_DEFAULT.thresholds,
+          sentryMinEvents24h: 50,
+          xrayFaultRatePct: 12,
+        },
+      };
+      await writeJson(path.join(project.dir, CONFIG), {
+        monitor: humanMonitor,
+        ...(recordedMonitor === undefined
+          ? {}
+          : { _lisaSync: { populated: { monitor: recordedMonitor } } }),
+      });
+
+      const report = await runConfigSync(project.dir);
+
+      const config = await readConfig();
+      expect(config.monitor).toEqual(humanMonitor);
+      expect(report.actions.filter(action => action.key === "monitor")).toEqual(
+        []
+      );
+    }
+  );
+
+  it("preserves conflicting legacy aliases while current monitor keys remain authoritative", async () => {
+    const bothKeyMonitor = {
+      ...PROVIDER_NEUTRAL_MONITOR_DEFAULT,
+      thresholds: {
+        ...PROVIDER_NEUTRAL_MONITOR_DEFAULT.thresholds,
+        sentryMinEvents24h: 99,
+        xrayFaultRatePct: 33,
+      },
+    };
+    await writeJson(path.join(project.dir, CONFIG), {
+      monitor: bothKeyMonitor,
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.monitor).toEqual(bothKeyMonitor);
+    expect(report.actions.filter(action => action.key === "monitor")).toEqual(
+      []
+    );
+  });
+
+  it.each([
+    ["an unrelated override", { maxCandidates: 7 }, true],
+    ["a current-key override", { thresholds: { minEvents24h: 7 } }, true],
+    ["a legacy-key override", { thresholds: { sentryMinEvents24h: 7 } }, false],
+  ])(
+    "handles recorded monitor provenance with local %s",
+    async (_scenario, localMonitor, shouldEvolve) => {
+      const local = { monitor: localMonitor };
+      await writeJson(path.join(project.dir, CONFIG), {
+        monitor: LEGACY_MONITOR_DEFAULT,
+        _lisaSync: { populated: { monitor: LEGACY_MONITOR_DEFAULT } },
+      });
+      await writeJson(path.join(project.dir, LOCAL_CONFIG), local);
+
+      const report = await runConfigSync(project.dir);
+
+      expect((await readConfig()).monitor).toEqual(
+        shouldEvolve ? PROVIDER_NEUTRAL_MONITOR_DEFAULT : LEGACY_MONITOR_DEFAULT
+      );
+      expect(await readJson(path.join(project.dir, LOCAL_CONFIG))).toEqual(
+        local
+      );
+      expect(
+        report.actions.some(
+          action => action.key === "monitor" && action.kind === DEFAULT_EVOLVED
+        )
+      ).toBe(shouldEvolve);
+    }
+  );
+
+  it("does not copy explicit local-only legacy aliases into committed config", async () => {
+    const local = {
+      monitor: {
+        thresholds: { sentryMinEvents24h: 0, xrayFaultRatePct: null },
+      },
+    };
+    await writeJson(path.join(project.dir, LOCAL_CONFIG), local);
+
+    const report = await runConfigSync(project.dir);
+
+    expect((await readConfig()).monitor).toBeUndefined();
+    expect(report.actions.filter(action => action.key === "monitor")).toEqual(
+      []
+    );
+    expect(await readJson(path.join(project.dir, LOCAL_CONFIG))).toEqual(local);
   });
 
   it("dry-run reports actions without writing anything", async () => {

--- a/ui/README.md
+++ b/ui/README.md
@@ -58,9 +58,11 @@ AWS CloudWatch Alarms, AWS X-Ray, and future providers, so
 and `faultRatePct` replace the legacy `sentryMinEvents24h` /
 `xrayFaultRatePct`. The Monitoring section shows which providers are
 connected (detected from credentials and instrumentation, not configured by
-hand). The runtime `lisa-monitor` skill still reads the legacy keys —
-renaming them in `config-resolution.md` and the skill is a tracked
-follow-up.
+hand). `lisa sync` migrates a legacy monitor block when provenance proves Lisa
+auto-populated the old default, while leaving human-chosen legacy values
+untouched. The runtime keeps accepting those deprecated aliases, prefers the
+provider-neutral key when both are present, and `lisa doctor` warns until a
+project finishes migrating.
 
 ## Starter provenance & sync (planned — documented, not wired)
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -3632,7 +3632,7 @@
           },
           {
             type: "callout",
-            text: "The runtime monitor skill still reads the legacy provider-prefixed keys (sentryMinEvents24h, xrayFaultRatePct) — renaming them to these provider-neutral keys in config-resolution.md and the lisa-monitor skill is a tracked follow-up.",
+            text: "lisa sync migrates a legacy monitor block when provenance proves Lisa auto-populated the old default, while preserving human-chosen legacy values. The runtime keeps accepting the deprecated aliases, prefers the provider-neutral key when both are present, and lisa doctor warns until migration is complete.",
           },
         ],
       };


### PR DESCRIPTION
## Summary

- evolve exact auto-populated legacy monitor defaults through the existing `default-evolved` path
- preserve human-owned legacy threshold behavior without inserting provider-neutral defaults that would shadow it
- make local-overlay provenance decisions explicit and prevent local values from leaking into committed config
- replace stale console follow-up wording with the current provider-neutral compatibility contract

Closes #1532

## Verification

- real compiled `lisa sync --json` journey: recorded historical default emitted `monitor/default-evolved`, persisted only provider-neutral keys, and updated provenance
- real compiled `lisa sync --json` journey: human legacy values `50`/`12` remained exact, no neutral shadow keys were inserted, and no monitor provenance was created
- repeat real CLI runs were idempotent (`actions: []`)
- 258 test files / 4,078 tests passed
- coverage gate passed: 83.10% statements, 73.66% branches, 85.56% functions, 83.84% lines
- integration: 8 files / 121 tests passed
- lint, slow lint, typecheck, Prettier, knip, AST scan, plugin parity, rule pairing, workflow-input contracts, security audit, and pre-push all passed
- repository-wide legacy-name audit: remaining hits are deliberate alias, fallback, doctor, deprecation, or regression-test references

## UI observation

The repository has no Playwright dependency/config, no Maestro dependency or `.maestro/` directory, and no root UI end-to-end runner. The available browser probe returned `No browser is available`, so screenshot evidence is explicitly **NOT RUN**. The highest practical check was the real `ui/index.html` / `ui/README.md` source-editor audit plus a zero-hit stale-wording sweep; no visual-execution claim is made.

## Scope

No monitor skill, doctor implementation, generated plugin artifact, wiki file, workspace file, default value, threshold semantic, or UI layout changed.
