### PR TITLE
feat(qa): human-QA acceptance skill family

### DIFF
--- a/plugins/lisa-agy/commands/lisa/qa-checklist.md
+++ b/plugins/lisa-agy/commands/lisa/qa-checklist.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the current manual regression checklist: curated journeys minus live automated E2E coverage, in plain language."
+argument-hint: ""
+---
+
+Use the /lisa-qa-checklist skill to serve the manual regression checklist. $ARGUMENTS

--- a/plugins/lisa-agy/commands/lisa/qa-clear.md
+++ b/plugins/lisa-agy/commands/lisa/qa-clear.md
@@ -1,0 +1,6 @@
+---
+description: "Bulk-move QA-queue tickets scoped entirely to non-user-facing repos to the configured certified status, with an auditable moved-list report."
+argument-hint: ""
+---
+
+Use the /lisa-qa-clear skill to clear non-human-verifiable tickets from the QA queue. $ARGUMENTS

--- a/plugins/lisa-agy/commands/lisa/qa-fail.md
+++ b/plugins/lisa-agy/commands/lisa/qa-fail.md
@@ -1,0 +1,6 @@
+---
+description: "File a QA failure: find the right ticket (never a duplicate), write the structured failure report, diagnose the expectation gap, label qa-fail, and return the ticket to build-ready."
+argument-hint: "[ticket-key] <what you saw, in your own words>"
+---
+
+Use the /lisa-qa-fail skill to file this QA failure. $ARGUMENTS

--- a/plugins/lisa-agy/commands/lisa/qa-queue.md
+++ b/plugins/lisa-agy/commands/lisa/qa-queue.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the next ticket awaiting QA verdict as a plain-language acceptance brief; record pass (→ certified) or fail (→ structured report via lisa-qa-fail)."
+argument-hint: "[pass | fail <description> | next]"
+---
+
+Use the /lisa-qa-queue skill to serve the QA acceptance queue. $ARGUMENTS

--- a/plugins/lisa-agy/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/lisa-agy/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual regression checklist to a human QA tester. Reads the project's curated journey list, cross-references it against what the automated suites (Playwright web E2E, Maestro native E2E) actually cover by scanning the spec files, and serves only the journeys that still need human eyes — each as plain-language steps. Keeps a single source of truth so testers never work from a stale personal copy, and shrinks automatically as automated coverage grows."
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/lisa-agy/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA tester cannot verify. Finds tickets in the configured QA queue status that are scoped entirely to non-user-facing repos (API/backend services, infrastructure) — where QA has only end-user access and nothing observable to test — and transitions them to the configured certified status, reporting the moved list for the record. Runnable from any coding agent as a single instruction like 'move all backend- and infrastructure-only tickets from the QA queue to certified'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/lisa-agy/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/lisa-agy/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door. Takes a human tester's plain-language failure description, finds the right ticket (the served ticket, or the original via duplicate-discovery when the report arrives untied), writes the structured failure report (repro / expected vs. actual / which acceptance criterion failed), diagnoses the EXPECTATION GAP — why the implementing agent's done-evidence said done when QA says it isn't — applies the qa-fail label that makes lisa-rework-triage detection deterministic, and transitions the ticket back to the build-ready status. QA never words a ticket again; agents never guess what QA meant."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/lisa-agy/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/lisa-agy/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human testers. Serves the next ticket awaiting QA verdict from the configured QA queue status as a plain-language acceptance brief — what the ticket promises, how to exercise it on the QA environment, in words a non-technical tester can follow. On 'pass', transitions the ticket to the configured certified status. On 'fail', delegates to lisa-qa-fail for the structured failure report, expectation-gap diagnosis, and return to the build-ready status. The conversational front door for human QA acceptance on any coding agent: testers say 'what's the next item?' / 'pass' / 'fail — here's what I saw'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/plugins/lisa-copilot/commands/lisa/qa-checklist.md
+++ b/plugins/lisa-copilot/commands/lisa/qa-checklist.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the current manual regression checklist: curated journeys minus live automated E2E coverage, in plain language."
+argument-hint: ""
+---
+
+Use the /lisa-qa-checklist skill to serve the manual regression checklist. $ARGUMENTS

--- a/plugins/lisa-copilot/commands/lisa/qa-clear.md
+++ b/plugins/lisa-copilot/commands/lisa/qa-clear.md
@@ -1,0 +1,6 @@
+---
+description: "Bulk-move QA-queue tickets scoped entirely to non-user-facing repos to the configured certified status, with an auditable moved-list report."
+argument-hint: ""
+---
+
+Use the /lisa-qa-clear skill to clear non-human-verifiable tickets from the QA queue. $ARGUMENTS

--- a/plugins/lisa-copilot/commands/lisa/qa-fail.md
+++ b/plugins/lisa-copilot/commands/lisa/qa-fail.md
@@ -1,0 +1,6 @@
+---
+description: "File a QA failure: find the right ticket (never a duplicate), write the structured failure report, diagnose the expectation gap, label qa-fail, and return the ticket to build-ready."
+argument-hint: "[ticket-key] <what you saw, in your own words>"
+---
+
+Use the /lisa-qa-fail skill to file this QA failure. $ARGUMENTS

--- a/plugins/lisa-copilot/commands/lisa/qa-queue.md
+++ b/plugins/lisa-copilot/commands/lisa/qa-queue.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the next ticket awaiting QA verdict as a plain-language acceptance brief; record pass (→ certified) or fail (→ structured report via lisa-qa-fail)."
+argument-hint: "[pass | fail <description> | next]"
+---
+
+Use the /lisa-qa-queue skill to serve the QA acceptance queue. $ARGUMENTS

