### PR TITLE
fix(sync): migrate legacy monitor thresholds

### DIFF
--- a/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/plugins/lisa/skills/lisa-monitor/SKILL.md
+++ b/plugins/lisa/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/plugins/src/base/skills/lisa-monitor/SKILL.md
+++ b/plugins/src/base/skills/lisa-monitor/SKILL.md
@@ -15,7 +15,7 @@ Spot-check application health, **audit observability completeness**, and **file 
 - `--all-gaps` — also file `recommended`-tier gaps (session replay, product analytics, etc.), not just `core`. Does not change anomaly thresholds.
 - `max_candidates=<n>` — cap tickets filed this run (default 20; config `monitor.maxCandidates`).
 
-## Monitor threshold compatibility
+## Deprecated monitor threshold aliases
 
 Before resolving anomaly thresholds, inspect the committed
 `.lisa.config.json` and local `.lisa.config.local.json` separately with `jq`.
@@ -27,6 +27,10 @@ that emits either entire config into agent context:
   `monitor.thresholds.sentryMinEvents24h`.
 - `monitor.thresholds.faultRatePct`, then
   `monitor.thresholds.xrayFaultRatePct`.
+
+The provider-neutral keys are the current contract. The legacy
+provider-prefixed keys are deprecated compatibility aliases and are used only
+when the matching provider-neutral key is absent.
 
 Run this fixed filter once with literal final argument `.lisa.config.json` and
 once with literal final argument `.lisa.config.local.json` when the respective

--- a/src/sync/config-sync.ts
+++ b/src/sync/config-sync.ts
@@ -32,9 +32,8 @@ import {
   type SyncedSetting,
 } from "./registry.js";
 import { aliasCompatibleDefault, hasLegacyAlias } from "./legacy-aliases.js";
-
-/** Key holding sync provenance metadata inside `.lisa.config.json`. */
-export const SYNC_METADATA_KEY = "_lisaSync";
+import { applyLegacyMonitorThresholdMigration } from "./legacy-monitor-thresholds.js";
+import { recordedPopulation, recordPopulation } from "./sync-population.js";
 
 /** What sync did (or would do, in dry-run) for one setting. */
 export type SyncActionKind =
@@ -42,8 +41,7 @@ export type SyncActionKind =
   | "populated-default"
   | "filled-missing"
   | "default-evolved"
-  | "artifact-synced"
-  | "unchanged";
+  | "artifact-synced";
 
 /** One reportable sync action. */
 export interface SyncAction {
@@ -103,9 +101,7 @@ function isRelevant(
   merged: JsonObject,
   relevantWhen: readonly string[] | undefined
 ): boolean {
-  if (relevantWhen === undefined) {
-    return true;
-  }
+  if (relevantWhen === undefined) return true;
   return relevantWhen.some(condition => conditionMatches(merged, condition));
 }
 
@@ -127,42 +123,6 @@ async function readArtifactValue(
     })
   );
   return reads.find(value => value !== undefined);
