### PR TITLE
feat(ui): show remote environment readiness

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -28,6 +28,65 @@ export interface UiCmdOptions {
   readonly sync?: boolean;
 }
 
+/** Secret/variable and generated-artifact status exposed to the console. */
+export interface RemoteEnvironmentStatus {
+  /** Whether each supported variable is visible to the `lisa ui` process. */
+  readonly variables: Readonly<Record<string, boolean>>;
+  /** Whether each remote-environment startup artifact exists in the project. */
+  readonly artifacts: Readonly<Record<string, boolean>>;
+}
+
+/** Variables the remote AWS bootstrap understands. Values are never exposed. */
+export const REMOTE_ENVIRONMENT_VARIABLES = [
+  "LISA_AWS_BOOTSTRAP_JSON",
+  "LISA_REMOTE_AGENT",
+  "LISA_AWS_DEFAULT_PROFILE",
+] as const;
+
+/** Project-relative artifacts used by remote coding environments. */
+export const REMOTE_ENVIRONMENT_ARTIFACTS = [
+  "scripts/remote-agent-aws-setup.sh",
+  ".cursor/environment.json",
+  ".github/workflows/copilot-setup-steps.yml",
+] as const;
+
+/**
+ * Read the CLI process environment through one explicit, reviewable exception.
+ * Only boolean presence checks derived from this map reach the browser.
+ * @returns Current process environment
+ */
+function getProcessEnvironment(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line no-restricted-syntax -- CLI status view must inspect externally supplied remote-environment variables once
+  return process.env;
+}
+
+/**
+ * Inspect remote-environment readiness without ever reading a variable value
+ * into the browser payload.
+ * @param destDir - Project root
+ * @param environment - Environment visible to the Lisa process
+ * @returns Boolean-only variable and artifact status
+ */
+export function inspectRemoteEnvironment(
+  destDir: string,
+  environment: NodeJS.ProcessEnv = getProcessEnvironment()
+): RemoteEnvironmentStatus {
+  return {
+    variables: Object.fromEntries(
+      REMOTE_ENVIRONMENT_VARIABLES.map(name => [
+        name,
+        typeof environment[name] === "string" && environment[name]!.length > 0,
+      ])
+    ),
+    artifacts: Object.fromEntries(
+      REMOTE_ENVIRONMENT_ARTIFACTS.map(relativePath => [
+        relativePath,
+        existsSync(path.join(destDir, relativePath)),
+      ])
+    ),
+  };
+}
+
 /**
  * Locate the packaged `ui/index.html` by walking up from this module until a
  * directory containing `ui/index.html` is found (works from both `src/` and
@@ -69,11 +128,23 @@ async function readMergedConfig(destDir: string): Promise<JsonObject> {
  * escaped so a value containing `</script>` cannot break out of the tag.
  * @param html - Packaged console HTML
  * @param config - Merged live config
+ * @param remoteEnvironment - Boolean-only secret and startup-artifact status
  * @returns HTML with the injected config
  */
