### PR TITLE
perf(postinstall): dedupe applies and version-gate plugin sync

### DIFF
--- a/all/copy-contents/gitignore
+++ b/all/copy-contents/gitignore
@@ -170,6 +170,8 @@ tasks.json
 **/.claude/debug/
 **/.claude/worktrees/
 **/.claude/scheduled_tasks.lock
+**/.claude/.lisa-plugins-synced
+**/.claude/.lisa-marketplace-heal-v2
 .roo
 .roo/
 .roomodes

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -55,8 +55,22 @@ detect_lisa_stack() {
   done
 }
 
+# One-time migration marker: once the user-wide Codex registrations are
+# confirmed retired, skip the `codex plugin marketplace list` probe (a codex
+# CLI spawn) on every subsequent install.
+CODEX_RETIRE_MARKER="$HOME/.codex/.lisa-legacy-plugins-retired"
+
+write_codex_retire_marker() {
+  mkdir -p "$HOME/.codex" 2>/dev/null && touch "$CODEX_RETIRE_MARKER" 2>/dev/null || true
+}
+
 remove_user_wide_codex_lisa_plugins() {
   command -v codex >/dev/null 2>&1 || return 0
+
+  # The marker is written only after the cleanup actually ran or was confirmed
+  # unnecessary — never on the CODEX_THREAD_ID deferral below, which must
+  # retry on a later install (see fix/defer-codex-retirement-postinstall).
+  [ -f "$CODEX_RETIRE_MARKER" ] && return 0
 
   # Removing a plugin relocates its cache directory. A running Codex session
   # has already captured absolute hook paths, so removal inside that session
@@ -84,6 +98,7 @@ remove_user_wide_codex_lisa_plugins() {
       }
     });
   '; then
+    write_codex_retire_marker
     return 0
   fi
 
@@ -102,6 +117,7 @@ remove_user_wide_codex_lisa_plugins() {
     codex plugin remove "${plugin}@lisa" </dev/null >/dev/null 2>&1 || true
   done
   codex plugin marketplace remove lisa </dev/null >/dev/null 2>&1 || true
+  write_codex_retire_marker
 }
 
 # Skip running Lisa's full template engine on itself — the Lisa repo IS the
@@ -144,8 +160,23 @@ fi
 # each path is written exactly once by its most-specific stack — there is no
 # intermediate clobbered state to be interrupted in. See src/core/lisa.ts
 # loadCopyOverwriteOwnership.
+# Dedup guard: when the host's own package.json postinstall already invokes
+# Lisa (wired by the ensure-lisa-postinstall migration), the package manager
+# will run that root lifecycle script in this same install — running the full
+# apply here too doubles the work for no benefit. The package-side apply
+# exists for the bootstrap chicken-and-egg (#1017: a never-applied project
+# has no postinstall to wire itself), so it still runs whenever the marker is
+# absent. Detection matches LISA_MARKER in ensure-lisa-postinstall.ts.
+HOST_HAS_LISA_POSTINSTALL="$(node -e "
+  const scripts = require('$PROJECT_ROOT/package.json').scripts || {};
+  const postinstall = scripts.postinstall || '';
+  process.stdout.write(postinstall.includes('node_modules/@codyswann/lisa/dist/index.js') ? 'true' : 'false');
+" 2>/dev/null || echo false)"
+
 if [ "$IS_LISA_SELF" != "true" ] && [ -z "${CI:-}" ]; then
-  if ! LISA_BOOTSTRAP=1 node "$LISA_DIR/dist/index.js" --yes --skip-git-check "$PROJECT_ROOT"; then
+  if [ "$HOST_HAS_LISA_POSTINSTALL" = "true" ]; then
+    echo "Lisa apply deferred to the host project's own postinstall script."
+  elif ! LISA_BOOTSTRAP=1 node "$LISA_DIR/dist/index.js" --yes --skip-git-check "$PROJECT_ROOT"; then
     echo "⚠️  Warning: Lisa template application failed. Migration may be incomplete." >&2
   fi
 fi
@@ -259,6 +290,38 @@ fi
 # Install plugins only when claude CLI is available
 if ! command -v claude &>/dev/null; then exit 0; fi
 
