### PR TITLE
fix(usage-accounting): preserve legacy ledgers

### DIFF
--- a/.lisa/plan-1550.md
+++ b/.lisa/plan-1550.md
@@ -1,0 +1,21 @@
+# Issue #1550 Post-Release Repair Plan
+
+## Outcome
+
+Keep measured-subset usage durable without breaking existing callers or presenting incomplete activity as a complete rollup.
+
+## Repair contract
+
+1. Legacy callers may omit the new measured-subset property; serialization normalizes omission to `null`.
+2. The parser accepts legacy 17-field tokens and the released 2.222.0 middle-field shape.
+3. Canonical rewrites migrate deterministically without dropping entries or emitting `undefined`.
+4. Mixed complete and measured-subset token ledgers retain the measured row but keep complete artifact token rollups unknown.
+5. Token completeness remains independent from trustworthy whole-run cost accounting.
+6. Canonical rules and all supported agent surfaces remain in generated parity.
+
+## Gates
+
+- Focused compatibility and measured-subset tests pass.
+- Typecheck, standard/slow lint, unit, integration, build, and plugin parity pass.
+- Independent reviewer, learner, and verifier return GO/PASS.
+- PR merges and the public npm package passes the unchanged-caller reproduction before #1550 returns to `status:done`.

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -1,25 +1,19 @@
 # Lisa Implement Roster Decision
 
-Work item: `CodySwannGT/lisa#1549`
+Work item: `CodySwannGT/lisa#1550` (post-release compatibility repair)
 
 Runtime delegation inventory:
 
-`INCLUDE - general-purpose collaboration agent - Codex exposes no enumerated specialist agent types; this is the only available delegation type and will be constrained by role-specific prompts.`
+`INCLUDE - general-purpose collaboration agent - Codex exposes one delegation type, constrained here by fresh role-specific prompts.`
 
-Runtime gap: Codex's collaboration surface does not expose separate built-in `Explore`, reproducer, implementer, reviewer, learner, verifier, release, or ops agent types. The general-purpose type is therefore assigned the following bounded specialist roles for this issue:
+`INCLUDE - input resolver - Confirmed #1550 was initially ready and later reopened after empirical npm verification.`
 
-`INCLUDE - input-resolver / Explore-equivalent - Completed the required live ticket, hierarchy, access, duplicate, and base-branch readiness pass.`
+`INCLUDE - reproducer and parity mapper - Reproduced the original gap, mapped canonical/generated surfaces, and now pins the released backward-compatibility regression.`
 
-`INCLUDE - reproduction and research specialist - Required to reproduce both F2 and F4 contradictions and inventory the canonical validator, generator parity surfaces, tests, documentation, and history before implementation.`
+`INCLUDE - implementer - Repairs the released 2.222.0 compatibility failure and mixed-rollup semantics from clean main.`
 
-`INCLUDE - implementation specialist - Required to correct the canonical contract and every generated coding-agent surface with focused regression coverage.`
+`INCLUDE - reviewer and learner - Independently gate contract correctness, source compatibility, and maintainability.`
 
-`INCLUDE - review specialist - Required independent contract, parity, scope, and regression review.`
-
-`INCLUDE - learner specialist - Required independent review of task learnings before team shutdown.`
-
-`INCLUDE - verification specialist - Required independent empirical validation and machine-readable verdict.`
-
-`INCLUDE - release and ops specialist - Required PR, CI, merge, package-release, and post-release health monitoring.`
+`INCLUDE - verifier and release operations - Validate local behavior, merged CI, release, and public npm artifact before terminal closeout.`
 
 No available delegation type is excluded.

--- a/plugins/lisa-agy/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/plugins/lisa-copilot/rules/eager/usage-accounting.md
+++ b/plugins/lisa-copilot/rules/eager/usage-accounting.md
@@ -17,7 +17,7 @@ Every artifact with inline body content gets exactly one section:
 Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is the stable dedupe key — rewriting the same logical run with the same `entry_id` updates in place; a different run gets a different `entry_id`.
 
 - **`source`**: `observed` (runtime supplied) / `estimated` (derived from trustworthy metadata + pricing contract) / `measured-subset` (a trustworthy subtotal exists, but the complete run total is unknown) / `unavailable`.
-- **`measured_subset_tokens`**: measured subtotal for `measured-subset` entries only. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
+- **`measured_subset_tokens`**: optional measured subtotal for `measured-subset` entries only. Omission is normalized to `null` for backward-compatible callers. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
 - **`pricing_status`**: same trinary plus `missing` (cost not known but should be).
 - **Absence ≠ zero.** `null` means unknown; `0` means explicitly zero. Always write the entry — never silently omit.
 - Do NOT replace observed counts with estimates.
@@ -26,4 +26,8 @@ Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is th
 
 Container artifacts (Epic, PRD, etc.) roll up usage from their direct children. Roll-up is recursive — a parent's `## Lisa Usage` aggregates its descendants' direct entries. Re-writes are idempotent: re-running an intake or lifecycle skill must not duplicate entries.
 
-Full schema (all 18 fields, pricing semantics, rollup math, idempotent-rewrite rules): [reference/usage-accounting.md](../reference/usage-accounting.md).
+Measured-child incompleteness is durable across ordinary rewrites through the optional
+`lisa:usage-rollup-token-status` extension. Do not infer completeness merely because a rewrite did
+not re-fetch child ledgers.
+
+Full schema (backward-compatible 17-field primary marker, correlated measured-subset extension, pricing semantics, rollup math, idempotent-migration rules): [reference/usage-accounting.md](../reference/usage-accounting.md).

--- a/plugins/lisa-copilot/rules/reference/usage-accounting.md
+++ b/plugins/lisa-copilot/rules/reference/usage-accounting.md
@@ -31,7 +31,7 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 | `output_tokens` | Output/completion tokens, or `null` when unavailable. |
 | `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
 | `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
-| `measured_subset_tokens` | Trustworthy measured subtotal for a known subset of the run, or `null`. |
+| `measured_subset_tokens` | Optional trustworthy measured subtotal for a known subset of the run. Omission is normalized to `null` so callers written before this field remain source-compatible. |
 | `cost` | Observed or estimated cost for this entry, or `null`. |
 | `currency` | ISO currency code when `cost` is known, otherwise `null`. |
 | `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
@@ -69,16 +69,34 @@ total.
 - `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
 
 Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+Token completeness and cost trust are independent: a `measured-subset` entry may still carry an
+observed trustworthy whole-run cost. Token rollups remain unknown, but that cost participates in
+cost rollups under the normal pricing and currency rules.
 
 ## Machine-readable tokens
 
-Every visible direct entry row ends with exactly one machine-readable token:
+Every visible direct entry row contains the backward-compatible 17-field primary token:
 
 ```text
-<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> measured_subset_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
+The row immediately follows it with a correlated measured-subset extension. Writers serialize an
+omitted value as `null` instead of `undefined`:
+
+```text
+<!-- lisa:usage-entry-measured-subset entry_id=<id> measured_subset_tokens=<n|null> -->
+```
+
+The primary field order is fixed and deliberately matches the pre-measured-subset contract so
+legacy 17-field readers continue to enumerate entries. Current readers correlate the extension by
+its percent-encoded `entry_id`. They also accept the `@codyswann/lisa@2.222.0` transitional marker,
+which placed `measured_subset_tokens` between `total_tokens` and `cost`, and migrate it to the
+primary-plus-extension layout on rewrite. Only that transitional additive field accepts the literal
+`undefined` emitted by an older caller and normalizes it to `null`; established numeric fields
+remain strict. String fields are percent-encoded before rendering and decoded after parsing, so
+whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the
+token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -90,6 +108,23 @@ Every managed section also ends with exactly one rollup token:
 - `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
+
+If a direct entry or freshly resolved child entry is `measured-subset`, the corresponding token
+scope and combined `total_tokens` are `null`; a measured subtotal is never added to complete token
+counts. Other established nullable-entry behavior is unchanged. Cost rollups are computed
+independently, so a trustworthy whole-run cost is not discarded merely because token completeness
+is unknown.
+
+When freshly resolved child work contains a measured subset, the primary rollup token is followed
+by this optional backward-compatible extension:
+
+```text
+<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->
+```
+
+The extension preserves child-token incompleteness across ordinary direct-entry rewrites that do
+not resolve children again. It is omitted when child token totals are not known to be incomplete,
+so legacy rollup objects and readers retain their established shape.
 
 The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
@@ -143,7 +178,9 @@ The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Sto
 - Recompute the entire section on every write; never append ad hoc rows.
 - Sort direct entries deterministically by `(flow, run_id, entry_id)`.
 - Preserve existing entries with unchanged `entry_id` and refreshed field values.
