### PR TITLE
feat(ui): make remote requirements project-aware

### DIFF
--- a/plugins/lisa-agy/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/plugins/lisa-copilot/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/plugins/lisa-cursor/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/plugins/lisa/.codex-plugin/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/plugins/lisa/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/lisa/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/plugins/src/base/skills/lisa-generate-claude-remote-build-script/SKILL.md
+++ b/plugins/src/base/skills/lisa-generate-claude-remote-build-script/SKILL.md
@@ -7,8 +7,9 @@ allowed-tools: ["Skill", "Bash", "Read", "Write", "Glob", "Grep"]
 # Generate Claude Remote Build Script: $ARGUMENTS
 
 Produce the artifacts a user pastes into a **Claude Code remote routine environment** so this repo
-runs in the cloud: a setup/build script that installs everything the environment needs, plus an
-environment-variable template and a network-allowlist list.
+runs in the cloud: a setup/build script that installs everything the environment needs, an
+environment-variable template, a network-allowlist list, and the names-only
+`.lisa/remote-environment.json` contract consumed by `lisa ui`.
 
 ## Purpose
 
@@ -97,6 +98,17 @@ tracker/source, plus the host project's own package manager and tooling — not 
    profile implementation. Add `bash scripts/remote-agent-aws-setup.sh` to the
    generated cloud setup after required package installation.
 
+3c. **Write the project-aware console contract.** Write
+   `.lisa/remote-environment.json` from the same fresh inventory. Its `variables`
+   array must contain only entries that are `required: true` for this project and
+   its active integrations; omit optional, conditional, and dormant integrations.
+   Each entry contains `name`, `reason`, `source`, `secret`, and `required`, but
+   never a value. Set `startupScripts.claude` to the generated `--out` path. Do
+   not add AWS merely because Lisa ships AWS support: add
+   `LISA_AWS_BOOTSTRAP_JSON` only when the inventory reports active AWS usage.
+   Preserve any valid startup-script entries for other agents that already exist
+   in the manifest.
+
 4. **Emit the allowlist + gaps notice.** List any custom domains the setup or runtime reaches
    (from `networkAccess.allowlistDomains`, falling back to legacy `allowlistDomains`) that the user
    must add when the environment needs Custom network access. Do not include default Trusted domains
@@ -106,10 +118,13 @@ tracker/source, plus the host project's own package manager and tooling — not 
    **cannot** fix.
 
 5. **Write and report.** Write the script to `--out` (default `scripts/claude-remote-setup.sh`),
