### PR TITLE
fix: expose github label event history

### DIFF
--- a/plugins/lisa-agy/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/plugins/lisa-copilot/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/plugins/lisa-cursor/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/plugins/lisa/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/plugins/src/base/skills/lisa-github-read-issue/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-read-issue/SKILL.md
@@ -139,15 +139,64 @@ If the primary issue has a parent sub-issue (i.e., is a Story / Task / Sub-task 
 
 If the primary issue IS an Epic, capture all children via Phase 3's `subIssues` traversal (already done).
 
-## Phase 6 — Fetch Linked PRs (Native `Resolves` / Cross-references)
+## Phase 6 — Fetch Linked PRs and Label-Event History
 
-GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship:
+GitHub's native `closingIssuesReferences` and timeline give the canonical PR↔Issue relationship. The same timeline read also exposes label events, which are Lisa's GitHub-native transition history. Keep this as one GraphQL read path; do not add a second REST timeline fetch.
 
 ```bash
-gh api graphql -f query='query($org:String!,$repo:String!,$number:Int!){repository(owner:$org,name:$repo){issue(number:$number){closedByPullRequestsReferences(first:50){nodes{number title state merged mergedAt url repository{nameWithOwner}}}timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{...on CrossReferencedEvent{source{...on PullRequest{number title state url repository{nameWithOwner}}}}}}}}}' -F org=<org> -F repo=<repo> -F number=<number>
+query='query($org:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$org,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes{number title state merged mergedAt url repository{nameWithOwner}}
+      }
+      timelineItems(
+        first:100
+        after:$cursor
+        itemTypes:[CROSS_REFERENCED_EVENT,LABELED_EVENT,UNLABELED_EVENT]
+      ){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          ...on CrossReferencedEvent{
+            createdAt
+            actor{login}
+            source{...on PullRequest{number title state url repository{nameWithOwner}}}
+          }
+          ...on LabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+          ...on UnlabeledEvent{
+            createdAt
+            actor{login}
+            label{name}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cursor=null
+while :; do
+  if [ "$cursor" = null ]; then
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number>)
+  else
+    page=$(gh api graphql -f query="$query" -F org=<org> -F repo=<repo> -F number=<number> -f cursor="$cursor")
+  fi
+  printf '%s\n' "$page"
+  has_next=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.hasNextPage')
+  cursor=$(printf '%s\n' "$page" | jq -r '.data.repository.issue.timelineItems.pageInfo.endCursor')
+  [ "$has_next" = true ] || break
+done
 ```
 
-Capture: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4.
+Capture:
+- **Linked PRs**: PR number, title, state, mergedAt, repo, url. Dedupe with PRs found in Phase 4. Preserve the existing `CrossReferencedEvent` behavior for PR linkage; widening the query must not change that consumer shape.
+- **Label-event history**: chronological `LabeledEvent` and `UnlabeledEvent` entries with event kind, label name, actor login, and `createdAt`. Preserve oldest→newest order across all pages. Status labels (`status:*`) are the GitHub transition history that downstream rejection detection consumes, but keep non-status label events too so callers can audit the full label stream.
+
+Pagination is mandatory. `timelineItems(first:100)` silently truncates busy issues unless `pageInfo.hasNextPage` / `endCursor` is followed. If a page fetch fails, record label-event history as `unknown` with the error and continue assembling the bundle; a history read failure must never block the build.
 
 For each PR, fetch unresolved review comments via `gh pr view <num> --repo <org>/<repo> --json reviews,reviewThreads`.
 
@@ -226,6 +275,12 @@ Produce a single structured output that the caller can pass verbatim to downstre
 
 ### Body-referenced (`Resolves #<n>`)
 <per-PR block>
+
+## Label-Event History
+- Status: <known|unknown>
+- Events:
+  - <ISO> — <labeled|unlabeled> — <label-name> — <actor-login>
+  - ...
 
 ## Sibling Sub-issues (other children of the same parent, <count>)
 - <ref> — <type> — <status> — <assignee> — <title>  **[FLAG: in progress by other assignee]**

--- a/tests/unit/strategies/github-read-issue-label-history.test.ts
+++ b/tests/unit/strategies/github-read-issue-label-history.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression coverage for GitHub issue transition-history reads.
+ *
+ * The skill is the executable contract for GitHub issue context reads. These
+ * assertions protect the widened timeline query that keeps PR cross-reference
+ * behavior while adding label-event history for rejection detection.
+ * @module tests/unit/strategies/github-read-issue-label-history
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const readSkill = (root: string): string =>
+  readFileSync(
+    path.resolve(root, "skills/lisa-github-read-issue/SKILL.md"),
+    "utf8"
+  );
+
+describe("github read issue label history contract", () => {
+  describe.each(ROOTS)("%s", root => {
+    const skill = readSkill(root);
+
+    it("widens the existing timeline query without dropping PR cross-references", () => {
+      expect(skill).toContain("CROSS_REFERENCED_EVENT");
+      expect(skill).toContain("LABELED_EVENT");
+      expect(skill).toContain("UNLABELED_EVENT");
+      expect(skill).toContain("...on CrossReferencedEvent");
+      expect(skill).toContain("...on LabeledEvent");
+      expect(skill).toContain("...on UnlabeledEvent");
+    });
+
+    it("captures label event payload and preserves pagination", () => {
+      expect(skill).toContain("pageInfo{hasNextPage endCursor}");
+      expect(skill).toContain("after:$cursor");
+      expect(skill).toMatch(/label\{name\}/);
+      expect(skill).toMatch(/actor\{login\}/);
+      expect(skill).toMatch(
+        /chronological `LabeledEvent` and `UnlabeledEvent`/
+      );
+      expect(skill).toContain("Preserve oldest");
+    });
+
+    it("documents non-blocking unknown history on read failure", () => {
+      expect(skill).toMatch(/label-event history as `unknown`/i);
+      expect(skill).toMatch(/must never block the build/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- widens `lisa-github-read-issue`'s existing GraphQL timeline query to include `LabeledEvent` and `UnlabeledEvent` while preserving `CrossReferencedEvent` PR linkage
- documents pagination via `pageInfo.hasNextPage` / `endCursor` so busy issue timelines are not silently truncated
- adds the Label-Event History section to the context bundle and marks timeline failures as non-blocking `unknown` history
- regenerates generated Lisa plugin artifacts for Claude, Codex, Cursor, agy, and Copilot surfaces

## Verification
- `bun test tests/unit/strategies/github-read-issue-label-history.test.ts`
- live `gh api graphql` query against `CodySwannGT/lisa#1572` returned label events including `status:ready` and `status:in-progress`
- `bun run check:plugins`
- pre-push hook: slow lint, knip, full unit coverage, integration tests

Closes #1572