-- Re-running with the same logical entry set must produce byte-identical output.
+- Re-running with the same logical entry set must produce byte-identical output. Rewriting a legacy
+  primary-only marker or the 2.222.0 transitional marker migrates once to the canonical
+  primary-plus-extension layout; subsequent rewrites are byte-identical.
 - Do not include timestamps in the section preamble or token lines.
 
 Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/plugins/lisa-copilot/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/plugins/lisa-cursor/rules/usage-accounting-reference.mdc
+++ b/plugins/lisa-cursor/rules/usage-accounting-reference.mdc
@@ -36,7 +36,7 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 | `output_tokens` | Output/completion tokens, or `null` when unavailable. |
 | `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
 | `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
-| `measured_subset_tokens` | Trustworthy measured subtotal for a known subset of the run, or `null`. |
+| `measured_subset_tokens` | Optional trustworthy measured subtotal for a known subset of the run. Omission is normalized to `null` so callers written before this field remain source-compatible. |
 | `cost` | Observed or estimated cost for this entry, or `null`. |
 | `currency` | ISO currency code when `cost` is known, otherwise `null`. |
 | `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
@@ -74,16 +74,34 @@ total.
 - `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
 
 Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+Token completeness and cost trust are independent: a `measured-subset` entry may still carry an
+observed trustworthy whole-run cost. Token rollups remain unknown, but that cost participates in
+cost rollups under the normal pricing and currency rules.
 
 ## Machine-readable tokens
 
-Every visible direct entry row ends with exactly one machine-readable token:
+Every visible direct entry row contains the backward-compatible 17-field primary token:
 
 ```text
-<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> measured_subset_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
+The row immediately follows it with a correlated measured-subset extension. Writers serialize an
+omitted value as `null` instead of `undefined`:
+
+```text
+<!-- lisa:usage-entry-measured-subset entry_id=<id> measured_subset_tokens=<n|null> -->
+```
+
+The primary field order is fixed and deliberately matches the pre-measured-subset contract so
+legacy 17-field readers continue to enumerate entries. Current readers correlate the extension by
+its percent-encoded `entry_id`. They also accept the `@codyswann/lisa@2.222.0` transitional marker,
+which placed `measured_subset_tokens` between `total_tokens` and `cost`, and migrate it to the
+primary-plus-extension layout on rewrite. Only that transitional additive field accepts the literal
+`undefined` emitted by an older caller and normalizes it to `null`; established numeric fields
+remain strict. String fields are percent-encoded before rendering and decoded after parsing, so
+whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the
+token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -95,6 +113,23 @@ Every managed section also ends with exactly one rollup token:
 - `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
+
+If a direct entry or freshly resolved child entry is `measured-subset`, the corresponding token
+scope and combined `total_tokens` are `null`; a measured subtotal is never added to complete token
+counts. Other established nullable-entry behavior is unchanged. Cost rollups are computed
+independently, so a trustworthy whole-run cost is not discarded merely because token completeness
+is unknown.
+
+When freshly resolved child work contains a measured subset, the primary rollup token is followed
+by this optional backward-compatible extension:
+
+```text
+<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->
+```
+
+The extension preserves child-token incompleteness across ordinary direct-entry rewrites that do
+not resolve children again. It is omitted when child token totals are not known to be incomplete,
+so legacy rollup objects and readers retain their established shape.
 
 The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
@@ -148,7 +183,9 @@ The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Sto
 - Recompute the entire section on every write; never append ad hoc rows.
 - Sort direct entries deterministically by `(flow, run_id, entry_id)`.
 - Preserve existing entries with unchanged `entry_id` and refreshed field values.
-- Re-running with the same logical entry set must produce byte-identical output.
+- Re-running with the same logical entry set must produce byte-identical output. Rewriting a legacy
+  primary-only marker or the 2.222.0 transitional marker migrates once to the canonical
+  primary-plus-extension layout; subsequent rewrites are byte-identical.
 - Do not include timestamps in the section preamble or token lines.
 
 Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/plugins/lisa-cursor/rules/usage-accounting.mdc
+++ b/plugins/lisa-cursor/rules/usage-accounting.mdc
@@ -22,7 +22,7 @@ Every artifact with inline body content gets exactly one section:
 Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is the stable dedupe key — rewriting the same logical run with the same `entry_id` updates in place; a different run gets a different `entry_id`.
 
 - **`source`**: `observed` (runtime supplied) / `estimated` (derived from trustworthy metadata + pricing contract) / `measured-subset` (a trustworthy subtotal exists, but the complete run total is unknown) / `unavailable`.
-- **`measured_subset_tokens`**: measured subtotal for `measured-subset` entries only. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
+- **`measured_subset_tokens`**: optional measured subtotal for `measured-subset` entries only. Omission is normalized to `null` for backward-compatible callers. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
 - **`pricing_status`**: same trinary plus `missing` (cost not known but should be).
 - **Absence ≠ zero.** `null` means unknown; `0` means explicitly zero. Always write the entry — never silently omit.
 - Do NOT replace observed counts with estimates.
@@ -31,4 +31,8 @@ Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is th
 
 Container artifacts (Epic, PRD, etc.) roll up usage from their direct children. Roll-up is recursive — a parent's `## Lisa Usage` aggregates its descendants' direct entries. Re-writes are idempotent: re-running an intake or lifecycle skill must not duplicate entries.
 
-Full schema (all 18 fields, pricing semantics, rollup math, idempotent-rewrite rules): [reference/usage-accounting.md](usage-accounting-reference.mdc).
+Measured-child incompleteness is durable across ordinary rewrites through the optional
+`lisa:usage-rollup-token-status` extension. Do not infer completeness merely because a rewrite did
+not re-fetch child ledgers.
+
+Full schema (backward-compatible 17-field primary marker, correlated measured-subset extension, pricing semantics, rollup math, idempotent-migration rules): [reference/usage-accounting.md](usage-accounting-reference.mdc).

--- a/plugins/lisa-cursor/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/plugins/lisa/.codex-plugin/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/plugins/lisa/rules/eager/usage-accounting.md
+++ b/plugins/lisa/rules/eager/usage-accounting.md
@@ -17,7 +17,7 @@ Every artifact with inline body content gets exactly one section:
 Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is the stable dedupe key — rewriting the same logical run with the same `entry_id` updates in place; a different run gets a different `entry_id`.
 
 - **`source`**: `observed` (runtime supplied) / `estimated` (derived from trustworthy metadata + pricing contract) / `measured-subset` (a trustworthy subtotal exists, but the complete run total is unknown) / `unavailable`.
-- **`measured_subset_tokens`**: measured subtotal for `measured-subset` entries only. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
+- **`measured_subset_tokens`**: optional measured subtotal for `measured-subset` entries only. Omission is normalized to `null` for backward-compatible callers. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
 - **`pricing_status`**: same trinary plus `missing` (cost not known but should be).
 - **Absence ≠ zero.** `null` means unknown; `0` means explicitly zero. Always write the entry — never silently omit.
 - Do NOT replace observed counts with estimates.
@@ -26,4 +26,8 @@ Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is th
 
 Container artifacts (Epic, PRD, etc.) roll up usage from their direct children. Roll-up is recursive — a parent's `## Lisa Usage` aggregates its descendants' direct entries. Re-writes are idempotent: re-running an intake or lifecycle skill must not duplicate entries.
 
-Full schema (all 18 fields, pricing semantics, rollup math, idempotent-rewrite rules): [reference/usage-accounting.md](../reference/usage-accounting.md).
+Measured-child incompleteness is durable across ordinary rewrites through the optional
+`lisa:usage-rollup-token-status` extension. Do not infer completeness merely because a rewrite did
+not re-fetch child ledgers.
+
+Full schema (backward-compatible 17-field primary marker, correlated measured-subset extension, pricing semantics, rollup math, idempotent-migration rules): [reference/usage-accounting.md](../reference/usage-accounting.md).

--- a/plugins/lisa/rules/reference/usage-accounting.md
+++ b/plugins/lisa/rules/reference/usage-accounting.md
@@ -31,7 +31,7 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 | `output_tokens` | Output/completion tokens, or `null` when unavailable. |
 | `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
 | `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
-| `measured_subset_tokens` | Trustworthy measured subtotal for a known subset of the run, or `null`. |
+| `measured_subset_tokens` | Optional trustworthy measured subtotal for a known subset of the run. Omission is normalized to `null` so callers written before this field remain source-compatible. |
 | `cost` | Observed or estimated cost for this entry, or `null`. |
 | `currency` | ISO currency code when `cost` is known, otherwise `null`. |
 | `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
@@ -69,16 +69,34 @@ total.
 - `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
 
 Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+Token completeness and cost trust are independent: a `measured-subset` entry may still carry an
+observed trustworthy whole-run cost. Token rollups remain unknown, but that cost participates in
+cost rollups under the normal pricing and currency rules.
 
 ## Machine-readable tokens
 
