### PR TITLE
fix: prune Expo Jest agent worktrees

### DIFF
--- a/.lisa/plan-1472.md
+++ b/.lisa/plan-1472.md
@@ -1,0 +1,69 @@
+# Plan: 1472-jest-expo-haste-prune
+
+Work item: `CodySwannGT/lisa#1472`
+
+Flow: `Implement/Fix`
+
+Target environment: not specified; recorded fallback is the remote default branch `main` (`production` in `.lisa.config.json`).
+
+## Task metadata
+
+```json
+{
+  "plan": "1472-jest-expo-haste-prune",
+  "type": "bug",
+  "acceptance_criteria": [
+    "getExpoJestConfig returns haste.forceNodeFilesystemAPI=true while preserving the existing Expo platform settings",
+    "getExpoJestConfig returns a root-anchored <rootDir>/\\.claude/ modulePathIgnorePatterns entry",
+    "Consumer haste values and modulePathIgnorePatterns remain merge-safe",
+    "A regression proves Jest's Node filesystem crawler does not descend into .claude/worktrees from a repository root or an agent-worktree root",
+    "The published @codyswann/lisa package exposes the verified configuration"
+  ],
+  "relevant_documentation": "src/configs/jest/expo.ts defines the factory; src/configs/jest/base.ts defines object merge and array concatenation; tests/unit/config/jest-expo.test.ts is the existing contract suite; Jest 30.2 jest-haste-map buffers native find output before filtering but the Node filesystem walker applies ignore rules before recursion; Jest 30 configuration documents haste.forceNodeFilesystemAPI and rootDir-anchored modulePathIgnorePatterns; PropSwapLLC/frontend commit 95298e16f3d009a37baf7cd593c375bd50e19917 is the production precedent.",
+  "testing_requirements": [
+    "Capture a pre-fix failing contract regression before changing production code",
+    "Prove exact returned defaults and merge behavior with focused unit coverage",
+    "Exercise the actual Jest HasteMap Node crawler with an isolated cache and a traversal tripwire; require named nonzero tests",
+    "Run lint, typecheck, build, unit, and integration quality gates",
+    "After merge and deploy, download @codyswann/lisa@latest and empirically inspect its exported factory"
+  ],
+  "skills": ["lisa-implement", "lisa-codify-verification", "lisa-usage-accounting", "lisa-drive-pr-to-merge"],
+  "learnings": [
+    "forceNodeFilesystemAPI prevents native find stdout buffering, while modulePathIgnorePatterns enables pre-recursion pruning; both settings are required",
+    "modulePathIgnorePatterns, not testPathIgnorePatterns, feeds Jest Runtime's HasteMap ignore pattern",
+    "the trailing-slash pattern may read .claude once but must never read .claude/worktrees or descendants",
+    "root anchoring preserves the current agent worktree while pruning only that worktree root's nested .claude tree",
+    "a tiny poison tree plus a live readdir tripwire proves pruning without reproducing hundreds of gigabytes",
+    "mergeConfigs preserves the safety defaults when consumers add haste fields or module ignore patterns",
+    "Jest 30.2's normalized default cannot honestly reproduce the historical native-find crash locally, so the regression proves the missing explicit distributed contract and traversal prune",
+    "an isolated cache directory plus resetCache prevents a stale HasteMap false green"
+  ],
+  "required_access": [
+    {"tool":"GitHub repository/issues/PRs","probe":"gh repo view CodySwannGT/lisa --json defaultBranchRef,viewerPermission","status":"pass"},
+    {"tool":"Git push and auto-merge","probe":"gh api -X GET repos/CodySwannGT/lisa --jq '{permissions,allow_auto_merge}'","status":"pass"},
+    {"tool":"GitHub Actions CI/deploy","probe":"gh run list --repo CodySwannGT/lisa --workflow ci.yml --limit 5 and deploy.yml equivalent","status":"pass"},
+    {"tool":"Public npm registry","probe":"npm view @codyswann/lisa version dist-tags.latest --json","status":"pass"},
+    {"tool":"Pinned Bun/Node and Jest toolchain","probe":"mise x bun@1.3.8 -- bun --version; mise x node@22.21.1 -- node --version; resolve jest-haste-map 30.2.0","status":"pass"}
+  ],
+  "verification": {
+    "type": "cli-test",
+    "command": "Pack @codyswann/lisa@latest from npm, import package/dist/configs/jest/expo.js, print its haste and modulePathIgnorePatterns, and exit nonzero unless forceNodeFilesystemAPI is true, platforms remain android/ios/native, and <rootDir>/\\.claude/ is present",
+    "expected": "Command exits 0 and prints JSON with ok=true; the named local crawler regression reports zero .claude/worktrees descendant reads and still discovers visible source from both roots"
+  }
+}
+```
+
+## Edge-case disposition
+
+- ACCEPT: runs from inside an agent worktree remain supported; cover with the second crawler-root scenario.
+- ACCEPT: consumer haste fields and extra module ignore patterns remain preserved; cover with merge assertions.
+- ACCEPT: stale haste cache could produce a false green; require an isolated unique cache directory and resetCache.
+- ACCEPT: `.claude` itself may be read once because the requested pattern prunes at `.claude/worktrees`; assert zero descendant reads, not zero `.claude` reads.
+- REJECT: browser/UI dual-runner coverage does not apply because this is a library configuration bug with no UI surface or UI harness requirement.
+- REJECT: Watchman behavior is not the reported failure path; exercise `useWatchman:false` while preserving the returned generic config.
+- DEFER: non-Expo Jest factories are explicitly advisory in the ticket and require separate scope/evidence.
+- DEFER: native Windows execution is unavailable locally; preserve Jest's documented normalized pattern and force-node behavior without claiming a Windows runtime proof.
+
+## Effective completion condition
+
+The merged and deployed public package passes the npm-tarball proof above, all required CI checks pass with named regression execution evidence, the source issue has verified PR linkage and terminal lifecycle state, and no non-Expo factory behavior changes.

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -1,9 +1,23 @@
-# Roster Decision: Project-Scoped Codex Delivery
+# Lisa Implement Roster Decision
 
