### PR TITLE
feat(learnings): preserve create-only project memory

### DIFF
--- a/all/create-only/.claude/rules/PROJECT_LEARNINGS.md
+++ b/all/create-only/.claude/rules/PROJECT_LEARNINGS.md
@@ -1,0 +1,7 @@
+# Project Learnings
+
+<!-- lisa-learnings-contract:v1 -->
+
+```jsonl
+
+```

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -72,13 +72,27 @@ import {
   harnessIncludesAgent,
 } from "./config.js";
 import { migrateInstructionFiles } from "./instruction-files-migration.js";
+import {
+  assertSafeLearningParents,
+  resolveSafeLearningTarget,
+} from "./learnings-file-safety.js";
 import type { IGitService } from "./git-service.js";
+import {
+  readProjectConfig,
+  resolveProjectLearningsFile,
+} from "./project-config.js";
 
 /**
  * Log fragment used when a create-only instruction file already exists and is
  * therefore left untouched (the host owns it).
  */
 const HOST_OWNED_LABEL = "already present (host-owned)";
+const CREATE_ONLY_STRATEGY = "create-only" as const;
+const PROJECT_LEARNINGS_TEMPLATE_PATH = path.join(
+  ".claude",
+  "rules",
+  "PROJECT_LEARNINGS.md"
+);
 
 /**
  * Dependencies for Lisa operations
@@ -152,6 +166,10 @@ export class Lisa {
    * skips existing files, so without help the parent would win).
    */
   private copyOverwriteOwnership: Map<string, string> = new Map();
+  /** Destination selected by the host project's projectRulesFile setting. */
+  private projectLearningsFile = PROJECT_LEARNINGS_TEMPLATE_PATH;
+  /** Whether the canonical all/create-only learnings source is registered. */
+  private projectLearningsTemplateRegistered = false;
   private readonly separator = "========================================";
   private readonly lisaignoreSuffix = "(.lisaignore)";
 
