### PR TITLE
feat: add secure lisa ui config write endpoint

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -27,6 +27,7 @@ import {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+import { serveConfigWrite } from "./ui-config-write.js";
 export {
   createGithubAuthProbe,
   runProbe,
@@ -247,11 +248,13 @@ function isLoopbackHost(host: string | undefined): boolean {
  * Build the request handler after validating the complete probe registry.
  * @param page - Hydrated settings console HTML
  * @param probes - Live-status probes registered for this server
+ * @param destDir - Project root served by this UI process
  * @returns Loopback HTTP request handler
  */
 function createUiRequestHandler(
   page: string,
-  probes: readonly StatusProbe[]
+  probes: readonly StatusProbe[],
+  destDir: string
 ): http.RequestListener {
   const readSnapshot = createStatusSnapshotReader(probes);
   validateStatusProbes(probes);
@@ -269,6 +272,10 @@ function createUiRequestHandler(
     }
     if (pathname === "/api/status") {
       serveStatus(request, response, readSnapshot);
+      return;
+    }
+    if (pathname === "/api/config") {
+      serveConfigWrite(request, response, destDir);
       return;
     }
     if (pathname === "/" || pathname === "/index.html") {
@@ -313,7 +320,9 @@ export async function runUi(
   );
   const page = injectLiveConfig(html, config, remoteEnvironment);
   const probes = dependencies.probes ?? [createGithubAuthProbe(destDir)];
-  const server = http.createServer(createUiRequestHandler(page, probes));
+  const server = http.createServer(
+    createUiRequestHandler(page, probes, destDir)
+  );
   await new Promise<void>(resolve => {
     server.listen(port, "127.0.0.1", resolve);
   });

--- a/src/cli/ui-config-write.ts
+++ b/src/cli/ui-config-write.ts
@@ -1,0 +1,282 @@
+/**
+ * Same-origin config write endpoint for `lisa ui`.
+ * @module cli/ui-config-write
+ */
+import * as http from "node:http";
+import * as path from "node:path";
+import {
+  isJsonObject,
+  setAtPath,
+  type JsonObject,
+  type JsonValue,
+} from "../sync/json-path.js";
+import { readJsonOrNull, writeJson } from "../utils/index.js";
+
+const CONFIG_FILE = ".lisa.config.json";
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+const MAX_CONFIG_WRITE_BYTES = 128 * 1024;
+const NO_STORE = "no-store";
+const TEXT_CONTENT_TYPE = "text/plain; charset=utf-8";
+
+/**
+ * Read the project's committed config file.
+ * @param destDir - Project root
+ * @returns Committed config object, or an empty config if absent/malformed
+ */
+async function readCommittedConfig(destDir: string): Promise<JsonObject> {
+  const committed = await readJsonOrNull<unknown>(
+    path.join(destDir, CONFIG_FILE)
+  );
+  return isJsonObject(committed) ? committed : {};
+}
+
+/**
+ * Restrict loopback origins to the authority advertised by `lisa ui`.
+ * @param host - Origin URL host
+ * @returns Whether the authority is 127.0.0.1 with an optional valid port
+ */
+function isLoopbackHost(host: string): boolean {
+  if (host === "127.0.0.1") {
+    return true;
+  }
+  const prefix = "127.0.0.1:";
+  if (!host.startsWith(prefix)) {
+    return false;
+  }
+  const portText = host.slice(prefix.length);
+  const digitsOnly = Array.from(portText).every(
+    character => character >= "0" && character <= "9"
+  );
+  const port = Number(portText);
+  return (
+    portText.length > 0 &&
+    portText.length <= 5 &&
+    digitsOnly &&
+    port > 0 &&
+    port <= 65_535
+  );
+}
+
+/**
+ * Reject request origins that are not the advertised loopback listener.
+ * @param origin - Incoming Origin header
+ * @param host - Incoming Host header
+ * @returns Whether the origin is the exact http://127.0.0.1 listener authority
+ */
+function isExpectedLoopbackOrigin(
+  origin: string | undefined,
+  host: string | undefined
+): boolean {
+  if (origin === undefined || host === undefined) {
+    return false;
+  }
+  try {
+    const parsed = new URL(origin);
+    return (
+      parsed.protocol === "http:" &&
+      parsed.host === host &&
+      isLoopbackHost(parsed.host)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether an unknown value can be serialized as JSON without dropping
+ * fields.
+ * @param value - Candidate payload value
+ * @returns Whether the value is JSON-compatible
+ */
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return Number.isFinite(value) || typeof value !== "number";
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  if (isJsonObject(value)) {
+    return Object.values(value).every(isJsonValue);
+  }
+  return false;
+}
+
+/**
+ * Validate a dot-path config key before it can be written to disk.
+ * @param key - Candidate config key
+ * @returns Specific validation error, or undefined when valid
+ */
+function validateConfigKey(key: string): string | undefined {
+  if (key.trim() !== key || key.length === 0) {
+    return "Config change keys must be non-empty dot paths";
+  }
+  const segments = key.split(".");
+  if (segments.some(segment => segment.length === 0)) {
+    return `Config change key "${key}" contains an empty path segment`;
+  }
+  const unsafe = new Set(["__proto__", "constructor", "prototype"]);
+  if (segments.some(segment => unsafe.has(segment))) {
+    return `Config change key "${key}" is not writable`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate one sparse config-write entry.
+ * @param key - Dot-path config key
+ * @param change - Candidate JSON value
+ * @returns Specific validation error, or undefined when valid
+ */
+function validateChangeEntry(key: string, change: unknown): string | undefined {
+  const keyError = validateConfigKey(key);
+  if (keyError !== undefined) {
+    return keyError;
+  }
+  if (!isJsonValue(change)) {
+    return `Config change "${key}" must be JSON-compatible`;
+  }
+  return undefined;
+}
+
+/**
+ * Parse and validate the sparse config-write payload.
+ * @param value - Parsed JSON request body
+ * @returns Dot-path changes, or a specific validation error
+ */
+function parseConfigWritePayload(
+  value: unknown
+): { changes: Record<string, JsonValue> } | { error: string } {
+  if (!isJsonObject(value)) {
+    return { error: "Payload must be a JSON object" };
+  }
+  const changes = value.changes;
+  if (!isJsonObject(changes)) {
+    return { error: "Payload must include a changes object" };
+  }
+  const entries = Object.entries(changes);
+  if (entries.length === 0) {
+    return { error: "Payload changes must include at least one config key" };
+  }
+  const error = entries
+    .map(([key, change]) => validateChangeEntry(key, change))
+    .find(Boolean);
+  if (error !== undefined) {
+    return { error };
+  }
+  return { changes: Object.fromEntries(entries) as Record<string, JsonValue> };
+}
+
+/**
+ * Read a bounded JSON body from an incoming request.
+ * @param request - Incoming HTTP request
+ * @returns Parsed JSON body
+ */
+async function readJsonBody(request: http.IncomingMessage): Promise<unknown> {
+  // eslint-disable-next-line functional/no-let -- bounded stream aggregation
+  let received = 0;
+  // eslint-disable-next-line functional/no-let -- bounded stream aggregation
+  let chunks: readonly Buffer[] = [];
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    received += buffer.byteLength;
+    if (received > MAX_CONFIG_WRITE_BYTES) {
+      throw new Error("Payload exceeds 128 KiB limit");
+    }
+    chunks = [...chunks, buffer];
+  }
+  if (chunks.length === 0) {
+    throw new Error("Payload body is required");
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  } catch {
+    throw new Error("Payload body must be valid JSON");
+  }
+}
+
+/**
+ * Write a sparse config payload after all validation has completed.
+ * @param destDir - Project root whose committed config is written
+ * @param changes - Validated dot-path changes
+ * @returns The updated committed config
+ */
+async function writeConfigChanges(
+  destDir: string,
+  changes: Record<string, JsonValue>
+): Promise<JsonObject> {
+  const original = await readCommittedConfig(destDir);
+  const next = Object.entries(changes).reduce<JsonObject>(
+    (state, [key, value]) => setAtPath(state, key, value),
+    original
+  );
+  await writeJson(path.join(destDir, CONFIG_FILE), next);
+  return next;
+}
+
+/**
+ * Serve the same-origin committed-config write endpoint.
+ * @param request - Incoming loopback request
+ * @param response - Response associated with the request
+ * @param destDir - Project root whose committed config is written
+ */
+export function serveConfigWrite(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  destDir: string
+): void {
+  if (request.method !== "POST") {
+    response.writeHead(405, {
+      allow: "POST",
+      "cache-control": NO_STORE,
+      "content-type": TEXT_CONTENT_TYPE,
+    });
+    response.end("Method not allowed");
+    return;
+  }
+  if (!isExpectedLoopbackOrigin(request.headers.origin, request.headers.host)) {
+    response.writeHead(403, {
+      "cache-control": NO_STORE,
+      "content-type": JSON_CONTENT_TYPE,
+    });
+    response.end(
+      JSON.stringify({
+        error: "Write requests must come from http://127.0.0.1",
+      })
+    );
+    return;
+  }
+  void readJsonBody(request)
+    .then(parseConfigWritePayload)
+    .then(async parsed => {
+      if ("error" in parsed) {
+        response.writeHead(400, {
+          "cache-control": NO_STORE,
+          "content-type": JSON_CONTENT_TYPE,
+        });
+        response.end(JSON.stringify({ error: parsed.error }));
+        return;
+      }
+      const committed = await writeConfigChanges(destDir, parsed.changes);
+      response.writeHead(200, {
+        "cache-control": NO_STORE,
+        "content-type": JSON_CONTENT_TYPE,
+      });
+      response.end(JSON.stringify({ ok: true, config: committed }));
+    })
+    .catch(error => {
+      response.writeHead(400, {
+        "cache-control": NO_STORE,
+        "content-type": JSON_CONTENT_TYPE,
+      });
+      response.end(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    });
+}

--- a/src/cli/ui-config-write.ts
+++ b/src/cli/ui-config-write.ts
@@ -4,19 +4,24 @@
  */
 import * as http from "node:http";
 import * as path from "node:path";
+import { readFile } from "node:fs/promises";
 import {
   isJsonObject,
   setAtPath,
   type JsonObject,
   type JsonValue,
 } from "../sync/json-path.js";
-import { readJsonOrNull, writeJson } from "../utils/index.js";
+import { writeJson } from "../utils/index.js";
 
 const CONFIG_FILE = ".lisa.config.json";
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 const MAX_CONFIG_WRITE_BYTES = 128 * 1024;
 const NO_STORE = "no-store";
 const TEXT_CONTENT_TYPE = "text/plain; charset=utf-8";
+const configWriteQueues = new Map<string, Promise<void>>();
+
+/** Error raised for malformed request bodies that should return 400. */
+class RequestBodyError extends Error {}
 
 /**
  * Read the project's committed config file.
@@ -24,10 +29,24 @@ const TEXT_CONTENT_TYPE = "text/plain; charset=utf-8";
  * @returns Committed config object, or an empty config if absent/malformed
  */
 async function readCommittedConfig(destDir: string): Promise<JsonObject> {
-  const committed = await readJsonOrNull<unknown>(
-    path.join(destDir, CONFIG_FILE)
-  );
-  return isJsonObject(committed) ? committed : {};
+  const configPath = path.join(destDir, CONFIG_FILE);
+  try {
+    const committed = JSON.parse(await readFile(configPath, "utf8")) as unknown;
+    if (!isJsonObject(committed)) {
+      throw new Error(`${CONFIG_FILE} must contain a JSON object`);
+    }
+    return committed;
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return {};
+    }
+    throw error;
+  }
 }
 
 /**
@@ -73,6 +92,7 @@ function isExpectedLoopbackOrigin(
   try {
     const parsed = new URL(origin);
     return (
+      origin === parsed.origin &&
       parsed.protocol === "http:" &&
       parsed.host === host &&
       isLoopbackHost(parsed.host)
@@ -185,17 +205,45 @@ async function readJsonBody(request: http.IncomingMessage): Promise<unknown> {
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     received += buffer.byteLength;
     if (received > MAX_CONFIG_WRITE_BYTES) {
-      throw new Error("Payload exceeds 128 KiB limit");
+      throw new RequestBodyError("Payload exceeds 128 KiB limit");
     }
     chunks = [...chunks, buffer];
   }
   if (chunks.length === 0) {
-    throw new Error("Payload body is required");
+    throw new RequestBodyError("Payload body is required");
   }
   try {
     return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
   } catch {
-    throw new Error("Payload body must be valid JSON");
+    throw new RequestBodyError("Payload body must be valid JSON");
+  }
+}
+
+/**
+ * Serialize committed-config writes per project root.
+ * @param destDir - Project root whose committed config is being written
+ * @param operation - Read-modify-write operation to run after prior writes
+ * @returns Result of the queued operation
+ */
+async function withConfigWriteLock<T>(
+  destDir: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = configWriteQueues.get(destDir) ?? Promise.resolve();
+  const running = previous.catch(() => undefined).then(operation);
+  const marker = running.then(
+    () => undefined,
+    () => undefined
+  );
+  // eslint-disable-next-line functional/immutable-data -- per-project async write queue
+  configWriteQueues.set(destDir, marker);
+  try {
+    return await running;
+  } finally {
+    if (configWriteQueues.get(destDir) === marker) {
+      // eslint-disable-next-line functional/immutable-data -- queue entry is complete
+      configWriteQueues.delete(destDir);
+    }
   }
 }
 
@@ -209,13 +257,15 @@ async function writeConfigChanges(
   destDir: string,
   changes: Record<string, JsonValue>
 ): Promise<JsonObject> {
-  const original = await readCommittedConfig(destDir);
-  const next = Object.entries(changes).reduce<JsonObject>(
-    (state, [key, value]) => setAtPath(state, key, value),
-    original
-  );
-  await writeJson(path.join(destDir, CONFIG_FILE), next);
-  return next;
+  return await withConfigWriteLock(destDir, async () => {
+    const original = await readCommittedConfig(destDir);
+    const next = Object.entries(changes).reduce<JsonObject>(
+      (state, [key, value]) => setAtPath(state, key, value),
+      original
+    );
+    await writeJson(path.join(destDir, CONFIG_FILE), next);
+    return next;
+  });
 }
 
 /**
@@ -269,13 +319,16 @@ export function serveConfigWrite(
       response.end(JSON.stringify({ ok: true, config: committed }));
     })
     .catch(error => {
-      response.writeHead(400, {
+      const isRequestBodyError = error instanceof RequestBodyError;
+      response.writeHead(isRequestBodyError ? 400 : 500, {
         "cache-control": NO_STORE,
         "content-type": JSON_CONTENT_TYPE,
       });
       response.end(
         JSON.stringify({
-          error: error instanceof Error ? error.message : String(error),
+          error: isRequestBodyError
+            ? error.message
+            : "Unable to write Lisa config",
         })
       );
     });

--- a/tests/unit/cli/ui-config-write.test.ts
+++ b/tests/unit/cli/ui-config-write.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runUi } from "../../../src/cli/ui-cmd.js";
+import { writeJson } from "../../../src/utils/index.js";
+
+/** Mutable resources owned by each write-endpoint test. */
+interface TestResources {
+  dir: string;
+  server: Server | undefined;
+}
+
+const resources: TestResources = { dir: "", server: undefined };
+const CONFIG_FILE = ".lisa.config.json";
+const LOCAL_CONFIG_FILE = ".lisa.config.local.json";
+const CONTENT_TYPE_JSON = "application/json";
+const PRIVATE_LOCAL_REPO = "private-local";
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-config-write-"));
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (resources.server !== undefined) {
+    await new Promise(resolve => resources.server?.close(resolve));
+    resources.server = undefined;
+  }
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+/**
+ * Read the port selected for the current test server.
+ * @returns Bound TCP port
+ */
+function serverPort(): number {
+  const address = resources.server?.address();
+  return typeof address === "object" && address !== null ? address.port : 0;
+}
+
+/**
+ * Read config files as raw bytes for no-partial-write assertions.
+ * @returns Raw committed/local config bytes
+ */
+async function readConfigBytes(): Promise<{
+  committed: Buffer;
+  local: Buffer;
+}> {
+  return {
+    committed: await readFile(path.join(resources.dir, CONFIG_FILE)),
+    local: await readFile(path.join(resources.dir, LOCAL_CONFIG_FILE)),
+  };
+}
+
+/** Write a pair of config files used by endpoint tests. */
+async function writeConfigPair(): Promise<void> {
+  await writeJson(path.join(resources.dir, CONFIG_FILE), {
+    tracker: "github",
+    quality: { testCoverage: { global: { statements: 74 } } },
+  });
+  await writeJson(path.join(resources.dir, LOCAL_CONFIG_FILE), {
+    github: { repo: PRIVATE_LOCAL_REPO },
+  });
+}
+
+describe("POST /api/config", () => {
+  it("rejects non-loopback origins without writing config files", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+    const before = await readConfigBytes();
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: "https://attacker.example",
+        },
+        body: JSON.stringify({ changes: { tracker: "jira" } }),
+      }
+    );
+    const body = (await response.json()) as { error: string };
+    const after = await readConfigBytes();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("http://127.0.0.1");
+    expect(after.committed.equals(before.committed)).toBe(true);
+    expect(after.local.equals(before.local)).toBe(true);
+  });
+
+  it("rejects a different loopback origin port without writing config files", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+    const before = await readConfigBytes();
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: "http://127.0.0.1:9",
+        },
+        body: JSON.stringify({ changes: { tracker: "jira" } }),
+      }
+    );
+    const after = await readConfigBytes();
+
+    expect(response.status).toBe(403);
+    expect(after.committed.equals(before.committed)).toBe(true);
+    expect(after.local.equals(before.local)).toBe(true);
+  });
+
+  it("rejects malformed write payloads before touching config files", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+    const before = await readConfigBytes();
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://127.0.0.1:${serverPort()}`,
+        },
+        body: JSON.stringify({ changes: { "quality..global": 80 } }),
+      }
+    );
+    const body = (await response.json()) as { error: string };
+    const after = await readConfigBytes();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("empty path segment");
+    expect(after.committed.equals(before.committed)).toBe(true);
+    expect(after.local.equals(before.local)).toBe(true);
+  });
+
+  it("accepts a same-origin sparse config write", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://127.0.0.1:${serverPort()}`,
+        },
+        body: JSON.stringify({
+          changes: {
+            "quality.testCoverage.global.statements": 80,
+            tracker: "linear",
+          },
+        }),
+      }
+    );
+    const result = (await response.json()) as { ok: boolean };
+    const committed = JSON.parse(
+      await readFile(path.join(resources.dir, CONFIG_FILE), "utf8")
+    ) as {
+      tracker: string;
+      quality: { testCoverage: { global: { statements: number } } };
+    };
+    const local = JSON.parse(
+      await readFile(path.join(resources.dir, LOCAL_CONFIG_FILE), "utf8")
+    ) as { github: { repo: string } };
+
+    expect(response.status).toBe(200);
+    expect(result.ok).toBe(true);
+    expect(committed.tracker).toBe("linear");
+    expect(committed.quality.testCoverage.global.statements).toBe(80);
+    expect(local.github.repo).toBe(PRIVATE_LOCAL_REPO);
+  });
+});