-INCLUDE - Explore - The runtime exposes only general-purpose agents, so one will be assigned a bounded read-only architecture and test-surface investigation.
-INCLUDE - Builder - The runtime exposes only general-purpose agents, so one will implement a bounded source-and-test slice after research completes.
-INCLUDE - Reviewer - The runtime exposes only general-purpose agents, so one will independently review the completed diff for behavioral regressions.
-INCLUDE - Verifier - The runtime exposes only general-purpose agents, so one will independently run the empirical Bun install/update and Codex prompt checks.
-EXCLUDE - Named repository specialists - Codex collaboration exposes no selectable specialist type; repository agent files cannot be selected through the available spawn API.
+Work item: `CodySwannGT/lisa#1472`
 
-Resolved request: keep all Lisa Codex delivery project-scoped; install only base plus detected-stack artifacts without duplication; prevent unrelated stack hooks and rules; and automatically reconcile the invoking project when Bun installs or updates Lisa.
+Runtime delegation inventory:
+
+`INCLUDE - general-purpose collaboration agent - Codex exposes no enumerated specialist agent types; this is the only available delegation type and will be constrained by role-specific prompts.`
+
+Runtime gap: Codex's collaboration surface does not expose separate built-in `Explore`, reviewer, learner, verifier, or ops agent types. The general-purpose type is therefore assigned the following bounded specialist roles for this issue:
+
+`INCLUDE - Explore-equivalent - Required read-only codebase, documentation, test, and git-history research before implementation.`
+
+`INCLUDE - implementation specialist - Required to implement the approved task and its regression coverage after research and access gates pass.`
+
+`INCLUDE - review specialist - Required independent correctness, scope, quality, and regression review.`
+
+`INCLUDE - learner specialist - Required independent review of task learnings before team shutdown.`
+
+`INCLUDE - verification specialist - Required independent local and remote empirical verification and machine-readable verdict.`
+
+`INCLUDE - ops specialist - Required PR/deploy lifecycle monitoring and post-deploy health evidence.`
+
+No available delegation type is excluded.