-Every visible direct entry row ends with exactly one machine-readable token:
+Every visible direct entry row contains the backward-compatible 17-field primary token:
 
 ```text
-<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> measured_subset_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
+The row immediately follows it with a correlated measured-subset extension. Writers serialize an
+omitted value as `null` instead of `undefined`:
+
+```text
+<!-- lisa:usage-entry-measured-subset entry_id=<id> measured_subset_tokens=<n|null> -->
+```
+
+The primary field order is fixed and deliberately matches the pre-measured-subset contract so
+legacy 17-field readers continue to enumerate entries. Current readers correlate the extension by
+its percent-encoded `entry_id`. They also accept the `@codyswann/lisa@2.222.0` transitional marker,
+which placed `measured_subset_tokens` between `total_tokens` and `cost`, and migrate it to the
+primary-plus-extension layout on rewrite. Only that transitional additive field accepts the literal
+`undefined` emitted by an older caller and normalizes it to `null`; established numeric fields
+remain strict. String fields are percent-encoded before rendering and decoded after parsing, so
+whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the
+token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -90,6 +108,23 @@ Every managed section also ends with exactly one rollup token:
 - `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
+
+If a direct entry or freshly resolved child entry is `measured-subset`, the corresponding token
+scope and combined `total_tokens` are `null`; a measured subtotal is never added to complete token
+counts. Other established nullable-entry behavior is unchanged. Cost rollups are computed
+independently, so a trustworthy whole-run cost is not discarded merely because token completeness
+is unknown.
+
+When freshly resolved child work contains a measured subset, the primary rollup token is followed
+by this optional backward-compatible extension:
+
+```text
+<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->
+```
+
+The extension preserves child-token incompleteness across ordinary direct-entry rewrites that do
+not resolve children again. It is omitted when child token totals are not known to be incomplete,
+so legacy rollup objects and readers retain their established shape.
 
 The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
@@ -143,7 +178,9 @@ The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Sto
 - Recompute the entire section on every write; never append ad hoc rows.
 - Sort direct entries deterministically by `(flow, run_id, entry_id)`.
 - Preserve existing entries with unchanged `entry_id` and refreshed field values.
-- Re-running with the same logical entry set must produce byte-identical output.
+- Re-running with the same logical entry set must produce byte-identical output. Rewriting a legacy
+  primary-only marker or the 2.222.0 transitional marker migrates once to the canonical
+  primary-plus-extension layout; subsequent rewrites are byte-identical.
 - Do not include timestamps in the section preamble or token lines.
 
 Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/plugins/lisa/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/lisa/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/plugins/src/base/rules/eager/usage-accounting.md
+++ b/plugins/src/base/rules/eager/usage-accounting.md
@@ -17,7 +17,7 @@ Every artifact with inline body content gets exactly one section:
 Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is the stable dedupe key — rewriting the same logical run with the same `entry_id` updates in place; a different run gets a different `entry_id`.
 
 - **`source`**: `observed` (runtime supplied) / `estimated` (derived from trustworthy metadata + pricing contract) / `measured-subset` (a trustworthy subtotal exists, but the complete run total is unknown) / `unavailable`.
-- **`measured_subset_tokens`**: measured subtotal for `measured-subset` entries only. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
+- **`measured_subset_tokens`**: optional measured subtotal for `measured-subset` entries only. Omission is normalized to `null` for backward-compatible callers. Keep `total_tokens = null` so rollups do not treat a subset as a complete total.
 - **`pricing_status`**: same trinary plus `missing` (cost not known but should be).
 - **Absence ≠ zero.** `null` means unknown; `0` means explicitly zero. Always write the entry — never silently omit.
 - Do NOT replace observed counts with estimates.
@@ -26,4 +26,8 @@ Each direct entry records ONE logical Lisa run on ONE artifact. `entry_id` is th
 
 Container artifacts (Epic, PRD, etc.) roll up usage from their direct children. Roll-up is recursive — a parent's `## Lisa Usage` aggregates its descendants' direct entries. Re-writes are idempotent: re-running an intake or lifecycle skill must not duplicate entries.
 
-Full schema (all 18 fields, pricing semantics, rollup math, idempotent-rewrite rules): [reference/usage-accounting.md](../reference/usage-accounting.md).
+Measured-child incompleteness is durable across ordinary rewrites through the optional
+`lisa:usage-rollup-token-status` extension. Do not infer completeness merely because a rewrite did
+not re-fetch child ledgers.
+
+Full schema (backward-compatible 17-field primary marker, correlated measured-subset extension, pricing semantics, rollup math, idempotent-migration rules): [reference/usage-accounting.md](../reference/usage-accounting.md).

--- a/plugins/src/base/rules/reference/usage-accounting.md
+++ b/plugins/src/base/rules/reference/usage-accounting.md
@@ -31,7 +31,7 @@ Each direct usage entry records one logical Lisa run or sub-run on one artifact.
 | `output_tokens` | Output/completion tokens, or `null` when unavailable. |
 | `reasoning_tokens` | Reasoning/internal tokens, or `null` when unavailable/not exposed. |
 | `total_tokens` | Total trustworthy tokens for the entry, or `null`. |
-| `measured_subset_tokens` | Trustworthy measured subtotal for a known subset of the run, or `null`. |
+| `measured_subset_tokens` | Optional trustworthy measured subtotal for a known subset of the run. Omission is normalized to `null` so callers written before this field remain source-compatible. |
 | `cost` | Observed or estimated cost for this entry, or `null`. |
 | `currency` | ISO currency code when `cost` is known, otherwise `null`. |
 | `pricing_status` | `observed`, `estimated`, `missing`, or `unavailable`. |
@@ -69,16 +69,34 @@ total.
 - `unavailable`: the runtime exposed neither trustworthy cost nor enough trustworthy token data to estimate cost.
 
 Runtime-observed cost always wins over estimates. Estimated cost never overwrites an observed value. Missing pricing preserves token counts and a `null` cost.
+Token completeness and cost trust are independent: a `measured-subset` entry may still carry an
+observed trustworthy whole-run cost. Token rollups remain unknown, but that cost participates in
+cost rollups under the normal pricing and currency rules.
 
 ## Machine-readable tokens
 
-Every visible direct entry row ends with exactly one machine-readable token:
+Every visible direct entry row contains the backward-compatible 17-field primary token:
 
 ```text
-<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> measured_subset_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
+<!-- lisa:usage-entry entry_id=<id> flow=<flow> run_id=<run-id> provider=<provider> model=<model> source=<source> input_tokens=<n|null> cached_input_tokens=<n|null> output_tokens=<n|null> reasoning_tokens=<n|null> total_tokens=<n|null> cost=<decimal|null> currency=<code|null> pricing_status=<status> pricing_source=<ref|null> artifact_ref=<ref> parent_artifact_ref=<ref-or-empty> -->
 ```
 
-Field order is fixed. A reader parses the usage ledger by matching `<!-- lisa:usage-entry ` lines only; it never needs to scrape prose or table cell positions. String fields are percent-encoded before rendering and decoded after parsing, so whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the token.
+The row immediately follows it with a correlated measured-subset extension. Writers serialize an
+omitted value as `null` instead of `undefined`:
+
+```text
+<!-- lisa:usage-entry-measured-subset entry_id=<id> measured_subset_tokens=<n|null> -->
+```
+
+The primary field order is fixed and deliberately matches the pre-measured-subset contract so
+legacy 17-field readers continue to enumerate entries. Current readers correlate the extension by
+its percent-encoded `entry_id`. They also accept the `@codyswann/lisa@2.222.0` transitional marker,
+which placed `measured_subset_tokens` between `total_tokens` and `cost`, and migrate it to the
+primary-plus-extension layout on rewrite. Only that transitional additive field accepts the literal
+`undefined` emitted by an older caller and normalizes it to `null`; established numeric fields
+remain strict. String fields are percent-encoded before rendering and decoded after parsing, so
+whitespace, commas, and HTML comment terminators inside source values cannot split or truncate the
+token.
 
 Every managed section also ends with exactly one rollup token:
 
@@ -90,6 +108,23 @@ Every managed section also ends with exactly one rollup token:
 - `child_entry_ids` enumerates deduped descendant entry ids included in the rollup.
 - `child_refs` enumerates the child artifacts consulted for the rollup.
 - `total_*` fields equal direct plus child totals over the deduped entry set.
+
+If a direct entry or freshly resolved child entry is `measured-subset`, the corresponding token
+scope and combined `total_tokens` are `null`; a measured subtotal is never added to complete token
+counts. Other established nullable-entry behavior is unchanged. Cost rollups are computed
+independently, so a trustworthy whole-run cost is not discarded merely because token completeness
+is unknown.
+
+When freshly resolved child work contains a measured subset, the primary rollup token is followed
+by this optional backward-compatible extension:
+
+```text
+<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->
+```
+
+The extension preserves child-token incompleteness across ordinary direct-entry rewrites that do
+not resolve children again. It is omitted when child token totals are not known to be incomplete,
+so legacy rollup objects and readers retain their established shape.
 
 The rollup token is the machine-readable summary. The visible rollup table mirrors it for humans. List fields are comma-delimited after encoding each item independently; commas inside an item are encoded as data, not treated as separators.
 
