### PR TITLE
chore(cdk): bump default aws-cdk-lib to 2.259.0

### DIFF
--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -49,8 +49,8 @@
   },
   "defaults": {
     "dependencies": {
-      "@aws-cdk/aws-amplify-alpha": "^2.246.0-alpha.0",
-      "aws-cdk-lib": "2.246.0"
+      "@aws-cdk/aws-amplify-alpha": "^2.259.0-alpha.0",
+      "aws-cdk-lib": "2.259.0"
     },
     "devDependencies": {
       "@codyswann/lisa": "^2.106.0"

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1579,9 +1579,9 @@ describe("PackageLisaStrategy", () => {
       }
       // Exact pins (not just "is defined") so an accidental version bump in
       // the template is caught by this regression test.
-      expect(template.defaults.dependencies["aws-cdk-lib"]).toBe("2.246.0");
+      expect(template.defaults.dependencies["aws-cdk-lib"]).toBe("2.259.0");
       expect(template.defaults.dependencies["@aws-cdk/aws-amplify-alpha"]).toBe(
-        "^2.246.0-alpha.0"
+        "^2.259.0-alpha.0"
       );
     });
 


### PR DESCRIPTION
## Summary
- Raise the CDK template's default `aws-cdk-lib` pin from 2.246.0 to 2.259.0 and `@aws-cdk/aws-amplify-alpha` to `^2.259.0-alpha.0`, so new scaffolds start on the version downstream projects (qualis/infrastructure) already run.
- Update the exact-pin regression test in `tests/unit/strategies/package-lisa.test.ts` to match.

The pin stays in `defaults` (not `force`), so existing projects keep their own aws-cdk-lib pace — this only affects new scaffolds and projects that don't declare the dep.

## Testing
- `npx vitest run tests/unit/strategies/package-lisa.test.ts` — 54 passed.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying platform components to newer supported versions, improving compatibility and access to the latest fixes.
  * Refreshed validation coverage to ensure generated configurations remain consistent with the updated platform versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->