--- a/plugins/lisa-copilot/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/lisa-copilot/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual regression checklist to a human QA tester. Reads the project's curated journey list, cross-references it against what the automated suites (Playwright web E2E, Maestro native E2E) actually cover by scanning the spec files, and serves only the journeys that still need human eyes — each as plain-language steps. Keeps a single source of truth so testers never work from a stale personal copy, and shrinks automatically as automated coverage grows."
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/lisa-copilot/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA tester cannot verify. Finds tickets in the configured QA queue status that are scoped entirely to non-user-facing repos (API/backend services, infrastructure) — where QA has only end-user access and nothing observable to test — and transitions them to the configured certified status, reporting the moved list for the record. Runnable from any coding agent as a single instruction like 'move all backend- and infrastructure-only tickets from the QA queue to certified'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/lisa-copilot/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/lisa-copilot/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door. Takes a human tester's plain-language failure description, finds the right ticket (the served ticket, or the original via duplicate-discovery when the report arrives untied), writes the structured failure report (repro / expected vs. actual / which acceptance criterion failed), diagnoses the EXPECTATION GAP — why the implementing agent's done-evidence said done when QA says it isn't — applies the qa-fail label that makes lisa-rework-triage detection deterministic, and transitions the ticket back to the build-ready status. QA never words a ticket again; agents never guess what QA meant."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/lisa-copilot/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/lisa-copilot/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human testers. Serves the next ticket awaiting QA verdict from the configured QA queue status as a plain-language acceptance brief — what the ticket promises, how to exercise it on the QA environment, in words a non-technical tester can follow. On 'pass', transitions the ticket to the configured certified status. On 'fail', delegates to lisa-qa-fail for the structured failure report, expectation-gap diagnosis, and return to the build-ready status. The conversational front door for human QA acceptance on any coding agent: testers say 'what's the next item?' / 'pass' / 'fail — here's what I saw'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/plugins/lisa-cursor/commands/lisa/qa-checklist.md
+++ b/plugins/lisa-cursor/commands/lisa/qa-checklist.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the current manual regression checklist: curated journeys minus live automated E2E coverage, in plain language."
+argument-hint: ""
+---
+
+Use the /lisa-qa-checklist skill to serve the manual regression checklist. $ARGUMENTS

--- a/plugins/lisa-cursor/commands/lisa/qa-clear.md
+++ b/plugins/lisa-cursor/commands/lisa/qa-clear.md
@@ -1,0 +1,6 @@
+---
+description: "Bulk-move QA-queue tickets scoped entirely to non-user-facing repos to the configured certified status, with an auditable moved-list report."
+argument-hint: ""
+---
+
+Use the /lisa-qa-clear skill to clear non-human-verifiable tickets from the QA queue. $ARGUMENTS

--- a/plugins/lisa-cursor/commands/lisa/qa-fail.md
+++ b/plugins/lisa-cursor/commands/lisa/qa-fail.md
@@ -1,0 +1,6 @@
+---
+description: "File a QA failure: find the right ticket (never a duplicate), write the structured failure report, diagnose the expectation gap, label qa-fail, and return the ticket to build-ready."
+argument-hint: "[ticket-key] <what you saw, in your own words>"
+---
+
+Use the /lisa-qa-fail skill to file this QA failure. $ARGUMENTS

--- a/plugins/lisa-cursor/commands/lisa/qa-queue.md
+++ b/plugins/lisa-cursor/commands/lisa/qa-queue.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the next ticket awaiting QA verdict as a plain-language acceptance brief; record pass (→ certified) or fail (→ structured report via lisa-qa-fail)."
+argument-hint: "[pass | fail <description> | next]"
+---
+
+Use the /lisa-qa-queue skill to serve the QA acceptance queue. $ARGUMENTS

--- a/plugins/lisa-cursor/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/lisa-cursor/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual regression checklist to a human QA tester. Reads the project's curated journey list, cross-references it against what the automated suites (Playwright web E2E, Maestro native E2E) actually cover by scanning the spec files, and serves only the journeys that still need human eyes — each as plain-language steps. Keeps a single source of truth so testers never work from a stale personal copy, and shrinks automatically as automated coverage grows."
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/lisa-cursor/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA tester cannot verify. Finds tickets in the configured QA queue status that are scoped entirely to non-user-facing repos (API/backend services, infrastructure) — where QA has only end-user access and nothing observable to test — and transitions them to the configured certified status, reporting the moved list for the record. Runnable from any coding agent as a single instruction like 'move all backend- and infrastructure-only tickets from the QA queue to certified'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/lisa-cursor/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/lisa-cursor/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door. Takes a human tester's plain-language failure description, finds the right ticket (the served ticket, or the original via duplicate-discovery when the report arrives untied), writes the structured failure report (repro / expected vs. actual / which acceptance criterion failed), diagnoses the EXPECTATION GAP — why the implementing agent's done-evidence said done when QA says it isn't — applies the qa-fail label that makes lisa-rework-triage detection deterministic, and transitions the ticket back to the build-ready status. QA never words a ticket again; agents never guess what QA meant."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/lisa-cursor/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/lisa-cursor/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human testers. Serves the next ticket awaiting QA verdict from the configured QA queue status as a plain-language acceptance brief — what the ticket promises, how to exercise it on the QA environment, in words a non-technical tester can follow. On 'pass', transitions the ticket to the configured certified status. On 'fail', delegates to lisa-qa-fail for the structured failure report, expectation-gap diagnosis, and return to the build-ready status. The conversational front door for human QA acceptance on any coding agent: testers say 'what's the next item?' / 'pass' / 'fail — here's what I saw'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual…"
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-checklist/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Checklist"
+short_description: "Serve the current manual…"
+default_prompt:
+  - "Use $lisa-qa-checklist: Serve the current manual…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA…"
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-clear/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Clear"
+short_description: "Bulk-clear tickets a human QA…"
+default_prompt:
+  - "Use $lisa-qa-clear: Bulk-clear tickets a human QA…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door"
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-fail/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Fail"
+short_description: "QA failure front door"
+default_prompt:
+  - "Use $lisa-qa-fail: QA failure front door."

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human…"
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/lisa/.codex-plugin/skills/lisa-qa-queue/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-qa-queue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Queue"
+short_description: "QA acceptance queue for human…"
+default_prompt:
+  - "Use $lisa-qa-queue: QA acceptance queue for human…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/plugins/lisa/commands/qa-checklist.md
+++ b/plugins/lisa/commands/qa-checklist.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the current manual regression checklist: curated journeys minus live automated E2E coverage, in plain language."
+argument-hint: ""
+---
+
+Use the /lisa-qa-checklist skill to serve the manual regression checklist. $ARGUMENTS