--- a/src/configs/jest/expo.ts
+++ b/src/configs/jest/expo.ts
@@ -128,8 +128,10 @@ export const getExpoJestConfig = ({
   testEnvironment: "jsdom",
   haste: {
     defaultPlatform: "ios",
+    forceNodeFilesystemAPI: true,
     platforms: ["android", "ios", "native"],
   },
+  modulePathIgnorePatterns: ["<rootDir>/\\.claude/"],
   // This resolver teaches Jest to resolve platform-extension files
   // (`.ios`/`.native`/`.web`); without it those variants do not resolve.
   // Its location moved between SDK 54 and SDK 56, so the path is chosen at

--- a/tests/integration/jest-expo-haste-pruning.test.ts
+++ b/tests/integration/jest-expo-haste-pruning.test.ts
@@ -1,0 +1,185 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, sep } from "node:path";
+
+import { replacePathSepForRegex } from "jest-regex-util";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { getExpoJestConfig } from "../../src/configs/jest/expo.js";
+
+const require = createRequire(import.meta.url);
+const gracefulFs = require("graceful-fs") as typeof import("node:fs");
+const originalReaddir = gracefulFs.readdir;
+
+/** Public Jest HasteMap constructor exercised by the traversal regression. */
+type HasteMapConstructor = (typeof import("jest-haste-map"))["default"];
+
+let HasteMap: HasteMapConstructor;
+let recordVisitedDirectories = false;
+let visitedDirectories: string[] = [];
+let temporaryRoot: string;
+
+const slash = (filePath: string): string => filePath.split(sep).join("/");
+
+const crawlWithExpoConfig = async (
+  rootDir: string
+): Promise<readonly string[]> => {
+  const config = getExpoJestConfig();
+  const ignorePatterns = (config.modulePathIgnorePatterns ?? []).map(pattern =>
+    replacePathSepForRegex(pattern.replaceAll("<rootDir>", rootDir))
+  );
+  const cacheDirectory = await mkdtemp(
+    join(tmpdir(), "lisa-jest-haste-cache-")
+  );
+
+  try {
+    recordVisitedDirectories = true;
+    const hasteMap = await HasteMap.create({
+      cacheDirectory,
+      computeDependencies: false,
+      extensions: ["ts"],
+      // Keep the pre-fix reproduction on the observable Node walker. The unit
+      // contract independently fails when the factory omits this required flag.
+      forceNodeFilesystemAPI: config.haste?.forceNodeFilesystemAPI ?? true,
+      id: "lisa-jest-expo-pruning",
+      ...(ignorePatterns.length > 0
+        ? { ignorePattern: new RegExp(ignorePatterns.join("|")) }
+        : {}),
+      maxWorkers: 1,
+      platforms: [...(config.haste?.platforms ?? [])],
+      resetCache: true,
+      retainAllFiles: true,
+      rootDir,
+      roots: [rootDir],
+      useWatchman: false,
+    });
+    const { hasteFS } = await hasteMap.build();
+
+    return hasteFS
+      .getAllFiles()
+      .map(filePath => slash(relative(rootDir, filePath)))
+      .sort((left, right) => left.localeCompare(right));
+  } finally {
+    recordVisitedDirectories = false;
+    await rm(cacheDirectory, { force: true, recursive: true });
+  }
+};
+
+const directoriesAtOrBelow = (directory: string): readonly string[] =>
+  visitedDirectories.filter(
+    visited => visited === directory || visited.startsWith(`${directory}${sep}`)
+  );
+
+describe("getExpoJestConfig haste traversal", () => {
+  beforeAll(() => {
+    const mutableGracefulFs = gracefulFs as unknown as {
+      readdir: (...args: unknown[]) => unknown;
+    };
+    mutableGracefulFs.readdir = (...args: unknown[]): unknown => {
+      if (recordVisitedDirectories) {
+        visitedDirectories.push(String(args[0]));
+      }
+      return Reflect.apply(
+        originalReaddir as (...parameters: unknown[]) => unknown,
+        gracefulFs,
+        args
+      );
+    };
+    HasteMap = (
+      require("jest-haste-map") as {
+        default: HasteMapConstructor;
+      }
+    ).default;
+  });
+
+  afterAll(() => {
+    recordVisitedDirectories = false;
+    gracefulFs.readdir = originalReaddir;
+  });
+
+  beforeEach(async () => {
+    visitedDirectories = [];
+    temporaryRoot = await mkdtemp(join(tmpdir(), "lisa-jest-haste-proof-"));
+  });
+
+  afterEach(async () => {
+    recordVisitedDirectories = false;
+    await rm(temporaryRoot, { force: true, recursive: true });
+  });
+
+  it("prunes repo-root .claude/worktrees before descending", async () => {
+    const projectRoot = join(temporaryRoot, "project");
+    const visibleFile = join(projectRoot, "src", "visible.ts");
+    const worktreesRoot = join(projectRoot, ".claude", "worktrees");
+    const hiddenFile = join(
+      worktreesRoot,
+      "poison",
+      "node_modules",
+      "package",
+      "hidden.ts"
+    );
+    await mkdir(dirname(visibleFile), { recursive: true });
+    await mkdir(dirname(hiddenFile), { recursive: true });
+    await writeFile(visibleFile, "export const visible = true;\n");
+    await writeFile(hiddenFile, "export const hidden = true;\n");
+
+    const files = await crawlWithExpoConfig(projectRoot);
+    const traversedWorktreeDirectories = directoriesAtOrBelow(worktreesRoot);
+
+    expect(visitedDirectories).toContain(projectRoot);
+    expect(visitedDirectories).toContain(dirname(visibleFile));
+    expect(
+      traversedWorktreeDirectories,
+      `expected the walker to prune ${worktreesRoot}; visited ${JSON.stringify(
+        traversedWorktreeDirectories
+      )}`
+    ).toEqual([]);
+    expect(files).toContain("src/visible.ts");
+    expect(files.filter(filePath => filePath.startsWith(".claude/"))).toEqual(
+      []
+    );
+  });
+
+  it("keeps the current agent worktree visible while pruning its nested .claude tree", async () => {
+    const worktreeRoot = join(
+      temporaryRoot,
+      "primary",
+      ".claude",
+      "worktrees",
+      "current"
+    );
+    const visibleFile = join(worktreeRoot, "src", "visible.ts");
+    const nestedWorktreesRoot = join(worktreeRoot, ".claude", "worktrees");
+    const hiddenFile = join(nestedWorktreesRoot, "stale", "hidden.ts");
+    await mkdir(dirname(visibleFile), { recursive: true });
+    await mkdir(dirname(hiddenFile), { recursive: true });
+    await writeFile(visibleFile, "export const visible = true;\n");
+    await writeFile(hiddenFile, "export const hidden = true;\n");
+
+    const files = await crawlWithExpoConfig(worktreeRoot);
+    const traversedNestedDirectories =
+      directoriesAtOrBelow(nestedWorktreesRoot);
+
+    expect(visitedDirectories).toContain(worktreeRoot);
+    expect(visitedDirectories).toContain(dirname(visibleFile));
+    expect(
+      traversedNestedDirectories,
+      `expected the walker to prune ${nestedWorktreesRoot}; visited ${JSON.stringify(
+        traversedNestedDirectories
+      )}`
+    ).toEqual([]);
+    expect(files).toContain("src/visible.ts");
+    expect(files.filter(filePath => filePath.startsWith(".claude/"))).toEqual(
+      []
+    );
+  });
+});

--- a/tests/unit/config/jest-expo.test.ts
+++ b/tests/unit/config/jest-expo.test.ts
@@ -1,5 +1,6 @@
 import {
   getExpoJestConfig,
+  mergeConfigs,
   selectExpoJestResolver,
 } from "../../../src/configs/jest/expo.js";
 import { defaultThresholds } from "../../../src/configs/jest/base.js";
@@ -37,8 +38,31 @@ describe("jest.expo", () => {
     it("configures haste for React Native platforms", () => {
       expect(config.haste).toEqual({
         defaultPlatform: "ios",
+        forceNodeFilesystemAPI: true,
         platforms: ["android", "ios", "native"],
       });
+    });
+
+    it("root-anchors .claude exclusion for the haste crawl", () => {
+      expect(config.modulePathIgnorePatterns).toEqual(["<rootDir>/\\.claude/"]);
+    });
+
+    it("preserves haste crawl safety when merged with local config", () => {
+      const merged = mergeConfigs(config, {
+        haste: { computeSha1: true },
+        modulePathIgnorePatterns: ["<rootDir>/generated/"],
+      });
+
+      expect(merged.haste).toEqual({
+        computeSha1: true,
+        defaultPlatform: "ios",
+        forceNodeFilesystemAPI: true,
+        platforms: ["android", "ios", "native"],
+      });
+      expect(merged.modulePathIgnorePatterns).toEqual([
+        "<rootDir>/\\.claude/",
+        "<rootDir>/generated/",
+      ]);
     });
 
     it("uses a valid React Native resolver path for the installed SDK", () => {


### PR DESCRIPTION
## Summary

- force the Expo Jest factory to use the Node filesystem crawler
- root-ignore `.claude` so accumulated worktrees are pruned before descent
- add unit merge-contract and actual HasteMap traversal regressions

Closes #1472

## Test plan

- `bun run build:dist`
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit` — 262 files, 4,109 tests passed
- `bun run test:integration` — 9 files, 128 tests passed
- focused regression — 2 files, 26 tests passed; both named HasteMap traversal scenarios executed
- compiled factory proof printed `ok: true` with the exact force flag, platforms, and root-anchored ignore

## Codified verifications

| Verification | Framework | Test file | Status |
|---|---|---|---|
| Repo-root `.claude/worktrees` is pruned before descent | Vitest + Jest HasteMap | `tests/integration/jest-expo-haste-pruning.test.ts` | PASS |
| Agent-worktree root remains visible while nested `.claude/worktrees` is pruned | Vitest + Jest HasteMap | `tests/integration/jest-expo-haste-pruning.test.ts` | PASS |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Expo Jest configuration to use Node filesystem traversal and exclude root-level `.claude` directories.

* **Bug Fixes**
  * Prevented Jest haste-map crawling from descending into `.claude/worktrees`, including nested stale worktrees.

* **Tests**
  * Added integration coverage for filesystem pruning and visible project paths.
  * Expanded unit coverage to verify configuration merging preserves the safety exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Evidence

[lisa-evidence] #1472 terminal verification

## Outcome

PASS — Expo Jest now prunes accumulated agent worktrees before traversal while preserving execution from inside the current agent worktree.

## Verification

- Pre-fix TDD proof: 2 files discovered, 5 named failures, 21 passes.
- Post-fix focused proof: 2 files, 26 tests passed, including both actual-HasteMap traversal scenarios.
- Full local gates: build, typecheck, lint, formatting, 4,109 unit tests, and 128 integration tests passed.
- PR #1670 merged at 9f6d842b3f71da93f3aaf03621ea485e60432545; the reviewed head is an ancestor of main.
- Release and Deploy run 29584062217 completed successfully with no failed jobs.
- Public npm package @codyswann/lisa@2.221.3 is latest and independently returned forceNodeFilesystemAPI=true plus <rootDir>/\\.claude/ while preserving ios/android/native platforms.

## Evidence artifacts

https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1670-01-local-verification.json
https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1670-02-remote-package-proof.json
https://github.com/CodySwannGT/lisa/releases/download/pr-assets/pr-1670-03-release-health.txt

## Scope

Only the Expo Jest factory changed. Non-Expo factories remain out of scope.

## Lisa Usage

_This section is managed by Lisa. Rewrites update matching usage entries in place and preserve older rows._

| Flow | Source | Model | Tokens | Cost |
| --- | --- | --- | ---: | ---: |
| lisa-verify | unavailable | openai/gpt-5 | null | null | <!-- lisa:usage-entry entry_id=lisa-verify-github-CodySwannGT-lisa-1472-2026-07-17 flow=lisa-verify run_id= provider=openai model=gpt-5 source=unavailable input_tokens=null cached_input_tokens=null output_tokens=null reasoning_tokens=null total_tokens=null cost=null currency=null pricing_status=unavailable pricing_source=null artifact_ref=github%3ACodySwannGT%2Flisa%231472%3Aevidence%3Apr-1670 parent_artifact_ref=github%3ACodySwannGT%2Flisa%231472 -->

<!-- lisa:usage-rollup direct_entry_ids=lisa-verify-github-CodySwannGT-lisa-1472-2026-07-17 child_entry_ids= child_refs= direct_tokens=null child_tokens=null total_tokens=null direct_cost=null child_cost=null total_cost=null currency=null child_currency=null -->
