### PR TITLE
fix(validate): align F2/F4 with lifecycle hierarchy

### DIFF
--- a/.lisa/plan-1549.md
+++ b/.lisa/plan-1549.md
@@ -1,0 +1,54 @@
+# Plan: 1549-validator-f2-f4-contract
+
+Work item: `CodySwannGT/lisa#1549`
+
+Flow: `Implement/Fix`
+
+Target environment: not specified; recorded fallback is the remote default branch `main` (`production` in `.lisa.config.json`).
+
+## Task metadata
+
+```json
+{
+  "plan": "1549-validator-f2-f4-contract",
+  "type": "bug",
+  "acceptance_criteria": [
+    "F2 accepts a configured PRD-labelled native parent for type:Epic children only in the permitted same-repository GitHub source+tracker shape while retaining Epic-to-Story validation",
+    "F4 exempts non-leaf containers from build status labels under leaf-only lifecycle",
+    "F4 accepts a backlog-mode leaf without status:* when the write declared build_ready:false",
+    "Invalid hierarchy and lifecycle combinations continue to fail with actionable diagnostics",
+    "Claude, Codex, Cursor, OpenCode, Antigravity, and Copilot equivalent validator surfaces remain in parity"
+  ],
+  "relevant_documentation": "plugins/src/base/skills/lisa-github-validate-issue/SKILL.md is the sole canonical F2/F4 logic source; plugins/src/base/skills/lisa-tracker-validate/SKILL.md is only a dispatcher. plugins/src/base/rules/reference/config-resolution.md defines configurable PRD lifecycle labels; plugins/src/base/skills/lisa-github-write-prd/SKILL.md defines PRD labels; plugins/src/base/skills/lisa-github-write-issue/SKILL.md defines build_ready false and omitted-default-ready semantics; plugins/src/base/rules/reference/leaf-only-lifecycle.md defines container/leaf label constraints and S15. scripts/build-plugins.sh fans the canonical source into Claude, Codex, Cursor, agy, and Copilot outputs; OpenCode copies the canonical built skill at install time through src/opencode/skills-installer.ts and src/core/lisa-skill-sources.ts. tests/unit/strategies/build-ready-control.test.ts and leaf-only-build-ready.test.ts cover adjacent writer/S15 behavior but not F2/F4.",
+  "testing_requirements": [
+    "Capture deterministic contract-text failures for the PRD-to-Epic and container-without-status rules",
+    "Add focused contract regressions for valid exemptions and invalid neighboring cases",
+    "Run plugin generation/parity checks for every supported coding-agent surface",
+    "Run lint, typecheck, focused tests, full unit/integration tests, and relevant package build gates",
+    "Record named nonzero regression execution evidence in the PR and verification verdict"
+  ],
+  "skills": ["lisa-implement", "lisa-usage-accounting", "lisa-drive-pr-to-merge"],
+  "learnings": [
+    "F2 needs a child-sensitive exception: only an Epic child in the permitted same-repository GitHub source+tracker shape may use a configured PRD lifecycle parent; ordinary non-Sub-task and Sub-task parent rules remain unchanged",
+    "F4 keeps type and priority unconditional, requires the configured github.labels.build.ready role only for build_ready:true leaves, and permits no status label for containers or build_ready:false leaves",
+    "Live issue validation derives build_ready from the configured ready-role label and cannot distinguish explicit false from an omitted historical label, so proposed-spec normalization preserves the writer's omitted-input default",
+    "S15 remains the independent guard that rejects any container carrying the configured build-ready role",
+    "Only the canonical source is hand-edited; bun run build:plugins regenerates five committed agent outputs while OpenCode consumes the canonical built skill at install time"
+  ],
+  "required_access": [
+    {"tool":"GitHub repository/issues/PRs","probe":"gh repo view CodySwannGT/lisa --json defaultBranchRef,viewerPermission","status":"pass"},
+    {"tool":"Git push, Actions, rulesets, and auto-merge","probe":"gh api -X GET repos/CodySwannGT/lisa and Actions/rulesets read probes","status":"pass"},
+    {"tool":"Bun/TypeScript toolchain","probe":"bun --version returns 1.3.11","status":"pass"},
+    {"tool":"Public npm registry","probe":"npm view @codyswann/lisa version returns 2.221.5","status":"pass"}
+  ],
+  "verification": {
+    "type": "contract-test",
+    "command": "Run tests/unit/strategies/github-validator-f2-f4-contract.test.ts against the canonical skill and generated agent surfaces, then run the plugin build/parity checks",
+    "expected": "Command exits 0; contract text documents the permitted PRD-to-Epic, container-without-status, build_ready:false backlog, configured-ready-role, and invalid-neighbor decisions consistently across supported agent surfaces"
+  }
+}
+```
+
+## Effective completion condition
+
+The merged `main` validator accepts the three valid hierarchy/lifecycle fixtures, continues rejecting the documented invalid neighbors, every supported coding-agent surface is generated in parity, named regressions execute nonzero in CI, the release containing the fix is published, and issue #1549 reaches its configured terminal lifecycle state.

