### PR TITLE
fix(remote-aws): wire Copilot bootstrap secret

### DIFF
--- a/docs/remote-agent-aws.md
+++ b/docs/remote-agent-aws.md
@@ -1,5 +1,7 @@
 # Remote coding-agent AWS access
 
+## Context
+
 Lisa supports AWS CLI access from remote coding environments through one
 vendor-neutral bootstrap contract. The AWS side creates one long-lived IAM user
 whose only permission is `sts:AssumeRole` on explicitly listed remote-agent
@@ -15,7 +17,19 @@ entire value—unchanged—as the platform secret `LISA_AWS_BOOTSTRAP_JSON`.
 Do not create separate `AWS_ACCESS_KEY_ID` variables: standard AWS variables can
 bypass the intended role profile.
 
-## Install repository adapters
+## Goal
+
+Give every supported remote coding agent renewable, least-privilege AWS CLI
+access without borrowing a developer identity or granting direct production
+repair.
+
+## Changes
+
+Lisa provides a shared bootstrap script plus native setup adapters for remote
+agent platforms. Dev and staging profiles can observe and repair; production
+and shared profiles remain observer-only.
+
+## Implementation
 
 Run the Lisa skill:
 
@@ -29,8 +43,6 @@ operator guide. The script installs AWS CLI v2, writes a private named bootstrap
 profile, creates each account role profile from the bundle, selects `dev` by
 default, and verifies the result with `sts:GetCallerIdentity`. AWS CLI and SDK
 role credentials refresh automatically while the bootstrap key remains valid.
-
-## Configure each remote platform
 
 | Platform | Configuration scope |
 |---|---|
@@ -46,8 +58,6 @@ one opaque secret, a writable home directory, and outbound HTTPS access to AWS
 STS and the permitted service endpoints. Set `LISA_REMOTE_AGENT` to a stable
 lowercase platform name; that value is used only as the AWS role session name.
 
-## Operator verification
-
 Start one remote session and run:
 
 ```bash
@@ -60,3 +70,10 @@ Then prove the policy boundary: a permitted dev/staging repair action should
 reach the service authorization layer, while `iam:PassRole` and a production
 mutation must return `AccessDenied`. Production repair continues to use the
 human-driven local-workstation role and is not present in the remote container.
+
+## Notes
+
+Store the complete bootstrap bundle only as the masked
+`LISA_AWS_BOOTSTRAP_JSON` platform secret. Rotate its IAM access key through
+infrastructure and replace the single platform secret everywhere. Disabling or
+deleting the bootstrap user immediately prevents new role sessions.

--- a/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
@@ -98,9 +98,12 @@ function installCopilotAdapter(project) {
   );
   mkdirSync(path.dirname(workflowPath), { recursive: true });
   const marker = "Lisa remote AWS bootstrap";
+  const secretEnvironment =
+    "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
   const step = [
     `      - name: ${marker}`,
     "        env:",
+    secretEnvironment,
     "          LISA_REMOTE_AGENT: copilot",
     `        run: ${INSTALL_COMMAND}`,
   ].join("\n");
@@ -127,8 +130,31 @@ function installCopilotAdapter(project) {
   }
 
   const current = readFileSync(workflowPath, "utf8");
-  if (current.includes(marker)) return path.relative(project, workflowPath);
   const lines = current.split("\n");
+  const markerIndex = lines.findIndex(line => line.includes(marker));
+  if (markerIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > markerIndex && /^\s{6}-\s/.test(line)
+    );
+    const managedStepEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const managedStep = lines.slice(markerIndex, managedStepEnd);
+    if (!managedStep.includes(secretEnvironment)) {
+      const environmentIndex = lines.findIndex(
+        (line, index) =>
+          index > markerIndex &&
+          index < managedStepEnd &&
+          /^\s{8}env:\s*$/.test(line)
+      );
+      if (environmentIndex < 0) {
+        throw new Error(
+          "Existing Lisa remote AWS bootstrap step must contain an env block"
+        );
+      }
+      lines.splice(environmentIndex + 1, 0, secretEnvironment);
+      writeFileSync(workflowPath, lines.join("\n"));
+    }
+    return path.relative(project, workflowPath);
+  }
   const jobIndex = lines.findIndex(line =>
     /^\s{2}copilot-setup-steps:\s*$/.test(line)
   );
@@ -161,13 +187,20 @@ function writeGuide(project, platform, secretName) {
     guidePath,
     `# Remote coding-agent AWS access
 
+## Context
+
 This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
 Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
 split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
 variables. The setup script writes a named source profile whose only permission
 is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
-## Runtime configuration
+## Goal
+
+Give supported remote coding agents renewable, least-privilege AWS CLI access
+without borrowing a developer identity or granting direct production repair.
+
+## Changes
 
 | Runtime | Setup |
 |---|---|