@@ -278,10 +296,27 @@ export class Lisa {
     for (const type of ["all", ...this.detectedTypes]) {
       const paths = await this.readPendingDeletionsForType(type);
       for (const p of paths) {
-        pending.add(p);
+        pending.add(path.normalize(p));
       }
     }
     this.pendingDeletions = pending;
+  }
+
+  /**
+   * Resolve the host-owned learnings destination before template ownership is
+   * computed. The canonical source stays at its stable package path while its
+   * destination follows the configured project-rules directory.
+   */
+  private async loadProjectLearningsFile(): Promise<void> {
+    const relativeFile = resolveProjectLearningsFile(
+      await readProjectConfig(this.config.destDir)
+    );
+    const { root, target } = resolveSafeLearningTarget(
+      this.config.destDir,
+      relativeFile
+    );
+    await assertSafeLearningParents(root, path.dirname(target));
+    this.projectLearningsFile = path.normalize(relativeFile);
   }
 
   /**
@@ -310,16 +345,37 @@ export class Lisa {
   private async loadCreateOnlyOwnership(): Promise<void> {
     const ownership = new Map<string, string>();
     for (const type of ["all", ...this.detectedTypes]) {
-      const createOnlyDir = path.join(this.config.lisaDir, type, "create-only");
+      const createOnlyDir = path.join(
+        this.config.lisaDir,
+        type,
+        CREATE_ONLY_STRATEGY
+      );
       if (!(await fse.pathExists(createOnlyDir))) {
         continue;
       }
       const files = await listFilesRecursive(createOnlyDir);
       for (const file of files) {
-        const relativePath = path.relative(createOnlyDir, file);
+        const sourceRelativePath = path.relative(createOnlyDir, file);
+        const relativePath = this.resolveTemplateDestination(
+          sourceRelativePath,
+          CREATE_ONLY_STRATEGY,
+          type
+        );
         // Later types overwrite earlier ones, so child wins over parent.
         ownership.set(relativePath, type);
       }
+    }
+    const canonicalSource = path.join(
+      this.config.lisaDir,
+      "all",
+      CREATE_ONLY_STRATEGY,
+      PROJECT_LEARNINGS_TEMPLATE_PATH
+    );
+    this.projectLearningsTemplateRegistered =
+      await fse.pathExists(canonicalSource);
+    if (this.projectLearningsTemplateRegistered) {
+      // Durable project memory is a single contract, not a stack override.
+      ownership.set(this.projectLearningsFile, "all");
     }
     this.createOnlyOwnership = ownership;
   }
@@ -450,6 +506,15 @@ export class Lisa {
    */
   private async processSingleDeletion(relativePath: string): Promise<void> {
     const { logger } = this.deps;
+    const normalizedRelativePath = path.normalize(relativePath);
+    if (
+      this.projectLearningsTemplateRegistered &&
+      normalizedRelativePath === this.projectLearningsFile
+    ) {
+      logger.info(`Kept (host-owned project learnings): ${relativePath}`);
+      this.counters.skipped++;
+      return;
+    }
     const targetPath = path.join(this.config.destDir, relativePath);
 
     const resolvedTarget = path.resolve(targetPath);
@@ -711,6 +776,7 @@ export class Lisa {
       await this.initServices();
       await this.detectTypes();
       await this.detectSelfApply();
+      await this.loadProjectLearningsFile();
       await this.loadPendingDeletions();
       await this.loadCreateOnlyOwnership();
       await this.loadCopyOverwriteOwnership();
@@ -1290,13 +1356,21 @@ export class Lisa {
     currentType: string
   ): Promise<void> {
     const allFiles = await listFilesRecursive(srcDir);
-    const files = allFiles.filter(srcFile =>
-      this.shouldProcessFile(
-        path.relative(srcDir, srcFile),
-        strategy.name,
-        currentType
-      )
-    );
+    const files = allFiles
+      .map(srcFile => {
+        const sourceRelativePath = path.relative(srcDir, srcFile);
+        return {
+          srcFile,
+          relativePath: this.resolveTemplateDestination(
+            sourceRelativePath,
+            strategy.name,
+            currentType
+          ),
+        };
+      })
+      .filter(({ relativePath }) =>
+        this.shouldProcessFile(relativePath, strategy.name, currentType)
+      );
 
     const context: StrategyContext = {
       config: this.config,
@@ -1309,8 +1383,7 @@ export class Lisa {
       },
     };
 
-    for (const srcFile of files) {
-      const relativePath = path.relative(srcDir, srcFile);
+    for (const { srcFile, relativePath } of files) {
       const destFile = path.join(this.config.destDir, relativePath);
 
       const result = await strategy.apply(
@@ -1322,6 +1395,42 @@ export class Lisa {
       this.updateCounters(result);
       this.logResult(result);
     }
+  }
+
+  /**
+   * Map the stable canonical learnings source to the project's configured
+   * sibling path. No other template source is redirected.
+   * @param sourceRelativePath - Path relative to the strategy source directory
+   * @param strategyName - Strategy delivering the source file
+   * @param currentType - Project type that owns the source directory
+   * @returns Destination path relative to the host project
+   */
+  private resolveTemplateDestination(
+    sourceRelativePath: string,
+    strategyName: CopyStrategy,
+    currentType: string
+  ): string {
+    if (
+      currentType === "all" &&
+      strategyName === CREATE_ONLY_STRATEGY &&
+      sourceRelativePath === PROJECT_LEARNINGS_TEMPLATE_PATH
+    ) {
+      return this.projectLearningsFile;
+    }
+    return sourceRelativePath;
+  }
+
+  /**
+   * Identify the single machine-managed file that remains host-owned after
+   * creation, regardless of later stack templates or deletion manifests.
+   * @param relativePath - Candidate destination path
+   * @returns Whether the path is the registered project learnings destination
+   */
+  private isProjectLearningsPath(relativePath: string): boolean {
+    return (
+      this.projectLearningsTemplateRegistered &&
+      relativePath === this.projectLearningsFile
+    );
   }
 
   /**
@@ -1355,7 +1464,8 @@ export class Lisa {
       this.logSkip(`ignored`, relativePath, "Ignored");
       return false;
     }
-    if (this.pendingDeletions.has(relativePath)) {
+    const isProjectLearnings = this.isProjectLearningsPath(relativePath);
+    if (this.pendingDeletions.has(relativePath) && !isProjectLearnings) {
       this.counters.skipped++;
       this.logSkip(
         "pending deletion by detected type",
@@ -1364,7 +1474,16 @@ export class Lisa {
       );
       return false;
     }
-    if (strategyName === "create-only") {
+    if (isProjectLearnings && strategyName !== CREATE_ONLY_STRATEGY) {
+      this.counters.skipped++;
+      this.logSkip(
+        "owned by all/create-only",
+        relativePath,
+        "Skipped (host-owned project learnings)"
+      );
+      return false;
+    }
+    if (strategyName === CREATE_ONLY_STRATEGY) {
       const owner = this.createOnlyOwnership.get(relativePath);
       if (owner !== undefined && owner !== currentType) {
         this.counters.skipped++;

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -291,6 +291,14 @@ function validateProjectRulesFile(value: unknown, source: string): string {
       `Invalid projectRulesFile in ${source}: expected a Markdown file`
     );
   }
+  if (
+    path.posix.basename(value).toLowerCase() ===
+    PROJECT_LEARNINGS_FILENAME.toLowerCase()
+  ) {
+    throw new Error(
+      `Invalid projectRulesFile in ${source}: ${PROJECT_LEARNINGS_FILENAME} is reserved for machine-managed learnings`
+    );
+  }
   return value;
 }
 

--- a/src/strategies/create-only.ts
+++ b/src/strategies/create-only.ts
@@ -1,8 +1,16 @@
 import * as fse from "fs-extra";
+import { constants } from "node:fs";
 import { copyFile } from "node:fs/promises";
 import type { FileOperationResult } from "../core/config.js";
 import type { ICopyStrategy, StrategyContext } from "./strategy.interface.js";
 import { ensureParentDir } from "../utils/file-operations.js";
+
+/** Copy one source into a destination that must not already exist. */
+type ExclusiveCopyFile = (
+  sourcePath: string,
+  destPath: string,
+  mode: number
+) => Promise<void>;
 
 /**
  * Create-only strategy: Create file if not exists, never update
@@ -11,6 +19,15 @@ import { ensureParentDir } from "../utils/file-operations.js";
  */
 export class CreateOnlyStrategy implements ICopyStrategy {
   readonly name = "create-only" as const;
+
+  /**
+   * Create a strategy backed by an atomic exclusive-copy primitive.
+   *
+   * @param copyFileExclusive - Injectable exclusive copy primitive for tests
+   */
+  constructor(
+    private readonly copyFileExclusive: ExclusiveCopyFile = copyFile
+  ) {}
 
   /**
    * Apply create-only strategy: Create file if not exists, never update
@@ -27,16 +44,28 @@ export class CreateOnlyStrategy implements ICopyStrategy {
     context: StrategyContext
   ): Promise<FileOperationResult> {
     const { config } = context;
-    const destExists = await fse.pathExists(destPath);
-
-    if (!destExists) {
-      if (!config.dryRun) {
-        await ensureParentDir(destPath);
-        await copyFile(sourcePath, destPath);
-      }
-      return { relativePath, strategy: this.name, action: "created" };
+    if (config.dryRun) {
+      const destExists = await fse.pathExists(destPath);
+      return {
+        relativePath,
+        strategy: this.name,
+        action: destExists ? "skipped" : "created",
+      };
     }
 
-    return { relativePath, strategy: this.name, action: "skipped" };
+    await ensureParentDir(destPath);
+    try {
+      await this.copyFileExclusive(
+        sourcePath,
+        destPath,
+        constants.COPYFILE_EXCL
+      );
+      return { relativePath, strategy: this.name, action: "created" };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return { relativePath, strategy: this.name, action: "skipped" };
+      }
+      throw error;
+    }
   }
 }

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra";
 import * as path from "node:path";
 import * as os from "node:os";
+import { renderLearningsFile } from "../../src/core/learnings-writer.js";
 
 const PACKAGE_JSON = "package.json";
 const TSCONFIG_JSON = "tsconfig.json";
@@ -190,26 +191,7 @@ async function createMockHarperFabricTemplates(dir: string): Promise<void> {
  * @param dir - Directory to create Lisa structure in
  */
 export async function createMockLisaDir(dir: string): Promise<void> {
-  // Create all/ directory with test files
-  const allCopyOverwrite = path.join(dir, "all", COPY_OVERWRITE);
-  const allCopyContents = path.join(dir, "all", COPY_CONTENTS);
-  const allCreateOnly = path.join(dir, "all", CREATE_ONLY);
-  const allMerge = path.join(dir, "all", "merge");
-
-  await fs.ensureDir(allCopyOverwrite);
-  await fs.ensureDir(allCopyContents);
-  await fs.ensureDir(allCreateOnly);
-  await fs.ensureDir(allMerge);
-
-  await fs.writeFile(path.join(allCopyOverwrite, "test.txt"), "test content\n");
-  await fs.writeFile(
-    path.join(allCopyContents, ".gitignore"),
-    "node_modules\n.env\n"
-  );
-  await fs.writeFile(path.join(allCreateOnly, "README.md"), "# Test\n");
-  await fs.writeJson(path.join(allMerge, PACKAGE_JSON), {
-    scripts: { test: "echo test" },
-  });
+  await createMockAllTemplates(dir);
 
   // Create all/deletions.json to mirror the real Lisa deletion of legacy manifest
   await fs.writeJson(path.join(dir, "all", DELETIONS_JSON), {
@@ -278,6 +260,34 @@ export async function createMockLisaDir(dir: string): Promise<void> {
   // Create rails/deletions.json
   await fs.writeJson(path.join(dir, "rails", DELETIONS_JSON), {
     paths: [".overcommit.yml"],
+  });
+}
+
+/**
+ * Create the mock all/ strategy tree, including the canonical learnings seed.
+ * @param dir - Absolute mock Lisa package root
+ */
+async function createMockAllTemplates(dir: string): Promise<void> {
+  const allCopyOverwrite = path.join(dir, "all", COPY_OVERWRITE);
+  const allCopyContents = path.join(dir, "all", COPY_CONTENTS);
+  const allCreateOnly = path.join(dir, "all", CREATE_ONLY);
+  const allMerge = path.join(dir, "all", "merge");
+  await fs.ensureDir(allCopyOverwrite);
+  await fs.ensureDir(allCopyContents);
+  await fs.ensureDir(allCreateOnly);
+  await fs.ensureDir(allMerge);
+  await fs.writeFile(path.join(allCopyOverwrite, "test.txt"), "test content\n");
+  await fs.writeFile(
+    path.join(allCopyContents, ".gitignore"),
+    "node_modules\n.env\n"
+  );
+  await fs.writeFile(path.join(allCreateOnly, "README.md"), "# Test\n");
+  await fs.outputFile(
+    path.join(allCreateOnly, ".claude", "rules", "PROJECT_LEARNINGS.md"),
+    renderLearningsFile([])
+  );
+  await fs.writeJson(path.join(allMerge, PACKAGE_JSON), {
+    scripts: { test: "echo test" },
   });
 }
 

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -10,6 +10,10 @@ import { SilentLogger } from "../../src/logging/silent-logger.js";
 import { MigrationRegistry } from "../../src/migrations/index.js";
 import { StrategyRegistry } from "../../src/strategies/index.js";
 import {
+  parseLearningsFile,
+  renderLearningsFile,
+} from "../../src/core/learnings-writer.js";
+import {
   BackupService,
   DryRunBackupService,
 } from "../../src/transaction/index.js";
@@ -42,6 +46,7 @@ const HARPER_FABRIC_TXT = "harper-fabric.txt";
 const JEST_CONFIG_LOCAL = "jest.config.local.ts";
 const PACKAGE_LISA_DIR = "package-lisa";
 const LISA_MANIFEST = ".lisa-manifest";
+const PROJECT_LEARNINGS = "PROJECT_LEARNINGS.md";
 const TSC_BUILD_SCRIPT = "tsc -p tsconfig.build.json";
 const WORKFLOWS_DIR = path.join(".github", "workflows");
 const CLAUDE_PACKAGE_MANAGER_WORKFLOWS = [
@@ -118,6 +123,129 @@ describe("Lisa Integration Tests", () => {
   }
 
   describe("apply", () => {
+    it("creates, preserves, and repeatedly leaves the default project learnings file byte-identical", async () => {
+      await createTypeScriptProject(destDir);
+      const learningsPath = path.join(
+        destDir,
+        ".claude",
+        "rules",
+        PROJECT_LEARNINGS
+      );
+
+      const first = await createLisa().apply();
+
+      expect(first.success).toBe(true);
+      const emptySeed = await fs.readFile(learningsPath, "utf8");
+      expect(emptySeed).toBe(renderLearningsFile([]));
+      expect(parseLearningsFile(emptySeed)).toEqual([]);
+
+      const populated = renderLearningsFile([
+        {
+          id: "learning-1576-sentinel",
+          rule: "Preserve the host-owned project learnings file.",
+          why: "Lisa apply must not erase durable project memory.",
+          provenance: ["https://github.com/CodySwannGT/lisa/issues/1576"],
+          first_learned: "2026-07-16T12:00:00.000Z",
+          last_confirmed: "2026-07-16T12:00:00.000Z",
+          confidence: "high",
+        },
+      ]);
+      await fs.writeFile(learningsPath, populated);
+
+      const second = await createLisa().apply();
+      const third = await createLisa().apply();
+
+      expect(second.success).toBe(true);
+      expect(third.success).toBe(true);
+      expect(await fs.readFile(learningsPath, "utf8")).toBe(populated);
+    });
+
+    it("uses only the configured project-rules sibling for project learnings", async () => {
+      await createTypeScriptProject(destDir);
+      await fs.writeJson(path.join(destDir, ".lisa.config.json"), {
+        harness: "claude",
+        projectRulesFile: "rules/CUSTOM_RULES.md",
+      });
+      const configuredPath = path.join(destDir, "rules", PROJECT_LEARNINGS);
+      const defaultPath = path.join(
+        destDir,
+        ".claude",
+        "rules",
+        PROJECT_LEARNINGS
+      );
+
+      const first = await createLisa().apply();
+
+      expect(first.success).toBe(true);
+      expect(await fs.readFile(configuredPath, "utf8")).toBe(
+        renderLearningsFile([])
+      );
+      expect(await fs.pathExists(defaultPath)).toBe(false);
+
+      const sentinel = `${renderLearningsFile([])}<!-- custom sentinel -->\n`;
+      await fs.writeFile(configuredPath, sentinel);
+      await createLisa().apply();
+      expect(await fs.readFile(configuredPath, "utf8")).toBe(sentinel);
+      expect(await fs.pathExists(defaultPath)).toBe(false);
+    });
+
+    it("rejects a configured learnings seed whose parent symlink escapes the host project", async () => {
+      await createTypeScriptProject(destDir);
+      const externalDir = path.join(tempDir, "external-rules");
+      await fs.ensureDir(externalDir);
+      await fs.symlink(externalDir, path.join(destDir, "rules"), "dir");
+      await fs.writeJson(path.join(destDir, ".lisa.config.json"), {
+        harness: "claude",
+        projectRulesFile: "rules/CUSTOM_RULES.md",
+      });
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual([
+        expect.stringMatching(/parent escapes project root/i),
+      ]);
+      expect(
+        await fs.pathExists(path.join(externalDir, PROJECT_LEARNINGS))
+      ).toBe(false);
+    });
+
+    it("negative control: copy-overwrite registration clobbers populated learnings", async () => {
+      await createTypeScriptProject(destDir);
+      const createOnlySource = path.join(
+        lisaDir,
+        "all",
+        CREATE_ONLY,
+        ".claude",
+        "rules",
+        PROJECT_LEARNINGS
+      );
+      const overwriteSource = path.join(
+        lisaDir,
+        "all",
+        COPY_OVERWRITE,
+        ".claude",
+        "rules",
+        PROJECT_LEARNINGS
+      );
+      await fs.outputFile(overwriteSource, renderLearningsFile([]));
+      await fs.remove(createOnlySource);
+      const destination = path.join(
+        destDir,
+        ".claude",
+        "rules",
+        PROJECT_LEARNINGS
+      );
+      await fs.outputFile(destination, "persisted sentinel\n");
+
+      const result = await createLisa().apply();
+
+      expect(result.success).toBe(true);
+      expect(await fs.readFile(destination, "utf8")).toBe(
+        renderLearningsFile([])
+      );
+    });
+
     it("applies configurations to TypeScript project", async () => {
       await createTypeScriptProject(destDir);
 

--- a/tests/unit/core/learnings-contract.test.ts
+++ b/tests/unit/core/learnings-contract.test.ts
@@ -108,6 +108,8 @@ describe("learnings contract", () => {
       "C:rules/PROJECT_RULES.md",
       "rules/\tPROJECT_RULES.md",
       "rules/\nPROJECT_RULES.md",
+      "rules/PROJECT_LEARNINGS.md",
+      "rules/project_learnings.md",
       path.resolve(tempDir, "ABSOLUTE_RULES.md"),
     ]) {
       expect(() => resolveProjectRulesFile({ projectRulesFile })).toThrow(

--- a/tests/unit/strategies/create-only.test.ts
+++ b/tests/unit/strategies/create-only.test.ts
@@ -103,6 +103,31 @@ describe("CreateOnlyStrategy", () => {
     expect(await fs.readFile(destFile, "utf-8")).toBe("# Custom Content\n");
   });
 
+  it("preserves a concurrent writer when exclusive creation reports EEXIST", async () => {
+    const srcFile = path.join(srcDir, "README.md");
+    const destFile = path.join(destDir, "README.md");
+    await fs.writeFile(srcFile, "# Default\n");
+    const racingStrategy = new CreateOnlyStrategy(
+      async (_sourcePath, destinationPath, mode) => {
+        expect(mode).not.toBe(0);
+        await fs.writeFile(destinationPath, "# Concurrent Writer\n");
+        throw Object.assign(new Error("destination won the race"), {
+          code: "EEXIST",
+        });
+      }
+    );
+
+    const result = await racingStrategy.apply(
+      srcFile,
+      destFile,
+      "README.md",
+      createContext()
+    );
+
+    expect(result.action).toBe("skipped");
+    expect(await fs.readFile(destFile, "utf-8")).toBe("# Concurrent Writer\n");
+  });
+
   it("creates parent directories when needed", async () => {
     const srcFile = path.join(srcDir, "docs", "README.md");
     const destFile = path.join(destDir, "docs", "README.md");

--- a/tests/unit/templates/project-learnings-template.test.ts
+++ b/tests/unit/templates/project-learnings-template.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import {
+  parseLearningsFile,
+  renderLearningsFile,
+} from "../../../src/core/learnings-writer.js";
+
+const TEMPLATE_PATH = path.join(
+  process.cwd(),
+  "all",
+  "create-only",
+  ".claude",
+  "rules",
+  "PROJECT_LEARNINGS.md"
+);
+
+describe("project learnings create-only template", () => {
+  it("is the canonical executable empty learnings document", async () => {
+    const template = await readFile(TEMPLATE_PATH, "utf8");
+
+    expect(template).toBe(renderLearningsFile([]));
+    expect(parseLearningsFile(template)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- register the canonical empty project-learnings seed under the create-only template tree
- route that seed to the configured `projectRulesFile` sibling without creating a default-path duplicate
- protect durable learnings from overwrite/deletion races, symlink escapes, and rules/learnings path collisions

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` (4,220 pass)
- `bun run build:dist`
- `bun run check:rules-pairing`
- `bun run check:plugins`
- pre-push coverage suite (4,142 unit; 126 integration)
- real CLI journey: default and configured-path checksums remained byte-identical; missing seed recreated canonically; configured path created exclusively

Closes #1576