--- a/tests/unit/cli/ui-config-write.test.ts
+++ b/tests/unit/cli/ui-config-write.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -27,6 +27,7 @@ beforeEach(async () => {
 afterEach(async () => {
   vi.restoreAllMocks();
   if (resources.server !== undefined) {
+    resources.server.closeAllConnections();
     await new Promise(resolve => resources.server?.close(resolve));
     resources.server = undefined;
   }
@@ -93,8 +94,8 @@ describe("POST /api/config", () => {
 
     expect(response.status).toBe(403);
     expect(body.error).toContain("http://127.0.0.1");
-    expect(after.committed.equals(before.committed)).toBe(true);
-    expect(after.local.equals(before.local)).toBe(true);
+    expect(after.committed).toStrictEqual(before.committed);
+    expect(after.local).toStrictEqual(before.local);
   });
 
   it("rejects a different loopback origin port without writing config files", async () => {
@@ -120,8 +121,35 @@ describe("POST /api/config", () => {
     const after = await readConfigBytes();
 
     expect(response.status).toBe(403);
-    expect(after.committed.equals(before.committed)).toBe(true);
-    expect(after.local.equals(before.local)).toBe(true);
+    expect(after.committed).toStrictEqual(before.committed);
+    expect(after.local).toStrictEqual(before.local);
+  });
+
+  it("rejects origins with credentials or extra URL components", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+    const before = await readConfigBytes();
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://user@127.0.0.1:${serverPort()}/path`,
+        },
+        body: JSON.stringify({ changes: { tracker: "jira" } }),
+      }
+    );
+    const after = await readConfigBytes();
+
+    expect(response.status).toBe(403);
+    expect(after.committed).toStrictEqual(before.committed);
+    expect(after.local).toStrictEqual(before.local);
   });
 
   it("rejects malformed write payloads before touching config files", async () => {
@@ -149,8 +177,40 @@ describe("POST /api/config", () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toContain("empty path segment");
-    expect(after.committed.equals(before.committed)).toBe(true);
-    expect(after.local.equals(before.local)).toBe(true);
+    expect(after.committed).toStrictEqual(before.committed);
+    expect(after.local).toStrictEqual(before.local);
+  });
+
+  it("rejects sparse writes when the committed config is malformed", async () => {
+    await writeFile(path.join(resources.dir, CONFIG_FILE), "{bad json");
+    await writeJson(path.join(resources.dir, LOCAL_CONFIG_FILE), {
+      github: { repo: PRIVATE_LOCAL_REPO },
+    });
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+    const before = await readConfigBytes();
+
+    const response = await fetch(
+      `http://127.0.0.1:${serverPort()}/api/config`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://127.0.0.1:${serverPort()}`,
+        },
+        body: JSON.stringify({ changes: { tracker: "linear" } }),
+      }
+    );
+    const body = (await response.json()) as { error: string };
+    const after = await readConfigBytes();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Unable to write Lisa config");
+    expect(after.committed).toStrictEqual(before.committed);
+    expect(after.local).toStrictEqual(before.local);
   });
 
   it("accepts a same-origin sparse config write", async () => {
@@ -190,8 +250,54 @@ describe("POST /api/config", () => {
 
     expect(response.status).toBe(200);
     expect(result.ok).toBe(true);
-    expect(committed.tracker).toBe("linear");
-    expect(committed.quality.testCoverage.global.statements).toBe(80);
-    expect(local.github.repo).toBe(PRIVATE_LOCAL_REPO);
+    expect(committed).toEqual({
+      tracker: "linear",
+      quality: { testCoverage: { global: { statements: 80 } } },
+    });
+    expect(local).toEqual({ github: { repo: PRIVATE_LOCAL_REPO } });
+  });
+
+  it("serializes concurrent sparse writes so changes are not lost", async () => {
+    await writeConfigPair();
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      { probes: [] }
+    );
+
+    const [trackerResponse, thresholdResponse] = await Promise.all([
+      fetch(`http://127.0.0.1:${serverPort()}/api/config`, {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://127.0.0.1:${serverPort()}`,
+        },
+        body: JSON.stringify({ changes: { tracker: "linear" } }),
+      }),
+      fetch(`http://127.0.0.1:${serverPort()}/api/config`, {
+        method: "POST",
+        headers: {
+          "content-type": CONTENT_TYPE_JSON,
+          origin: `http://127.0.0.1:${serverPort()}`,
+        },
+        body: JSON.stringify({
+          changes: { "quality.testCoverage.global.statements": 81 },
+        }),
+      }),
+    ]);
+    const committed = JSON.parse(
+      await readFile(path.join(resources.dir, CONFIG_FILE), "utf8")
+    ) as {
+      tracker: string;
+      quality: { testCoverage: { global: { statements: number } } };
+    };
+
+    expect([trackerResponse.status, thresholdResponse.status]).toEqual([
+      200, 200,
+    ]);
+    expect(committed).toEqual({
+      tracker: "linear",
+      quality: { testCoverage: { global: { statements: 81 } } },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `POST /api/config` for sparse dot-path writes to `.lisa.config.json` from `lisa ui`.
- Requires exact same-origin `http://127.0.0.1:<port>` Origin/Host matching and keeps the server bound to `127.0.0.1`.
- Validates the whole payload before writing so rejected requests leave `.lisa.config.json` and `.lisa.config.local.json` byte-identical.

Fixes #1508

## Verification

- `bun test tests/unit/cli/ui-cmd.test.ts tests/unit/cli/ui-config-write.test.ts tests/unit/cli/ui-status-http-edge.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check src/cli/ui-config-write.ts tests/unit/cli/ui-config-write.test.ts`
- `bun run build:dist`
- `bun run check:plugins`
- `bun run check:workflow-inputs`
- `bun run knip:check`
- pre-push hook: security audit, slow lint, `knip`, coverage unit tests, integration tests
- Live CLI replay: `node dist/index.js ui /tmp/lisa-ui-write-final-OiCc5c --port 4794 --no-sync`; verified `lsof` bind on `127.0.0.1:4794`, forged non-loopback Origin 403 + byte-identical config checksums, different loopback port Origin 403 + byte-identical config checksums, malformed same-origin payload 400 + byte-identical config checksums, and browser same-origin `fetch('/api/config')` 200 updating only `.lisa.config.json`.

Note: a broad raw `bun test` run still collects Playwright `test()` files and errors with “Playwright Test did not expect test() to be called here”; the repo pre-push hook uses the passing Vitest unit/integration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local UI endpoint for saving updates to the project’s committed configuration.
  * Supports secure same-origin writes with validation for malformed or unsafe settings.
  * Returns the updated configuration after successful changes.

* **Bug Fixes**
  * Prevents unauthorized origins, invalid requests, and oversized or malformed configuration data from being written.

* **Tests**
  * Added coverage for successful updates and rejected requests, confirming configuration files remain unchanged when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->