### PR TITLE
feat: add vendor-neutral remote-agent AWS bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Skill bodies are not copied into the project and unrelated Lisa stacks are not
 loaded. Project settings use `[features].hooks`; the deprecated `codex_hooks`
 key is removed during reconciliation.
 
+Remote coding environments use one vendor-neutral AWS bootstrap rather than
+repository-specific or agent-specific IAM users. Run `/lisa:setup-remote-aws`
+to install the common setup script and native Cursor/Copilot adapters; Claude,
+Codex, Cursor, Copilot, and user-managed Antigravity/OpenCode hosts all consume
+the same `LISA_AWS_BOOTSTRAP_JSON` bundle. See
+[Remote coding-agent AWS access](docs/remote-agent-aws.md).
+
 The supported stacks, setup flags, and exact invocation evolve as the project grows, so ask for the current set rather than copying a list that may have moved on:
 
 > **Prompt for your coding agent**

--- a/all/create-only/scripts/remote-agent-aws-setup.sh
+++ b/all/create-only/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Installed by Lisa. The authoritative implementation is shipped by the
+# lisa-setup-remote-aws skill and the @codyswann/lisa package.
+
+set -euo pipefail
+
+LOCAL_LISA_SCRIPT="$(npm root 2>/dev/null)/@codyswann/lisa/plugins/lisa/scripts/remote-agent-aws-setup.sh"
+[ -x "$LOCAL_LISA_SCRIPT" ] && exec "$LOCAL_LISA_SCRIPT" "$@"
+
+echo "remote-agent-aws-setup: install @codyswann/lisa before running this setup script" >&2
+exit 1

--- a/docs/remote-agent-aws.md
+++ b/docs/remote-agent-aws.md
@@ -1,0 +1,62 @@
+# Remote coding-agent AWS access
+
+Lisa supports AWS CLI access from remote coding environments through one
+vendor-neutral bootstrap contract. The AWS side creates one long-lived IAM user
+whose only permission is `sts:AssumeRole` on explicitly listed remote-agent
+roles. The user has no direct service permissions. Dev and staging roles may
+carry the separately reviewed repair policy; production and shared roles are
+observer-only.
+
+The cdkstarter agent-operations stack stores a complete JSON bootstrap bundle
+in Secrets Manager under the configured `agentOperations.secretName` (the
+starter default is `remote-agent-credentials`). Retrieve the secret's
+`SecretString` and configure that
+entire value—unchanged—as the platform secret `LISA_AWS_BOOTSTRAP_JSON`.
+Do not create separate `AWS_ACCESS_KEY_ID` variables: standard AWS variables can
+bypass the intended role profile.
+
+## Install repository adapters
+
+Run the Lisa skill:
+
+```text
+/lisa:setup-remote-aws --platform=all
+```
+
+It installs `scripts/remote-agent-aws-setup.sh`, adds the Cursor install command,
+creates or merges GitHub Copilot's setup workflow, and writes a project-specific
+operator guide. The script installs AWS CLI v2, writes a private named bootstrap
+profile, creates each account role profile from the bundle, selects `dev` by
+default, and verifies the result with `sts:GetCallerIdentity`. AWS CLI and SDK
+role credentials refresh automatically while the bootstrap key remains valid.
+
+## Configure each remote platform
+
+| Platform | Configuration scope |
+|---|---|
+| Claude | Cloud environment: secret `LISA_AWS_BOOTSTRAP_JSON`, plain `LISA_REMOTE_AGENT=claude`, setup command `bash scripts/remote-agent-aws-setup.sh`. |
+| Codex | Cloud environment setup secret plus `LISA_REMOTE_AGENT=codex`; allow the required AWS endpoints during the agent phase. |
+| Cursor | Cloud-environment secret. The generated `.cursor/environment.json` install command supplies `LISA_REMOTE_AGENT=cursor`. Multi-repository environments can share the configuration. |
+| Copilot | Organization-level **Agents** secret. The generated `copilot-setup-steps.yml` supplies `LISA_REMOTE_AGENT=copilot`. |
+| Antigravity | Use the script on a user-managed remote host. Google's managed remote-agent preview does not currently document arbitrary AWS credential-file or environment-secret injection. |
+| OpenCode | Run the script on the VPS/container hosting `opencode serve`; OpenCode supplies the agent server, not the compute host. |
+
+Any future agent is compatible when it provides a Linux shell, a setup hook,
+one opaque secret, a writable home directory, and outbound HTTPS access to AWS
+STS and the permitted service endpoints. Set `LISA_REMOTE_AGENT` to a stable
+lowercase platform name; that value is used only as the AWS role session name.
+
+## Operator verification
+
+Start one remote session and run:
+
+```bash
+aws sts get-caller-identity
+aws --profile staging sts get-caller-identity
+aws --profile production sts get-caller-identity
+```
+
+Then prove the policy boundary: a permitted dev/staging repair action should
+reach the service authorization layer, while `iam:PassRole` and a production
+mutation must return `AccessDenied`. Production repair continues to use the
+human-driven local-workstation role and is not present in the remote container.

--- a/plugins/lisa-agy/commands/lisa/setup-remote-aws.md
+++ b/plugins/lisa-agy/commands/lisa/setup-remote-aws.md
@@ -1,0 +1,6 @@
+---
+description: "Install Lisa's vendor-neutral AWS CLI bootstrap and platform adapters for remote coding environments."
+argument-hint: "[--platform=all|claude|codex|cursor|copilot|agy|opencode] [--project=<path>] [--secret-name=<name>]"
+---
+
+Use the /lisa-setup-remote-aws skill to install and validate remote coding-agent AWS access. $ARGUMENTS

