### PR TITLE
fix(workflows): hash source root in build caches

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -130,7 +130,7 @@ on:
         default: 1
         type: number
       cache_build:
-        description: 'Cache the Expo web build output between runs to skip `expo export` and `<pm> run build` when source unchanged. Default false = full rebuild every run (unchanged behavior). When true, cache key hashes lockfiles + app/components/features sources + Expo/Metro/Babel/TS configs; invalidates when any of those change.'
+        description: 'Cache build output between runs to skip `expo export` and `<pm> run build` when source unchanged. Default false = full rebuild every run (unchanged behavior). When true, cache key hashes lockfiles + src/app/components/features sources + Expo/Metro/Babel/TS configs; invalidates when any of those change.'
         required: false
         default: false
         type: boolean
@@ -1002,7 +1002,7 @@ jobs:
       #
       # Cache invalidation contract:
       #   Key hashes (in order): lockfiles → source directories → config files.
-      #   Any change to a lockfile, app/components/features source, or
+      #   Any change to a lockfile, src/app/components/features source, or
       #   Expo/Metro/Babel/TS config will miss the cache and force a rebuild.
       #   Runner OS is part of the key to prevent cross-OS cache reuse.
       # Cached paths:
@@ -1018,7 +1018,7 @@ jobs:
             ${{ inputs.working_directory || '.' }}/dist
             ${{ inputs.working_directory || '.' }}/.expo
             ${{ inputs.working_directory || '.' }}/node_modules/.cache
-          key: ${{ runner.os }}-expo-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
+          key: ${{ runner.os }}-expo-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/src/**', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
           restore-keys: |
             ${{ runner.os }}-expo-build-
 
@@ -1250,7 +1250,7 @@ jobs:
       # Build output cache — opt-in via `cache_build: true`.
       #
       # Cache invalidation contract (same as playwright_e2e):
-      #   Key hashes lockfiles → app/components/features sources →
+      #   Key hashes lockfiles → src/app/components/features sources →
       #   Expo/Metro/Babel/TS configs. Any change forces a rebuild.
       # Cached paths cover common build output directories (dist, build,
       # .next, out) plus bundler caches. Default false = unchanged behavior.
@@ -1266,7 +1266,7 @@ jobs:
             ${{ inputs.working_directory || '.' }}/out
             ${{ inputs.working_directory || '.' }}/.expo
             ${{ inputs.working_directory || '.' }}/node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/src/**', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
           restore-keys: |
             ${{ runner.os }}-build-
 

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -143,6 +143,18 @@ describe("quality.yml reusable workflow", () => {
       expect(input?.default).toBe(false);
       expect(input?.type).toBe("boolean");
     });
+
+    it("includes the source root in build cache keys", () => {
+      const playwrightExpoCache = workflow.jobs.playwright_e2e.steps?.find(
+        step => step.id === "expo_cache"
+      );
+      const buildCache = workflow.jobs.build.steps?.find(
+        step => step.id === "build_cache"
+      );
+
+      expect(playwrightExpoCache?.with?.key).toContain("'**/src/**'");
+      expect(buildCache?.with?.key).toContain("'**/src/**'");
+    });
   });
 
   describe("cross-run concurrency mutex (opt-in)", () => {


### PR DESCRIPTION
## Summary
- add `**/src/**` to the Expo Playwright export cache key and generic build cache key
- update the cache_build description/comments to reflect the source-root invalidation contract
- add a workflow contract test that asserts both cache keys include the source root

Closes #1628

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run check:workflow-inputs`
- `bunx prettier --check .github/workflows/quality.yml tests/integration/quality-workflow.test.ts`
- `bun run typecheck`
- `bunx oxlint --no-error-on-unmatched-pattern tests/integration/quality-workflow.test.ts`
- `bunx eslint --quiet --no-error-on-unmatched-pattern --no-warn-ignored tests/integration/quality-workflow.test.ts`
- `bun run sg:scan -- tests/integration/quality-workflow.test.ts`
- pre-push hook: security audit, slow lint, knip, full unit coverage, integration tests