--- a/plugins/lisa/commands/qa-clear.md
+++ b/plugins/lisa/commands/qa-clear.md
@@ -1,0 +1,6 @@
+---
+description: "Bulk-move QA-queue tickets scoped entirely to non-user-facing repos to the configured certified status, with an auditable moved-list report."
+argument-hint: ""
+---
+
+Use the /lisa-qa-clear skill to clear non-human-verifiable tickets from the QA queue. $ARGUMENTS

--- a/plugins/lisa/commands/qa-fail.md
+++ b/plugins/lisa/commands/qa-fail.md
@@ -1,0 +1,6 @@
+---
+description: "File a QA failure: find the right ticket (never a duplicate), write the structured failure report, diagnose the expectation gap, label qa-fail, and return the ticket to build-ready."
+argument-hint: "[ticket-key] <what you saw, in your own words>"
+---
+
+Use the /lisa-qa-fail skill to file this QA failure. $ARGUMENTS

--- a/plugins/lisa/commands/qa-queue.md
+++ b/plugins/lisa/commands/qa-queue.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the next ticket awaiting QA verdict as a plain-language acceptance brief; record pass (→ certified) or fail (→ structured report via lisa-qa-fail)."
+argument-hint: "[pass | fail <description> | next]"
+---
+
+Use the /lisa-qa-queue skill to serve the QA acceptance queue. $ARGUMENTS

--- a/plugins/lisa/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/lisa/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual regression checklist to a human QA tester. Reads the project's curated journey list, cross-references it against what the automated suites (Playwright web E2E, Maestro native E2E) actually cover by scanning the spec files, and serves only the journeys that still need human eyes — each as plain-language steps. Keeps a single source of truth so testers never work from a stale personal copy, and shrinks automatically as automated coverage grows."
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/lisa/skills/lisa-qa-checklist/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-qa-checklist/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Checklist"
+short_description: "Serve the current manual regression checklist to a human QA tester"
+default_prompt:
+  - "Use $lisa-qa-checklist: Serve the current manual regression checklist to a human QA tester."

--- a/plugins/lisa/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA tester cannot verify. Finds tickets in the configured QA queue status that are scoped entirely to non-user-facing repos (API/backend services, infrastructure) — where QA has only end-user access and nothing observable to test — and transitions them to the configured certified status, reporting the moved list for the record. Runnable from any coding agent as a single instruction like 'move all backend- and infrastructure-only tickets from the QA queue to certified'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/lisa/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/lisa/skills/lisa-qa-clear/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-qa-clear/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Clear"
+short_description: "Bulk-clear tickets a human QA tester cannot verify"
+default_prompt:
+  - "Use $lisa-qa-clear: Bulk-clear tickets a human QA tester cannot verify."

--- a/plugins/lisa/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door. Takes a human tester's plain-language failure description, finds the right ticket (the served ticket, or the original via duplicate-discovery when the report arrives untied), writes the structured failure report (repro / expected vs. actual / which acceptance criterion failed), diagnoses the EXPECTATION GAP — why the implementing agent's done-evidence said done when QA says it isn't — applies the qa-fail label that makes lisa-rework-triage detection deterministic, and transitions the ticket back to the build-ready status. QA never words a ticket again; agents never guess what QA meant."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/lisa/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/lisa/skills/lisa-qa-fail/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-qa-fail/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Fail"
+short_description: "QA failure front door"
+default_prompt:
+  - "Use $lisa-qa-fail: QA failure front door."

--- a/plugins/lisa/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/lisa/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human testers. Serves the next ticket awaiting QA verdict from the configured QA queue status as a plain-language acceptance brief — what the ticket promises, how to exercise it on the QA environment, in words a non-technical tester can follow. On 'pass', transitions the ticket to the configured certified status. On 'fail', delegates to lisa-qa-fail for the structured failure report, expectation-gap diagnosis, and return to the build-ready status. The conversational front door for human QA acceptance on any coding agent: testers say 'what's the next item?' / 'pass' / 'fail — here's what I saw'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/lisa/skills/lisa-qa-queue/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-qa-queue/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "QA Queue"
+short_description: "QA acceptance queue for human testers"
+default_prompt:
+  - "Use $lisa-qa-queue: QA acceptance queue for human testers."

--- a/plugins/lisa/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/plugins/src/base/commands/qa-checklist.md
+++ b/plugins/src/base/commands/qa-checklist.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the current manual regression checklist: curated journeys minus live automated E2E coverage, in plain language."
+argument-hint: ""
+---
+
+Use the /lisa-qa-checklist skill to serve the manual regression checklist. $ARGUMENTS

--- a/plugins/src/base/commands/qa-clear.md
+++ b/plugins/src/base/commands/qa-clear.md
@@ -1,0 +1,6 @@
+---
+description: "Bulk-move QA-queue tickets scoped entirely to non-user-facing repos to the configured certified status, with an auditable moved-list report."
+argument-hint: ""
+---
+
+Use the /lisa-qa-clear skill to clear non-human-verifiable tickets from the QA queue. $ARGUMENTS

--- a/plugins/src/base/commands/qa-fail.md
+++ b/plugins/src/base/commands/qa-fail.md
@@ -1,0 +1,6 @@
+---
+description: "File a QA failure: find the right ticket (never a duplicate), write the structured failure report, diagnose the expectation gap, label qa-fail, and return the ticket to build-ready."
+argument-hint: "[ticket-key] <what you saw, in your own words>"
+---
+
+Use the /lisa-qa-fail skill to file this QA failure. $ARGUMENTS

