### PR TITLE
feat(learnings): fan out project learnings rules

### DIFF
--- a/plugins/lisa-copilot/rules/eager/project-learnings.md
+++ b/plugins/lisa-copilot/rules/eager/project-learnings.md
@@ -1,0 +1,15 @@
+# Project Learnings (load-bearing)
+
+Before normal task work, resolve this repository's committed `.lisa.config.json`
+and derive the canonical learnings file as the sibling of `projectRulesFile`
+(default: `.claude/rules/PROJECT_LEARNINGS.md`). If that file exists, consume it
+through the executable Lisa learnings contract exported by
+`@codyswann/lisa/learnings` before relying on ad-hoc memory or prior-session
+notes.
+
+Missing learnings are a silent no-op. Malformed, non-canonical, unsafe, or
+over-budget learnings produce one readable warning, apply no entry, and must not
+block unrelated task work. Never append automated learnings to
+`PROJECT_RULES.md`; project learnings are a separate machine-managed document.
+
+Full prose: [reference/project-learnings.md](../reference/project-learnings.md).

--- a/plugins/lisa-copilot/rules/reference/project-learnings.md
+++ b/plugins/lisa-copilot/rules/reference/project-learnings.md
@@ -1,0 +1,37 @@
+# Project Learnings
+
+Project learnings are Lisa's bounded, repo-local memory surface. They are stored
+in `PROJECT_LEARNINGS.md`, derived as the sibling of the configured
+`.lisa.config.json` `projectRulesFile` value. With no config override, the path
+is `.claude/rules/PROJECT_LEARNINGS.md`.
+
+Consume learnings before normal task work whenever the file exists. Use the
+executable contract from `@codyswann/lisa/learnings` to parse, validate, and
+budget-check the document. Do not duplicate numeric caps in rules or prompts;
+the exported contract is the source of truth.
+
+Each persisted entry has seven fields:
+
+- `id`
+- `rule`
+- `why`
+- `provenance`
+- `first_learned`
+- `last_confirmed`
+- `confidence`
+
+Only entries accepted by the executable contract may influence the session. A
+missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
+paths, non-canonical content, or over-budget documents produce one readable
+warning, apply no entry, and do not block unrelated work.
+
+Precedence:
+
+1. System, developer, user, and repo instructions still outrank learnings.
+2. Committed project rules remain durable human-authored guidance.
+3. Project learnings add recent operational knowledge, but never rewrite or
+   append to `PROJECT_RULES.md`.
+
+Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
+a bounded `AGENTS.md` bridge that points agy at this same file without copying
+learning bodies or restoring the retired full rules bake.

--- a/plugins/lisa-cursor/rules/project-learnings-reference.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings-reference.mdc
@@ -1,0 +1,42 @@
+---
+description: "Project Learnings"
+alwaysApply: false
+---
+
+# Project Learnings
+
+Project learnings are Lisa's bounded, repo-local memory surface. They are stored
+in `PROJECT_LEARNINGS.md`, derived as the sibling of the configured
+`.lisa.config.json` `projectRulesFile` value. With no config override, the path
+is `.claude/rules/PROJECT_LEARNINGS.md`.
+
+Consume learnings before normal task work whenever the file exists. Use the
+executable contract from `@codyswann/lisa/learnings` to parse, validate, and
+budget-check the document. Do not duplicate numeric caps in rules or prompts;
+the exported contract is the source of truth.
+
+Each persisted entry has seven fields:
+
+- `id`
+- `rule`
+- `why`
+- `provenance`
+- `first_learned`
+- `last_confirmed`
+- `confidence`
+
+Only entries accepted by the executable contract may influence the session. A
+missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
+paths, non-canonical content, or over-budget documents produce one readable
+warning, apply no entry, and do not block unrelated work.
+
+Precedence:
+
+1. System, developer, user, and repo instructions still outrank learnings.
+2. Committed project rules remain durable human-authored guidance.
+3. Project learnings add recent operational knowledge, but never rewrite or
+   append to `PROJECT_RULES.md`.
+
+Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
+a bounded `AGENTS.md` bridge that points agy at this same file without copying
+learning bodies or restoring the retired full rules bake.

--- a/plugins/lisa-cursor/rules/project-learnings.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings.mdc
@@ -1,0 +1,20 @@
+---
+description: "Project Learnings (load-bearing)"
+alwaysApply: true
+---
+
+# Project Learnings (load-bearing)
+
+Before normal task work, resolve this repository's committed `.lisa.config.json`
+and derive the canonical learnings file as the sibling of `projectRulesFile`
+(default: `.claude/rules/PROJECT_LEARNINGS.md`). If that file exists, consume it
+through the executable Lisa learnings contract exported by
+`@codyswann/lisa/learnings` before relying on ad-hoc memory or prior-session
+notes.
+
+Missing learnings are a silent no-op. Malformed, non-canonical, unsafe, or
+over-budget learnings produce one readable warning, apply no entry, and must not
+block unrelated task work. Never append automated learnings to
+`PROJECT_RULES.md`; project learnings are a separate machine-managed document.
+
+Full prose: [reference/project-learnings.md](project-learnings-reference.mdc).

