### PR TITLE
feat(learnings): define bounded project learning contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./learnings": "./dist/core/learnings.js",
     "./eslint": "./dist/configs/eslint/index.js",
     "./eslint/base": "./dist/configs/eslint/base.js",
     "./eslint/typescript": "./dist/configs/eslint/typescript.js",

--- a/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa-copilot/rules/eager/config-resolution.md
+++ b/plugins/lisa-copilot/rules/eager/config-resolution.md
@@ -25,6 +25,15 @@ Project tracker (`jira` / `github` / `linear`) is read from `.lisa.config.json` 
 
 `repo:<name>` is the canonical label for which repo a work item belongs to. Resolve current-repo identity in this priority order: `.lisa.config.local.json` `repo` → `.lisa.config.json` `repo` → `.lisa.config.json` `github.repo` → `basename -s .git "$(git remote get-url origin)"`. If none resolve, stop with a clear error.
 
+## Project rules and learnings
+
+Resolve hand-authored project rules from `.lisa.config.json`
+`projectRulesFile`, defaulting to `.claude/rules/PROJECT_RULES.md`. Automated
+learnings never append to that file: they use the separate
+`PROJECT_LEARNINGS.md` sibling derived from the configured rules directory.
+Both writers and budget checks import the executable contract from
+`@codyswann/lisa/learnings`; they must not copy its numeric limits.
+
 ## Env → base branch
 
 For implementation work, map the work item's `## Target Backend Environment` to

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -33,6 +33,7 @@ fi
 {
   "tracker": "jira",
   "source":  "notion",
+  "projectRulesFile": ".claude/rules/PROJECT_RULES.md",
 
   "atlassian":  { "cloudId": "<uuid>", "site": "<host>" },
   "jira": {
@@ -178,6 +179,7 @@ fi
 |-------|----------|---------|-------|
 | `tracker` | **yes** | — | Destination for ticket writes. One of `"jira"`, `"github"`, `"linear"`. Missing → fail with instruction to run the matching `/lisa:setup:*` skill. |
 | `source` | no | — | Default PRD source for batch skills (`/lisa:intake`) and arg-less single-PRD skills. One of `"notion"`, `"confluence"`, `"linear"`, `"github"`, `"jira"`. Explicit URLs/keys passed to a skill always win over `source`; this is a default, not a lock. |
+| `projectRulesFile` | no | `.claude/rules/PROJECT_RULES.md` | Safe repo-relative Markdown path for hand-authored project rules. The bounded learning writer derives a separate `PROJECT_LEARNINGS.md` sibling in the same directory; there is intentionally no second path setting. |
 | `usage` | no | — | Optional token/cost pricing metadata consumed by the `usage-accounting` rule. Missing pricing never blocks a lifecycle flow; Lisa records token counts with `estimated_cost: null` when no trustworthy price source is configured. |
 | `wiki` | no | — | Wiki location for the `wiki-knowledge-source` rule. Omit for a local in-repo wiki (`wiki/`). See **Wiki source** below. |
 

--- a/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -38,6 +38,7 @@ fi
 {
   "tracker": "jira",
   "source":  "notion",
+  "projectRulesFile": ".claude/rules/PROJECT_RULES.md",
 
   "atlassian":  { "cloudId": "<uuid>", "site": "<host>" },
   "jira": {
@@ -183,6 +184,7 @@ fi
 |-------|----------|---------|-------|
 | `tracker` | **yes** | — | Destination for ticket writes. One of `"jira"`, `"github"`, `"linear"`. Missing → fail with instruction to run the matching `/lisa:setup:*` skill. |
 | `source` | no | — | Default PRD source for batch skills (`/lisa:intake`) and arg-less single-PRD skills. One of `"notion"`, `"confluence"`, `"linear"`, `"github"`, `"jira"`. Explicit URLs/keys passed to a skill always win over `source`; this is a default, not a lock. |
+| `projectRulesFile` | no | `.claude/rules/PROJECT_RULES.md` | Safe repo-relative Markdown path for hand-authored project rules. The bounded learning writer derives a separate `PROJECT_LEARNINGS.md` sibling in the same directory; there is intentionally no second path setting. |
 | `usage` | no | — | Optional token/cost pricing metadata consumed by the `usage-accounting` rule. Missing pricing never blocks a lifecycle flow; Lisa records token counts with `estimated_cost: null` when no trustworthy price source is configured. |
 | `wiki` | no | — | Wiki location for the `wiki-knowledge-source` rule. Omit for a local in-repo wiki (`wiki/`). See **Wiki source** below. |
 

--- a/plugins/lisa-cursor/rules/config-resolution.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution.mdc
@@ -30,6 +30,15 @@ Project tracker (`jira` / `github` / `linear`) is read from `.lisa.config.json` 
 
 `repo:<name>` is the canonical label for which repo a work item belongs to. Resolve current-repo identity in this priority order: `.lisa.config.local.json` `repo` → `.lisa.config.json` `repo` → `.lisa.config.json` `github.repo` → `basename -s .git "$(git remote get-url origin)"`. If none resolve, stop with a clear error.
 
+## Project rules and learnings
+
+Resolve hand-authored project rules from `.lisa.config.json`
+`projectRulesFile`, defaulting to `.claude/rules/PROJECT_RULES.md`. Automated
+learnings never append to that file: they use the separate
+`PROJECT_LEARNINGS.md` sibling derived from the configured rules directory.
+Both writers and budget checks import the executable contract from
+`@codyswann/lisa/learnings`; they must not copy its numeric limits.
+
 ## Env → base branch
 
 For implementation work, map the work item's `## Target Backend Environment` to

--- a/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa/rules/eager/config-resolution.md
+++ b/plugins/lisa/rules/eager/config-resolution.md
@@ -25,6 +25,15 @@ Project tracker (`jira` / `github` / `linear`) is read from `.lisa.config.json` 
 
 `repo:<name>` is the canonical label for which repo a work item belongs to. Resolve current-repo identity in this priority order: `.lisa.config.local.json` `repo` → `.lisa.config.json` `repo` → `.lisa.config.json` `github.repo` → `basename -s .git "$(git remote get-url origin)"`. If none resolve, stop with a clear error.
 
+## Project rules and learnings
+
+Resolve hand-authored project rules from `.lisa.config.json`
+`projectRulesFile`, defaulting to `.claude/rules/PROJECT_RULES.md`. Automated
+learnings never append to that file: they use the separate
+`PROJECT_LEARNINGS.md` sibling derived from the configured rules directory.
+Both writers and budget checks import the executable contract from
+`@codyswann/lisa/learnings`; they must not copy its numeric limits.
+
 ## Env → base branch
 
 For implementation work, map the work item's `## Target Backend Environment` to

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -33,6 +33,7 @@ fi
 {
   "tracker": "jira",
   "source":  "notion",
+  "projectRulesFile": ".claude/rules/PROJECT_RULES.md",
 
   "atlassian":  { "cloudId": "<uuid>", "site": "<host>" },
   "jira": {
@@ -178,6 +179,7 @@ fi
 |-------|----------|---------|-------|
 | `tracker` | **yes** | — | Destination for ticket writes. One of `"jira"`, `"github"`, `"linear"`. Missing → fail with instruction to run the matching `/lisa:setup:*` skill. |
 | `source` | no | — | Default PRD source for batch skills (`/lisa:intake`) and arg-less single-PRD skills. One of `"notion"`, `"confluence"`, `"linear"`, `"github"`, `"jira"`. Explicit URLs/keys passed to a skill always win over `source`; this is a default, not a lock. |
+| `projectRulesFile` | no | `.claude/rules/PROJECT_RULES.md` | Safe repo-relative Markdown path for hand-authored project rules. The bounded learning writer derives a separate `PROJECT_LEARNINGS.md` sibling in the same directory; there is intentionally no second path setting. |
 | `usage` | no | — | Optional token/cost pricing metadata consumed by the `usage-accounting` rule. Missing pricing never blocks a lifecycle flow; Lisa records token counts with `estimated_cost: null` when no trustworthy price source is configured. |
 | `wiki` | no | — | Wiki location for the `wiki-knowledge-source` rule. Omit for a local in-repo wiki (`wiki/`). See **Wiki source** below. |
 

--- a/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/src/base/rules/eager/config-resolution.md
+++ b/plugins/src/base/rules/eager/config-resolution.md
@@ -25,6 +25,15 @@ Project tracker (`jira` / `github` / `linear`) is read from `.lisa.config.json` 
 
 `repo:<name>` is the canonical label for which repo a work item belongs to. Resolve current-repo identity in this priority order: `.lisa.config.local.json` `repo` → `.lisa.config.json` `repo` → `.lisa.config.json` `github.repo` → `basename -s .git "$(git remote get-url origin)"`. If none resolve, stop with a clear error.
 
+## Project rules and learnings
+
+Resolve hand-authored project rules from `.lisa.config.json`
+`projectRulesFile`, defaulting to `.claude/rules/PROJECT_RULES.md`. Automated
+learnings never append to that file: they use the separate
+`PROJECT_LEARNINGS.md` sibling derived from the configured rules directory.
+Both writers and budget checks import the executable contract from
+`@codyswann/lisa/learnings`; they must not copy its numeric limits.
+
 ## Env → base branch
 
 For implementation work, map the work item's `## Target Backend Environment` to

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -33,6 +33,7 @@ fi
 {
   "tracker": "jira",
   "source":  "notion",
+  "projectRulesFile": ".claude/rules/PROJECT_RULES.md",
 
   "atlassian":  { "cloudId": "<uuid>", "site": "<host>" },
   "jira": {
@@ -178,6 +179,7 @@ fi
 |-------|----------|---------|-------|
 | `tracker` | **yes** | — | Destination for ticket writes. One of `"jira"`, `"github"`, `"linear"`. Missing → fail with instruction to run the matching `/lisa:setup:*` skill. |
 | `source` | no | — | Default PRD source for batch skills (`/lisa:intake`) and arg-less single-PRD skills. One of `"notion"`, `"confluence"`, `"linear"`, `"github"`, `"jira"`. Explicit URLs/keys passed to a skill always win over `source`; this is a default, not a lock. |
+| `projectRulesFile` | no | `.claude/rules/PROJECT_RULES.md` | Safe repo-relative Markdown path for hand-authored project rules. The bounded learning writer derives a separate `PROJECT_LEARNINGS.md` sibling in the same directory; there is intentionally no second path setting. |
 | `usage` | no | — | Optional token/cost pricing metadata consumed by the `usage-accounting` rule. Missing pricing never blocks a lifecycle flow; Lisa records token counts with `estimated_cost: null` when no trustworthy price source is configured. |
 | `wiki` | no | — | Wiki location for the `wiki-knowledge-source` rule. Omit for a local in-repo wiki (`wiki/`). See **Wiki source** below. |
 

--- a/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
@@ -30,7 +30,7 @@ For every row marked **Accept**:
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
 | Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), project-rules file (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
 
 ## Routing rules
 
@@ -28,9 +28,9 @@ For every row marked **Accept**:
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
 | Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Project rules file | Append a one-line guideline to `PROJECT_RULES.md` under an appropriate heading (or create one). |
+| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
 | Tooling gap | Configured tracker | Create a new ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc. Label appropriately (`type:tooling`, `lifecycle-improvement`, etc.). |
-| Convention drift | `CLAUDE.md` (project) or `PROJECT_RULES.md` | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | `CLAUDE.md` (project) or configured project rules file | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 

--- a/src/core/learnings-contract.ts
+++ b/src/core/learnings-contract.ts
@@ -1,0 +1,51 @@
+/**
+ * Executable contract shared by every project-learnings writer and checker.
+ * Keeping the numeric limits here prevents documentation, writers, and CI
+ * from drifting to different budgets.
+ * @module learnings-contract
+ */
+
+export const LEARNING_CONFIDENCE_VALUES = ["low", "medium", "high"] as const;
+
+/** Confidence vocabulary persisted in every learning entry. */
+export type LearningConfidence = (typeof LEARNING_CONFIDENCE_VALUES)[number];
+
+export const LEARNINGS_CONTRACT = Object.freeze({
+  version: 1,
+  fields: Object.freeze([
+    "id",
+    "rule",
+    "why",
+    "provenance",
+    "first_learned",
+    "last_confirmed",
+    "confidence",
+  ] as const),
+  maxRuleCharacters: 240,
+  maxRuleLines: 2,
+  maxEntries: 20,
+  maxTokens: 4000,
+  measurement: "utf8-bytes-upper-bound",
+} as const);
+
+/** Complete persisted schema for one project learning. */
+export interface LearningEntry {
+  readonly id: string;
+  readonly rule: string;
+  readonly why: string;
+  readonly provenance: readonly string[];
+  readonly first_learned: string;
+  readonly last_confirmed: string;
+  readonly confidence: LearningConfidence;
+}
+
+/**
+ * Estimate tokens deterministically without coupling the persisted contract to
+ * a model-specific tokenizer. A byte count is a conservative upper bound for
+ * byte-level tokenizers and is reproducible in both the writer and CI.
+ * @param content - Canonical full Markdown document
+ * @returns Reproducible estimated token count
+ */
+export function estimateLearningTokens(content: string): number {
+  return Buffer.byteLength(content, "utf8");
+}

--- a/src/core/learnings-contract.ts
+++ b/src/core/learnings-contract.ts
@@ -23,6 +23,7 @@ export const LEARNINGS_CONTRACT = Object.freeze({
   ] as const),
   maxRuleCharacters: 240,
   maxRuleLines: 2,
+  maxProvenanceReferences: 20,
   maxEntries: 20,
   maxTokens: 4000,
   measurement: "utf8-bytes-upper-bound",

--- a/src/core/learnings-entry.ts
+++ b/src/core/learnings-entry.ts
@@ -163,10 +163,10 @@ function requireProvenance(value: unknown): readonly string[] {
     typeof length !== "number" ||
     !Number.isSafeInteger(length) ||
     length < 1 ||
-    length > LEARNINGS_CONTRACT.maxEntries
+    length > LEARNINGS_CONTRACT.maxProvenanceReferences
   ) {
     throw new Error(
-      `Invalid provenance: expected 1-${LEARNINGS_CONTRACT.maxEntries} references`
+      `Invalid provenance: expected 1-${LEARNINGS_CONTRACT.maxProvenanceReferences} references`
     );
   }
   const provenance = Array.from({ length }, (_unused, index) =>

--- a/src/core/learnings-entry.ts
+++ b/src/core/learnings-entry.ts
@@ -1,0 +1,303 @@
+/** Strict validation for the seven-field project learning schema. */
+import {
+  LEARNINGS_CONTRACT,
+  LEARNING_CONFIDENCE_VALUES,
+  type LearningConfidence,
+  type LearningEntry,
+} from "./learnings-contract.js";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const STABLE_ID = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+/** Field names in the executable seven-field contract. */
+type EntryField = (typeof LEARNINGS_CONTRACT.fields)[number];
+
+/**
+ * Validate an untrusted entry and return a normalized immutable copy.
+ * @param candidate - Value to validate against the executable contract
+ * @returns Validated learning entry
+ */
+export function validateLearningEntry(candidate: unknown): LearningEntry {
+  const descriptors = requireEntryDescriptors(candidate);
+  const value = (field: EntryField): unknown =>
+    readDataProperty(descriptors, field);
+  const id = requireStableId(value("id"));
+  const rule = requireRule(value("rule"));
+  const why = requireWhy(value("why"));
+  const provenance = requireProvenance(value("provenance"));
+  const firstLearned = requireIsoDate(value("first_learned"), "first_learned");
+  const lastConfirmed = requireIsoDate(
+    value("last_confirmed"),
+    "last_confirmed"
+  );
+  const confidence = requireConfidence(value("confidence"));
+  if (lastConfirmed < firstLearned) {
+    throw new Error("Invalid dates: last_confirmed precedes first_learned");
+  }
+  return Object.freeze({
+    id,
+    rule,
+    why,
+    provenance: Object.freeze(provenance),
+    first_learned: firstLearned,
+    last_confirmed: lastConfirmed,
+    confidence,
+  });
+}
+
+/**
+ * Require an object with exactly seven accessor-free own fields.
+ * @param candidate - Untrusted candidate object
+ * @returns Exact own-property descriptor map
+ */
+function requireEntryDescriptors(candidate: unknown): PropertyDescriptorMap {
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    Array.isArray(candidate)
+  ) {
+    throw new Error("Invalid learning entry: expected an object");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(candidate);
+  const ownKeys = Reflect.ownKeys(descriptors);
+  if (ownKeys.some(key => typeof key !== "string")) {
+    throw new Error(
+      "Invalid learning entry fields: symbol keys are not allowed"
+    );
+  }
+  if (
+    ownKeys.length !== LEARNINGS_CONTRACT.fields.length ||
+    LEARNINGS_CONTRACT.fields.some(field => descriptors[field] === undefined)
+  ) {
+    throw new Error(
+      `Invalid learning entry fields: expected exactly ${LEARNINGS_CONTRACT.fields.join(", ")}`
+    );
+  }
+  return descriptors;
+}
+
+/**
+ * Read one exact-schema field without invoking an accessor.
+ * @param descriptors - Candidate descriptor map
+ * @param field - Required contract field
+ * @returns Stored data value
+ */
+function readDataProperty(
+  descriptors: PropertyDescriptorMap,
+  field: EntryField
+): unknown {
+  const descriptor = descriptors[field];
+  if (descriptor === undefined || !("value" in descriptor)) {
+    throw new Error(`Invalid ${field}: accessors are not allowed`);
+  }
+  return descriptor.value as unknown;
+}
+
+/**
+ * Require and bound a stable learning id.
+ * @param value - Untrusted id value
+ * @returns Valid stable id
+ */
+function requireStableId(value: unknown): string {
+  const id = requireNonEmptyString(value, "id");
+  assertUtf8Budget(id, "id");
+  if (!STABLE_ID.test(id)) {
+    throw new Error(
+      "Invalid learning id: use lowercase letters, numbers, dots, underscores, or hyphens"
+    );
+  }
+  return id;
+}
+
+/**
+ * Require a rule within both hard character and line caps.
+ * @param value - Untrusted rule value
+ * @returns Valid bounded rule
+ */
+function requireRule(value: unknown): string {
+  const rule = requireNonEmptyString(value, "rule");
+  if (rule.length > LEARNINGS_CONTRACT.maxRuleCharacters) {
+    throw new Error(
+      `rule exceeds maxRuleCharacters ${LEARNINGS_CONTRACT.maxRuleCharacters}`
+    );
+  }
+  const ruleLines = rule
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .replaceAll("\u0085", "\n")
+    .replaceAll("\u2028", "\n")
+    .replaceAll("\u2029", "\n")
+    .split("\n").length;
+  if (ruleLines > LEARNINGS_CONTRACT.maxRuleLines) {
+    throw new Error(
+      `rule exceeds maxRuleLines ${LEARNINGS_CONTRACT.maxRuleLines}`
+    );
+  }
+  return rule;
+}
+
+/**
+ * Require bounded explanatory text.
+ * @param value - Untrusted why value
+ * @returns Valid bounded explanation
+ */
+function requireWhy(value: unknown): string {
+  const why = requireNonBlankText(value, "why");
+  assertUtf8Budget(why, "why");
+  return why;
+}
+
+/**
+ * Validate a dense, accessor-free provenance list with bounded allocation.
+ * @param value - Untrusted provenance value
+ * @returns Valid provenance references
+ */
+function requireProvenance(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid provenance: expected an array of references");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(
+    value
+  ) as unknown as PropertyDescriptorMap;
+  const length = Object.getOwnPropertyDescriptor(value, "length")?.value;
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 1 ||
+    length > LEARNINGS_CONTRACT.maxEntries
+  ) {
+    throw new Error(
+      `Invalid provenance: expected 1-${LEARNINGS_CONTRACT.maxEntries} references`
+    );
+  }
+  const provenance = Array.from({ length }, (_unused, index) =>
+    requireProvenanceItem(descriptors, index)
+  );
+  if (new Set(provenance).size !== provenance.length) {
+    throw new Error("Invalid provenance: duplicate references are not allowed");
+  }
+  return provenance;
+}
+
+/**
+ * Read and bound one accessor-free provenance element.
+ * @param descriptors - Provenance array descriptors
+ * @param index - Reference index
+ * @returns Valid provenance reference
+ */
+function requireProvenanceItem(
+  descriptors: PropertyDescriptorMap,
+  index: number
+): string {
+  const descriptor = descriptors[String(index)];
+  if (descriptor === undefined || !("value" in descriptor)) {
+    throw new Error(`Invalid provenance[${index}]: accessors are not allowed`);
+  }
+  const reference = requireNonEmptyString(
+    descriptor.value,
+    `provenance[${index}]`
+  );
+  assertUtf8Budget(reference, `provenance[${index}]`);
+  return reference;
+}
+
+/**
+ * Require one of the persisted confidence values.
+ * @param value - Untrusted confidence value
+ * @returns Valid confidence
+ */
+function requireConfidence(value: unknown): LearningConfidence {
+  if (
+    typeof value !== "string" ||
+    !(LEARNING_CONFIDENCE_VALUES as readonly string[]).includes(value)
+  ) {
+    throw new Error(
+      `Invalid confidence: expected ${LEARNING_CONFIDENCE_VALUES.join(" | ")}`
+    );
+  }
+  return value as LearningConfidence;
+}
+
+/**
+ * Require a trimmed, non-empty, control-character-free string.
+ * @param value - Untrusted string value
+ * @param field - Field name for errors
+ * @returns Valid non-empty string
+ */
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.trim() !== value ||
+    containsForbiddenTextControl(value)
+  ) {
+    throw new Error(`Invalid ${field}: expected a trimmed non-empty string`);
+  }
+  return value;
+}
+
+/**
+ * Require non-blank text and normalize its outer whitespace.
+ * @param value - Untrusted text value
+ * @param field - Field name for errors
+ * @returns Normalized non-blank text
+ */
+function requireNonBlankText(value: unknown, field: string): string {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    containsForbiddenTextControl(value)
+  ) {
+    throw new Error(`Invalid ${field}: expected non-blank text`);
+  }
+  return value.trim();
+}
+
+/**
+ * Require a real calendar date in ISO date form.
+ * @param value - Untrusted date value
+ * @param field - Field name for errors
+ * @returns Valid ISO date
+ */
+function requireIsoDate(value: unknown, field: string): string {
+  const result = requireNonEmptyString(value, field);
+  const date = new Date(`${result}T00:00:00.000Z`);
+  if (
+    !ISO_DATE.test(result) ||
+    Number.isNaN(date.valueOf()) ||
+    date.toISOString().slice(0, 10) !== result
+  ) {
+    throw new Error(`Invalid ${field}: expected a real YYYY-MM-DD date`);
+  }
+  return result;
+}
+
+/**
+ * Bound individual untrusted fields before document rendering allocates them.
+ * @param value - Valid string value
+ * @param field - Field name for errors
+ */
+function assertUtf8Budget(value: string, field: string): void {
+  if (Buffer.byteLength(value, "utf8") > LEARNINGS_CONTRACT.maxTokens) {
+    throw new Error(
+      `${field} exceeds maxTokens ${LEARNINGS_CONTRACT.maxTokens}`
+    );
+  }
+}
+
+/**
+ * Reject non-whitespace controls while allowing rule line separators.
+ * @param value - Entry text
+ * @returns True when a forbidden control is present
+ */
+function containsForbiddenTextControl(value: string): boolean {
+  return Array.from(value).some(character => {
+    const code = character.charCodeAt(0);
+    return (
+      code <= 8 ||
+      code === 11 ||
+      code === 12 ||
+      (code >= 14 && code <= 31) ||
+      code === 127
+    );
+  });
+}

--- a/src/core/learnings-file-safety.ts
+++ b/src/core/learnings-file-safety.ts
@@ -1,0 +1,107 @@
+/** Filesystem containment and safe reads for project learnings. */
+import * as fse from "fs-extra";
+import { lstat, open, realpath } from "node:fs/promises";
+import * as path from "node:path";
+import { LEARNINGS_CONTRACT } from "./learnings-contract.js";
+
+/**
+ * Resolve the configured target without permitting project-root escape.
+ * @param projectRoot - Host project root
+ * @param relativeFile - Configured project-relative file
+ * @returns Resolved root and target paths
+ */
+export function resolveSafeLearningTarget(
+  projectRoot: string,
+  relativeFile: string
+): { readonly root: string; readonly target: string } {
+  const root = path.resolve(projectRoot);
+  const target = path.resolve(root, relativeFile);
+  if (target === root || !target.startsWith(`${root}${path.sep}`)) {
+    throw new Error(
+      "Unsafe projectRulesFile: learnings path escapes project root"
+    );
+  }
+  return { root, target };
+}
+
+/**
+ * Read only a bounded regular file from the inode that was safety-checked.
+ * @param target - Resolved learnings file path
+ * @returns Existing content, or undefined when the file does not exist
+ */
+export async function readExistingLearnings(
+  target: string
+): Promise<string | undefined> {
+  try {
+    const beforeOpen = await lstat(target);
+    if (!beforeOpen.isFile()) {
+      throw new Error(
+        "Unsafe project learnings path: target is not a regular file"
+      );
+    }
+    const handle = await open(target, "r");
+    try {
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        opened.dev !== beforeOpen.dev ||
+        opened.ino !== beforeOpen.ino
+      ) {
+        throw new Error(
+          "Unsafe project learnings path: target changed during open"
+        );
+      }
+      if (opened.size > LEARNINGS_CONTRACT.maxTokens) {
+        throw new Error(
+          `Project learnings payload exceeds maxTokens ${LEARNINGS_CONTRACT.maxTokens}`
+        );
+      }
+      return handle.readFile({ encoding: "utf8" });
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reject parent-directory symlinks that resolve outside the project root.
+ * @param root - Resolved project root
+ * @param parent - Target parent directory
+ */
+export async function assertSafeLearningParents(
+  root: string,
+  parent: string
+): Promise<void> {
+  const realRoot = await realpath(root);
+  const cursor = await findExistingAncestor(parent);
+  const realParent = await realpath(cursor);
+  if (
+    realParent !== realRoot &&
+    !realParent.startsWith(`${realRoot}${path.sep}`)
+  ) {
+    throw new Error(
+      "Unsafe project learnings path: parent escapes project root"
+    );
+  }
+}
+
+/**
+ * Find the nearest existing ancestor without mutable traversal state.
+ * @param candidate - Starting filesystem path
+ * @returns Nearest existing ancestor
+ */
+async function findExistingAncestor(candidate: string): Promise<string> {
+  if (await fse.pathExists(candidate)) {
+    return candidate;
+  }
+  const parent = path.dirname(candidate);
+  if (parent === candidate) {
+    throw new Error("Unsafe project learnings path: no project ancestor");
+  }
+  return findExistingAncestor(parent);
+}

--- a/src/core/learnings-lock.ts
+++ b/src/core/learnings-lock.ts
@@ -1,0 +1,266 @@
+/** Cross-process serialization for project learnings writes. */
+import { link, lstat, readFile, unlink, writeFile } from "node:fs/promises";
+
+const MAX_LOCK_ATTEMPTS = 200;
+const LOCK_RETRY_DELAY_MS = 10;
+const STALE_LOCK_MS = 30_000;
+
+/** Ownership metadata published atomically with each lock. */
+interface LockOwner {
+  readonly token: string;
+  readonly pid: number;
+  readonly createdAt: number;
+}
+
+/** Owner metadata plus the retained hard link proving inode ownership. */
+interface LockLease {
+  readonly owner: LockOwner;
+  readonly ownerPath: string;
+}
+
+/**
+ * Serialize same-target writers across processes with an exclusive hard link.
+ * @param target - Absolute learnings target
+ * @param operation - Complete read, validate, and atomic-write transaction
+ * @returns Operation result
+ */
+export async function withLearningTargetLock<T>(
+  target: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const lockPath = `${target}.lock`;
+  const owner = {
+    token: crypto.randomUUID(),
+    pid: process.pid,
+    createdAt: Date.now(),
+  } as const;
+  const lease = await acquireLock(lockPath, owner, 0);
+  try {
+    return await operation();
+  } finally {
+    await releaseLock(lockPath, lease);
+  }
+}
+
+/**
+ * Publish complete owner metadata atomically via a hard link.
+ * @param lockPath - Shared lock path
+ * @param owner - Unique owner metadata
+ * @param attempt - Current retry count
+ * @returns Acquired lock lease
+ */
+async function acquireLock(
+  lockPath: string,
+  owner: LockOwner,
+  attempt: number
+): Promise<LockLease> {
+  const ownerPath = `${lockPath}.${owner.token}.owner`;
+  await writeFile(ownerPath, JSON.stringify(owner), {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  const acquired = await publishOwnerLink(ownerPath, lockPath);
+  if (acquired) {
+    return { owner, ownerPath };
+  }
+  await removeFileIfPresent(ownerPath);
+  if (attempt >= MAX_LOCK_ATTEMPTS) {
+    throw new Error(`Timed out waiting for learnings lock: ${lockPath}`);
+  }
+  await reclaimStaleLock(lockPath);
+  await delay(LOCK_RETRY_DELAY_MS);
+  return acquireLock(lockPath, owner, attempt + 1);
+}
+
+/**
+ * Try to hard-link fully written owner metadata into the lock path.
+ * @param ownerPath - Fully written owner metadata file
+ * @param lockPath - Destination lock path
+ * @returns Whether publication acquired the lock
+ */
+async function publishOwnerLink(
+  ownerPath: string,
+  lockPath: string
+): Promise<boolean> {
+  try {
+    await link(ownerPath, lockPath);
+    return true;
+  } catch (error) {
+    if (
+      (error as NodeJS.ErrnoException).code === "EEXIST" ||
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Remove only the lock inode still linked to this lease's owner file.
+ * @param lockPath - Shared lock path
+ * @param lease - Owner lease retaining the same inode
+ */
+async function releaseLock(lockPath: string, lease: LockLease): Promise<void> {
+  try {
+    if (await sameFile(lockPath, lease.ownerPath)) {
+      await unlink(lockPath);
+    }
+  } finally {
+    await removeFileIfPresent(lease.ownerPath);
+  }
+}
+
+/**
+ * Reclaim an expired lock only when its declared process is no longer live.
+ * @param lockPath - Shared lock path
+ */
+async function reclaimStaleLock(lockPath: string): Promise<void> {
+  const before = await statFile(lockPath);
+  if (before === undefined || !before.isFile()) {
+    return;
+  }
+  const owner = await readLockOwner(lockPath);
+  const timestamp = owner?.createdAt ?? Number(before.mtimeMs);
+  if (
+    Date.now() - timestamp <= STALE_LOCK_MS ||
+    (owner !== undefined && isProcessLive(owner.pid))
+  ) {
+    return;
+  }
+  const retainedOwnerPath =
+    owner === undefined ? undefined : `${lockPath}.${owner.token}.owner`;
+  const quarantine =
+    retainedOwnerPath !== undefined &&
+    (await sameFile(lockPath, retainedOwnerPath))
+      ? retainedOwnerPath
+      : `${lockPath}.${crypto.randomUUID()}.stale`;
+  const linked =
+    quarantine === retainedOwnerPath
+      ? true
+      : await publishOwnerLink(lockPath, quarantine);
+  if (!linked) {
+    return;
+  }
+  try {
+    if (await sameFile(lockPath, quarantine)) {
+      await removeFileIfPresent(lockPath);
+    }
+  } finally {
+    await removeFileIfPresent(quarantine);
+  }
+}
+
+/**
+ * Read bounded owner metadata; partial or special lock files are unowned.
+ * @param lockPath - Shared lock path
+ * @returns Parsed owner or undefined
+ */
+async function readLockOwner(lockPath: string): Promise<LockOwner | undefined> {
+  const metadata = await statFile(lockPath);
+  if (metadata === undefined || !metadata.isFile() || metadata.size > 512) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(await readFile(lockPath, "utf8")) as unknown;
+    return isLockOwner(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compare two regular-file paths by device and inode.
+ * @param left - First file path
+ * @param right - Second file path
+ * @returns Whether both paths retain the same regular-file inode
+ */
+async function sameFile(left: string, right: string): Promise<boolean> {
+  const [leftStat, rightStat] = await Promise.all([
+    statFile(left),
+    statFile(right),
+  ]);
+  return (
+    leftStat !== undefined &&
+    rightStat !== undefined &&
+    leftStat.isFile() &&
+    rightStat.isFile() &&
+    leftStat.dev === rightStat.dev &&
+    leftStat.ino === rightStat.ino
+  );
+}
+
+/**
+ * Read file metadata without treating an absent path as an error.
+ * @param filePath - Filesystem path
+ * @returns File metadata or undefined
+ */
+async function statFile(
+  filePath: string
+): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Remove one path without recursive deletion.
+ * @param filePath - Regular file or hard-link path
+ */
+async function removeFileIfPresent(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Narrow parsed lock metadata to the exact ownership shape.
+ * @param value - Parsed metadata
+ * @returns Whether the metadata is a lock owner
+ */
+function isLockOwner(value: unknown): value is LockOwner {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const owner = value as Partial<LockOwner>;
+  return (
+    typeof owner.token === "string" &&
+    typeof owner.pid === "number" &&
+    Number.isSafeInteger(owner.pid) &&
+    typeof owner.createdAt === "number" &&
+    Number.isSafeInteger(owner.createdAt)
+  );
+}
+
+/**
+ * Treat permission-denied PID probes as live and missing PIDs as dead.
+ * @param pid - Declared owner process id
+ * @returns Whether the process may still be alive
+ */
+function isProcessLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/**
+ * Await a short retry delay without blocking the event loop.
+ * @param milliseconds - Delay duration
+ */
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, milliseconds);
+  });
+}

--- a/src/core/learnings-lock.ts
+++ b/src/core/learnings-lock.ts
@@ -236,6 +236,7 @@ function isLockOwner(value: unknown): value is LockOwner {
     typeof owner.token === "string" &&
     typeof owner.pid === "number" &&
     Number.isSafeInteger(owner.pid) &&
+    owner.pid > 0 &&
     typeof owner.createdAt === "number" &&
     Number.isSafeInteger(owner.createdAt)
   );

--- a/src/core/learnings-writer.ts
+++ b/src/core/learnings-writer.ts
@@ -1,0 +1,170 @@
+/** Deterministic persistence for project-local learnings. */
+import * as fse from "fs-extra";
+import { rename, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import {
+  LEARNINGS_CONTRACT,
+  estimateLearningTokens,
+  type LearningEntry,
+} from "./learnings-contract.js";
+import { validateLearningEntry } from "./learnings-entry.js";
+import {
+  assertSafeLearningParents,
+  readExistingLearnings,
+  resolveSafeLearningTarget,
+} from "./learnings-file-safety.js";
+import { withLearningTargetLock } from "./learnings-lock.js";
+import {
+  readProjectConfig,
+  resolveProjectLearningsFile,
+} from "./project-config.js";
+
+const FILE_HEADER = `# Project Learnings
+
+<!-- lisa-learnings-contract:v${LEARNINGS_CONTRACT.version} -->
+
+`;
+const JSON_FENCE_START = "```jsonl\n";
+const JSON_FENCE_END = "\n```\n";
+
+/**
+ * Persist one already-selected learning without generating or truncating it.
+ * @param projectRoot - Absolute path to the host project root
+ * @param candidate - Untrusted seven-field learning entry
+ * @returns Absolute path to the persisted learnings file
+ */
+export async function persistLearningEntry(
+  projectRoot: string,
+  candidate: unknown
+): Promise<string> {
+  const entry = validateLearningEntry(candidate);
+  const initialDocument = buildNextDocument([], entry);
+  const config = await readProjectConfig(projectRoot);
+  const relativeFile = resolveProjectLearningsFile(config);
+  const { root, target } = resolveSafeLearningTarget(projectRoot, relativeFile);
+  await assertSafeLearningParents(root, path.dirname(target));
+  await fse.ensureDir(path.dirname(target));
+  return withLearningTargetLock(target, async () => {
+    await assertSafeLearningParents(root, path.dirname(target));
+    const existing = await readExistingLearnings(target);
+    const entries = existing === undefined ? [] : parseLearningsFile(existing);
+    const rendered =
+      existing === undefined
+        ? initialDocument
+        : buildNextDocument(entries, entry);
+    const temporary = path.join(
+      path.dirname(target),
+      `.${path.basename(target)}.${process.pid}.${crypto.randomUUID()}.tmp`
+    );
+    try {
+      await writeFile(temporary, rendered, { encoding: "utf8", flag: "wx" });
+      await assertSafeLearningParents(root, path.dirname(target));
+      await rename(temporary, target);
+    } finally {
+      await fse.remove(temporary);
+    }
+    return target;
+  });
+}
+
+/**
+ * Render the complete file in one stable, machine-readable Markdown form.
+ * @param entries - Validated entries to serialize
+ * @returns Canonical Markdown plus JSONL document
+ */
+export function renderLearningsFile(entries: readonly LearningEntry[]): string {
+  const lines = entries.map(entry => JSON.stringify(entry)).join("\n");
+  return `${FILE_HEADER}${JSON_FENCE_START}${lines}${JSON_FENCE_END}`;
+}
+
+/**
+ * Parse and revalidate an existing file before it participates in a write.
+ * @param content - Existing learnings document
+ * @returns Revalidated entries from the document
+ */
+export function parseLearningsFile(content: string): LearningEntry[] {
+  if (estimateLearningTokens(content) > LEARNINGS_CONTRACT.maxTokens) {
+    throw new Error(
+      `Project learnings payload exceeds maxTokens ${LEARNINGS_CONTRACT.maxTokens}`
+    );
+  }
+  if (
+    !content.startsWith(`${FILE_HEADER}${JSON_FENCE_START}`) ||
+    !content.endsWith(JSON_FENCE_END)
+  ) {
+    throw new Error("Invalid project learnings file format");
+  }
+  const jsonStart = FILE_HEADER.length + JSON_FENCE_START.length;
+  const jsonEnd = content.length - JSON_FENCE_END.length;
+  const entries = parseJsonLines(content.slice(jsonStart, jsonEnd)).map(
+    validateLearningEntry
+  );
+  if (new Set(entries.map(entry => entry.id)).size !== entries.length) {
+    throw new Error("Invalid project learnings payload: duplicate ids");
+  }
+  assertDocumentBudget(content, entries.length, "Project learnings payload");
+  return entries;
+}
+
+export { validateLearningEntry } from "./learnings-entry.js";
+
+/**
+ * Build and budget-check the next canonical document.
+ * @param entries - Existing validated entries
+ * @param entry - New validated entry
+ * @returns Next canonical document
+ */
+function buildNextDocument(
+  entries: readonly LearningEntry[],
+  entry: LearningEntry
+): string {
+  if (entries.some(current => current.id === entry.id)) {
+    throw new Error(`Duplicate learning id: ${entry.id}`);
+  }
+  const nextEntries = [...entries, entry].sort((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const rendered = renderLearningsFile(nextEntries);
+  assertDocumentBudget(rendered, nextEntries.length, "Learnings file");
+  return rendered;
+}
+
+/**
+ * Enforce the shared entry-count and model-agnostic token upper bounds.
+ * @param content - Canonical document
+ * @param entryCount - Number of entries in the document
+ * @param context - Error-message prefix
+ */
+function assertDocumentBudget(
+  content: string,
+  entryCount: number,
+  context: string
+): void {
+  if (entryCount > LEARNINGS_CONTRACT.maxEntries) {
+    throw new Error(
+      `${context} exceeds maxEntries ${LEARNINGS_CONTRACT.maxEntries}`
+    );
+  }
+  const estimatedTokens = estimateLearningTokens(content);
+  if (estimatedTokens > LEARNINGS_CONTRACT.maxTokens) {
+    throw new Error(
+      `${context} exceeds maxTokens ${LEARNINGS_CONTRACT.maxTokens} (measured ${estimatedTokens})`
+    );
+  }
+}
+
+/**
+ * Parse the strict JSONL payload with a stable, user-facing error.
+ * @param payload - JSONL payload
+ * @returns Parsed unknown entry values
+ */
+function parseJsonLines(payload: string): unknown[] {
+  if (payload === "") {
+    return [];
+  }
+  try {
+    return payload.split("\n").map(line => JSON.parse(line) as unknown);
+  } catch {
+    throw new Error("Invalid project learnings JSONL payload");
+  }
+}

--- a/src/core/learnings.ts
+++ b/src/core/learnings.ts
@@ -1,0 +1,9 @@
+export * from "./learnings-contract.js";
+export * from "./learnings-writer.js";
+export {
+  DEFAULT_PROJECT_RULES_FILE,
+  PROJECT_LEARNINGS_FILENAME,
+  resolveProjectLearningsFile,
+  resolveProjectRulesFile,
+  type ProjectConfig,
+} from "./project-config.js";

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -245,8 +245,7 @@ function validateOptionalHarness(
   const legacy =
     typeof value === "string" ? LEGACY_HARNESS_ALIASES[value] : undefined;
   const normalized =
-    legacy ??
-    (typeof value === "string" ? normalizeHarness(value) : undefined);
+    legacy ?? (typeof value === "string" ? normalizeHarness(value) : undefined);
   if (normalized !== undefined) {
     return normalized;
   }

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -22,6 +22,12 @@ import {
 /** Filename of the per-project config, relative to the destination root */
 export const PROJECT_CONFIG_FILENAME = ".lisa.config.json";
 
+/** Default durable project-rules destination used by governance skills. */
+export const DEFAULT_PROJECT_RULES_FILE = ".claude/rules/PROJECT_RULES.md";
+
+/** Fixed sibling filename for machine-managed project learnings. */
+export const PROJECT_LEARNINGS_FILENAME = "PROJECT_LEARNINGS.md";
+
 /**
  * Schema of `.lisa.config.json`. Additional fields may be added in future
  * versions; unknown fields are preserved on round-trip.
@@ -29,6 +35,33 @@ export const PROJECT_CONFIG_FILENAME = ".lisa.config.json";
 export interface ProjectConfig {
   /** Target harness(es) for emitted artifacts */
   readonly harness?: Harness;
+  /** Relative path to the project's durable rules file. */
+  readonly projectRulesFile?: string;
+}
+
+/**
+ * Resolve the validated project-rules path from config or its default.
+ * @param config - Parsed project configuration
+ * @returns Safe project-relative Markdown path
+ */
+export function resolveProjectRulesFile(config: ProjectConfig): string {
+  return validateProjectRulesFile(
+    config.projectRulesFile ?? DEFAULT_PROJECT_RULES_FILE,
+    PROJECT_CONFIG_FILENAME
+  );
+}
+
+/**
+ * Keep learned rules separate from hand-authored rules while honoring the same
+ * configured directory.
+ * @param config - Parsed project configuration
+ * @returns Safe project-relative learnings Markdown path
+ */
+export function resolveProjectLearningsFile(config: ProjectConfig): string {
+  return path.posix.join(
+    path.posix.dirname(resolveProjectRulesFile(config)),
+    PROJECT_LEARNINGS_FILENAME
+  );
 }
 
 /**
@@ -175,35 +208,103 @@ function validateProjectConfig(
   parsed: unknown,
   configPath: string
 ): ProjectConfig {
-  if (parsed === null || typeof parsed !== "object") {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(
       `Invalid ${PROJECT_CONFIG_FILENAME} at ${configPath}: expected JSON object`
     );
   }
   const obj = parsed as Record<string, unknown>;
-  if (obj.harness === undefined) {
-    return {};
+  const harness = validateOptionalHarness(obj.harness, configPath);
+  const projectRulesFile =
+    obj.projectRulesFile === undefined
+      ? undefined
+      : validateProjectRulesFile(obj.projectRulesFile, configPath);
+  return {
+    ...(harness === undefined ? {} : { harness }),
+    ...(projectRulesFile === undefined ? {} : { projectRulesFile }),
+  };
+}
+
+/**
+ * Validate the optional harness while preserving an absent value.
+ * @param value - Raw harness value
+ * @param configPath - Config source for errors
+ * @returns Normalized harness or undefined
+ */
+function validateOptionalHarness(
+  value: unknown,
+  configPath: string
+): Harness | undefined {
+  if (value === undefined) {
+    return undefined;
   }
   // A persisted, retired legacy value (e.g. "both") is migrated to its
   // canonical form rather than rejected — apply rewrites the file (see
   // detectLegacyHarnessMigration). This keeps pre-fleet projects applying
   // instead of hard-failing every run on a value newer Lisa versions removed.
   const legacy =
-    typeof obj.harness === "string"
-      ? LEGACY_HARNESS_ALIASES[obj.harness]
-      : undefined;
+    typeof value === "string" ? LEGACY_HARNESS_ALIASES[value] : undefined;
   const normalized =
     legacy ??
-    (typeof obj.harness === "string"
-      ? normalizeHarness(obj.harness)
-      : undefined);
-  if (normalized === undefined) {
-    const allowed = ACCEPTED_HARNESS_INPUTS.join(" | ");
+    (typeof value === "string" ? normalizeHarness(value) : undefined);
+  if (normalized !== undefined) {
+    return normalized;
+  }
+  const allowed = ACCEPTED_HARNESS_INPUTS.join(" | ");
+  throw new Error(
+    `Invalid harness in ${configPath}: expected ${allowed}, got ${JSON.stringify(value)}`
+  );
+}
+
+/**
+ * Validate the configurable rules destination as a safe Markdown path.
+ * @param value - Raw configured path
+ * @param source - Config source for errors
+ * @returns Validated project-relative path
+ */
+function validateProjectRulesFile(value: unknown, source: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.trim() !== value ||
+    value.includes("\\") ||
+    containsControlCharacter(value) ||
+    /^[a-z]:/iu.test(value) ||
+    path.posix.isAbsolute(value) ||
+    path.win32.isAbsolute(value)
+  ) {
     throw new Error(
-      `Invalid harness in ${configPath}: expected ${allowed}, got ${JSON.stringify(obj.harness)}`
+      `Invalid projectRulesFile in ${source}: expected a safe relative POSIX path`
     );
   }
-  return { harness: normalized };
+  const segments = value.split("/");
+  if (
+    segments.some(
+      segment => segment === "" || segment === "." || segment === ".."
+    )
+  ) {
+    throw new Error(
+      `Invalid projectRulesFile in ${source}: path traversal is not allowed`
+    );
+  }
+  if (path.posix.extname(value).toLowerCase() !== ".md") {
+    throw new Error(
+      `Invalid projectRulesFile in ${source}: expected a Markdown file`
+    );
+  }
+  return value;
+}
+
+/**
+ * Whether a path contains an ASCII control character.
+ * @param value - Configured path
+ * @returns True when any control character is present
+ */
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some(character => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
 }
 
 /**

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -10,6 +10,7 @@
  * completely missing.
  * @module sync/registry
  */
+import { DEFAULT_PROJECT_RULES_FILE } from "../core/project-config.js";
 import type { JsonValue } from "./json-path.js";
 import type { LegacyAliasMapping } from "./legacy-aliases.js";
 
@@ -106,7 +107,7 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
   },
   {
     key: "projectRulesFile",
-    defaultValue: ".claude/rules/PROJECT_RULES.md",
+    defaultValue: DEFAULT_PROJECT_RULES_FILE,
     description: "Project rules file used to derive PROJECT_LEARNINGS.md",
   },
   {

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -105,6 +105,11 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
     description: "Target coding-agent harness(es)",
   },
   {
+    key: "projectRulesFile",
+    defaultValue: ".claude/rules/PROJECT_RULES.md",
+    description: "Project rules file used to derive PROJECT_LEARNINGS.md",
+  },
+  {
     key: "quality.testCoverage",
     defaultValue: COVERAGE_DEFAULTS,
     artifacts: [

--- a/tests/unit/core/learnings-concurrency.test.ts
+++ b/tests/unit/core/learnings-concurrency.test.ts
@@ -1,0 +1,82 @@
+/** Cross-process contention regression tests for the learnings writer. */
+import * as fs from "fs-extra";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  parseLearningsFile,
+  type LearningEntry,
+} from "../../../src/core/learnings.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const execFileAsync = promisify(execFile);
+const LEARNINGS_FILENAME = "PROJECT_LEARNINGS.md";
+const CROSS_PROCESS_WRITER = `
+import { persistLearningEntry } from "./src/core/learnings-writer.ts";
+const projectRoot = process.env.LEARNINGS_PROJECT_ROOT;
+const serializedEntry = process.env.LEARNINGS_ENTRY_JSON;
+if (projectRoot === undefined || serializedEntry === undefined) {
+  throw new Error("Missing cross-process writer input");
+}
+await persistLearningEntry(projectRoot, JSON.parse(serializedEntry));
+`;
+
+/**
+ * Build one compact valid entry for a child-process writer.
+ * @param index - Stable numeric suffix
+ * @returns Valid learning entry
+ */
+function numberedEntry(index: number): LearningEntry {
+  return {
+    id: `learning-${index}`,
+    rule: `Rule ${index}.`,
+    why: "Reason.",
+    provenance: [`issue:#${index}`],
+    first_learned: "2026-07-16",
+    last_confirmed: "2026-07-16",
+    confidence: "high",
+  };
+}
+
+describe("learnings writer cross-process concurrency", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("serializes writers from separate processes without losing entries", async () => {
+    const projectRoot = path.join(tempDir, "cross-process");
+    await fs.ensureDir(projectRoot);
+    const entries = Array.from({ length: 10 }, (_unused, index) =>
+      numberedEntry(index)
+    );
+    await Promise.all(
+      entries.map(entry =>
+        execFileAsync("bun", ["--eval", CROSS_PROCESS_WRITER], {
+          cwd: path.resolve("."),
+          env: {
+            ...process.env,
+            LEARNINGS_PROJECT_ROOT: projectRoot,
+            LEARNINGS_ENTRY_JSON: JSON.stringify(entry),
+          },
+        })
+      )
+    );
+    const persisted = parseLearningsFile(
+      await readFile(
+        path.join(projectRoot, ".claude", "rules", LEARNINGS_FILENAME),
+        "utf8"
+      )
+    );
+    expect(persisted.map(entry => entry.id)).toEqual(
+      entries.map(entry => entry.id)
+    );
+  });
+});

--- a/tests/unit/core/learnings-contract.test.ts
+++ b/tests/unit/core/learnings-contract.test.ts
@@ -42,6 +42,7 @@ describe("learnings contract", () => {
   it.each([
     "maxRuleCharacters",
     "maxRuleLines",
+    "maxProvenanceReferences",
     "maxEntries",
     "maxTokens",
   ] as const)("exports %s as a positive checkable integer", limit => {
@@ -54,6 +55,7 @@ describe("learnings contract", () => {
     expect(LEARNINGS_CONTRACT).toMatchObject({
       maxRuleCharacters: 240,
       maxRuleLines: 2,
+      maxProvenanceReferences: 20,
       maxEntries: 20,
       maxTokens: 4000,
       measurement: "utf8-bytes-upper-bound",

--- a/tests/unit/core/learnings-contract.test.ts
+++ b/tests/unit/core/learnings-contract.test.ts
@@ -1,0 +1,116 @@
+/** Contract, public export, and shared path-resolution tests for issue #1568. */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LEARNINGS_CONTRACT } from "../../../src/core/learnings-contract.js";
+import {
+  DEFAULT_PROJECT_RULES_FILE,
+  PROJECT_CONFIG_FILENAME,
+  readProjectConfig,
+  resolveProjectLearningsFile,
+  resolveProjectRulesFile,
+} from "../../../src/core/project-config.js";
+import { SYNC_REGISTRY } from "../../../src/sync/registry.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const EXPECTED_ENTRY_FIELDS = [
+  "id",
+  "rule",
+  "why",
+  "provenance",
+  "first_learned",
+  "last_confirmed",
+  "confidence",
+] as const;
+const CUSTOM_PROJECT_RULES_FILE = "rules/CUSTOM_RULES.md";
+
+describe("learnings contract", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("declares exactly the seven required entry fields", () => {
+    expect(LEARNINGS_CONTRACT.fields).toEqual(EXPECTED_ENTRY_FIELDS);
+  });
+
+  it.each([
+    "maxRuleCharacters",
+    "maxRuleLines",
+    "maxEntries",
+    "maxTokens",
+  ] as const)("exports %s as a positive checkable integer", limit => {
+    const value = LEARNINGS_CONTRACT[limit];
+    expect(Number.isInteger(value)).toBe(true);
+    expect(value).toBeGreaterThan(0);
+  });
+
+  it("defines hard entry and file budgets with a conservative measurement", () => {
+    expect(LEARNINGS_CONTRACT).toMatchObject({
+      maxRuleCharacters: 240,
+      maxRuleLines: 2,
+      maxEntries: 20,
+      maxTokens: 4000,
+      measurement: "utf8-bytes-upper-bound",
+    });
+  });
+
+  it("publishes the contract for the future CI budget reader", async () => {
+    const packageJson = (await fs.readJson(path.resolve("package.json"))) as {
+      exports?: Record<string, string>;
+    };
+    expect(packageJson.exports?.["./learnings"]).toBe(
+      "./dist/core/learnings.js"
+    );
+  });
+
+  it("registers the project rules default for lisa sync", () => {
+    expect(
+      SYNC_REGISTRY.find(setting => setting.key === "projectRulesFile")
+    ).toMatchObject({ defaultValue: DEFAULT_PROJECT_RULES_FILE });
+  });
+
+  it("formalizes projectRulesFile in .lisa.config.json", async () => {
+    await fs.writeJson(path.join(tempDir, PROJECT_CONFIG_FILENAME), {
+      projectRulesFile: CUSTOM_PROJECT_RULES_FILE,
+    });
+    await expect(readProjectConfig(tempDir)).resolves.toEqual({
+      projectRulesFile: CUSTOM_PROJECT_RULES_FILE,
+    });
+  });
+
+  it("resolves the default rules file and its separate learnings sibling", () => {
+    expect(DEFAULT_PROJECT_RULES_FILE).toBe(".claude/rules/PROJECT_RULES.md");
+    expect(resolveProjectRulesFile({})).toBe(DEFAULT_PROJECT_RULES_FILE);
+    expect(resolveProjectLearningsFile({})).toBe(
+      ".claude/rules/PROJECT_LEARNINGS.md"
+    );
+  });
+
+  it("derives the learnings file beside a configured project-rules file", () => {
+    const config = { projectRulesFile: CUSTOM_PROJECT_RULES_FILE };
+    expect(resolveProjectRulesFile(config)).toBe(CUSTOM_PROJECT_RULES_FILE);
+    expect(resolveProjectLearningsFile(config)).toBe(
+      "rules/PROJECT_LEARNINGS.md"
+    );
+  });
+
+  it("rejects unsafe projectRulesFile paths", () => {
+    for (const projectRulesFile of [
+      "../ESCAPE.md",
+      "C:rules/PROJECT_RULES.md",
+      "rules/\tPROJECT_RULES.md",
+      "rules/\nPROJECT_RULES.md",
+      path.resolve(tempDir, "ABSOLUTE_RULES.md"),
+    ]) {
+      expect(() => resolveProjectRulesFile({ projectRulesFile })).toThrow(
+        /projectRulesFile/i
+      );
+    }
+  });
+});

--- a/tests/unit/core/learnings-writer.test.ts
+++ b/tests/unit/core/learnings-writer.test.ts
@@ -171,6 +171,32 @@ describe("learnings writer", () => {
     expect(await fs.pathExists(lockPath)).toBe(false);
   });
 
+  it.each([0, -1])("reclaims a malformed lock-owner pid %i", async pid => {
+    const lockPath = `${learningsPath}.lock`;
+    await fs.outputJson(lockPath, {
+      token: "invalid-pid-owner",
+      pid,
+      createdAt: Date.now() - 60_000,
+    });
+    const stale = new Date(Date.now() - 60_000);
+    await fs.utimes(lockPath, stale, stale);
+    await persistLearningEntry(tempDir, VALID_ENTRY);
+    expect(await fs.pathExists(lockPath)).toBe(false);
+  });
+
+  it("rejects provenance beyond its dedicated reference cap", () => {
+    const provenance = Array.from(
+      { length: LEARNINGS_CONTRACT.maxProvenanceReferences + 1 },
+      (_unused, index) => `issue:#${index}`
+    );
+    expect(() => validateLearningEntry({ ...VALID_ENTRY, provenance })).toThrow(
+      new RegExp(
+        `provenance.*${LEARNINGS_CONTRACT.maxProvenanceReferences}`,
+        "i"
+      )
+    );
+  });
+
   it.each(["", "{"])(
     "reclaims stale partial lock content %j after a crashed acquisition",
     async partial => {

--- a/tests/unit/core/learnings-writer.test.ts
+++ b/tests/unit/core/learnings-writer.test.ts
@@ -1,0 +1,284 @@
+/** Persistence, validation, concurrency, and filesystem-safety tests. */
+import * as fs from "fs-extra";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LEARNINGS_CONTRACT } from "../../../src/core/learnings-contract.js";
+import {
+  parseLearningsFile,
+  persistLearningEntry,
+  renderLearningsFile,
+  validateLearningEntry,
+} from "../../../src/core/learnings-writer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const LEARNINGS_FILENAME = "PROJECT_LEARNINGS.md";
+const VALID_ENTRY = {
+  id: "learning-stable-id",
+  rule: "Reject over-budget learnings before persistence.",
+  why: "Silent truncation destroys the rule and its audit trail.",
+  provenance: ["issue:#1568", "pr:#example"],
+  first_learned: "2026-07-16",
+  last_confirmed: "2026-07-16",
+  confidence: "high",
+} as const;
+
+/**
+ * Build a compact valid entry for file-budget tests.
+ * @param index - Stable numeric suffix
+ * @returns Compact valid entry
+ */
+function numberedEntry(index: number) {
+  return {
+    ...VALID_ENTRY,
+    id: `learning-${index}`,
+    rule: `Rule ${index}.`,
+    why: "Reason.",
+    provenance: [`issue:#${index}`],
+  } as const;
+}
+
+describe("learnings writer", () => {
+  let tempDir: string;
+  let learningsPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    learningsPath = path.join(tempDir, ".claude", "rules", LEARNINGS_FILENAME);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("persists a valid caller-supplied entry with all seven fields", async () => {
+    await persistLearningEntry(tempDir, VALID_ENTRY);
+    const persisted = await readFile(learningsPath, "utf8");
+    for (const field of LEARNINGS_CONTRACT.fields) {
+      expect(persisted).toContain(`"${field}"`);
+    }
+    expect(parseLearningsFile(persisted)).toEqual([VALID_ENTRY]);
+  });
+
+  it("rejects an over-cap rule and leaves the file byte-identical", async () => {
+    await persistLearningEntry(tempDir, VALID_ENTRY);
+    const before = await readFile(learningsPath, "utf8");
+    const overCapEntry = {
+      ...VALID_ENTRY,
+      id: "learning-over-cap",
+      rule: "x".repeat(LEARNINGS_CONTRACT.maxRuleCharacters + 1),
+    };
+    await expect(persistLearningEntry(tempDir, overCapEntry)).rejects.toThrow(
+      new RegExp(
+        `maxRuleCharacters.*${LEARNINGS_CONTRACT.maxRuleCharacters}`,
+        "i"
+      )
+    );
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("counts ASCII and Unicode line separators toward maxRuleLines", () => {
+    for (const rule of [
+      "one\rtwo\rthree",
+      "one\ntwo\nthree",
+      "one\r\ntwo\r\nthree",
+      "one\u0085two\u0085three",
+      "one\u2028two\u2028three",
+      "one\u2029two\u2029three",
+    ]) {
+      expect(() => validateLearningEntry({ ...VALID_ENTRY, rule })).toThrow(
+        /maxRuleLines.*2/i
+      );
+    }
+  });
+
+  it("rejects accessor-backed fields without invoking them", () => {
+    const candidate = { ...VALID_ENTRY } as Record<string, unknown>;
+    const getter = vi.fn(() => "high");
+    Object.defineProperty(candidate, "confidence", {
+      enumerable: true,
+      get: getter,
+    });
+    expect(() => validateLearningEntry(candidate)).toThrow(/accessor/i);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing why", { ...VALID_ENTRY, why: undefined }, /why/i],
+    ["empty provenance", { ...VALID_ENTRY, provenance: [] }, /provenance/i],
+    ["invalid date", { ...VALID_ENTRY, first_learned: "July 16" }, /date/i],
+    [
+      "invalid confidence",
+      { ...VALID_ENTRY, confidence: "certain" },
+      /confidence/i,
+    ],
+    ["unknown field", { ...VALID_ENTRY, extra: true }, /field/i],
+  ] as const)("rejects malformed entry: %s", async (_name, entry, error) => {
+    await expect(persistLearningEntry(tempDir, entry as never)).rejects.toThrow(
+      error
+    );
+  });
+
+  it("rejects duplicate ids without changing the file", async () => {
+    await persistLearningEntry(tempDir, VALID_ENTRY);
+    const before = await readFile(learningsPath, "utf8");
+    await expect(
+      persistLearningEntry(tempDir, { ...VALID_ENTRY, rule: "Different rule." })
+    ).rejects.toThrow(/duplicate.*id/i);
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("serializes concurrent unique writes without losing entries", async () => {
+    const entries = Array.from({ length: 10 }, (_unused, index) =>
+      numberedEntry(index)
+    );
+    await Promise.all(
+      entries.map(entry => persistLearningEntry(tempDir, entry))
+    );
+    const persisted = parseLearningsFile(await readFile(learningsPath, "utf8"));
+    expect(persisted.map(entry => entry.id)).toEqual(
+      entries.map(entry => entry.id)
+    );
+  });
+
+  it("publishes lock ownership atomically under repeated contention", async () => {
+    for (let round = 0; round < 10; round += 1) {
+      const projectRoot = path.join(tempDir, `round-${round}`);
+      await fs.ensureDir(projectRoot);
+      const entries = Array.from({ length: 10 }, (_unused, index) =>
+        numberedEntry(index)
+      );
+      await Promise.all(
+        entries.map(entry => persistLearningEntry(projectRoot, entry))
+      );
+      const content = await readFile(
+        path.join(projectRoot, ".claude", "rules", LEARNINGS_FILENAME),
+        "utf8"
+      );
+      expect(parseLearningsFile(content)).toHaveLength(entries.length);
+    }
+  });
+
+  it("reclaims a stale owned lock and removes it after success", async () => {
+    const lockPath = `${learningsPath}.lock`;
+    await fs.outputJson(lockPath, {
+      token: "dead-owner",
+      pid: 2_147_483_647,
+      createdAt: Date.now() - 60_000,
+    });
+    await persistLearningEntry(tempDir, VALID_ENTRY);
+    expect(await fs.pathExists(lockPath)).toBe(false);
+  });
+
+  it.each(["", "{"])(
+    "reclaims stale partial lock content %j after a crashed acquisition",
+    async partial => {
+      const lockPath = `${learningsPath}.lock`;
+      await fs.outputFile(lockPath, partial);
+      const stale = new Date(Date.now() - 60_000);
+      await fs.utimes(lockPath, stale, stale);
+      await persistLearningEntry(tempDir, VALID_ENTRY);
+      expect(await fs.pathExists(lockPath)).toBe(false);
+    }
+  );
+
+  it.each([false, true])(
+    "recovers one stale lock under concurrent writers (retained owner: %s)",
+    async retainedOwner => {
+      const lockPath = `${learningsPath}.lock`;
+      const owner = {
+        token: "crashed-owner",
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 60_000,
+      };
+      const ownerPath = `${lockPath}.${owner.token}.owner`;
+      if (retainedOwner) {
+        await fs.outputJson(ownerPath, owner);
+        await fs.ensureLink(ownerPath, lockPath);
+      } else {
+        await fs.outputJson(lockPath, owner);
+      }
+      const entries = Array.from({ length: 10 }, (_unused, index) =>
+        numberedEntry(index)
+      );
+      await Promise.all(
+        entries.map(entry => persistLearningEntry(tempDir, entry))
+      );
+      const persisted = parseLearningsFile(
+        await readFile(learningsPath, "utf8")
+      );
+      expect(persisted).toHaveLength(entries.length);
+    }
+  );
+
+  it("rejects entry and token budgets without changing persisted bytes", async () => {
+    for (let index = 0; index < LEARNINGS_CONTRACT.maxEntries; index += 1) {
+      await persistLearningEntry(tempDir, numberedEntry(index));
+    }
+    const before = await readFile(learningsPath, "utf8");
+    await expect(
+      persistLearningEntry(
+        tempDir,
+        numberedEntry(LEARNINGS_CONTRACT.maxEntries)
+      )
+    ).rejects.toThrow(/maxEntries/i);
+    await expect(
+      persistLearningEntry(tempDir, {
+        ...VALID_ENTRY,
+        id: "learning-over-token-budget",
+        why: "x".repeat(LEARNINGS_CONTRACT.maxTokens + 1),
+      })
+    ).rejects.toThrow(/maxTokens/i);
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("rejects a single over-budget entry before creating directories", async () => {
+    await expect(
+      persistLearningEntry(tempDir, {
+        ...VALID_ENTRY,
+        why: "x".repeat(LEARNINGS_CONTRACT.maxTokens - 20),
+      })
+    ).rejects.toThrow(/maxTokens/i);
+    expect(await fs.pathExists(path.join(tempDir, ".claude"))).toBe(false);
+  });
+
+  it("rejects malformed fences and existing documents without mutation", async () => {
+    const valid = renderLearningsFile([VALID_ENTRY]);
+    expect(() =>
+      parseLearningsFile(valid.replace("```jsonl\n", "123456789"))
+    ).toThrow(/format/i);
+    await fs.outputFile(learningsPath, "# Project Learnings\n\nnot-jsonl\n");
+    const before = await readFile(learningsPath, "utf8");
+    await expect(persistLearningEntry(tempDir, VALID_ENTRY)).rejects.toThrow(
+      /format|json/i
+    );
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("rejects an oversized public parser input before JSONL processing", () => {
+    expect(() =>
+      parseLearningsFile("{".repeat(LEARNINGS_CONTRACT.maxTokens + 1))
+    ).toThrow(/maxTokens/i);
+  });
+
+  it("rejects a symlink before reading external content", async () => {
+    const external = path.join(tempDir, "external.md");
+    await fs.writeFile(external, renderLearningsFile([VALID_ENTRY]));
+    await fs.ensureDir(path.dirname(learningsPath));
+    await fs.symlink(external, learningsPath);
+    await expect(persistLearningEntry(tempDir, VALID_ENTRY)).rejects.toThrow(
+      /not a regular file/i
+    );
+  });
+
+  it("imports the executable contract instead of copying cap constants", async () => {
+    const source = await readFile(
+      path.resolve("src/core/learnings-writer.ts"),
+      "utf8"
+    );
+    expect(source).toMatch(/import\s+\{[^}]*LEARNINGS_CONTRACT/s);
+    expect(source).not.toMatch(/const\s+MAX_(?:RULE|ENTRIES|TOKENS)/);
+    expect(createHash("sha256").update(source).digest("hex")).toHaveLength(64);
+  });
+});


### PR DESCRIPTION
## Summary

- define the executable seven-field project learning entry contract and publish it at `@codyswann/lisa/learnings`
- formalize `projectRulesFile`, derive a distinct `PROJECT_LEARNINGS.md`, and reject unsafe configured paths
- add strict bounded validation plus atomic, lock-safe persistence for compact Markdown/JSONL learning files
- regenerate every supported agent plugin surface from the canonical sources

## Verification

- `bun test tests/unit/core/learnings-contract.test.ts tests/unit/core/learnings-writer.test.ts` (35 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- `bun run check:rules-pairing`
- `bun run check:plugins`
- full unit suite (3990 pass before final conflict-free rebase)
- built-package journey: valid seven-field entry persisted; over-cap entry rejected with byte-identical file; exported contract reported the configured entry/token budgets

Closes #1568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable project rules file support through `.lisa.config.json`.
  - Automated learnings are now stored separately in a sibling `PROJECT_LEARNINGS.md` file.
  - Added a public `learnings` package export for consistent learning-management capabilities.
  - Learning entries are validated, bounded, safely persisted, and protected against concurrent updates.

- **Documentation**
  - Updated configuration and debrief guidance across supported integrations to reflect configurable destinations and separate learning storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->