+# Version-gated plugin sync (perf). `claude plugin marketplace update` is a
+# network git pull of the whole Lisa repo and every `claude plugin install`
+# spawns the Claude CLI (seconds each); re-running all of it on every install
+# made a single `bun add` cost minutes. A full sync still runs whenever the
+# installed Lisa version differs from the .claude/.lisa-plugins-synced marker
+# (shared with Lisa.apply's registerPlugins); between version changes only
+# plugins missing for this project are installed, so the self-heal property
+# (a removed plugin comes back on the next install) survives at the cost of a
+# single `claude plugin list` call.
+LISA_VERSION="$(node -e "console.log(require('$LISA_DIR/package.json').version || '')" 2>/dev/null || true)"
+PLUGIN_SYNC_MARKER="$PROJECT_ROOT/.claude/.lisa-plugins-synced"
+FORCE_PLUGIN_SYNC=true
+if [ -n "$LISA_VERSION" ] && [ -f "$PLUGIN_SYNC_MARKER" ] \
+  && [ "$(cat "$PLUGIN_SYNC_MARKER" 2>/dev/null)" = "$LISA_VERSION" ]; then
+  FORCE_PLUGIN_SYNC=false
+fi
+
+INSTALLED_PLUGINS_FOR_PROJECT=""
+if command -v jq >/dev/null 2>&1; then
+  INSTALLED_PLUGINS_FOR_PROJECT="$(claude plugin list --json 2>/dev/null \
+    | jq -r --arg cwd "$PROJECT_ROOT" '.[] | select(.projectPath == $cwd) | .id' 2>/dev/null || true)"
+fi
+
+install_plugin_if_missing() {
+  local plugin="$1"
+  if [ "$FORCE_PLUGIN_SYNC" != "true" ] && [ -n "$INSTALLED_PLUGINS_FOR_PROJECT" ] \
+    && printf '%s\n' "$INSTALLED_PLUGINS_FOR_PROJECT" | grep -qxF "$plugin"; then
+    return 0
+  fi
+  claude plugin install "$plugin" --scope project </dev/null 2>&1 || true
+}
+
 # The Lisa marketplace is registered via extraKnownMarketplaces in .claude/settings.json
 # pointing to the GitHub repo (CodySwannGT/lisa). Built plugins are committed to the repo
 # so relative paths in marketplace.json resolve correctly.
@@ -272,7 +335,10 @@ if ! command -v claude &>/dev/null; then exit 0; fi
 # "Update now" action with: "Local plugins cannot be updated remotely."
 # If we detect a non-github marketplace named "lisa", uninstall the plugins
 # sourced from it and remove the registration so the github source can take over.
-if command -v jq >/dev/null 2>&1; then
+# Gated on version change: the stale registration can only exist in state
+# written by an older Lisa, so re-probing it on every same-version install
+# spends a claude CLI spawn to re-confirm a fact that cannot have changed.
+if [ "$FORCE_PLUGIN_SYNC" = "true" ] && command -v jq >/dev/null 2>&1; then
   STALE_LISA_SOURCE=$(claude plugin marketplace list --json 2>/dev/null \
     | jq -r '.[] | select(.name == "lisa" and .source != "github") | .source' 2>/dev/null \
     | head -n 1)
@@ -339,7 +405,12 @@ heal_local_classification() {
 
 if command -v jq >/dev/null 2>&1; then
   # Refresh the cached marketplace.json so we're reading the latest schema.
-  claude plugin marketplace update lisa </dev/null >/dev/null 2>&1 || true
+  # Gated: the pull is a network git fetch of the whole Lisa repo; once this
+  # version's plugins are synced and the project's heal-v2 marker exists, a
+  # fresh pull cannot change the outcome of the schema check below.
+  if [ "$FORCE_PLUGIN_SYNC" = "true" ] || [ ! -f "$PROJECT_ROOT/.claude/$HEAL_V2_MARKER_NAME" ]; then
+    claude plugin marketplace update lisa </dev/null >/dev/null 2>&1 || true
+  fi
 
   MARKETPLACE_JSON_PATH="$HOME/.claude/plugins/marketplaces/lisa/.claude-plugin/marketplace.json"
   NEW_SCHEMA="false"
@@ -364,8 +435,8 @@ if command -v jq >/dev/null 2>&1; then
   fi
 fi
 
-# Always install the base plugin (universal governance for all projects)
-claude plugin install "lisa@lisa" --scope project </dev/null 2>&1 || true
+# Always ensure the base plugin (universal governance for all projects)
+install_plugin_if_missing "lisa@lisa"
 
 # Detect which stack plugin to install from .claude/settings.json
 LISA_STACK="$(detect_lisa_stack "$SETTINGS_FILE")"
@@ -374,13 +445,13 @@ LISA_STACK="$(detect_lisa_stack "$SETTINGS_FILE")"
 case "$LISA_STACK" in
   rails) ;; # Rails doesn't get typescript plugin
   *)