@@ -180,7 +213,7 @@ is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
 Generated for: \`${platform}\`.
 
-## Profiles
+## Implementation
 
 The bootstrap bundle defines the available profile names. \`dev\` is the
 default when present. Select another account explicitly, for example:
@@ -192,8 +225,6 @@ aws --profile production cloudformation describe-stacks
 
 Production and shared profiles are observer-only. Production repair remains a
 human-driven local-workstation operation.
-
-## Administrator rollout
 
 After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
 the complete bundle from the shared account. Do not extract or distribute its
@@ -209,6 +240,8 @@ aws --profile shared secretsmanager get-secret-value \\
 Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
 remote-agent platform. Run the setup command and require its live
 \`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+## Notes
 
 Rotate by replacing the bootstrap IAM access key through infrastructure and
 then updating this one secret on every configured platform. Disabling or

--- a/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-agy/scripts/install-remote-agent-aws.mjs
@@ -100,6 +100,11 @@ function installCopilotAdapter(project) {
   const marker = "Lisa remote AWS bootstrap";
   const secretEnvironment =
     "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+  const checkoutStep = [
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          persist-credentials: false",
+  ].join("\n");
   const step = [
     `      - name: ${marker}`,
     "        env:",
@@ -121,7 +126,7 @@ function installCopilotAdapter(project) {
         "    permissions:",
         "      contents: read",
         "    steps:",
-        "      - uses: actions/checkout@v4",
+        checkoutStep,
         step,
         "",
       ].join("\n")
@@ -131,6 +136,67 @@ function installCopilotAdapter(project) {
 
   const current = readFileSync(workflowPath, "utf8");
   const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+
+  let changed = false;
+  const checkoutIndex = lines.findIndex(
+    (line, index) =>
+      index > stepsIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{6}-\s+uses:\s+actions\/checkout@/.test(line)
+  );
+  if (checkoutIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
+    );
+    const checkoutEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const withIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{8}with:\s*$/.test(line)
+    );
+    const persistenceIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{10}persist-credentials:\s*/.test(line)
+    );
+    if (persistenceIndex >= 0) {
+      if (lines[persistenceIndex] !== "          persist-credentials: false") {
+        lines[persistenceIndex] = "          persist-credentials: false";
+        changed = true;
+      }
+    } else if (withIndex >= 0) {
+      lines.splice(withIndex + 1, 0, "          persist-credentials: false");
+      changed = true;
+    } else {
+      lines.splice(
+        checkoutIndex + 1,
+        0,
+        "        with:",
+        "          persist-credentials: false"
+      );
+      changed = true;
+    }
+  }
+
   const markerIndex = lines.findIndex(line => line.includes(marker));
   if (markerIndex >= 0) {
     const nextStepIndex = lines.findIndex(
@@ -151,31 +217,31 @@ function installCopilotAdapter(project) {
         );
       }
       lines.splice(environmentIndex + 1, 0, secretEnvironment);
-      writeFileSync(workflowPath, lines.join("\n"));
+      changed = true;
     }
+    if (checkoutIndex < 0) {
+      lines.splice(stepsIndex + 1, 0, ...checkoutStep.split("\n"));
+      changed = true;
+    }
+    if (changed) writeFileSync(workflowPath, lines.join("\n"));
     return path.relative(project, workflowPath);
   }
-  const jobIndex = lines.findIndex(line =>
-    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  const additions = checkoutIndex >= 0 ? [step] : [checkoutStep, step];
+  const nextCheckoutStepIndex = lines.findIndex(
+    (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
   );
-  const jobEndIndex = lines.findIndex(
+  const updatedJobEndIndex = lines.findIndex(
     (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
   );
-  const stepsIndex = lines.findIndex(
-    (line, index) =>
-      index > jobIndex &&
-      (jobEndIndex < 0 || index < jobEndIndex) &&
-      /^\s{4}steps:\s*$/.test(line)
-  );
-  if (jobIndex < 0 || stepsIndex < 0) {
-    throw new Error(
-      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
-    );
-  }
-  const additions = current.includes("actions/checkout@")
-    ? [step]
-    : ["      - uses: actions/checkout@v4", step];
-  lines.splice(stepsIndex + 1, 0, ...additions);
+  const additionIndex =
+    checkoutIndex < 0
+      ? stepsIndex + 1
+      : nextCheckoutStepIndex >= 0
+        ? nextCheckoutStepIndex
+        : updatedJobEndIndex >= 0
+          ? updatedJobEndIndex
+          : lines.length;
+  lines.splice(additionIndex, 0, ...additions);
   writeFileSync(workflowPath, lines.join("\n"));
   return path.relative(project, workflowPath);
 }

--- a/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 umask 077
 
 BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+AWS_CLI_VERSION="2.36.2"
 
 fail() {
   echo "remote-agent-aws-setup: $*" >&2
@@ -35,17 +36,17 @@ as_root() {
 }
 
 install_base_tools() {
-  need curl && need unzip && need jq && return 0
+  need curl && need unzip && need jq && need gpg && return 0
 
   if need apt-get; then
     as_root apt-get update -y
-    as_root apt-get install -y curl unzip jq
+    as_root apt-get install -y curl unzip jq gnupg
   elif need dnf; then
-    as_root dnf install -y curl unzip jq
+    as_root dnf install -y curl unzip jq gnupg2
   elif need yum; then
-    as_root yum install -y curl unzip jq
+    as_root yum install -y curl unzip jq gnupg2
   else
-    fail "install curl, unzip, and jq in the remote image before running this script"
+    fail "install curl, unzip, jq, and gpg in the remote image before running this script"
   fi
 }
 
@@ -62,9 +63,49 @@ install_aws_cli() {
 
   temporary_directory="$(mktemp -d)"
   trap 'rm -rf "${temporary_directory:-}"' EXIT
+  local installer_url
+  installer_url="https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
   curl -fsSL \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    "$installer_url" \
     -o "$temporary_directory/awscliv2.zip"
+  curl -fsSL "$installer_url.sig" -o "$temporary_directory/awscliv2.sig"
+  cat >"$temporary_directory/aws-cli-public-key.asc" <<'AWS_CLI_PUBLIC_KEY'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+akV0ygUJDqP4lQAKCRCmMQrMRnJHXFHjD/9eyZLYcKuQOlLvtqSDtUBiEZf6ZZjM
+i3ygYH8rJNtuToUH+HvSpe819urJCquXhDrlK6N+aqW0hCLtNABJG/vsafIgvIYJ
+hSGgpgtNnQyMV1jViRWqPjbouw8OkYKBThUfT1i2Y+wn58ifs6ODBCmTexWtXspA
+Si+Gt49xDOW0APmbOPnI+a4HJW6tVEo6MWS0WjzpiBayR3d1A4pt4YrPfSdDgpLo
+h2SLQqlRqvvVZJaWBjhkErNFpfsBA06sDcPEOb0G8LBUbR4WOcdvhe5LubJbZuxC
+AG9kNPCVeQP1ixwjgjXKysaxeQ6rv0VzIQgRp6tLVLWhy6AKDNvLjFSsmXZ1Wl08
+Y/RlOHXlzLuQMRE6sR1wOdRxc9TsrNWTGiBK65cvSWOy03JeBkQQ8pesqltiyxI9
+U21kkgiXtTSKNGfKK8pO27D81YANhRqPK7iTp6kuFiY2WtOg90KTMNlIT+Ff85Y2
+b1rHj6Z0SrCkJujhWk3IBPic/wJgz01LEc/OAdUPlby90RJZcIBhSlWhT7mXnXIO
+c0HWlNQrns2s3CTyYwZSiSlYe9ApeLwhjDo8NhbFuCAy61l6O5UsR4AfZxx/rGKv
+2wFb1/RN/P4gNe6vmxZAPjR0AQcwD3tc2McimOLr/22kmPz8IH3I0X7WoSFr0Biz
+E91G7bb0hOb/cA==
+=knv7
+-----END PGP PUBLIC KEY BLOCK-----
+AWS_CLI_PUBLIC_KEY
+  mkdir -m 700 "$temporary_directory/gnupg"
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --import "$temporary_directory/aws-cli-public-key.asc" >/dev/null 2>&1
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --verify "$temporary_directory/awscliv2.sig" \
+    "$temporary_directory/awscliv2.zip"
   unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
   as_root "$temporary_directory/aws/install" \
     --install-dir /usr/local/aws-cli \

--- a/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
@@ -98,9 +98,12 @@ function installCopilotAdapter(project) {
   );
   mkdirSync(path.dirname(workflowPath), { recursive: true });
   const marker = "Lisa remote AWS bootstrap";
+  const secretEnvironment =
+    "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
   const step = [
     `      - name: ${marker}`,
     "        env:",
+    secretEnvironment,
     "          LISA_REMOTE_AGENT: copilot",
     `        run: ${INSTALL_COMMAND}`,
   ].join("\n");
@@ -127,8 +130,31 @@ function installCopilotAdapter(project) {
   }
 
   const current = readFileSync(workflowPath, "utf8");
-  if (current.includes(marker)) return path.relative(project, workflowPath);
   const lines = current.split("\n");
+  const markerIndex = lines.findIndex(line => line.includes(marker));
+  if (markerIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > markerIndex && /^\s{6}-\s/.test(line)
+    );
+    const managedStepEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const managedStep = lines.slice(markerIndex, managedStepEnd);
+    if (!managedStep.includes(secretEnvironment)) {
+      const environmentIndex = lines.findIndex(
+        (line, index) =>
+          index > markerIndex &&
+          index < managedStepEnd &&
+          /^\s{8}env:\s*$/.test(line)
+      );
+      if (environmentIndex < 0) {
+        throw new Error(
+          "Existing Lisa remote AWS bootstrap step must contain an env block"
+        );
+      }
+      lines.splice(environmentIndex + 1, 0, secretEnvironment);
+      writeFileSync(workflowPath, lines.join("\n"));
+    }
+    return path.relative(project, workflowPath);
+  }
   const jobIndex = lines.findIndex(line =>
     /^\s{2}copilot-setup-steps:\s*$/.test(line)
   );
@@ -161,13 +187,20 @@ function writeGuide(project, platform, secretName) {
     guidePath,
     `# Remote coding-agent AWS access
 
+## Context
+
 This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
 Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
 split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
 variables. The setup script writes a named source profile whose only permission
 is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
-## Runtime configuration
+## Goal
+
+Give supported remote coding agents renewable, least-privilege AWS CLI access
+without borrowing a developer identity or granting direct production repair.
+
+## Changes
 
 | Runtime | Setup |
 |---|---|