-   `chmod +x` it, and print: the path, a one-line summary of what it installs and which env vars to
-   set, and the exact next step (paste its contents — or a `bash scripts/claude-remote-setup.sh`
-   invocation — into the routine environment's setup script, and add the env vars in the
-   environment config). When `--print` is passed, print to stdout and do not write a file.
+   `chmod +x` it, and write `.lisa/remote-environment.json`. Print both paths, a
+   one-line summary of what the script installs and which env vars to set, and
+   the exact next step (paste its contents — or a
+   `bash scripts/claude-remote-setup.sh` invocation — into the routine
+   environment's setup script, and add the env vars in the environment config).
+   When `--print` is passed, print the script to stdout and do not write either
+   file.
 
 ## Generated script shape
 
@@ -192,8 +207,8 @@ to stop are: the analysis could not run, or the `--out` path is not writable.
 
 ## Rules
 
-- Always derive the script from a fresh `/lisa:analyze-claude-remote` run — never from a stale or
-  assumed inventory.
+- Always derive the script and `.lisa/remote-environment.json` from a fresh
+  `/lisa:analyze-claude-remote` run — never from a stale or assumed inventory.
 - Never write real secret values into the script or template — names and placeholders only.
 - For active tracker/source credentials, carry the analysis's `Acquire:` URL and `Access:` scope into
   the template as comments, and emit only the env-var form of the name — never a keychain command.

--- a/src/cli/remote-environment-catalog.ts
+++ b/src/cli/remote-environment-catalog.ts
@@ -1,0 +1,193 @@
+import type { ProjectType } from "../core/config.js";
+import type { JsonObject } from "../sync/json-path.js";
+import type {
+  IntegrationFlags,
+  VariableRequirement,
+} from "./remote-environment-contract.js";
+
+const JIRA_SOURCE = "Lisa config: Jira tracker";
+
+/**
+ * Build the active Jira tracker requirements.
+ * @returns Required jira-cli variables
+ */
+function jiraRequirements(): readonly VariableRequirement[] {
+  return [
+    {
+      name: "JIRA_API_TOKEN",
+      reason: "Jira API authentication for the active tracker",
+      source: JIRA_SOURCE,
+      secret: true,
+    },
+    {
+      name: "JIRA_SERVER",
+      reason: "Jira Cloud site used by jira-cli",
+      source: JIRA_SOURCE,
+      secret: false,
+    },
+    {
+      name: "JIRA_LOGIN",
+      reason: "Jira account used by jira-cli",
+      source: JIRA_SOURCE,
+      secret: false,
+    },
+    {
+      name: "JIRA_PROJECT",
+      reason: "Jira project key used by the factory",
+      source: JIRA_SOURCE,
+      secret: false,
+    },
+  ];
+}
+
+/**
+ * Resolve the most specific AWS detection source.
+ * @param projectTypes - Detected Lisa project types
+ * @returns Human-readable detection source
+ */
+function awsRequirementSource(projectTypes: readonly ProjectType[]): string {
+  return projectTypes.includes("cdk")
+    ? "Project type: CDK"
+    : "Integration: AWS";
+}
+
+/**
+ * Build requirements implied by the active Lisa tracker and PRD source.
+ * @param config - Merged Lisa project config
+ * @returns Active integration requirements
+ */
+export function configuredIntegrationRequirements(
+  config: JsonObject
+): readonly VariableRequirement[] {
+  const tracker = typeof config.tracker === "string" ? config.tracker : "";
+  const source = typeof config.source === "string" ? config.source : "";
+  const catalog = [
+    {
+      active: tracker === "github" || source === "github",
+      requirements: [
+        {
+          name: "GH_TOKEN",
+          reason: "GitHub CLI access for the active tracker or PRD source",
+          source: "Lisa config: GitHub",
+          secret: true,
+        },
+      ],
+    },
+    { active: tracker === "jira", requirements: jiraRequirements() },
+    {
+      active: tracker === "linear" || source === "linear",
+      requirements: [
+        {
+          name: "LINEAR_API_KEY",
+          reason: "Headless Linear access for the active tracker or source",
+          source: "Lisa config: Linear",
+          secret: true,
+        },
+      ],
+    },
+    {
+      active: source === "notion",
+      requirements: [
+        {
+          name: "NOTION_API_TOKEN",
+          reason: "Notion integration access for the active PRD source",
+          source: "Lisa config: Notion source",
+          secret: true,
+        },
+      ],
+    },
+    {
+      active: source === "confluence",
+      requirements: [
+        {
+          name: "ATLASSIAN_API_TOKEN",
+          reason: "Confluence API access for the active PRD source",
+          source: "Lisa config: Confluence source",
+          secret: true,
+        },
+      ],
+    },
+  ];
+  return catalog.flatMap(entry => (entry.active ? entry.requirements : []));
+}
+
+/**
+ * Convert active flags to names-only variable requirements.
+ * @param flags - Detected integrations
+ * @param projectTypes - Detected Lisa project types
+ * @returns Active project requirements
+ */
+export function requirementsForFlags(
+  flags: IntegrationFlags,
+  projectTypes: readonly ProjectType[]
+): readonly VariableRequirement[] {
+  const catalog: readonly {
+    readonly active: boolean;
+    readonly requirement: VariableRequirement;
+  }[] = [
+    {
+      active: flags.jam,
+      requirement: {
+        name: "JAM_PAT",
+        reason: "Jam CLI access for the detected Jam integration",
+        source: "Integration: @jam.dev",
+        secret: true,
+      },
+    },
+    {
+      active: flags.aws,
+      requirement: {
+        name: "LISA_AWS_BOOTSTRAP_JSON",
+        reason: "Renewable AWS CLI profiles for this AWS-enabled project",
+        source: awsRequirementSource(projectTypes),
+        secret: true,
+      },
+    },
+    {
+      active: flags.sonar,
+      requirement: {
+        name: "SONAR_TOKEN",
+        reason: "SonarCloud diagnostics for the configured project",
+        source: "Integration: SonarCloud",
+        secret: true,
+      },
+    },
+    {
+      active: flags.sentry,
+      requirement: {
+        name: "SENTRY_AUTH_TOKEN",
+        reason: "Sentry diagnostics and release tooling",
+        source: "Integration: Sentry",
+        secret: true,
+      },
+    },
+    {
+      active: flags.figma,
+      requirement: {
+        name: "FIGMA_ACCESS_TOKEN",
+        reason: "Figma tooling referenced by the project setup",
+        source: "Integration: Figma",
+        secret: true,
+      },
+    },
+    {
+      active: flags.eas,
+      requirement: {
+        name: "EXPO_TOKEN",
+        reason: "EAS operations for this Expo project",
+        source: "Project type: Expo with EAS",
+        secret: true,
+      },
+    },
+    {
+      active: flags.maestro,
+      requirement: {
+        name: "MAESTRO_API_KEY",
+        reason: "Maestro Cloud verification for this project",
+        source: "Integration: Maestro Cloud",
+        secret: true,
+      },
+    },
+  ];
+  return catalog.filter(entry => entry.active).map(entry => entry.requirement);
+}

--- a/src/cli/remote-environment-contract.ts
+++ b/src/cli/remote-environment-contract.ts
@@ -1,0 +1,163 @@
+import type { Harness, ProjectType } from "../core/config.js";
+import { HARNESS_VALUES } from "../core/config.js";
+
+/** Project-owned extension point for remote-environment requirements. */
+export const REMOTE_ENVIRONMENT_MANIFEST =
+  ".lisa/remote-environment.json" as const;
+
+/** One concrete coding agent, excluding the fleet aggregate. */
+export type RemoteAgent = Exclude<Harness, "fleet">;
+
+/** A variable the current project requires in a remote coding environment. */
+export interface RemoteEnvironmentVariableStatus {
+  /** Environment-variable name. Values are never exposed. */
+  readonly name: string;
+  /** Why this project requires the variable. */
+  readonly reason: string;
+  /** Project signal that activated the requirement. */
+  readonly source: string;
+  /** Whether the variable contains a credential. */
+  readonly secret: boolean;
+  /** Whether the variable is visible to the `lisa ui` process. */
+  readonly set: boolean;
+}
+
+/** Startup artifact expected by one supported remote coding agent. */
+export interface RemoteEnvironmentStartupStatus {
+  /** Agent whose remote environment consumes the artifact. */
+  readonly agent: RemoteAgent;
+  /** Project-relative setup artifact, when one is configured. */
+  readonly artifact?: string;
+  /** Whether the configured artifact exists. */
+  readonly installed: boolean;
+}
+
+/** Project-aware remote-environment readiness exposed to the console. */
+export interface RemoteEnvironmentStatus {
+  /** Lisa project types detected for the current project. */
+  readonly projectTypes: readonly ProjectType[];
+  /** Required variables only; optional/dormant integrations are omitted. */
+  readonly variables: readonly RemoteEnvironmentVariableStatus[];
+  /** Startup artifact status for every supported agent. */
+  readonly startupScripts: readonly RemoteEnvironmentStartupStatus[];
+}
+
+/** Internal names-only variable requirement. */
+export interface VariableRequirement {
+  /** Environment-variable name. */
+  readonly name: string;
+  /** Human-readable reason the project requires it. */
+  readonly reason: string;
+  /** Project signal that activated it. */
+  readonly source: string;
+  /** Whether it contains a credential. */
+  readonly secret: boolean;
+}
+
+/** Active remote-tool integrations detected from the host project. */
+export interface IntegrationFlags {
+  /** AWS SDK/infrastructure/operational integration. */
+  readonly aws: boolean;
+  /** Expo Application Services integration. */
+  readonly eas: boolean;
+  /** Figma tooling integration. */
+  readonly figma: boolean;
+  /** Jam debugging integration. */
+  readonly jam: boolean;
+  /** Maestro Cloud integration. */
+  readonly maestro: boolean;
+  /** Sentry tooling integration. */
+  readonly sentry: boolean;
+  /** SonarCloud integration. */
+  readonly sonar: boolean;
+}
+
+/** Raw project-owned manifest shape; every field is validated before use. */
+export interface RemoteEnvironmentManifest {
+  /** Names-only variable declarations. */
+  readonly variables?: readonly {
+    readonly name?: unknown;
+    readonly reason?: unknown;
+    readonly source?: unknown;
+    readonly secret?: unknown;
+    readonly required?: unknown;
+  }[];
+  /** Per-agent project-relative startup artifacts. */
+  readonly startupScripts?: Readonly<Record<string, unknown>>;
+}
+
+/** Supported concrete agents in canonical order. */
+export const REMOTE_AGENTS: readonly RemoteAgent[] = HARNESS_VALUES.filter(
+  (harness): harness is RemoteAgent => harness !== "fleet"
+);
+
+const GENERIC_STARTUP_ARTIFACT = "scripts/remote-agent-setup.sh";
+
+/** Default project artifacts recognized for each remote agent. */
+export const DEFAULT_STARTUP_ARTIFACTS: Readonly<
+  Record<RemoteAgent, readonly string[]>
+> = {
+  claude: ["scripts/claude-remote-setup.sh", GENERIC_STARTUP_ARTIFACT],
+  codex: ["scripts/codex-remote-setup.sh", GENERIC_STARTUP_ARTIFACT],
+  cursor: [
+    ".cursor/environment.json",
+    "scripts/cursor-remote-setup.sh",
+    GENERIC_STARTUP_ARTIFACT,
+  ],
+  agy: ["scripts/agy-remote-setup.sh", GENERIC_STARTUP_ARTIFACT],
+  copilot: [
+    ".github/workflows/copilot-setup-steps.yml",
+    "scripts/copilot-remote-setup.sh",
+    GENERIC_STARTUP_ARTIFACT,
+  ],
+  opencode: ["scripts/opencode-remote-setup.sh", GENERIC_STARTUP_ARTIFACT],
+};
+
+/**
+ * Validate project-owned manifest variable declarations.
+ * @param manifest - Parsed manifest
+ * @returns Required variable declarations only
+ */
+export function manifestRequirements(
+  manifest: RemoteEnvironmentManifest | null
+): readonly VariableRequirement[] {
+  return (manifest?.variables ?? []).flatMap(entry => {
+    if (
+      entry.required === false ||
+      typeof entry.name !== "string" ||
+      !/^[A-Z][A-Z0-9_]*$/u.test(entry.name)
+    ) {
+      return [];
+    }
+    return [
+      {
+        name: entry.name,
+        reason:
+          typeof entry.reason === "string"
+            ? entry.reason
+            : "Required by the project remote-environment manifest",
+        source:
+          typeof entry.source === "string"
+            ? entry.source
+            : REMOTE_ENVIRONMENT_MANIFEST,
+        secret: entry.secret !== false,
+      },
+    ];
+  });
+}
+
+/**
+ * Deduplicate requirements by variable name while preserving first-source order.
+ * @param requirements - Requirements from config, detection, and manifest
+ * @returns Deduplicated requirements
+ */
+export function uniqueRequirements(
+  requirements: readonly VariableRequirement[]
+): readonly VariableRequirement[] {
+  return requirements.filter(
+    (requirement, index) =>
+      requirements.findIndex(
+        candidate => candidate.name === requirement.name
+      ) === index
+  );
+}

--- a/src/cli/remote-environment-detection.ts
+++ b/src/cli/remote-environment-detection.ts
@@ -1,0 +1,168 @@
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import type { ProjectType } from "../core/config.js";
+import { readJsonOrNull } from "../utils/index.js";
+import { requirementsForFlags } from "./remote-environment-catalog.js";
+import type {
+  IntegrationFlags,
+  VariableRequirement,
+} from "./remote-environment-contract.js";
+
+/** Selected host-project surfaces used by integration detectors. */
+interface ProjectSignals {
+  readonly dependencies: ReadonlySet<string>;
+  readonly envExample: string;
+  readonly remoteSetup: string;
+  readonly workflows: string;
+}
+
+/**
+ * Read a UTF-8 file, returning an empty string when it is absent.
+ * @param filePath - Absolute path
+ * @returns File contents or an empty string
+ */
+export async function readTextOrEmpty(filePath: string): Promise<string> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? error.code
+        : undefined;
+    if (code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+/**
+ * Return whether a project-relative file exists.
+ * @param destDir - Project root
+ * @param relativePath - Project-relative path
+ * @returns True when the file can be read and is non-empty
+ */
+export async function projectFileExists(
+  destDir: string,
+  relativePath: string
+): Promise<boolean> {
+  return (await readTextOrEmpty(path.join(destDir, relativePath))) !== "";
+}
+
+/**
+ * Read dependency names and selected project-owned integration surfaces.
+ * @param destDir - Project root
+ * @returns Signals used by the requirement detectors
+ */
+async function readProjectSignals(destDir: string): Promise<ProjectSignals> {
+  const packageJson = await readJsonOrNull<{
+    readonly dependencies?: Readonly<Record<string, unknown>>;
+    readonly devDependencies?: Readonly<Record<string, unknown>>;
+  }>(path.join(destDir, "package.json"));
+  const dependencies = new Set([
+    ...Object.keys(packageJson?.dependencies ?? {}),
+    ...Object.keys(packageJson?.devDependencies ?? {}),
+  ]);
+  const workflows = ["ci", "deploy", "quality"].flatMap(name => [
+    `.github/workflows/${name}.yml`,
+    `.github/workflows/${name}.yaml`,
+  ]);
+  const [envExample, remoteSetup, ...workflowContents] = await Promise.all([
+    readTextOrEmpty(path.join(destDir, ".env.example")),
+    readTextOrEmpty(path.join(destDir, "scripts/claude-remote-setup.sh")),
+    ...workflows.map(relativePath =>
+      readTextOrEmpty(path.join(destDir, relativePath))
+    ),
+  ]);
+  return {
+    dependencies,
+    envExample,
+    remoteSetup,
+    workflows: workflowContents.join("\n"),
+  };
+}
+
+/**
+ * Test dependency presence by exact name or namespace prefix.
+ * @param dependencies - Project dependency names
+ * @param names - Exact names or prefixes ending in `/`
+ * @returns Whether any dependency matches
+ */
+function hasDependency(
+  dependencies: ReadonlySet<string>,
+  names: readonly string[]
+): boolean {
+  return Array.from(dependencies).some(dependency =>
+    names.some(name =>
+      name.endsWith("/") ? dependency.startsWith(name) : dependency === name
+    )
+  );
+}
+
+/**
+ * Detect active project integrations from dependencies and committed surfaces.
+ * @param destDir - Project root
+ * @param projectTypes - Detected Lisa project types
+ * @param signals - Project signals
+ * @returns Boolean integration flags
+ */
+async function detectIntegrationFlags(
+  destDir: string,
+  projectTypes: readonly ProjectType[],
+  signals: ProjectSignals
+): Promise<IntegrationFlags> {
+  const { dependencies, envExample, remoteSetup, workflows } = signals;
+  const [serverlessYml, serverlessYaml, sstTs, sstJs, sonar, eas, maestro] =
+    await Promise.all(
+      [
+        "serverless.yml",
+        "serverless.yaml",
+        "sst.config.ts",
+        "sst.config.js",
+        "sonar-project.properties",
+        "eas.json",
+        ".maestro/config.yaml",
+      ].map(relativePath => projectFileExists(destDir, relativePath))
+    );
+  return {
+    aws:
+      projectTypes.includes("cdk") ||
+      hasDependency(dependencies, [
+        "@aws-sdk/",
+        "aws-cdk-lib",
+        "serverless",
+        "sst",
+      ]) ||
+      /^(AWS_PROFILE|CDK_CONTEXT_ACCOUNT|CDK_CONTEXT_ENV)=/mu.test(
+        envExample
+      ) ||
+      [serverlessYml, serverlessYaml, sstTs, sstJs].some(Boolean),
+    eas:
+      projectTypes.includes("expo") &&
+      (eas || workflows.includes("EXPO_TOKEN")),
+    figma: remoteSetup.includes("FIGMA_ACCESS_TOKEN"),
+    jam: hasDependency(dependencies, ["@jam.dev/"]),
+    maestro: maestro === true && workflows.includes("MAESTRO_API_KEY"),
+    sentry:
+      hasDependency(dependencies, ["@sentry/"]) &&
+      (remoteSetup.includes("SENTRY_AUTH_TOKEN") ||
+        workflows.includes("SENTRY_AUTH_TOKEN")),
+    sonar:
+      sonar === true &&
+      (remoteSetup.includes("SONAR_TOKEN") ||
+        workflows.includes("SONAR_TOKEN")),
+  };
+}
+
+/**
+ * Build requirements activated by detected project type and integrations.
+ * @param destDir - Project root
+ * @param projectTypes - Detected Lisa project types
+ * @returns Project-specific requirements
+ */
+export async function detectedProjectRequirements(
+  destDir: string,
+  projectTypes: readonly ProjectType[]
+): Promise<readonly VariableRequirement[]> {
+  const signals = await readProjectSignals(destDir);
+  const flags = await detectIntegrationFlags(destDir, projectTypes, signals);
+  return requirementsForFlags(flags, projectTypes);
+}

--- a/src/cli/remote-environment.ts
+++ b/src/cli/remote-environment.ts
@@ -1,0 +1,114 @@
+import * as path from "node:path";
+import { createDetectorRegistry } from "../detection/index.js";
+import type { JsonObject } from "../sync/json-path.js";
+import { readJsonOrNull } from "../utils/index.js";
+import {
+  DEFAULT_STARTUP_ARTIFACTS,
+  manifestRequirements,
+  REMOTE_AGENTS,
+  REMOTE_ENVIRONMENT_MANIFEST,
+  type RemoteAgent,
+  type RemoteEnvironmentManifest,
+  type RemoteEnvironmentStartupStatus,
+  type RemoteEnvironmentStatus,
+  uniqueRequirements,
+} from "./remote-environment-contract.js";
+import { configuredIntegrationRequirements } from "./remote-environment-catalog.js";
+import {
+  detectedProjectRequirements,
+  projectFileExists,
+} from "./remote-environment-detection.js";
+
+export type {
+  RemoteEnvironmentStartupStatus,
+  RemoteEnvironmentStatus,
+  RemoteEnvironmentVariableStatus,
+} from "./remote-environment-contract.js";
+
+/**
+ * Restrict manifest artifacts to files beneath the host project.
+ * @param candidate - Project-owned manifest value
+ * @returns Whether the value is a safe project-relative path
+ */
+function isSafeProjectArtifact(candidate: string): boolean {
+  return (
+    candidate.length > 0 &&
+    !path.isAbsolute(candidate) &&
+    !candidate.split(/[\\/]/u).includes("..")
+  );
+}
+
+/**
+ * Resolve an explicitly configured or discovered startup artifact for one agent.
+ * @param destDir - Project root
+ * @param agent - Supported coding agent
+ * @param manifest - Project-owned manifest
+ * @returns Startup artifact status
+ */
+async function resolveStartupScript(
+  destDir: string,
+  agent: RemoteAgent,
+  manifest: RemoteEnvironmentManifest | null
+): Promise<RemoteEnvironmentStartupStatus> {
+  const configured = manifest?.startupScripts?.[agent];
+  const explicit =
+    typeof configured === "string" && isSafeProjectArtifact(configured)
+      ? configured
+      : undefined;
+  const candidates =
+    explicit === undefined ? DEFAULT_STARTUP_ARTIFACTS[agent] : [explicit];
+  const existence = await Promise.all(
+    candidates.map(async artifact => ({
+      artifact,
+      exists: await projectFileExists(destDir, artifact),
+    }))
+  );
+  const installed = existence.find(candidate => candidate.exists);
+  return installed === undefined
+    ? {
+        agent,
+        ...(explicit === undefined ? {} : { artifact: explicit }),
+        installed: false,
+      }
+    : { agent, artifact: installed.artifact, installed: true };
+}
+
+/**
+ * Inspect requirements for this particular project without exposing values.
+ * @param destDir - Project root
+ * @param config - Merged Lisa project config
+ * @param environment - Environment visible to the Lisa process
+ * @returns Project-aware variable and startup-artifact status
+ */
+export async function inspectRemoteEnvironment(
+  destDir: string,
+  config: JsonObject,
+  environment: NodeJS.ProcessEnv
+): Promise<RemoteEnvironmentStatus> {
+  const detectorRegistry = createDetectorRegistry();
+  const [detectedTypes, manifest] = await Promise.all([
+    detectorRegistry.detectAll(destDir),
+    readJsonOrNull<RemoteEnvironmentManifest>(
+      path.join(destDir, REMOTE_ENVIRONMENT_MANIFEST)
+    ),
+  ]);
+  const projectTypes = detectorRegistry.expandAndOrderTypes(detectedTypes);
+  const requirements = uniqueRequirements([
+    ...configuredIntegrationRequirements(config),
+    ...(await detectedProjectRequirements(destDir, projectTypes)),
+    ...manifestRequirements(manifest),
+  ]);
+  const startupScripts = await Promise.all(
+    REMOTE_AGENTS.map(agent => resolveStartupScript(destDir, agent, manifest))
+  );
+  return {
+    projectTypes,
+    variables: requirements.map(requirement => ({
+      ...requirement,
+      set:
+        typeof environment[requirement.name] === "string" &&
+        environment[requirement.name]!.length > 0,
+    })),
+    startupScripts,
+  };
+}

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -17,6 +17,10 @@ import { isJsonObject, type JsonObject } from "../sync/json-path.js";
 import { deepMerge, readJsonOrNull } from "../utils/index.js";
 import { printSyncReport } from "./sync-cmd.js";
 import {
+  inspectRemoteEnvironment,
+  type RemoteEnvironmentStatus,
+} from "./remote-environment.js";
+import {
   createGithubAuthProbe,
   readStatusSnapshot,
   validateStatusProbes,
@@ -31,6 +35,7 @@ export {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+export { inspectRemoteEnvironment } from "./remote-environment.js";
 
 /** Default port for the settings console. */
 export const DEFAULT_UI_PORT = 4780;
@@ -52,28 +57,6 @@ export interface UiRuntimeDependencies {
   readonly probes?: readonly StatusProbe[];
 }
 
-/** Secret/variable and generated-artifact status exposed to the console. */
-export interface RemoteEnvironmentStatus {
-  /** Whether each supported variable is visible to the `lisa ui` process. */
-  readonly variables: Readonly<Record<string, boolean>>;
-  /** Whether each remote-environment startup artifact exists in the project. */
-  readonly artifacts: Readonly<Record<string, boolean>>;
-}
-
-/** Variables the remote AWS bootstrap understands. Values are never exposed. */
-export const REMOTE_ENVIRONMENT_VARIABLES = [
-  "LISA_AWS_BOOTSTRAP_JSON",
-  "LISA_REMOTE_AGENT",
-  "LISA_AWS_DEFAULT_PROFILE",
-] as const;
-
-/** Project-relative artifacts used by remote coding environments. */
-export const REMOTE_ENVIRONMENT_ARTIFACTS = [
-  "scripts/remote-agent-aws-setup.sh",
-  ".cursor/environment.json",
-  ".github/workflows/copilot-setup-steps.yml",
-] as const;
-
 /**
  * Read the CLI process environment through one explicit, reviewable exception.
  * Only boolean presence checks derived from this map reach the browser.
@@ -82,33 +65,6 @@ export const REMOTE_ENVIRONMENT_ARTIFACTS = [
 function getProcessEnvironment(): NodeJS.ProcessEnv {
   // eslint-disable-next-line no-restricted-syntax -- CLI status view must inspect externally supplied remote-environment variables once
   return process.env;
-}
-
-/**
- * Inspect remote-environment readiness without ever reading a variable value
- * into the browser payload.
- * @param destDir - Project root
- * @param environment - Environment visible to the Lisa process
- * @returns Boolean-only variable and artifact status
- */
-export function inspectRemoteEnvironment(
-  destDir: string,
-  environment: NodeJS.ProcessEnv = getProcessEnvironment()
-): RemoteEnvironmentStatus {
-  return {
-    variables: Object.fromEntries(
-      REMOTE_ENVIRONMENT_VARIABLES.map(name => [
-        name,
-        typeof environment[name] === "string" && environment[name]!.length > 0,
-      ])
-    ),
-    artifacts: Object.fromEntries(
-      REMOTE_ENVIRONMENT_ARTIFACTS.map(relativePath => [
-        relativePath,
-        existsSync(path.join(destDir, relativePath)),
-      ])
-    ),
-  };
 }
 
 /**
@@ -159,8 +115,9 @@ export function injectLiveConfig(
   html: string,
   config: JsonObject,
   remoteEnvironment: RemoteEnvironmentStatus = {
-    variables: {},
-    artifacts: {},
+    projectTypes: [],
+    variables: [],
+    startupScripts: [],
   }
 ): string {
   const payload = JSON.stringify(config).replace(/<\//g, "<\\/");
@@ -349,7 +306,11 @@ export async function runUi(
   const htmlPath = findUiHtml(moduleDir);
   const html = await readFile(htmlPath, "utf8");
   const config = await readMergedConfig(destDir);
-  const remoteEnvironment = inspectRemoteEnvironment(destDir);
+  const remoteEnvironment = await inspectRemoteEnvironment(
+    destDir,
+    config,
+    getProcessEnvironment()
+  );
   const page = injectLiveConfig(html, config, remoteEnvironment);
   const probes = dependencies.probes ?? [createGithubAuthProbe(destDir)];
   const server = http.createServer(createUiRequestHandler(page, probes));

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -60,40 +60,148 @@ describe("injectLiveConfig", () => {
       "</body>",
       { harness: "codex" },
       {
-        variables: { LISA_AWS_BOOTSTRAP_JSON: true },
-        artifacts: { "scripts/remote-agent-aws-setup.sh": false },
+        projectTypes: ["cdk"],
+        variables: [
+          {
+            name: "LISA_AWS_BOOTSTRAP_JSON",
+            reason: "AWS access",
+            source: "Project type: CDK",
+            secret: true,
+            set: true,
+          },
+        ],
+        startupScripts: [],
       }
     );
 
     expect(injected).toContain("window.LISA_REMOTE_ENVIRONMENT");
-    expect(injected).toContain('"LISA_AWS_BOOTSTRAP_JSON":true');
+    expect(injected).toContain('"name":"LISA_AWS_BOOTSTRAP_JSON"');
+    expect(injected).toContain('"set":true');
     expect(injected).not.toContain("secretAccessKey");
   });
 });
 
 describe("inspectRemoteEnvironment", () => {
-  it("reports variable presence and project startup artifacts without values", async () => {
-    await mkdir(path.join(resources.dir, ".cursor"));
-    await writeJson(path.join(resources.dir, ".cursor", "environment.json"), {
-      install: "bootstrap",
+  it("detects only integrations required by the current project", async () => {
+    await writeJson(path.join(resources.dir, "package.json"), {
+      dependencies: { expo: "latest", "@jam.dev/sdk": "latest" },
     });
+    await writeFile(
+      path.join(resources.dir, ".env.example"),
+      "AWS_PROFILE=gemini-dev-v2\n"
+    );
+    await mkdir(path.join(resources.dir, "scripts"));
+    await writeFile(
+      path.join(resources.dir, "scripts", "claude-remote-setup.sh"),
+      '[ -n "${JAM_PAT:-}" ] && jam auth login --token\n'
+    );
 
-    const status = inspectRemoteEnvironment(resources.dir, {
-      LISA_AWS_BOOTSTRAP_JSON: "sensitive-value",
-      LISA_REMOTE_AGENT: "",
-    });
+    const status = await inspectRemoteEnvironment(
+      resources.dir,
+      { tracker: "jira", source: "notion" },
+      { JAM_PAT: "sensitive-value" }
+    );
 
-    expect(status.variables).toEqual({
-      LISA_AWS_BOOTSTRAP_JSON: true,
-      LISA_REMOTE_AGENT: false,
-      LISA_AWS_DEFAULT_PROFILE: false,
+    expect(status.projectTypes).toEqual(["typescript", "expo"]);
+    expect(status.variables.map(variable => variable.name)).toEqual([
+      "JIRA_API_TOKEN",
+      "JIRA_SERVER",
+      "JIRA_LOGIN",
+      "JIRA_PROJECT",
+      "NOTION_API_TOKEN",
+      "JAM_PAT",
+      "LISA_AWS_BOOTSTRAP_JSON",
+    ]);
+    expect(
+      status.variables.find(variable => variable.name === "JAM_PAT")
+    ).toMatchObject({ set: true, source: "Integration: @jam.dev" });
+    expect(status.startupScripts).toContainEqual({
+      agent: "claude",
+      artifact: "scripts/claude-remote-setup.sh",
+      installed: true,
     });
-    expect(status.artifacts).toMatchObject({
-      ".cursor/environment.json": true,
-      "scripts/remote-agent-aws-setup.sh": false,
-      ".github/workflows/copilot-setup-steps.yml": false,
+    expect(status.startupScripts).toContainEqual({
+      agent: "codex",
+      installed: false,
     });
     expect(JSON.stringify(status)).not.toContain("sensitive-value");
+  });
+
+  it("does not require AWS merely because Lisa ships the reusable AWS setup", async () => {
+    await writeJson(path.join(resources.dir, "package.json"), {
+      name: "@codyswann/lisa",
+      devDependencies: { typescript: "latest" },
+    });
+    await mkdir(path.join(resources.dir, "scripts"));
+    await writeFile(
+      path.join(resources.dir, "scripts", "remote-agent-aws-setup.sh"),
+      "#!/usr/bin/env bash\n"
+    );
+    await writeFile(
+      path.join(resources.dir, "scripts", "claude-remote-setup.sh"),
+      "# AWS when this routine needs it: LISA_AWS_BOOTSTRAP_JSON\n"
+    );
+
+    const status = await inspectRemoteEnvironment(
+      resources.dir,
+      { tracker: "github", source: "github" },
+      { GH_TOKEN: "configured" }
+    );
+
+    expect(status.variables).toEqual([
+      {
+        name: "GH_TOKEN",
+        reason: "GitHub CLI access for the active tracker or PRD source",
+        source: "Lisa config: GitHub",
+        secret: true,
+        set: true,
+      },
+    ]);
+  });
+
+  it("uses the project manifest for project-owned requirements and startup scripts", async () => {
+    await mkdir(path.join(resources.dir, ".lisa"));
+    await mkdir(path.join(resources.dir, "scripts"));
+    await writeFile(
+      path.join(resources.dir, "scripts", "codex-remote-setup.sh"),
+      "#!/usr/bin/env bash\n"
+    );
+    await writeJson(
+      path.join(resources.dir, ".lisa", "remote-environment.json"),
+      {
+        variables: [
+          {
+            name: "PROJECT_API_TOKEN",
+            reason: "Project-specific service",
+            secret: true,
+            required: true,
+          },
+          { name: "DORMANT_TOKEN", required: false },
+        ],
+        startupScripts: {
+          codex: "scripts/codex-remote-setup.sh",
+          agy: "../../outside-project.sh",
+        },
+      }
+    );
+
+    const status = await inspectRemoteEnvironment(resources.dir, {}, {});
+
+    expect(status.variables.map(variable => variable.name)).toEqual([
+      "PROJECT_API_TOKEN",
+    ]);
+    expect(status.startupScripts).toContainEqual({
+      agent: "codex",
+      artifact: "scripts/codex-remote-setup.sh",
+      installed: true,
+    });
+    expect(status.startupScripts).toContainEqual({
+      agent: "agy",
+      installed: false,
+    });
+    expect(JSON.stringify(status.startupScripts)).not.toContain(
+      "outside-project.sh"
+    );
   });
 });
 

--- a/tests/unit/strategies/claude-remote-substrates.test.ts
+++ b/tests/unit/strategies/claude-remote-substrates.test.ts
@@ -85,5 +85,15 @@ describe("generate-claude-remote-build-script substrate output", () => {
       );
       expect(content).toContain("mcpHeaders");
     });
+
+    it("writes a names-only project-aware console contract", () => {
+      expect(content).toContain(".lisa/remote-environment.json");
+      expect(content).toMatch(/only entries that are `required: true`/i);
+      expect(content).toMatch(/omit optional, conditional, and dormant/i);
+      expect(content).toMatch(/never a value/i);
+      expect(content).toMatch(
+        /Do\s+not add AWS merely because Lisa ships AWS support/i
+      );
+    });
   });
 });

--- a/ui/README.md
+++ b/ui/README.md
@@ -157,6 +157,33 @@ Results render as a per-check table (pass / warn / fail, with the layer that
 produced each finding), and the last full check's date + verdict stays
 visible in the section.
 
+### Remote-environment requirements
+
+The console derives required remote-environment variables from the active
+tracker/source, detected project types, and integration signals in the host
+project. Projects can extend or override startup-artifact discovery with
+`.lisa/remote-environment.json`:
+
+```json
+{
+  "variables": [
+    {
+      "name": "PROJECT_API_TOKEN",
+      "reason": "Project-specific service access",
+      "secret": true,
+      "required": true
+    }
+  ],
+  "startupScripts": {
+    "claude": "scripts/claude-remote-setup.sh",
+    "codex": "scripts/codex-remote-setup.sh"
+  }
+}
+```
+
+Only required entries are displayed. Secret values are never read into the
+browser payload; the server exposes names and boolean presence only.
+
 ## What it catalogs
 
 | Section | Source of truth in this repo |
@@ -168,7 +195,7 @@ visible in the section.
 | General (`harness`, `tracker`, `source`, `repo`, package manager) | `src/core/config.ts`, `plugins/src/base/rules/reference/config-resolution.md` |
 | Project types (8 stacks + template strategies) | `src/detection/`, `src/strategies/`, `<stack>/` template dirs |
 | Coding agents (claude/codex/cursor/agy/copilot/opencode/fleet) | `src/core/lisa.ts`, `scripts/generate-*-plugin-artifacts.mjs` |
-| Remote Environment (variable presence + active-agent startup scripts) | `src/cli/ui-cmd.ts`, `plugins/src/base/scripts/remote-agent-aws-setup.sh` |
+| Remote Environment (project-aware variable presence + active-agent startup scripts) | `src/cli/remote-environment.ts`, `.lisa/remote-environment.json`, detected config/types/integrations |
 | Work tracker (JIRA / GitHub Issues / Linear) | `config-resolution.md`, `lisa-setup-*` skills |
 | PRD source (Notion / Confluence / Linear / GitHub) | `config-resolution.md`, `lisa-setup-*` skills |
 | Deploy & environments (`deploy.*`, `github.environments`) | `scripts/lisa-github-environments.sh` |

--- a/ui/index.html
+++ b/ui/index.html
@@ -2403,26 +2403,26 @@
       /* -------------------------- Remote environment -------------------------- */
       DATA.sections.remote = {
         title: "Remote Environment",
-        desc: "AWS CLI bootstrap readiness for the project's active remote coding agents. Secret values are never sent to the browser — the console receives presence checks only.",
-        src: "scripts/remote-agent-aws-setup.sh · remote platform environments",
+        desc: "Remote coding-environment requirements detected for this project, its project types, and its active integrations. Values are never sent to the browser — the console receives presence checks only.",
+        src: ".lisa/remote-environment.json · project config · detected integrations",
         blocks: [
           {
             type: "table",
             card: "Variables",
-            note: "Set status reflects variables visible to the lisa ui process; values remain hidden",
-            cols: ["Variable", "Purpose", "Status"],
+            note: "Only required variables are listed; status reflects the lisa ui process and values remain hidden",
+            cols: ["Variable", "Why required", "Detected from", "Status"],
             rows: [],
           },
           {
             type: "table",
             card: "Startup Script",
             note: "Only agents enabled by the current harness are listed",
-            cols: ["Agent", "Remote environment setup", "Project artifact"],
+            cols: ["Agent", "Project startup artifact", "Status"],
             rows: [],
           },
           {
             type: "callout",
-            text: "<b>One bootstrap bundle, renewable sessions.</b> Store the complete Secrets Manager value as <code>LISA_AWS_BOOTSTRAP_JSON</code>. Each startup command writes the assume-only source credential and renewable role profiles; do not configure <code>AWS_ACCESS_KEY_ID</code> or <code>AWS_SECRET_ACCESS_KEY</code> directly.",
+            text: "<b>Project-aware by design.</b> Lisa combines the active tracker/source, detected project types, integration signals, and an optional <code>.lisa/remote-environment.json</code> project contract. A credential is never listed merely because Lisa knows how to support it.",
           },
         ],
       };
@@ -5870,48 +5870,11 @@
         "copilot",
         "opencode",
       ];
-      const REMOTE_STARTUP = {
-        claude: {
-          command:
-            "LISA_REMOTE_AGENT=claude bash scripts/remote-agent-aws-setup.sh",
-          artifacts: ["scripts/remote-agent-aws-setup.sh"],
-        },
-        codex: {
-          command:
-            "LISA_REMOTE_AGENT=codex bash scripts/remote-agent-aws-setup.sh",
-          artifacts: ["scripts/remote-agent-aws-setup.sh"],
-        },
-        cursor: {
-          command:
-            ".cursor/environment.json → LISA_REMOTE_AGENT=cursor bash scripts/remote-agent-aws-setup.sh",
-          artifacts: [
-            "scripts/remote-agent-aws-setup.sh",
-            ".cursor/environment.json",
-          ],
-        },
-        agy: {
-          command:
-            "LISA_REMOTE_AGENT=agy bash scripts/remote-agent-aws-setup.sh (user-managed host)",
-          artifacts: ["scripts/remote-agent-aws-setup.sh"],
-        },
-        copilot: {
-          command:
-            ".github/workflows/copilot-setup-steps.yml → bash scripts/remote-agent-aws-setup.sh",
-          artifacts: [
-            "scripts/remote-agent-aws-setup.sh",
-            ".github/workflows/copilot-setup-steps.yml",
-          ],
-        },
-        opencode: {
-          command:
-            "LISA_REMOTE_AGENT=opencode bash scripts/remote-agent-aws-setup.sh (opencode serve host)",
-          artifacts: ["scripts/remote-agent-aws-setup.sh"],
-        },
-      };
       function configureRemoteEnvironment(cfg) {
         const snapshot = window.LISA_REMOTE_ENVIRONMENT || {
-          variables: {},
-          artifacts: {},
+          projectTypes: [],
+          variables: [],
+          startupScripts: [],
         };
         const harness = cfg && cfg.harness ? cfg.harness : "fleet";
         const activeAgents =
@@ -5920,50 +5883,46 @@
             : REMOTE_AGENT_ORDER.includes(harness)
               ? [harness]
               : ["claude"];
-        const variableRows = [
-          [
-            "LISA_AWS_BOOTSTRAP_JSON",
-            "Required secret — complete vendor-neutral bootstrap bundle",
-          ],
-          [
-            "LISA_REMOTE_AGENT",
-            "Platform label used as the AWS role session name (startup commands set it inline)",
-          ],
-          [
-            "LISA_AWS_DEFAULT_PROFILE",
-            "Optional default account profile; dev is used when unset",
-          ],
-        ].map(([name, purpose]) => {
-          const isSet = snapshot.variables[name] === true;
-          return [
-            { t: "mono", v: name },
-            { t: "text", v: purpose },
+        const variableRows = snapshot.variables.map(variable => [
+          { t: "mono", v: variable.name },
+          { t: "text", v: variable.reason },
+          { t: "text", v: variable.source },
+          {
+            t: "badge",
+            v: variable.set ? "set" : "not set",
+            cls: variable.set ? "pass" : "fail",
+          },
+        ]);
+        if (variableRows.length === 0) {
+          variableRows.push([
             {
-              t: "badge",
-              v: isSet ? "set" : "not set",
-              cls: isSet
-                ? "pass"
-                : name.endsWith("DEFAULT_PROFILE")
-                  ? "warn"
-                  : "fail",
+              t: "text",
+              v: "No project-specific remote variables detected",
             },
-          ];
-        });
+            { t: "text", v: "—" },
+            { t: "text", v: "—" },
+            { t: "badge", v: "none", cls: "default" },
+          ]);
+        }
         const startupRows = activeAgents.map(agent => {
-          const startup = REMOTE_STARTUP[agent];
-          const ready = startup.artifacts.every(
-            artifact => snapshot.artifacts[artifact] === true
-          );
+          const startup = snapshot.startupScripts.find(
+            candidate => candidate.agent === agent
+          ) || { agent, installed: false };
           return [
             { t: "mono", v: agent },
-            { t: "mono", v: startup.command },
+            { t: "mono", v: startup.artifact || "Not configured" },
             {
               t: "badge",
-              v: ready ? "installed" : "missing",
-              cls: ready ? "pass" : "fail",
+              v: startup.installed ? "installed" : "missing",
+              cls: startup.installed ? "pass" : "fail",
             },
           ];
         });
+        const projectTypes = snapshot.projectTypes || [];
+        DATA.sections.remote.blocks[0].note =
+          "Required for this project (" +
+          (projectTypes.length ? projectTypes.join(", ") : "no Lisa type") +
+          "); values remain hidden";
         DATA.sections.remote.blocks[0].rows = variableRows;
         DATA.sections.remote.blocks[1].rows = startupRows;
       }


### PR DESCRIPTION
## Summary

- replace the hardcoded AWS Remote Environment UI with project-aware requirements derived from active Lisa config, detected project types, and actual integrations
- detect Jam-enabled projects and surface `JAM_PAT`; only surface AWS bootstrap when the host project has active AWS signals
- add a names-only `.lisa/remote-environment.json` extension contract and per-agent startup-artifact discovery
- propagate the generator contract across Claude, Codex, Cursor, OpenCode, Antigravity, and Copilot surfaces
- keep all credential values server-side and expose boolean presence only

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test:unit` (4,487 tests)
- protected push gates: Knip, coverage suite (4,616 tests), integration suite (129 tests)
- live UI inspection against Gemini `frontend-v2`: `JAM_PAT` shown from `@jam.dev`; Lisa itself does not show AWS