### PR TITLE
chore: update @codyswann/lisa self-dependency to 2.217.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,13 +106,16 @@
   ],
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
+    "form-data": ">=4.0.6",
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
+    "multer": ">=2.2.0",
+    "undici": ">=6.27.0",
     "vite": "^8.0.16",
-    "ws": ">=8.20.1",
+    "ws": ">=8.21.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/package.json
+++ b/package.json
@@ -76,23 +76,29 @@
   ],
   "resolutions": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
-    "vite": ">=8.0.16",
-    "ws": ">=8.20.1"
+    "vite": "$vite",
+    "ws": ">=8.21.0",
+    "multer": ">=2.2.0",
+    "undici": ">=6.27.0",
+    "form-data": ">=4.0.6"
   },
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
-    "vite": "^8.0.16",
-    "ws": ">=8.20.1"
+    "vite": "$vite",
+    "ws": ">=8.21.0",
+    "multer": ">=2.2.0",
+    "undici": ">=6.27.0",
+    "form-data": ">=4.0.6"
   },
   "name": "@codyswann/lisa",
   "version": "2.217.6",


### PR DESCRIPTION
## Summary

- Bumps the self-dependency `^2.195.6` → `^2.217.6` and syncs the lockfile, picking up the governed security floors (axios ≥1.15.2, ws ≥8.21.0, new multer/undici/form-data floors, `$vite` self-reference — safe here since vite is a direct devDependency).
- **Deliberately excludes the template apply output.** Running the downstream apply against the source repo pollutes it: wrong-stack templates (jest configs on this vitest repo, sync-down workflow on a single-env repo), overwrites of the repo's own eslint/tsconfig with templates that import from the package itself, deletion of the repo-internal `.claude/commands/lisa/*` commands via `all/deletions.json`, and a self-bootstrapping `postinstall` that would re-run the apply on every local install. All reverted; only the dep bump + governed dependency floors ship.

## Upstream follow-up (tracked for the batch fixes PR)

The self-apply needs a source-repo profile: skip template/deletion application (or apply a source-repo allowlist) and never install the self-bootstrap postinstall when the target repo IS CodySwannGT/lisa.

## Test plan

- `bun install` clean with the new lockfile; pre-push gauntlet runs on push
- CI quality checks on this PR are the verification

🤖 Generated with Claude Code