@@ -180,7 +213,7 @@ is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
 Generated for: \`${platform}\`.
 
-## Profiles
+## Implementation
 
 The bootstrap bundle defines the available profile names. \`dev\` is the
 default when present. Select another account explicitly, for example:
@@ -192,8 +225,6 @@ aws --profile production cloudformation describe-stacks
 
 Production and shared profiles are observer-only. Production repair remains a
 human-driven local-workstation operation.
-
-## Administrator rollout
 
 After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
 the complete bundle from the shared account. Do not extract or distribute its
@@ -209,6 +240,8 @@ aws --profile shared secretsmanager get-secret-value \\
 Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
 remote-agent platform. Run the setup command and require its live
 \`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+## Notes
 
 Rotate by replacing the bootstrap IAM access key through infrastructure and
 then updating this one secret on every configured platform. Disabling or

--- a/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs
@@ -100,6 +100,11 @@ function installCopilotAdapter(project) {
   const marker = "Lisa remote AWS bootstrap";
   const secretEnvironment =
     "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+  const checkoutStep = [
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          persist-credentials: false",
+  ].join("\n");
   const step = [
     `      - name: ${marker}`,
     "        env:",
@@ -121,7 +126,7 @@ function installCopilotAdapter(project) {
         "    permissions:",
         "      contents: read",
         "    steps:",
-        "      - uses: actions/checkout@v4",
+        checkoutStep,
         step,
         "",
       ].join("\n")
@@ -131,6 +136,67 @@ function installCopilotAdapter(project) {
 
   const current = readFileSync(workflowPath, "utf8");
   const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+
+  let changed = false;
+  const checkoutIndex = lines.findIndex(
+    (line, index) =>
+      index > stepsIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{6}-\s+uses:\s+actions\/checkout@/.test(line)
+  );
+  if (checkoutIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
+    );
+    const checkoutEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const withIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{8}with:\s*$/.test(line)
+    );
+    const persistenceIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{10}persist-credentials:\s*/.test(line)
+    );
+    if (persistenceIndex >= 0) {
+      if (lines[persistenceIndex] !== "          persist-credentials: false") {
+        lines[persistenceIndex] = "          persist-credentials: false";
+        changed = true;
+      }
+    } else if (withIndex >= 0) {
+      lines.splice(withIndex + 1, 0, "          persist-credentials: false");
+      changed = true;
+    } else {
+      lines.splice(
+        checkoutIndex + 1,
+        0,
+        "        with:",
+        "          persist-credentials: false"
+      );
+      changed = true;
+    }
+  }
+
   const markerIndex = lines.findIndex(line => line.includes(marker));
   if (markerIndex >= 0) {
     const nextStepIndex = lines.findIndex(
@@ -151,31 +217,31 @@ function installCopilotAdapter(project) {
         );
       }
       lines.splice(environmentIndex + 1, 0, secretEnvironment);
-      writeFileSync(workflowPath, lines.join("\n"));
+      changed = true;
     }
+    if (checkoutIndex < 0) {
+      lines.splice(stepsIndex + 1, 0, ...checkoutStep.split("\n"));
+      changed = true;
+    }
+    if (changed) writeFileSync(workflowPath, lines.join("\n"));
     return path.relative(project, workflowPath);
   }
-  const jobIndex = lines.findIndex(line =>
-    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  const additions = checkoutIndex >= 0 ? [step] : [checkoutStep, step];
+  const nextCheckoutStepIndex = lines.findIndex(
+    (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
   );
-  const jobEndIndex = lines.findIndex(
+  const updatedJobEndIndex = lines.findIndex(
     (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
   );
-  const stepsIndex = lines.findIndex(
-    (line, index) =>
-      index > jobIndex &&
-      (jobEndIndex < 0 || index < jobEndIndex) &&
-      /^\s{4}steps:\s*$/.test(line)
-  );
-  if (jobIndex < 0 || stepsIndex < 0) {
-    throw new Error(
-      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
-    );
-  }
-  const additions = current.includes("actions/checkout@")
-    ? [step]
-    : ["      - uses: actions/checkout@v4", step];
-  lines.splice(stepsIndex + 1, 0, ...additions);
+  const additionIndex =
+    checkoutIndex < 0
+      ? stepsIndex + 1
+      : nextCheckoutStepIndex >= 0
+        ? nextCheckoutStepIndex
+        : updatedJobEndIndex >= 0
+          ? updatedJobEndIndex
+          : lines.length;
+  lines.splice(additionIndex, 0, ...additions);
   writeFileSync(workflowPath, lines.join("\n"));
   return path.relative(project, workflowPath);
 }

--- a/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 umask 077
 
 BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+AWS_CLI_VERSION="2.36.2"
 
 fail() {
   echo "remote-agent-aws-setup: $*" >&2
@@ -35,17 +36,17 @@ as_root() {
 }
 
 install_base_tools() {
-  need curl && need unzip && need jq && return 0
+  need curl && need unzip && need jq && need gpg && return 0
 
   if need apt-get; then
     as_root apt-get update -y
-    as_root apt-get install -y curl unzip jq
+    as_root apt-get install -y curl unzip jq gnupg
   elif need dnf; then
-    as_root dnf install -y curl unzip jq
+    as_root dnf install -y curl unzip jq gnupg2
   elif need yum; then
-    as_root yum install -y curl unzip jq
+    as_root yum install -y curl unzip jq gnupg2
   else
-    fail "install curl, unzip, and jq in the remote image before running this script"
+    fail "install curl, unzip, jq, and gpg in the remote image before running this script"
   fi
 }
 
@@ -62,9 +63,49 @@ install_aws_cli() {
 
   temporary_directory="$(mktemp -d)"
   trap 'rm -rf "${temporary_directory:-}"' EXIT
+  local installer_url
+  installer_url="https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
   curl -fsSL \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    "$installer_url" \
     -o "$temporary_directory/awscliv2.zip"
+  curl -fsSL "$installer_url.sig" -o "$temporary_directory/awscliv2.sig"
+  cat >"$temporary_directory/aws-cli-public-key.asc" <<'AWS_CLI_PUBLIC_KEY'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+akV0ygUJDqP4lQAKCRCmMQrMRnJHXFHjD/9eyZLYcKuQOlLvtqSDtUBiEZf6ZZjM
+i3ygYH8rJNtuToUH+HvSpe819urJCquXhDrlK6N+aqW0hCLtNABJG/vsafIgvIYJ
+hSGgpgtNnQyMV1jViRWqPjbouw8OkYKBThUfT1i2Y+wn58ifs6ODBCmTexWtXspA
+Si+Gt49xDOW0APmbOPnI+a4HJW6tVEo6MWS0WjzpiBayR3d1A4pt4YrPfSdDgpLo
+h2SLQqlRqvvVZJaWBjhkErNFpfsBA06sDcPEOb0G8LBUbR4WOcdvhe5LubJbZuxC
+AG9kNPCVeQP1ixwjgjXKysaxeQ6rv0VzIQgRp6tLVLWhy6AKDNvLjFSsmXZ1Wl08
+Y/RlOHXlzLuQMRE6sR1wOdRxc9TsrNWTGiBK65cvSWOy03JeBkQQ8pesqltiyxI9
+U21kkgiXtTSKNGfKK8pO27D81YANhRqPK7iTp6kuFiY2WtOg90KTMNlIT+Ff85Y2
+b1rHj6Z0SrCkJujhWk3IBPic/wJgz01LEc/OAdUPlby90RJZcIBhSlWhT7mXnXIO
+c0HWlNQrns2s3CTyYwZSiSlYe9ApeLwhjDo8NhbFuCAy61l6O5UsR4AfZxx/rGKv
+2wFb1/RN/P4gNe6vmxZAPjR0AQcwD3tc2McimOLr/22kmPz8IH3I0X7WoSFr0Biz
+E91G7bb0hOb/cA==
+=knv7
+-----END PGP PUBLIC KEY BLOCK-----
+AWS_CLI_PUBLIC_KEY
+  mkdir -m 700 "$temporary_directory/gnupg"
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --import "$temporary_directory/aws-cli-public-key.asc" >/dev/null 2>&1
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --verify "$temporary_directory/awscliv2.sig" \
+    "$temporary_directory/awscliv2.zip"
   unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
   as_root "$temporary_directory/aws/install" \
     --install-dir /usr/local/aws-cli \

--- a/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
@@ -98,9 +98,12 @@ function installCopilotAdapter(project) {
   );
   mkdirSync(path.dirname(workflowPath), { recursive: true });
   const marker = "Lisa remote AWS bootstrap";
+  const secretEnvironment =
+    "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
   const step = [
     `      - name: ${marker}`,
     "        env:",
+    secretEnvironment,
     "          LISA_REMOTE_AGENT: copilot",
     `        run: ${INSTALL_COMMAND}`,
   ].join("\n");
@@ -127,8 +130,31 @@ function installCopilotAdapter(project) {
   }
 
   const current = readFileSync(workflowPath, "utf8");
-  if (current.includes(marker)) return path.relative(project, workflowPath);
   const lines = current.split("\n");
+  const markerIndex = lines.findIndex(line => line.includes(marker));
+  if (markerIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > markerIndex && /^\s{6}-\s/.test(line)
+    );
+    const managedStepEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const managedStep = lines.slice(markerIndex, managedStepEnd);
+    if (!managedStep.includes(secretEnvironment)) {
+      const environmentIndex = lines.findIndex(
+        (line, index) =>
+          index > markerIndex &&
+          index < managedStepEnd &&
+          /^\s{8}env:\s*$/.test(line)
+      );
+      if (environmentIndex < 0) {
+        throw new Error(
+          "Existing Lisa remote AWS bootstrap step must contain an env block"
+        );
+      }
+      lines.splice(environmentIndex + 1, 0, secretEnvironment);
+      writeFileSync(workflowPath, lines.join("\n"));
+    }
+    return path.relative(project, workflowPath);
+  }
   const jobIndex = lines.findIndex(line =>
     /^\s{2}copilot-setup-steps:\s*$/.test(line)
   );
@@ -161,13 +187,20 @@ function writeGuide(project, platform, secretName) {
     guidePath,
     `# Remote coding-agent AWS access
 