--- a/.lisa/plan-1549.md
+++ b/.lisa/plan-1549.md
@@ -25,7 +25,7 @@ Target environment: not specified; recorded fallback is the remote default branc
     "Add focused contract regressions for valid exemptions and invalid neighboring cases",
     "Run plugin generation/parity checks for every supported coding-agent surface",
     "Run lint, typecheck, focused tests, full unit/integration tests, and relevant package build gates",
-    "Record named nonzero regression execution evidence in the PR and verification verdict"
+    "Record named successful zero-exit regression execution evidence in the PR and verification verdict"
   ],
   "skills": ["lisa-implement", "lisa-usage-accounting", "lisa-drive-pr-to-merge"],
   "learnings": [
@@ -51,4 +51,4 @@ Target environment: not specified; recorded fallback is the remote default branc
 
 ## Effective completion condition
 
-The merged `main` validator accepts the three valid hierarchy/lifecycle fixtures, continues rejecting the documented invalid neighbors, every supported coding-agent surface is generated in parity, named regressions execute nonzero in CI, the release containing the fix is published, and issue #1549 reaches its configured terminal lifecycle state.
+The merged `main` validator accepts the three valid hierarchy/lifecycle fixtures, continues rejecting the documented invalid neighbors, every supported coding-agent surface is generated in parity, named regressions execute successfully with exit code 0 in CI, the release containing the fix is published, and issue #1549 reaches its configured terminal lifecycle state.

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -1,23 +1,25 @@
 # Lisa Implement Roster Decision
 
-Work item: `CodySwannGT/lisa#1472`
+Work item: `CodySwannGT/lisa#1549`
 
 Runtime delegation inventory:
 
 `INCLUDE - general-purpose collaboration agent - Codex exposes no enumerated specialist agent types; this is the only available delegation type and will be constrained by role-specific prompts.`
 
-Runtime gap: Codex's collaboration surface does not expose separate built-in `Explore`, reviewer, learner, verifier, or ops agent types. The general-purpose type is therefore assigned the following bounded specialist roles for this issue:
+Runtime gap: Codex's collaboration surface does not expose separate built-in `Explore`, reproducer, implementer, reviewer, learner, verifier, release, or ops agent types. The general-purpose type is therefore assigned the following bounded specialist roles for this issue:
 
-`INCLUDE - Explore-equivalent - Required read-only codebase, documentation, test, and git-history research before implementation.`
+`INCLUDE - input-resolver / Explore-equivalent - Completed the required live ticket, hierarchy, access, duplicate, and base-branch readiness pass.`
 
-`INCLUDE - implementation specialist - Required to implement the approved task and its regression coverage after research and access gates pass.`
+`INCLUDE - reproduction and research specialist - Required to reproduce both F2 and F4 contradictions and inventory the canonical validator, generator parity surfaces, tests, documentation, and history before implementation.`
 
-`INCLUDE - review specialist - Required independent correctness, scope, quality, and regression review.`
+`INCLUDE - implementation specialist - Required to correct the canonical contract and every generated coding-agent surface with focused regression coverage.`
+
+`INCLUDE - review specialist - Required independent contract, parity, scope, and regression review.`
 
 `INCLUDE - learner specialist - Required independent review of task learnings before team shutdown.`
 
-`INCLUDE - verification specialist - Required independent local and remote empirical verification and machine-readable verdict.`
+`INCLUDE - verification specialist - Required independent empirical validation and machine-readable verdict.`
 
-`INCLUDE - ops specialist - Required PR/deploy lifecycle monitoring and post-deploy health evidence.`
+`INCLUDE - release and ops specialist - Required PR, CI, merge, package-release, and post-release health monitoring.`
 
 No available delegation type is excluded.

--- a/plugins/lisa-agy/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/plugins/lisa-copilot/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/plugins/lisa-cursor/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/plugins/lisa/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/plugins/src/base/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-validate-issue/SKILL.md
@@ -25,7 +25,7 @@ org: my-org
 repo: my-repo
 summary: "[CU-1.2] Upload contract PDF from settings"
 priority: medium
-parent_ref: "my-org/my-repo#1234"   # Parent Epic for non-Bug/non-Epic; Story for Sub-task
+parent_ref: "my-org/my-repo#1234"   # Parent Epic for ordinary children; PRD for an Epic only in the same-repo GitHub self-host shape; Story/etc. for Sub-task
 body: |
   ## Context / Business Value
   ...
@@ -63,7 +63,7 @@ artifacts_attached: true          # → requires Source Precedence section
 links: [{ ref: "my-org/my-repo#99", type: "is blocked by" }]   # known issue links (may be empty)
 remote_links: [{ url: "https://github.com/.../pull/42", title: "PR #42" }]
 journey_followup: auto            # auto | none — see S11
-build_ready: true                 # caller asserts the build-ready role (status:ready) is/would be applied — see S15
+build_ready: true                 # caller asserts the configured build-ready role (github.labels.build.ready, default status:ready) is/would be applied — see S15
 child_refs: ["my-org/my-repo#601", "my-org/my-repo#602"]   # known child work (sub-issues / task-list / "Blocked by" parentage) — see S15
 prd_source: "https://notion.so/..."    # set when the issue was generated from a PRD — requires the Source Requirement section, see S16
 ```
@@ -213,9 +213,11 @@ This gate depends on S11. It is `N/A` for containers — an **Epic**, or any ite
 
 #### S15 — Leaf-only build-ready
 
-Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `status:ready` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+Enforces the build-side of the vendor-neutral `leaf-only-lifecycle` rule: **only a leaf work unit may carry the build-ready role.** Before evaluating this gate, resolve `READY_ROLE` from merged project config (`.lisa.config.local.json` over `.lisa.config.json`) at `github.labels.build.ready`, defaulting to `status:ready` per `config-resolution`. Use that resolved value everywhere this validator interprets build readiness; a project-specific label is not an alias for the literal default.
 
-**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include `status:ready`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous).
+This is the symmetric write-side guard for the GitHub validator — a stale or hand-applied `READY_ROLE` on a container is a lifecycle error and must FAIL here, regardless of how the issue was produced. (Mirrors the "Build-ready label is leaf-only" rule that `lisa-github-write-issue` applies at write time.)
+
+**When the gate applies.** Run S15 whenever the issue is build-ready — i.e. `build_ready = true`, or the spec/live labels include the resolved `READY_ROLE`. If the issue is not build-ready, S15 is `N/A` (nothing claims a non-ready issue, so the invariant is vacuous). For example, if `github.labels.build.ready = "queue:approved"`, a container carrying `queue:approved` FAILs S15 even when it does not carry the literal `status:ready` default.
 
 **Resolve container vs. leaf — structural first, then nominal.** Per `leaf-only-lifecycle` the classification is structural: an item is a **container** if it has child work, whatever its declared type; otherwise the **type label** decides. Determine child work from (in order) `child_refs`, native sub-issues, body task-list checkboxes, and `Blocked by #<n>` / parent references — the same hierarchy resolution `lisa-github-read-issue` uses. When validating a live ref, query sub-issues alongside the issue fetch.
 
@@ -233,7 +235,7 @@ PASS (the childless-parent exception) when the issue is build-ready and is a **l
 | Epic | no | yes | **FAIL** (childless Epic — pure rollup container, exception does not apply) |
 | any | any | no | **N/A** (not build-ready) |
 
-Remediation: `"Build-ready (status:ready) is leaf-only per leaf-only-lifecycle. Move status:ready off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
+Remediation (render `<READY_ROLE>` as the resolved configured label, never as a hard-coded default): `"Build-ready (<READY_ROLE>; status:ready by default) is leaf-only per leaf-only-lifecycle. Move <READY_ROLE> off this container onto its leaf children (or, for a childless Epic, decompose it into leaf children or reclassify it to a leaf type); a parent's lifecycle state rolls up from its children and is never set to ready directly."`
 
 `product_relevant: false` — a build-ready container is a lifecycle/decomposition error for the caller to repair, not a product question.
 
@@ -284,8 +286,37 @@ gh issue view <number> --repo <org>/<repo> --json number,labels,state
 ```
 
 Confirm the parent issue exists and:
-- For non-Sub-task children: parent has `type:Epic` label.
-- For Sub-task children: parent has `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` (anything that can host sub-tasks).
+
+- For an `Epic` child, first resolve whether the validator can prove the native PRD-parent shape
+  allowed by `prd-lifecycle-rollup`: merged project config has `source = github` and
+  `tracker = github`; the spec/live child's `org` and `repo` match configured `github.org` and
+  `github.repo`; and `parent_ref` names that same `org/repo`. These facts are available from the
+  existing spec/live ref plus project config; do not infer the exception from label spelling alone.
+  Only in that proven same-repository GitHub self-host shape may the parent qualify by having one of
+  the configured PRD lifecycle labels from
+  `github.labels.prd` (`draft`, `ready`, `in_review`, `blocked`, `ticketed`, `shipped`, or
+  `verified`; defaults use the `prd-*` namespace). Resolve the configured values from
+  `.lisa.config.local.json` over `.lisa.config.json`, using the defaults from `config-resolution`.
+  The `sentinel` label is not a lifecycle role and does not qualify. This is the native
+  PRD→generated-Epic hierarchy used when GitHub is both source and tracker in one repository; the
+  PRD parent does **not** need `type:Epic`. If any self-host/same-repository predicate is false, a
+  PRD label does not grant the exception: native hierarchy cannot cross repositories or source
+  systems, so a PRD-labelled parent alone FAILs F2.
+- For a `Sub-task` child: the parent has `type:Story`, `type:Task`, `type:Bug`, or
+  `type:Improvement` (anything that can host sub-tasks). This allowlist is unchanged; a PRD
+  lifecycle label or `type:Epic` alone does not qualify.
+- For every other non-Sub-task child: the parent has `type:Epic`. A PRD lifecycle label alone does
+  not qualify, so the Epic→Story (and Epic→ordinary-leaf) hierarchy remains enforced.
+
+| child type | relationship shape | qualifying parent label | F2 |
+|---|---|---|---|
+| `Epic` | source GitHub + tracker GitHub + configured child repo = parent repo | configured PRD lifecycle label | **PASS** |
+| `Epic` | cross-repository or source/tracker is not same-repo GitHub | PRD lifecycle label only | **FAIL** |
+| `Epic` | permitted self-host shape | unconfigured `prd-*` lookalike or `prd-intake-feedback` sentinel only | **FAIL** |
+| `Sub-task` | any | `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` | **PASS** |
+| `Sub-task` | any | PRD lifecycle label or `type:Epic` only | **FAIL** |
+| any other non-Sub-task | any | `type:Epic` | **PASS** |
+| any other non-Sub-task | any | PRD lifecycle label only | **FAIL** |
 
 #### F3 — Linked issues exist
 
@@ -293,7 +324,35 @@ For each entry in `links`, run `gh issue view <number> --repo <link-org>/<link-r
 
 #### F4 — Required labels populated
 
-Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry: `type:<issue_type>`, `status:<status>`, `priority:<priority>`. If any are missing from the spec / live issue, FAIL with the missing label name.
+Per `Phase 5` of `lisa-github-write-issue`, every issue MUST carry
+`type:<issue_type>` and `priority:<priority>`. These two labels are unconditional: if either is
+missing from the proposed spec or live issue, FAIL with the missing label name.
+
+The `status:*` requirement uses this validator's S15 leaf/container classification while preserving
+the writer's documented `build_ready` control-input defaults:
+
+1. Classify the issue structurally using the S15 child-resolution rules. A container (any issue
+   with child work, plus a childless `Epic`) may omit `status:*`; its state rolls up rather than
+   being assigned directly.
+2. For a proposed leaf spec, normalize omitted `build_ready` to `true`, preserving the writer's
+   backward-compatible default-ready behavior. Explicit `build_ready: false` means backlog mode.
+3. For a live issue ref, derive `build_ready` from the labels (`true` exactly when the S15-resolved
+   `READY_ROLE` from `github.labels.build.ready`, default `status:ready`, is present). A live backlog leaf without a status label
+   therefore validates as `build_ready: false`; live data cannot distinguish an explicit false from
+   a historical write that omitted the label.
+4. A leaf with normalized `build_ready: true` MUST carry that same resolved `READY_ROLE`. A leaf with `build_ready: false` may omit
+   `status:*`.
+
+| classification | normalized build_ready | status label | F4 |
+|---|---:|---|---|
+| container | any | omitted | **PASS** |
+| leaf | `false` | omitted | **PASS** |
+| leaf | `true` | configured build-ready role (`status:ready` by default) | **PASS** |
+| leaf | `true` | omitted or a different `status:*` label | **FAIL** |
+
+F4 does not make a container build-ready. S15 remains the independent lifecycle prohibition: any
+container carrying the build-ready role still FAILs S15, even though F4's status-presence check is
+not applicable to containers.
 
 #### F5 — Required external access provable
 
@@ -322,7 +381,7 @@ system, and never invent or ask for credentials inline.
 
 ## Execution
 
-1. Parse `$ARGUMENTS`. If it's an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains `status:ready`) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec.
+1. Parse `$ARGUMENTS`. Resolve `READY_ROLE` from merged `github.labels.build.ready` config (default `status:ready`). If the input is an issue ref, fetch via `gh issue view --json` and derive the spec fields — including `build_ready` (label set contains the resolved `READY_ROLE`, not a hard-coded label) and `child_refs` (native sub-issues plus body task-list / `Blocked by #<n>` parentage, resolved as in `lisa-github-read-issue`) so S15 can classify the issue. Otherwise parse the YAML spec and preserve the proposed `build_ready` value for S15/F4 normalization.
 2. Confirm `gh auth status` succeeds before any feasibility gate runs.
 3. Run every Specification gate in order. Collect PASS / FAIL / N/A with a one-line reason.
 4. Unless the caller passed `--spec-only`, run every Feasibility gate.

--- a/tests/unit/strategies/github-validator-f2-f4-contract.test.ts
+++ b/tests/unit/strategies/github-validator-f2-f4-contract.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Contract-text regressions for the GitHub validator contradictions reported
+ * in #1549. The validator is an agent contract, so these assertions verify the
+ * canonical SKILL.md instructions agents follow; they do not execute a
+ * programmatic validator implementation or live GitHub fixture.
+ * @module tests/unit/strategies/github-validator-f2-f4-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const VALIDATOR_PATHS = [
+  "plugins/src/base/skills/lisa-github-validate-issue/SKILL.md",
+  "plugins/lisa/skills/lisa-github-validate-issue/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-github-validate-issue/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-github-validate-issue/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-github-validate-issue/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-github-validate-issue/SKILL.md",
+] as const;
+
+/**
+ * Return one gate section without leaking into the next gate.
+ * @param validator full validator skill text
+ * @param gate gate identifier to extract
+ * @returns markdown for the requested gate
+ */
+const gateSection = (validator: string, gate: "F2" | "F4" | "S15"): string => {
+  const heading = `#### ${gate} —`;
+  const start = validator.indexOf(heading);
+  const end = validator.indexOf("\n#### ", start + heading.length);
+
+  expect(start).toBeGreaterThan(-1);
+  return end === -1 ? validator.slice(start) : validator.slice(start, end);
+};
+
+describe.each(VALIDATOR_PATHS)(
+  "GitHub validator F2/F4 contract (#1549): %s",
+  validatorPath => {
+    const validator = readFileSync(path.resolve(validatorPath), "utf8");
+    const f2 = gateSection(validator, "F2");
+    const f4 = gateSection(validator, "F4");
+    const s15 = gateSection(validator, "S15");
+
+    it("accepts an Epic under a configured PRD parent only in the same-repo GitHub self-host shape", () => {
+      expect(f2).toMatch(
+        /`Epic` \| source GitHub \+ tracker GitHub \+ configured child repo = parent repo \| configured PRD lifecycle label \| \*\*PASS\*\*/
+      );
+      expect(f2).toContain("github.labels.prd");
+      expect(f2).toContain("prd-lifecycle-rollup");
+    });
+
+    it("rejects the PRD-parent exception across repositories or unsupported source shapes", () => {
+      expect(f2).toMatch(
+        /`Epic` \| cross-repository or source\/tracker is not same-repo GitHub \| PRD lifecycle label only \| \*\*FAIL\*\*/
+      );
+      expect(f2).toMatch(
+        /do not infer the exception from label spelling alone/
+      );
+    });
+
+    it("rejects Epic parents that only look like configured PRD lifecycle labels", () => {
+      expect(f2).toMatch(
+        /`Epic` \| permitted self-host shape \| unconfigured `prd-\*` lookalike or `prd-intake-feedback` sentinel only \| \*\*FAIL\*\*/
+      );
+    });
+
+    it("keeps the Sub-task parent allowlist unchanged", () => {
+      expect(f2).toMatch(
+        /`Sub-task` \| any \| `type:Story`, `type:Task`, `type:Bug`, or `type:Improvement` \| \*\*PASS\*\*/
+      );
+      expect(f2).toMatch(
+        /`Sub-task` \| any \| PRD lifecycle label or `type:Epic` only \| \*\*FAIL\*\*/
+      );
+    });
+
+    it("still requires type:Epic for ordinary non-Sub-task children", () => {
+      expect(f2).toMatch(
+        /any other non-Sub-task \| any \| `type:Epic` \| \*\*PASS\*\*/
+      );
+      expect(f2).toMatch(
+        /any other non-Sub-task \| any \| PRD lifecycle label only \| \*\*FAIL\*\*/
+      );
+    });
+
+    it("requires type and priority labels unconditionally", () => {
+      expect(f4).toMatch(/`type:<issue_type>` and `priority:<priority>`/);
+      expect(f4).toMatch(/two labels are unconditional/i);
+    });
+
+    it("allows containers and build_ready:false leaves to omit status", () => {
+      expect(f4).toMatch(/container \| any \| omitted \| \*\*PASS\*\*/);
+      expect(f4).toMatch(/leaf \| `false` \| omitted \| \*\*PASS\*\*/);
+    });
+
+    it("preserves the omitted writer input as default-ready for proposed leaves", () => {
+      expect(f4).toMatch(
+        /proposed leaf spec[^.]*omitted `build_ready` to `true`/i
+      );
+      expect(f4).toMatch(/backward-compatible default-ready behavior/i);
+    });
+
+    it("requires status:ready for build_ready:true leaves", () => {
+      expect(f4).toMatch(
+        /leaf \| `true` \| configured build-ready role \(`status:ready` by default\) \| \*\*PASS\*\*/
+      );
+      expect(f4).toMatch(
+        /leaf \| `true` \| omitted or a different `status:\*` label \| \*\*FAIL\*\*/
+      );
+    });
+
+    it("resolves custom ready labels consistently in input, live parsing, F4, and S15", () => {
+      expect(validator).toMatch(
+        /build_ready: true[^\n]*github\.labels\.build\.ready/
+      );
+      expect(s15).toContain("resolve `READY_ROLE`");
+      expect(s15).toContain("`github.labels.build.ready`");
+      expect(f4).toContain("derive `build_ready`");
+      expect(f4).toContain("S15-resolved");
+      expect(f4).toContain("`READY_ROLE`");
+      expect(validator).toMatch(
+        /derive the spec fields[^\n]*label set contains the resolved `READY_ROLE`, not a hard-coded label/
+      );
+    });
+
+    it("fails a container carrying the configured ready label and renders that label in remediation", () => {
+      expect(s15).toContain('`github.labels.build.ready = "queue:approved"`');
+      expect(s15).toMatch(
+        /container carrying `queue:approved` FAILs S15[^.]*literal `status:ready`/
+      );
+      expect(s15).toContain("Move <READY_ROLE> off this container");
+    });
+
+    it("retains S15 as the container build-ready prohibition", () => {
+      expect(f4).toMatch(
+        /container carrying the build-ready role still FAILs S15/
+      );
+    });
+  }
+);


### PR DESCRIPTION
## Summary

- accept same-repository GitHub PRD parents for Epic children while preserving every neighboring F2 rejection
- make F4 and S15 honor leaf-only lifecycle, backlog leaves, and configured build-ready labels consistently
- regenerate Claude, Codex, Cursor, OpenCode-source, Antigravity, and Copilot contract surfaces with parity tests

Closes #1549

## Test plan

- bunx vitest run tests/unit/strategies/github-validator-f2-f4-contract.test.ts
- bunx vitest run tests/unit/strategies/build-ready-control.test.ts tests/unit/strategies/leaf-only-build-ready.test.ts tests/unit/strategies/github-validator-f2-f4-contract.test.ts
- bun run lint && bun run lint:slow && bun run typecheck
- bun run test:unit && bun run test:integration
- bun run build && bun run check:plugins
- pre-push security audit, dead-code check, 4,310 coverage tests, and 129 integration tests

## Verification

Independent verifier: PASS, 10/10 criteria. Canonical plus five committed agent bodies share SHA-256 ac735e1c933c2da38f2d23e18fb5a2b784969bb36ef29e85382b3f98a85af; OpenCode canonical install path was also exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build-readiness validation now supports project-configured ready labels while retaining `status:ready` as the default.
  * Improved handling of Epic/PRD parent relationships and Sub-task hierarchy rules.
  * Validation now allows appropriate container and backlog issues to omit status labels.

* **Bug Fixes**
  * Standardized F2, F4, and S15 validation behavior across supported plugins.
  * Added clearer remediation guidance for invalid build-ready labels.

* **Tests**
  * Added contract tests covering label requirements, hierarchy exceptions, custom ready labels, and build-ready rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->