-}
-
-/**
- * Read the recorded populated-default value for a key, if any. Provenance
- * keys are stored literally (dots included) inside `_lisaSync.populated`.
- * @param committed - Committed config object
- * @param key - Config key
- * @returns The value recorded at population time, or undefined
- */
-function recordedPopulation(
-  committed: JsonObject,
-  key: string
-): JsonValue | undefined {
-  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
-  return isJsonObject(populated) ? populated[key] : undefined;
-}
-
-/**
- * Record that a key was auto-populated with a default value, storing the key
- * literally (dots included) so later runs can detect default evolution.
- * @param committed - Committed config object
- * @param key - Config key
- * @param value - The default value written
- * @returns Updated committed config
- */
-function recordPopulation(
-  committed: JsonObject,
-  key: string,
-  value: JsonValue
-): JsonObject {
-  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
-  const populatedObject = isJsonObject(populated) ? populated : {};
-  return setAtPath(committed, `${SYNC_METADATA_KEY}.populated`, {
-    ...populatedObject,
-    [key]: value,
-  });
 }
 
 /**
@@ -229,13 +189,21 @@ function populateEntry(
   local: JsonObject,
   artifactValue: JsonValue | undefined
 ): SyncState {
-  const configValue = getAtPath(merged, entry.key);
+  const stateAfterMigration = applyLegacyMonitorThresholdMigration(
+    state,
+    entry.key
+  );
+  const mergedAfterMigration =
+    stateAfterMigration === state
+      ? merged
+      : (deepMerge(stateAfterMigration.committed, local) as JsonObject);
+  const configValue = getAtPath(mergedAfterMigration, entry.key);
   if (configValue === undefined) {
-    return populateMissing(state, entry, artifactValue);
+    return populateMissing(stateAfterMigration, entry, artifactValue);
   }
-  const committedValue = getAtPath(state.committed, entry.key);
+  const committedValue = getAtPath(stateAfterMigration.committed, entry.key);
   const localValue = getAtPath(local, entry.key);
-  const recorded = recordedPopulation(state.committed, entry.key);
+  const recorded = recordedPopulation(stateAfterMigration.committed, entry.key);
   const evolutionValue =
     entry.legacyAliases === undefined ? configValue : committedValue;
   if (
@@ -245,11 +213,11 @@ function populateEntry(
     !hasLegacyAlias(localValue, entry.legacyAliases)
   ) {
     const committed = recordPopulation(
-      setAtPath(state.committed, entry.key, entry.defaultValue),
+      setAtPath(stateAfterMigration.committed, entry.key, entry.defaultValue),
       entry.key,
       entry.defaultValue
     );
-    return withAction(state, committed, {
+    return withAction(stateAfterMigration, committed, {
       key: entry.key,
       kind: "default-evolved",
       detail: "value still matched the old default; updated to the new one",
@@ -257,7 +225,7 @@ function populateEntry(
   }
   const hasEffectiveAlias = hasLegacyAlias(configValue, entry.legacyAliases);
   if (hasEffectiveAlias && committedValue === undefined) {
-    return state;
+    return stateAfterMigration;
   }
   // Compatibility fills are based only on committed state. Each present alias
   // prunes its own mapped current default while unrelated defaults still fill.
@@ -271,13 +239,17 @@ function populateEntry(
     : entry.defaultValue;
   const filled = fillMissing(fillSource, fallback);
   if (!jsonEquals(filled, fillSource)) {
-    return withAction(state, setAtPath(state.committed, entry.key, filled), {
-      key: entry.key,
-      kind: "filled-missing",
-      detail: "missing sub-keys filled with defaults",
-    });
+    return withAction(
+      stateAfterMigration,
+      setAtPath(stateAfterMigration.committed, entry.key, filled),
+      {
+        key: entry.key,
+        kind: "filled-missing",
+        detail: "missing sub-keys filled with defaults",
+      }
+    );
   }
-  return state;
+  return stateAfterMigration;
 }
 
 /**

--- a/src/sync/legacy-monitor-thresholds.ts
+++ b/src/sync/legacy-monitor-thresholds.ts
@@ -1,0 +1,149 @@
+/**
+ * Compatibility helpers for migrating deprecated monitor threshold keys.
+ * @module sync/legacy-monitor-thresholds
+ */
+import {
+  getAtPath,
+  isJsonObject,
+  jsonEquals,
+  setAtPath,
+  type JsonObject,
+} from "./json-path.js";
+import {
+  recordedPopulation,
+  recordPopulation,
+  removePopulation,
+} from "./sync-population.js";
+
+const LEGACY_MONITOR_THRESHOLD_MIGRATIONS = [
+  {
+    legacyKey: "monitor.thresholds.sentryMinEvents24h",
+    currentKey: "monitor.thresholds.minEvents24h",
+  },
+  {
+    legacyKey: "monitor.thresholds.xrayFaultRatePct",
+    currentKey: "monitor.thresholds.faultRatePct",
+  },
+] as const;
+
+/** Result of applying legacy monitor-threshold migration to one config. */
+export interface LegacyMonitorThresholdMigration {
+  /** Updated committed config object */
+  readonly committed: JsonObject;
+  /** Reportable migration actions */
+  readonly actions: readonly { key: string; detail: string }[];
+}
+
+/** Minimal sync-state shape needed to append migration actions. */
+interface MigrationState {
+  /** Updated committed config object */
+  readonly committed: JsonObject;
+  /** Existing reportable sync actions */
+  readonly actions: readonly {
+    readonly key: string;
+    readonly kind: string;
+    readonly detail: string;
+  }[];
+}
+
+/**
+ * Return a copy of an object with one dot-path property removed.
+ * @param root - Object to copy
+ * @param dotPath - Dot-separated key path to remove
+ * @returns Updated object without the path
+ */
+function removeAtPath(root: JsonObject, dotPath: string): JsonObject {
+  const dotIndex = dotPath.indexOf(".");
+  const head = dotIndex === -1 ? dotPath : dotPath.slice(0, dotIndex);
+  const rest = dotIndex === -1 ? "" : dotPath.slice(dotIndex + 1);
+  if (rest === "") {
+    const { [head]: _removed, ...remaining } = root;
+    return remaining;
+  }
+  const child = root[head];
+  if (!isJsonObject(child)) {
+    return root;
+  }
+  return { ...root, [head]: removeAtPath(child, rest) };
+}
+
+/**
+ * Move legacy monitor thresholds to provider-neutral keys when provenance
+ * proves Lisa populated the legacy value.
+ * @param committed - Committed config object
+ * @returns Updated config and migration actions
+ */
+export function migrateLegacyMonitorThresholds(
+  committed: JsonObject
+): LegacyMonitorThresholdMigration {
+  return LEGACY_MONITOR_THRESHOLD_MIGRATIONS.reduce<LegacyMonitorThresholdMigration>(
+    (current, migration) => {
+      const legacyValue = getAtPath(current.committed, migration.legacyKey);
+      const currentValue = getAtPath(current.committed, migration.currentKey);
+      const recorded = recordedPopulation(
+        current.committed,
+        migration.legacyKey
+      );
+      if (
+        legacyValue === undefined ||
+        currentValue !== undefined ||
+        recorded === undefined ||
+        !jsonEquals(legacyValue, recorded)
+      ) {
+        return current;
+      }
+      const committed = recordPopulation(
+        removePopulation(
+          removeAtPath(
+            setAtPath(current.committed, migration.currentKey, legacyValue),
+            migration.legacyKey
+          ),
+          migration.legacyKey
+        ),
+        migration.currentKey,
+        legacyValue
+      );
+      return {
+        committed,
+        actions: [
+          ...current.actions,
+          {
+            key: migration.currentKey,
+            detail: `auto-populated legacy ${migration.legacyKey} migrated to provider-neutral key`,
+          },
+        ],
+      };
+    },
+    { committed, actions: [] }
+  );
+}
+
+/**
+ * Append legacy monitor-threshold migration actions to a sync state.
+ * @param state - Sync state containing committed config and actions
+ * @param entryKey - Registry entry key currently being populated
+ * @returns Updated state with migration actions appended
+ */
+export function applyLegacyMonitorThresholdMigration<T extends MigrationState>(
+  state: T,
+  entryKey: string
+): T {
+  if (entryKey !== "monitor") {
+    return state;
+  }
+  const migration = migrateLegacyMonitorThresholds(state.committed);
+  if (migration.actions.length === 0) {
+    return state;
+  }
+  return {
+    ...state,
+    committed: migration.committed,
+    actions: [
+      ...state.actions,
+      ...migration.actions.map(action => ({
+        ...action,
+        kind: "default-evolved" as const,
+      })),
+    ],
+  } as T;
+}