+## Context
+
 This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
 Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
 split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
 variables. The setup script writes a named source profile whose only permission
 is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
-## Runtime configuration
+## Goal
+
+Give supported remote coding agents renewable, least-privilege AWS CLI access
+without borrowing a developer identity or granting direct production repair.
+
+## Changes
 
 | Runtime | Setup |
 |---|---|
@@ -180,7 +213,7 @@ is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
 Generated for: \`${platform}\`.
 
-## Profiles
+## Implementation
 
 The bootstrap bundle defines the available profile names. \`dev\` is the
 default when present. Select another account explicitly, for example:
@@ -192,8 +225,6 @@ aws --profile production cloudformation describe-stacks
 
 Production and shared profiles are observer-only. Production repair remains a
 human-driven local-workstation operation.
-
-## Administrator rollout
 
 After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
 the complete bundle from the shared account. Do not extract or distribute its
@@ -209,6 +240,8 @@ aws --profile shared secretsmanager get-secret-value \\
 Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
 remote-agent platform. Run the setup command and require its live
 \`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+## Notes
 
 Rotate by replacing the bootstrap IAM access key through infrastructure and
 then updating this one secret on every configured platform. Disabling or

--- a/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs
@@ -100,6 +100,11 @@ function installCopilotAdapter(project) {
   const marker = "Lisa remote AWS bootstrap";
   const secretEnvironment =
     "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+  const checkoutStep = [
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          persist-credentials: false",
+  ].join("\n");
   const step = [
     `      - name: ${marker}`,
     "        env:",
@@ -121,7 +126,7 @@ function installCopilotAdapter(project) {
         "    permissions:",
         "      contents: read",
         "    steps:",
-        "      - uses: actions/checkout@v4",
+        checkoutStep,
         step,
         "",
       ].join("\n")
@@ -131,6 +136,67 @@ function installCopilotAdapter(project) {
 
   const current = readFileSync(workflowPath, "utf8");
   const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+
+  let changed = false;
+  const checkoutIndex = lines.findIndex(
+    (line, index) =>
+      index > stepsIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{6}-\s+uses:\s+actions\/checkout@/.test(line)
+  );
+  if (checkoutIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
+    );
+    const checkoutEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const withIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{8}with:\s*$/.test(line)
+    );
+    const persistenceIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{10}persist-credentials:\s*/.test(line)
+    );
+    if (persistenceIndex >= 0) {
+      if (lines[persistenceIndex] !== "          persist-credentials: false") {
+        lines[persistenceIndex] = "          persist-credentials: false";
+        changed = true;
+      }
+    } else if (withIndex >= 0) {
+      lines.splice(withIndex + 1, 0, "          persist-credentials: false");
+      changed = true;
+    } else {
+      lines.splice(
+        checkoutIndex + 1,
+        0,
+        "        with:",
+        "          persist-credentials: false"
+      );
+      changed = true;
+    }
+  }
+
   const markerIndex = lines.findIndex(line => line.includes(marker));
   if (markerIndex >= 0) {
     const nextStepIndex = lines.findIndex(
@@ -151,31 +217,31 @@ function installCopilotAdapter(project) {
         );
       }
       lines.splice(environmentIndex + 1, 0, secretEnvironment);
-      writeFileSync(workflowPath, lines.join("\n"));
+      changed = true;
     }
+    if (checkoutIndex < 0) {
+      lines.splice(stepsIndex + 1, 0, ...checkoutStep.split("\n"));
+      changed = true;
+    }
+    if (changed) writeFileSync(workflowPath, lines.join("\n"));
     return path.relative(project, workflowPath);
   }
-  const jobIndex = lines.findIndex(line =>
-    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  const additions = checkoutIndex >= 0 ? [step] : [checkoutStep, step];
+  const nextCheckoutStepIndex = lines.findIndex(
+    (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
   );
-  const jobEndIndex = lines.findIndex(
+  const updatedJobEndIndex = lines.findIndex(
     (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
   );
-  const stepsIndex = lines.findIndex(
-    (line, index) =>
-      index > jobIndex &&
-      (jobEndIndex < 0 || index < jobEndIndex) &&
-      /^\s{4}steps:\s*$/.test(line)
-  );
-  if (jobIndex < 0 || stepsIndex < 0) {
-    throw new Error(
-      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
-    );
-  }
-  const additions = current.includes("actions/checkout@")
-    ? [step]
-    : ["      - uses: actions/checkout@v4", step];
-  lines.splice(stepsIndex + 1, 0, ...additions);
+  const additionIndex =
+    checkoutIndex < 0
+      ? stepsIndex + 1
+      : nextCheckoutStepIndex >= 0
+        ? nextCheckoutStepIndex
+        : updatedJobEndIndex >= 0
+          ? updatedJobEndIndex
+          : lines.length;
+  lines.splice(additionIndex, 0, ...additions);
   writeFileSync(workflowPath, lines.join("\n"));
   return path.relative(project, workflowPath);
 }

--- a/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 umask 077
 
 BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+AWS_CLI_VERSION="2.36.2"
 
 fail() {
   echo "remote-agent-aws-setup: $*" >&2
@@ -35,17 +36,17 @@ as_root() {
 }
 
 install_base_tools() {
-  need curl && need unzip && need jq && return 0
+  need curl && need unzip && need jq && need gpg && return 0
 
   if need apt-get; then
     as_root apt-get update -y
-    as_root apt-get install -y curl unzip jq
+    as_root apt-get install -y curl unzip jq gnupg
   elif need dnf; then
-    as_root dnf install -y curl unzip jq
+    as_root dnf install -y curl unzip jq gnupg2
   elif need yum; then
-    as_root yum install -y curl unzip jq
+    as_root yum install -y curl unzip jq gnupg2
   else
-    fail "install curl, unzip, and jq in the remote image before running this script"
+    fail "install curl, unzip, jq, and gpg in the remote image before running this script"
   fi
 }
 
@@ -62,9 +63,49 @@ install_aws_cli() {
 
   temporary_directory="$(mktemp -d)"
   trap 'rm -rf "${temporary_directory:-}"' EXIT
+  local installer_url
+  installer_url="https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
   curl -fsSL \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    "$installer_url" \
     -o "$temporary_directory/awscliv2.zip"
+  curl -fsSL "$installer_url.sig" -o "$temporary_directory/awscliv2.sig"
+  cat >"$temporary_directory/aws-cli-public-key.asc" <<'AWS_CLI_PUBLIC_KEY'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+akV0ygUJDqP4lQAKCRCmMQrMRnJHXFHjD/9eyZLYcKuQOlLvtqSDtUBiEZf6ZZjM
+i3ygYH8rJNtuToUH+HvSpe819urJCquXhDrlK6N+aqW0hCLtNABJG/vsafIgvIYJ
+hSGgpgtNnQyMV1jViRWqPjbouw8OkYKBThUfT1i2Y+wn58ifs6ODBCmTexWtXspA
+Si+Gt49xDOW0APmbOPnI+a4HJW6tVEo6MWS0WjzpiBayR3d1A4pt4YrPfSdDgpLo
+h2SLQqlRqvvVZJaWBjhkErNFpfsBA06sDcPEOb0G8LBUbR4WOcdvhe5LubJbZuxC
+AG9kNPCVeQP1ixwjgjXKysaxeQ6rv0VzIQgRp6tLVLWhy6AKDNvLjFSsmXZ1Wl08
+Y/RlOHXlzLuQMRE6sR1wOdRxc9TsrNWTGiBK65cvSWOy03JeBkQQ8pesqltiyxI9
+U21kkgiXtTSKNGfKK8pO27D81YANhRqPK7iTp6kuFiY2WtOg90KTMNlIT+Ff85Y2
+b1rHj6Z0SrCkJujhWk3IBPic/wJgz01LEc/OAdUPlby90RJZcIBhSlWhT7mXnXIO
+c0HWlNQrns2s3CTyYwZSiSlYe9ApeLwhjDo8NhbFuCAy61l6O5UsR4AfZxx/rGKv
+2wFb1/RN/P4gNe6vmxZAPjR0AQcwD3tc2McimOLr/22kmPz8IH3I0X7WoSFr0Biz
+E91G7bb0hOb/cA==
+=knv7
+-----END PGP PUBLIC KEY BLOCK-----
+AWS_CLI_PUBLIC_KEY
+  mkdir -m 700 "$temporary_directory/gnupg"
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --import "$temporary_directory/aws-cli-public-key.asc" >/dev/null 2>&1
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --verify "$temporary_directory/awscliv2.sig" \
+    "$temporary_directory/awscliv2.zip"
   unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
   as_root "$temporary_directory/aws/install" \
     --install-dir /usr/local/aws-cli \

--- a/plugins/lisa/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa/scripts/install-remote-agent-aws.mjs
@@ -98,9 +98,12 @@ function installCopilotAdapter(project) {
   );
   mkdirSync(path.dirname(workflowPath), { recursive: true });
   const marker = "Lisa remote AWS bootstrap";
+  const secretEnvironment =
+    "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
   const step = [
     `      - name: ${marker}`,
     "        env:",
+    secretEnvironment,
     "          LISA_REMOTE_AGENT: copilot",
     `        run: ${INSTALL_COMMAND}`,
   ].join("\n");
@@ -127,8 +130,31 @@ function installCopilotAdapter(project) {
   }
 
   const current = readFileSync(workflowPath, "utf8");
-  if (current.includes(marker)) return path.relative(project, workflowPath);
   const lines = current.split("\n");
+  const markerIndex = lines.findIndex(line => line.includes(marker));
+  if (markerIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > markerIndex && /^\s{6}-\s/.test(line)
+    );
+    const managedStepEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const managedStep = lines.slice(markerIndex, managedStepEnd);
+    if (!managedStep.includes(secretEnvironment)) {
+      const environmentIndex = lines.findIndex(
+        (line, index) =>
+          index > markerIndex &&
+          index < managedStepEnd &&
+          /^\s{8}env:\s*$/.test(line)
+      );
+      if (environmentIndex < 0) {
+        throw new Error(
+          "Existing Lisa remote AWS bootstrap step must contain an env block"
+        );
+      }
+      lines.splice(environmentIndex + 1, 0, secretEnvironment);
+      writeFileSync(workflowPath, lines.join("\n"));
+    }
+    return path.relative(project, workflowPath);
+  }
   const jobIndex = lines.findIndex(line =>
     /^\s{2}copilot-setup-steps:\s*$/.test(line)
   );
@@ -161,13 +187,20 @@ function writeGuide(project, platform, secretName) {
     guidePath,
     `# Remote coding-agent AWS access
 
