### PR TITLE
fix: sync npm lifecycle lockfiles before exit

### DIFF
--- a/src/utils/postinstall-trampoline.ts
+++ b/src/utils/postinstall-trampoline.ts
@@ -28,6 +28,8 @@ const LIFECYCLE_ENV_VAR = "npm_package_json";
  * re-run does not itself attempt to re-schedule (prevents infinite trampolines).
  */
 const TRAMPOLINE_ENV_VAR = "LISA_POSTINSTALL_TRAMPOLINE";
+const NPM_USER_AGENT_ENV_VAR = "npm_config_user_agent";
+const NPM_EXEC_PATH_ENV_VAR = "npm_execpath";
 
 /**
  * How long the trampoline will wait for the parent package manager to exit before
@@ -93,6 +95,30 @@ export function isRunningAsTrampoline(): boolean {
 }
 
 /**
+ * Determine whether the current lifecycle parent is npm itself.
+ *
+ * npm writes package-lock.json before dependency package postinstall scripts run,
+ * and it does not repair the lock after a child script mutates the host
+ * package.json. A detached trampoline fixes that eventually, but an immediate
+ * `npm ci` can race it. For npm lifecycle runs we can safely reuse Lisa's
+ * existing in-process lockfile regeneration before the install command exits.
+ *
+ * Bun/yarn/pnpm lifecycle behavior remains on the detached trampoline path
+ * because those managers can still rewrite package.json after scripts finish.
+ * @returns true when npm lifecycle env identifies npm as the parent package manager
+ */
+function isNpmLifecycleParent(): boolean {
+  const userAgent = readEnv(NPM_USER_AGENT_ENV_VAR);
+  if (userAgent?.startsWith("npm/")) {
+    return true;
+  }
+  const execPath = readEnv(NPM_EXEC_PATH_ENV_VAR);
+  return (
+    execPath !== undefined && /(?:^|[/\\])npm(?:-cli\.js)?$/.test(execPath)
+  );
+}
+
+/**
  * Detect whether Lisa is running inside a CI environment.
  *
  * Returns false when running inside a Vitest or Jest test runner, even if
@@ -146,6 +172,7 @@ export function shouldSchedulePostinstallReconciliation(
   // package-manager processes and the trampoline must not spawn from them.
   if (readEnv("VITEST") !== undefined) return false;
   if (readEnv("JEST_WORKER_ID") !== undefined) return false;
+  if (isNpmLifecycleParent()) return false;
   return isRunningAsLifecycleScript();
 }
 

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -109,10 +109,23 @@ describe("postinstall-trampoline", () => {
   describe("shouldSchedulePostinstallReconciliation", () => {
     it("returns true inside a lifecycle script when not a trampoline and not dry-run", () => {
       process.env.npm_package_json = FAKE_PACKAGE_JSON_PATH;
+      delete process.env.npm_config_user_agent;
+      delete process.env.npm_execpath;
       delete process.env.LISA_POSTINSTALL_TRAMPOLINE;
       delete process.env.VITEST;
       delete process.env.JEST_WORKER_ID;
       expect(shouldSchedulePostinstallReconciliation(false)).toBe(true);
+    });
+
+    it("returns false for npm lifecycle scripts so package-lock regeneration runs synchronously", () => {
+      process.env.npm_package_json = FAKE_PACKAGE_JSON_PATH;
+      process.env.npm_config_user_agent =
+        "npm/10.9.0 node/v22.21.1 darwin arm64 workspaces/false";
+      delete process.env.npm_execpath;
+      delete process.env.LISA_POSTINSTALL_TRAMPOLINE;
+      delete process.env.VITEST;
+      delete process.env.JEST_WORKER_ID;
+      expect(shouldSchedulePostinstallReconciliation(false)).toBe(false);
     });
 
     it("returns false when in dry-run mode", () => {


### PR DESCRIPTION
## Summary

Fixes #1683.

- Detect npm lifecycle parents from `npm_config_user_agent` / `npm_execpath`.
- Keep npm lifecycle runs on Lisa's existing synchronous lockfile-regeneration path so `package-lock.json` is coherent before install exits.
- Preserve the detached trampoline for Bun/yarn/pnpm or unknown lifecycle contexts where package.json may still be rewritten after scripts finish.

## Verification

- `bunx vitest run tests/unit/utils/postinstall-trampoline.test.ts`
- `bun run typecheck`
- `bunx vitest run tests/integration/lisa.test.ts --testNamePattern='postinstall-safe|package'`
- `bun run lint`
- pre-push hook: security audit, slow lint, `knip`, full unit coverage, full integration suite



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved postinstall behavior when running within npm lifecycle scripts by preventing unnecessary reconciliation scheduling.
  * Preserved existing opt-outs for dry runs, test environments, and trampoline child processes.

* **Tests**
  * Added coverage to verify npm lifecycle scripts are correctly detected and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->