-    claude plugin install "lisa-typescript@lisa" --scope project </dev/null 2>&1 || true
+    install_plugin_if_missing "lisa-typescript@lisa"
     ;;
 esac
 
 # Install stack-specific plugin if not plain typescript
 if [ -n "$LISA_STACK" ]; then
-  claude plugin install "lisa-${LISA_STACK}@lisa" --scope project </dev/null 2>&1 || true
+  install_plugin_if_missing "lisa-${LISA_STACK}@lisa"
 fi
 
 # Uninstall old monolithic plugins during migration
@@ -403,7 +474,7 @@ for plugin in \
   "skill-creator@claude-plugins-official" \
   "atlassian@claude-plugins-official" \
   "safety-net@cc-marketplace"; do
-  claude plugin install "$plugin" --scope project </dev/null 2>&1 || true
+  install_plugin_if_missing "$plugin"
 done
 
 # Install stack-specific third-party plugins
@@ -411,6 +482,15 @@ if [ "$LISA_STACK" = "expo" ] || [ "$LISA_STACK" = "harper-fabric" ]; then
   for plugin in \
     "playwright@claude-plugins-official" \
     "posthog@claude-plugins-official"; do
-    claude plugin install "$plugin" --scope project </dev/null 2>&1 || true
+    install_plugin_if_missing "$plugin"
   done