--- a/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Install Lisa's vendor-neutral remote AWS bootstrap into a host project.
+ *
+ * This installer writes only non-secret repository artifacts. The bootstrap
+ * SecretString is configured directly in each remote-agent platform.
+ * @module install-remote-agent-aws
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = "remote-agent-aws-setup.sh";
+const INSTALL_COMMAND = `bash scripts/${SCRIPT_NAME}`;
+const VALID_PLATFORMS = new Set([
+  "all",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "agy",
+  "opencode",
+]);
+
+function parseArguments(arguments_) {
+  let project = process.cwd();
+  let platform = "all";
+  let secretName = "remote-agent-credentials";
+  for (const argument of arguments_) {
+    if (argument.startsWith("--project=")) {
+      project = path.resolve(argument.slice("--project=".length));
+    } else if (argument.startsWith("--platform=")) {
+      platform = argument.slice("--platform=".length).toLowerCase();
+    } else if (argument.startsWith("--secret-name=")) {
+      secretName = argument.slice("--secret-name=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!VALID_PLATFORMS.has(platform)) {
+    throw new Error(
+      `Unsupported platform '${platform}'. Expected one of: ${[...VALID_PLATFORMS].join(", ")}`
+    );
+  }
+  if (!/^[A-Za-z0-9/_+=.@-]+$/.test(secretName)) {
+    throw new Error("--secret-name must be a valid Secrets Manager name");
+  }
+  return { project, platform, secretName };
+}
+
+function writeSetupScript(project) {
+  const source = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    SCRIPT_NAME
+  );
+  const destination = path.join(project, "scripts", SCRIPT_NAME);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, readFileSync(source));
+  chmodSync(destination, 0o700);
+  return path.relative(project, destination);
+}
+
+function installCursorAdapter(project) {
+  const environmentPath = path.join(project, ".cursor", "environment.json");
+  mkdirSync(path.dirname(environmentPath), { recursive: true });
+
+  const environment = existsSync(environmentPath)
+    ? JSON.parse(readFileSync(environmentPath, "utf8"))
+    : {};
+  const existingInstall = environment.install;
+  if (existingInstall !== undefined && typeof existingInstall !== "string") {
+    throw new Error(
+      `.cursor/environment.json install must be a string before Lisa can merge ${INSTALL_COMMAND}`
+    );
+  }
+  const lisaInstall = `LISA_REMOTE_AGENT=cursor ${INSTALL_COMMAND}`;
+  if (!existingInstall?.includes(SCRIPT_NAME)) {
+    environment.install = existingInstall
+      ? `${lisaInstall} && ${existingInstall}`
+      : lisaInstall;
+  }
+  writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`);
+  return path.relative(project, environmentPath);
+}
+
+function installCopilotAdapter(project) {
+  const workflowPath = path.join(
+    project,
+    ".github",
+    "workflows",
+    "copilot-setup-steps.yml"
+  );
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  const marker = "Lisa remote AWS bootstrap";
+  const step = [
+    `      - name: ${marker}`,
+    "        env:",
+    "          LISA_REMOTE_AGENT: copilot",
+    `        run: ${INSTALL_COMMAND}`,
+  ].join("\n");
+
+  if (!existsSync(workflowPath)) {
+    writeFileSync(
+      workflowPath,
+      [
+        'name: "Copilot Setup Steps"',
+        "on:",
+        "  workflow_dispatch:",
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    permissions:",
+        "      contents: read",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        step,
+        "",
+      ].join("\n")
+    );
+    return path.relative(project, workflowPath);
+  }
+
+  const current = readFileSync(workflowPath, "utf8");
+  if (current.includes(marker)) return path.relative(project, workflowPath);
+  const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+  const additions = current.includes("actions/checkout@")
+    ? [step]
+    : ["      - uses: actions/checkout@v4", step];
+  lines.splice(stepsIndex + 1, 0, ...additions);
+  writeFileSync(workflowPath, lines.join("\n"));
+  return path.relative(project, workflowPath);
+}
+
+function writeGuide(project, platform, secretName) {
+  const guidePath = path.join(project, "docs", "remote-agent-aws.md");
+  mkdirSync(path.dirname(guidePath), { recursive: true });
+  writeFileSync(
+    guidePath,
+    `# Remote coding-agent AWS access
+
+This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
+Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
+split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
+variables. The setup script writes a named source profile whose only permission
+is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
+
+## Runtime configuration
+
+| Runtime | Setup |
+|---|---|
+| Claude | Add \`LISA_AWS_BOOTSTRAP_JSON\` to the cloud environment, set \`LISA_REMOTE_AGENT=claude\`, and run \`${INSTALL_COMMAND}\` in the setup script. |
+| Codex | Add \`LISA_AWS_BOOTSTRAP_JSON\` as a setup secret, set \`LISA_REMOTE_AGENT=codex\`, and run \`${INSTALL_COMMAND}\` in the setup script. Permit required AWS endpoints during the agent phase. |
+| Cursor | Add the secret to the selected cloud environment. \`.cursor/environment.json\` runs the setup script with \`LISA_REMOTE_AGENT=cursor\`. |
+| Copilot | Add the value as an organization-level **Agents** secret. \`copilot-setup-steps.yml\` runs the setup script with \`LISA_REMOTE_AGENT=copilot\`. |
+| Antigravity | Direct AWS CLI is supported only on a user-managed remote host. Google's managed preview currently documents proxy-injected HTTP credentials, not arbitrary AWS credential files. |
+| OpenCode | Run the setup script on the VPS/container that hosts \`opencode serve\`, with \`LISA_REMOTE_AGENT=opencode\`. OpenCode does not supply the host. |
+
+Generated for: \`${platform}\`.
+
+## Profiles
+
+The bootstrap bundle defines the available profile names. \`dev\` is the
+default when present. Select another account explicitly, for example:
+
+\`\`\`bash
+aws --profile staging sts get-caller-identity
+aws --profile production cloudformation describe-stacks
+\`\`\`
+
+Production and shared profiles are observer-only. Production repair remains a
+human-driven local-workstation operation.
+
+## Administrator rollout
+
+After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
+the complete bundle from the shared account. Do not extract or distribute its
+individual access-key fields:
+
+\`\`\`bash
+aws --profile shared secretsmanager get-secret-value \\
+  --secret-id ${secretName} \\
+  --query SecretString \\
+  --output text
+\`\`\`
+
+Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
+remote-agent platform. Run the setup command and require its live
+\`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+Rotate by replacing the bootstrap IAM access key through infrastructure and
+then updating this one secret on every configured platform. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.
+`
+  );
+  return path.relative(project, guidePath);
+}
+
+export function installRemoteAgentAws(arguments_ = process.argv.slice(2)) {
+  const { project, platform, secretName } = parseArguments(arguments_);
+  if (!existsSync(project))
+    throw new Error(`Project does not exist: ${project}`);
+
+  const written = [writeSetupScript(project)];
+  if (platform === "all" || platform === "cursor") {
+    written.push(installCursorAdapter(project));
+  }
+  if (platform === "all" || platform === "copilot") {
+    written.push(installCopilotAdapter(project));
+  }
+  written.push(writeGuide(project, platform, secretName));
+  return { project, platform, secretName, written };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(installRemoteAgentAws(), null, 2)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `install-remote-agent-aws: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Vendor-neutral AWS CLI bootstrap for remote coding environments. This is the
+# source copied into every generated Lisa agent plugin.
+#
+# Required secret:
+#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
+#                            remote-agent IAM kit.
+# Optional plain variables:
+#   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
+#   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.
+#   LISA_AWS_SKIP_VERIFY    Set to 1 only for an offline image build.
+
+set -euo pipefail
+umask 077
+
+BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+
+fail() {
+  echo "remote-agent-aws-setup: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif need sudo; then
+    sudo "$@"
+  else
+    fail "root access is required to install $1"
+  fi
+}
+
+install_base_tools() {
+  need curl && need unzip && need jq && return 0
+
+  if need apt-get; then
+    as_root apt-get update -y
+    as_root apt-get install -y curl unzip jq
+  elif need dnf; then
+    as_root dnf install -y curl unzip jq
+  elif need yum; then
+    as_root yum install -y curl unzip jq
+  else
+    fail "install curl, unzip, and jq in the remote image before running this script"
+  fi
+}
+
+install_aws_cli() {
+  need aws && return 0
+
+  local architecture aws_architecture temporary_directory
+  architecture="$(uname -m)"
+  case "$architecture" in
+    x86_64 | amd64) aws_architecture="x86_64" ;;
+    aarch64 | arm64) aws_architecture="aarch64" ;;
+    *) fail "unsupported AWS CLI architecture: $architecture" ;;
+  esac
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "${temporary_directory:-}"' EXIT
+  curl -fsSL \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    -o "$temporary_directory/awscliv2.zip"
+  unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
+  as_root "$temporary_directory/aws/install" \
+    --install-dir /usr/local/aws-cli \
+    --bin-dir /usr/local/bin
+  rm -rf "$temporary_directory"
+  trap - EXIT
+}
+
+sanitize_session_name() {
+  local candidate
+  candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
+    | sed 's/[^A-Za-z0-9_+=,.@-]/-/g' \
+    | cut -c1-64)"
+  [ "${#candidate}" -ge 2 ] || candidate="remote-agent"
+  printf '%s\n' "$candidate"
+}
+
+install_base_tools
+install_aws_cli
+
+[ -z "${AWS_ACCESS_KEY_ID:-}" ] || fail \
+  "do not set AWS_ACCESS_KEY_ID directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || fail \
+  "do not set AWS_SECRET_ACCESS_KEY directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+
+bootstrap_json="${LISA_AWS_BOOTSTRAP_JSON:-}"
+[ -n "$bootstrap_json" ] || fail "LISA_AWS_BOOTSTRAP_JSON is required"
+
+printf '%s' "$bootstrap_json" | jq -e '
+  type == "object" and
+  (.accessKeyId | type == "string" and length > 0) and
+  (.secretAccessKey | type == "string" and length > 0) and
+  (.externalId | type == "string" and length > 0) and
+  (.profiles | (type == "object" or type == "string"))
+' >/dev/null || fail "LISA_AWS_BOOTSTRAP_JSON is not a valid remote-agent bootstrap bundle"
+
+access_key_id="$(printf '%s' "$bootstrap_json" | jq -er '.accessKeyId')"
+secret_access_key="$(printf '%s' "$bootstrap_json" | jq -er '.secretAccessKey')"
+external_id="$(printf '%s' "$bootstrap_json" | jq -er '.externalId')"
+session_token="$(printf '%s' "$bootstrap_json" | jq -r '.sessionToken // empty')"
+profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
+  if (.profiles | type) == "string" then
+    .profiles | fromjson
+  else
+    .profiles
+  end
+')"
+
+printf '%s' "$profiles_json" | jq -e '
+  type == "object" and length > 0 and
+  all(to_entries[];
+    (.key | test("^[A-Za-z0-9_-]+$")) and
+    (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
+    (.value.region | type == "string" and length > 0)
+  )
+' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
+
+mkdir -p "$HOME/.aws"
+chmod 700 "$HOME/.aws"
+
+aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
+aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
+if [ -n "$session_token" ]; then
+  aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+fi
+
+session_name="$(sanitize_session_name)"
+while IFS=$'\t' read -r profile_name role_arn region; do
+  aws configure set role_arn "$role_arn" --profile "$profile_name"
+  aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile "$profile_name"
+  aws configure set external_id "$external_id" --profile "$profile_name"
+  aws configure set role_session_name "$session_name" --profile "$profile_name"
+  aws configure set region "$region" --profile "$profile_name"
+done < <(printf '%s' "$profiles_json" | jq -r 'to_entries[] | [.key, .value.roleArn, .value.region] | @tsv')
+
+default_profile="${LISA_AWS_DEFAULT_PROFILE:-dev}"
+if ! printf '%s' "$profiles_json" | jq -e --arg profile "$default_profile" 'has($profile)' >/dev/null; then
+  default_profile="$(printf '%s' "$profiles_json" | jq -r 'keys[0]')"
+fi
+
+default_role_arn="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].roleArn')"
+default_region="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].region')"
+aws configure set role_arn "$default_role_arn" --profile default
+aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile default
+aws configure set external_id "$external_id" --profile default
+aws configure set role_session_name "$session_name" --profile default
+aws configure set region "$default_region" --profile default
+
+chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+
+if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
+  AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null
+fi
+
+profile_names="$(printf '%s' "$profiles_json" | jq -r 'keys | join(", ")')"
+echo "remote-agent-aws-setup: ready (${session_name}; default=${default_profile}; profiles=${profile_names})"

--- a/plugins/lisa-agy/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/lisa-agy/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/lisa-agy/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments. Supports Claude, Codex, Cursor, GitHub Copilot, Antigravity on user-managed hosts, OpenCode on user-managed hosts, and future Linux remote agents through one capability contract. Writes no secrets; it installs the common setup script, merges native Cursor/Copilot adapters, and emits exact operator guidance for the selected platform."
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/plugins/lisa-copilot/commands/lisa/setup-remote-aws.md
+++ b/plugins/lisa-copilot/commands/lisa/setup-remote-aws.md
@@ -1,0 +1,6 @@
+---
+description: "Install Lisa's vendor-neutral AWS CLI bootstrap and platform adapters for remote coding environments."
+argument-hint: "[--platform=all|claude|codex|cursor|copilot|agy|opencode] [--project=<path>] [--secret-name=<name>]"
+---
+
+Use the /lisa-setup-remote-aws skill to install and validate remote coding-agent AWS access. $ARGUMENTS

--- a/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Install Lisa's vendor-neutral remote AWS bootstrap into a host project.
+ *
+ * This installer writes only non-secret repository artifacts. The bootstrap
+ * SecretString is configured directly in each remote-agent platform.
+ * @module install-remote-agent-aws
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = "remote-agent-aws-setup.sh";
+const INSTALL_COMMAND = `bash scripts/${SCRIPT_NAME}`;
+const VALID_PLATFORMS = new Set([
+  "all",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "agy",
+  "opencode",
+]);
+
+function parseArguments(arguments_) {
+  let project = process.cwd();
+  let platform = "all";
+  let secretName = "remote-agent-credentials";
+  for (const argument of arguments_) {
+    if (argument.startsWith("--project=")) {
+      project = path.resolve(argument.slice("--project=".length));
+    } else if (argument.startsWith("--platform=")) {
+      platform = argument.slice("--platform=".length).toLowerCase();
+    } else if (argument.startsWith("--secret-name=")) {
+      secretName = argument.slice("--secret-name=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!VALID_PLATFORMS.has(platform)) {
+    throw new Error(
+      `Unsupported platform '${platform}'. Expected one of: ${[...VALID_PLATFORMS].join(", ")}`
+    );
+  }
+  if (!/^[A-Za-z0-9/_+=.@-]+$/.test(secretName)) {
+    throw new Error("--secret-name must be a valid Secrets Manager name");
+  }
+  return { project, platform, secretName };
+}
+
+function writeSetupScript(project) {
+  const source = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    SCRIPT_NAME
+  );
+  const destination = path.join(project, "scripts", SCRIPT_NAME);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, readFileSync(source));
+  chmodSync(destination, 0o700);
+  return path.relative(project, destination);
+}
+
+function installCursorAdapter(project) {
+  const environmentPath = path.join(project, ".cursor", "environment.json");
+  mkdirSync(path.dirname(environmentPath), { recursive: true });
+
+  const environment = existsSync(environmentPath)
+    ? JSON.parse(readFileSync(environmentPath, "utf8"))
+    : {};
+  const existingInstall = environment.install;
+  if (existingInstall !== undefined && typeof existingInstall !== "string") {
+    throw new Error(
+      `.cursor/environment.json install must be a string before Lisa can merge ${INSTALL_COMMAND}`
+    );
+  }
+  const lisaInstall = `LISA_REMOTE_AGENT=cursor ${INSTALL_COMMAND}`;
+  if (!existingInstall?.includes(SCRIPT_NAME)) {
+    environment.install = existingInstall
+      ? `${lisaInstall} && ${existingInstall}`
+      : lisaInstall;
+  }
+  writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`);
+  return path.relative(project, environmentPath);
+}
+
+function installCopilotAdapter(project) {
+  const workflowPath = path.join(
+    project,
+    ".github",
+    "workflows",
+    "copilot-setup-steps.yml"
+  );
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  const marker = "Lisa remote AWS bootstrap";
+  const step = [
+    `      - name: ${marker}`,
+    "        env:",
+    "          LISA_REMOTE_AGENT: copilot",
+    `        run: ${INSTALL_COMMAND}`,
+  ].join("\n");
+
+  if (!existsSync(workflowPath)) {
+    writeFileSync(
+      workflowPath,
+      [
+        'name: "Copilot Setup Steps"',
+        "on:",
+        "  workflow_dispatch:",
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    permissions:",
+        "      contents: read",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        step,
+        "",
+      ].join("\n")
+    );
+    return path.relative(project, workflowPath);
+  }
+
+  const current = readFileSync(workflowPath, "utf8");
+  if (current.includes(marker)) return path.relative(project, workflowPath);
+  const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+  const additions = current.includes("actions/checkout@")
+    ? [step]
+    : ["      - uses: actions/checkout@v4", step];
+  lines.splice(stepsIndex + 1, 0, ...additions);
+  writeFileSync(workflowPath, lines.join("\n"));
+  return path.relative(project, workflowPath);
+}
+
+function writeGuide(project, platform, secretName) {
+  const guidePath = path.join(project, "docs", "remote-agent-aws.md");
+  mkdirSync(path.dirname(guidePath), { recursive: true });
+  writeFileSync(
+    guidePath,
+    `# Remote coding-agent AWS access
+
+This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
+Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
+split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
+variables. The setup script writes a named source profile whose only permission
+is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
+
+## Runtime configuration
+
+| Runtime | Setup |
+|---|---|
+| Claude | Add \`LISA_AWS_BOOTSTRAP_JSON\` to the cloud environment, set \`LISA_REMOTE_AGENT=claude\`, and run \`${INSTALL_COMMAND}\` in the setup script. |
+| Codex | Add \`LISA_AWS_BOOTSTRAP_JSON\` as a setup secret, set \`LISA_REMOTE_AGENT=codex\`, and run \`${INSTALL_COMMAND}\` in the setup script. Permit required AWS endpoints during the agent phase. |
+| Cursor | Add the secret to the selected cloud environment. \`.cursor/environment.json\` runs the setup script with \`LISA_REMOTE_AGENT=cursor\`. |
+| Copilot | Add the value as an organization-level **Agents** secret. \`copilot-setup-steps.yml\` runs the setup script with \`LISA_REMOTE_AGENT=copilot\`. |
+| Antigravity | Direct AWS CLI is supported only on a user-managed remote host. Google's managed preview currently documents proxy-injected HTTP credentials, not arbitrary AWS credential files. |
+| OpenCode | Run the setup script on the VPS/container that hosts \`opencode serve\`, with \`LISA_REMOTE_AGENT=opencode\`. OpenCode does not supply the host. |
+
+Generated for: \`${platform}\`.
+
+## Profiles
+
+The bootstrap bundle defines the available profile names. \`dev\` is the
+default when present. Select another account explicitly, for example:
+
+\`\`\`bash
+aws --profile staging sts get-caller-identity
+aws --profile production cloudformation describe-stacks
+\`\`\`
+
+Production and shared profiles are observer-only. Production repair remains a
+human-driven local-workstation operation.
+
+## Administrator rollout
+
+After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
+the complete bundle from the shared account. Do not extract or distribute its
+individual access-key fields:
+
+\`\`\`bash
+aws --profile shared secretsmanager get-secret-value \\
+  --secret-id ${secretName} \\
+  --query SecretString \\
+  --output text
+\`\`\`
+
+Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
+remote-agent platform. Run the setup command and require its live
+\`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+Rotate by replacing the bootstrap IAM access key through infrastructure and
+then updating this one secret on every configured platform. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.
+`
+  );
+  return path.relative(project, guidePath);
+}
+
+export function installRemoteAgentAws(arguments_ = process.argv.slice(2)) {
+  const { project, platform, secretName } = parseArguments(arguments_);
+  if (!existsSync(project))
+    throw new Error(`Project does not exist: ${project}`);
+
+  const written = [writeSetupScript(project)];
+  if (platform === "all" || platform === "cursor") {
+    written.push(installCursorAdapter(project));
+  }
+  if (platform === "all" || platform === "copilot") {
+    written.push(installCopilotAdapter(project));
+  }
+  written.push(writeGuide(project, platform, secretName));
+  return { project, platform, secretName, written };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(installRemoteAgentAws(), null, 2)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `install-remote-agent-aws: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Vendor-neutral AWS CLI bootstrap for remote coding environments. This is the
+# source copied into every generated Lisa agent plugin.
+#
+# Required secret:
+#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
+#                            remote-agent IAM kit.
+# Optional plain variables:
+#   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
+#   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.
+#   LISA_AWS_SKIP_VERIFY    Set to 1 only for an offline image build.
+
+set -euo pipefail
+umask 077
+
+BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+
+fail() {
+  echo "remote-agent-aws-setup: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif need sudo; then
+    sudo "$@"
+  else
+    fail "root access is required to install $1"
+  fi
+}
+
+install_base_tools() {
+  need curl && need unzip && need jq && return 0
+
+  if need apt-get; then
+    as_root apt-get update -y
+    as_root apt-get install -y curl unzip jq
+  elif need dnf; then
+    as_root dnf install -y curl unzip jq
+  elif need yum; then
+    as_root yum install -y curl unzip jq
+  else
+    fail "install curl, unzip, and jq in the remote image before running this script"
+  fi
+}
+
+install_aws_cli() {
+  need aws && return 0
+
+  local architecture aws_architecture temporary_directory
+  architecture="$(uname -m)"
+  case "$architecture" in
+    x86_64 | amd64) aws_architecture="x86_64" ;;
+    aarch64 | arm64) aws_architecture="aarch64" ;;
+    *) fail "unsupported AWS CLI architecture: $architecture" ;;
+  esac
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "${temporary_directory:-}"' EXIT
+  curl -fsSL \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    -o "$temporary_directory/awscliv2.zip"
+  unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
+  as_root "$temporary_directory/aws/install" \
+    --install-dir /usr/local/aws-cli \
+    --bin-dir /usr/local/bin
+  rm -rf "$temporary_directory"
+  trap - EXIT
+}
+
+sanitize_session_name() {
+  local candidate
+  candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
+    | sed 's/[^A-Za-z0-9_+=,.@-]/-/g' \
+    | cut -c1-64)"
+  [ "${#candidate}" -ge 2 ] || candidate="remote-agent"
+  printf '%s\n' "$candidate"
+}
+
+install_base_tools
+install_aws_cli
+
+[ -z "${AWS_ACCESS_KEY_ID:-}" ] || fail \
+  "do not set AWS_ACCESS_KEY_ID directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || fail \
+  "do not set AWS_SECRET_ACCESS_KEY directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+
+bootstrap_json="${LISA_AWS_BOOTSTRAP_JSON:-}"
+[ -n "$bootstrap_json" ] || fail "LISA_AWS_BOOTSTRAP_JSON is required"
+
+printf '%s' "$bootstrap_json" | jq -e '
+  type == "object" and
+  (.accessKeyId | type == "string" and length > 0) and
+  (.secretAccessKey | type == "string" and length > 0) and
+  (.externalId | type == "string" and length > 0) and
+  (.profiles | (type == "object" or type == "string"))
+' >/dev/null || fail "LISA_AWS_BOOTSTRAP_JSON is not a valid remote-agent bootstrap bundle"
+
+access_key_id="$(printf '%s' "$bootstrap_json" | jq -er '.accessKeyId')"
+secret_access_key="$(printf '%s' "$bootstrap_json" | jq -er '.secretAccessKey')"
+external_id="$(printf '%s' "$bootstrap_json" | jq -er '.externalId')"
+session_token="$(printf '%s' "$bootstrap_json" | jq -r '.sessionToken // empty')"
+profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
+  if (.profiles | type) == "string" then
+    .profiles | fromjson
+  else
+    .profiles
+  end
+')"
+
+printf '%s' "$profiles_json" | jq -e '
+  type == "object" and length > 0 and
+  all(to_entries[];
+    (.key | test("^[A-Za-z0-9_-]+$")) and
+    (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
+    (.value.region | type == "string" and length > 0)
+  )
+' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
+
+mkdir -p "$HOME/.aws"
+chmod 700 "$HOME/.aws"
+
+aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
+aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
+if [ -n "$session_token" ]; then
+  aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+fi
+
+session_name="$(sanitize_session_name)"
+while IFS=$'\t' read -r profile_name role_arn region; do
+  aws configure set role_arn "$role_arn" --profile "$profile_name"
+  aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile "$profile_name"
+  aws configure set external_id "$external_id" --profile "$profile_name"
+  aws configure set role_session_name "$session_name" --profile "$profile_name"
+  aws configure set region "$region" --profile "$profile_name"
+done < <(printf '%s' "$profiles_json" | jq -r 'to_entries[] | [.key, .value.roleArn, .value.region] | @tsv')
+
+default_profile="${LISA_AWS_DEFAULT_PROFILE:-dev}"
+if ! printf '%s' "$profiles_json" | jq -e --arg profile "$default_profile" 'has($profile)' >/dev/null; then
+  default_profile="$(printf '%s' "$profiles_json" | jq -r 'keys[0]')"
+fi
+
+default_role_arn="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].roleArn')"
+default_region="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].region')"
+aws configure set role_arn "$default_role_arn" --profile default
+aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile default
+aws configure set external_id "$external_id" --profile default
+aws configure set role_session_name "$session_name" --profile default
+aws configure set region "$default_region" --profile default
+
+chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+
+if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
+  AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null
+fi
+
+profile_names="$(printf '%s' "$profiles_json" | jq -r 'keys | join(", ")')"
+echo "remote-agent-aws-setup: ready (${session_name}; default=${default_profile}; profiles=${profile_names})"

--- a/plugins/lisa-copilot/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/lisa-copilot/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments. Supports Claude, Codex, Cursor, GitHub Copilot, Antigravity on user-managed hosts, OpenCode on user-managed hosts, and future Linux remote agents through one capability contract. Writes no secrets; it installs the common setup script, merges native Cursor/Copilot adapters, and emits exact operator guidance for the selected platform."
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/plugins/lisa-cursor/commands/lisa/setup-remote-aws.md
+++ b/plugins/lisa-cursor/commands/lisa/setup-remote-aws.md
@@ -1,0 +1,6 @@
+---
+description: "Install Lisa's vendor-neutral AWS CLI bootstrap and platform adapters for remote coding environments."
+argument-hint: "[--platform=all|claude|codex|cursor|copilot|agy|opencode] [--project=<path>] [--secret-name=<name>]"
+---
+
+Use the /lisa-setup-remote-aws skill to install and validate remote coding-agent AWS access. $ARGUMENTS

--- a/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Install Lisa's vendor-neutral remote AWS bootstrap into a host project.
+ *
+ * This installer writes only non-secret repository artifacts. The bootstrap
+ * SecretString is configured directly in each remote-agent platform.
+ * @module install-remote-agent-aws
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = "remote-agent-aws-setup.sh";
+const INSTALL_COMMAND = `bash scripts/${SCRIPT_NAME}`;
+const VALID_PLATFORMS = new Set([
+  "all",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "agy",
+  "opencode",
+]);
+
+function parseArguments(arguments_) {
+  let project = process.cwd();
+  let platform = "all";
+  let secretName = "remote-agent-credentials";
+  for (const argument of arguments_) {
+    if (argument.startsWith("--project=")) {
+      project = path.resolve(argument.slice("--project=".length));
+    } else if (argument.startsWith("--platform=")) {
+      platform = argument.slice("--platform=".length).toLowerCase();
+    } else if (argument.startsWith("--secret-name=")) {
+      secretName = argument.slice("--secret-name=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!VALID_PLATFORMS.has(platform)) {
+    throw new Error(
+      `Unsupported platform '${platform}'. Expected one of: ${[...VALID_PLATFORMS].join(", ")}`
+    );
+  }
+  if (!/^[A-Za-z0-9/_+=.@-]+$/.test(secretName)) {
+    throw new Error("--secret-name must be a valid Secrets Manager name");
+  }
+  return { project, platform, secretName };
+}
+
+function writeSetupScript(project) {
+  const source = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    SCRIPT_NAME
+  );
+  const destination = path.join(project, "scripts", SCRIPT_NAME);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, readFileSync(source));
+  chmodSync(destination, 0o700);
+  return path.relative(project, destination);
+}
+
+function installCursorAdapter(project) {
+  const environmentPath = path.join(project, ".cursor", "environment.json");
+  mkdirSync(path.dirname(environmentPath), { recursive: true });
+
+  const environment = existsSync(environmentPath)
+    ? JSON.parse(readFileSync(environmentPath, "utf8"))
+    : {};
+  const existingInstall = environment.install;
+  if (existingInstall !== undefined && typeof existingInstall !== "string") {
+    throw new Error(
+      `.cursor/environment.json install must be a string before Lisa can merge ${INSTALL_COMMAND}`
+    );
+  }
+  const lisaInstall = `LISA_REMOTE_AGENT=cursor ${INSTALL_COMMAND}`;
+  if (!existingInstall?.includes(SCRIPT_NAME)) {
+    environment.install = existingInstall
+      ? `${lisaInstall} && ${existingInstall}`
+      : lisaInstall;
+  }
+  writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`);
+  return path.relative(project, environmentPath);
+}
+
+function installCopilotAdapter(project) {
+  const workflowPath = path.join(
+    project,
+    ".github",
+    "workflows",
+    "copilot-setup-steps.yml"
+  );
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  const marker = "Lisa remote AWS bootstrap";
+  const step = [
+    `      - name: ${marker}`,
+    "        env:",
+    "          LISA_REMOTE_AGENT: copilot",
+    `        run: ${INSTALL_COMMAND}`,
+  ].join("\n");
+
+  if (!existsSync(workflowPath)) {
+    writeFileSync(
+      workflowPath,
+      [
+        'name: "Copilot Setup Steps"',
+        "on:",
+        "  workflow_dispatch:",
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    permissions:",
+        "      contents: read",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        step,
+        "",
+      ].join("\n")
+    );
+    return path.relative(project, workflowPath);
+  }
+
+  const current = readFileSync(workflowPath, "utf8");
+  if (current.includes(marker)) return path.relative(project, workflowPath);
+  const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+  const additions = current.includes("actions/checkout@")
+    ? [step]
+    : ["      - uses: actions/checkout@v4", step];
+  lines.splice(stepsIndex + 1, 0, ...additions);
+  writeFileSync(workflowPath, lines.join("\n"));
+  return path.relative(project, workflowPath);
+}
+
+function writeGuide(project, platform, secretName) {
+  const guidePath = path.join(project, "docs", "remote-agent-aws.md");
+  mkdirSync(path.dirname(guidePath), { recursive: true });
+  writeFileSync(
+    guidePath,
+    `# Remote coding-agent AWS access
+
+This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
+Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
+split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
+variables. The setup script writes a named source profile whose only permission
+is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
+
+## Runtime configuration
+
+| Runtime | Setup |
+|---|---|
+| Claude | Add \`LISA_AWS_BOOTSTRAP_JSON\` to the cloud environment, set \`LISA_REMOTE_AGENT=claude\`, and run \`${INSTALL_COMMAND}\` in the setup script. |
+| Codex | Add \`LISA_AWS_BOOTSTRAP_JSON\` as a setup secret, set \`LISA_REMOTE_AGENT=codex\`, and run \`${INSTALL_COMMAND}\` in the setup script. Permit required AWS endpoints during the agent phase. |
+| Cursor | Add the secret to the selected cloud environment. \`.cursor/environment.json\` runs the setup script with \`LISA_REMOTE_AGENT=cursor\`. |
+| Copilot | Add the value as an organization-level **Agents** secret. \`copilot-setup-steps.yml\` runs the setup script with \`LISA_REMOTE_AGENT=copilot\`. |
+| Antigravity | Direct AWS CLI is supported only on a user-managed remote host. Google's managed preview currently documents proxy-injected HTTP credentials, not arbitrary AWS credential files. |
+| OpenCode | Run the setup script on the VPS/container that hosts \`opencode serve\`, with \`LISA_REMOTE_AGENT=opencode\`. OpenCode does not supply the host. |
+
+Generated for: \`${platform}\`.
+
+## Profiles
+
+The bootstrap bundle defines the available profile names. \`dev\` is the
+default when present. Select another account explicitly, for example:
+
+\`\`\`bash
+aws --profile staging sts get-caller-identity
+aws --profile production cloudformation describe-stacks
+\`\`\`
+
+Production and shared profiles are observer-only. Production repair remains a
+human-driven local-workstation operation.
+
+## Administrator rollout
+
+After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
+the complete bundle from the shared account. Do not extract or distribute its
+individual access-key fields:
+
+\`\`\`bash
+aws --profile shared secretsmanager get-secret-value \\
+  --secret-id ${secretName} \\
+  --query SecretString \\
+  --output text
+\`\`\`
+
+Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
+remote-agent platform. Run the setup command and require its live
+\`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+Rotate by replacing the bootstrap IAM access key through infrastructure and
+then updating this one secret on every configured platform. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.
+`
+  );
+  return path.relative(project, guidePath);
+}
+
+export function installRemoteAgentAws(arguments_ = process.argv.slice(2)) {
+  const { project, platform, secretName } = parseArguments(arguments_);
+  if (!existsSync(project))
+    throw new Error(`Project does not exist: ${project}`);
+
+  const written = [writeSetupScript(project)];
+  if (platform === "all" || platform === "cursor") {
+    written.push(installCursorAdapter(project));
+  }
+  if (platform === "all" || platform === "copilot") {
+    written.push(installCopilotAdapter(project));
+  }
+  written.push(writeGuide(project, platform, secretName));
+  return { project, platform, secretName, written };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(installRemoteAgentAws(), null, 2)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `install-remote-agent-aws: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Vendor-neutral AWS CLI bootstrap for remote coding environments. This is the
+# source copied into every generated Lisa agent plugin.
+#
+# Required secret:
+#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
+#                            remote-agent IAM kit.
+# Optional plain variables:
+#   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
+#   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.
+#   LISA_AWS_SKIP_VERIFY    Set to 1 only for an offline image build.
+
+set -euo pipefail
+umask 077
+
+BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+
+fail() {
+  echo "remote-agent-aws-setup: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif need sudo; then
+    sudo "$@"
+  else
+    fail "root access is required to install $1"
+  fi
+}
+
+install_base_tools() {
+  need curl && need unzip && need jq && return 0
+
+  if need apt-get; then
+    as_root apt-get update -y
+    as_root apt-get install -y curl unzip jq
+  elif need dnf; then
+    as_root dnf install -y curl unzip jq
+  elif need yum; then
+    as_root yum install -y curl unzip jq
+  else
+    fail "install curl, unzip, and jq in the remote image before running this script"
+  fi
+}
+
+install_aws_cli() {
+  need aws && return 0
+
+  local architecture aws_architecture temporary_directory
+  architecture="$(uname -m)"
+  case "$architecture" in
+    x86_64 | amd64) aws_architecture="x86_64" ;;
+    aarch64 | arm64) aws_architecture="aarch64" ;;
+    *) fail "unsupported AWS CLI architecture: $architecture" ;;
+  esac
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "${temporary_directory:-}"' EXIT
+  curl -fsSL \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    -o "$temporary_directory/awscliv2.zip"
+  unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
+  as_root "$temporary_directory/aws/install" \
+    --install-dir /usr/local/aws-cli \
+    --bin-dir /usr/local/bin
+  rm -rf "$temporary_directory"
+  trap - EXIT
+}
+
+sanitize_session_name() {
+  local candidate
+  candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
+    | sed 's/[^A-Za-z0-9_+=,.@-]/-/g' \
+    | cut -c1-64)"
+  [ "${#candidate}" -ge 2 ] || candidate="remote-agent"
+  printf '%s\n' "$candidate"
+}
+
+install_base_tools
+install_aws_cli
+
+[ -z "${AWS_ACCESS_KEY_ID:-}" ] || fail \
+  "do not set AWS_ACCESS_KEY_ID directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || fail \
+  "do not set AWS_SECRET_ACCESS_KEY directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+
+bootstrap_json="${LISA_AWS_BOOTSTRAP_JSON:-}"
+[ -n "$bootstrap_json" ] || fail "LISA_AWS_BOOTSTRAP_JSON is required"
+
+printf '%s' "$bootstrap_json" | jq -e '
+  type == "object" and
+  (.accessKeyId | type == "string" and length > 0) and
+  (.secretAccessKey | type == "string" and length > 0) and
+  (.externalId | type == "string" and length > 0) and
+  (.profiles | (type == "object" or type == "string"))
+' >/dev/null || fail "LISA_AWS_BOOTSTRAP_JSON is not a valid remote-agent bootstrap bundle"
+
+access_key_id="$(printf '%s' "$bootstrap_json" | jq -er '.accessKeyId')"
+secret_access_key="$(printf '%s' "$bootstrap_json" | jq -er '.secretAccessKey')"
+external_id="$(printf '%s' "$bootstrap_json" | jq -er '.externalId')"
+session_token="$(printf '%s' "$bootstrap_json" | jq -r '.sessionToken // empty')"
+profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
+  if (.profiles | type) == "string" then
+    .profiles | fromjson
+  else
+    .profiles
+  end
+')"
+
+printf '%s' "$profiles_json" | jq -e '
+  type == "object" and length > 0 and
+  all(to_entries[];
+    (.key | test("^[A-Za-z0-9_-]+$")) and
+    (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
+    (.value.region | type == "string" and length > 0)
+  )
+' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
+
+mkdir -p "$HOME/.aws"
+chmod 700 "$HOME/.aws"
+
+aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
+aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
+if [ -n "$session_token" ]; then
+  aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+fi
+
+session_name="$(sanitize_session_name)"
+while IFS=$'\t' read -r profile_name role_arn region; do
+  aws configure set role_arn "$role_arn" --profile "$profile_name"
+  aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile "$profile_name"
+  aws configure set external_id "$external_id" --profile "$profile_name"
+  aws configure set role_session_name "$session_name" --profile "$profile_name"
+  aws configure set region "$region" --profile "$profile_name"
+done < <(printf '%s' "$profiles_json" | jq -r 'to_entries[] | [.key, .value.roleArn, .value.region] | @tsv')
+
+default_profile="${LISA_AWS_DEFAULT_PROFILE:-dev}"
+if ! printf '%s' "$profiles_json" | jq -e --arg profile "$default_profile" 'has($profile)' >/dev/null; then
+  default_profile="$(printf '%s' "$profiles_json" | jq -r 'keys[0]')"
+fi
+
+default_role_arn="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].roleArn')"
+default_region="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].region')"
+aws configure set role_arn "$default_role_arn" --profile default
+aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile default
+aws configure set external_id "$external_id" --profile default
+aws configure set role_session_name "$session_name" --profile default
+aws configure set region "$default_region" --profile default
+
+chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+
+if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
+  AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null
+fi
+
+profile_names="$(printf '%s' "$profiles_json" | jq -r 'keys | join(", ")')"
+echo "remote-agent-aws-setup: ready (${session_name}; default=${default_profile}; profiles=${profile_names})"

--- a/plugins/lisa-cursor/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/lisa-cursor/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments. Supports Claude, Codex, Cursor, GitHub Copilot, Antigravity on user-managed hosts, OpenCode on user-managed hosts, and future Linux remote agents through one capability contract. Writes no secrets; it installs the common setup script, merges native Cursor/Copilot adapters, and emits exact operator guidance for the selected platform."
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/plugins/lisa/.codex-plugin/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/lisa/.codex-plugin/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's…"
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Setup Remote AWS"
+short_description: "Install and validate Lisa's…"
+default_prompt:
+  - "Use $lisa-setup-remote-aws: Install and validate Lisa's…."

--- a/plugins/lisa/commands/setup-remote-aws.md
+++ b/plugins/lisa/commands/setup-remote-aws.md
@@ -1,0 +1,6 @@
+---
+description: "Install Lisa's vendor-neutral AWS CLI bootstrap and platform adapters for remote coding environments."
+argument-hint: "[--platform=all|claude|codex|cursor|copilot|agy|opencode] [--project=<path>] [--secret-name=<name>]"
+---
+
+Use the /lisa-setup-remote-aws skill to install and validate remote coding-agent AWS access. $ARGUMENTS

--- a/plugins/lisa/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa/scripts/install-remote-agent-aws.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Install Lisa's vendor-neutral remote AWS bootstrap into a host project.
+ *
+ * This installer writes only non-secret repository artifacts. The bootstrap
+ * SecretString is configured directly in each remote-agent platform.
+ * @module install-remote-agent-aws
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = "remote-agent-aws-setup.sh";
+const INSTALL_COMMAND = `bash scripts/${SCRIPT_NAME}`;
+const VALID_PLATFORMS = new Set([
+  "all",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "agy",
+  "opencode",
+]);
+
+function parseArguments(arguments_) {
+  let project = process.cwd();
+  let platform = "all";
+  let secretName = "remote-agent-credentials";
+  for (const argument of arguments_) {
+    if (argument.startsWith("--project=")) {
+      project = path.resolve(argument.slice("--project=".length));
+    } else if (argument.startsWith("--platform=")) {
+      platform = argument.slice("--platform=".length).toLowerCase();
+    } else if (argument.startsWith("--secret-name=")) {
+      secretName = argument.slice("--secret-name=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!VALID_PLATFORMS.has(platform)) {
+    throw new Error(
+      `Unsupported platform '${platform}'. Expected one of: ${[...VALID_PLATFORMS].join(", ")}`
+    );
+  }
+  if (!/^[A-Za-z0-9/_+=.@-]+$/.test(secretName)) {
+    throw new Error("--secret-name must be a valid Secrets Manager name");
+  }
+  return { project, platform, secretName };
+}
+
+function writeSetupScript(project) {
+  const source = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    SCRIPT_NAME
+  );
+  const destination = path.join(project, "scripts", SCRIPT_NAME);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, readFileSync(source));
+  chmodSync(destination, 0o700);
+  return path.relative(project, destination);
+}
+
+function installCursorAdapter(project) {
+  const environmentPath = path.join(project, ".cursor", "environment.json");
+  mkdirSync(path.dirname(environmentPath), { recursive: true });
+
+  const environment = existsSync(environmentPath)
+    ? JSON.parse(readFileSync(environmentPath, "utf8"))
+    : {};
+  const existingInstall = environment.install;
+  if (existingInstall !== undefined && typeof existingInstall !== "string") {
+    throw new Error(
+      `.cursor/environment.json install must be a string before Lisa can merge ${INSTALL_COMMAND}`
+    );
+  }
+  const lisaInstall = `LISA_REMOTE_AGENT=cursor ${INSTALL_COMMAND}`;
+  if (!existingInstall?.includes(SCRIPT_NAME)) {
+    environment.install = existingInstall
+      ? `${lisaInstall} && ${existingInstall}`
+      : lisaInstall;
+  }
+  writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`);
+  return path.relative(project, environmentPath);
+}
+
+function installCopilotAdapter(project) {
+  const workflowPath = path.join(
+    project,
+    ".github",
+    "workflows",
+    "copilot-setup-steps.yml"
+  );
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  const marker = "Lisa remote AWS bootstrap";
+  const step = [
+    `      - name: ${marker}`,
+    "        env:",
+    "          LISA_REMOTE_AGENT: copilot",
+    `        run: ${INSTALL_COMMAND}`,
+  ].join("\n");
+
+  if (!existsSync(workflowPath)) {
+    writeFileSync(
+      workflowPath,
+      [
+        'name: "Copilot Setup Steps"',
+        "on:",
+        "  workflow_dispatch:",
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    permissions:",
+        "      contents: read",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        step,
+        "",
+      ].join("\n")
+    );
+    return path.relative(project, workflowPath);
+  }
+
+  const current = readFileSync(workflowPath, "utf8");
+  if (current.includes(marker)) return path.relative(project, workflowPath);
+  const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+  const additions = current.includes("actions/checkout@")
+    ? [step]
+    : ["      - uses: actions/checkout@v4", step];
+  lines.splice(stepsIndex + 1, 0, ...additions);
+  writeFileSync(workflowPath, lines.join("\n"));
+  return path.relative(project, workflowPath);
+}
+
+function writeGuide(project, platform, secretName) {
+  const guidePath = path.join(project, "docs", "remote-agent-aws.md");
+  mkdirSync(path.dirname(guidePath), { recursive: true });
+  writeFileSync(
+    guidePath,
+    `# Remote coding-agent AWS access
+
+This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
+Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
+split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
+variables. The setup script writes a named source profile whose only permission
+is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
+
+## Runtime configuration
+
+| Runtime | Setup |
+|---|---|
+| Claude | Add \`LISA_AWS_BOOTSTRAP_JSON\` to the cloud environment, set \`LISA_REMOTE_AGENT=claude\`, and run \`${INSTALL_COMMAND}\` in the setup script. |
+| Codex | Add \`LISA_AWS_BOOTSTRAP_JSON\` as a setup secret, set \`LISA_REMOTE_AGENT=codex\`, and run \`${INSTALL_COMMAND}\` in the setup script. Permit required AWS endpoints during the agent phase. |
+| Cursor | Add the secret to the selected cloud environment. \`.cursor/environment.json\` runs the setup script with \`LISA_REMOTE_AGENT=cursor\`. |
+| Copilot | Add the value as an organization-level **Agents** secret. \`copilot-setup-steps.yml\` runs the setup script with \`LISA_REMOTE_AGENT=copilot\`. |
+| Antigravity | Direct AWS CLI is supported only on a user-managed remote host. Google's managed preview currently documents proxy-injected HTTP credentials, not arbitrary AWS credential files. |
+| OpenCode | Run the setup script on the VPS/container that hosts \`opencode serve\`, with \`LISA_REMOTE_AGENT=opencode\`. OpenCode does not supply the host. |
+
+Generated for: \`${platform}\`.
+
+## Profiles
+
+The bootstrap bundle defines the available profile names. \`dev\` is the
+default when present. Select another account explicitly, for example:
+
+\`\`\`bash
+aws --profile staging sts get-caller-identity
+aws --profile production cloudformation describe-stacks
+\`\`\`
+
+Production and shared profiles are observer-only. Production repair remains a
+human-driven local-workstation operation.
+
+## Administrator rollout
+
+After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
+the complete bundle from the shared account. Do not extract or distribute its
+individual access-key fields:
+
+\`\`\`bash
+aws --profile shared secretsmanager get-secret-value \\
+  --secret-id ${secretName} \\
+  --query SecretString \\
+  --output text
+\`\`\`
+
+Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
+remote-agent platform. Run the setup command and require its live
+\`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+Rotate by replacing the bootstrap IAM access key through infrastructure and
+then updating this one secret on every configured platform. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.
+`
+  );
+  return path.relative(project, guidePath);
+}
+
+export function installRemoteAgentAws(arguments_ = process.argv.slice(2)) {
+  const { project, platform, secretName } = parseArguments(arguments_);
+  if (!existsSync(project))
+    throw new Error(`Project does not exist: ${project}`);
+
+  const written = [writeSetupScript(project)];
+  if (platform === "all" || platform === "cursor") {
+    written.push(installCursorAdapter(project));
+  }
+  if (platform === "all" || platform === "copilot") {
+    written.push(installCopilotAdapter(project));
+  }
+  written.push(writeGuide(project, platform, secretName));
+  return { project, platform, secretName, written };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(installRemoteAgentAws(), null, 2)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `install-remote-agent-aws: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/plugins/lisa/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Vendor-neutral AWS CLI bootstrap for remote coding environments. This is the
+# source copied into every generated Lisa agent plugin.
+#
+# Required secret:
+#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
+#                            remote-agent IAM kit.
+# Optional plain variables:
+#   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
+#   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.
+#   LISA_AWS_SKIP_VERIFY    Set to 1 only for an offline image build.
+
+set -euo pipefail
+umask 077
+
+BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+
+fail() {
+  echo "remote-agent-aws-setup: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif need sudo; then
+    sudo "$@"
+  else
+    fail "root access is required to install $1"
+  fi
+}
+
+install_base_tools() {
+  need curl && need unzip && need jq && return 0
+
+  if need apt-get; then
+    as_root apt-get update -y
+    as_root apt-get install -y curl unzip jq
+  elif need dnf; then
+    as_root dnf install -y curl unzip jq
+  elif need yum; then
+    as_root yum install -y curl unzip jq
+  else
+    fail "install curl, unzip, and jq in the remote image before running this script"
+  fi
+}
+
+install_aws_cli() {
+  need aws && return 0
+
+  local architecture aws_architecture temporary_directory
+  architecture="$(uname -m)"
+  case "$architecture" in
+    x86_64 | amd64) aws_architecture="x86_64" ;;
+    aarch64 | arm64) aws_architecture="aarch64" ;;
+    *) fail "unsupported AWS CLI architecture: $architecture" ;;
+  esac
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "${temporary_directory:-}"' EXIT
+  curl -fsSL \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    -o "$temporary_directory/awscliv2.zip"
+  unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
+  as_root "$temporary_directory/aws/install" \
+    --install-dir /usr/local/aws-cli \
+    --bin-dir /usr/local/bin
+  rm -rf "$temporary_directory"
+  trap - EXIT
+}
+
+sanitize_session_name() {
+  local candidate
+  candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
+    | sed 's/[^A-Za-z0-9_+=,.@-]/-/g' \
+    | cut -c1-64)"
+  [ "${#candidate}" -ge 2 ] || candidate="remote-agent"
+  printf '%s\n' "$candidate"
+}
+
+install_base_tools
+install_aws_cli
+
+[ -z "${AWS_ACCESS_KEY_ID:-}" ] || fail \
+  "do not set AWS_ACCESS_KEY_ID directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || fail \
+  "do not set AWS_SECRET_ACCESS_KEY directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+
+bootstrap_json="${LISA_AWS_BOOTSTRAP_JSON:-}"
+[ -n "$bootstrap_json" ] || fail "LISA_AWS_BOOTSTRAP_JSON is required"
+
+printf '%s' "$bootstrap_json" | jq -e '
+  type == "object" and
+  (.accessKeyId | type == "string" and length > 0) and
+  (.secretAccessKey | type == "string" and length > 0) and
+  (.externalId | type == "string" and length > 0) and
+  (.profiles | (type == "object" or type == "string"))
+' >/dev/null || fail "LISA_AWS_BOOTSTRAP_JSON is not a valid remote-agent bootstrap bundle"
+
+access_key_id="$(printf '%s' "$bootstrap_json" | jq -er '.accessKeyId')"
+secret_access_key="$(printf '%s' "$bootstrap_json" | jq -er '.secretAccessKey')"
+external_id="$(printf '%s' "$bootstrap_json" | jq -er '.externalId')"
+session_token="$(printf '%s' "$bootstrap_json" | jq -r '.sessionToken // empty')"
+profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
+  if (.profiles | type) == "string" then
+    .profiles | fromjson
+  else
+    .profiles
+  end
+')"
+
+printf '%s' "$profiles_json" | jq -e '
+  type == "object" and length > 0 and
+  all(to_entries[];
+    (.key | test("^[A-Za-z0-9_-]+$")) and
+    (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
+    (.value.region | type == "string" and length > 0)
+  )
+' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
+
+mkdir -p "$HOME/.aws"
+chmod 700 "$HOME/.aws"
+
+aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
+aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
+if [ -n "$session_token" ]; then
+  aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+fi
+
+session_name="$(sanitize_session_name)"
+while IFS=$'\t' read -r profile_name role_arn region; do
+  aws configure set role_arn "$role_arn" --profile "$profile_name"
+  aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile "$profile_name"
+  aws configure set external_id "$external_id" --profile "$profile_name"
+  aws configure set role_session_name "$session_name" --profile "$profile_name"
+  aws configure set region "$region" --profile "$profile_name"
+done < <(printf '%s' "$profiles_json" | jq -r 'to_entries[] | [.key, .value.roleArn, .value.region] | @tsv')
+
+default_profile="${LISA_AWS_DEFAULT_PROFILE:-dev}"
+if ! printf '%s' "$profiles_json" | jq -e --arg profile "$default_profile" 'has($profile)' >/dev/null; then
+  default_profile="$(printf '%s' "$profiles_json" | jq -r 'keys[0]')"
+fi
+
+default_role_arn="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].roleArn')"
+default_region="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].region')"
+aws configure set role_arn "$default_role_arn" --profile default
+aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile default
+aws configure set external_id "$external_id" --profile default
+aws configure set role_session_name "$session_name" --profile default
+aws configure set region "$default_region" --profile default
+
+chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+
+if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
+  AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null
+fi
+
+profile_names="$(printf '%s' "$profiles_json" | jq -r 'keys | join(", ")')"
+echo "remote-agent-aws-setup: ready (${session_name}; default=${default_profile}; profiles=${profile_names})"

--- a/plugins/lisa/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/lisa/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/lisa/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments. Supports Claude, Codex, Cursor, GitHub Copilot, Antigravity on user-managed hosts, OpenCode on user-managed hosts, and future Linux remote agents through one capability contract. Writes no secrets; it installs the common setup script, merges native Cursor/Copilot adapters, and emits exact operator guidance for the selected platform."
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/plugins/lisa/skills/lisa-setup-remote-aws/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-setup-remote-aws/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Setup Remote AWS"
+short_description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments"
+default_prompt:
+  - "Use $lisa-setup-remote-aws: Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments."

--- a/plugins/src/base/commands/setup-remote-aws.md
+++ b/plugins/src/base/commands/setup-remote-aws.md
@@ -1,0 +1,6 @@
+---
+description: "Install Lisa's vendor-neutral AWS CLI bootstrap and platform adapters for remote coding environments."
+argument-hint: "[--platform=all|claude|codex|cursor|copilot|agy|opencode] [--project=<path>] [--secret-name=<name>]"
+---
+
+Use the /lisa-setup-remote-aws skill to install and validate remote coding-agent AWS access. $ARGUMENTS

--- a/plugins/src/base/scripts/install-remote-agent-aws.mjs
+++ b/plugins/src/base/scripts/install-remote-agent-aws.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Install Lisa's vendor-neutral remote AWS bootstrap into a host project.
+ *
+ * This installer writes only non-secret repository artifacts. The bootstrap
+ * SecretString is configured directly in each remote-agent platform.
+ * @module install-remote-agent-aws
+ */
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_NAME = "remote-agent-aws-setup.sh";
+const INSTALL_COMMAND = `bash scripts/${SCRIPT_NAME}`;
+const VALID_PLATFORMS = new Set([
+  "all",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "agy",
+  "opencode",
+]);
+
+function parseArguments(arguments_) {
+  let project = process.cwd();
+  let platform = "all";
+  let secretName = "remote-agent-credentials";
+  for (const argument of arguments_) {
+    if (argument.startsWith("--project=")) {
+      project = path.resolve(argument.slice("--project=".length));
+    } else if (argument.startsWith("--platform=")) {
+      platform = argument.slice("--platform=".length).toLowerCase();
+    } else if (argument.startsWith("--secret-name=")) {
+      secretName = argument.slice("--secret-name=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!VALID_PLATFORMS.has(platform)) {
+    throw new Error(
+      `Unsupported platform '${platform}'. Expected one of: ${[...VALID_PLATFORMS].join(", ")}`
+    );
+  }
+  if (!/^[A-Za-z0-9/_+=.@-]+$/.test(secretName)) {
+    throw new Error("--secret-name must be a valid Secrets Manager name");
+  }
+  return { project, platform, secretName };
+}
+
+function writeSetupScript(project) {
+  const source = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    SCRIPT_NAME
+  );
+  const destination = path.join(project, "scripts", SCRIPT_NAME);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, readFileSync(source));
+  chmodSync(destination, 0o700);
+  return path.relative(project, destination);
+}
+
+function installCursorAdapter(project) {
+  const environmentPath = path.join(project, ".cursor", "environment.json");
+  mkdirSync(path.dirname(environmentPath), { recursive: true });
+
+  const environment = existsSync(environmentPath)
+    ? JSON.parse(readFileSync(environmentPath, "utf8"))
+    : {};
+  const existingInstall = environment.install;
+  if (existingInstall !== undefined && typeof existingInstall !== "string") {
+    throw new Error(
+      `.cursor/environment.json install must be a string before Lisa can merge ${INSTALL_COMMAND}`
+    );
+  }
+  const lisaInstall = `LISA_REMOTE_AGENT=cursor ${INSTALL_COMMAND}`;
+  if (!existingInstall?.includes(SCRIPT_NAME)) {
+    environment.install = existingInstall
+      ? `${lisaInstall} && ${existingInstall}`
+      : lisaInstall;
+  }
+  writeFileSync(environmentPath, `${JSON.stringify(environment, null, 2)}\n`);
+  return path.relative(project, environmentPath);
+}
+
+function installCopilotAdapter(project) {
+  const workflowPath = path.join(
+    project,
+    ".github",
+    "workflows",
+    "copilot-setup-steps.yml"
+  );
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  const marker = "Lisa remote AWS bootstrap";
+  const step = [
+    `      - name: ${marker}`,
+    "        env:",
+    "          LISA_REMOTE_AGENT: copilot",
+    `        run: ${INSTALL_COMMAND}`,
+  ].join("\n");
+
+  if (!existsSync(workflowPath)) {
+    writeFileSync(
+      workflowPath,
+      [
+        'name: "Copilot Setup Steps"',
+        "on:",
+        "  workflow_dispatch:",
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    permissions:",
+        "      contents: read",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        step,
+        "",
+      ].join("\n")
+    );
+    return path.relative(project, workflowPath);
+  }
+
+  const current = readFileSync(workflowPath, "utf8");
+  if (current.includes(marker)) return path.relative(project, workflowPath);
+  const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+  const additions = current.includes("actions/checkout@")
+    ? [step]
+    : ["      - uses: actions/checkout@v4", step];
+  lines.splice(stepsIndex + 1, 0, ...additions);
+  writeFileSync(workflowPath, lines.join("\n"));
+  return path.relative(project, workflowPath);
+}
+
+function writeGuide(project, platform, secretName) {
+  const guidePath = path.join(project, "docs", "remote-agent-aws.md");
+  mkdirSync(path.dirname(guidePath), { recursive: true });
+  writeFileSync(
+    guidePath,
+    `# Remote coding-agent AWS access
+
+This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
+Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
+split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
+variables. The setup script writes a named source profile whose only permission
+is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
+
+## Runtime configuration
+
+| Runtime | Setup |
+|---|---|
+| Claude | Add \`LISA_AWS_BOOTSTRAP_JSON\` to the cloud environment, set \`LISA_REMOTE_AGENT=claude\`, and run \`${INSTALL_COMMAND}\` in the setup script. |
+| Codex | Add \`LISA_AWS_BOOTSTRAP_JSON\` as a setup secret, set \`LISA_REMOTE_AGENT=codex\`, and run \`${INSTALL_COMMAND}\` in the setup script. Permit required AWS endpoints during the agent phase. |
+| Cursor | Add the secret to the selected cloud environment. \`.cursor/environment.json\` runs the setup script with \`LISA_REMOTE_AGENT=cursor\`. |
+| Copilot | Add the value as an organization-level **Agents** secret. \`copilot-setup-steps.yml\` runs the setup script with \`LISA_REMOTE_AGENT=copilot\`. |
+| Antigravity | Direct AWS CLI is supported only on a user-managed remote host. Google's managed preview currently documents proxy-injected HTTP credentials, not arbitrary AWS credential files. |
+| OpenCode | Run the setup script on the VPS/container that hosts \`opencode serve\`, with \`LISA_REMOTE_AGENT=opencode\`. OpenCode does not supply the host. |
+
+Generated for: \`${platform}\`.
+
+## Profiles
+
+The bootstrap bundle defines the available profile names. \`dev\` is the
+default when present. Select another account explicitly, for example:
+
+\`\`\`bash
+aws --profile staging sts get-caller-identity
+aws --profile production cloudformation describe-stacks
+\`\`\`
+
+Production and shared profiles are observer-only. Production repair remains a
+human-driven local-workstation operation.
+
+## Administrator rollout
+
+After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
+the complete bundle from the shared account. Do not extract or distribute its
+individual access-key fields:
+
+\`\`\`bash
+aws --profile shared secretsmanager get-secret-value \\
+  --secret-id ${secretName} \\
+  --query SecretString \\
+  --output text
+\`\`\`
+
+Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
+remote-agent platform. Run the setup command and require its live
+\`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+Rotate by replacing the bootstrap IAM access key through infrastructure and
+then updating this one secret on every configured platform. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.
+`
+  );
+  return path.relative(project, guidePath);
+}
+
+export function installRemoteAgentAws(arguments_ = process.argv.slice(2)) {
+  const { project, platform, secretName } = parseArguments(arguments_);
+  if (!existsSync(project))
+    throw new Error(`Project does not exist: ${project}`);
+
+  const written = [writeSetupScript(project)];
+  if (platform === "all" || platform === "cursor") {
+    written.push(installCursorAdapter(project));
+  }
+  if (platform === "all" || platform === "copilot") {
+    written.push(installCopilotAdapter(project));
+  }
+  written.push(writeGuide(project, platform, secretName));
+  return { project, platform, secretName, written };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(installRemoteAgentAws(), null, 2)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `install-remote-agent-aws: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/plugins/src/base/scripts/remote-agent-aws-setup.sh
+++ b/plugins/src/base/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Vendor-neutral AWS CLI bootstrap for remote coding environments. This is the
+# source copied into every generated Lisa agent plugin.
+#
+# Required secret:
+#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
+#                            remote-agent IAM kit.
+# Optional plain variables:
+#   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
+#   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.
+#   LISA_AWS_SKIP_VERIFY    Set to 1 only for an offline image build.
+
+set -euo pipefail
+umask 077
+
+BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+
+fail() {
+  echo "remote-agent-aws-setup: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+as_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif need sudo; then
+    sudo "$@"
+  else
+    fail "root access is required to install $1"
+  fi
+}
+
+install_base_tools() {
+  need curl && need unzip && need jq && return 0
+
+  if need apt-get; then
+    as_root apt-get update -y
+    as_root apt-get install -y curl unzip jq
+  elif need dnf; then
+    as_root dnf install -y curl unzip jq
+  elif need yum; then
+    as_root yum install -y curl unzip jq
+  else
+    fail "install curl, unzip, and jq in the remote image before running this script"
+  fi
+}
+
+install_aws_cli() {
+  need aws && return 0
+
+  local architecture aws_architecture temporary_directory
+  architecture="$(uname -m)"
+  case "$architecture" in
+    x86_64 | amd64) aws_architecture="x86_64" ;;
+    aarch64 | arm64) aws_architecture="aarch64" ;;
+    *) fail "unsupported AWS CLI architecture: $architecture" ;;
+  esac
+
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "${temporary_directory:-}"' EXIT
+  curl -fsSL \
+    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    -o "$temporary_directory/awscliv2.zip"
+  unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
+  as_root "$temporary_directory/aws/install" \
+    --install-dir /usr/local/aws-cli \
+    --bin-dir /usr/local/bin
+  rm -rf "$temporary_directory"
+  trap - EXIT
+}
+
+sanitize_session_name() {
+  local candidate
+  candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
+    | sed 's/[^A-Za-z0-9_+=,.@-]/-/g' \
+    | cut -c1-64)"
+  [ "${#candidate}" -ge 2 ] || candidate="remote-agent"
+  printf '%s\n' "$candidate"
+}
+
+install_base_tools
+install_aws_cli
+
+[ -z "${AWS_ACCESS_KEY_ID:-}" ] || fail \
+  "do not set AWS_ACCESS_KEY_ID directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || fail \
+  "do not set AWS_SECRET_ACCESS_KEY directly; set only LISA_AWS_BOOTSTRAP_JSON so role profiles cannot be bypassed"
+
+bootstrap_json="${LISA_AWS_BOOTSTRAP_JSON:-}"
+[ -n "$bootstrap_json" ] || fail "LISA_AWS_BOOTSTRAP_JSON is required"
+
+printf '%s' "$bootstrap_json" | jq -e '
+  type == "object" and
+  (.accessKeyId | type == "string" and length > 0) and
+  (.secretAccessKey | type == "string" and length > 0) and
+  (.externalId | type == "string" and length > 0) and
+  (.profiles | (type == "object" or type == "string"))
+' >/dev/null || fail "LISA_AWS_BOOTSTRAP_JSON is not a valid remote-agent bootstrap bundle"
+
+access_key_id="$(printf '%s' "$bootstrap_json" | jq -er '.accessKeyId')"
+secret_access_key="$(printf '%s' "$bootstrap_json" | jq -er '.secretAccessKey')"
+external_id="$(printf '%s' "$bootstrap_json" | jq -er '.externalId')"
+session_token="$(printf '%s' "$bootstrap_json" | jq -r '.sessionToken // empty')"
+profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
+  if (.profiles | type) == "string" then
+    .profiles | fromjson
+  else
+    .profiles
+  end
+')"
+
+printf '%s' "$profiles_json" | jq -e '
+  type == "object" and length > 0 and
+  all(to_entries[];
+    (.key | test("^[A-Za-z0-9_-]+$")) and
+    (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
+    (.value.region | type == "string" and length > 0)
+  )
+' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
+
+mkdir -p "$HOME/.aws"
+chmod 700 "$HOME/.aws"
+
+aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
+aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
+if [ -n "$session_token" ]; then
+  aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+fi
+
+session_name="$(sanitize_session_name)"
+while IFS=$'\t' read -r profile_name role_arn region; do
+  aws configure set role_arn "$role_arn" --profile "$profile_name"
+  aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile "$profile_name"
+  aws configure set external_id "$external_id" --profile "$profile_name"
+  aws configure set role_session_name "$session_name" --profile "$profile_name"
+  aws configure set region "$region" --profile "$profile_name"
+done < <(printf '%s' "$profiles_json" | jq -r 'to_entries[] | [.key, .value.roleArn, .value.region] | @tsv')
+
+default_profile="${LISA_AWS_DEFAULT_PROFILE:-dev}"
+if ! printf '%s' "$profiles_json" | jq -e --arg profile "$default_profile" 'has($profile)' >/dev/null; then
+  default_profile="$(printf '%s' "$profiles_json" | jq -r 'keys[0]')"
+fi
+
+default_role_arn="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].roleArn')"
+default_region="$(printf '%s' "$profiles_json" | jq -er --arg profile "$default_profile" '.[$profile].region')"
+aws configure set role_arn "$default_role_arn" --profile default
+aws configure set source_profile "$BOOTSTRAP_PROFILE" --profile default
+aws configure set external_id "$external_id" --profile default
+aws configure set role_session_name "$session_name" --profile default
+aws configure set region "$default_region" --profile default
+
+chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+
+if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
+  AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null
+fi
+
+profile_names="$(printf '%s' "$profiles_json" | jq -r 'keys | join(", ")')"
+echo "remote-agent-aws-setup: ready (${session_name}; default=${default_profile}; profiles=${profile_names})"

--- a/plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md
@@ -150,24 +150,27 @@ Group the findings as:
      Terraform providers).
    - `aws sso login`, `aws:signin:*`, `sso_start_url`, `sso_account_id`, `sso_role_name`, or
      `sso_session` in docs or config.
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`,
-     `AWS_PROFILE`, role ARN, external ID, account, or CloudWatch/STS references.
+   - `LISA_AWS_BOOTSTRAP_JSON`, legacy `AWS_ACCESS_KEY_ID` /
+     `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, role ARN, external ID, account, or
+     CloudWatch/STS references.
 
    If AWS is present, emit an AWS credential finding and inventory entry. If the repo's current
    local path is `aws sso login` or an `aws:signin:*` script, classify that local path as a `GAP`
    for headless remote routines: it is an interactive browser/device-authorization flow and cannot
    complete in the cloud. Route to the AWS row in the Credential reference instead of suggesting
-   SSO auth. The finding must name the headless substrate: a dedicated IAM principal (user or role)
-   with only permission to `sts:AssumeRole`, environment credentials in the routine UI, and
-   `~/.aws/config` profiles using `role_arn`, `credential_source = Environment`, optional
-   `external_id`, and `region`.
+   SSO auth. The finding must name Lisa's headless substrate: one dedicated IAM
+   user with only `sts:AssumeRole`; one complete Secrets Manager SecretString
+   set as `LISA_AWS_BOOTSTRAP_JSON`; and `/lisa:setup-remote-aws`, which writes a
+   named source profile plus automatically refreshed role profiles. Explicitly
+   reject standard `AWS_ACCESS_KEY_ID` variables because they can bypass the
+   intended assume-role profile.
 
    When the repository contains concrete non-secret AWS metadata (role ARNs, account aliases,
    profile names, regions, or ExternalId values), include it in an `awsProfiles` inventory array so
    `/lisa:generate-claude-remote-build-script` can write matching `~/.aws/config` profiles. Never
-   invent account IDs, ExternalIds, role names, or regions. If AWS is detected but profile metadata
-   is absent, emit the required AWS secret names plus an action to add project-specific profile
-   metadata to the generated artifact or environment notes.
+   invent account IDs, ExternalIds, role names, or regions. If AWS is detected
+   but profile metadata is absent, require a cdkstarter bootstrap bundle rather
+   than asking the repository to reconstruct account metadata by hand.
 
 5. **MCP servers** — read every committed `.mcp.json`. For each server report transport and auth.
    Project-scoped HTTP/SSE servers with no interactive auth are `OK`. Flag stdio servers as
@@ -276,14 +279,14 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 - Access: the personal API key inherits the user's workspace permissions — the user must be able to read/create/update Issues in the destination team.
 
 ### AWS — host-project operations, logs, deploys, CDK/Serverless/SST, or AWS SDK usage
-- Headless substrate: a dedicated IAM principal (user or role) with long-lived bootstrap credentials
-  stored in the routine environment, used only to call `sts:AssumeRole` into per-account operational
-  roles. The routine writes `~/.aws/config` profiles with `role_arn`, `credential_source =
-  Environment`, optional `external_id`, and `region`; agents use `aws --profile <profile> ...`.
-- Env: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` for temporary
-  bootstrap credentials; `AWS_DEFAULT_REGION` when no profile region is provided. Role ARNs,
-  ExternalIds, profile names, and regions are non-secret project metadata and belong in generated
-  artifacts or project docs, not in the skill's global guidance.
+- Headless substrate: cdkstarter's vendor-neutral remote-agent kit. Its single
+  Secrets Manager SecretString contains the assume-only access key, ExternalId,
+  and per-account role metadata. `/lisa:setup-remote-aws` writes a private named
+  source profile and renewable role profiles; agents use
+  `aws --profile <profile> ...`.
+- Env: `LISA_AWS_BOOTSTRAP_JSON` (secret, required) and
+  `LISA_REMOTE_AGENT` (plain platform label). Do not set `AWS_ACCESS_KEY_ID` or
+  `AWS_SECRET_ACCESS_KEY` in the remote environment.
 - Allowlist: `*.amazonaws.com`, or narrower service hosts such as `sts.amazonaws.com`,
   `logs.<region>.amazonaws.com`, `cloudwatch.<region>.amazonaws.com`,
   `xray.<region>.amazonaws.com`, `ssm.<region>.amazonaws.com`, and service-specific endpoints the
@@ -366,7 +369,7 @@ so the generator can render acquisition comments into its template:
     {
       "name": "dev",
       "roleArn": "arn:aws:iam::<account-id>:role/<role-name>",
-      "credentialSource": "Environment",
+      "credentialSource": "lisa-remote-agent-bootstrap",
       "externalId": "<project-external-id>",
       "region": "us-east-1"
     }

--- a/plugins/src/base/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -71,9 +71,9 @@ tracker/source, plus the host project's own package manager and tooling — not 
    include `JAM_PAT`, `SONAR_TOKEN`, or similar documented substrate env vars
    only as optional secrets, with their acquire/scope comments when the analysis
    supplied them. Never invent values or promote dormant substrates to required.
-   When AWS entries are present, list `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
-   `AWS_SESSION_TOKEN`, and `AWS_DEFAULT_REGION` exactly as the analysis reported. State that these
-   bootstrap credentials are for STS assume-role only; do not emit or recommend `aws sso login`.
+   When AWS entries are present, list only `LISA_AWS_BOOTSTRAP_JSON` as the
+   required secret and `LISA_REMOTE_AGENT=claude` as plain configuration. Never
+   emit standard `AWS_ACCESS_KEY_ID` variables and never recommend `aws sso login`.
 
 3a. **Emit substrate setup snippets.** When the inventory marks an MCP
    `headlessUsable: true` through a documented substrate, render the matching
@@ -91,18 +91,11 @@ tracker/source, plus the host project's own package manager and tooling — not 
      transport supports static-token auth. Do not print a Jam `.mcp.json` header snippet because
      Jam's preferred headless substrate is its PAT-authenticated CLI.
 
-3b. **Emit AWS assume-role profile setup.** When the inventory includes `awsProfiles`, write an
-   idempotent `~/.aws/config` block gated on `[ -n "${AWS_ACCESS_KEY_ID:-}" ]`. The generated block
-   must:
-   - `mkdir -p "$HOME/.aws"` and create or append profile stanzas without writing secrets.
-   - Emit one `[profile <name>]` stanza per inventory profile with `role_arn`,
-     `credential_source = Environment`, `region` when present, and `external_id` when present.
-   - Keep regions and ExternalIds as non-secret project metadata from the inventory; never invent
-     account IDs, role names, profile names, regions, or ExternalIds.
-   - Warn and skip profile writing when AWS profile metadata is absent, while still listing the
-     required `AWS_*` env var names in the secret template.
-   - Include a comment that agents should use `aws --profile <name> ...` and must not run
-     `aws sso login` in headless routines.
+3b. **Install the shared AWS bootstrap.** When AWS is present, invoke
+   `/lisa:setup-remote-aws --platform=claude`. Reuse the resulting
+   `scripts/remote-agent-aws-setup.sh`; do not generate a second credential or
+   profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
+   generated cloud setup after required package installation.
 
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
@@ -139,9 +132,9 @@ shape, not a fixed payload):
 #   # Note: GH_TOKEN is for gh CLI only. Raw git uses Claude's connected-GitHub proxy/identity;
 #   # sibling repos reached only by raw git do not need to be in this token scope.
 #   - GH_TOKEN=<token>                          # REQUIRED, github is the active tracker+source
-#   - AWS_ACCESS_KEY_ID=<access-key-id>          # REQUIRED when AWS inventory is active
-#   - AWS_SECRET_ACCESS_KEY=<secret-access-key>  # REQUIRED when AWS inventory is active
-#   - AWS_SESSION_TOKEN=<session-token>          # OPTIONAL for temporary bootstrap creds
+#   - LISA_AWS_BOOTSTRAP_JSON=<complete SecretString> # REQUIRED for AWS
+# PLAIN:
+#   - LISA_REMOTE_AGENT=claude
 # NETWORK: set the environment to Custom and allowlist these non-default domains if not on Full:
 #   - <networkAccess.allowlistDomains, if any>
 set -uo pipefail
@@ -184,13 +177,8 @@ need gh || (sudo apt-get update -y && sudo apt-get install -y gh)
 need jq || sudo apt-get install -y jq
 require gh; require jq
 
-# --- AWS assume-role profiles, when inventory includes awsProfiles ---
-if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
-  mkdir -p "$HOME/.aws"
-  # Generated stanzas use credential_source=Environment and contain no secrets.
-  # Agents should run: aws --profile <profile> ...
-  # Do not run aws sso login in headless routines; SSO requires an interactive browser/device flow.
-fi
+# --- AWS assume-role profiles, when AWS inventory is active ---
+bash scripts/remote-agent-aws-setup.sh
 
 # --- optional, only with --include-optional ---
 # (docker / ruby / chromium / etc., guarded)
@@ -213,8 +201,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
   raw git/cross-repo clone guidance must not expand the token scope to sibling repositories.
 - Never emit an install for a tool the analysis did not surface, and never install `OPTIONAL` tools
   unless `--include-optional` is set.
-- When AWS is in the inventory, generate environment-backed assume-role profile stanzas from
-  `awsProfiles`; never emit `aws sso login` as a remote setup step.
+- When AWS is in the inventory, reuse `/lisa:setup-remote-aws` and its shared
+  setup script; never emit a second profile implementation or `aws sso login`.
 - Prefer `networkAccess.allowlistDomains` over legacy top-level `allowlistDomains`; never emit
   domains already covered by the routine environment's default Trusted list.
 - Keep the script idempotent and detect-before-install so it is safe to re-run and cache.

--- a/plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lisa-setup-remote-aws
+description: "Install and validate Lisa's drop-in AWS CLI bootstrap for remote coding environments. Supports Claude, Codex, Cursor, GitHub Copilot, Antigravity on user-managed hosts, OpenCode on user-managed hosts, and future Linux remote agents through one capability contract. Writes no secrets; it installs the common setup script, merges native Cursor/Copilot adapters, and emits exact operator guidance for the selected platform."
+allowed-tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Set up remote-agent AWS access: $ARGUMENTS
+
+Install the vendor-neutral AWS bootstrap into the current repository.
+
+## Arguments
+
+- `--platform=all|claude|codex|cursor|copilot|agy|opencode` (default `all`)
+- `--project=<path>` (default current working directory)
+- `--secret-name=<name>` (default `remote-agent-credentials`)
+
+## Procedure
+
+1. Resolve the plugin root from `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`,
+   `CURSOR_PLUGIN_ROOT`, or the installed `@codyswann/lisa/plugins/lisa` package.
+2. Run:
+
+   ```bash
+   node "$PLUGIN_ROOT/scripts/install-remote-agent-aws.mjs" $ARGUMENTS
+   ```
+
+3. Inspect every path returned by the installer. It must install
+   `scripts/remote-agent-aws-setup.sh`; for Cursor it merges
+   `.cursor/environment.json`; for Copilot it creates or merges
+   `.github/workflows/copilot-setup-steps.yml`; and it always writes
+   `docs/remote-agent-aws.md`.
+4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
+5. Never write or request the actual bootstrap SecretString in repository
+   files. Tell the operator to retrieve the `remote-agent-credentials` secret
+   from the shared AWS account and paste its complete SecretString into the
+   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
+   secret name is `remote-agent-credentials`; downstream infrastructure may
+   configure a different name. Pass that name with `--secret-name` so the
+   generated runbook contains the exact retrieval command.
+6. Report the external step that remains: configure that one secret in the
+   remote environment and launch a smoke session.
+
+## Contract
+
+A future coding agent is supported without an AWS change when its remote
+environment provides a Linux shell, a setup/start hook, one opaque secret,
+a writable home directory, and HTTPS access to AWS STS plus the allowed service
+endpoints. Set `LISA_REMOTE_AGENT` to a stable lowercase platform label; it is
+used only as `role_session_name`.
+
+Do not create per-repository or per-agent IAM users. Do not expose the bootstrap
+key through standard `AWS_ACCESS_KEY_ID` variables. Do not add production repair
+permissions; production repair is a human-driven local-workstation workflow.

--- a/scripts/claude-remote-setup.sh
+++ b/scripts/claude-remote-setup.sh
@@ -23,6 +23,9 @@
 #     #          Pull requests R/W, Metadata R (+Workflows R/W if editing .github/workflows,
 #     #          +Projects R/W if using ProjectV2). Identity needs WRITE+ on the repo.
 #     - GH_TOKEN=<token>        # REQUIRED unless the routine's repo connection already auths `gh`
+#   AWS (when this routine needs account access):
+#     - LISA_AWS_BOOTSTRAP_JSON=<complete remote-agent-credentials SecretString>
+#     - LISA_REMOTE_AGENT=claude
 #   Dormant (set ONLY if you switch .lisa.config.json tracker/source):
 #     - JIRA_API_TOKEN / JIRA_SERVER / JIRA_LOGIN / JIRA_PROJECT   # tracker=jira
 #     - ATLASSIAN_API_TOKEN                                        # source=confluence (8 Confluence scopes)
@@ -69,6 +72,12 @@ if ! need gh; then
 fi
 require jq
 require gh
+
+# --- AWS CLI + renewable role profiles (when configured) ---
+if [ -n "${LISA_AWS_BOOTSTRAP_JSON:-}" ]; then
+  LISA_REMOTE_AGENT="${LISA_REMOTE_AGENT:-claude}" \
+    bash scripts/remote-agent-aws-setup.sh
+fi
 
 # --- gitleaks (REQUIRED: pre-commit secret scan) ---
 if ! need gitleaks; then
@@ -133,8 +142,6 @@ if [ "$INCLUDE_OPTIONAL" = "1" ]; then
   # Chromium for Lighthouse/Playwright (heavy — can strain the cache budget)
   npx playwright install chromium || echo "WARN: chromium install failed (optional)"
 
-  # aws CLI (cleanup scripts)
-  need aws || apt_get install -y awscli || echo "WARN: awscli install failed (optional)"
 fi
 
 echo "claude-remote-setup: done."

--- a/scripts/remote-agent-aws-setup.sh
+++ b/scripts/remote-agent-aws-setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Package-level convenience wrapper. The implementation is authored upstream
+# in plugins/src/base and copied into plugins/lisa by build:plugins.
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+for candidate in \
+  "$REPOSITORY_ROOT/plugins/lisa/scripts/remote-agent-aws-setup.sh" \
+  "$REPOSITORY_ROOT/plugins/src/base/scripts/remote-agent-aws-setup.sh"; do
+  if [ -x "$candidate" ]; then
+    exec "$candidate" "$@"
+  fi
+done
+
+echo "remote-agent-aws-setup: Lisa plugin script is missing; run bun run build:plugins" >&2
+exit 1

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Vendor-neutral remote AWS bootstrap and platform-adapter coverage.
+ * @module tests/unit/strategies/remote-agent-aws-setup
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installRemoteAgentAws } from "../../../plugins/src/base/scripts/install-remote-agent-aws.mjs";
+
+const temporaryDirectories: string[] = [];
+const REMOTE_SETUP_SCRIPT_PATH =
+  "plugins/src/base/scripts/remote-agent-aws-setup.sh";
+const CURSOR_ENVIRONMENT_PATH = ".cursor/environment.json";
+const COPILOT_WORKFLOW_PATH = ".github/workflows/copilot-setup-steps.yml";
+const REMOTE_AWS_GUIDE_PATH = "docs/remote-agent-aws.md";
+const GENERATED_PLUGIN_ROOTS = [
+  "plugins/lisa",
+  "plugins/lisa-cursor",
+  "plugins/lisa-agy",
+  "plugins/lisa-copilot",
+] as const;
+
+/**
+ * Create and register a disposable project directory.
+ * @returns Absolute path to the disposable directory
+ */
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "lisa-remote-aws-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("remote AWS platform installer", () => {
+  it("installs the common script and native Cursor and Copilot adapters", () => {
+    const project = temporaryDirectory();
+    const result = installRemoteAgentAws([
+      `--project=${project}`,
+      "--platform=all",
+      "--secret-name=company-remote-agent",
+    ]);
+
+    expect(result.written).toEqual(
+      expect.arrayContaining([
+        "scripts/remote-agent-aws-setup.sh",
+        CURSOR_ENVIRONMENT_PATH,
+        COPILOT_WORKFLOW_PATH,
+        REMOTE_AWS_GUIDE_PATH,
+      ])
+    );
+    expect(
+      JSON.parse(
+        readFileSync(path.join(project, CURSOR_ENVIRONMENT_PATH), "utf8")
+      ).install
+    ).toBe("LISA_REMOTE_AGENT=cursor bash scripts/remote-agent-aws-setup.sh");
+    const workflow = readFileSync(
+      path.join(project, COPILOT_WORKFLOW_PATH),
+      "utf8"
+    );
+    expect(workflow).toContain("Lisa remote AWS bootstrap");
+    expect(workflow).toContain("LISA_REMOTE_AGENT: copilot");
+    expect(workflow).not.toContain("  push:");
+    expect(
+      readFileSync(path.join(project, REMOTE_AWS_GUIDE_PATH), "utf8")
+    ).toContain("--secret-id company-remote-agent");
+  });
+
+  it("preserves an existing Cursor install command and is idempotent", () => {
+    const project = temporaryDirectory();
+    mkdirSync(path.join(project, ".cursor"), { recursive: true });
+    writeFileSync(
+      path.join(project, CURSOR_ENVIRONMENT_PATH),
+      '{"install":"npm ci"}\n'
+    );
+
+    installRemoteAgentAws([`--project=${project}`, "--platform=cursor"]);
+    installRemoteAgentAws([`--project=${project}`, "--platform=cursor"]);
+
+    const environment = JSON.parse(
+      readFileSync(path.join(project, CURSOR_ENVIRONMENT_PATH), "utf8")
+    );
+    expect(environment.install).toBe(
+      "LISA_REMOTE_AGENT=cursor bash scripts/remote-agent-aws-setup.sh && npm ci"
+    );
+  });
+
+  it("merges the Copilot step once into an existing setup workflow", () => {
+    const project = temporaryDirectory();
+    const workflowPath = path.join(project, COPILOT_WORKFLOW_PATH);
+    mkdirSync(path.dirname(workflowPath), { recursive: true });
+    writeFileSync(
+      workflowPath,
+      "jobs:\n  copilot-setup-steps:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm ci\n"
+    );
+
+    installRemoteAgentAws([`--project=${project}`, "--platform=copilot"]);
+    installRemoteAgentAws([`--project=${project}`, "--platform=copilot"]);
+
+    const workflow = readFileSync(workflowPath, "utf8");
+    expect(workflow.match(/Lisa remote AWS bootstrap/g)).toHaveLength(1);
+    expect(workflow.match(/actions\/checkout@v4/g)).toHaveLength(1);
+    expect(workflow).toContain("- run: npm ci");
+  });
+});
+
+describe("remote AWS runtime parity", () => {
+  it("ships the setup skill and executable through every generated runtime", () => {
+    const canonicalScript = readFileSync(REMOTE_SETUP_SCRIPT_PATH, "utf8");
+    for (const root of GENERATED_PLUGIN_ROOTS) {
+      expect(
+        existsSync(path.join(root, "skills/lisa-setup-remote-aws/SKILL.md"))
+      ).toBe(true);
+      expect(
+        readFileSync(
+          path.join(root, "scripts/remote-agent-aws-setup.sh"),
+          "utf8"
+        )
+      ).toBe(canonicalScript);
+    }
+    expect(
+      existsSync(
+        "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/SKILL.md"
+      )
+    ).toBe(true);
+  });
+
+  it("documents every supported or explicitly bounded remote-agent surface", () => {
+    const guide = readFileSync(REMOTE_AWS_GUIDE_PATH, "utf8");
+    for (const platform of [
+      "Claude",
+      "Codex",
+      "Cursor",
+      "Copilot",
+      "Antigravity",
+      "OpenCode",
+    ]) {
+      expect(guide).toContain(platform);
+    }
+  });
+});
+
+/* eslint-disable sonarjs/no-os-command-from-path -- Test-only PATH shims inject the fake aws executable. */
+describe("remote AWS bootstrap script", () => {
+  /**
+   * Install a test-only AWS CLI shim that records every invocation.
+   * @param directory - Disposable test root
+   * @returns Fake binary directory and invocation log path
+   */
+  function createFakeAws(directory: string): {
+    readonly binaryDirectory: string;
+    readonly logPath: string;
+  } {
+    const binaryDirectory = path.join(directory, "bin");
+    const logPath = path.join(directory, "aws.log");
+    const awsPath = path.join(binaryDirectory, "aws");
+    mkdirSync(binaryDirectory, { recursive: true });
+    writeFileSync(
+      awsPath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_AWS_LOG"
+if [ "\${1:-}" = "configure" ]; then
+  mkdir -p "$HOME/.aws"
+  touch "$HOME/.aws/credentials" "$HOME/.aws/config"
+fi
+if [ "\${1:-}" = "sts" ]; then
+  printf '%s\\n' '{"Account":"111111111111"}'
+fi
+`
+    );
+    chmodSync(awsPath, 0o700);
+    return { binaryDirectory, logPath };
+  }
+
+  it("writes renewable role profiles from the one bootstrap JSON secret", () => {
+    const root = temporaryDirectory();
+    const home = path.join(root, "home");
+    mkdirSync(home, { recursive: true });
+    const { binaryDirectory, logPath } = createFakeAws(root);
+    const profiles = {
+      dev: {
+        roleArn: "arn:aws:iam::111111111111:role/RemoteAgent",
+        region: "us-east-1",
+      },
+      production: {
+        roleArn: "arn:aws:iam::222222222222:role/RemoteAgent",
+        region: "us-west-2",
+      },
+    };
+    const bootstrap = JSON.stringify({
+      accessKeyId: "AKIATEST",
+      secretAccessKey: "test-secret",
+      externalId: "external-id",
+      roleName: "RemoteAgent",
+      profiles: JSON.stringify(profiles),
+    });
+
+    const output = execFileSync("bash", [REMOTE_SETUP_SCRIPT_PATH], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+        FAKE_AWS_LOG: logPath,
+        LISA_AWS_BOOTSTRAP_JSON: bootstrap,
+        LISA_REMOTE_AGENT: "codex",
+      },
+    });
+
+    const awsCalls = readFileSync(logPath, "utf8");
+    expect(awsCalls).toContain(
+      "configure set source_profile lisa-remote-agent-bootstrap --profile dev"
+    );
+    expect(awsCalls).toContain(
+      "configure set role_session_name codex --profile production"
+    );
+    expect(awsCalls).toContain("sts get-caller-identity --profile dev");
+    expect(output).toContain("default=dev");
+    expect(output).toContain("profiles=dev, production");
+  });
+
+  it("rejects standard AWS credential variables that could bypass the role", () => {
+    const root = temporaryDirectory();
+    const home = path.join(root, "home");
+    mkdirSync(home, { recursive: true });
+    const { binaryDirectory, logPath } = createFakeAws(root);
+    const result = spawnSync("bash", [REMOTE_SETUP_SCRIPT_PATH], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
+        FAKE_AWS_LOG: logPath,
+        AWS_ACCESS_KEY_ID: "must-not-be-used",
+        LISA_AWS_BOOTSTRAP_JSON: "{}",
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("do not set AWS_ACCESS_KEY_ID directly");
+  });
+});
+/* eslint-enable sonarjs/no-os-command-from-path -- End test-only PATH shim scope. */


### PR DESCRIPTION
## What changed

- Add `/lisa:setup-remote-aws` and a vendor-neutral AWS CLI bootstrap driven by one opaque `LISA_AWS_BOOTSTRAP_JSON` secret.
- Generate renewable AWS role profiles with static per-platform session names.
- Add native Cursor and GitHub Copilot setup adapters plus guidance for Claude, Codex, Antigravity, OpenCode, and future compatible Linux remote environments.
- Replace legacy guidance that exposed standard AWS credential variables.
- Ship the implementation across Claude, Codex, Cursor, Copilot, and Antigravity plugin surfaces.

## Why

Remote coding agents need unattended AWS CLI access without inheriting a developer identity or receiving direct service permissions. The bootstrap identity can only assume explicitly listed roles; authorization remains in the per-account observer and repair roles.

## Impact

Host repositories can install one setup script and configure one platform secret. AWS role credentials refresh automatically. Production repair remains outside remote containers and human-driven.

## Validation

- Build, typecheck, lint, slow lint, dead-code detection, and Gitleaks passed.
- 4,568 unit tests passed with coverage.
- 129 integration tests passed.
- Clean downstream installation into infrastructure-v2 passed its full suite.