@@ -143,7 +178,9 @@ The rollup contract is additive across the hierarchy: PRDs may roll up Epics/Sto
 - Recompute the entire section on every write; never append ad hoc rows.
 - Sort direct entries deterministically by `(flow, run_id, entry_id)`.
 - Preserve existing entries with unchanged `entry_id` and refreshed field values.
-- Re-running with the same logical entry set must produce byte-identical output.
+- Re-running with the same logical entry set must produce byte-identical output. Rewriting a legacy
+  primary-only marker or the 2.222.0 transitional marker migrates once to the canonical
+  primary-plus-extension layout; subsequent rewrites are byte-identical.
 - Do not include timestamps in the section preamble or token lines.
 
 Idempotency is enforced by `entry_id` for direct entries and by the fixed rollup token field order for totals.

--- a/plugins/src/base/skills/lisa-usage-accounting/SKILL.md
+++ b/plugins/src/base/skills/lisa-usage-accounting/SKILL.md
@@ -69,7 +69,10 @@ fields.
 
 When the runtime exposes only a trustworthy subtotal, callers MUST use `source: measured-subset`,
 write the subtotal to `measured_subset_tokens`, and leave `total_tokens: null`. Do not coerce a
-known subset into `total_tokens`; rollups use `total_tokens` only for complete totals.
+known subset into `total_tokens`; rollups use `total_tokens` only for complete totals. The
+`measured_subset_tokens` field is optional for backward compatibility with callers that construct
+ordinary observed, estimated, or unavailable entries; the shared serializer normalizes omission
+to `null`. A trustworthy whole-run cost remains valid independently of incomplete token telemetry.
 
 ## Return shape
 
@@ -168,6 +171,11 @@ failures into a generic "usage update failed."
   canonical `usage-accounting` rule.
 - Never append a second `## Lisa Usage` section or a second managed usage comment.
 - Never treat missing usage as zero. Callers must record explicit `source: unavailable` entries.
