### PR TITLE
fix: make postinstall bootstrap idempotent

### DIFF
--- a/src/migrations/ensure-lisa-postinstall.ts
+++ b/src/migrations/ensure-lisa-postinstall.ts
@@ -44,18 +44,8 @@ async function readPackageJson(
  * have this form chained with other commands; we detect and replace it so
  * the CI guard is introduced without duplicating the invocation.
  */
-const LEGACY_LISA_INVOCATION_RE =
-  /(?:\[ -n "\$CI" \] \|\| )?(?:LISA_BOOTSTRAP=1 )?node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
-
-/**
- * Guarded Lisa invocation pattern (CI guard directly gates the Lisa command).
- * Used to detect when the migration has already been applied. Avoids false
- * positives where the CI guard precedes an unrelated command (e.g.
- * `[ -n "$CI" ] || patch-package && node ...lisa...`), which would leave Lisa
- * effectively unguarded inside a `&&` chain.
- */
-const GUARDED_LISA_INVOCATION_RE =
-  /\[ -n "\$CI" \] \|\| LISA_BOOTSTRAP=1 node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
+const LISA_INVOCATION_RE =
+  /(?:(?:\[ -n "\$CI" \] \|\| )|(?:LISA_BOOTSTRAP=1 ))*node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
 
 /**
  * Compose the new postinstall, prepending the Lisa invocation to any existing command.
@@ -70,7 +60,7 @@ function composePostinstall(existing: string | undefined): string {
     return LISA_INVOCATION;
   }
   if (trimmed.includes(LISA_MARKER)) {
-    return trimmed.replace(LEGACY_LISA_INVOCATION_RE, LISA_INVOCATION);
+    return trimmed.replace(LISA_INVOCATION_RE, LISA_INVOCATION);
   }
   return `${LISA_INVOCATION} && ${trimmed}`;
 }
@@ -132,17 +122,17 @@ export class EnsureLisaPostinstallMigration implements Migration {
       return false;
     }
     const postinstall = pkg.scripts?.postinstall;
+    if (!postinstall) {
+      return hasNodePostinstallType(ctx.detectedTypes);
+    }
+    const normalizedPostinstall = composePostinstall(postinstall);
     if (!hasNodePostinstallType(ctx.detectedTypes)) {
       return (
-        !!postinstall &&
         postinstall.includes(LISA_MARKER) &&
-        !GUARDED_LISA_INVOCATION_RE.test(postinstall)
+        normalizedPostinstall !== postinstall
       );
     }
-    if (postinstall && GUARDED_LISA_INVOCATION_RE.test(postinstall)) {
-      return false;
-    }
-    return true;
+    return normalizedPostinstall !== postinstall;
   }
 
   /**

--- a/src/strategies/copy-contents.ts
+++ b/src/strategies/copy-contents.ts
@@ -225,6 +225,14 @@ export class CopyContentsStrategy implements ICopyStrategy {
       };
     }
 
+    if (context.config.skipGitCheck) {
+      return {
+        relativePath: realRelativePath,
+        strategy: this.name,
+        action: "skipped",
+      };
+    }
+
     const sourceContent = await readFile(sourcePath, "utf-8");
     const destContent = await readFile(realDestPath, "utf-8");
 

--- a/src/strategies/copy-overwrite.ts
+++ b/src/strategies/copy-overwrite.ts
@@ -13,11 +13,6 @@ import { filesIdentical, ensureParentDir } from "../utils/file-operations.js";
  */
 export class CopyOverwriteStrategy implements ICopyStrategy {
   readonly name = "copy-overwrite" as const;
-  private readonly postinstallHostOwnedPaths = new Set([
-    ".lintstagedrc.json",
-    ".safety-net.json",
-    "knip.json",
-  ]);
 
   /**
    * Apply copy-overwrite strategy: Create, skip, or prompt to overwrite file
@@ -48,10 +43,7 @@ export class CopyOverwriteStrategy implements ICopyStrategy {
       return { relativePath, strategy: this.name, action: "skipped" };
     }
 
-    if (
-      config.skipGitCheck &&
-      this.postinstallHostOwnedPaths.has(relativePath)
-    ) {
+    if (config.skipGitCheck) {
       return { relativePath, strategy: this.name, action: "skipped" };
     }
 

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -34,6 +34,7 @@ const PACKAGE_JSON = "package.json";
 const SETTINGS_JSON = "settings.json";
 const TEST_TXT = "test.txt";
 const TSCONFIG_BASE = "tsconfig.base.json";
+const TSCONFIG_JSON = "tsconfig.json";
 const LISAIGNORE = ".lisaignore";
 const LEGACY_WORKFLOW = "legacy-workflow.yml";
 const CREATE_ONLY = "create-only";
@@ -41,6 +42,9 @@ const COPY_OVERWRITE = "copy-overwrite";
 const KNIP_JSON = "knip.json";
 const LINT_STAGED_JSON = ".lintstagedrc.json";
 const SAFETY_NET_JSON = ".safety-net.json";
+const GITIGNORE = ".gitignore";
+const ESLINT_IGNORE_CONFIG = "eslint.ignore.config.json";
+const GITHUB_ACTIONS_MD = path.join(".github", "GITHUB_ACTIONS.md");
 const HARPER_FABRIC_TYPE = "harper-fabric";
 const HARPER_FABRIC_TXT = "harper-fabric.txt";
 const JEST_CONFIG_LOCAL = "jest.config.local.ts";
@@ -342,20 +346,45 @@ describe("Lisa Integration Tests", () => {
       await createTypeScriptProject(destDir);
       const guardedPostinstall =
         '[ -n "$CI" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true';
+      const duplicatedPostinstall = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${guardedPostinstall}`;
       const hostPackageJson = {
         name: "host-project",
         dependencies: { typescript: "^5.0.0" },
-        scripts: { postinstall: guardedPostinstall, test: "host test" },
+        scripts: { postinstall: duplicatedPostinstall, test: "host test" },
         devDependencies: { oxlint: "^0.1.0" },
+      };
+      const expectedPackageJson = {
+        ...hostPackageJson,
+        scripts: {
+          ...hostPackageJson.scripts,
+          postinstall: guardedPostinstall,
+        },
       };
       const hostKnip = { ignoreDependencies: ["shell-quote"] };
       const hostLintStaged = { "*.ts": "host-lint" };
       const hostSafetyNet = { rules: [] };
+      const hostGitignore = "node_modules/\n.env.local\n";
+      const hostEslintIgnore = { ignores: ["dist/**", "host-owned/**"] };
+      const hostTsconfig = {
+        compilerOptions: { strict: true },
+        include: ["src/**/*.ts", "host/**/*.ts"],
+      };
+      const hostGithubActions = "# Host GitHub Actions guidance\n";
 
       await fs.writeJson(path.join(destDir, PACKAGE_JSON), hostPackageJson);
       await fs.writeJson(path.join(destDir, KNIP_JSON), hostKnip);
       await fs.writeJson(path.join(destDir, LINT_STAGED_JSON), hostLintStaged);
       await fs.writeJson(path.join(destDir, SAFETY_NET_JSON), hostSafetyNet);
+      await fs.writeFile(path.join(destDir, GITIGNORE), hostGitignore);
+      await fs.writeJson(
+        path.join(destDir, ESLINT_IGNORE_CONFIG),
+        hostEslintIgnore
+      );
+      await fs.writeJson(path.join(destDir, TSCONFIG_JSON), hostTsconfig);
+      await fs.outputFile(
+        path.join(destDir, GITHUB_ACTIONS_MD),
+        hostGithubActions
+      );
 
       const tsCopyOverwrite = path.join(lisaDir, "typescript", COPY_OVERWRITE);
       await fs.writeJson(path.join(tsCopyOverwrite, KNIP_JSON), {
@@ -367,6 +396,17 @@ describe("Lisa Integration Tests", () => {
       await fs.writeJson(path.join(tsCopyOverwrite, SAFETY_NET_JSON), {
         rules: [{ match: "no-verify" }],
       });
+      await fs.writeFile(path.join(tsCopyOverwrite, GITIGNORE), "dist/\n");
+      await fs.writeJson(path.join(tsCopyOverwrite, ESLINT_IGNORE_CONFIG), {
+        ignores: ["lisa-template/**"],
+      });
+      await fs.writeJson(path.join(tsCopyOverwrite, TSCONFIG_JSON), {
+        extends: "./tsconfig.base.json",
+      });
+      await fs.outputFile(
+        path.join(tsCopyOverwrite, GITHUB_ACTIONS_MD),
+        "# Lisa GitHub Actions guidance\n"
+      );
       const packageLisaDir = path.join(lisaDir, "typescript", "package-lisa");
       await fs.ensureDir(packageLisaDir);
       await fs.writeJson(path.join(packageLisaDir, "package.lisa.json"), {
@@ -380,7 +420,7 @@ describe("Lisa Integration Tests", () => {
 
       expect(result.success).toBe(true);
       expect(await fs.readJson(path.join(destDir, PACKAGE_JSON))).toEqual(
-        hostPackageJson
+        expectedPackageJson
       );
       expect(await fs.readJson(path.join(destDir, KNIP_JSON))).toEqual(
         hostKnip
@@ -391,6 +431,18 @@ describe("Lisa Integration Tests", () => {
       expect(await fs.readJson(path.join(destDir, SAFETY_NET_JSON))).toEqual(
         hostSafetyNet
       );
+      expect(await fs.readFile(path.join(destDir, GITIGNORE), "utf8")).toBe(
+        hostGitignore
+      );
+      expect(
+        await fs.readJson(path.join(destDir, ESLINT_IGNORE_CONFIG))
+      ).toEqual(hostEslintIgnore);
+      expect(await fs.readJson(path.join(destDir, TSCONFIG_JSON))).toEqual(
+        hostTsconfig
+      );
+      expect(
+        await fs.readFile(path.join(destDir, GITHUB_ACTIONS_MD), "utf8")
+      ).toBe(hostGithubActions);
     });
 
     it("does not regenerate committed agent trees during postinstall-safe apply", async () => {
@@ -713,7 +765,6 @@ describe("Lisa Integration Tests", () => {
     });
 
     it("child stack create-only suppresses parent copy-overwrite for the same path", async () => {
-      const TSCONFIG_JSON = "tsconfig.json";
       const TS_CONFIG = `${JSON.stringify({
         extends: [
           "@codyswann/lisa/tsconfig/typescript",

--- a/tests/unit/migrations/ensure-lisa-postinstall.test.ts
+++ b/tests/unit/migrations/ensure-lisa-postinstall.test.ts
@@ -10,6 +10,7 @@ const LEGACY_LISA_INVOCATION =
   "node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true";
 const OLD_GUARDED_LISA_INVOCATION = `[ -n "$CI" ] || ${LEGACY_LISA_INVOCATION}`;
 const LISA_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${LEGACY_LISA_INVOCATION}`;
+const DUPLICATED_GUARD_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${LISA_INVOCATION}`;
 const PACKAGE_JSON = "package.json";
 const PATCH_PACKAGE = "patch-package";
 
@@ -309,6 +310,19 @@ describe("EnsureLisaPostinstallMigration", () => {
 
       const pkg = await fs.readJson(path.join(projectDir, PACKAGE_JSON));
       expect(pkg.scripts.postinstall).toBe(LISA_INVOCATION);
+      expect(await migration.applies(createContext())).toBe(false);
+    });
+
+    it("repairs duplicated guard/bootstrap prefixes without extending them", async () => {
+      await writePackageJson({
+        scripts: { postinstall: DUPLICATED_GUARD_INVOCATION },
+      });
+
+      await migration.apply(createContext());
+
+      const pkg = await fs.readJson(path.join(projectDir, PACKAGE_JSON));
+      expect(pkg.scripts.postinstall).toBe(LISA_INVOCATION);
+      expect(await migration.applies(createContext())).toBe(false);
     });
 
     it("replaces legacy Lisa invocation preserving chained commands", async () => {

--- a/tests/unit/strategies/copy-overwrite.test.ts
+++ b/tests/unit/strategies/copy-overwrite.test.ts
@@ -169,7 +169,7 @@ describe("CopyOverwriteStrategy", () => {
     });
   });
 
-  it("still overwrites other Lisa-managed files during skip-git-check applies", async () => {
+  it("preserves any existing host file during skip-git-check applies", async () => {
     const srcFile = path.join(srcDir, TSCONFIG_JSON);
     const destFile = path.join(destDir, TSCONFIG_JSON);
     await fs.writeJson(srcFile, { extends: "./tsconfig.base.json" });
@@ -182,10 +182,8 @@ describe("CopyOverwriteStrategy", () => {
       createContext({ skipGitCheck: true })
     );
 
-    expect(result.action).toBe("overwritten");
-    expect(await fs.readJson(destFile)).toEqual({
-      extends: "./tsconfig.base.json",
-    });
+    expect(result.action).toBe("skipped");
+    expect(await fs.readJson(destFile)).toEqual({});
   });
 
   it("creates parent directories when needed", async () => {


### PR DESCRIPTION
## Summary

- normalize Lisa postinstall invocations so duplicated CI/bootstrap prefixes collapse back to the canonical command
- make postinstall-safe `--skip-git-check` applies preserve existing host files for `copy-overwrite` and `copy-contents`
- expand regression coverage for package.json repair and preservation of `.gitignore`, `eslint.ignore.config.json`, `tsconfig.json`, and `.github/GITHUB_ACTIONS.md`

Closes #1710.

## Verification

- `bun test tests/unit/migrations/ensure-lisa-postinstall.test.ts tests/unit/strategies/copy-overwrite.test.ts tests/unit/strategies/copy-contents.test.ts`
- `bun test tests/integration/lisa.test.ts -t "preserves host-owned config during postinstall-safe apply"`
- `bun run typecheck`
- `bun run lint`
- pre-push hook: security audit, slow lint, knip, full unit coverage, and integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Lisa postinstall scripts, including legacy, guarded, and duplicated invocations.
  * Prevented repeated migrations from making unnecessary changes.
  * Ensured existing host files are preserved when Git checks are skipped.
  * Updated file-copy behavior to consistently skip overwriting protected files when configured.
* **Tests**
  * Expanded coverage for postinstall normalization and host-owned file preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->