+## Context
+
 This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
 Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
 split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
 variables. The setup script writes a named source profile whose only permission
 is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
-## Runtime configuration
+## Goal
+
+Give supported remote coding agents renewable, least-privilege AWS CLI access
+without borrowing a developer identity or granting direct production repair.
+
+## Changes
 
 | Runtime | Setup |
 |---|---|
@@ -180,7 +213,7 @@ is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
 Generated for: \`${platform}\`.
 
-## Profiles
+## Implementation
 
 The bootstrap bundle defines the available profile names. \`dev\` is the
 default when present. Select another account explicitly, for example:
@@ -192,8 +225,6 @@ aws --profile production cloudformation describe-stacks
 
 Production and shared profiles are observer-only. Production repair remains a
 human-driven local-workstation operation.
-
-## Administrator rollout
 
 After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
 the complete bundle from the shared account. Do not extract or distribute its
@@ -209,6 +240,8 @@ aws --profile shared secretsmanager get-secret-value \\
 Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
 remote-agent platform. Run the setup command and require its live
 \`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+## Notes
 
 Rotate by replacing the bootstrap IAM access key through infrastructure and
 then updating this one secret on every configured platform. Disabling or

--- a/plugins/lisa/scripts/install-remote-agent-aws.mjs
+++ b/plugins/lisa/scripts/install-remote-agent-aws.mjs
@@ -100,6 +100,11 @@ function installCopilotAdapter(project) {
   const marker = "Lisa remote AWS bootstrap";
   const secretEnvironment =
     "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+  const checkoutStep = [
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          persist-credentials: false",
+  ].join("\n");
   const step = [
     `      - name: ${marker}`,
     "        env:",
@@ -121,7 +126,7 @@ function installCopilotAdapter(project) {
         "    permissions:",
         "      contents: read",
         "    steps:",
-        "      - uses: actions/checkout@v4",
+        checkoutStep,
         step,
         "",
       ].join("\n")
@@ -131,6 +136,67 @@ function installCopilotAdapter(project) {
 
   const current = readFileSync(workflowPath, "utf8");
   const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+
+  let changed = false;
+  const checkoutIndex = lines.findIndex(
+    (line, index) =>
+      index > stepsIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{6}-\s+uses:\s+actions\/checkout@/.test(line)
+  );
+  if (checkoutIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
+    );
+    const checkoutEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const withIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{8}with:\s*$/.test(line)
+    );
+    const persistenceIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{10}persist-credentials:\s*/.test(line)
+    );
+    if (persistenceIndex >= 0) {
+      if (lines[persistenceIndex] !== "          persist-credentials: false") {
+        lines[persistenceIndex] = "          persist-credentials: false";
+        changed = true;
+      }
+    } else if (withIndex >= 0) {
+      lines.splice(withIndex + 1, 0, "          persist-credentials: false");
+      changed = true;
+    } else {
+      lines.splice(
+        checkoutIndex + 1,
+        0,
+        "        with:",
+        "          persist-credentials: false"
+      );
+      changed = true;
+    }
+  }
+
   const markerIndex = lines.findIndex(line => line.includes(marker));
   if (markerIndex >= 0) {
     const nextStepIndex = lines.findIndex(
@@ -151,31 +217,31 @@ function installCopilotAdapter(project) {
         );
       }
       lines.splice(environmentIndex + 1, 0, secretEnvironment);
-      writeFileSync(workflowPath, lines.join("\n"));
+      changed = true;
     }
+    if (checkoutIndex < 0) {
+      lines.splice(stepsIndex + 1, 0, ...checkoutStep.split("\n"));
+      changed = true;
+    }
+    if (changed) writeFileSync(workflowPath, lines.join("\n"));
     return path.relative(project, workflowPath);
   }
-  const jobIndex = lines.findIndex(line =>
-    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  const additions = checkoutIndex >= 0 ? [step] : [checkoutStep, step];
+  const nextCheckoutStepIndex = lines.findIndex(
+    (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
   );
-  const jobEndIndex = lines.findIndex(
+  const updatedJobEndIndex = lines.findIndex(
     (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
   );
-  const stepsIndex = lines.findIndex(
-    (line, index) =>
-      index > jobIndex &&
-      (jobEndIndex < 0 || index < jobEndIndex) &&
-      /^\s{4}steps:\s*$/.test(line)
-  );
-  if (jobIndex < 0 || stepsIndex < 0) {
-    throw new Error(
-      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
-    );
-  }
-  const additions = current.includes("actions/checkout@")
-    ? [step]
-    : ["      - uses: actions/checkout@v4", step];
-  lines.splice(stepsIndex + 1, 0, ...additions);
+  const additionIndex =
+    checkoutIndex < 0
+      ? stepsIndex + 1
+      : nextCheckoutStepIndex >= 0
+        ? nextCheckoutStepIndex
+        : updatedJobEndIndex >= 0
+          ? updatedJobEndIndex
+          : lines.length;
+  lines.splice(additionIndex, 0, ...additions);
   writeFileSync(workflowPath, lines.join("\n"));
   return path.relative(project, workflowPath);
 }

--- a/plugins/lisa/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa/scripts/remote-agent-aws-setup.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 umask 077
 
 BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+AWS_CLI_VERSION="2.36.2"
 
 fail() {
   echo "remote-agent-aws-setup: $*" >&2
@@ -35,17 +36,17 @@ as_root() {
 }
 
 install_base_tools() {
-  need curl && need unzip && need jq && return 0
+  need curl && need unzip && need jq && need gpg && return 0
 
   if need apt-get; then
     as_root apt-get update -y
-    as_root apt-get install -y curl unzip jq
+    as_root apt-get install -y curl unzip jq gnupg
   elif need dnf; then
-    as_root dnf install -y curl unzip jq
+    as_root dnf install -y curl unzip jq gnupg2
   elif need yum; then
-    as_root yum install -y curl unzip jq
+    as_root yum install -y curl unzip jq gnupg2
   else
-    fail "install curl, unzip, and jq in the remote image before running this script"
+    fail "install curl, unzip, jq, and gpg in the remote image before running this script"
   fi
 }
 
@@ -62,9 +63,49 @@ install_aws_cli() {
 
   temporary_directory="$(mktemp -d)"
   trap 'rm -rf "${temporary_directory:-}"' EXIT
+  local installer_url
+  installer_url="https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
   curl -fsSL \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    "$installer_url" \
     -o "$temporary_directory/awscliv2.zip"
+  curl -fsSL "$installer_url.sig" -o "$temporary_directory/awscliv2.sig"
+  cat >"$temporary_directory/aws-cli-public-key.asc" <<'AWS_CLI_PUBLIC_KEY'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+akV0ygUJDqP4lQAKCRCmMQrMRnJHXFHjD/9eyZLYcKuQOlLvtqSDtUBiEZf6ZZjM
+i3ygYH8rJNtuToUH+HvSpe819urJCquXhDrlK6N+aqW0hCLtNABJG/vsafIgvIYJ
+hSGgpgtNnQyMV1jViRWqPjbouw8OkYKBThUfT1i2Y+wn58ifs6ODBCmTexWtXspA
+Si+Gt49xDOW0APmbOPnI+a4HJW6tVEo6MWS0WjzpiBayR3d1A4pt4YrPfSdDgpLo
+h2SLQqlRqvvVZJaWBjhkErNFpfsBA06sDcPEOb0G8LBUbR4WOcdvhe5LubJbZuxC
+AG9kNPCVeQP1ixwjgjXKysaxeQ6rv0VzIQgRp6tLVLWhy6AKDNvLjFSsmXZ1Wl08
+Y/RlOHXlzLuQMRE6sR1wOdRxc9TsrNWTGiBK65cvSWOy03JeBkQQ8pesqltiyxI9
+U21kkgiXtTSKNGfKK8pO27D81YANhRqPK7iTp6kuFiY2WtOg90KTMNlIT+Ff85Y2
+b1rHj6Z0SrCkJujhWk3IBPic/wJgz01LEc/OAdUPlby90RJZcIBhSlWhT7mXnXIO
+c0HWlNQrns2s3CTyYwZSiSlYe9ApeLwhjDo8NhbFuCAy61l6O5UsR4AfZxx/rGKv
+2wFb1/RN/P4gNe6vmxZAPjR0AQcwD3tc2McimOLr/22kmPz8IH3I0X7WoSFr0Biz
+E91G7bb0hOb/cA==
+=knv7
+-----END PGP PUBLIC KEY BLOCK-----
+AWS_CLI_PUBLIC_KEY
+  mkdir -m 700 "$temporary_directory/gnupg"
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --import "$temporary_directory/aws-cli-public-key.asc" >/dev/null 2>&1
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --verify "$temporary_directory/awscliv2.sig" \
+    "$temporary_directory/awscliv2.zip"
   unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
   as_root "$temporary_directory/aws/install" \
     --install-dir /usr/local/aws-cli \

--- a/plugins/src/base/scripts/install-remote-agent-aws.mjs
+++ b/plugins/src/base/scripts/install-remote-agent-aws.mjs
@@ -98,9 +98,12 @@ function installCopilotAdapter(project) {
   );
   mkdirSync(path.dirname(workflowPath), { recursive: true });
   const marker = "Lisa remote AWS bootstrap";
+  const secretEnvironment =
+    "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
   const step = [
     `      - name: ${marker}`,
     "        env:",
+    secretEnvironment,
     "          LISA_REMOTE_AGENT: copilot",
     `        run: ${INSTALL_COMMAND}`,
   ].join("\n");
@@ -127,8 +130,31 @@ function installCopilotAdapter(project) {
   }
 
   const current = readFileSync(workflowPath, "utf8");
-  if (current.includes(marker)) return path.relative(project, workflowPath);
   const lines = current.split("\n");
+  const markerIndex = lines.findIndex(line => line.includes(marker));
+  if (markerIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > markerIndex && /^\s{6}-\s/.test(line)
+    );
+    const managedStepEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const managedStep = lines.slice(markerIndex, managedStepEnd);
+    if (!managedStep.includes(secretEnvironment)) {
+      const environmentIndex = lines.findIndex(
+        (line, index) =>
+          index > markerIndex &&
+          index < managedStepEnd &&
+          /^\s{8}env:\s*$/.test(line)
+      );
+      if (environmentIndex < 0) {
+        throw new Error(
+          "Existing Lisa remote AWS bootstrap step must contain an env block"
+        );
+      }
+      lines.splice(environmentIndex + 1, 0, secretEnvironment);
+      writeFileSync(workflowPath, lines.join("\n"));
+    }
+    return path.relative(project, workflowPath);
+  }
   const jobIndex = lines.findIndex(line =>
     /^\s{2}copilot-setup-steps:\s*$/.test(line)
   );
@@ -161,13 +187,20 @@ function writeGuide(project, platform, secretName) {
     guidePath,
     `# Remote coding-agent AWS access
 
