### PR TITLE
fix(hooks): ignore heredoc prose in safety net

### DIFF
--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -45,8 +45,14 @@ def strip_heredocs(text: str) -> str:
     lines = text.splitlines()
     output = []
     pending = []
+    # Quoted strings are matched (and thereby skipped over) as plain,
+    # non-capturing alternatives BEFORE the heredoc-marker alternative gets a
+    # chance to run, so a "<<MARKER"-looking sequence inside a string literal
+    # (e.g. `echo "hello <<MARKER"`) is never mistaken for a real heredoc
+    # start. Only the heredoc-marker alternative captures a group.
     marker_pattern = re.compile(
-        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+        r'"(?:\\.|[^"])*"|\'[^\']*\''
+        r"|<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
     )
     index = 0
     while index < len(lines):
@@ -55,14 +61,19 @@ def strip_heredocs(text: str) -> str:
         pending.extend(
             next(group for group in match.groups() if group)
             for match in marker_pattern.finditer(line)
+            if any(match.groups())
         )
         index += 1
+        # Consume every pending heredoc body in order (chained same-line
+        # heredocs, e.g. `cat <<A <<B`, push more than one marker at once).
+        # Do NOT stop after the first terminator — dropping the `break` lets
+        # this loop keep dropping body lines until each pending marker is
+        # matched, instead of leaking the second body back into `output`
+        # where the destructive-pattern guards would see it.
         while pending and index < len(lines):
             if lines[index].strip() == pending[0]:
                 output.append(lines[index])
                 pending.pop(0)