--- a/plugins/src/base/commands/qa-queue.md
+++ b/plugins/src/base/commands/qa-queue.md
@@ -1,0 +1,6 @@
+---
+description: "Serve the next ticket awaiting QA verdict as a plain-language acceptance brief; record pass (→ certified) or fail (→ structured report via lisa-qa-fail)."
+argument-hint: "[pass | fail <description> | next]"
+---
+
+Use the /lisa-qa-queue skill to serve the QA acceptance queue. $ARGUMENTS

--- a/plugins/src/base/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-checklist/SKILL.md
@@ -20,11 +20,15 @@ moment the tester asks.
    blocks, write the draft, and ask the operator to curate it once. Never invent
    journeys silently.
 2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
-   locate via the project's e2e/test directories). A journey counts as covered only when
-   its `automation:` line names a spec file that exists AND is not skipped
-   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
-   silently un-covers its journey — that is exactly the regression this check exists to
-   catch; call it out loudly.
+   locate via the project's e2e/test directories). An `automation:` line must name BOTH
+   the spec file and the specific test within it (the Playwright `describe`/`test` title
+   or Maestro flow name): `automation: <spec-path> :: <test-or-flow-name>`. A journey
+   counts as covered only when that spec file exists, the named test/flow is present in
+   it, and it is not skipped (`test.skip`, commented-out flow, or excluded from CI). A
+   file-only line, a named test that no longer matches, or any ambiguous mapping is
+   treated as **uncovered** — a live filename proves nothing about what the spec
+   exercises. A deleted, renamed, or skipped test silently un-covers its journey — the
+   very regression this check exists to catch; call it out loudly.
 
 ## Serving the sweep
 
@@ -50,8 +54,9 @@ can resume mid-sweep.
   (this skill may apply the edit on request; it is a repo file, so changes ride normal
   review).
 - When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
-  `automation:` line — on request this skill locates the covering spec and writes the
-  line itself.
+  `automation: <spec-path> :: <test-or-flow-name>` line — on request this skill locates
+  the covering spec and test, confirms the named test actually drives the journey's
+  steps, and writes the line itself.
 - Never maintain per-tester copies; the file is the single source of truth and the
   computed view is always derived fresh.
 

--- a/plugins/src/base/skills/lisa-qa-checklist/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lisa-qa-checklist
+description: "Serve the current manual regression checklist to a human QA tester. Reads the project's curated journey list, cross-references it against what the automated suites (Playwright web E2E, Maestro native E2E) actually cover by scanning the spec files, and serves only the journeys that still need human eyes — each as plain-language steps. Keeps a single source of truth so testers never work from a stale personal copy, and shrinks automatically as automated coverage grows."
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "Write", "Edit"]
+---
+
+# QA Checklist: $ARGUMENTS
+
+The manual regression sweep exists to catch what automation does not. Its checklist must
+therefore be computed, not remembered: curated journeys minus automated coverage, at the
+moment the tester asks.
+
+## Sources
+
+1. **Curated journey list** — `qa.checklistFile` in `.lisa.config.json`, default
+   `.lisa/qa-checklist.md`. Format: one `## Journey: <name>` section per user journey,
+   with plain-language steps and an optional `automation:` line naming the covering spec
+   file(s) once one exists. If the file does not exist, offer to bootstrap it: derive
+   candidate journeys from the app's route map and the existing E2E suites' describe
+   blocks, write the draft, and ask the operator to curate it once. Never invent
+   journeys silently.
+2. **Automated coverage** — scan the repo's E2E suites (Playwright specs, Maestro flows;
+   locate via the project's e2e/test directories). A journey counts as covered only when
+   its `automation:` line names a spec file that exists AND is not skipped
+   (`test.skip`, commented-out flow, or excluded from CI). A deleted or skipped spec
+   silently un-covers its journey — that is exactly the regression this check exists to
+   catch; call it out loudly.
+
+## Serving the sweep
+
+Present two lists, human-first:
+
+```text
+## Manual sweep — <n> journeys need your eyes
+1. <Journey name> — <plain-language steps>
+   Why manual: <no automation | automation skipped/stale: <spec>>
+...
+
+## Covered by automation — <n> journeys (skim, don't re-test)
+- <Journey name> — <spec file> (<playwright|maestro>)
+```
+
+Rules for the served text: steps an intern can follow, no spec-file jargon in the manual
+section beyond the "why manual" line, and stable journey ordering (file order) so testers
+can resume mid-sweep.
+
+## Maintaining the list
+
+- Tester or operator adds/edits journeys in plain language → edit the checklist file
+  (this skill may apply the edit on request; it is a repo file, so changes ride normal
+  review).
+- When a journey gains automation (e.g. `lisa-codify-verification` lands a spec), add its
+  `automation:` line — on request this skill locates the covering spec and writes the
+  line itself.
+- Never maintain per-tester copies; the file is the single source of truth and the
+  computed view is always derived fresh.
+
+## Rules
+
+- Coverage claims must point at an existing, non-skipped spec — "there's a test somewhere"
+  does not count.
+- Serving is read-only by default; file edits happen only on explicit request.
+- If the automated-coverage scan finds specs exercising a journey that is missing from
+  the curated list entirely, surface it as a suggested addition — the human curates, the
+  skill proposes.