--- a/src/sync/sync-population.ts
+++ b/src/sync/sync-population.ts
@@ -1,0 +1,65 @@
+/**
+ * Helpers for `_lisaSync.populated` provenance metadata.
+ * @module sync/sync-population
+ */
+import {
+  getAtPath,
+  isJsonObject,
+  setAtPath,
+  type JsonObject,
+  type JsonValue,
+} from "./json-path.js";
+
+const SYNC_METADATA_KEY = "_lisaSync";
+
+/**
+ * Read recorded sync provenance for one literal config key.
+ * @param committed - Committed config object
+ * @param key - Literal provenance key
+ * @returns Recorded value, when present
+ */
+export function recordedPopulation(
+  committed: JsonObject,
+  key: string
+): JsonValue | undefined {
+  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
+  return isJsonObject(populated) ? populated[key] : undefined;
+}
+
+/**
+ * Record sync provenance for one literal config key.
+ * @param committed - Committed config object
+ * @param key - Literal provenance key
+ * @param value - Value to record
+ * @returns Updated committed config
+ */
+export function recordPopulation(
+  committed: JsonObject,
+  key: string,
+  value: JsonValue
+): JsonObject {
+  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
+  const populatedObject = isJsonObject(populated) ? populated : {};
+  return setAtPath(committed, `${SYNC_METADATA_KEY}.populated`, {
+    ...populatedObject,
+    [key]: value,
+  });
+}
+
+/**
+ * Remove one literal provenance key from `_lisaSync.populated`.
+ * @param committed - Committed config object
+ * @param key - Literal provenance key to remove
+ * @returns Updated committed config
+ */
+export function removePopulation(
+  committed: JsonObject,
+  key: string
+): JsonObject {
+  const populated = getAtPath(committed, `${SYNC_METADATA_KEY}.populated`);
+  if (!isJsonObject(populated) || !Object.hasOwn(populated, key)) {
+    return committed;
+  }
+  const { [key]: _removed, ...remaining } = populated;
+  return setAtPath(committed, `${SYNC_METADATA_KEY}.populated`, remaining);
+}