-export function injectLiveConfig(html: string, config: JsonObject): string {
+export function injectLiveConfig(
+  html: string,
+  config: JsonObject,
+  remoteEnvironment: RemoteEnvironmentStatus = {
+    variables: {},
+    artifacts: {},
+  }
+): string {
   const payload = JSON.stringify(config).replace(/<\//g, "<\\/");
-  const tag = `<script>window.LISA_LIVE_CONFIG = ${payload};</script>`;
+  const remotePayload = JSON.stringify(remoteEnvironment).replace(
+    /<\//g,
+    "<\\/"
+  );
+  const tag = `<script>window.LISA_LIVE_CONFIG = ${payload}; window.LISA_REMOTE_ENVIRONMENT = ${remotePayload};</script>`;
   return html.replace("</body>", `${tag}\n</body>`);
 }
 
@@ -100,7 +171,8 @@ export async function runUi(
   const htmlPath = findUiHtml(moduleDir);
   const html = await readFile(htmlPath, "utf8");
   const config = await readMergedConfig(destDir);
-  const page = injectLiveConfig(html, config);
+  const remoteEnvironment = inspectRemoteEnvironment(destDir);
+  const page = injectLiveConfig(html, config, remoteEnvironment);
 
   const server = http.createServer((request, response) => {
     const url = request.url ?? "/";

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   findUiHtml,
   injectLiveConfig,
+  inspectRemoteEnvironment,
   runUi,
 } from "../../../src/cli/ui-cmd.js";
 import { writeJson } from "../../../src/utils/index.js";
@@ -53,6 +54,47 @@ describe("injectLiveConfig", () => {
     expect(injected).not.toContain("</script><script>alert(1)");
     expect(injected).toContain("<\\/script>");
   });
+
+  it("injects boolean-only remote environment status", () => {
+    const injected = injectLiveConfig(
+      "</body>",
+      { harness: "codex" },
+      {
+        variables: { LISA_AWS_BOOTSTRAP_JSON: true },
+        artifacts: { "scripts/remote-agent-aws-setup.sh": false },
+      }
+    );
+
+    expect(injected).toContain("window.LISA_REMOTE_ENVIRONMENT");
+    expect(injected).toContain('"LISA_AWS_BOOTSTRAP_JSON":true');
+    expect(injected).not.toContain("secretAccessKey");
+  });
+});
+
+describe("inspectRemoteEnvironment", () => {
+  it("reports variable presence and project startup artifacts without values", async () => {
+    await mkdir(path.join(resources.dir, ".cursor"));
+    await writeJson(path.join(resources.dir, ".cursor", "environment.json"), {
+      install: "bootstrap",
+    });
+
+    const status = inspectRemoteEnvironment(resources.dir, {
+      LISA_AWS_BOOTSTRAP_JSON: "sensitive-value",
+      LISA_REMOTE_AGENT: "",
+    });
+
+    expect(status.variables).toEqual({
+      LISA_AWS_BOOTSTRAP_JSON: true,
+      LISA_REMOTE_AGENT: false,
+      LISA_AWS_DEFAULT_PROFILE: false,
+    });
+    expect(status.artifacts).toMatchObject({
+      ".cursor/environment.json": true,
+      "scripts/remote-agent-aws-setup.sh": false,
+      ".github/workflows/copilot-setup-steps.yml": false,
+    });
+    expect(JSON.stringify(status)).not.toContain("sensitive-value");
+  });
 });
 
 describe("findUiHtml", () => {
@@ -88,6 +130,7 @@ describe("runUi", () => {
     expect(response.status).toBe(200);
     expect(body).toContain('"tracker":"linear"');
     expect(body).toContain("Lisa Console");
+    expect(body).toContain("window.LISA_REMOTE_ENVIRONMENT");
     const missing = await fetch(`http://127.0.0.1:${port}/nope`);
     expect(missing.status).toBe(404);
   });

--- a/ui/README.md
+++ b/ui/README.md
@@ -153,6 +153,7 @@ visible in the section.
 | General (`harness`, `tracker`, `source`, `repo`, package manager) | `src/core/config.ts`, `plugins/src/base/rules/reference/config-resolution.md` |
 | Project types (8 stacks + template strategies) | `src/detection/`, `src/strategies/`, `<stack>/` template dirs |
 | Coding agents (claude/codex/cursor/agy/copilot/opencode/fleet) | `src/core/lisa.ts`, `scripts/generate-*-plugin-artifacts.mjs` |
+| Remote Environment (variable presence + active-agent startup scripts) | `src/cli/ui-cmd.ts`, `plugins/src/base/scripts/remote-agent-aws-setup.sh` |
 | Work tracker (JIRA / GitHub Issues / Linear) | `config-resolution.md`, `lisa-setup-*` skills |
 | PRD source (Notion / Confluence / Linear / GitHub) | `config-resolution.md`, `lisa-setup-*` skills |
 | Deploy & environments (`deploy.*`, `github.environments`) | `scripts/lisa-github-environments.sh` |

--- a/ui/index.html
+++ b/ui/index.html
@@ -1259,6 +1259,7 @@
               "stacks",
               "starters",
               "agents",
+              "remote",
             ],
           },
           {
@@ -2344,6 +2345,33 @@
           {
             type: "callout",
             text: "<b>Parity guarantee.</b> Claude is the reference harness. Every other agent receives an equivalent generated surface; where a capability cannot be represented, the gap is documented rather than silently dropped.",
+          },
+        ],
+      };
+
+      /* -------------------------- Remote environment -------------------------- */
+      DATA.sections.remote = {
+        title: "Remote Environment",
+        desc: "AWS CLI bootstrap readiness for the project's active remote coding agents. Secret values are never sent to the browser — the console receives presence checks only.",
+        src: "scripts/remote-agent-aws-setup.sh · remote platform environments",
+        blocks: [
+          {
+            type: "table",
+            card: "Variables",
+            note: "Set status reflects variables visible to the lisa ui process; values remain hidden",
+            cols: ["Variable", "Purpose", "Status"],
+            rows: [],
+          },
+          {
+            type: "table",
+            card: "Startup Script",
+            note: "Only agents enabled by the current harness are listed",
+            cols: ["Agent", "Remote environment setup", "Project artifact"],
+            rows: [],
+          },
+          {
+            type: "callout",
+            text: "<b>One bootstrap bundle, renewable sessions.</b> Store the complete Secrets Manager value as <code>LISA_AWS_BOOTSTRAP_JSON</code>. Each startup command writes the assume-only source credential and renewable role profiles; do not configure <code>AWS_ACCESS_KEY_ID</code> or <code>AWS_SECRET_ACCESS_KEY</code> directly.",
           },
         ],
       };
@@ -5783,16 +5811,123 @@
         if (control.type === "static" && typeof value === "string")
           control.value = value;
       }