--- a/plugins/src/base/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-clear/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lisa-qa-clear
+description: "Bulk-clear tickets a human QA tester cannot verify. Finds tickets in the configured QA queue status that are scoped entirely to non-user-facing repos (API/backend services, infrastructure) — where QA has only end-user access and nothing observable to test — and transitions them to the configured certified status, reporting the moved list for the record. Runnable from any coding agent as a single instruction like 'move all backend- and infrastructure-only tickets from the QA queue to certified'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Clear: $ARGUMENTS
+
+Human QA can only judge what a user can see. Tickets whose entire scope is a
+non-user-facing repo were already verified by the automated lifecycle before reaching the
+QA queue; holding them for a human who cannot observe them is pure queue noise. Clear
+them in one auditable batch.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to
+  `jira.workflow.done.staging`.
+- **Certified status** — `jira.workflow.qa.certified`. Required; if missing, stop and
+  instruct the operator — never guess a terminal status.
+- **Tracker dispatch** — `tracker` decides the surface as everywhere; on GitHub or
+  Linear the status names above map to the equivalent labels/states.
+- **Non-user-facing repos** — `qa.nonUserFacingRepos` (array of repo names, e.g.
+  `["api", "infrastructure"]`). If the key is missing, derive a proposal from
+  the project registry (repos with no UI framework signals — no expo/react/native/web
+  app surface) and **present it for operator confirmation before moving anything**; never
+  bulk-transition on an unconfirmed inference. Recommend persisting the confirmed list to
+  the config.
+
+## Procedure
+
+1. Query all tickets in the QA queue status.
+2. Classify each by repo scope, in order:
+   - `repo:<name>` label or matching component → that repo.
+   - Unlabeled → determine the repo from the ticket content (description, AC, technical
+     approach) exactly as build-intake's repo-scope gate does, and stamp the
+     `repo:<name>` label while you're there so the next sweep is cheap.
+   - Undeterminable → leave in place; flag for the operator.
+3. Partition:
+   - **Every** touched repo is non-user-facing → eligible to clear.
+   - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
+     human pass via `lisa-qa-queue`.
+4. For each eligible ticket: transition to the certified status and post
+   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
+   end-user access. Verified by the automated lifecycle pre-promotion.`
+5. Report the batch:
+
+```text
+## QA Clear — <date>
+Moved to <certified>: <n> (<KEY-1>, <KEY-2>, …) — repo per ticket
+Left in queue (user-facing): <n>
+Left in queue (undeterminable repo — needs operator): <keys or none>
+```
+
+The operator (or tester) reviews the moved list; anything that "sounds user-facing" can
+be pulled back with a single instruction — the transition is reversible and the comment
+marks exactly what was auto-cleared.
+
+## Rules
+
+- Never clear a mixed-scope ticket — partial human-verifiability means human QA.
+- Never bulk-move on an inferred repo list without explicit operator confirmation.
+- Every cleared ticket carries the audit comment; a transition without the comment is a
+  bug in this procedure.
+- Idempotent: tickets already in the certified status, or already carrying this sweep's
+  `[lisa-qa-clear]` comment, are skipped silently.

--- a/plugins/src/base/skills/lisa-qa-clear/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-clear/SKILL.md
@@ -41,9 +41,14 @@ Read `.lisa.config.json`:
    - **Every** touched repo is non-user-facing → eligible to clear.
    - Any user-facing repo in scope (including mixed-scope) → stays in the queue for the
      human pass via `lisa-qa-queue`.
-4. For each eligible ticket: transition to the certified status and post
-   `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable with
-   end-user access. Verified by the automated lifecycle pre-promotion.`
+4. For each eligible ticket, in this order — the pairing must be failure-safe:
+   1. Post the audit comment first:
+      `[lisa-qa-clear] Certified without human QA: scope is <repo(s)>, not observable
+      with end-user access. Verified by the automated lifecycle pre-promotion.`
+   2. Then transition to the certified status.
+   3. Verify both halves landed before counting the ticket as moved. A comment without
+      the transition, or a transition without the comment, is a **partial** — report it
+      as such, never as completed.
 5. Report the batch:
 
 ```text
@@ -63,5 +68,7 @@ marks exactly what was auto-cleared.
 - Never bulk-move on an inferred repo list without explicit operator confirmation.
 - Every cleared ticket carries the audit comment; a transition without the comment is a
   bug in this procedure.
-- Idempotent: tickets already in the certified status, or already carrying this sweep's
-  `[lisa-qa-clear]` comment, are skipped silently.
+- Idempotent by repair, not by skip: a ticket is complete only when it has BOTH the
+  `[lisa-qa-clear]` comment AND the certified status. Re-runs finish partials — comment
+  present but not certified → transition it; certified but no comment → post the
+  comment. Only fully-complete tickets are skipped silently.