+## Context
+
 This repository uses Lisa's vendor-neutral AWS bootstrap. Configure the complete
 Secrets Manager SecretString as the secret \`LISA_AWS_BOOTSTRAP_JSON\`; do not
 split it into \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` environment
 variables. The setup script writes a named source profile whose only permission
 is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
-## Runtime configuration
+## Goal
+
+Give supported remote coding agents renewable, least-privilege AWS CLI access
+without borrowing a developer identity or granting direct production repair.
+
+## Changes
 
 | Runtime | Setup |
 |---|---|
@@ -180,7 +213,7 @@ is \`sts:AssumeRole\`, then creates automatically refreshed role profiles.
 
 Generated for: \`${platform}\`.
 
-## Profiles
+## Implementation
 
 The bootstrap bundle defines the available profile names. \`dev\` is the
 default when present. Select another account explicitly, for example:
@@ -192,8 +225,6 @@ aws --profile production cloudformation describe-stacks
 
 Production and shared profiles are observer-only. Production repair remains a
 human-driven local-workstation operation.
-
-## Administrator rollout
 
 After the infrastructure pipeline deploys the remote-agent IAM stacks, retrieve
 the complete bundle from the shared account. Do not extract or distribute its
@@ -209,6 +240,8 @@ aws --profile shared secretsmanager get-secret-value \\
 Store that exact output as the masked secret \`LISA_AWS_BOOTSTRAP_JSON\` on each
 remote-agent platform. Run the setup command and require its live
 \`sts:GetCallerIdentity\` check to pass before considering the platform ready.
+
+## Notes
 
 Rotate by replacing the bootstrap IAM access key through infrastructure and
 then updating this one secret on every configured platform. Disabling or

--- a/plugins/src/base/scripts/install-remote-agent-aws.mjs
+++ b/plugins/src/base/scripts/install-remote-agent-aws.mjs
@@ -100,6 +100,11 @@ function installCopilotAdapter(project) {
   const marker = "Lisa remote AWS bootstrap";
   const secretEnvironment =
     "          LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+  const checkoutStep = [
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          persist-credentials: false",
+  ].join("\n");
   const step = [
     `      - name: ${marker}`,
     "        env:",
@@ -121,7 +126,7 @@ function installCopilotAdapter(project) {
         "    permissions:",
         "      contents: read",
         "    steps:",
-        "      - uses: actions/checkout@v4",
+        checkoutStep,
         step,
         "",
       ].join("\n")
@@ -131,6 +136,67 @@ function installCopilotAdapter(project) {
 
   const current = readFileSync(workflowPath, "utf8");
   const lines = current.split("\n");
+  const jobIndex = lines.findIndex(line =>
+    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  );
+  const jobEndIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
+  );
+  const stepsIndex = lines.findIndex(
+    (line, index) =>
+      index > jobIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{4}steps:\s*$/.test(line)
+  );
+  if (jobIndex < 0 || stepsIndex < 0) {
+    throw new Error(
+      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
+    );
+  }
+
+  let changed = false;
+  const checkoutIndex = lines.findIndex(
+    (line, index) =>
+      index > stepsIndex &&
+      (jobEndIndex < 0 || index < jobEndIndex) &&
+      /^\s{6}-\s+uses:\s+actions\/checkout@/.test(line)
+  );
+  if (checkoutIndex >= 0) {
+    const nextStepIndex = lines.findIndex(
+      (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
+    );
+    const checkoutEnd = nextStepIndex < 0 ? lines.length : nextStepIndex;
+    const withIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{8}with:\s*$/.test(line)
+    );
+    const persistenceIndex = lines.findIndex(
+      (line, index) =>
+        index > checkoutIndex &&
+        index < checkoutEnd &&
+        /^\s{10}persist-credentials:\s*/.test(line)
+    );
+    if (persistenceIndex >= 0) {
+      if (lines[persistenceIndex] !== "          persist-credentials: false") {
+        lines[persistenceIndex] = "          persist-credentials: false";
+        changed = true;
+      }
+    } else if (withIndex >= 0) {
+      lines.splice(withIndex + 1, 0, "          persist-credentials: false");
+      changed = true;
+    } else {
+      lines.splice(
+        checkoutIndex + 1,
+        0,
+        "        with:",
+        "          persist-credentials: false"
+      );
+      changed = true;
+    }
+  }
+
   const markerIndex = lines.findIndex(line => line.includes(marker));
   if (markerIndex >= 0) {
     const nextStepIndex = lines.findIndex(
@@ -151,31 +217,31 @@ function installCopilotAdapter(project) {
         );
       }
       lines.splice(environmentIndex + 1, 0, secretEnvironment);
-      writeFileSync(workflowPath, lines.join("\n"));
+      changed = true;
     }
+    if (checkoutIndex < 0) {
+      lines.splice(stepsIndex + 1, 0, ...checkoutStep.split("\n"));
+      changed = true;
+    }
+    if (changed) writeFileSync(workflowPath, lines.join("\n"));
     return path.relative(project, workflowPath);
   }
-  const jobIndex = lines.findIndex(line =>
-    /^\s{2}copilot-setup-steps:\s*$/.test(line)
+  const additions = checkoutIndex >= 0 ? [step] : [checkoutStep, step];
+  const nextCheckoutStepIndex = lines.findIndex(
+    (line, index) => index > checkoutIndex && /^\s{6}-\s/.test(line)
   );
-  const jobEndIndex = lines.findIndex(
+  const updatedJobEndIndex = lines.findIndex(
     (line, index) => index > jobIndex && /^\s{2}\S[^:]*:\s*$/.test(line)
   );
-  const stepsIndex = lines.findIndex(
-    (line, index) =>
-      index > jobIndex &&
-      (jobEndIndex < 0 || index < jobEndIndex) &&
-      /^\s{4}steps:\s*$/.test(line)
-  );
-  if (jobIndex < 0 || stepsIndex < 0) {
-    throw new Error(
-      "Existing copilot-setup-steps.yml must contain jobs.copilot-setup-steps.steps before Lisa can merge the AWS bootstrap step"
-    );
-  }
-  const additions = current.includes("actions/checkout@")
-    ? [step]
-    : ["      - uses: actions/checkout@v4", step];
-  lines.splice(stepsIndex + 1, 0, ...additions);
+  const additionIndex =
+    checkoutIndex < 0
+      ? stepsIndex + 1
+      : nextCheckoutStepIndex >= 0
+        ? nextCheckoutStepIndex
+        : updatedJobEndIndex >= 0
+          ? updatedJobEndIndex
+          : lines.length;
+  lines.splice(additionIndex, 0, ...additions);
   writeFileSync(workflowPath, lines.join("\n"));
   return path.relative(project, workflowPath);
 }

--- a/plugins/src/base/scripts/remote-agent-aws-setup.sh
+++ b/plugins/src/base/scripts/remote-agent-aws-setup.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 umask 077
 
 BOOTSTRAP_PROFILE="lisa-remote-agent-bootstrap"
+AWS_CLI_VERSION="2.36.2"
 
 fail() {
   echo "remote-agent-aws-setup: $*" >&2
@@ -35,17 +36,17 @@ as_root() {
 }
 
 install_base_tools() {
-  need curl && need unzip && need jq && return 0
+  need curl && need unzip && need jq && need gpg && return 0
 
   if need apt-get; then
     as_root apt-get update -y
-    as_root apt-get install -y curl unzip jq
+    as_root apt-get install -y curl unzip jq gnupg
   elif need dnf; then
-    as_root dnf install -y curl unzip jq
+    as_root dnf install -y curl unzip jq gnupg2
   elif need yum; then
-    as_root yum install -y curl unzip jq
+    as_root yum install -y curl unzip jq gnupg2
   else
-    fail "install curl, unzip, and jq in the remote image before running this script"
+    fail "install curl, unzip, jq, and gpg in the remote image before running this script"
   fi
 }
 
@@ -62,9 +63,49 @@ install_aws_cli() {
 
   temporary_directory="$(mktemp -d)"
   trap 'rm -rf "${temporary_directory:-}"' EXIT
+  local installer_url
+  installer_url="https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
   curl -fsSL \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${aws_architecture}.zip" \
+    "$installer_url" \
     -o "$temporary_directory/awscliv2.zip"
+  curl -fsSL "$installer_url.sig" -o "$temporary_directory/awscliv2.sig"
+  cat >"$temporary_directory/aws-cli-public-key.asc" <<'AWS_CLI_PUBLIC_KEY'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+akV0ygUJDqP4lQAKCRCmMQrMRnJHXFHjD/9eyZLYcKuQOlLvtqSDtUBiEZf6ZZjM
+i3ygYH8rJNtuToUH+HvSpe819urJCquXhDrlK6N+aqW0hCLtNABJG/vsafIgvIYJ
+hSGgpgtNnQyMV1jViRWqPjbouw8OkYKBThUfT1i2Y+wn58ifs6ODBCmTexWtXspA
+Si+Gt49xDOW0APmbOPnI+a4HJW6tVEo6MWS0WjzpiBayR3d1A4pt4YrPfSdDgpLo
+h2SLQqlRqvvVZJaWBjhkErNFpfsBA06sDcPEOb0G8LBUbR4WOcdvhe5LubJbZuxC
+AG9kNPCVeQP1ixwjgjXKysaxeQ6rv0VzIQgRp6tLVLWhy6AKDNvLjFSsmXZ1Wl08
+Y/RlOHXlzLuQMRE6sR1wOdRxc9TsrNWTGiBK65cvSWOy03JeBkQQ8pesqltiyxI9
+U21kkgiXtTSKNGfKK8pO27D81YANhRqPK7iTp6kuFiY2WtOg90KTMNlIT+Ff85Y2
+b1rHj6Z0SrCkJujhWk3IBPic/wJgz01LEc/OAdUPlby90RJZcIBhSlWhT7mXnXIO
+c0HWlNQrns2s3CTyYwZSiSlYe9ApeLwhjDo8NhbFuCAy61l6O5UsR4AfZxx/rGKv
+2wFb1/RN/P4gNe6vmxZAPjR0AQcwD3tc2McimOLr/22kmPz8IH3I0X7WoSFr0Biz
+E91G7bb0hOb/cA==
+=knv7
+-----END PGP PUBLIC KEY BLOCK-----
+AWS_CLI_PUBLIC_KEY
+  mkdir -m 700 "$temporary_directory/gnupg"
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --import "$temporary_directory/aws-cli-public-key.asc" >/dev/null 2>&1
+  gpg --batch --homedir "$temporary_directory/gnupg" \
+    --verify "$temporary_directory/awscliv2.sig" \
+    "$temporary_directory/awscliv2.zip"
   unzip -q "$temporary_directory/awscliv2.zip" -d "$temporary_directory"
   as_root "$temporary_directory/aws/install" \
     --install-dir /usr/local/aws-cli \

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -29,6 +29,8 @@ const COPILOT_PLATFORM_ARGUMENT = "--platform=copilot";
 const NPM_INSTALL_STEP = "- run: npm ci";
 const COPILOT_BOOTSTRAP_SECRET =
   "LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
+const COPILOT_BOOTSTRAP_MARKER = "Lisa remote AWS bootstrap";
+const CHECKOUT_CREDENTIAL_ISOLATION = "persist-credentials: false";
 const GENERATED_PLUGIN_ROOTS = [
   "plugins/lisa",
   "plugins/lisa-cursor",
@@ -78,9 +80,10 @@ describe("remote AWS platform installer", () => {
       path.join(project, COPILOT_WORKFLOW_PATH),
       "utf8"
     );
-    expect(workflow).toContain("Lisa remote AWS bootstrap");
+    expect(workflow).toContain(COPILOT_BOOTSTRAP_MARKER);
     expect(workflow).toContain(COPILOT_BOOTSTRAP_SECRET);
     expect(workflow).toContain("LISA_REMOTE_AGENT: copilot");
+    expect(workflow).toContain(CHECKOUT_CREDENTIAL_ISOLATION);
     expect(workflow).not.toContain("  push:");
     const guide = readFileSync(
       path.join(project, REMOTE_AWS_GUIDE_PATH),
@@ -123,7 +126,7 @@ describe("remote AWS platform installer", () => {
     mkdirSync(path.dirname(workflowPath), { recursive: true });
     writeFileSync(
       workflowPath,
-      "jobs:\n  copilot-setup-steps:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm ci\n"
+      "jobs:\n  copilot-setup-steps:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci\n"
     );
 
     installRemoteAgentAws([`--project=${project}`, COPILOT_PLATFORM_ARGUMENT]);
@@ -134,6 +137,13 @@ describe("remote AWS platform installer", () => {
     expect(workflow.match(/actions\/checkout@v4/g)).toHaveLength(1);
     expect(workflow).toContain(NPM_INSTALL_STEP);
     expect(workflow).toContain(COPILOT_BOOTSTRAP_SECRET);
+    expect(workflow).toContain(CHECKOUT_CREDENTIAL_ISOLATION);
+    expect(workflow.indexOf("actions/checkout@v4")).toBeLessThan(
+      workflow.indexOf(COPILOT_BOOTSTRAP_MARKER)
+    );
+    expect(workflow.indexOf(COPILOT_BOOTSTRAP_MARKER)).toBeLessThan(
+      workflow.indexOf(NPM_INSTALL_STEP)
+    );
   });
 
   it("upgrades an existing Lisa Copilot step with the bootstrap secret", () => {
@@ -161,12 +171,19 @@ describe("remote AWS platform installer", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow.match(/LISA_AWS_BOOTSTRAP_JSON/g)).toHaveLength(2);
     expect(workflow).toContain(`      ${NPM_INSTALL_STEP}`);
+    expect(workflow).toContain(CHECKOUT_CREDENTIAL_ISOLATION);
   });
 });
 
 describe("remote AWS runtime parity", () => {
   it("ships the setup skill and executable through every generated runtime", () => {
     const canonicalScript = readFileSync(REMOTE_SETUP_SCRIPT_PATH, "utf8");
+    expect(canonicalScript).toContain('AWS_CLI_VERSION="2.36.2"');
+    expect(canonicalScript).toContain(
+      "awscli-exe-linux-${aws_architecture}-${AWS_CLI_VERSION}.zip"
+    );
+    expect(canonicalScript).toContain("gpg --batch --homedir");
+    expect(canonicalScript).toContain("--verify");
     for (const root of GENERATED_PLUGIN_ROOTS) {
       expect(
         existsSync(path.join(root, "skills/lisa-setup-remote-aws/SKILL.md"))

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -25,6 +25,10 @@ const REMOTE_SETUP_SCRIPT_PATH =
 const CURSOR_ENVIRONMENT_PATH = ".cursor/environment.json";
 const COPILOT_WORKFLOW_PATH = ".github/workflows/copilot-setup-steps.yml";
 const REMOTE_AWS_GUIDE_PATH = "docs/remote-agent-aws.md";
+const COPILOT_PLATFORM_ARGUMENT = "--platform=copilot";
+const NPM_INSTALL_STEP = "- run: npm ci";
+const COPILOT_BOOTSTRAP_SECRET =
+  "LISA_AWS_BOOTSTRAP_JSON: ${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}";
 const GENERATED_PLUGIN_ROOTS = [
   "plugins/lisa",
   "plugins/lisa-cursor",
@@ -75,11 +79,23 @@ describe("remote AWS platform installer", () => {
       "utf8"
     );
     expect(workflow).toContain("Lisa remote AWS bootstrap");
+    expect(workflow).toContain(COPILOT_BOOTSTRAP_SECRET);
     expect(workflow).toContain("LISA_REMOTE_AGENT: copilot");
     expect(workflow).not.toContain("  push:");
-    expect(
-      readFileSync(path.join(project, REMOTE_AWS_GUIDE_PATH), "utf8")
-    ).toContain("--secret-id company-remote-agent");
+    const guide = readFileSync(
+      path.join(project, REMOTE_AWS_GUIDE_PATH),
+      "utf8"
+    );
+    expect(guide).toContain("--secret-id company-remote-agent");
+    for (const heading of [
+      "## Context",
+      "## Goal",
+      "## Changes",
+      "## Implementation",
+      "## Notes",
+    ]) {
+      expect(guide).toContain(heading);
+    }
   });
 
   it("preserves an existing Cursor install command and is idempotent", () => {
@@ -110,13 +126,41 @@ describe("remote AWS platform installer", () => {
       "jobs:\n  copilot-setup-steps:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm ci\n"
     );
 
-    installRemoteAgentAws([`--project=${project}`, "--platform=copilot"]);
-    installRemoteAgentAws([`--project=${project}`, "--platform=copilot"]);
+    installRemoteAgentAws([`--project=${project}`, COPILOT_PLATFORM_ARGUMENT]);
+    installRemoteAgentAws([`--project=${project}`, COPILOT_PLATFORM_ARGUMENT]);
 
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow.match(/Lisa remote AWS bootstrap/g)).toHaveLength(1);
     expect(workflow.match(/actions\/checkout@v4/g)).toHaveLength(1);
-    expect(workflow).toContain("- run: npm ci");
+    expect(workflow).toContain(NPM_INSTALL_STEP);
+    expect(workflow).toContain(COPILOT_BOOTSTRAP_SECRET);
+  });
+
+  it("upgrades an existing Lisa Copilot step with the bootstrap secret", () => {
+    const project = temporaryDirectory();
+    const workflowPath = path.join(project, COPILOT_WORKFLOW_PATH);
+    mkdirSync(path.dirname(workflowPath), { recursive: true });
+    writeFileSync(
+      workflowPath,
+      [
+        "jobs:",
+        "  copilot-setup-steps:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - name: Lisa remote AWS bootstrap",
+        "        env:",
+        "          LISA_REMOTE_AGENT: copilot",
+        "        run: bash scripts/remote-agent-aws-setup.sh",
+        "      - run: npm ci",
+        "",
+      ].join("\n")
+    );
+
+    installRemoteAgentAws([`--project=${project}`, COPILOT_PLATFORM_ARGUMENT]);
+
+    const workflow = readFileSync(workflowPath, "utf8");
+    expect(workflow.match(/LISA_AWS_BOOTSTRAP_JSON/g)).toHaveLength(2);
+    expect(workflow).toContain(`      ${NPM_INSTALL_STEP}`);
   });
 });
 


### PR DESCRIPTION
## Context

The remote AWS bootstrap generator created a Copilot setup step without explicitly mapping the organization Agents secret into the process environment. Existing generated workflows were also treated as complete and could not be upgraded.

## Goal

Make the Copilot adapter immediately usable with the single `LISA_AWS_BOOTSTRAP_JSON` secret and keep generated operator documentation compliant with Lisa's standard structure.

## Changes

- map `${{ secrets.LISA_AWS_BOOTSTRAP_JSON }}` into the Copilot setup step
- upgrade existing Lisa-managed Copilot steps in place
- emit the required Context, Goal, Changes, Implementation, and Notes runbook sections
- rebuild Claude, Codex, Cursor, Antigravity, and Copilot plugin artifacts
- add regression coverage for new installs and upgrades

## Verification

- `bun run build:plugins`
- `bun run typecheck`
- `bun run lint`
- targeted remote AWS tests: 8 passed
- pre-push suite: 4,569 unit tests and 129 integration tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS remote-agent setup now passes bootstrap secret data securely through the Copilot workflow.
  * Existing setup workflows are upgraded automatically without duplicating configuration.

* **Documentation**
  * Reorganized the AWS remote-agent guide with clearer sections covering context, goals, implementation, changes, and operational notes.

* **Tests**
  * Expanded coverage for secret configuration, documentation headings, workflow preservation, and repeatable upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->