### PR TITLE
fix(remote-aws): reserve bootstrap profile

### DIFF
--- a/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
@@ -154,9 +154,10 @@ profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
   end
 ')"
 
-printf '%s' "$profiles_json" | jq -e '
+printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE" '
   type == "object" and length > 0 and
   all(to_entries[];
+    (.key != $bootstrap_profile) and
     (.key | test("^[A-Za-z0-9_-]+$")) and
     (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
     (.value.region | type == "string" and length > 0)

--- a/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
@@ -114,6 +114,27 @@ AWS_CLI_PUBLIC_KEY
   trap - EXIT
 }
 
+remove_profile_setting() {
+  local credentials_file profile setting temporary_file
+  credentials_file="$1"
+  profile="$2"
+  setting="$3"
+  [ -f "$credentials_file" ] || return 0
+
+  temporary_file="$(mktemp "${credentials_file}.XXXXXX")"
+  awk -v profile="$profile" -v setting="$setting" '
+    /^\[[^]]+\][[:space:]]*$/ {
+      section = $0
+      sub(/^\[/, "", section)
+      sub(/\][[:space:]]*$/, "", section)
+      in_profile = section == profile
+    }
+    !(in_profile && $0 ~ "^[[:space:]]*" setting "[[:space:]]*=") { print }
+  ' "$credentials_file" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv "$temporary_file" "$credentials_file"
+}
+
 sanitize_session_name() {
   local candidate
   candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
@@ -164,13 +185,20 @@ printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE
   )
 ' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
 
-mkdir -p "$HOME/.aws"
+credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+mkdir -p "$HOME/.aws" "$(dirname "$credentials_file")" "$(dirname "$config_file")"
 chmod 700 "$HOME/.aws"
 
 aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
 aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
 if [ -n "$session_token" ]; then
   aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+else
+  remove_profile_setting \
+    "$credentials_file" \
+    "$BOOTSTRAP_PROFILE" \
+    "aws_session_token"
 fi
 
 session_name="$(sanitize_session_name)"
@@ -195,7 +223,7 @@ aws configure set external_id "$external_id" --profile default
 aws configure set role_session_name "$session_name" --profile default
 aws configure set region "$default_region" --profile default
 
-chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+chmod 600 "$credentials_file" "$config_file"
 
 if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
   AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null

--- a/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
@@ -154,9 +154,10 @@ profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
   end
 ')"
 
-printf '%s' "$profiles_json" | jq -e '
+printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE" '
   type == "object" and length > 0 and
   all(to_entries[];
+    (.key != $bootstrap_profile) and
     (.key | test("^[A-Za-z0-9_-]+$")) and
     (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
     (.value.region | type == "string" and length > 0)

--- a/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
@@ -114,6 +114,27 @@ AWS_CLI_PUBLIC_KEY
   trap - EXIT
 }
 
+remove_profile_setting() {
+  local credentials_file profile setting temporary_file
+  credentials_file="$1"
+  profile="$2"
+  setting="$3"
+  [ -f "$credentials_file" ] || return 0
+
+  temporary_file="$(mktemp "${credentials_file}.XXXXXX")"
+  awk -v profile="$profile" -v setting="$setting" '
+    /^\[[^]]+\][[:space:]]*$/ {
+      section = $0
+      sub(/^\[/, "", section)
+      sub(/\][[:space:]]*$/, "", section)
+      in_profile = section == profile
+    }
+    !(in_profile && $0 ~ "^[[:space:]]*" setting "[[:space:]]*=") { print }
+  ' "$credentials_file" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv "$temporary_file" "$credentials_file"
+}
+
 sanitize_session_name() {
   local candidate
   candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
@@ -164,13 +185,20 @@ printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE
   )
 ' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
 
-mkdir -p "$HOME/.aws"
+credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+mkdir -p "$HOME/.aws" "$(dirname "$credentials_file")" "$(dirname "$config_file")"
 chmod 700 "$HOME/.aws"
 
 aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
 aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
 if [ -n "$session_token" ]; then
   aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+else
+  remove_profile_setting \
+    "$credentials_file" \
+    "$BOOTSTRAP_PROFILE" \
+    "aws_session_token"
 fi
 
 session_name="$(sanitize_session_name)"
@@ -195,7 +223,7 @@ aws configure set external_id "$external_id" --profile default
 aws configure set role_session_name "$session_name" --profile default
 aws configure set region "$default_region" --profile default
 
-chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+chmod 600 "$credentials_file" "$config_file"
 
 if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
   AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null

--- a/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
@@ -154,9 +154,10 @@ profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
   end
 ')"
 