--- a/plugins/lisa/rules/eager/project-learnings.md
+++ b/plugins/lisa/rules/eager/project-learnings.md
@@ -1,0 +1,15 @@
+# Project Learnings (load-bearing)
+
+Before normal task work, resolve this repository's committed `.lisa.config.json`
+and derive the canonical learnings file as the sibling of `projectRulesFile`
+(default: `.claude/rules/PROJECT_LEARNINGS.md`). If that file exists, consume it
+through the executable Lisa learnings contract exported by
+`@codyswann/lisa/learnings` before relying on ad-hoc memory or prior-session
+notes.
+
+Missing learnings are a silent no-op. Malformed, non-canonical, unsafe, or
+over-budget learnings produce one readable warning, apply no entry, and must not
+block unrelated task work. Never append automated learnings to
+`PROJECT_RULES.md`; project learnings are a separate machine-managed document.
+
+Full prose: [reference/project-learnings.md](../reference/project-learnings.md).

--- a/plugins/lisa/rules/reference/project-learnings.md
+++ b/plugins/lisa/rules/reference/project-learnings.md
@@ -1,0 +1,37 @@
+# Project Learnings
+
+Project learnings are Lisa's bounded, repo-local memory surface. They are stored
+in `PROJECT_LEARNINGS.md`, derived as the sibling of the configured
+`.lisa.config.json` `projectRulesFile` value. With no config override, the path
+is `.claude/rules/PROJECT_LEARNINGS.md`.
+
+Consume learnings before normal task work whenever the file exists. Use the
+executable contract from `@codyswann/lisa/learnings` to parse, validate, and
+budget-check the document. Do not duplicate numeric caps in rules or prompts;
+the exported contract is the source of truth.
+
+Each persisted entry has seven fields:
+
+- `id`
+- `rule`
+- `why`
+- `provenance`
+- `first_learned`
+- `last_confirmed`
+- `confidence`
+
+Only entries accepted by the executable contract may influence the session. A
+missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
+paths, non-canonical content, or over-budget documents produce one readable
+warning, apply no entry, and do not block unrelated work.
+
+Precedence:
+
+1. System, developer, user, and repo instructions still outrank learnings.
+2. Committed project rules remain durable human-authored guidance.
+3. Project learnings add recent operational knowledge, but never rewrite or
+   append to `PROJECT_RULES.md`.
+
+Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
+a bounded `AGENTS.md` bridge that points agy at this same file without copying
+learning bodies or restoring the retired full rules bake.

--- a/plugins/src/base/rules/eager/project-learnings.md
+++ b/plugins/src/base/rules/eager/project-learnings.md
@@ -1,0 +1,15 @@
+# Project Learnings (load-bearing)
+
+Before normal task work, resolve this repository's committed `.lisa.config.json`
+and derive the canonical learnings file as the sibling of `projectRulesFile`
+(default: `.claude/rules/PROJECT_LEARNINGS.md`). If that file exists, consume it
+through the executable Lisa learnings contract exported by
+`@codyswann/lisa/learnings` before relying on ad-hoc memory or prior-session
+notes.
+
+Missing learnings are a silent no-op. Malformed, non-canonical, unsafe, or
+over-budget learnings produce one readable warning, apply no entry, and must not
+block unrelated task work. Never append automated learnings to
+`PROJECT_RULES.md`; project learnings are a separate machine-managed document.
+
+Full prose: [reference/project-learnings.md](../reference/project-learnings.md).

--- a/plugins/src/base/rules/reference/project-learnings.md
+++ b/plugins/src/base/rules/reference/project-learnings.md
@@ -1,0 +1,37 @@
+# Project Learnings
+
+Project learnings are Lisa's bounded, repo-local memory surface. They are stored
+in `PROJECT_LEARNINGS.md`, derived as the sibling of the configured
+`.lisa.config.json` `projectRulesFile` value. With no config override, the path
+is `.claude/rules/PROJECT_LEARNINGS.md`.
+
+Consume learnings before normal task work whenever the file exists. Use the
+executable contract from `@codyswann/lisa/learnings` to parse, validate, and
+budget-check the document. Do not duplicate numeric caps in rules or prompts;
+the exported contract is the source of truth.
+
+Each persisted entry has seven fields:
+
+- `id`
+- `rule`
+- `why`
+- `provenance`
+- `first_learned`
+- `last_confirmed`
+- `confidence`
+
+Only entries accepted by the executable contract may influence the session. A
+missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
+paths, non-canonical content, or over-budget documents produce one readable
+warning, apply no entry, and do not block unrelated work.
+
+Precedence:
+
+1. System, developer, user, and repo instructions still outrank learnings.
+2. Committed project rules remain durable human-authored guidance.
+3. Project learnings add recent operational knowledge, but never rewrite or
+   append to `PROJECT_RULES.md`.
+
+Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
+a bounded `AGENTS.md` bridge that points agy at this same file without copying
+learning bodies or restoring the retired full rules bake.

--- a/scripts/generate-agy-plugin-artifacts.mjs
+++ b/scripts/generate-agy-plugin-artifacts.mjs
@@ -25,7 +25,8 @@
  * MCP (user-global, NOT plugin-bundled): agy ignores plugin-bundled MCP and only
  * reads the user-global `~/.gemini/config/mcp_config.json`, so MCP is delivered
  * by the runtime installer (`src/agy/mcp-installer.ts`), and this generator