--- a/plugins/src/base/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-fail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: lisa-qa-fail
+description: "QA failure front door. Takes a human tester's plain-language failure description, finds the right ticket (the served ticket, or the original via duplicate-discovery when the report arrives untied), writes the structured failure report (repro / expected vs. actual / which acceptance criterion failed), diagnoses the EXPECTATION GAP — why the implementing agent's done-evidence said done when QA says it isn't — applies the qa-fail label that makes lisa-rework-triage detection deterministic, and transitions the ticket back to the build-ready status. QA never words a ticket again; agents never guess what QA meant."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Fail: $ARGUMENTS
+
+Convert a human failure observation into the exact artifact the fixing agent needs. Two
+inputs arrive together or the report cannot be filed: a **target ticket** and the
+**tester's verbatim description** (what they did, what they expected, what happened,
+plus any screenshots).
+
+## Phase 1 — Resolve the target ticket
+
+- **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
+- **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
+  write, reusing the mandatory relationship-discovery searches from the tracker write
+  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
+  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  covers it, that ticket is the target — update it, never file a twin. Only when the
+  search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
+  the full quality gates) and treat it as the target. Report which path was taken.
+
+## Phase 2 — Structured failure report
+
+Fetch the bundle via `lisa-tracker-read`. Post one comment:
+
+```text
+[lisa-qa-fail] QA failure — <one-line summary>
+Reported by: <tester> on <date>, against <environment>
+Steps to reproduce: <numbered, from the tester's words>
+Expected: <what the ticket/AC promised, quoted or paraphrased faithfully>
+Actual: <what the tester observed, verbatim where possible>
+Failed acceptance criterion: <AC number/text from the ticket — or "not covered by any AC" (see gap)>
+Attachments: <screenshots if provided>
+```
+
+Preserve the tester's language in `Actual` — their words are the evidence; your job is
+structure, not rewording.
+
+## Phase 3 — Expectation-gap diagnosis
+
+Answer explicitly: **why did the implementing agent believe this was done?** Locate the
+prior cycle's done-evidence — the build-evidence comment (`lisa-tracker-evidence` output),
+the merged PR's verification section, and any codified regression test — and compare it
+against the failure. Classify the gap (exactly one):
+
+| Gap | Meaning |
+|-----|---------|
+| `ac-mismatch` | The evidence verified a different reading of the AC than QA's — the criterion is ambiguous or the ticket distorted it. |
+| `verification-weakness` | The evidence never actually exercised the failing path (asserted adjacent behavior, mocked the surface, or skipped the step). |
+| `environment-difference` | Verified where it works (e.g. dev) but fails on the QA environment — config, data, or deployment drift. |
+| `data-difference` | Behavior depends on data present in one environment and absent in the other. |
+| `regression-since-merge` | The evidence was genuinely valid when produced; later merges broke it. |
+| `not-covered-by-ac` | QA's expectation is real but no AC promises it — a spec gap, not an implementation failure. |
+
+Append to the same comment:
+
+```text
+Expectation gap: <classification>
+Why the agent thought it was done: <2-3 lines citing the specific evidence artifact>
+```
+
+If no done-evidence exists at all, say so — `Expectation gap: no-evidence-found` is
+itself a serious finding (the verification lifecycle was skipped) and must be surfaced,
+not smoothed over.
+
+For `not-covered-by-ac`, do NOT transition the ticket — the spec question goes to the
+human product gate. Flag it in the response and stop after posting.
+
+## Phase 4 — Label and transition
+
+1. Apply the `qa-fail` label — this is the deterministic rework signal `lisa-rework-triage`
+   keys on at next claim, and the gap classification above becomes its primary evidence.
+2. Transition the ticket to the build-ready status (`jira.workflow.ready`, or the
+   configured tracker's equivalent ready label/state when `tracker` is GitHub or
+   Linear). The rework loop takes it from here: intake claims it, `lisa-ticket-triage` Phase 2.5 runs
+   `lisa-rework-triage`, and the fix proceeds with full context.
+3. Confirm to the tester in one plain sentence: what was recorded, and that the fix is
+   queued — no further action needed from them.
+
+## Rules
+
+- Never file a new ticket without the documented duplicate search (Phase 1).
+- Never paraphrase away the tester's observation; structure around it.
+- One `[lisa-qa-fail]` comment per failure event — if the same tester reports the same
+  failure again before a fix ships, add a short "seen again <date>" line to the existing
+  comment instead of a new block.
+- The expectation gap must cite a specific evidence artifact or say `no-evidence-found` —
+  a gap classification without a citation is a guess, and guesses are worse than
+  `no-evidence-found`.

--- a/plugins/src/base/skills/lisa-qa-fail/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-fail/SKILL.md
@@ -15,9 +15,9 @@ plus any screenshots).
 
 - **Tied report** (invoked from `lisa-qa-queue` with a key): use it.
 - **Untied report** ("I found something broken: …"): run duplicate-discovery BEFORE any
-  write, reusing the mandatory relationship-discovery searches from the tracker write
-  path (`lisa-jira-write-ticket` Phase 4 semantics): search open and recently-closed
-  tickets in the affected area, and the current QA-queue set. If an existing ticket
+  write, reusing the mandatory relationship-discovery searches defined by the configured
+  tracker's write skill (dispatched through `lisa-tracker-write`): search open and
+  recently-closed tickets in the affected area, and the current QA-queue set. If an existing ticket
   covers it, that ticket is the target — update it, never file a twin. Only when the
   search documents no match, create a new Bug via `lisa-tracker-write` (which enforces
   the full quality gates) and treat it as the target. Report which path was taken.

--- a/plugins/src/base/skills/lisa-qa-queue/SKILL.md
+++ b/plugins/src/base/skills/lisa-qa-queue/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: lisa-qa-queue
+description: "QA acceptance queue for human testers. Serves the next ticket awaiting QA verdict from the configured QA queue status as a plain-language acceptance brief — what the ticket promises, how to exercise it on the QA environment, in words a non-technical tester can follow. On 'pass', transitions the ticket to the configured certified status. On 'fail', delegates to lisa-qa-fail for the structured failure report, expectation-gap diagnosis, and return to the build-ready status. The conversational front door for human QA acceptance on any coding agent: testers say 'what's the next item?' / 'pass' / 'fail — here's what I saw'."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# QA Queue: $ARGUMENTS
+
+Serve one ticket at a time to a human QA tester and record their verdict. The tester is
+assumed **non-technical**: everything you present must be readable by an intern on their
+first day — no stack traces, no jargon, no internal identifiers without explanation.
+
+## Config resolution
+
+Read `.lisa.config.json`:
+
+- **QA queue status** — `jira.workflow.qa.queue`, falling back to `jira.workflow.done.staging`
+  (whatever status the project uses for "deployed to the environment QA tests against").
+  If neither exists, stop and report the missing config.
+- **Certified status** — `jira.workflow.qa.certified` (the project's "passed QA, ships
+  with the next release" status). Required for the pass path; if missing, stop and
+  instruct the operator to add it — never guess a terminal status.
+- **Build-ready status** — `jira.workflow.ready` (fail path, via `lisa-qa-fail`).
+- **Tracker dispatch** — as everywhere: `tracker` decides JIRA / GitHub / Linear surfaces;
+  status names above map to labels/states on non-JIRA trackers.
+
+## Serving the next item
+
+1. Query the QA queue: tickets in the queue status, oldest first, excluding tickets
+   already carrying an unresolved `[lisa-qa-fail]` verdict from this sweep. Skip tickets
+   whose repo is listed in `qa.nonUserFacingRepos` — those belong to `lisa-qa-clear`,
+   not a human tester; note any encountered so the operator knows to run the clear.
+2. Fetch the full context bundle via `lisa-tracker-read` (never serve from a bare summary).
+3. Present ONE ticket as an **acceptance brief**:
+   - **What changed, in user terms** — one or two sentences, translated from the ticket's
+     stakeholder section.
+   - **How to try it** — concrete steps on the QA environment (the `exploration` /
+     Validation Journey config supplies the URL and test credentials): where to go, what
+     to click or type, which account to use.
+   - **What success looks like** — each acceptance criterion rewritten as an observable
+     check ("you should see …"), numbered so the tester can cite one on failure.
+   - **Worth poking at** — up to three edge probes drawn from the ticket's edge-case
+     triage findings, phrased as actions ("try it with an empty search box").
+4. End with: "Say **pass**, or describe what you saw if it failed."
+
+## Recording the verdict
+
+- **Pass** — transition the ticket to the certified status via the tracker access layer,
+  post a brief `[lisa-qa-queue] QA pass` comment naming who verified and when, and offer
+  the next item.
+- **Fail** — invoke `lisa-qa-fail` with the ticket key and the tester's own words
+  (verbatim — do not paraphrase away detail; attach any screenshots they provided). That
+  skill owns the failure report, the expectation-gap diagnosis, the `qa-fail` label, and
+  the transition back to build-ready. When it completes, confirm to the tester in one
+  plain sentence what was recorded and offer the next item.
+- **Unclear / can't test** — if the tester cannot exercise the ticket (missing access,
+  feature flag off, no test data), do NOT guess a verdict. Post a
+  `[lisa-qa-queue] QA blocked: <reason>` comment, leave the status untouched, flag it in
+  the session summary for the operator, and serve the next item.
+
+## Rules
+
+- One ticket at a time — never dump the queue on the tester.
+- The tester's verbatim description is evidence; preserve it exactly in whatever is posted.
+- Never transition to certified without an explicit "pass" from the tester.
+- All tracker writes go through the access layer / `lisa-qa-fail` — this skill never
+  hand-crafts tracker mutations beyond the pass transition and its comment.
+- Session summary on request ("how did we do?"): counts of passed / failed / blocked /
+  remaining in queue.