-                index += 1
-                break
             index += 1
     return "\n".join(output)
 

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -32,6 +32,46 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
+command_for_guards="$command_str"
+if command -v python3 >/dev/null 2>&1; then
+  command_for_guards="$(SAFETY_NET_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+
+command = os.environ.get("SAFETY_NET_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+print(strip_heredocs(command), end="")
+PY
+)"
+fi
+
 # block() prints the reason to stderr (surfaced to the model) and exits 2 so the
 # Bash tool call is denied. $1 = human-readable reason for the block.
 block() {
@@ -49,11 +89,11 @@ EOF
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_str" \
+  || printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_str" \
+  if printf '%s' "$command_for_guards" \
     | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
@@ -76,7 +116,7 @@ fi
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
 # protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_str" \
+normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
@@ -93,7 +133,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a
 #    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -101,7 +141,7 @@ if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+rese
 fi
 
 # 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
@@ -113,7 +153,7 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_str" | grep -Eiq -- "$rule"; then
+    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
       block "matched a project custom safety rule (${rules_file##*/}): $rule"
     fi
   done <"$rules_file"

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -45,8 +45,14 @@ def strip_heredocs(text: str) -> str:
     lines = text.splitlines()
     output = []
     pending = []
+    # Quoted strings are matched (and thereby skipped over) as plain,
+    # non-capturing alternatives BEFORE the heredoc-marker alternative gets a
+    # chance to run, so a "<<MARKER"-looking sequence inside a string literal
+    # (e.g. `echo "hello <<MARKER"`) is never mistaken for a real heredoc
+    # start. Only the heredoc-marker alternative captures a group.
     marker_pattern = re.compile(
-        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+        r'"(?:\\.|[^"])*"|\'[^\']*\''
+        r"|<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
     )
     index = 0
     while index < len(lines):
@@ -55,14 +61,19 @@ def strip_heredocs(text: str) -> str:
         pending.extend(
             next(group for group in match.groups() if group)
             for match in marker_pattern.finditer(line)
+            if any(match.groups())
         )
         index += 1
+        # Consume every pending heredoc body in order (chained same-line
+        # heredocs, e.g. `cat <<A <<B`, push more than one marker at once).
+        # Do NOT stop after the first terminator — dropping the `break` lets
+        # this loop keep dropping body lines until each pending marker is
+        # matched, instead of leaking the second body back into `output`
+        # where the destructive-pattern guards would see it.
         while pending and index < len(lines):
             if lines[index].strip() == pending[0]:
                 output.append(lines[index])
                 pending.pop(0)
-                index += 1
-                break
             index += 1
     return "\n".join(output)
 

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -32,6 +32,46 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
+command_for_guards="$command_str"
+if command -v python3 >/dev/null 2>&1; then
+  command_for_guards="$(SAFETY_NET_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+
+command = os.environ.get("SAFETY_NET_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+print(strip_heredocs(command), end="")
+PY
+)"
+fi
+
 # block() prints the reason to stderr (surfaced to the model) and exits 2 so the
 # Bash tool call is denied. $1 = human-readable reason for the block.
 block() {
@@ -49,11 +89,11 @@ EOF
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_str" \
+  || printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_str" \
+  if printf '%s' "$command_for_guards" \
     | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
@@ -76,7 +116,7 @@ fi
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
 # protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_str" \
+normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
@@ -93,7 +133,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a
 #    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -101,7 +141,7 @@ if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+rese
 fi
 
 # 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
@@ -113,7 +153,7 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_str" | grep -Eiq -- "$rule"; then
+    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
       block "matched a project custom safety rule (${rules_file##*/}): $rule"
     fi
   done <"$rules_file"

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -45,8 +45,14 @@ def strip_heredocs(text: str) -> str:
     lines = text.splitlines()
     output = []
     pending = []
+    # Quoted strings are matched (and thereby skipped over) as plain,
+    # non-capturing alternatives BEFORE the heredoc-marker alternative gets a
+    # chance to run, so a "<<MARKER"-looking sequence inside a string literal
+    # (e.g. `echo "hello <<MARKER"`) is never mistaken for a real heredoc
+    # start. Only the heredoc-marker alternative captures a group.
     marker_pattern = re.compile(
-        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+        r'"(?:\\.|[^"])*"|\'[^\']*\''
+        r"|<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
     )
     index = 0
     while index < len(lines):
@@ -55,14 +61,19 @@ def strip_heredocs(text: str) -> str:
         pending.extend(
             next(group for group in match.groups() if group)
             for match in marker_pattern.finditer(line)
+            if any(match.groups())
         )
         index += 1
+        # Consume every pending heredoc body in order (chained same-line
+        # heredocs, e.g. `cat <<A <<B`, push more than one marker at once).
+        # Do NOT stop after the first terminator — dropping the `break` lets
+        # this loop keep dropping body lines until each pending marker is
+        # matched, instead of leaking the second body back into `output`
+        # where the destructive-pattern guards would see it.
         while pending and index < len(lines):
             if lines[index].strip() == pending[0]:
                 output.append(lines[index])
                 pending.pop(0)
-                index += 1
-                break
             index += 1
     return "\n".join(output)
 

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -32,6 +32,46 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
+command_for_guards="$command_str"
+if command -v python3 >/dev/null 2>&1; then
+  command_for_guards="$(SAFETY_NET_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+
+command = os.environ.get("SAFETY_NET_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+print(strip_heredocs(command), end="")
+PY
+)"
+fi
+
 # block() prints the reason to stderr (surfaced to the model) and exits 2 so the
 # Bash tool call is denied. $1 = human-readable reason for the block.
 block() {
@@ -49,11 +89,11 @@ EOF
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_str" \
+  || printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_str" \
+  if printf '%s' "$command_for_guards" \
     | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
@@ -76,7 +116,7 @@ fi
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
 # protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_str" \
+normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
@@ -93,7 +133,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a
 #    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -101,7 +141,7 @@ if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+rese
 fi
 
 # 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
@@ -113,7 +153,7 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_str" | grep -Eiq -- "$rule"; then
+    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
       block "matched a project custom safety rule (${rules_file##*/}): $rule"
     fi
   done <"$rules_file"

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -45,8 +45,14 @@ def strip_heredocs(text: str) -> str:
     lines = text.splitlines()
     output = []
     pending = []
+    # Quoted strings are matched (and thereby skipped over) as plain,
+    # non-capturing alternatives BEFORE the heredoc-marker alternative gets a
+    # chance to run, so a "<<MARKER"-looking sequence inside a string literal
+    # (e.g. `echo "hello <<MARKER"`) is never mistaken for a real heredoc
+    # start. Only the heredoc-marker alternative captures a group.
     marker_pattern = re.compile(
-        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+        r'"(?:\\.|[^"])*"|\'[^\']*\''
+        r"|<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
     )
     index = 0
     while index < len(lines):
@@ -55,14 +61,19 @@ def strip_heredocs(text: str) -> str:
         pending.extend(
             next(group for group in match.groups() if group)
             for match in marker_pattern.finditer(line)
+            if any(match.groups())
         )
         index += 1
+        # Consume every pending heredoc body in order (chained same-line
+        # heredocs, e.g. `cat <<A <<B`, push more than one marker at once).
+        # Do NOT stop after the first terminator — dropping the `break` lets
+        # this loop keep dropping body lines until each pending marker is
+        # matched, instead of leaking the second body back into `output`
+        # where the destructive-pattern guards would see it.
         while pending and index < len(lines):
             if lines[index].strip() == pending[0]:
                 output.append(lines[index])
                 pending.pop(0)
-                index += 1
-                break
             index += 1
     return "\n".join(output)
 

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -32,6 +32,46 @@ if [ -z "$command_str" ]; then
   exit 0
 fi
 
+command_for_guards="$command_str"
+if command -v python3 >/dev/null 2>&1; then
+  command_for_guards="$(SAFETY_NET_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+
+command = os.environ.get("SAFETY_NET_COMMAND", "")
+
+
+def strip_heredocs(text: str) -> str:
+    lines = text.splitlines()
+    output = []
+    pending = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        pending.extend(
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        )
+        index += 1
+        while pending and index < len(lines):
+            if lines[index].strip() == pending[0]:
+                output.append(lines[index])
+                pending.pop(0)
+                index += 1
+                break
+            index += 1
+    return "\n".join(output)
+
+
+print(strip_heredocs(command), end="")
+PY
+)"
+fi
+
 # block() prints the reason to stderr (surfaced to the model) and exits 2 so the
 # Bash tool call is denied. $1 = human-readable reason for the block.
 block() {
@@ -49,11 +89,11 @@ EOF
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_str" \
+  || printf '%s' "$command_for_guards" \
   | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_str" \
+  if printf '%s' "$command_for_guards" \
     | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
@@ -76,7 +116,7 @@ fi
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
 # protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_str" \
+normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
 
 while IFS= read -r push_stmt; do
@@ -93,7 +133,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 # 3. `git reset --hard` while the working tree has uncommitted changes — this
 #    silently discards them. Only blocks when the tree is actually dirty, so a
 #    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -101,7 +141,7 @@ if printf '%s' "$command_str" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+rese
 fi
 
 # 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_str" \
+if printf '%s' "$command_for_guards" \
   | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
@@ -113,7 +153,7 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_str" | grep -Eiq -- "$rule"; then
+    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
       block "matched a project custom safety rule (${rules_file##*/}): $rule"
     fi
   done <"$rules_file"

--- a/tests/unit/hooks/parity-safety-net.test.ts
+++ b/tests/unit/hooks/parity-safety-net.test.ts
@@ -56,6 +56,34 @@ describe("parity-safety-net.sh — force-push guard", () => {
 
       expect(runHook("Bash", cmd).status).toBe(EXIT_BLOCKED);
     });
+
+    it("still blocks a destructive command following a quoted '<<' that looks like a heredoc marker", () => {
+      // The `<<MARKER` sequence here is inside a double-quoted echo argument, not
+      // a real heredoc start. A quote-unaware heredoc parser mistakes it for one
+      // and then treats the real `rm -rf /` command (up to the "MARKER" line) as
+      // heredoc body content, stripping it from what the guards see — hiding a
+      // real destructive command from the safety net.
+      const cmd = ['echo "hello <<MARKER"', "rm -rf /", "MARKER"].join("\n");
+
+      expect(runHook("Bash", cmd).status).toBe(EXIT_BLOCKED);
+    });
+
+    it("fully consumes chained same-line heredocs so the second body doesn't leak into the guard input", () => {
+      // `cat <<A <<B` opens two heredocs on one line. A parser that stops
+      // tracking after the first terminator lets the second heredoc's body
+      // "leak" back into the text that the destructive-pattern guards scan,
+      // which can cause the guard to misfire on data that was never a command.
+      const cmd = [
+        "cat <<A <<B",
+        "body A",
+        "A",
+        "body B with rm -rf /",
+        "B",
+        'echo "done"',
+      ].join("\n");
+
+      expect(runHook("Bash", cmd).status).toBe(EXIT_ALLOWED);
+    });
   });
 
   describe("blocks force-pushing a protected branch", () => {

--- a/tests/unit/hooks/parity-safety-net.test.ts
+++ b/tests/unit/hooks/parity-safety-net.test.ts
@@ -35,6 +35,29 @@ const runHook = (
 };
 
 describe("parity-safety-net.sh — force-push guard", () => {
+  describe("ignores prose-only heredoc payloads", () => {
+    it("allows an issue body that quotes rm -rf plugins/lisa", () => {
+      const cmd = [
+        "gh issue create --body-file - <<'EOF'",
+        "The build step runs `rm -rf plugins/lisa` before regenerating artifacts.",
+        "EOF",
+      ].join("\n");
+
+      expect(runHook("Bash", cmd).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("still blocks a destructive command before a heredoc body", () => {
+      const cmd = [
+        "rm -rf /",
+        "gh issue create --body-file - <<'EOF'",
+        "This payload is not the executable statement.",
+        "EOF",
+      ].join("\n");
+
+      expect(runHook("Bash", cmd).status).toBe(EXIT_BLOCKED);
+    });
+  });
+
   describe("blocks force-pushing a protected branch", () => {
     it("blocks git push --force origin main", () => {
       expect(runHook("Bash", "git push --force origin main").status).toBe(


### PR DESCRIPTION
## Summary

- strip heredoc payload text before parity-safety-net destructive command scans
- keep executable statements outside heredocs guarded, including real rm -rf / attempts
- add regression coverage for issue bodies that quote generated-artifact cleanup commands

Fixes #1594.

## Verification

- bun test tests/unit/hooks/parity-safety-net.test.ts
- bun test tests/unit/hooks/parity-safety-net.test.ts tests/unit/hooks/block-no-verify.test.ts
- bun run check:plugins
- git push pre-push suite: security audit, slow lint, knip, vitest coverage, integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved destructive-command safeguards by ignoring heredoc body content during matching, reducing false positives.
  * Ensured protections remain enforced for dangerous file deletion, protected-branch force pushes, `git reset --hard`, destructive SQL, and custom safety rules.
  * Kept existing blocking behavior, messages, and exit semantics unchanged.
* **Tests**
  * Added unit coverage for heredoc scenarios, confirming prose-only heredoc payloads don’t trigger blocks while real destructive commands still do.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->