### PR TITLE
fix(skills): harden distributed validation guidance

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -597,15 +597,14 @@ Enable compliance validation:
 uses: ./.github/workflows/quality.yml
 with:
   compliance_framework: 'soc2'  # or iso27001, hipaa, pci-dss
-  require_approval: true
-  approval_environment: 'production'
 ```
 
-**Note**: Create the environment in **Settings** > **Environments** first (or
-declare it under `github.environments` in `.lisa.config.json` and run
-`/lisa:setup:github-repo`). Unlike release.yml's environment-enforced gate,
-quality.yml's `approval_gate` job only records an audit artifact — it does not
-pause the run. For an enforced human gate, use release.yml's `require_approval`.
+**Note**: quality.yml's `approval_gate` job only records an audit artifact; it
+does not pause the run. Do not pass `require_approval` or `approval_environment`
+to this quality.yml example. For an enforced human gate, pass those inputs to
+release.yml and create the environment in **Settings** > **Environments** first
+(or declare it under `github.environments` in `.lisa.config.json` and run
+`/lisa:setup:github-repo`).
 
 ### Custom Node Version
 

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa-agy/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-agy/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-agy/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa-copilot/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-copilot/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-copilot/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa-cursor/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-cursor/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa-cursor/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/lisa/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/lisa/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/lisa/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -307,31 +307,63 @@ pull Lisa's own git history and read what actually changed:
 
    ```bash
    gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp \
-     --jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | .commit.message | split("\n")[0]]}'
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
    ```
 
    `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before `--jq` runs — without `--slurp`, `--jq` applies per page and prints one JSON object
-   per page instead of one merged result. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages.
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
+   cannot be established.
 
    The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
    on the first page, capped at 300 total — a large version window can silently drop commits or
    files. If `total_commits` or the file count looks truncated, re-run with the
    `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the shallow-clone `git log` below. When completeness
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
    still can't be established, say so in the finding and mark it `WARN` rather than attributing
    drift with unverified confidence.
 
    Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
    path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a shallow
-   clone (`git clone --filter=blob:none --no-checkout` then `git log v<installed>..v<latest> --
-   <paths>`), which *is* bounded to the window and should be preferred for definitive attribution; or
-   the local marketplace/plugin cache checkout when the runtime has one. If none are reachable, or
-   only the unbounded path-scoped fallback is reachable, report the gap as a `WARN`-level
-   observability note — never fail the audit because history was unavailable or incomplete.
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
+   history was unavailable or incomplete.
 3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
    generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
    `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped

--- a/plugins/src/base/skills/lisa-github-validate-issue/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-validate-issue/SKILL.md
@@ -366,13 +366,23 @@ reach every external surface the work requires. Enumerate the surfaces this issu
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the issue needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/src/base/skills/lisa-jira-validate-ticket/SKILL.md
+++ b/plugins/src/base/skills/lisa-jira-validate-ticket/SKILL.md
@@ -297,13 +297,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/plugins/src/base/skills/lisa-linear-validate-issue/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-validate-issue/SKILL.md
@@ -303,13 +303,23 @@ reach every external surface the work requires. Enumerate the surfaces this item
   alarms", "pull the copy from the Google Doc", "check the Sentry issues"),
 - tooling the work plainly implies (a deploy target, a database, a third-party API).
 
-For each surface, prove **read** access from the current runtime with the cheapest read-only probe
-through the sanctioned access layer: the matching MCP tool or `lisa-*-access` skill, CLI auth
-(`aws sts get-caller-identity`, `gh auth status`, vendor equivalents), or an authenticated fetch of
-the linked artifact. Attempt to resolve a gap before failing — an alternate substrate, a configured
-access layer, a keychain credential — mirroring the intake agent's discover-first duty.
+For each surface, prove **read** access from the current runtime with a target-resource-specific,
+read-only probe through its sanctioned access layer: the matching MCP tool or `lisa-*-access` skill,
+or an authenticated fetch using environment-injected authentication. Identity-only commands such as
+`aws sts get-caller-identity`, `gh auth status`, and vendor equivalents are preflight checks only;
+they never satisfy F5 by themselves. A successful probe for one surface does not cover another:
+reading the named GitHub repository, CloudWatch log group, Sentry project, or linked document must
+each succeed separately when that surface is required.
 
