### PR TITLE
fix(expo): ignore companion route files

### DIFF
--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -69,11 +69,13 @@ export function routeFromFile(relativePath) {
   // Companion files are not screens. Ignore bracket contents before checking
   // for a remaining dot so catch-all routes such as `[...slug]` stay valid.
   if (
-    [...basename].some(
-      (character, index) =>
-        character === "." &&
-        basename.lastIndexOf("[", index) <= basename.lastIndexOf("]", index)
-    )
+    basename
+      .split("")
+      .some(
+        (character, index) =>
+          character === "." &&
+          basename.lastIndexOf("[", index) <= basename.lastIndexOf("]", index)
+      )
   ) {
     return null;
   }

--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -37,6 +37,7 @@ export const defaultThresholds = {
 };
 
 const ROUTE_FILE_PATTERN = /\.(?:tsx|ts|jsx|js)$/;
+const PLATFORM_SUFFIX_PATTERN = /\.(?:ios|android|native|web)$/;
 const SPEC_FILE_PATTERN = /\.(?:tsx|ts|jsx|js|mjs)$/;
 const FLOW_FILE_PATTERN = /\.(?:yaml|yml)$/;
 // `e2e-route: /path` inside any comment declares a route as covered even when
@@ -58,14 +59,28 @@ export function routeFromFile(relativePath) {
   }
   const withoutExtension = relativePath.replace(ROUTE_FILE_PATTERN, "");
   const rawSegments = withoutExtension.split("/");
-  const basename = rawSegments[rawSegments.length - 1];
+  const basename = rawSegments[rawSegments.length - 1].replace(
+    PLATFORM_SUFFIX_PATTERN,
+    ""
+  );
   if (basename.startsWith("+") || basename.endsWith("+api")) {
+    return null;
+  }
+  // Companion files are not screens. Ignore bracket contents before checking
+  // for a remaining dot so catch-all routes such as `[...slug]` stay valid.
+  if (
+    [...basename].some(
+      (character, index) =>
+        character === "." &&
+        basename.lastIndexOf("[", index) <= basename.lastIndexOf("]", index)
+    )
+  ) {
     return null;
   }
   if (rawSegments.some(segment => segment.startsWith("_"))) {
     return null;
   }
-  const segments = rawSegments
+  const segments = [...rawSegments.slice(0, -1), basename]
     // Route groups like "(tabs)" organize files without affecting the URL.
     .filter(segment => !(segment.startsWith("(") && segment.endsWith(")")))
     .filter(segment => segment !== "index");

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -98,6 +98,7 @@ describe("check-e2e-coverage", () => {
     it("keeps dynamic and catch-all segments", () => {
       expect(routeFromFile("players/[id].tsx")).toBe(PLAYERS_ROUTE);
       expect(routeFromFile("docs/[...slug].tsx")).toBe(DOCS_ROUTE);
+      expect(routeFromFile("players/[🚀🚀id].tsx")).toBe("/players/[🚀🚀id]");
     });
 
     it("maps Metro platform files to their shared route", () => {
@@ -114,6 +115,7 @@ describe("check-e2e-coverage", () => {
       expect(routeFromFile("index.test.tsx")).toBeNull();
       expect(routeFromFile("spike/indexability.spec.ts")).toBeNull();
       expect(routeFromFile("players/[id].test.tsx")).toBeNull();
+      expect(routeFromFile("players/[🚀🚀id].test.tsx")).toBeNull();
       expect(routeFromFile("docs/[...slug].stories.tsx")).toBeNull();
       expect(routeFromFile("Card.stories.web.tsx")).toBeNull();
     });

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -100,6 +100,24 @@ describe("check-e2e-coverage", () => {
       expect(routeFromFile("docs/[...slug].tsx")).toBe(DOCS_ROUTE);
     });
 
+    it("maps Metro platform files to their shared route", () => {
+      expect(routeFromFile("index.web.tsx")).toBe("/");
+      expect(routeFromFile("profile/index.ios.tsx")).toBe("/profile");
+      expect(routeFromFile("settings.native.tsx")).toBe("/settings");
+      expect(routeFromFile("players/[id].android.tsx")).toBe(PLAYERS_ROUTE);
+      expect(routeFromFile("docs/[...slug].web.tsx")).toBe(DOCS_ROUTE);
+    });
+
+    it("excludes double-extension companion files", () => {
+      expect(routeFromFile("global.d.ts")).toBeNull();
+      expect(routeFromFile("Card.stories.tsx")).toBeNull();
+      expect(routeFromFile("index.test.tsx")).toBeNull();
+      expect(routeFromFile("spike/indexability.spec.ts")).toBeNull();
+      expect(routeFromFile("players/[id].test.tsx")).toBeNull();
+      expect(routeFromFile("docs/[...slug].stories.tsx")).toBeNull();
+      expect(routeFromFile("Card.stories.web.tsx")).toBeNull();
+    });
+
     it("excludes layouts, private files, special files, and API routes", () => {
       expect(routeFromFile("_layout.tsx")).toBeNull();
       expect(routeFromFile("(tabs)/_layout.tsx")).toBeNull();


### PR DESCRIPTION
## Summary\n- exclude double-extension companion files from Expo Router route enumeration\n- preserve bracketed dynamic and catch-all routes\n- normalize Metro platform suffixes to the shared route\n- add focused regression coverage for mixed platform, companion, and dynamic cases\n\n## Verification\n- 30/30 focused Vitest cases passed\n- independent 28-case route matrix passed\n- full pre-push unit coverage suite passed\n- 129/129 integration tests passed\n- typecheck, lint-staged, slow lint, dead-code detection, formatting, diff check, production audit, and secret scan passed\n- independent blocker review: CLEAR\n\nRefs #1624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route detection for platform-specific files, ensuring web, iOS, Android, and native variants map to the correct shared routes.
  - Prevented companion files such as stories, tests, specifications, and type declarations from being incorrectly treated as navigable screens.
  - Preserved support for dynamic and catch-all routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->