+- Never add a measured subset to complete token totals. A mixed complete-plus-measured-subset
+  direct or child scope has `null` token rollups, while trustworthy whole-run cost rolls up
+  independently.
+- Never discard the optional child-token incompleteness state parsed from an existing rollup when
+  `child_refs` were not refreshed. Preserve it through ordinary direct-entry rewrites.
 - Never skip rollup dedupe. Child totals are keyed by stable `entry_id`, not by child ref count.
 - Never silently drop to comments. Return `outcome: comment-fallback` so the caller can surface the
   writable surface that actually holds the ledger.

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -701,12 +701,20 @@ export function upsertLisaUsageSection(
 ): string {
   const parsed = parseLisaUsageSection(document);
   const mergedEntries = mergeLisaUsageEntries(parsed.entries, input.entries);
+  const previousRollup =
+    input.childArtifacts === undefined &&
+    input.rollup !== null &&
+    input.rollup !== undefined &&
+    input.rollup.childTokensIncomplete === undefined &&
+    parsed.rollup?.childTokensIncomplete === true
+      ? { ...input.rollup, childTokensIncomplete: true }
+      : (input.rollup ?? parsed.rollup);
   const rollup =
     mergedEntries.length === 0 && input.rollup
-      ? input.rollup
+      ? (previousRollup ?? input.rollup)
       : createLisaUsageRollup(
           mergedEntries,
-          input.rollup ?? parsed.rollup,
+          previousRollup,
           input.childArtifacts
         );
   const usageSection = renderLisaUsageSection({

--- a/src/utils/usage-accounting.ts
+++ b/src/utils/usage-accounting.ts
@@ -16,7 +16,7 @@ export interface LisaUsageEntry {
   entryId: string;
   flow: string;
   inputTokens: number | null;
-  measuredSubsetTokens: number | null;
+  measuredSubsetTokens?: number | null;
   model: string;
   outputTokens: number | null;
   parentArtifactRef: string | null;
@@ -38,6 +38,7 @@ export interface LisaUsageRollup {
   childEntryIds: readonly string[];
   childRefs: readonly string[];
   childTokens: number | null;
+  childTokensIncomplete?: boolean;
   currency: string | null;
   directCost: number | null;
   directEntryIds: readonly string[];
@@ -63,11 +64,22 @@ export interface ParsedLisaUsageSection {
   rollup: LisaUsageRollup | null;
 }
 
-const ENTRY_PATTERN =
-  /<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=(\S+) provider=(\S+) model=(\S+) source=(\S+) input_tokens=(\S+) cached_input_tokens=(\S+) output_tokens=(\S+) reasoning_tokens=(\S+) total_tokens=(\S+) (?:measured_subset_tokens=(\S+) )?cost=(\S+) currency=(\S+) pricing_status=(\S+) pricing_source=(\S+) artifact_ref=(\S+) parent_artifact_ref=(\S*) -->/g;
+const ENTRY_TOKEN_PATTERN = /<!-- lisa:usage-entry [^\r\n]*? -->/g;
+
+const LEGACY_ENTRY_PATTERN =
+  /^<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=(\S+) provider=(\S+) model=(\S+) source=(\S+) input_tokens=(\S+) cached_input_tokens=(\S+) output_tokens=(\S+) reasoning_tokens=(\S+) total_tokens=(\S+) cost=(\S+) currency=(\S+) pricing_status=(\S+) pricing_source=(\S+) artifact_ref=(\S+) parent_artifact_ref=(\S*) -->$/;
+
+const RELEASED_MIDDLE_FIELD_ENTRY_PATTERN =
+  /^<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=(\S+) provider=(\S+) model=(\S+) source=(\S+) input_tokens=(\S+) cached_input_tokens=(\S+) output_tokens=(\S+) reasoning_tokens=(\S+) total_tokens=(\S+) measured_subset_tokens=(\S+) cost=(\S+) currency=(\S+) pricing_status=(\S+) pricing_source=(\S+) artifact_ref=(\S+) parent_artifact_ref=(\S*) -->$/;
+
+const MEASURED_SUBSET_PATTERN =
+  /<!-- lisa:usage-entry-measured-subset entry_id=(\S+) measured_subset_tokens=(\S+) -->/g;
 
 const ROLLUP_PATTERN =
   /<!-- lisa:usage-rollup direct_entry_ids=(\S*) child_entry_ids=(\S*) child_refs=(\S*) direct_tokens=(\S+) child_tokens=(\S+) total_tokens=(\S+) direct_cost=(\S+) child_cost=(\S+) total_cost=(\S+) currency=(\S+)(?: child_currency=(\S+))? -->/;
+
+const ROLLUP_TOKEN_STATUS_PATTERN =
+  /<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->/;
 
 const MIXED_CURRENCY = "mixed";
 
@@ -88,6 +100,18 @@ function parseNullableNumber(value: string): number | null {
   }
 
   return parsed;
+}
+
+/**
+ * Parse the additive field from the published 2.222.0 marker. Legacy callers
+ * could serialize an omitted property as the literal `undefined`; no other
+ * numeric field receives this compatibility exception.
+ *
+ * @param value Transitional measured-subset token value.
+ * @returns The parsed subtotal, or null for the published undefined omission.
+ */
+function parseReleasedMeasuredSubset(value: string): number | null {
+  return value === "undefined" ? null : parseNullableNumber(value);
 }
 
 /**
@@ -184,6 +208,19 @@ function sumNullable(values: readonly (number | null)[]): number | null {
 }
 
 /**
+ * Detect an entry whose recorded count is explicitly only part of a run.
+ *
+ * @param entry Usage entry to inspect.
+ * @returns Whether token rollups must remain incomplete for this entry.
+ */
+function hasMeasuredSubset(entry: LisaUsageEntry): boolean {
+  return (
+    entry.source === "measured-subset" ||
+    (entry.measuredSubsetTokens ?? null) !== null
+  );
+}
+
+/**
  * Resolve the only currency represented by present cost values.
  *
  * @param entries Usage entries to inspect.
@@ -277,7 +314,7 @@ function formatEntryTokens(entry: LisaUsageEntry): string {
     return formatTokens(entry.totalTokens);
   }
 
-  return entry.measuredSubsetTokens === null
+  return (entry.measuredSubsetTokens ?? null) === null
     ? "null"
     : `${entry.measuredSubsetTokens} measured subset`;
 }
@@ -342,6 +379,7 @@ function resolveChildRollupParts(
   childEntryIds: readonly string[];
   childRefs: readonly string[];
   childTokens: number | null;
+  childTokensIncomplete: boolean;
 } {
   if (childArtifacts !== undefined) {
     const collected = collectLisaUsageChildArtifacts(
@@ -350,11 +388,15 @@ function resolveChildRollupParts(
     );
     const deduped = collected.childEntries;
     const childCurrency = resolveDirectCostCurrency(deduped);
+    const childTokensIncomplete = deduped.some(hasMeasuredSubset);
     const rawChildCost = sumNullableDecimals(deduped.map(entry => entry.cost));
     return {
       childEntryIds: deduped.map(entry => entry.entryId),
       childRefs: collected.childRefs,
-      childTokens: sumNullable(deduped.map(entry => entry.totalTokens)),
+      childTokens: childTokensIncomplete
+        ? null
+        : sumNullable(deduped.map(entry => entry.totalTokens)),
+      childTokensIncomplete,
       childCurrency,
       childCost: childCurrency === MIXED_CURRENCY ? null : rawChildCost,
     };
@@ -374,6 +416,7 @@ function resolveChildRollupParts(
     childEntryIds: previousRollup?.childEntryIds ?? [],
     childRefs: previousRollup?.childRefs ?? [],
     childTokens: previousRollup?.childTokens ?? null,
+    childTokensIncomplete: previousRollup?.childTokensIncomplete ?? false,
     childCurrency,
     childCost: childCurrency === MIXED_CURRENCY ? null : rawChildCost,
   };
@@ -425,20 +468,31 @@ export function createLisaUsageRollup(
   childArtifacts?: readonly LisaUsageChildArtifact[]
 ): LisaUsageRollup {
   const directEntryIds = entries.map(entry => entry.entryId);
-  const directTokens = sumNullable(entries.map(entry => entry.totalTokens));
+  const directTokensIncomplete = entries.some(hasMeasuredSubset);
+  const directTokens = directTokensIncomplete
+    ? null
+    : sumNullable(entries.map(entry => entry.totalTokens));
   const directCurrency = resolveDirectCostCurrency(entries);
   const directCost =
     directCurrency === MIXED_CURRENCY
       ? null
       : sumNullableDecimals(entries.map(entry => entry.cost));
 
-  const { childEntryIds, childRefs, childTokens, childCurrency, childCost } =
-    resolveChildRollupParts(previousRollup, childArtifacts, directEntryIds);
+  const {
+    childEntryIds,
+    childRefs,
+    childTokens,
+    childTokensIncomplete,
+    childCurrency,
+    childCost,
+  } = resolveChildRollupParts(previousRollup, childArtifacts, directEntryIds);
 
   const totalTokens =
-    directTokens === null && childTokens === null
+    directTokensIncomplete || childTokensIncomplete
       ? null
-      : (directTokens ?? 0) + (childTokens ?? 0);
+      : directTokens === null && childTokens === null
+        ? null
+        : (directTokens ?? 0) + (childTokens ?? 0);
   const currency = resolveRollupCurrency(
     directCurrency,
     childCurrency,
@@ -456,6 +510,7 @@ export function createLisaUsageRollup(
     childRefs,
     directTokens,
     childTokens,
+    ...(childTokensIncomplete ? { childTokensIncomplete: true } : {}),
     totalTokens,
     directCost,
     childCost,
@@ -469,10 +524,12 @@ export function createLisaUsageRollup(
  * Render the machine-readable token for a single direct usage row.
  *
  * @param entry Direct usage entry to serialize.
- * @returns The canonical `lisa:usage-entry` token line.
+ * @returns The legacy-readable primary token plus its measured-subset extension.
  */
 export function renderLisaUsageEntryToken(entry: LisaUsageEntry): string {
-  return `<!-- lisa:usage-entry entry_id=${encodeTokenValue(entry.entryId)} flow=${encodeTokenValue(entry.flow)} run_id=${encodeTokenValue(entry.runId)} provider=${encodeTokenValue(entry.provider)} model=${encodeTokenValue(entry.model)} source=${encodeTokenValue(entry.source)} input_tokens=${renderNullable(entry.inputTokens)} cached_input_tokens=${renderNullable(entry.cachedInputTokens)} output_tokens=${renderNullable(entry.outputTokens)} reasoning_tokens=${renderNullable(entry.reasoningTokens)} total_tokens=${renderNullable(entry.totalTokens)} measured_subset_tokens=${renderNullable(entry.measuredSubsetTokens)} cost=${renderNullable(entry.cost)} currency=${renderNullable(entry.currency)} pricing_status=${encodeTokenValue(entry.pricingStatus)} pricing_source=${renderNullable(entry.pricingSource)} artifact_ref=${encodeTokenValue(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeTokenValue(entry.parentArtifactRef)} -->`;
+  const primaryToken = `<!-- lisa:usage-entry entry_id=${encodeTokenValue(entry.entryId)} flow=${encodeTokenValue(entry.flow)} run_id=${encodeTokenValue(entry.runId)} provider=${encodeTokenValue(entry.provider)} model=${encodeTokenValue(entry.model)} source=${encodeTokenValue(entry.source)} input_tokens=${renderNullable(entry.inputTokens)} cached_input_tokens=${renderNullable(entry.cachedInputTokens)} output_tokens=${renderNullable(entry.outputTokens)} reasoning_tokens=${renderNullable(entry.reasoningTokens)} total_tokens=${renderNullable(entry.totalTokens)} cost=${renderNullable(entry.cost)} currency=${renderNullable(entry.currency)} pricing_status=${encodeTokenValue(entry.pricingStatus)} pricing_source=${renderNullable(entry.pricingSource)} artifact_ref=${encodeTokenValue(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeTokenValue(entry.parentArtifactRef)} -->`;
+  const measuredSubsetToken = `<!-- lisa:usage-entry-measured-subset entry_id=${encodeTokenValue(entry.entryId)} measured_subset_tokens=${renderNullable(entry.measuredSubsetTokens ?? null)} -->`;
+  return `${primaryToken} ${measuredSubsetToken}`;
 }
 
 /**
@@ -482,7 +539,10 @@ export function renderLisaUsageEntryToken(entry: LisaUsageEntry): string {
  * @returns The canonical `lisa:usage-rollup` token line.
  */
 export function renderLisaUsageRollupToken(rollup: LisaUsageRollup): string {
-  return `<!-- lisa:usage-rollup direct_entry_ids=${renderCsv(rollup.directEntryIds)} child_entry_ids=${renderCsv(rollup.childEntryIds)} child_refs=${renderCsv(rollup.childRefs)} direct_tokens=${renderNullable(rollup.directTokens)} child_tokens=${renderNullable(rollup.childTokens)} total_tokens=${renderNullable(rollup.totalTokens)} direct_cost=${renderNullable(rollup.directCost)} child_cost=${renderNullable(rollup.childCost)} total_cost=${renderNullable(rollup.totalCost)} currency=${renderNullable(rollup.currency)} child_currency=${renderNullable(rollup.childCurrency)} -->`;
+  const primaryToken = `<!-- lisa:usage-rollup direct_entry_ids=${renderCsv(rollup.directEntryIds)} child_entry_ids=${renderCsv(rollup.childEntryIds)} child_refs=${renderCsv(rollup.childRefs)} direct_tokens=${renderNullable(rollup.directTokens)} child_tokens=${renderNullable(rollup.childTokens)} total_tokens=${renderNullable(rollup.totalTokens)} direct_cost=${renderNullable(rollup.directCost)} child_cost=${renderNullable(rollup.childCost)} total_cost=${renderNullable(rollup.totalCost)} currency=${renderNullable(rollup.currency)} child_currency=${renderNullable(rollup.childCurrency)} -->`;
+  return rollup.childTokensIncomplete === true
+    ? `${primaryToken} <!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->`
+    : primaryToken;
 }
 
 /**
@@ -522,6 +582,36 @@ export function renderLisaUsageSection(input: {
 }
 
 /**
+ * Parse the managed rollup and its optional token-completeness extension.
+ *
+ * @param section Managed usage section text.
+ * @returns The parsed rollup, or null when the section has no rollup token.
+ */
+function parseLisaUsageRollup(section: string): LisaUsageRollup | null {
+  const match = ROLLUP_PATTERN.exec(section);
+  if (match === null) {
+    return null;
+  }
+
+  return {
+    directEntryIds: parseCsv(match[1] ?? ""),
+    childEntryIds: parseCsv(match[2] ?? ""),
+    childRefs: parseCsv(match[3] ?? ""),
+    directTokens: parseNullableNumber(match[4] ?? ""),
+    childTokens: parseNullableNumber(match[5] ?? ""),
+    ...(ROLLUP_TOKEN_STATUS_PATTERN.test(section)
+      ? { childTokensIncomplete: true }
+      : {}),
+    totalTokens: parseNullableNumber(match[6] ?? ""),
+    directCost: parseNullableNumber(match[7] ?? ""),
+    childCost: parseNullableNumber(match[8] ?? ""),
+    totalCost: parseNullableNumber(match[9] ?? ""),
+    currency: parseNullableString(match[10] ?? ""),
+    childCurrency: parseNullableString(match[11] ?? ""),
+  };
+}
+
+/**
  * Parse the managed usage section out of an artifact body or comment.
  *
  * @param document Artifact markdown to inspect.
@@ -532,46 +622,62 @@ export function parseLisaUsageSection(
 ): ParsedLisaUsageSection {
   const range = findUsageSectionRange(document);
   const section = range ? document.slice(range.start, range.end) : "";
-  const entries = Array.from(section.matchAll(ENTRY_PATTERN), match => ({
-    entryId: decodeTokenValue(match[1] ?? ""),
-    flow: decodeTokenValue(match[2] ?? ""),
-    runId: decodeTokenValue(match[3] ?? ""),
-    provider: decodeTokenValue(match[4] ?? ""),
-    model: decodeTokenValue(match[5] ?? ""),
-    source: decodeTokenValue(match[6] ?? ""),
-    inputTokens: parseNullableNumber(match[7] ?? ""),
-    cachedInputTokens: parseNullableNumber(match[8] ?? ""),
-    outputTokens: parseNullableNumber(match[9] ?? ""),
-    reasoningTokens: parseNullableNumber(match[10] ?? ""),
-    totalTokens: parseNullableNumber(match[11] ?? ""),
-    measuredSubsetTokens:
-      match[12] === undefined ? null : parseNullableNumber(match[12]),
-    cost: parseNullableNumber(match[13] ?? ""),
-    currency: parseNullableString(match[14] ?? ""),
-    pricingStatus: decodeTokenValue(match[15] ?? ""),
-    pricingSource: parseNullableString(match[16] ?? ""),
-    artifactRef: decodeTokenValue(match[17] ?? ""),
-    parentArtifactRef: parseNullableString(match[18] ?? ""),
-  }));
-
-  const rollupMatch = ROLLUP_PATTERN.exec(section);
-  const rollup: LisaUsageRollup | null = rollupMatch
-    ? {
-        directEntryIds: parseCsv(rollupMatch[1] ?? ""),
-        childEntryIds: parseCsv(rollupMatch[2] ?? ""),
-        childRefs: parseCsv(rollupMatch[3] ?? ""),
-        directTokens: parseNullableNumber(rollupMatch[4] ?? ""),
-        childTokens: parseNullableNumber(rollupMatch[5] ?? ""),
-        totalTokens: parseNullableNumber(rollupMatch[6] ?? ""),
-        directCost: parseNullableNumber(rollupMatch[7] ?? ""),
-        childCost: parseNullableNumber(rollupMatch[8] ?? ""),
-        totalCost: parseNullableNumber(rollupMatch[9] ?? ""),
-        currency: parseNullableString(rollupMatch[10] ?? ""),
-        childCurrency: parseNullableString(rollupMatch[11] ?? ""),
+  const measuredSubsets = new Map(
+    Array.from(
+      section.matchAll(MEASURED_SUBSET_PATTERN),
+      match =>
+        [
+          decodeTokenValue(match[1] ?? ""),
+          parseNullableNumber(match[2] ?? ""),
+        ] as const
+    )
+  );
+  const entries = Array.from(
+    section.matchAll(ENTRY_TOKEN_PATTERN),
+    tokenMatch => {
+      const token = tokenMatch[0];
+      const releasedMatch = RELEASED_MIDDLE_FIELD_ENTRY_PATTERN.exec(token);
+      const match = releasedMatch ?? LEGACY_ENTRY_PATTERN.exec(token);
+      if (match === null) {
+        throw new Error(`Invalid Lisa usage entry token: ${token}`);
       }
-    : null;
 
-  return { entries, rollup, range };
+      const releasedFieldOffset = releasedMatch === null ? 0 : 1;
+      const entryId = decodeTokenValue(match[1] ?? "");
+      const embeddedMeasuredSubset =
+        releasedMatch === null
+          ? null
+          : parseReleasedMeasuredSubset(match[12] ?? "");
+      return {
+        entryId,
+        flow: decodeTokenValue(match[2] ?? ""),
+        runId: decodeTokenValue(match[3] ?? ""),
+        provider: decodeTokenValue(match[4] ?? ""),
+        model: decodeTokenValue(match[5] ?? ""),
+        source: decodeTokenValue(match[6] ?? ""),
+        inputTokens: parseNullableNumber(match[7] ?? ""),
+        cachedInputTokens: parseNullableNumber(match[8] ?? ""),
+        outputTokens: parseNullableNumber(match[9] ?? ""),
+        reasoningTokens: parseNullableNumber(match[10] ?? ""),
+        totalTokens: parseNullableNumber(match[11] ?? ""),
+        measuredSubsetTokens: measuredSubsets.has(entryId)
+          ? (measuredSubsets.get(entryId) ?? null)
+          : embeddedMeasuredSubset,
+        cost: parseNullableNumber(match[12 + releasedFieldOffset] ?? ""),
+        currency: parseNullableString(match[13 + releasedFieldOffset] ?? ""),
+        pricingStatus: decodeTokenValue(match[14 + releasedFieldOffset] ?? ""),
+        pricingSource: parseNullableString(
+          match[15 + releasedFieldOffset] ?? ""
+        ),
+        artifactRef: decodeTokenValue(match[16 + releasedFieldOffset] ?? ""),
+        parentArtifactRef: parseNullableString(
+          match[17 + releasedFieldOffset] ?? ""
+        ),
+      };
+    }
+  );
+
+  return { entries, rollup: parseLisaUsageRollup(section), range };
 }
 
 /**

--- a/tests/unit/strategies/usage-accounting-contract.test.ts
+++ b/tests/unit/strategies/usage-accounting-contract.test.ts
@@ -96,7 +96,7 @@ const renderCsv = (values: readonly string[]): string =>
   values.map(value => encodeURIComponent(value)).join(",");
 
 const renderEntryToken = (entry: UsageEntry): string =>
-  `<!-- lisa:usage-entry entry_id=${encodeURIComponent(entry.entryId)} flow=${encodeURIComponent(entry.flow)} run_id=${encodeURIComponent(entry.runId)} provider=${encodeURIComponent(entry.provider)} model=${encodeURIComponent(entry.model)} source=${encodeURIComponent(entry.source)} input_tokens=${renderValue(entry.inputTokens)} cached_input_tokens=${renderValue(entry.cachedInputTokens)} output_tokens=${renderValue(entry.outputTokens)} reasoning_tokens=${renderValue(entry.reasoningTokens)} total_tokens=${renderValue(entry.totalTokens)} measured_subset_tokens=${renderValue(entry.measuredSubsetTokens)} cost=${renderValue(entry.cost)} currency=${renderValue(entry.currency)} pricing_status=${encodeURIComponent(entry.pricingStatus)} pricing_source=${renderValue(entry.pricingSource)} artifact_ref=${encodeURIComponent(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeURIComponent(entry.parentArtifactRef)} -->`;
+  `<!-- lisa:usage-entry entry_id=${encodeURIComponent(entry.entryId)} flow=${encodeURIComponent(entry.flow)} run_id=${encodeURIComponent(entry.runId)} provider=${encodeURIComponent(entry.provider)} model=${encodeURIComponent(entry.model)} source=${encodeURIComponent(entry.source)} input_tokens=${renderValue(entry.inputTokens)} cached_input_tokens=${renderValue(entry.cachedInputTokens)} output_tokens=${renderValue(entry.outputTokens)} reasoning_tokens=${renderValue(entry.reasoningTokens)} total_tokens=${renderValue(entry.totalTokens)} cost=${renderValue(entry.cost)} currency=${renderValue(entry.currency)} pricing_status=${encodeURIComponent(entry.pricingStatus)} pricing_source=${renderValue(entry.pricingSource)} artifact_ref=${encodeURIComponent(entry.artifactRef)} parent_artifact_ref=${entry.parentArtifactRef === null ? "" : encodeURIComponent(entry.parentArtifactRef)} --> <!-- lisa:usage-entry-measured-subset entry_id=${encodeURIComponent(entry.entryId)} measured_subset_tokens=${renderValue(entry.measuredSubsetTokens)} -->`;
 
 const renderRollupToken = (
   directEntryIds: readonly string[],
@@ -151,7 +151,7 @@ const renderSection = (entries: readonly UsageEntry[]): string => {
 
 const parseEntries = (section: string): readonly ParsedEntry[] => {
   const tokenPattern =
-    /<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=\S+ provider=\S+ model=\S+ source=(\S+) input_tokens=\S+ cached_input_tokens=\S+ output_tokens=\S+ reasoning_tokens=\S+ total_tokens=(\S+) measured_subset_tokens=\S+ cost=\S+ currency=\S+ pricing_status=\S+ pricing_source=\S+ artifact_ref=\S+ parent_artifact_ref=\S* -->/g;
+    /<!-- lisa:usage-entry entry_id=(\S+) flow=(\S+) run_id=\S+ provider=\S+ model=\S+ source=(\S+) input_tokens=\S+ cached_input_tokens=\S+ output_tokens=\S+ reasoning_tokens=\S+ total_tokens=(\S+) cost=\S+ currency=\S+ pricing_status=\S+ pricing_source=\S+ artifact_ref=\S+ parent_artifact_ref=\S* -->/g;
   const entries: ParsedEntry[] = [];
   let match = tokenPattern.exec(section);
   while (match !== null) {
@@ -206,6 +206,7 @@ describe("usage-accounting contract docs", () => {
       expect(content).toMatch(/estimated/i);
       expect(content).toMatch(/measured-subset/i);
       expect(content).toContain("measured_subset_tokens");
+      expect(content).toContain("lisa:usage-entry-measured-subset");
       expect(content).toMatch(/unavailable/i);
       expect(content).toMatch(/missing telemetry/i);
     });
@@ -213,6 +214,7 @@ describe("usage-accounting contract docs", () => {
     it("documents fixed-order usage-entry and usage-rollup tokens", () => {
       expect(content).toContain("<!-- lisa:usage-entry entry_id=");
       expect(content).toContain("<!-- lisa:usage-rollup");
+      expect(content).toContain("lisa:usage-rollup-token-status");
       expect(content).toMatch(/Field order is fixed/i);
       expect(content).toMatch(/machine-readable summary/i);
       expect(content).toMatch(/percent-encoded/i);

--- a/tests/unit/utils/usage-accounting-backward-compatibility.test.ts
+++ b/tests/unit/utils/usage-accounting-backward-compatibility.test.ts
@@ -1,0 +1,264 @@
+import {
+  createLisaUsageRollup,
+  parseLisaUsageSection,
+  type LisaUsageChildArtifact,
+  type LisaUsageEntry,
+  upsertLisaUsageSection,
+} from "../../../src/utils/usage-accounting.js";
+
+const ARTIFACT_DOCUMENT = "# Artifact\n";
+const UNDEFINED_MEASURED_SUBSET = "measured_subset_tokens=undefined";
+const LEGACY_FIXED_ORDER_ENTRY_PATTERN = new RegExp(
+  [
+    "<!-- lisa:usage-entry entry_id=\\S+ flow=\\S+ run_id=\\S+",
+    "provider=\\S+ model=\\S+ source=\\S+ input_tokens=\\S+",
+    "cached_input_tokens=\\S+ output_tokens=\\S+ reasoning_tokens=\\S+",
+    "total_tokens=\\S+ cost=\\S+ currency=\\S+ pricing_status=\\S+",
+    "pricing_source=\\S+ artifact_ref=\\S+ parent_artifact_ref=\\S* -->",
+  ].join(" ")
+);
+
+/** Usage sources accepted by callers written before measured subsets existed. */
+type LegacySource = "estimated" | "observed" | "unavailable";
+
+/**
+ * Reproduce a pre-2.222 TypeScript caller without the newly added field.
+ *
+ * @param source Legacy usage source.
+ * @returns A source-compatible legacy entry.
+ */
+function makeLegacyEntry(source: LegacySource): LisaUsageEntry {
+  const unavailable = source === "unavailable";
+  return {
+    artifactRef: `github:issue:1550-${source}`,
+    cachedInputTokens: null,
+    cost: unavailable ? null : 0.12,
+    currency: unavailable ? null : "USD",
+    entryId: `legacy-${source}`,
+    flow: "lisa-implement",
+    inputTokens: unavailable ? null : 100,
+    model: "gpt-5",
+    outputTokens: unavailable ? null : 20,
+    parentArtifactRef: null,
+    pricingSource: unavailable ? null : "catalog",
+    pricingStatus: source,
+    provider: "openai",
+    reasoningTokens: null,
+    runId: `run-${source}`,
+    source,
+    totalTokens: unavailable ? null : 120,
+  };
+}
+
+/**
+ * Create a measured-subset entry using the current public model.
+ *
+ * @param entryId Stable entry identifier.
+ * @returns A current measured-subset entry.
+ */
+function makeMeasuredSubsetEntry(entryId: string): LisaUsageEntry {
+  return {
+    artifactRef: "github:issue:1550",
+    cachedInputTokens: null,
+    cost: null,
+    currency: null,
+    entryId,
+    flow: "lisa-plan",
+    inputTokens: null,
+    measuredSubsetTokens: 42,
+    model: "gpt-5",
+    outputTokens: null,
+    parentArtifactRef: null,
+    pricingSource: null,
+    pricingStatus: "unavailable",
+    provider: "openai",
+    reasoningTokens: null,
+    runId: "run-subset",
+    source: "measured-subset",
+    totalTokens: null,
+  };
+}
+
+/**
+ * Create a complete observed entry for mixed-ledger rollup tests.
+ *
+ * @returns A complete observed entry.
+ */
+function makeCompleteEntry(): LisaUsageEntry {
+  return {
+    ...makeMeasuredSubsetEntry("complete"),
+    cost: 0.12,
+    currency: "USD",
+    inputTokens: 100,
+    measuredSubsetTokens: null,
+    outputTokens: 20,
+    pricingSource: "runtime",
+    pricingStatus: "observed",
+    source: "observed",
+    totalTokens: 120,
+  };
+}
+
+const RELEASED_2_222_DOCUMENT = [
+  ARTIFACT_DOCUMENT.trimEnd(),
+  "",
+  "## Lisa Usage",
+  "",
+  "| Flow | Source | Model | Tokens | Cost |",
+  "| --- | --- | --- | ---: | ---: |",
+  "| lisa-plan | measured-subset | openai/gpt-5 | 42 measured subset | null | <!-- lisa:usage-entry entry_id=released-middle flow=lisa-plan run_id=run-subset provider=openai model=gpt-5 source=measured-subset input_tokens=null cached_input_tokens=null output_tokens=null reasoning_tokens=null total_tokens=null measured_subset_tokens=42 cost=null currency=null pricing_status=unavailable pricing_source=null artifact_ref=github%3Aissue%3A1550 parent_artifact_ref= -->",
+  "",
+  "<!-- lisa:usage-rollup direct_entry_ids=released-middle child_entry_ids= child_refs= direct_tokens=null child_tokens=null total_tokens=null direct_cost=null child_cost=null total_cost=null currency=null child_currency=null -->",
+  "",
+].join("\n");
+
+const RELEASED_2_222_UNDEFINED_DOCUMENT = RELEASED_2_222_DOCUMENT.replace(
+  "measured_subset_tokens=42",
+  UNDEFINED_MEASURED_SUBSET
+);
+
+describe("usage-accounting backward compatibility", () => {
+  it.each(["observed", "estimated", "unavailable"] as const)(
+    "null-normalizes the additive field for a legacy %s caller",
+    source => {
+      const entry = makeLegacyEntry(source);
+      const serialized = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+        entries: [entry],
+      });
+
+      expect(serialized).toContain("measured_subset_tokens=null");
+      expect(serialized).not.toContain(UNDEFINED_MEASURED_SUBSET);
+      expect(parseLisaUsageSection(serialized).entries[0]).toMatchObject({
+        entryId: `legacy-${source}`,
+        measuredSubsetTokens: null,
+      });
+      expect(upsertLisaUsageSection(serialized, { entries: [] })).toBe(
+        serialized
+      );
+    }
+  );
+
+  it("keeps the canonical primary marker legacy-readable", () => {
+    const entry = makeMeasuredSubsetEntry("canonical-subset");
+    const serialized = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [entry],
+    });
+
+    expect(serialized).toMatch(LEGACY_FIXED_ORDER_ENTRY_PATTERN);
+    expect(serialized).toContain(
+      "<!-- lisa:usage-entry-measured-subset entry_id=canonical-subset measured_subset_tokens=42 -->"
+    );
+    expect(parseLisaUsageSection(serialized).entries[0]).toEqual(entry);
+  });
+
+  it("migrates released 2.222.0 middle-field markers idempotently", () => {
+    const parsedReleased = parseLisaUsageSection(RELEASED_2_222_DOCUMENT);
+
+    expect(parsedReleased.entries[0]?.measuredSubsetTokens).toBe(42);
+
+    const migrated = upsertLisaUsageSection(RELEASED_2_222_DOCUMENT, {
+      entries: [],
+    });
+
+    expect(migrated).toMatch(LEGACY_FIXED_ORDER_ENTRY_PATTERN);
+    expect(migrated).not.toContain(
+      "total_tokens=null measured_subset_tokens=42 cost=null"
+    );
+    expect(
+      parseLisaUsageSection(migrated).entries[0]?.measuredSubsetTokens
+    ).toBe(42);
+    expect(upsertLisaUsageSection(migrated, { entries: [] })).toBe(migrated);
+  });
+
+  it("null-normalizes only the omitted 2.222.0 additive field during migration", () => {
+    const parsedReleased = parseLisaUsageSection(
+      RELEASED_2_222_UNDEFINED_DOCUMENT
+    );
+
+    expect(parsedReleased.entries[0]?.measuredSubsetTokens).toBeNull();
+
+    const migrated = upsertLisaUsageSection(RELEASED_2_222_UNDEFINED_DOCUMENT, {
+      entries: [],
+    });
+
+    expect(migrated).toContain("measured_subset_tokens=null");
+    expect(migrated).not.toContain(UNDEFINED_MEASURED_SUBSET);
+    expect(upsertLisaUsageSection(migrated, { entries: [] })).toBe(migrated);
+  });
+
+  it("keeps established 2.222.0 numeric fields strict", () => {
+    const corrupted = RELEASED_2_222_DOCUMENT.replace(
+      "cost=null",
+      "cost=undefined"
+    );
+
+    expect(() => parseLisaUsageSection(corrupted)).toThrow(
+      "Invalid Lisa usage numeric token: undefined"
+    );
+  });
+
+  it("keeps direct and artifact totals unknown for a mixed direct ledger", () => {
+    const rollup = createLisaUsageRollup([
+      makeCompleteEntry(),
+      makeMeasuredSubsetEntry("partial-direct"),
+    ]);
+
+    expect(rollup).toMatchObject({
+      childTokens: null,
+      directCost: 0.12,
+      directTokens: null,
+      totalCost: 0.12,
+      totalTokens: null,
+    });
+  });
+
+  it("keeps artifact totals unknown when child work is only a subset", () => {
+    const childArtifacts: readonly LisaUsageChildArtifact[] = [
+      {
+        artifactRef: "github:issue:child",
+        entries: [makeMeasuredSubsetEntry("partial-child")],
+      },
+    ];
+    const rollup = createLisaUsageRollup(
+      [makeCompleteEntry()],
+      null,
+      childArtifacts
+    );
+
+    expect(rollup).toMatchObject({
+      childCost: null,
+      childTokens: null,
+      directCost: 0.12,
+      directTokens: 120,
+      totalCost: 0.12,
+      totalTokens: null,
+    });
+  });
+
+  it("preserves measured-child incompleteness across ordinary rewrites", () => {
+    const childArtifacts: readonly LisaUsageChildArtifact[] = [
+      {
+        artifactRef: "github:issue:child",
+        entries: [makeMeasuredSubsetEntry("partial-child")],
+      },
+    ];
+    const firstWrite = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [makeCompleteEntry()],
+      childArtifacts,
+    });
+
+    expect(firstWrite).toContain(
+      "<!-- lisa:usage-rollup-token-status child_tokens_incomplete=true -->"
+    );
+    expect(parseLisaUsageSection(firstWrite).rollup).toMatchObject({
+      childTokens: null,
+      childTokensIncomplete: true,
+      directTokens: 120,
+      totalCost: 0.12,
+      totalTokens: null,
+    });
+    expect(upsertLisaUsageSection(firstWrite, { entries: [] })).toBe(
+      firstWrite
+    );
+  });
+});