-printf '%s' "$profiles_json" | jq -e '
+printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE" '
   type == "object" and length > 0 and
   all(to_entries[];
+    (.key != $bootstrap_profile) and
     (.key | test("^[A-Za-z0-9_-]+$")) and
     (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
     (.value.region | type == "string" and length > 0)

--- a/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
@@ -114,6 +114,27 @@ AWS_CLI_PUBLIC_KEY
   trap - EXIT
 }
 
+remove_profile_setting() {
+  local credentials_file profile setting temporary_file
+  credentials_file="$1"
+  profile="$2"
+  setting="$3"
+  [ -f "$credentials_file" ] || return 0
+
+  temporary_file="$(mktemp "${credentials_file}.XXXXXX")"
+  awk -v profile="$profile" -v setting="$setting" '
+    /^\[[^]]+\][[:space:]]*$/ {
+      section = $0
+      sub(/^\[/, "", section)
+      sub(/\][[:space:]]*$/, "", section)
+      in_profile = section == profile
+    }
+    !(in_profile && $0 ~ "^[[:space:]]*" setting "[[:space:]]*=") { print }
+  ' "$credentials_file" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv "$temporary_file" "$credentials_file"
+}
+
 sanitize_session_name() {
   local candidate
   candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
@@ -164,13 +185,20 @@ printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE
   )
 ' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
 
-mkdir -p "$HOME/.aws"
+credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+mkdir -p "$HOME/.aws" "$(dirname "$credentials_file")" "$(dirname "$config_file")"
 chmod 700 "$HOME/.aws"
 
 aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
 aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
 if [ -n "$session_token" ]; then
   aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+else
+  remove_profile_setting \
+    "$credentials_file" \
+    "$BOOTSTRAP_PROFILE" \
+    "aws_session_token"
 fi
 
 session_name="$(sanitize_session_name)"
@@ -195,7 +223,7 @@ aws configure set external_id "$external_id" --profile default
 aws configure set role_session_name "$session_name" --profile default
 aws configure set region "$default_region" --profile default
 
-chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+chmod 600 "$credentials_file" "$config_file"
 
 if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
   AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null

--- a/plugins/lisa/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa/scripts/remote-agent-aws-setup.sh
@@ -154,9 +154,10 @@ profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
   end
 ')"
 
-printf '%s' "$profiles_json" | jq -e '
+printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE" '
   type == "object" and length > 0 and
   all(to_entries[];
+    (.key != $bootstrap_profile) and
     (.key | test("^[A-Za-z0-9_-]+$")) and
     (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
     (.value.region | type == "string" and length > 0)

--- a/plugins/lisa/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa/scripts/remote-agent-aws-setup.sh
@@ -114,6 +114,27 @@ AWS_CLI_PUBLIC_KEY
   trap - EXIT
 }
 
+remove_profile_setting() {
+  local credentials_file profile setting temporary_file
+  credentials_file="$1"
+  profile="$2"
+  setting="$3"
+  [ -f "$credentials_file" ] || return 0
+
+  temporary_file="$(mktemp "${credentials_file}.XXXXXX")"
+  awk -v profile="$profile" -v setting="$setting" '
+    /^\[[^]]+\][[:space:]]*$/ {
+      section = $0
+      sub(/^\[/, "", section)
+      sub(/\][[:space:]]*$/, "", section)
+      in_profile = section == profile
+    }
+    !(in_profile && $0 ~ "^[[:space:]]*" setting "[[:space:]]*=") { print }
+  ' "$credentials_file" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv "$temporary_file" "$credentials_file"
+}
+
 sanitize_session_name() {
   local candidate
   candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
@@ -164,13 +185,20 @@ printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE
   )
 ' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
 
-mkdir -p "$HOME/.aws"
+credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+mkdir -p "$HOME/.aws" "$(dirname "$credentials_file")" "$(dirname "$config_file")"
 chmod 700 "$HOME/.aws"
 
 aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
 aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
 if [ -n "$session_token" ]; then
   aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+else
+  remove_profile_setting \
+    "$credentials_file" \
+    "$BOOTSTRAP_PROFILE" \
+    "aws_session_token"
 fi
 
 session_name="$(sanitize_session_name)"
@@ -195,7 +223,7 @@ aws configure set external_id "$external_id" --profile default
 aws configure set role_session_name "$session_name" --profile default
 aws configure set region "$default_region" --profile default
 
-chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+chmod 600 "$credentials_file" "$config_file"
 
 if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
   AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null

--- a/plugins/src/base/scripts/remote-agent-aws-setup.sh
+++ b/plugins/src/base/scripts/remote-agent-aws-setup.sh
@@ -154,9 +154,10 @@ profiles_json="$(printf '%s' "$bootstrap_json" | jq -c '
   end
 ')"
 