-      function hydrateFromLiveConfig() {
-        const cfg = window.LISA_LIVE_CONFIG;
-        if (!cfg) return;
-        Object.values(DATA.sections).forEach(section => {
-          walkRows(section.blocks, row => {
-            if (!row.key || !row.control) return;
-            const value = liveGet(cfg, row.key);
-            if (value !== undefined) hydrateControl(row.control, value);
-          });
+      const REMOTE_AGENT_ORDER = [
+        "claude",
+        "codex",
+        "cursor",
+        "agy",
+        "copilot",
+        "opencode",
+      ];
+      const REMOTE_STARTUP = {
+        claude: {
+          command:
+            "LISA_REMOTE_AGENT=claude bash scripts/remote-agent-aws-setup.sh",
+          artifacts: ["scripts/remote-agent-aws-setup.sh"],
+        },
+        codex: {
+          command:
+            "LISA_REMOTE_AGENT=codex bash scripts/remote-agent-aws-setup.sh",
+          artifacts: ["scripts/remote-agent-aws-setup.sh"],
+        },
+        cursor: {
+          command:
+            ".cursor/environment.json → LISA_REMOTE_AGENT=cursor bash scripts/remote-agent-aws-setup.sh",
+          artifacts: [
+            "scripts/remote-agent-aws-setup.sh",
+            ".cursor/environment.json",
+          ],
+        },
+        agy: {
+          command:
+            "LISA_REMOTE_AGENT=agy bash scripts/remote-agent-aws-setup.sh (user-managed host)",
+          artifacts: ["scripts/remote-agent-aws-setup.sh"],
+        },
+        copilot: {
+          command:
+            ".github/workflows/copilot-setup-steps.yml → bash scripts/remote-agent-aws-setup.sh",
+          artifacts: [
+            "scripts/remote-agent-aws-setup.sh",
+            ".github/workflows/copilot-setup-steps.yml",
+          ],
+        },
+        opencode: {
+          command:
+            "LISA_REMOTE_AGENT=opencode bash scripts/remote-agent-aws-setup.sh (opencode serve host)",
+          artifacts: ["scripts/remote-agent-aws-setup.sh"],
+        },
+      };
+      function configureRemoteEnvironment(cfg) {
+        const snapshot = window.LISA_REMOTE_ENVIRONMENT || {
+          variables: {},
+          artifacts: {},
+        };
+        const harness = cfg && cfg.harness ? cfg.harness : "fleet";
+        const activeAgents =
+          harness === "fleet" || harness === "all"
+            ? REMOTE_AGENT_ORDER
+            : REMOTE_AGENT_ORDER.includes(harness)
+              ? [harness]
+              : ["claude"];
+        const variableRows = [
+          [
+            "LISA_AWS_BOOTSTRAP_JSON",
+            "Required secret — complete vendor-neutral bootstrap bundle",
+          ],
+          [
+            "LISA_REMOTE_AGENT",
+            "Platform label used as the AWS role session name (startup commands set it inline)",
+          ],
+          [
+            "LISA_AWS_DEFAULT_PROFILE",
+            "Optional default account profile; dev is used when unset",
+          ],
+        ].map(([name, purpose]) => {
+          const isSet = snapshot.variables[name] === true;
+          return [
+            { t: "mono", v: name },
+            { t: "text", v: purpose },
+            {
+              t: "badge",
+              v: isSet ? "set" : "not set",
+              cls: isSet
+                ? "pass"
+                : name.endsWith("DEFAULT_PROFILE")
+                  ? "warn"
+                  : "fail",
+            },
+          ];
         });
+        const startupRows = activeAgents.map(agent => {
+          const startup = REMOTE_STARTUP[agent];
+          const ready = startup.artifacts.every(
+            artifact => snapshot.artifacts[artifact] === true
+          );
+          return [
+            { t: "mono", v: agent },
+            { t: "mono", v: startup.command },
+            {
+              t: "badge",
+              v: ready ? "installed" : "missing",
+              cls: ready ? "pass" : "fail",
+            },
+          ];
+        });
+        DATA.sections.remote.blocks[0].rows = variableRows;
+        DATA.sections.remote.blocks[1].rows = startupRows;
+      }
+      function hydrateFromLiveConfig() {
+        const cfg = window.LISA_LIVE_CONFIG || {};
+        if (window.LISA_LIVE_CONFIG) {
+          Object.values(DATA.sections).forEach(section => {
+            walkRows(section.blocks, row => {
+              if (!row.key || !row.control) return;
+              const value = liveGet(cfg, row.key);
+              if (value !== undefined) hydrateControl(row.control, value);
+            });
+          });
+        }
+        configureRemoteEnvironment(cfg);
         const repoEl = document.querySelector(".project-switch .repo");
         if (repoEl && cfg.github && cfg.github.org && cfg.github.repo) {
           repoEl.textContent = cfg.github.org + "/" + cfg.github.repo;


### PR DESCRIPTION
## Summary

- add a **Remote Environment** section to the Lisa Console
- show boolean set/not-set status for the AWS bootstrap variables without exposing values
- list the startup command and installed/missing artifact status for each active coding agent
- include Claude, Codex, Cursor, Antigravity, Copilot, and OpenCode parity

## Validation

- `bun run typecheck`
- fast and slow lint
- `knip`
- 4,571 unit tests with coverage
- 129 integration tests
- local `lisa ui` HTTP smoke test