--- a/tests/unit/utils/usage-accounting-backward-compatibility.test.ts
+++ b/tests/unit/utils/usage-accounting-backward-compatibility.test.ts
@@ -3,10 +3,13 @@ import {
   parseLisaUsageSection,
   type LisaUsageChildArtifact,
   type LisaUsageEntry,
+  type LisaUsageRollup,
   upsertLisaUsageSection,
 } from "../../../src/utils/usage-accounting.js";
 
 const ARTIFACT_DOCUMENT = "# Artifact\n";
+const CHILD_ARTIFACT_REF = "github:issue:child";
+const PARTIAL_CHILD_ENTRY_ID = "partial-child";
 const UNDEFINED_MEASURED_SUBSET = "measured_subset_tokens=undefined";
 const LEGACY_FIXED_ORDER_ENTRY_PATTERN = new RegExp(
   [
@@ -215,8 +218,8 @@ describe("usage-accounting backward compatibility", () => {
   it("keeps artifact totals unknown when child work is only a subset", () => {
     const childArtifacts: readonly LisaUsageChildArtifact[] = [
       {
-        artifactRef: "github:issue:child",
-        entries: [makeMeasuredSubsetEntry("partial-child")],
+        artifactRef: CHILD_ARTIFACT_REF,
+        entries: [makeMeasuredSubsetEntry(PARTIAL_CHILD_ENTRY_ID)],
       },
     ];
     const rollup = createLisaUsageRollup(
@@ -238,8 +241,8 @@ describe("usage-accounting backward compatibility", () => {
   it("preserves measured-child incompleteness across ordinary rewrites", () => {
     const childArtifacts: readonly LisaUsageChildArtifact[] = [
       {
-        artifactRef: "github:issue:child",
-        entries: [makeMeasuredSubsetEntry("partial-child")],
+        artifactRef: CHILD_ARTIFACT_REF,
+        entries: [makeMeasuredSubsetEntry(PARTIAL_CHILD_ENTRY_ID)],
       },
     ];
     const firstWrite = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
@@ -259,6 +262,48 @@ describe("usage-accounting backward compatibility", () => {
     });
     expect(upsertLisaUsageSection(firstWrite, { entries: [] })).toBe(
       firstWrite
+    );
+  });
+
+  it("preserves measured-child state when an explicit legacy rollup omits it", () => {
+    const childArtifacts: readonly LisaUsageChildArtifact[] = [
+      {
+        artifactRef: CHILD_ARTIFACT_REF,
+        entries: [makeMeasuredSubsetEntry(PARTIAL_CHILD_ENTRY_ID)],
+      },
+    ];
+    const directEntry = makeCompleteEntry();
+    const firstWrite = upsertLisaUsageSection(ARTIFACT_DOCUMENT, {
+      entries: [directEntry],
+      childArtifacts,
+    });
+    const parsedRollup = parseLisaUsageSection(firstWrite).rollup;
+    if (parsedRollup === null) {
+      throw new Error("Expected the first write to contain a rollup");
+    }
+    const legacyRollup: LisaUsageRollup = { ...parsedRollup };
+    delete legacyRollup.childTokensIncomplete;
+
+    const rewritten = upsertLisaUsageSection(firstWrite, {
+      entries: [directEntry],
+      rollup: legacyRollup,
+    });
+
+    expect(rewritten).toBe(firstWrite);
+    expect(parseLisaUsageSection(rewritten).rollup).toMatchObject({
+      childTokens: null,
+      childTokensIncomplete: true,
+      totalCost: 0.12,
+      totalTokens: null,
+    });
+
+    const explicitlyComplete = upsertLisaUsageSection(firstWrite, {
+      entries: [directEntry],
+      rollup: { ...legacyRollup, childTokensIncomplete: false },
+    });
+    expect(explicitlyComplete).not.toContain("lisa:usage-rollup-token-status");
+    expect(parseLisaUsageSection(explicitlyComplete).rollup?.totalTokens).toBe(
+      120
     );
   });
 });


### PR DESCRIPTION
## Summary

- restore the exact legacy 17-field usage-entry marker and move measured-subset data into a correlated extension marker
- accept and idempotently migrate both valid and `undefined` transitional markers published in 2.222.0 while keeping established numeric corruption strict
- preserve measured-child token incompleteness across ordinary rewrites without discarding independently trustworthy whole-run costs
- regenerate Claude, Codex, Cursor, Antigravity, and Copilot surfaces; OpenCode consumes the synchronized base artifacts

Closes #1550

## Verification

- 56 focused compatibility and adjacent tests
- 4,192 unit tests
- 129 integration tests
- typecheck, standard lint, slow lint, build, rules pairing, plugin sync, diff check
- independent reviewer: GO
- independent verifier: PASS
- pre-push coverage: 4,321 tests; statements 83.86%, branches 75.44%, functions 86.62%, lines 84.55%

## Release regression repaired

`@codyswann/lisa@2.222.0` serialized omitted `measuredSubsetTokens` as literal `undefined`, then failed to parse its own ledger. This PR normalizes only that transitional additive field to `null`; established numeric fields remain strict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for partial token measurements without treating them as complete totals.
  * Preserved token incompleteness indicators across rollup updates.
  * Kept valid cost totals available even when token totals are incomplete.
  * Added compatibility for legacy usage records and one-time migration to the current token format.

* **Bug Fixes**
  * Prevented partial token data from being incorrectly combined into complete totals.
  * Ensured repeated rewrites produce stable, identical output.

* **Documentation**
  * Updated usage-accounting contracts and guidance across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->