--- a/tests/unit/sync/legacy-monitor-thresholds.test.ts
+++ b/tests/unit/sync/legacy-monitor-thresholds.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runConfigSync } from "../../../src/sync/config-sync.js";
+import { readJson, writeJson } from "../../../src/utils/index.js";
+
+const CONFIG = ".lisa.config.json";
+
+/** Holder for the per-test temp project directory. */
+interface TempProject {
+  dir: string;
+}
+
+const project: TempProject = { dir: "" };
+
+beforeEach(async () => {
+  project.dir = await mkdtemp(path.join(tmpdir(), "lisa-sync-legacy-"));
+});
+
+afterEach(async () => {
+  await rm(project.dir, { recursive: true, force: true });
+});
+
+/**
+ * Read the committed config from the temp project.
+ * @returns Parsed config object
+ */
+async function readConfig(): Promise<Record<string, unknown>> {
+  return readJson<Record<string, unknown>>(path.join(project.dir, CONFIG));
+}
+
+describe("runConfigSync — legacy monitor threshold migration", () => {
+  it("migrates auto-populated legacy monitor thresholds to provider-neutral keys", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      monitor: {
+        thresholds: {
+          sentryMinEvents24h: 1,
+          xrayFaultRatePct: 5,
+        },
+      },
+      _lisaSync: {
+        populated: {
+          "monitor.thresholds.sentryMinEvents24h": 1,
+          "monitor.thresholds.xrayFaultRatePct": 5,
+        },
+      },
+    });
+
+    const report = await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    expect(config.monitor).toMatchObject({
+      thresholds: {
+        minEvents24h: 1,
+        faultRatePct: 5,
+      },
+    });
+    const thresholds = (config.monitor as Record<string, unknown>)
+      .thresholds as Record<string, unknown>;
+    expect(thresholds.sentryMinEvents24h).toBeUndefined();
+    expect(thresholds.xrayFaultRatePct).toBeUndefined();
+    const meta = config._lisaSync as { populated: Record<string, unknown> };
+    expect(meta.populated["monitor.thresholds.minEvents24h"]).toBe(1);
+    expect(meta.populated["monitor.thresholds.faultRatePct"]).toBe(5);
+    expect(
+      meta.populated["monitor.thresholds.sentryMinEvents24h"]
+    ).toBeUndefined();
+    expect(
+      meta.populated["monitor.thresholds.xrayFaultRatePct"]
+    ).toBeUndefined();
+    expect(
+      report.actions.filter(action => action.kind === "default-evolved")
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "monitor.thresholds.minEvents24h" }),
+        expect.objectContaining({ key: "monitor.thresholds.faultRatePct" }),
+      ])
+    );
+  });
+
+  it("does not shadow a human-chosen legacy monitor threshold with a current default", async () => {
+    await writeJson(path.join(project.dir, CONFIG), {
+      monitor: {
+        thresholds: {
+          sentryMinEvents24h: 50,
+          xrayFaultRatePct: 12,
+        },
+      },
+    });
+
+    await runConfigSync(project.dir);
+
+    const config = await readConfig();
+    const thresholds = (config.monitor as Record<string, unknown>)
+      .thresholds as Record<string, unknown>;
+    expect(thresholds.sentryMinEvents24h).toBe(50);
+    expect(thresholds.xrayFaultRatePct).toBe(12);
+    expect(thresholds.minEvents24h).toBeUndefined();
+    expect(thresholds.faultRatePct).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1532.

- Migrates auto-populated legacy monitor threshold keys to provider-neutral keys through `lisa sync` using `default-evolved` actions.
- Preserves human-owned legacy threshold values without adding current-key defaults that would shadow the runtime compatibility fallback.
- Updates UI/docs and generated monitor skill copies so legacy names are described only as deprecated aliases.

## Evidence

- `bunx vitest run tests/unit/sync/config-sync.test.ts tests/unit/cli/doctor-monitor-thresholds.test.ts tests/unit/strategies/monitor-threshold-compatibility.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run build`
- `bun run check:plugins`
- Push hook: security audit, slow lint, `knip`, coverage suite, and integration tests passed.
- Real CLI sync fixture: auto-populated legacy project emitted `default-evolved` for `monitor.thresholds.minEvents24h` and `monitor.thresholds.faultRatePct`, removed legacy keys, and recorded provider-neutral provenance.
- Real CLI sync fixture: human-owned legacy project preserved `sentryMinEvents24h: 50` and `xrayFaultRatePct: 12` without adding `minEvents24h` or `faultRatePct` defaults.
- Repo-wide `rg 'sentryMinEvents24h|xrayFaultRatePct'` now shows only migration, doctor warning, UI deprecation, and monitor alias references.

Co-authored-by: Codex <codex@openai.com>