-- `PASS` — every required surface is provably readable.
+Attempt to resolve a gap before failing, but only through another configured brokered access layer
+or environment-injected authentication. A sanctioned broker may use its own credential store
+internally; the validator must never autonomously inspect, read, copy, print, or export raw
+credentials, keychains, credential files, or token stores, and must never invoke low-level secret
+tools to recover them. This preserves the intake agent's discover-first duty without exposing
+credential material.
+
+- `PASS` — every required surface has its own successful target-resource read probe or authenticated
+  fetch through the sanctioned access layer.
 - `N/A` — the item needs nothing beyond the repository and the tracker itself.
 - `FAIL` — a required surface is unreachable after the resolution attempt. Name the exact surface
   and what was probed. Intake callers must route this to `blocked` + human escalation with the

--- a/tests/unit/strategies/distributed-content-round2-contract.test.ts
+++ b/tests/unit/strategies/distributed-content-round2-contract.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression contract for the nine upstream distributed-content findings in
+ * #1622. These skills are agent instructions, so the assertions cover the
+ * canonical source and every checked-in runtime projection.
+ * @module tests/unit/strategies/distributed-content-round2-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+const SKILL_ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa/.codex-plugin/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+
+const VALIDATORS = [
+  "lisa-github-validate-issue",
+  "lisa-jira-validate-ticket",
+  "lisa-linear-validate-issue",
+] as const;
+
+const section = (
+  content: string,
+  startHeading: string,
+  nextHeading: string
+): string => {
+  const start = content.indexOf(startHeading);
+  const end = content.indexOf(nextHeading, start + startHeading.length);
+
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return content.slice(start, end);
+};
+
+describe.each(SKILL_ROOTS)("distributed F5 contract (%s)", skillRoot => {
+  it.each(VALIDATORS)(
+    "%s requires one target-resource proof per external surface",
+    validatorName => {
+      const f5 = section(
+        read(`${skillRoot}/${validatorName}/SKILL.md`),
+        "#### F5 — Required external access provable",
+        "## Execution"
+      );
+
+      expect(f5).toMatch(/target-resource-specific/);
+      expect(f5).toMatch(/preflight checks only/);
+      expect(f5).toMatch(/never satisfy F5 by themselves/);
+      expect(f5).toMatch(/one surface does not cover another/);
+      expect(f5).toMatch(/each succeed separately/);
+      expect(f5).toMatch(
+        /every required surface has its own successful target-resource read probe/
+      );
+    }
+  );
+
+  it.each(VALIDATORS)(
+    "%s permits only brokered or environment-injected credential recovery",
+    validatorName => {
+      const f5 = section(
+        read(`${skillRoot}/${validatorName}/SKILL.md`),
+        "#### F5 — Required external access provable",
+        "## Execution"
+      );
+
+      expect(f5).toMatch(/configured brokered access layer/);
+      expect(f5).toMatch(/environment-injected authentication/);
+      expect(f5).toMatch(
+        /never autonomously inspect, read, copy, print, or export raw/
+      );
+      expect(f5).toMatch(/keychains, credential files, or token stores/);
+      expect(f5).toMatch(/never invoke low-level secret\s+tools/);
+      expect(f5).not.toMatch(/a keychain credential/);
+    }
+  );
+});
+
+describe.each(SKILL_ROOTS)("distributed doctor history contract (%s)", root => {
+  const doctor = read(`${root}/lisa-doctor/SKILL.md`);
+
+  it("retains commit identity and targeted diff context", () => {
+    expect(doctor).toContain("--paginate --slurp |");
+    expect(doctor).toMatch(/jq '\{total_commits:/);
+    expect(doctor).not.toMatch(/--slurp \\\n\s+--jq/);
+    expect(doctor).toContain("commits: [.[].commits[]? | {sha, subject:");
+    expect(doctor).toContain("repos/CodySwannGT/lisa/commits/<sha>");
+    expect(doctor).toMatch(
+      /filename, status, additions, deletions, changes, patch/
+    );
+    expect(doctor).toMatch(/rather than attributing from the subject alone/);
+  });
+
+  it("uses a finite, explicit-ref history fallback", () => {
+    expect(doctor).toMatch(/fetch --no-tags --filter=blob:none --depth=256/);
+    expect(doctor).toContain('lisa_history_dir="$(mktemp -d)"');
+    expect(doctor).toContain("refs/tags/v<installed>:refs/tags/v<installed>");
+    expect(doctor).toContain("refs/tags/v<latest>:refs/tags/v<latest>");
+    expect(doctor).toMatch(/merge-base --is-ancestor/);
+    expect(doctor).toMatch(/Do not\s+silently deepen beyond that ceiling/);
+    expect(doctor).not.toContain("git clone --filter=blob:none --no-checkout");
+    expect(doctor).not.toContain("shallow-clone");
+  });
+});
+
+describe.each([
+  "typescript/copy-overwrite/.github/GITHUB_ACTIONS.md",
+  ".github/GITHUB_ACTIONS.md",
+])("GitHub Actions approval examples (%s)", actionsGuidePath => {
+  const actionsGuide = read(actionsGuidePath);
+
+  it("keeps approval inputs out of the quality.yml compliance example", () => {
+    const qualityExample = section(
+      actionsGuide,
+      "### Compliance Frameworks",
+      "### Custom Node Version"
+    );
+    const yaml = section(qualityExample, "```yaml", "```");
+
+    expect(yaml).toContain("quality.yml");
+    expect(yaml).not.toContain("require_approval");
+    expect(yaml).not.toContain("approval_environment");
+    expect(qualityExample).toMatch(/only records an audit artifact/);
+    expect(qualityExample).toMatch(/does not pause the run/);
+  });
+
+  it("documents approval inputs as release.yml-only", () => {
+    const qualityExample = section(
+      actionsGuide,
+      "### Compliance Frameworks",
+      "### Custom Node Version"
+    );
+
+    expect(qualityExample).toMatch(/Do not pass `require_approval` or/);
+    expect(qualityExample).toMatch(/those inputs to\s+release.yml/);
+    expect(actionsGuide).toMatch(
+      /uses: CodySwannGT\/lisa\/\.github\/workflows\/release\.yml@main[\s\S]*require_approval: true[\s\S]*approval_environment: 'production'/
+    );
+  });
+});
+
+describe("OpenCode distribution", () => {
+  it("continues to copy the corrected bundled skills verbatim", () => {
+    const installer = read("src/opencode/skills-installer.ts");
+
+    expect(installer).toMatch(/Copy one bundled skill folder verbatim/);
+    expect(installer).toContain("await copyFile(srcPath, destPath)");
+  });
+});

--- a/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
+++ b/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
@@ -601,15 +601,14 @@ Enable compliance validation:
 uses: ./.github/workflows/quality.yml
 with:
   compliance_framework: 'soc2'  # or iso27001, hipaa, pci-dss
-  require_approval: true
-  approval_environment: 'production'
 ```
 
-**Note**: Create the environment in **Settings** > **Environments** first (or
-declare it under `github.environments` in `.lisa.config.json` and run
-`/lisa:setup:github-repo`). Unlike release.yml's environment-enforced gate,
-quality.yml's `approval_gate` job only records an audit artifact — it does not
-pause the run. For an enforced human gate, use release.yml's `require_approval`.
+**Note**: quality.yml's `approval_gate` job only records an audit artifact; it
+does not pause the run. Do not pass `require_approval` or `approval_environment`
+to this quality.yml example. For an enforced human gate, pass those inputs to
+release.yml and create the environment in **Settings** > **Environments** first
+(or declare it under `github.environments` in `.lisa.config.json` and run
+`/lisa:setup:github-repo`).
 
 ### Custom Node Version
 


### PR DESCRIPTION
## Summary

- require a target-resource read probe for every F5 external surface; identity checks remain preflight only
- restrict credential-gap recovery to sanctioned brokers or environment-injected authentication and prohibit raw keychain/file/token inspection
- retain commit SHA and per-commit diff context in doctor attribution while using an executable, finite-depth explicit-tag fallback
- remove unsupported approval inputs from both the canonical and dogfooded quality-workflow examples
- regenerate all supported agent surfaces and add cross-runtime regression coverage for all nine findings

## Verification

- `bun run test` — 4,530 tests
- pre-push coverage suite — 4,530 tests, 83.61% statements
- `bun run test:integration` — 129 tests
- focused/adjacent suites — 208 tests
- independent frozen-diff review — clear; post-review consistency check clear
- live compare API projection and bounded explicit-tag fetch recipes exercised successfully
- lint, slow lint, typecheck, format, knip, production audit, secret scan, and plugin parity passed

Refs #1622