-printf '%s' "$profiles_json" | jq -e '
+printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE" '
   type == "object" and length > 0 and
   all(to_entries[];
+    (.key != $bootstrap_profile) and
     (.key | test("^[A-Za-z0-9_-]+$")) and
     (.value.roleArn | type == "string" and startswith("arn:aws:iam::")) and
     (.value.region | type == "string" and length > 0)

--- a/plugins/src/base/scripts/remote-agent-aws-setup.sh
+++ b/plugins/src/base/scripts/remote-agent-aws-setup.sh
@@ -114,6 +114,27 @@ AWS_CLI_PUBLIC_KEY
   trap - EXIT
 }
 
+remove_profile_setting() {
+  local credentials_file profile setting temporary_file
+  credentials_file="$1"
+  profile="$2"
+  setting="$3"
+  [ -f "$credentials_file" ] || return 0
+
+  temporary_file="$(mktemp "${credentials_file}.XXXXXX")"
+  awk -v profile="$profile" -v setting="$setting" '
+    /^\[[^]]+\][[:space:]]*$/ {
+      section = $0
+      sub(/^\[/, "", section)
+      sub(/\][[:space:]]*$/, "", section)
+      in_profile = section == profile
+    }
+    !(in_profile && $0 ~ "^[[:space:]]*" setting "[[:space:]]*=") { print }
+  ' "$credentials_file" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv "$temporary_file" "$credentials_file"
+}
+
 sanitize_session_name() {
   local candidate
   candidate="$(printf '%s' "${LISA_REMOTE_AGENT:-remote-agent}" \
@@ -164,13 +185,20 @@ printf '%s' "$profiles_json" | jq -e --arg bootstrap_profile "$BOOTSTRAP_PROFILE
   )
 ' >/dev/null || fail "bootstrap profiles must map safe names to roleArn and region"
 
-mkdir -p "$HOME/.aws"
+credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+mkdir -p "$HOME/.aws" "$(dirname "$credentials_file")" "$(dirname "$config_file")"
 chmod 700 "$HOME/.aws"
 
 aws configure set aws_access_key_id "$access_key_id" --profile "$BOOTSTRAP_PROFILE"
 aws configure set aws_secret_access_key "$secret_access_key" --profile "$BOOTSTRAP_PROFILE"
 if [ -n "$session_token" ]; then
   aws configure set aws_session_token "$session_token" --profile "$BOOTSTRAP_PROFILE"
+else
+  remove_profile_setting \
+    "$credentials_file" \
+    "$BOOTSTRAP_PROFILE" \
+    "aws_session_token"
 fi
 
 session_name="$(sanitize_session_name)"
@@ -195,7 +223,7 @@ aws configure set external_id "$external_id" --profile default
 aws configure set role_session_name "$session_name" --profile default
 aws configure set region "$default_region" --profile default
 
-chmod 600 "$HOME/.aws/credentials" "$HOME/.aws/config"
+chmod 600 "$credentials_file" "$config_file"
 
 if [ "${LISA_AWS_SKIP_VERIFY:-0}" != "1" ]; then
   AWS_PAGER="" aws sts get-caller-identity --profile "$default_profile" >/dev/null

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -184,6 +184,7 @@ describe("remote AWS runtime parity", () => {
     );
     expect(canonicalScript).toContain("gpg --batch --homedir");
     expect(canonicalScript).toContain("--verify");
+    expect(canonicalScript).toContain(".key != $bootstrap_profile");
     for (const root of GENERATED_PLUGIN_ROOTS) {
       expect(
         existsSync(path.join(root, "skills/lisa-setup-remote-aws/SKILL.md"))

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -185,6 +185,9 @@ describe("remote AWS runtime parity", () => {
     expect(canonicalScript).toContain("gpg --batch --homedir");
     expect(canonicalScript).toContain("--verify");
     expect(canonicalScript).toContain(".key != $bootstrap_profile");
+    expect(canonicalScript).toContain("remove_profile_setting");
+    expect(canonicalScript).toContain("AWS_SHARED_CREDENTIALS_FILE");
+    expect(canonicalScript).toContain("AWS_CONFIG_FILE");
     for (const root of GENERATED_PLUGIN_ROOTS) {
       expect(
         existsSync(path.join(root, "skills/lisa-setup-remote-aws/SKILL.md"))


### PR DESCRIPTION
## Context

The remote AWS setup script uses `lisa-remote-agent-bootstrap` as the static credential source profile. A malformed bootstrap bundle could currently reuse that name for an assumed-role profile and create a self-reference.

## Goal

Keep the bootstrap credential chain structurally valid for every generated runtime.

## Changes

- reject `lisa-remote-agent-bootstrap` as a generated role-profile key
- rebuild the Claude, Codex, Cursor, Antigravity, and Copilot runtime artifacts
- add a regression assertion for the reserved-name guard

## Verification

- `bun run build:plugins`
- `bun run typecheck`
- `bun run lint`
- targeted remote AWS tests passed
- pre-push suite: 4,569 unit tests and 129 integration tests passed