+fi
+
+# Record the fully-synced Lisa version so same-version installs skip the
+# marketplace pulls and forced reinstalls above. Written last so any earlier
+# failure exits (set -e) without recording a sync that did not finish.
+if [ -n "$LISA_VERSION" ]; then
+  mkdir -p "$PROJECT_ROOT/.claude" 2>/dev/null \
+    && printf '%s' "$LISA_VERSION" > "$PLUGIN_SYNC_MARKER" 2>/dev/null \
+    || true
 fi

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -5,6 +5,7 @@ import { readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import pc from "picocolors";
 import type { IPrompter } from "../cli/prompts.js";
+import { getPackageVersion } from "../cli/version.js";
 import { installAgentsMd } from "../codex/agents-md-installer.js";
 import { installCodexProjectOverlay } from "../codex/project-overlay.js";
 import { installAgyPlugin } from "../agy/plugin-installer.js";
@@ -106,6 +107,14 @@ export interface LisaDependencies {
   readonly gitService: IGitService;
   readonly migrationRegistry: MigrationRegistry;
 }
+
+/**
+ * Shape of the promisified exec function used for Claude CLI plugin commands.
+ */
+type PluginExecAsync = (
+  cmd: string,
+  opts: Record<string, unknown>
+) => Promise<unknown>;
 
 /**
  * Main Lisa orchestrator
@@ -659,54 +668,214 @@ export class Lisa {
   }
 
   /**
-   * Install each plugin and refresh the Lisa marketplace cache
+   * Install each plugin and refresh the Lisa marketplace cache.
+   *
+   * Version-gated (perf): `claude plugin marketplace update` is a network git
+   * pull of the Lisa repo and every `claude plugin install` spawns the Claude
+   * CLI (seconds each); re-running all of it on every apply made a single
+   * `bun add` cost minutes across the repeated apply passes. A full sync
+   * (marketplace refresh + install every plugin) still runs whenever the
+   * installed Lisa version differs from the `.claude/.lisa-plugins-synced`
+   * marker; between version changes only plugins missing for this project are
+   * installed, so the self-heal property (a removed plugin comes back on the
+   * next install) survives at the cost of one `claude plugin list` call.
    * @param execAsync - Promisified exec function for running shell commands
    * @param plugins - Plugin identifiers from enabledPlugins (e.g. "lisa@lisa")
    */
   private async installPluginsAndUpdateMarketplace(
-    execAsync: (cmd: string, opts: Record<string, unknown>) => Promise<unknown>,
+    execAsync: PluginExecAsync,
     plugins: readonly string[]
   ): Promise<void> {
     const { logger } = this.deps;
     const validPluginName = /^[\w@./-]+$/;
+    const { fullSync, toInstall, version } = await this.computePluginSyncPlan(
+      execAsync,
+      plugins
+    );
+
+    if (!fullSync && toInstall.length === 0) {
+      logger.info(
+        pc.gray(`Plugins already in sync for Lisa ${version}; skipping`)
+      );
+      return;
+    }
 
     logger.info("Registering plugins with Claude Code (project scope)...");
 
-    try {
-      await execAsync("claude plugin marketplace update lisa", {
-        cwd: this.config.destDir,
-        shell: "/bin/sh",
-      });
-    } catch {
+    if (fullSync) {
       // Best-effort cache refresh. Individual plugin installs below will still
       // report whether the marketplace entry is available.
+      await this.updateLisaMarketplace(execAsync, false);
     }
 
-    for (const plugin of plugins) {
+    for (const plugin of toInstall) {
       if (!validPluginName.test(plugin)) {
         logger.warn(`Skipping invalid plugin name: ${plugin}`);
         continue;
       }
-
-      try {
-        await execAsync(`claude plugin install ${plugin} --scope project`, {
-          cwd: this.config.destDir,
-          shell: "/bin/sh",
-        });
-        logger.success(`Registered plugin: ${plugin}`);
-      } catch {
-        logger.warn(`Could not register plugin: ${plugin}`);
-      }
+      await this.installPlugin(execAsync, plugin);
     }
 
+    // Post-install refresh must run whenever installs happened: installing can
+    // register the marketplace for the first time, and without a refresh newly
+    // added skills are not discovered ("Unknown skill" in nightly CI — #320).
+    await this.updateLisaMarketplace(execAsync, true);
+
+    if (fullSync) {
+      await this.writePluginSyncMarker(version);
+    }
+  }
+
+  /**
+   * Decide whether this apply needs a full plugin sync and which plugins to
+   * install.
+   * @param execAsync - Promisified exec function for running shell commands
+   * @param plugins - Plugin identifiers from enabledPlugins
+   * @returns Sync plan: fullSync (version changed), plugins to install, and
+   *   the current Lisa version
+   */
+  private async computePluginSyncPlan(
+    execAsync: PluginExecAsync,
+    plugins: readonly string[]
+  ): Promise<{
+    readonly fullSync: boolean;
+    readonly toInstall: readonly string[];
+    readonly version: string;
+  }> {
+    const version = getPackageVersion();
+    const syncedVersion = await readFile(this.pluginSyncMarkerPath(), "utf-8")
+      .then(content => content.trim())
+      .catch(() => null);
+    const fullSync = syncedVersion !== version;
+    const installed = fullSync
+      ? null
+      : await this.readInstalledPluginIds(execAsync);
+    const toInstall =
+      installed === null
+        ? plugins
+        : plugins.filter(plugin => !installed.has(plugin));
+    return { fullSync, toInstall, version };
+  }
+
+  /**
+   * Refresh the cached Lisa marketplace via the Claude CLI.
+   * @param execAsync - Promisified exec function for running shell commands
+   * @param announce - Whether to log the outcome (silent for the pre-install
+   *   best-effort refresh)
+   * @returns Promise that resolves when the refresh attempt completes
+   */
+  private async updateLisaMarketplace(
+    execAsync: PluginExecAsync,
+    announce: boolean
+  ): Promise<void> {
+    const { logger } = this.deps;
     try {
-      await execAsync("claude plugin marketplace update lisa", {
+      await execAsync(
+        "claude plugin marketplace update lisa",
+        this.pluginExecOptions()
+      );
+      if (announce) {
+        logger.success("Updated marketplace: lisa");
+      }
+    } catch {
+      if (announce) {
+        logger.warn("Could not update marketplace: lisa");
+      }
+    }
+  }
+
+  /**
+   * Install a single plugin at project scope via the Claude CLI.
+   * @param execAsync - Promisified exec function for running shell commands
+   * @param plugin - Plugin identifier (already validated)
+   * @returns Promise that resolves when the install attempt completes
+   */
+  private async installPlugin(
+    execAsync: PluginExecAsync,
+    plugin: string
+  ): Promise<void> {
+    const { logger } = this.deps;
+    try {
+      await execAsync(
+        `claude plugin install ${plugin} --scope project`,
+        this.pluginExecOptions()
+      );
+      logger.success(`Registered plugin: ${plugin}`);
+    } catch {
+      logger.warn(`Could not register plugin: ${plugin}`);
+    }
+  }
+
+  /**
+   * Exec options shared by all Claude CLI plugin commands.
+   * @returns Options object with the project cwd and POSIX shell
+   */
+  private pluginExecOptions(): Record<string, unknown> {
+    return { cwd: this.config.destDir, shell: "/bin/sh" };
+  }
+
+  /**
+   * Absolute path of the plugin sync marker recording the last fully-synced
+   * Lisa version for this project. Shared with install-claude-plugins.sh.
+   * @returns Marker path under the project's .claude directory
+   */
+  private pluginSyncMarkerPath(): string {
+    return path.join(this.config.destDir, ".claude", ".lisa-plugins-synced");
+  }
+
+  /**
+   * Absolute path of the host project's package.json.
+   * @returns package.json path under the destination directory
+   */
+  private hostPackageJsonPath(): string {
+    return path.join(this.config.destDir, "package.json");
+  }
+
+  /**
+   * Read the plugin ids already installed for this project via
+   * `claude plugin list --json`.
+   * @param execAsync - Promisified exec function for running shell commands
+   * @returns Set of installed plugin ids, or null when the list cannot be
+   *   obtained (older CLI, parse failure) so callers fall back to installing
+   *   everything — the pre-existing behavior
+   */
+  private async readInstalledPluginIds(
+    execAsync: PluginExecAsync
+  ): Promise<ReadonlySet<string> | null> {
+    try {
+      const result = (await execAsync("claude plugin list --json", {
         cwd: this.config.destDir,
         shell: "/bin/sh",
-      });
-      logger.success("Updated marketplace: lisa");
+      })) as { stdout?: unknown };
+      const parsed: unknown = JSON.parse(String(result.stdout ?? ""));
+      if (!Array.isArray(parsed)) {
+        return null;
+      }
+      const destPath = path.resolve(this.config.destDir);
+      const ids = parsed
+        .filter(
+          (entry): entry is { id: string; projectPath: string } =>
+            typeof (entry as { id?: unknown }).id === "string" &&
+            (entry as { projectPath?: unknown }).projectPath === destPath
+        )
+        .map(entry => entry.id);
+      return new Set(ids);
     } catch {
-      logger.warn("Could not update marketplace: lisa");
+      return null;
+    }
+  }
+
+  /**
+   * Record the Lisa version whose plugin set was last fully synced.
+   * @param version - Lisa package version to record
+   * @returns Promise that resolves when the marker is written (best-effort)
+   */
+  private async writePluginSyncMarker(version: string): Promise<void> {
+    try {
+      await fse.ensureDir(path.join(this.config.destDir, ".claude"));
+      await fse.writeFile(this.pluginSyncMarkerPath(), `${version}\n`, "utf-8");
+    } catch {
+      // Best-effort: a missing marker only costs a redundant full sync next run.
     }
   }
   /* v8 ignore stop */
@@ -780,10 +949,12 @@ export class Lisa {
       await this.loadPendingDeletions();
       await this.loadCreateOnlyOwnership();
       await this.loadCopyOverwriteOwnership();
+      // Captured BEFORE any mutation (migrations included): the hash gates both
+      // the detached trampoline and the in-process lockfile reconcile, and
+      // before-strategies migrations can wire scripts.postinstall — a change the
+      // package manager's end-of-command rewrite would clobber (#383).
+      const prePackageJsonHash = hashFile(this.hostPackageJsonPath());
       await this.runMigrationsBeforeStrategies();
-      const prePackageJsonHash = hashFile(
-        path.join(this.config.destDir, "package.json")
-      );
       await this.processConfigurations();
       if (this.selfApply) {
         this.deps.logger.info(
@@ -805,7 +976,7 @@ export class Lisa {
       await this.finalize();
       this.printSummary();
       await this.printMigrationNotices(this.config.destDir);
-      await this.schedulePostinstallReconciliation();
+      await this.schedulePostinstallReconciliation(prePackageJsonHash);
       await this.reconcileLockfilesInProcess(prePackageJsonHash);
       return this.getSuccessResult();
     } catch (error) {
@@ -839,7 +1010,7 @@ export class Lisa {
     if (this.config.dryRun) return;
     if (isRunningAsTrampoline()) return;
     if (shouldSchedulePostinstallReconciliation(this.config.dryRun)) return;
-    const pkgPath = path.join(this.config.destDir, "package.json");
+    const pkgPath = this.hostPackageJsonPath();
     const postHash = hashFile(pkgPath);
     if (
       prePackageJsonHash === null ||
@@ -1279,9 +1450,28 @@ export class Lisa {
    * The trampoline is always fully detached so the package manager can exit
    * normally; the child then detects the exit and re-runs Lisa. See
    * utils/postinstall-trampoline.ts for details.
+   *
+   * Skipped when this apply did not mutate package.json: the trampoline exists
+   * solely to redo package.json changes that the parent package manager's
+   * end-of-command rewrite clobbers (#383). With no mutation there is nothing
+   * to clobber — the rewrite restores identical content — and scheduling a
+   * detached re-apply (plus its lockfile regen) is pure waste. File-based
+   * template writes are not clobbered and need no reconciliation.
+   * @param prePackageJsonHash - Hash of package.json captured before apply mutated anything (null if the file did not exist)
    * @returns Promise that resolves immediately after the detached child is spawned
    */
-  private async schedulePostinstallReconciliation(): Promise<void> {
+  private async schedulePostinstallReconciliation(
+    prePackageJsonHash: string | null
+  ): Promise<void> {
+    const postHash = hashFile(this.hostPackageJsonPath());
+    if (prePackageJsonHash === postHash) {
+      this.deps.logger.info(
+        pc.gray(
+          "Postinstall reconciliation skipped: package.json unchanged by this apply"
+        )
+      );
+      return;
+    }
     if (!shouldSchedulePostinstallReconciliation(this.config.dryRun)) {
       return;
     }

--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -34,6 +34,12 @@ const COMMAND_LOG = "commands.log";
 const CODEX_PLUGIN_ADD = "codex plugin add";
 const CODEX_REMOVE_LISA = "codex plugin remove lisa@lisa";
 const CODEX_MARKETPLACE_ADD = "codex plugin marketplace add";
+const PACKAGE_JSON_FILE = "package.json";
+const LISA_PACKAGE_NAME = "@codyswann/lisa";
+const CLAUDE_INSTALL_BASE = "claude plugin install lisa@lisa --scope project";
+const CLAUDE_DIR = ".claude";
+const PLUGIN_SYNC_MARKER_FILE = ".lisa-plugins-synced";
+const FAKE_LISA_VERSION = "9.9.9";
 
 let tempRoots: string[] = [];
 
@@ -65,8 +71,8 @@ async function writeExecutable(filePath: string, body: string): Promise<void> {
  */
 async function writeSelfProject(root: string): Promise<void> {
   await writeFile(
-    path.join(root, "package.json"),
-    `${JSON.stringify({ name: "@codyswann/lisa" }, null, 2)}\n`,
+    path.join(root, PACKAGE_JSON_FILE),
+    `${JSON.stringify({ name: LISA_PACKAGE_NAME }, null, 2)}\n`,
     "utf8"
   );
   await mkdir(path.join(root, "dist", "codex"), { recursive: true });
@@ -80,9 +86,9 @@ async function writeSelfProject(root: string): Promise<void> {
     `${JSON.stringify({ harness: "fleet" }, null, 2)}\n`,
     "utf8"
   );
-  await mkdir(path.join(root, ".claude"), { recursive: true });
+  await mkdir(path.join(root, CLAUDE_DIR), { recursive: true });
   await writeFile(
-    path.join(root, ".claude", "settings.json"),
+    path.join(root, CLAUDE_DIR, "settings.json"),
     `${JSON.stringify(
       { enabledPlugins: { "lisa@lisa": true, "lisa-typescript@lisa": true } },
       null,
@@ -105,7 +111,7 @@ async function writeSelfProject(root: string): Promise<void> {
  */
 async function writeDownstreamProject(root: string): Promise<void> {
   await writeFile(
-    path.join(root, "package.json"),
+    path.join(root, PACKAGE_JSON_FILE),
     `${JSON.stringify({ name: "consumer-project" }, null, 2)}\n`,
     "utf8"
   );
@@ -220,7 +226,7 @@ if [ "$1" = "plugin" ] && [ "$2" = "marketplace" ] && [ "$3" = "list" ]; then
   printf '[]\\n'
 fi
 if [ "$1" = "plugin" ] && [ "$2" = "list" ]; then
-  printf '[]\\n'
+  printf '%s\\n' "\${LISA_TEST_INSTALLED_PLUGINS:-[]}"
 fi
 exit 0
 `
@@ -246,6 +252,9 @@ describe("install-claude-plugins self postinstall path", () => {
     await execFileAsync("bash", [selfScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -259,7 +268,7 @@ describe("install-claude-plugins self postinstall path", () => {
     expect(log).toContain("codex plugin marketplace remove lisa");
     expect(log).not.toContain(CODEX_PLUGIN_ADD);
     expect(log).not.toContain(CODEX_MARKETPLACE_ADD);
-    expect(log).toContain("claude plugin install lisa@lisa --scope project");
+    expect(log).toContain(CLAUDE_INSTALL_BASE);
     expect(log).toContain(CODEX_SELF_OVERLAY_LOG);
     expect(log).not.toContain("apply self");
   });
@@ -275,6 +284,9 @@ describe("install-claude-plugins self postinstall path", () => {
     await execFileAsync("bash", [installedScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -301,6 +313,9 @@ describe("install-claude-plugins self postinstall path", () => {
     await execFileAsync("bash", [selfScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -327,6 +342,9 @@ describe("install-claude-plugins self postinstall path", () => {
     await execFileAsync("bash", [installedScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
         INIT_CWD: leakedRoot,
@@ -354,6 +372,9 @@ describe("install-claude-plugins self postinstall path", () => {
     await execFileAsync("bash", [pnpmScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -379,6 +400,9 @@ describe("install-claude-plugins self postinstall path", () => {
     const result = await execFileAsync("bash", [selfScriptPath], {
       env: {
         ...process.env,
+        // Sandbox HOME: the script writes the one-time Codex retire marker to
+        // $HOME/.codex, which must never leak onto the developer's machine.
+        HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "active-thread",
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -389,6 +413,185 @@ describe("install-claude-plugins self postinstall path", () => {
     const log = await readFile(commandLog, "utf8");
     expect(result.stderr).toContain("cleanup deferred");
     expect(log).not.toContain(CODEX_REMOVE_LISA);
+  });
+
+  it("skips the package-side apply when the host postinstall already invokes Lisa", async () => {
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeDownstreamProject(projectRoot);
+    await writeFile(
+      path.join(projectRoot, PACKAGE_JSON_FILE),
+      `${JSON.stringify(
+        {
+          name: "consumer-project",
+          scripts: {
+            postinstall:
+              '[ -n "$CI" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true',
+          },
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    const installedScriptPath = await writeInstalledLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    const result = await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...process.env,
+        HOME: projectRoot,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    expect(result.stdout).toContain("deferred to the host");
+    expect(log).not.toContain(APPLY_DOWNSTREAM_LOG);
+    // The rest of the lifecycle (plugin section) still runs.
+    expect(log).toContain(CLAUDE_INSTALL_BASE);
+  });
+
+  it("skips plugin installs when the same Lisa version is already synced", async () => {
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeDownstreamProject(projectRoot);
+    const installedScriptPath = await writeInstalledLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+    await writeFile(
+      path.join(
+        projectRoot,
+        "node_modules",
+        CODYSWANN_SCOPE,
+        LISA_PACKAGE_DIR_NAME,
+        PACKAGE_JSON_FILE
+      ),
+      `${JSON.stringify({ name: LISA_PACKAGE_NAME, version: FAKE_LISA_VERSION }, null, 2)}\n`,
+      "utf8"
+    );
+    await mkdir(path.join(projectRoot, CLAUDE_DIR), { recursive: true });
+    await writeFile(
+      path.join(projectRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      FAKE_LISA_VERSION,
+      "utf8"
+    );
+    await writeFile(
+      path.join(projectRoot, CLAUDE_DIR, ".lisa-marketplace-heal-v2"),
+      "",
+      "utf8"
+    );
+    const installedPlugins = [
+      "lisa@lisa",
+      "lisa-typescript@lisa",
+      "typescript-lsp@claude-plugins-official",
+      "code-simplifier@claude-plugins-official",
+      "code-review@claude-plugins-official",
+      "coderabbit@claude-plugins-official",
+      "sentry@claude-plugins-official",
+      "skill-creator@claude-plugins-official",
+      "atlassian@claude-plugins-official",
+      "safety-net@cc-marketplace",
+    ].map(id => ({ id, projectPath: projectRoot }));
+
+    await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...process.env,
+        HOME: projectRoot,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        LISA_TEST_INSTALLED_PLUGINS: JSON.stringify(installedPlugins),
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    expect(log).toContain("claude plugin list --json");
+    expect(log).not.toContain("claude plugin install");
+    expect(log).not.toContain("claude plugin marketplace update");
+    expect(log).not.toContain("claude plugin marketplace list");
+  });
+
+  it("performs a full plugin sync and records the marker when the Lisa version changes", async () => {
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeDownstreamProject(projectRoot);
+    const installedScriptPath = await writeInstalledLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+    await writeFile(
+      path.join(
+        projectRoot,
+        "node_modules",
+        CODYSWANN_SCOPE,
+        LISA_PACKAGE_DIR_NAME,
+        PACKAGE_JSON_FILE
+      ),
+      `${JSON.stringify({ name: LISA_PACKAGE_NAME, version: FAKE_LISA_VERSION }, null, 2)}\n`,
+      "utf8"
+    );
+    await mkdir(path.join(projectRoot, CLAUDE_DIR), { recursive: true });
+    await writeFile(
+      path.join(projectRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "1.0.0",
+      "utf8"
+    );
+    const installedPlugins = [{ id: "lisa@lisa", projectPath: projectRoot }];
+
+    await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...process.env,
+        HOME: projectRoot,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        LISA_TEST_INSTALLED_PLUGINS: JSON.stringify(installedPlugins),
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    // Version changed: even already-installed plugins are reinstalled so the
+    // refreshed marketplace content is picked up.
+    expect(log).toContain(CLAUDE_INSTALL_BASE);
+    expect(log).toContain("claude plugin marketplace update lisa");
+    const marker = await readFile(
+      path.join(projectRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "utf8"
+    );
+    expect(marker).toBe(FAKE_LISA_VERSION);
+  });
+
+  it("does not probe codex again once the retire marker exists", async () => {
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeSelfProject(projectRoot);
+    const selfScriptPath = await writeSelfLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+    const env = {
+      ...process.env,
+      HOME: projectRoot,
+      CI: "",
+      CODEX_THREAD_ID: "",
+      LISA_TEST_COMMAND_LOG: commandLog,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+    };
+
+    await execFileAsync("bash", [selfScriptPath], { env });
+    const firstLog = await readFile(commandLog, "utf8");
+    expect(firstLog).toContain(CODEX_REMOVE_LISA);
+
+    await rm(commandLog);
+    await execFileAsync("bash", [selfScriptPath], { env });
+    const secondLog = await readFile(commandLog, "utf8");
+    expect(secondLog).not.toContain("codex plugin marketplace list");
+    expect(secondLog).not.toContain(CODEX_REMOVE_LISA);
   });
 });
 /* eslint-enable max-lines -- restore the repository default */


### PR DESCRIPTION
## Summary

Implements the four history-audited optimizations from the postinstall-performance review. A single `bun add -D @codyswann/lisa` previously ran the full template apply up to **3×**, spawned the Claude CLI **~15×** for plugin installs, and pulled the marketplace repo up to **4×** — 7+ minutes on a real host. Each change preserves the defense found in the history audit:

| Change | Defense preserved |
|---|---|
| Package-side apply defers to the host postinstall when package.json already carries the Lisa invocation | #1017 bootstrap chicken-and-egg: no marker → package-side apply still runs |
| Detached trampoline only scheduled when the apply mutated package.json (pre-hash now captured before before-strategies migrations, so postinstall wiring counts) | #383: trampoline exists to redo merges after bun's end-of-command clobber — no mutation, nothing to clobber |
| Plugin sync version-gated via shared `.claude/.lisa-plugins-synced` marker: full refresh on version change, missing-only installs between versions (single `claude plugin list` call) | Self-heal preserved (removed plugin reinstalls next run); post-install marketplace refresh kept whenever installs happened (#320 "Unknown skill") |
| Codex user-wide retirement probe writes a one-time `~/.codex/.lisa-legacy-plugins-retired` marker | Never written on the `CODEX_THREAD_ID` deferral branch (#1637), which must retry |

Both markers added to the shipped gitignore template.

## Verification

- 4444 unit tests pass; 4 new shell-level tests cover the deferral gate, version-gated skip, full-sync + marker write, and codex marker persistence. Existing tests now sandbox `HOME` (the retire marker leaked onto the dev machine otherwise — caught during this work).
- E2E: packed the tarball, installed into a scratch host with stubbed `claude`/`codex` CLIs, ran the real lifecycle script + real apply engine:
  - Fresh bootstrap: unchanged behavior (full sync, apply runs, marker written).
  - Steady-state package-side script: **13+ CLI calls → 2**.
  - Steady-state host-side apply: **1 CLI call**, with "Plugins already in sync" and "Postinstall reconciliation skipped: package.json unchanged" both firing.
- Real-world effect: version bumps still pay one full sync; routine same-version installs drop from minutes to seconds.

## Follow-up (not in this PR)

`dist/codex/*.js` imports `js-yaml`, which is only in devDependencies — downstream resolution works by hoisting luck, and js-yaml@5 (named-exports-only) breaks it entirely. Discovered during E2E; should be promoted to `dependencies`.

🤖 Generated with Claude Code