- * drops `.mcp.json`. Rules use the AGENTS.md bake (rules-once invariant).
+ * drops `.mcp.json`. Rules remain out of agy artifacts; the runtime reconciles
+ * only a bounded AGENTS.md project-learnings bridge.
  *
  * Net: the agy variant ships a root `hooks.json` (base only) + its agy-protocol
  * script under `hooks/`, but NO `mcp_config.json`, NO `.mcp.json`, NO `rules/`,
@@ -132,7 +133,7 @@ export function generateAgyVariant(srcDir, outDir, version) {
     // hooks.json (root) + the agy-protocol script are re-emitted by
     // emitAgyPluginHooks below.
     if (relPath.startsWith("hooks/") || relPath === "hooks") return false;
-    if (relPath.startsWith("rules/") || relPath === "rules") return false; // rules delivered via AGENTS.md bake
+    if (relPath.startsWith("rules/") || relPath === "rules") return false; // no full rules tree in agy artifacts
     // Drop the untranslated Claude .mcp.json — agy ignores it (and the agy
     // MCP shape differs); MCP is delivered by the user-global runtime MCP installer.
     if (relPath === ".mcp.json") return false;
@@ -206,7 +207,7 @@ export function generateAgyVariant(srcDir, outDir, version) {
  * agy-protocol script copied into the variant's hooks/ and referenced by the
  * command. NOTE: install-pkgs / setup-jira-cli are SessionStart-only, which agy
  * hooks don't support, so they are intentionally absent. inject-rules is absent
- * too (rules-once via the AGENTS.md bake).
+ * too (rules stay out of agy artifacts).
  */
 const AGY_PLUGIN_HOOKS = [
   {

--- a/scripts/lib/per-agent-hook-filter.mjs
+++ b/scripts/lib/per-agent-hook-filter.mjs
@@ -25,7 +25,7 @@
  *     agy doesn't support SessionStart, so install-pkgs / setup-jira-cli can't
  *     ship as agy hooks. The agy column below is retained only as conceptual
  *     ship-list documentation (block-no-verify.sh, install-pkgs.sh,
- *     setup-jira-cli.sh; strips inject-rules.sh — rules-once via AGENTS.md bake
+ *     setup-jira-cli.sh; strips inject-rules.sh — no full rules tree on agy
  *     — enforce-team-first.sh, inject-flow-context.sh, and `entire ...` calls).
  *   - Copilot: strip SubagentStart hooks (event missing), strip Claude-team-specific
  *     scripts, conditionally strip inject-rules.sh if the rules-auto-load probe is
@@ -54,7 +54,7 @@ const SCRIPT_RULES = {
     claude: true,
     codex: true,
     cursor: false, // rules ship as native rules/*.mdc (single delivery path); injecting would double-deliver
-    agy: false, // rules delivered via AGENTS.md bake, not a hook (rules-once invariant)
+    agy: false, // no full rules tree on agy; AGENTS.md carries only bounded bridges
     copilot: true, // conservative default; conditionally stripped if rules-auto-load probe positive
   },
   "inject-flow-context.sh": {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -70,7 +70,7 @@ export const COPY_STRATEGIES: readonly CopyStrategy[] = [
  * - "claude":  emit Claude Code artifacts (.claude/, .claude-plugin/, CLAUDE.md)
  * - "codex":   emit OpenAI Codex CLI artifacts (.codex/, .codex-plugin/, .agents/, AGENTS.md)
  * - "cursor":  emit Cursor artifacts (Cursor reads .claude-plugin/ natively; no per-project files)
- * - "agy":     emit Antigravity artifacts (~/.gemini/config/mcp_config.json + AGENTS.md with baked rules)
+ * - "agy":     emit Antigravity artifacts (~/.gemini/config/mcp_config.json + AGENTS.md learnings bridge)
  * - "copilot": emit GitHub Copilot artifacts (.github/copilot-instructions.md + plugin install)
  * - "opencode": emit OpenCode artifacts (.opencode/skills/lisa/ + AGENTS.md, read natively)
  * - "fleet":   emit for every supported agent (Claude + Codex + Cursor + agy + Copilot + OpenCode)

--- a/src/core/instruction-files-migration.ts
+++ b/src/core/instruction-files-migration.ts
@@ -33,6 +33,11 @@ import {
   CLAUDE_MD_FILENAME,
   installClaudeMd,
 } from "../claude/claude-md-installer.js";
+import { harnessIncludesAgent } from "./config.js";
+import {
+  readProjectConfig,
+  resolveProjectLearningsFile,
+} from "./project-config.js";
 
 /**
  * Marker that opened the legacy agy "baked rules" block in `AGENTS.md`. Retained
@@ -42,6 +47,12 @@ import {
 export const LISA_RULES_START_MARKER = "<!-- LISA_RULES_START -->";
 /** Marker that closed the legacy agy "baked rules" block in `AGENTS.md`. */
 export const LISA_RULES_END_MARKER = "<!-- LISA_RULES_END -->";
+/** Marker opening Lisa's bounded Antigravity project-learnings bridge. */
+export const LISA_PROJECT_LEARNINGS_START_MARKER =
+  "<!-- LISA_PROJECT_LEARNINGS_START -->";
+/** Marker closing Lisa's bounded Antigravity project-learnings bridge. */
+export const LISA_PROJECT_LEARNINGS_END_MARKER =
+  "<!-- LISA_PROJECT_LEARNINGS_END -->";
 
 /** Outcome of an instruction-files migration pass. */
 export interface InstructionFilesMigrationResult {
@@ -62,6 +73,17 @@ export interface MigrateInstructionFilesOptions {
    * way.
    */
   readonly createClaudePointer?: boolean;
+  /**
+   * Whether to reconcile the agy project-learnings bridge in `AGENTS.md`.
+   * Defaults from `.lisa.config.json`: enabled only when the effective harness
+   * includes agy.
+   */
+  readonly reconcileAgyProjectLearnings?: boolean;
+  /**
+   * Resolved project-relative learnings path. Defaults to the sibling of the
+   * configured `projectRulesFile`.
+   */
+  readonly projectLearningsFile?: string;
 }
 
 /**
@@ -84,24 +106,141 @@ export function stripBakedAgyRulesBlock(body: string): string {
 }
 
 /**
+ * Remove a managed project-learnings bridge from AGENTS.md. Malformed marker
+ * pairs are left unchanged so Lisa never guesses which host bytes to delete.
+ * @param body - Existing `AGENTS.md` contents.
+ * @returns The body with the managed bridge removed, when a full block exists.
+ */
+export function stripAgyProjectLearningsBridge(body: string): string {
+  return replaceManagedAgyProjectLearningsBridge(body, "");
+}
+
+/**
+ * Build the exact bounded Antigravity project-learnings bridge block.
+ * @param projectLearningsFile - Project-relative resolved learnings path.
+ * @returns Managed bridge block with surrounding markers.
+ */
+export function buildAgyProjectLearningsBridge(
+  projectLearningsFile: string
+): string {
+  return [
+    LISA_PROJECT_LEARNINGS_START_MARKER,
+    "Antigravity startup bridge: before normal task work, resolve the canonical",
+    "project-learnings file from `.lisa.config.json` (`projectRulesFile`'s sibling",
+    "`PROJECT_LEARNINGS.md`; default `.claude/rules/PROJECT_LEARNINGS.md`). If it",
+    "exists and satisfies the Lisa learnings contract, read and apply its entries.",
+    "If it is absent, continue silently. If it is malformed, warn once and ignore it.",
+    "",
+    `Resolved path for this project: \`${projectLearningsFile}\`.`,
+    LISA_PROJECT_LEARNINGS_END_MARKER,
+  ].join("\n");
+}
+
+/**
+ * Add, replace, or remove the managed project-learnings bridge. If exactly one
+ * marker is present, return the original body unchanged to preserve host bytes.
+ * @param body - Existing AGENTS.md body.
+ * @param replacement - Full replacement block, or empty string to remove.
+ * @returns Updated body, or the original body for malformed markers.
+ */
+function replaceManagedAgyProjectLearningsBridge(
+  body: string,
+  replacement: string
+): string {
+  const startIdx = body.indexOf(LISA_PROJECT_LEARNINGS_START_MARKER);
+  const endIdx = body.indexOf(LISA_PROJECT_LEARNINGS_END_MARKER);
+  const hasStart = startIdx !== -1;
+  const hasEnd = endIdx !== -1;
+  if (hasStart !== hasEnd || (hasStart && endIdx < startIdx)) {
+    return body;
+  }
+  if (!hasStart) {
+    if (replacement === "") {
+      return body;
+    }
+    const separator = body.endsWith("\n") ? "\n" : "\n\n";
+    return `${body}${separator}${replacement}\n`;
+  }
+  const before = body.slice(0, startIdx);
+  const after = body.slice(endIdx + LISA_PROJECT_LEARNINGS_END_MARKER.length);
+  const next = `${before}${replacement}${after}`;
+  return `${next.replace(/\n\n\n+/g, "\n\n").trim()}\n`;
+}
+
+/**
  * Ensure a canonical `AGENTS.md` exists and carries no legacy agy baked-rules
  * block.
  * @param destDir - Absolute path to the host project root.
+ * @param agyProjectLearnings - Desired state for the Antigravity bridge.
+ * @param agyProjectLearnings.enabled - Whether the bridge should be present.
+ * @param agyProjectLearnings.projectLearningsFile - Resolved project-relative
+ *   learnings file path to include in the bridge.
  * @returns Action strings describing what changed (empty when nothing did).
  */
-async function reconcileAgentsMd(destDir: string): Promise<string[]> {
+async function reconcileAgentsMd(
+  destDir: string,
+  agyProjectLearnings: {
+    readonly enabled: boolean;
+    readonly projectLearningsFile: string;
+  }
+): Promise<string[]> {
   const filePath = path.join(destDir, AGENTS_MD_FILENAME);
   if (!existsSync(filePath)) {
     const result = await installAgentsMd(destDir);
-    return result.created ? [`created ${AGENTS_MD_FILENAME}`] : [];
+    const actions = result.created ? [`created ${AGENTS_MD_FILENAME}`] : [];
+    return [
+      ...actions,
+      ...(await reconcileAgyProjectLearningsBridge(
+        filePath,
+        agyProjectLearnings
+      )),
+    ];
   }
+  return reconcileAgyProjectLearningsBridge(filePath, agyProjectLearnings);
+}
+
+/**
+ * Reconcile the removable legacy bake and the bounded agy learnings bridge.
+ * @param filePath - Absolute AGENTS.md path.
+ * @param agyProjectLearnings - Desired bridge state.
+ * @param agyProjectLearnings.enabled - Whether the bridge should be present.
+ * @param agyProjectLearnings.projectLearningsFile - Resolved project-relative
+ *   learnings file path to include in the bridge.
+ * @returns Action strings describing changed state.
+ */
+async function reconcileAgyProjectLearningsBridge(
+  filePath: string,
+  agyProjectLearnings: {
+    readonly enabled: boolean;
+    readonly projectLearningsFile: string;
+  }
+): Promise<string[]> {
   const existing = await readFile(filePath, "utf8");
   const stripped = stripBakedAgyRulesBlock(existing);
-  if (stripped === existing) {
+  const desired = agyProjectLearnings.enabled
+    ? replaceManagedAgyProjectLearningsBridge(
+        stripped,
+        buildAgyProjectLearningsBridge(agyProjectLearnings.projectLearningsFile)
+      )
+    : stripAgyProjectLearningsBridge(stripped);
+  if (desired === existing) {
     return [];
   }
-  await writeFile(filePath, stripped, "utf8");
-  return [`removed legacy baked-rules block from ${AGENTS_MD_FILENAME}`];
+  await writeFile(filePath, desired, "utf8");
+  const bakedRuleActions =
+    stripped !== existing
+      ? [`removed legacy baked-rules block from ${AGENTS_MD_FILENAME}`]
+      : [];
+  const bridgeActions =
+    desired !== stripped
+      ? [
+          agyProjectLearnings.enabled
+            ? `reconciled agy project-learnings bridge in ${AGENTS_MD_FILENAME}`
+            : `removed agy project-learnings bridge from ${AGENTS_MD_FILENAME}`,
+        ]
+      : [];
+  const actions = [...bakedRuleActions, ...bridgeActions];
+  return actions;
 }
 
 /**
@@ -145,8 +284,17 @@ export async function migrateInstructionFiles(
   destDir: string,
   options: MigrateInstructionFilesOptions = {}
 ): Promise<InstructionFilesMigrationResult> {
+  const projectConfig = await readProjectConfig(destDir);
   const createClaudePointer = options.createClaudePointer ?? true;
-  const agentsActions = await reconcileAgentsMd(destDir);
+  const agyProjectLearnings = {
+    enabled:
+      options.reconcileAgyProjectLearnings ??
+      harnessIncludesAgent(projectConfig.harness ?? "claude", "agy"),
+    projectLearningsFile:
+      options.projectLearningsFile ??
+      resolveProjectLearningsFile(projectConfig),
+  };
+  const agentsActions = await reconcileAgentsMd(destDir, agyProjectLearnings);
   const claudeActions = await reconcileClaudeMd(destDir, createClaudePointer);
   const actions = [...agentsActions, ...claudeActions];
   return { changed: actions.length > 0, actions };

--- a/src/core/instruction-files-migration.ts
+++ b/src/core/instruction-files-migration.ts
@@ -137,8 +137,10 @@ export function buildAgyProjectLearningsBridge(
 }
 
 /**
- * Add, replace, or remove the managed project-learnings bridge. If exactly one
- * marker is present, return the original body unchanged to preserve host bytes.
+ * Add, replace, or remove the managed project-learnings bridge. Returns the
+ * original body unchanged whenever the markers are malformed: only one of the
+ * pair is present, the end precedes the start, or either marker occurs more
+ * than once.
  * @param body - Existing AGENTS.md body.
  * @param replacement - Full replacement block, or empty string to remove.
  * @returns Updated body, or the original body for malformed markers.
@@ -151,7 +153,24 @@ function replaceManagedAgyProjectLearningsBridge(
   const endIdx = body.indexOf(LISA_PROJECT_LEARNINGS_END_MARKER);
   const hasStart = startIdx !== -1;
   const hasEnd = endIdx !== -1;
-  if (hasStart !== hasEnd || (hasStart && endIdx < startIdx)) {
+  const hasDuplicateStart =
+    hasStart &&
+    body.indexOf(
+      LISA_PROJECT_LEARNINGS_START_MARKER,
+      startIdx + LISA_PROJECT_LEARNINGS_START_MARKER.length
+    ) !== -1;
+  const hasDuplicateEnd =
+    hasEnd &&
+    body.indexOf(
+      LISA_PROJECT_LEARNINGS_END_MARKER,
+      endIdx + LISA_PROJECT_LEARNINGS_END_MARKER.length
+    ) !== -1;
+  if (
+    hasStart !== hasEnd ||
+    (hasStart && endIdx < startIdx) ||
+    hasDuplicateStart ||
+    hasDuplicateEnd
+  ) {
     return body;
   }
   if (!hasStart) {

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -956,11 +956,12 @@ export class Lisa {
    *      tagged-merge preserving host entries). Cross-project caveat: the most
    *      recent `lisa apply` carrying MCP wins globally.
    *   4. Instruction file → the canonical create-only `AGENTS.md` (the same file
-   *      every other agent reads). Lisa no longer bakes eager rule bodies into
-   *      AGENTS.md: a giant generated file is not worth carrying just to polyfill
-   *      agy's headless (`-p`) mode, where SessionStart hooks don't fire. agy
-   *      gets the thin host-owned AGENTS.md like everyone else; in interactive
-   *      mode it still receives Lisa's plugin (skills/agents/MCP) above.
+   *      every other agent reads), plus a bounded project-learnings bridge
+   *      reconciled by `processInstructionFilesMigration`. Lisa does not bake
+   *      eager rule bodies into AGENTS.md: a giant generated file is not worth
+   *      carrying just to polyfill agy's headless (`-p`) mode, where SessionStart
+   *      hooks don't fire. In interactive mode it still receives Lisa's plugin
+   *      (skills/agents/MCP) above.
    */
   private async processAgyEmit(): Promise<void> {
     const { harness } = this.config;
@@ -1017,7 +1018,8 @@ export class Lisa {
     // agy variant (emitted at build time by generate-agy-plugin-artifacts.mjs,
     // installed via `agy plugin install` above) — NOT written here at apply time.
 
-    // Instruction file: the canonical, create-only AGENTS.md (no baked rules).
+    // Instruction file: the canonical, create-only AGENTS.md. The bounded
+    // project-learnings bridge is reconciled after all emit paths run.
     const agentsMdResult = await installAgentsMd(this.config.destDir);
 
     const attempted = pluginResults.some(r => r.attempted);

--- a/tests/unit/core/instruction-files-migration.test.ts
+++ b/tests/unit/core/instruction-files-migration.test.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CLAUDE_MD_AGENTS_IMPORT } from "../../../src/claude/claude-md-installer.js";
 import {
+  LISA_PROJECT_LEARNINGS_END_MARKER,
   LISA_PROJECT_LEARNINGS_START_MARKER,
   LISA_RULES_END_MARKER,
   LISA_RULES_START_MARKER,
@@ -240,6 +241,28 @@ describe("core/instruction-files-migration", () => {
 
     it("leaves malformed markers unchanged", () => {
       const body = `Before\n${LISA_PROJECT_LEARNINGS_START_MARKER}\nAfter\n`;
+      expect(stripAgyProjectLearningsBridge(body)).toBe(body);
+    });
+
+    it("leaves duplicate marker pairs unchanged rather than deleting only the first pair", () => {
+      const bridge = buildAgyProjectLearningsBridge(CUSTOM_LEARNINGS_PATH);
+      // Two full bridge blocks back to back is malformed for this managed-block
+      // contract: indexOf would only find the first pair, silently stranding the
+      // second block's markers and text as stale host content.
+      const body = `Before\n\n${bridge}\n\n${bridge}\n\nAfter\n`;
+      expect(stripAgyProjectLearningsBridge(body)).toBe(body);
+    });
+
+    it("leaves a duplicated start marker unchanged even with a single end marker", () => {
+      const body = [
+        "Before",
+        LISA_PROJECT_LEARNINGS_START_MARKER,
+        "first",
+        LISA_PROJECT_LEARNINGS_START_MARKER,
+        "second",
+        LISA_PROJECT_LEARNINGS_END_MARKER,
+        "After",
+      ].join("\n");
       expect(stripAgyProjectLearningsBridge(body)).toBe(body);
     });
   });

--- a/tests/unit/core/instruction-files-migration.test.ts
+++ b/tests/unit/core/instruction-files-migration.test.ts
@@ -8,12 +8,23 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CLAUDE_MD_AGENTS_IMPORT } from "../../../src/claude/claude-md-installer.js";
 import {
+  LISA_PROJECT_LEARNINGS_START_MARKER,
   LISA_RULES_END_MARKER,
   LISA_RULES_START_MARKER,
+  buildAgyProjectLearningsBridge,
   migrateInstructionFiles,
+  stripAgyProjectLearningsBridge,
   stripBakedAgyRulesBlock,
 } from "../../../src/core/instruction-files-migration.js";
 import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const CONFIG_PATH = ".lisa.config.json";
+const CUSTOM_RULES_PATH = "rules/CUSTOM_RULES.md";
+const DEFAULT_LEARNINGS_LINE =
+  "Resolved path for this project: `.claude/rules/PROJECT_LEARNINGS.md`.";
+const CUSTOM_LEARNINGS_LINE =
+  "Resolved path for this project: `rules/PROJECT_LEARNINGS.md`.";
+const CUSTOM_LEARNINGS_PATH = "rules/PROJECT_LEARNINGS.md";
 
 describe("core/instruction-files-migration", () => {
   let dir: string;
@@ -107,6 +118,90 @@ describe("core/instruction-files-migration", () => {
     expect(second.actions).toEqual([]);
   });
 
+  it("adds the bounded agy project-learnings bridge for agy harnesses", async () => {
+    await fs.writeJson(path.join(dir, CONFIG_PATH), {
+      harness: "agy",
+    });
+
+    const result = await migrateInstructionFiles(dir);
+
+    const agents = await fs.readFile(agentsPath(), "utf8");
+    expect(result.actions.some(a => a.includes("project-learnings"))).toBe(
+      true
+    );
+    expect(agents).toContain(LISA_PROJECT_LEARNINGS_START_MARKER);
+    expect(agents).toContain(DEFAULT_LEARNINGS_LINE);
+    expect(agents).not.toContain(LISA_RULES_START_MARKER);
+  });
+
+  it("replaces the agy bridge when projectRulesFile moves the learnings sibling", async () => {
+    await fs.writeJson(path.join(dir, CONFIG_PATH), {
+      harness: "agy",
+    });
+    await migrateInstructionFiles(dir);
+    await fs.writeJson(path.join(dir, CONFIG_PATH), {
+      harness: "agy",
+      projectRulesFile: CUSTOM_RULES_PATH,
+    });
+
+    const result = await migrateInstructionFiles(dir);
+
+    const agents = await fs.readFile(agentsPath(), "utf8");
+    expect(result.changed).toBe(true);
+    expect(agents.match(/LISA_PROJECT_LEARNINGS_START/g)).toHaveLength(1);
+    expect(agents).toContain(CUSTOM_LEARNINGS_LINE);
+    expect(agents).not.toContain(DEFAULT_LEARNINGS_LINE);
+  });
+
+  it("removes the agy bridge when the harness no longer includes agy", async () => {
+    await fs.writeFile(
+      agentsPath(),
+      `Host\n\n${buildAgyProjectLearningsBridge(CUSTOM_LEARNINGS_PATH)}\n\nAfter\n`,
+      "utf8"
+    );
+    await fs.writeJson(path.join(dir, CONFIG_PATH), {
+      harness: "codex",
+    });
+
+    const result = await migrateInstructionFiles(dir);
+
+    const agents = await fs.readFile(agentsPath(), "utf8");
+    expect(result.actions.some(a => a.includes("removed agy"))).toBe(true);
+    expect(agents).not.toContain(LISA_PROJECT_LEARNINGS_START_MARKER);
+    expect(agents).toContain("Host");
+    expect(agents).toContain("After");
+  });
+
+  it("removes legacy baked rules while preserving the bounded agy learnings bridge", async () => {
+    await fs.writeFile(
+      agentsPath(),
+      [
+        "Host before.",
+        "",
+        LISA_RULES_START_MARKER,
+        "Full eager rule body that must not survive.",
+        LISA_RULES_END_MARKER,
+        "",
+        buildAgyProjectLearningsBridge(CUSTOM_LEARNINGS_PATH),
+        "",
+        "Host after.",
+      ].join("\n"),
+      "utf8"
+    );
+    await fs.writeJson(path.join(dir, CONFIG_PATH), {
+      harness: "agy",
+      projectRulesFile: CUSTOM_RULES_PATH,
+    });
+
+    await migrateInstructionFiles(dir);
+
+    const agents = await fs.readFile(agentsPath(), "utf8");
+    expect(agents).not.toContain("Full eager rule body");
+    expect(agents).toContain(LISA_PROJECT_LEARNINGS_START_MARKER);
+    expect(agents).toContain("Host before.");
+    expect(agents).toContain("Host after.");
+  });
+
   it("does not re-add the import when CLAUDE.md already points at AGENTS.md", async () => {
     await fs.writeFile(claudePath(), "# Claude\n\n@AGENTS.md\n", "utf8");
 
@@ -131,6 +226,21 @@ describe("core/instruction-files-migration", () => {
       expect(stripped).toContain("Before");
       expect(stripped).toContain("After");
       expect(stripped).not.toMatch(/\n\n\n/);
+    });
+  });
+
+  describe("stripAgyProjectLearningsBridge", () => {
+    it("removes a well-formed managed bridge and preserves surrounding text", () => {
+      const body = `Before\n\n${buildAgyProjectLearningsBridge(CUSTOM_LEARNINGS_PATH)}\n\nAfter\n`;
+      const stripped = stripAgyProjectLearningsBridge(body);
+      expect(stripped).not.toContain(LISA_PROJECT_LEARNINGS_START_MARKER);
+      expect(stripped).toContain("Before");
+      expect(stripped).toContain("After");
+    });
+
+    it("leaves malformed markers unchanged", () => {
+      const body = `Before\n${LISA_PROJECT_LEARNINGS_START_MARKER}\nAfter\n`;
+      expect(stripAgyProjectLearningsBridge(body)).toBe(body);
     });
   });
 });

--- a/tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts
+++ b/tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts
@@ -36,7 +36,19 @@ const REPO_ROOT = path.resolve(
 );
 const CURSOR_BASE = path.join(REPO_ROOT, "plugins", "lisa-cursor");
 const CURSOR_EXPO = path.join(REPO_ROOT, "plugins", "lisa-expo-cursor");
+const SOURCE_RULES_BASE = path.join(
+  REPO_ROOT,
+  "plugins",
+  "src",
+  "base",
+  "rules"
+);
 const REFERENCE_SUFFIX = "-reference.mdc";
+
+const sourceRuleCount = (tier: "eager" | "reference"): number =>
+  fs
+    .readdirSync(path.join(SOURCE_RULES_BASE, tier))
+    .filter(f => f.endsWith(".md")).length;
 
 describe("committed Cursor artifacts (regression — issue #1055)", () => {
   describe("base lisa-cursor — rules", () => {
@@ -44,7 +56,7 @@ describe("committed Cursor artifacts (regression — issue #1055)", () => {
     const mdcFiles = (): readonly string[] =>
       fs.readdirSync(rulesDir).filter(f => f.endsWith(".mdc"));
 
-    it("ships 38 flat .mdc (19 eager + 19 reference), no nested dirs, no plain .md", () => {
+    it("ships one flat .mdc per source rule, no nested dirs, no plain .md", () => {
       expect(fs.existsSync(rulesDir)).toBe(true);
       expect(fs.existsSync(path.join(rulesDir, "eager"))).toBe(false);
       expect(fs.existsSync(path.join(rulesDir, "reference"))).toBe(false);
@@ -53,9 +65,15 @@ describe("committed Cursor artifacts (regression — issue #1055)", () => {
         expect(e.name.endsWith(".mdc")).toBe(true);
       }
       const mdc = mdcFiles();
-      expect(mdc.length).toBe(38);
-      expect(mdc.filter(f => f.endsWith(REFERENCE_SUFFIX)).length).toBe(19);
-      expect(mdc.filter(f => !f.endsWith(REFERENCE_SUFFIX)).length).toBe(19);
+      const eagerCount = sourceRuleCount("eager");
+      const referenceCount = sourceRuleCount("reference");
+      expect(mdc.length).toBe(eagerCount + referenceCount);
+      expect(mdc.filter(f => f.endsWith(REFERENCE_SUFFIX)).length).toBe(
+        referenceCount
+      );
+      expect(mdc.filter(f => !f.endsWith(REFERENCE_SUFFIX)).length).toBe(
+        eagerCount
+      );
     });
 
     it("eager rules carry alwaysApply:true; reference rules alwaysApply:false + description", () => {

--- a/tests/unit/scripts/per-agent-hook-filter.test.ts
+++ b/tests/unit/scripts/per-agent-hook-filter.test.ts
@@ -151,7 +151,7 @@ describe("per-agent-hook-filter", () => {
       ).toBe(false);
     });
 
-    it("strips inject-rules.sh hook on agy (rules delivered via AGENTS.md bake)", () => {
+    it("strips inject-rules.sh hook on agy (no full rules tree)", () => {
       const hook = {
         type: "command",
         command: INJECT_RULES_HOOK_CMD,

--- a/tests/unit/strategies/project-learnings-rule-pair.test.ts
+++ b/tests/unit/strategies/project-learnings-rule-pair.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const EAGER = "plugins/src/base/rules/eager/project-learnings.md";
+const REFERENCE = "plugins/src/base/rules/reference/project-learnings.md";
+
+describe("project-learnings eager/reference rule pair", () => {
+  it("ships the canonical eager and reference pair from plugin source", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("# Project Learnings (load-bearing)");
+    expect(eager).toContain("@codyswann/lisa/learnings");
+    expect(eager).toContain("PROJECT_LEARNINGS.md");
+    expect(eager).not.toMatch(/maxEntries|maxTokens|maxRuleCharacters/);
+
+    expect(reference).toContain("# Project Learnings");
+    expect(reference).toContain("@codyswann/lisa/learnings");
+    expect(reference).toContain("id");
+    expect(reference).toContain("confidence");
+    expect(reference).not.toMatch(/maxEntries|maxTokens|maxRuleCharacters/);
+  });
+});

--- a/tests/unit/strategies/project-learnings-rule-pair.test.ts
+++ b/tests/unit/strategies/project-learnings-rule-pair.test.ts
@@ -16,8 +16,8 @@ describe("project-learnings eager/reference rule pair", () => {
 
     expect(reference).toContain("# Project Learnings");
     expect(reference).toContain("@codyswann/lisa/learnings");
-    expect(reference).toContain("id");
-    expect(reference).toContain("confidence");
+    expect(reference).toMatch(/^-\s*`id`\s*$/m);
+    expect(reference).toMatch(/^-\s*`confidence`\s*$/m);
     expect(reference).not.toMatch(/maxEntries|maxTokens|maxRuleCharacters/);
   });
 });


### PR DESCRIPTION
## Summary
- Add the canonical project-learnings eager/reference rule pair under plugin source and regenerate Claude/Codex/Cursor/Copilot artifacts.
- Reconcile a bounded Antigravity AGENTS.md project-learnings bridge instead of shipping the full rules tree to agy.
- Update Cursor artifact tests to derive expected rule counts from source pairs.

Refs #1577

## Verification
- bun test tests/unit/core/instruction-files-migration.test.ts tests/unit/strategies/project-learnings-rule-pair.test.ts tests/unit/scripts/generate-agy-plugin-artifacts.test.ts tests/unit/scripts/per-agent-hook-filter.test.ts
- bun test tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts
- bun test tests/integration/lisa.test.ts -t "uses only the configured project-rules sibling|creates, preserves, and repeatedly leaves|does not regenerate committed agent trees"
- bun run check:rules-pairing
- bun run typecheck
- bun run check:plugins
- git push pre-push hook: audit, slow lint, knip, coverage unit suite, integration suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded, repository-local Project Learnings support across Lisa integrations.
  * Project Learnings are discovered from project configuration and consumed before normal task work.
  * Added a bounded learnings bridge for compatible harnesses so the effective `PROJECT_LEARNINGS.md` location is shared via `AGENTS.md`.
* **Bug Fixes**
  * Missing learnings are silently ignored.
  * Invalid, unsafe, non-canonical, or over-budget learnings now emit exactly one warning and do not block unrelated work.
  * Automated learnings are kept separate from durable `PROJECT_RULES.md`.
* **Tests**
  * Expanded unit coverage and updated artifact/regression expectations for Project Learnings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->