--- a/plugins/src/base/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/src/base/skills/lisa-rework-triage/SKILL.md
@@ -24,9 +24,9 @@ If none confirm, output `## Verdict: NOT_REWORK` and stop — this skill takes n
 first-attempt work.
 
 1. **Status history shows a post-implementation regression transition.** The ticket's
-   changelog contains a transition from a post-build state (the configured `claimed`, any
-   `done.*` environment state — e.g. `On Dev`, `On Stg` — or a review state) back to the
-   configured `ready` state.
+   changelog contains a transition from a post-build state (the configured `claimed`,
+   any configured `done.*` environment state, or a review state) back to the configured
+   `ready` state.
    - JIRA: fetch the changelog via the `lisa-atlassian-access` REST substrate —
      `GET /rest/api/3/issue/<KEY>/changelog` — and scan `items[].field == "status"` entries.
    - GitHub: `gh issue view <n> --json timelineItems` (or the timeline API) — scan for the

--- a/tests/unit/strategies/qa-acceptance-skills.test.ts
+++ b/tests/unit/strategies/qa-acceptance-skills.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for the human-QA acceptance skill family.
+ *
+ * These skills are the front door between a non-technical human tester and
+ * the agent lifecycle: qa-queue serves acceptance briefs and records
+ * verdicts, qa-fail converts a plain-language failure into the structured
+ * artifact the fixing agent needs (including the expectation-gap diagnosis
+ * and the qa-fail label that rework-triage keys on), qa-clear batch-certifies
+ * work a human cannot observe, and qa-checklist computes the manual
+ * regression sweep as curated-journeys-minus-automated-coverage. The
+ * contract under test is genericity (config-driven statuses and repos, no
+ * project-specific names, no single-agent assumptions) plus the safety
+ * rules that keep humans out of raw tracker mutation.
+ *
+ * Both source and generated plugin roots are asserted so a missed
+ * `bun run build:plugins` fails this suite.
+ * @module tests/unit/strategies/qa-acceptance-skills
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+const GENERATED_SKILL_ROOTS = [
+  "plugins/lisa/skills",
+  "plugins/lisa/.codex-plugin/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+const QA_QUEUE = "lisa-qa-queue";
+const QA_FAIL = "lisa-qa-fail";
+const QA_CLEAR = "lisa-qa-clear";
+const QA_CHECKLIST = "lisa-qa-checklist";
+const SKILLS = [QA_QUEUE, QA_FAIL, QA_CLEAR, QA_CHECKLIST] as const;
+const COMMANDS = ["qa-queue", "qa-fail", "qa-clear", "qa-checklist"] as const;
+const QA_QUEUE_KEY = "jira.workflow.qa.queue";
+const CERTIFIED_KEY = "jira.workflow.qa.certified";
+const FORBIDDEN_SPECIFICS = [
+  "gemini",
+  "Gemini",
+  "ON STG",
+  "Certified For Release",
+  "backend-v2",
+  "frontend-v2",
+  "infrastructure-v2",
+  "ask-gemini",
+  "Claude Tag",
+  "Slack",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+const skillRel = (name: string): string => `skills/${name}/SKILL.md`;
+
+describe("qa acceptance skill family", () => {
+  describe.each(ROOTS)("%s", root => {
+    it("ships every skill with its pass-through command", () => {
+      for (const name of SKILLS) {
+        expect(existsSync(path.resolve(root, skillRel(name)))).toBe(true);
+      }
+      for (const cmd of COMMANDS) {
+        const command = read(root, `commands/${cmd}.md`);
+        expect(command).toContain(`Use the /lisa-${cmd} skill`);
+        expect(command).toContain("$ARGUMENTS");
+      }
+    });
+
+    it("stays generic: no project names, no single-agent or chat-surface assumptions", () => {
+      for (const name of SKILLS) {
+        const skill = read(root, skillRel(name));
+        for (const forbidden of FORBIDDEN_SPECIFICS) {
+          expect(skill).not.toContain(forbidden);
+        }
+      }
+    });
+
+    it("resolves statuses from config and never guesses terminal statuses", () => {
+      const queue = read(root, skillRel(QA_QUEUE));
+      const clear = read(root, skillRel(QA_CLEAR));
+      for (const doc of [queue, clear]) {
+        expect(doc).toContain(QA_QUEUE_KEY);
+        expect(doc).toContain(CERTIFIED_KEY);
+        expect(doc).toMatch(/never guess a terminal status/);
+      }
+      expect(queue).toContain("jira.workflow.done.staging");
+    });
+
+    it("qa-queue never certifies without an explicit pass and serves one ticket at a time", () => {
+      const queue = read(root, skillRel(QA_QUEUE));
+      expect(queue).toMatch(
+        /Never transition to certified without an explicit "pass"/
+      );
+      expect(queue).toMatch(/One ticket at a time/);
+      expect(queue).toContain("lisa-qa-fail");
+      expect(queue).toContain("lisa-tracker-read");
+    });
+
+    it("qa-fail requires duplicate discovery, preserves tester words, and diagnoses the gap", () => {
+      const fail = read(root, skillRel(QA_FAIL));
+      expect(fail).toMatch(/duplicate/i);
+      expect(fail).toMatch(/Never paraphrase away the tester's observation/);
+      expect(fail).toContain("Expectation gap");
+      expect(fail).toContain("no-evidence-found");
+      expect(fail).toContain("qa-fail");
+      expect(fail).toContain("lisa-rework-triage");
+      for (const gap of [
+        "ac-mismatch",
+        "verification-weakness",
+        "environment-difference",
+        "data-difference",
+        "regression-since-merge",
+        "not-covered-by-ac",
+      ]) {
+        expect(fail).toContain(gap);
+      }
+    });
+
+    it("qa-clear never moves mixed scope and never bulk-moves unconfirmed inferences", () => {
+      const clear = read(root, skillRel(QA_CLEAR));
+      expect(clear).toContain("qa.nonUserFacingRepos");
+      expect(clear).toMatch(/Never clear a mixed-scope ticket/);
+      expect(clear).toMatch(/without explicit operator confirmation/);
+      expect(clear).toMatch(/audit comment/);
+    });
+
+    it("qa-checklist derives coverage from live specs and keeps one source of truth", () => {
+      const checklist = read(root, skillRel(QA_CHECKLIST));
+      expect(checklist).toContain("qa.checklistFile");
+      expect(checklist).toMatch(/existing, non-skipped spec/);
+      expect(checklist).toMatch(/single source of truth/);
+    });
+  });
+
+  describe.each(GENERATED_SKILL_ROOTS)("generated root %s", root => {
+    it("carries all four qa skills", () => {
+      for (const name of SKILLS) {
+        expect(existsSync(path.resolve(root, `${name}/SKILL.md`))).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Four generic, config-driven skills forming the front door between a **non-technical human QA tester** and the agent lifecycle — usable from any coding agent in the fleet (Claude, Codex, Cursor, agy, Copilot, OpenCode). No project-specific names, statuses, or chat-surface assumptions anywhere; a regression test enforces that permanently.

### The skills

- **`lisa-qa-queue`** — serves one QA-queue ticket at a time as a plain-language acceptance brief (what changed in user terms, how to try it, numbered success checks, edge probes from triage findings). Pass → configured certified status. Fail → delegates to `lisa-qa-fail`. Can't-test → recorded without guessing a verdict. Never certifies without an explicit "pass".
- **`lisa-qa-fail`** — converts the tester's verbatim description into the structured report the fixing agent needs (repro / expected vs. actual / failed AC), then diagnoses the **expectation gap**: why the implementing agent's done-evidence said done when QA says otherwise (`ac-mismatch`, `verification-weakness`, `environment-difference`, `data-difference`, `regression-since-merge`, `not-covered-by-ac`, or `no-evidence-found` — each requiring a cited evidence artifact). Applies the `qa-fail` label (the deterministic `lisa-rework-triage` detection signal) and returns the ticket to build-ready. Untied reports run duplicate-discovery before any write — never a twin ticket.
- **`lisa-qa-clear`** — batch-certifies QA-queue tickets scoped entirely to configured non-user-facing repos (nothing observable with end-user access; already verified by the automated lifecycle pre-promotion). Per-ticket audit comments + moved-list report; never clears mixed scope; never bulk-moves on an unconfirmed repo inference.
- **`lisa-qa-checklist`** — computes the manual regression sweep as curated journeys minus **live** automated E2E coverage (existing, non-skipped specs only — a deleted/skipped spec un-covers its journey loudly). Single source of truth; no per-tester copies.

### Config contract

`jira.workflow.qa.queue` (falls back to `jira.workflow.done.staging`) · `jira.workflow.qa.certified` (required for certify paths — never guessed) · `qa.nonUserFacingRepos` · `qa.checklistFile` — all vendor-mapped to labels/states for GitHub/Linear trackers.

### Lifecycle integration

`lisa-qa-fail`'s `qa-fail` label + expectation-gap classification feed `lisa-rework-triage` at next claim, closing the QA→classification→hardening loop end to end: human observes → structured artifact → agent fixes with context → harness learns.

## Testing

- `tests/unit/strategies/qa-acceptance-skills.test.ts` — 19 assertions across source + all generated fleet roots, including a genericity guard (fails CI if any project-specific name or chat-surface assumption appears in these skills)
- Full `tests/unit/strategies` suite: 118 files / 2,498 tests pass
- eslint/oxlint/prettier clean

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual QA checklist that highlights journeys requiring human review and separates those covered by automation.
  * Added a QA queue workflow for serving acceptance briefs and recording pass, fail, or blocked outcomes.
  * Added structured QA failure reporting with duplicate detection, evidence-based diagnosis, and rework routing.
  * Added bulk clearing for QA items that cannot be human-verified, with safety checks and audit reporting.
  * Added these QA capabilities across supported assistant integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->