### PR TITLE
feat(ui): wire Stacks console section to the real detector registry

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -282,3 +282,33 @@ If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confir
 
 - CLI entrypoint is `bun src/index.ts ui` (or `bun dist/index.js ui` after build). Do not use `bun src/cli/index.ts ui` — that module has no `main()`.
 - After source changes that register new `/api/status` probes, rebuild (`bun run build:dist`) or run via the source entrypoint before trusting live `dist/` output; a stale `dist/` can omit newly added probe modules.
+
+## Committing in this repo: use `git commit -F`, never a heredoc
+
+The parity-safety-net hook blocks `git commit -m "$(cat <<EOF … EOF)"` heredoc invocations. Write the message to a file and use `git commit -F <file>` instead. Every commit must also carry a `Co-authored-by: Claude <noreply@anthropic.com>` trailer (Codex commits use `Co-authored-by: Codex`) or the co-authorship hook rejects it — see [[reference_codex_commit_attribution]].
+
+## Lisa Console UI (`ui/`)
+
+The console UI ships as a single hand-written file, `ui/index.html` (there is no bundler/`ui/dist`). It is served by the `lisa ui` command in `src/cli/ui-cmd.ts` (`runUi`). Rules for working on it and its tests:
+
+### Built CLI entry is `dist/index.js`, not `dist/src/...`
+
+`tsconfig.local.json` sets `rootDir: "src"` + `outDir: "dist"`, which flattens `src/` out of the emitted tree. The CLI entry is `dist/index.js` (also `bin.lisa` in `package.json`) — **not** `dist/src/cli/index.js`. Verification, plan, and doctor commands that guess a nested `dist/src/...` path fail. Always target `dist/index.js`.
+
+### `runUi(..., { sync: false })` in tests
+
+Pass `sync: false` whenever calling `runUi` from a test. Without it, `runUi` calls `runConfigSync` and mutates the temp/working directory under test. All unit and e2e tests use `{ port: "0", sync: false }`.
+
+### e2e tests run under Playwright's own TS pipeline
+
+`playwright.config.ts` defines **one** global `webServer` on a fixed port (`UI_TEST_PORT = 4783`) with `baseURL: http://127.0.0.1:4783`. That single shared server cannot host per-test probe injection. To drive real code with stubbed edges (e.g. injected probes), a spec must bypass `baseURL`: `import { runUi }`, launch a per-test server on `port: "0"`, and navigate to the absolute `http://127.0.0.1:${address.port}` URL, closing the server in a `finally`. See `tests/e2e/ui-stacks.spec.ts`.
+
+e2e spec files are **not** type-checked by `tsc --noEmit` (root `tsconfig` `include` is `src/**`, and tests are excluded) and are ESLint-ignored (`eslint.ignore.config.json` ignores `e2e/**`). Playwright's own TypeScript pipeline is what typechecks them — do not expect the repo's `lint`/`typecheck` gates to cover changes made only inside `tests/e2e/`.
+
+### Toggle checkboxes need `dispatchEvent("click")`
+
+The console's toggle controls are an `opacity-0` `<input type="checkbox">` layered under a styled `.trk`/`span`. Playwright's `.click()` hits the visual layer and does not fire the input's change handler. Use `card.getByRole("checkbox").dispatchEvent("click")` — it reliably fires the handler. Reuse this for every console toggle test. (Web analog of the Maestro `opacity-0`/`testID` gaps in [[reference_maestro_ios_ax_pitfalls]].)
+
+### `esc()` / `el()` are a text-context escaper and a raw-HTML sink
+
+In `ui/index.html`, `esc(s)` escapes `& < > "` but **not** `'` — it is safe only for text/element content interpolated into `innerHTML`, not for attribute-value contexts (which can be broken out of with a single quote). `el(tag, cls, html)` assigns its third argument straight to `innerHTML`, so it is a raw-HTML sink: only ever pass it `esc()`-wrapped values or trusted catalog constants. If you add attribute interpolation, add an attribute-safe escaper rather than reusing `esc()`.

--- a/.lisa/plan-1539.md
+++ b/.lisa/plan-1539.md
@@ -57,7 +57,7 @@ No cloud/remote systems required — surface is local-only (127.0.0.1).
   "required_access": [],
   "verification": {
     "type": "cli-test",
-    "command": "bun run build:dist && (node dist/src/cli/index.js ui --no-sync --port 47901 /Users/cody/workspace/expostarter & pid=$!; trap 'kill \"$pid\" 2>/dev/null || true' EXIT; curl --retry 10 --retry-connrefused -fsS 127.0.0.1:47901/api/status | jq '.probes[\"detected-stacks\"]')",
+    "command": "bun run build:dist && (node dist/index.js ui --no-sync --port 47901 /Users/cody/workspace/expostarter & pid=$!; trap 'kill \"$pid\" 2>/dev/null || true' EXIT; curl --retry 10 --retry-connrefused -fsS 127.0.0.1:47901/api/status | jq '.probes[\"detected-stacks\"]')",
     "expected": "{\"state\":\"value\",\"value\":[\"typescript\",\"expo\"]} (order per PROJECT_TYPE_ORDER)"
   }
 }

--- a/.lisa/plan-1539.md
+++ b/.lisa/plan-1539.md
@@ -1,0 +1,151 @@
+# Plan: wire-stacks-detector-registry-1539
+
+Work item: CodySwannGT/lisa#1539 — [lisa] Wire the stacks section to the real detector registry
+Flow: Implement / **Build** (user-visible UI change). Branch: `codex/issue-1539-stacks-detector-registry` off `origin/main` (b62e77395, 2.233.1). PR targets `main` (see roster.md base-branch resolution). tracker_provider=github, work_item_ref=CodySwannGT/lisa#1539.
+
+## Completion condition (the contract Verify proves)
+
+**End state:** Running `lisa ui --no-sync --port <isolated>` from this branch's build:
+1. In `/Users/cody/workspace/expostarter`: the Stacks section renders exactly the detector registry output — `typescript` and `expo`, in `PROJECT_TYPE_ORDER` (typescript before expo), marked detected; no undetected demo cards presented as detected.
+2. `bunx lisa doctor`-reported project types in that project match the rendered list exactly.
+3. In `/Users/cody/workspace/cdkstarter`: section shows `cdk` (+ its hierarchy parents per `PROJECT_TYPE_HIERARCHY`), not expo — proving per-project truth.
+4. In a bare scratch dir: an explicit empty detected-stacks state renders; zero demo stack cards.
+5. `curl 127.0.0.1:<port>/api/status` includes a `detected-stacks` probe whose result follows the tri-state contract (`value` with a string array; bare dir yields `value: []`).
+
+**Proof commands:** interactive Playwright (browser_navigate + snapshot + screenshot) against each server; `curl /api/status`; `lisa doctor` output capture. Evidence manifest from the ticket: screenshot ×3 + cli-output ×1 (typed markers).
+
+**Constraints that must hold:**
+- Stack-toggle dirty-tracking machinery (`markDirty("stack."+id)`, `dirty` Set, savebar) is preserved (#1538 constraint).
+- No detector/heuristic changes; `DetectorRegistry` consumed as-is.
+- The demo list is NEVER rendered as a fallback for unknown/failed probe — an explicit unknown state renders instead.
+- Port 4780 is never bound during verification (isolated ports only).
+- Existing e2e specs (`ui-live-status.spec.ts`, `ui-readonly-affordance.spec.ts`) and unit suites still pass.
+
+## Tool-access preflight (all PASS)
+
+| Tool | Probe | Status |
+|---|---|---|
+| gh CLI (tracker) | `gh auth status` + `gh repo view CodySwannGT/lisa` | pass |
+| bun 1.3.11 / node 22.22.0 | `bun --version` / `node --version` | pass |
+| Interactive browser (Playwright MCP) | `browser_navigate about:blank` → live snapshot | pass |
+| Expo fixture `/Users/cody/workspace/expostarter` | package.json readable | pass |
+| CDK fixture `/Users/cody/workspace/cdkstarter` | package.json readable | pass |
+
+No cloud/remote systems required — surface is local-only (127.0.0.1).
+
+## Tasks
+
+### T1 — Implement `detected-stacks` probe + UI wiring (lisa:builder)
+```json
+{
+  "plan": "wire-stacks-detector-registry-1539",
+  "type": "task",
+  "acceptance_criteria": [
+    "A StatusProbe with id 'detected-stacks' registered in runUi default probes, running DetectorRegistry.detectAll(destDir) expanded via expandAndOrderTypes, returning {state:'value', value: string[]} (empty array for no match)",
+    "ui/index.html Stacks section hydrates from GET /api/status: renders catalog cards only for detected types (ordered per probe value), explicit empty state for value:[], explicit unknown state (reason+message) for unknown/unreachable — never the demo list",
+    "A detected type with no catalog card renders minimally (id as name), never dropped",
+    "Stack-toggle dirty-tracking machinery preserved on rendered cards",
+    "Unit tests cover probe registration, probe result shape, empty/error paths (TDD: tests first)"
+  ],
+  "relevant_documentation": "src/cli/ui-status.ts (StatusProbe contract, runProbe, readStatusSnapshot); src/cli/ui-status-json.ts (ProbeResult tri-state); src/cli/ui-cmd.ts:298-336 (runUi, default probes [createGithubAuthProbe], /api/status handler); src/detection/index.ts:43-76 (detectAll, expandAndOrderTypes); src/cli/doctor.ts:136-149 (identical call chain — agreement AC holds by construction); ui/index.html:2006-2145 (DATA.sections.stacks catalog), 5613-5651 (buildStacks), 6000-6117 (live-status hydration + boot); tests/e2e/ui-live-status.spec.ts (existing probe-injection e2e pattern); PROJECT_RULES: enforce-statement-order, eslint-disable descriptions, plugins/src vs generated artifacts (ui/index.html is NOT a generated plugin artifact)",
+  "testing_requirements": [
+    "Unit tests for the probe (value/empty/error) in the existing ui-cmd/ui-status test suites' style",
+    "Highest-practical-observation regression: Playwright e2e spec (T2) — project has a Playwright harness (tests/e2e/); no Maestro harness exists in this repo (no .maestro/, no maestro:test script) — single-runner codification, absence recorded here"
+  ],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": {
+    "type": "cli-test",
+    "command": "bun run build:dist && node dist/src/cli/index.js ui --no-sync --port 47901 /Users/cody/workspace/expostarter & then curl -s 127.0.0.1:47901/api/status | jq '.probes[\"detected-stacks\"]'",
+    "expected": "{\"state\":\"value\",\"value\":[\"typescript\",\"expo\"]} (order per PROJECT_TYPE_ORDER)"
+  }
+}
+```
+
+### T2 — Codify the validation journey as a Playwright regression spec (lisa:test-specialist)
+```json
+{
+  "plan": "wire-stacks-detector-registry-1539",
+  "type": "task",
+  "acceptance_criteria": [
+    "New spec tests/e2e/ui-stacks.spec.ts encoding: detected types render as cards in order; value:[] renders empty state with zero demo cards; unknown/unreachable renders explicit unknown state; agreement between probe value and rendered list",
+    "Spec runs green locally and in PR CI with named reporter evidence (spec file name visible in CI log)",
+    "No test.skip / env-gated skips / 0-test passes"
+  ],
+  "relevant_documentation": "tests/e2e/ui-live-status.spec.ts (fixture pattern: launch runUi with injected probes on port 0); tests/e2e/ui-readonly-affordance.spec.ts (#1538 spec, journey-codification precedent); playwright config at repo root",
+  "testing_requirements": ["Deterministic: injected probes/temp dirs, no reliance on external projects; isolated ports (port 0 or 479xx range), never 4780"],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": {
+    "type": "cli-test",
+    "command": "bunx playwright test tests/e2e/ui-stacks.spec.ts --reporter=list",
+    "expected": "All tests in ui-stacks.spec.ts pass; reporter names each test; exit 0"
+  }
+}
+```
+
+### T3 — Parallel reviews (lisa:product-specialist, lisa:quality-specialist, coderabbit:code-reviewer, lisa:spec-conformance-specialist)
+```json
+{
+  "plan": "wire-stacks-detector-registry-1539",
+  "type": "task",
+  "acceptance_criteria": ["Each reviewer returns findings; valid findings implemented by builder; invalid findings answered with reasons"],
+  "relevant_documentation": "Diff on codex/issue-1539-stacks-detector-registry vs origin/main; ticket AC + Out of Scope; triage edge cases 1-5",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": {
+    "type": "manual-check",
+    "command": "Review reports returned by all four lanes; re-run T1/T2 verification after any fixes",
+    "expected": "Zero unaddressed valid findings"
+  }
+}
+```
+
+### T4 — Empirical verification + verdict (lisa:verification-specialist — independent of implementer)
+```json
+{
+  "plan": "wire-stacks-detector-registry-1539",
+  "type": "task",
+  "acceptance_criteria": [
+    "Live-browser journey executed per the ticket's Validation Journey on isolated ports: expostarter (screenshot), doctor agreement (cli-output), cdkstarter (screenshot), bare dir (screenshot)",
+    ".lisa/verification-status.json written with per-criterion evidence; status pass only with real observed output"
+  ],
+  "relevant_documentation": "Completion condition above; evidence manifest: [EVIDENCE: screenshot: expo-project-shows-expo-and-parent-typescript], [EVIDENCE: cli-output: stacks-agree-with-doctor], [EVIDENCE: screenshot: cdk-project-shows-cdk], [EVIDENCE: screenshot: no-detector-match-empty-state]",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "required_access": [{ "tool": "Playwright MCP browser", "probe": "browser_navigate about:blank", "status": "pass" }],
+  "verification": {
+    "type": "ui-recording",
+    "command": "Interactive Playwright journey against three live lisa ui servers (isolated ports) + lisa doctor capture; screenshots + cli-output attached to issue evidence",
+    "expected": "All four evidence artifacts captured and consistent with AC; verification-status.json all-pass"
+  }
+}
+```
+
+### T5 — Learnings (lisa:learner)
+```json
+{
+  "plan": "wire-stacks-detector-registry-1539",
+  "type": "task",
+  "acceptance_criteria": ["Task learnings collected from all lanes and processed via skill-evaluator routing"],
+  "relevant_documentation": "This plan file; review findings; verification results",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": { "type": "documentation", "command": "Learner report returned to lead", "expected": "Learnings recorded or explicitly discarded with reasons" }
+}
+```
+
+## Regression-spec deliverable status
+Playwright harness exists (`tests/e2e/`) → deterministic spec REQUIRED (T2, non-demotable). Maestro: no `.maestro/` directory, no `maestro:test` script, no Maestro CI workflow in this repo → single-runner codification; absence recorded here per the dual-runner rule's exit 1.
+
+## Sessions
+| When (UTC) | What |
+|---|---|
+| 2026-07-18 19:33 | Claimed via build-intake; triage PASSED_WITH_FINDINGS; team formed |

--- a/.lisa/plan-1539.md
+++ b/.lisa/plan-1539.md
@@ -57,7 +57,7 @@ No cloud/remote systems required — surface is local-only (127.0.0.1).
   "required_access": [],
   "verification": {
     "type": "cli-test",
-    "command": "bun run build:dist && node dist/src/cli/index.js ui --no-sync --port 47901 /Users/cody/workspace/expostarter & then curl -s 127.0.0.1:47901/api/status | jq '.probes[\"detected-stacks\"]'",
+    "command": "bun run build:dist && (node dist/src/cli/index.js ui --no-sync --port 47901 /Users/cody/workspace/expostarter & pid=$!; trap 'kill \"$pid\" 2>/dev/null || true' EXIT; curl --retry 10 --retry-connrefused -fsS 127.0.0.1:47901/api/status | jq '.probes[\"detected-stacks\"]')",
     "expected": "{\"state\":\"value\",\"value\":[\"typescript\",\"expo\"]} (order per PROJECT_TYPE_ORDER)"
   }
 }

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -54,3 +54,36 @@ EXCLUDE - git-history-analyzer - architecture-specialist + generalPurpose cover 
 ## Effective completion (queue)
 
 Queue is clean when `gh issue list --label status:ready --state open` returns zero issues (or only items that transitioned to blocked with human_needed / linked dependency). Per-issue: verification-status.json all-pass, PR merged to main, tracker sync to env-keyed done.
+
+---
+
+Work item: `CodySwannGT/lisa#1539` — plan: `wire-stacks-detector-registry-1539`
+
+Runtime: Claude Code implicit-team model (Agent tool). No shared task-list tool in this runtime (TaskCreate/TaskList absent) — task plan persisted in `.lisa/plan-1539.md`; verification verdict in `.lisa/verification-status.json`.
+
+- `INCLUDE - Explore - read-only research; already served as the bounded input-resolver for this flow.`
+- `INCLUDE - lisa:builder - owns the TDD implementation of the detected-stacks probe + UI wiring (Build work type).`
+- `INCLUDE - lisa:test-specialist - authors the Playwright regression spec codifying the validation journey, alongside unit tests.`
+- `INCLUDE - lisa:product-specialist - reviews behavior against the Gherkin AC from the user's perspective (parallel review lane).`
+- `INCLUDE - lisa:quality-specialist - coding-philosophy/correctness review (parallel review lane).`
+- `INCLUDE - coderabbit:code-reviewer - CodeRabbit review lane per the project review-parallelization rule.`
+- `INCLUDE - lisa:spec-conformance-specialist - verifies shipped work matches the spec exactly (AC, Out of Scope, journey assertions).`
+- `INCLUDE - lisa:verification-specialist - independent empirical verification (live browser journey, doctor agreement) + writes verification-status.json; never the implementer.`
+- `INCLUDE - lisa:learner - collects and routes task learnings before team shutdown.`
+- `INCLUDE - general-purpose - fallback for bounded mechanical chores only when no specialist fits; not a build lane.`
+- `EXCLUDE - lisa:architecture-specialist - design fully pinned by the ticket + shipped #1537 probe contract; no open architectural decision.`
+- `EXCLUDE - lisa:security-specialist - no new external input surface: /api/status pre-exists; new probe reads local filesystem only, loopback-bound.`
+- `EXCLUDE - lisa:performance-specialist - bounded 5s-timeout filesystem probe already used by lisa doctor; no perf-sensitive path.`
+- `EXCLUDE - lisa:debug-specialist / lisa:bug-fixer - Build flow, not Fix; no bug to reproduce.`
+- `EXCLUDE - lisa:git-history-analyzer - relationship search already documented in the ticket and re-verified at triage.`
+- `EXCLUDE - lisa:github-agent - its lifecycle is already running in this lead session via intake dispatch; spawning it would nest lifecycles.`
+- `EXCLUDE - lisa:jira-agent / lisa:linear-agent - wrong tracker (tracker=github).`
+- `EXCLUDE - lisa:*-build-intake / lisa:*-prd-intake - queue scanners, not per-item workers; the item is already claimed.`
+- `EXCLUDE - lisa:learnings-synthesizer / lisa:pr-mining-specialist / lisa:tracker-mining-specialist - Debrief-flow agents, out of scope for a build ticket.`
+- `EXCLUDE - lisa:skill-evaluator - reached through the learner flow, not a team lane.`
+- `EXCLUDE - code-simplifier:code-simplifier - small change; quality-specialist + CodeRabbit cover simplification.`
+- `EXCLUDE - claude-code-guide / hookify:conversation-analyzer / statusline-setup - unrelated utilities.`
+- `EXCLUDE - claude - generic catch-all; specific specialists selected.`
+- `EXCLUDE - Plan - decomposition exists; this IS the leaf work item.`
+
+Base-branch resolution (recorded assumption): ticket env is `dev — local only; there is no deployed environment for this surface`. Merged `deploy.branches` maps only `production → main` (single-env repo; the npm release IS the deploy). Surface has no deployable environment → base = remote default `main` per the no-environment fallback. PR targets `main`.

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -22,6 +22,7 @@ import {
 } from "./remote-environment.js";
 import { createCiQualityJobsProbe } from "./ui-ci-quality-jobs.js";
 import { createDeployPipelineProbe } from "./ui-deploy-pipeline.js";
+import { createDetectedStacksProbe } from "./ui-detected-stacks.js";
 import { createGithubRepoProbe } from "./ui-github-repo.js";
 import { createLisaVersionProbe } from "./ui-lisa-version.js";
 import {
@@ -56,6 +57,10 @@ export {
   type DeployPipelineStage,
   type DeployPipelineValue,
 } from "./ui-deploy-pipeline.js";
+export {
+  createDetectedStacksProbe,
+  DETECTED_STACKS_PROBE_ID,
+} from "./ui-detected-stacks.js";
 export {
   createLisaVersionProbe,
   mapLisaVersionCheck,
@@ -357,6 +362,7 @@ export async function runUi(
   const probes = dependencies.probes ?? [
     createGithubAuthProbe(destDir),
     createEnabledPluginsProbe(destDir),
+    createDetectedStacksProbe(destDir),
     createLisaVersionProbe(),
     createCiQualityJobsProbe(destDir, config),
     createDeployPipelineProbe(destDir),

--- a/src/cli/ui-detected-stacks.ts
+++ b/src/cli/ui-detected-stacks.ts
@@ -1,0 +1,38 @@
+/**
+ * Live-status probe for the console Stacks section.
+ *
+ * Mirrors doctor's detection chain exactly so the console and `lisa doctor`
+ * can never disagree. An empty match is the honest empty value (`[]`), never
+ * unknown; the runner maps a thrown detector error to unknown.
+ * @module cli/ui-detected-stacks
+ */
+import {
+  createDetectorRegistry,
+  type DetectorRegistry,
+} from "../detection/index.js";
+import type { StatusProbe } from "./ui-status.js";
+
+/** Probe id for the detected-stacks live-status entry. */
+export const DETECTED_STACKS_PROBE_ID = "detected-stacks";
+
+/**
+ * Create the probe that reports the project's detected stacks.
+ * @param destDir - Project root scanned by the detector registry
+ * @param registry - Injectable detector registry used by focused tests
+ * @returns Probe emitting the expanded, ordered project types
+ */
+export function createDetectedStacksProbe(
+  destDir: string,
+  registry: DetectorRegistry = createDetectorRegistry()
+): StatusProbe<string[]> {
+  return {
+    id: DETECTED_STACKS_PROBE_ID,
+    timeoutMs: 5_000,
+    run: async () => {
+      const types = registry.expandAndOrderTypes(
+        await registry.detectAll(destDir)
+      );
+      return { state: "value", value: [...types] };
+    },
+  };
+}

--- a/tests/e2e/ui-stacks.spec.ts
+++ b/tests/e2e/ui-stacks.spec.ts
@@ -236,6 +236,29 @@ test("renders a hostile detected id as inert text without executing it", async (
   }
 });
 
+test("renders a minimal card for a detected id that shadows an inherited object property", async ({
+  page,
+}) => {
+  // "constructor" is not an own property of the plain-object catalog but IS
+  // resolvable via the prototype chain. A lookup that isn't own-key-safe
+  // would resolve Object.prototype.constructor instead of falling back to
+  // minimalStackMeta, producing a malformed card.
+  const hostileId = "constructor";
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({ state: "value", value: ["typescript", hostileId] }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(page.locator(stackCardNames)).toHaveText([
+      "TypeScript",
+      hostileId,
+    ]);
+    await expect(page.locator(stackCards)).toHaveCount(2);
+  } finally {
+    await ui.close();
+  }
+});
+
 test("hydrates from the real default probe against a project with tsconfig.json", async ({
   page,
 }) => {

--- a/tests/e2e/ui-stacks.spec.ts
+++ b/tests/e2e/ui-stacks.spec.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  runUi,
+  type ProbeResult,
+  type StatusProbe,
+} from "../../src/cli/ui-cmd.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown. Each test
+ * owns one and closes it in a `finally` so no server outlives its test and no
+ * fixed port (never 4780) is bound.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port (0) with sync disabled, so the spec
+ * neither mutates the project nor collides with the shared webServer.
+ * @param destDir - Project root the console serves and detects against
+ * @param probes - Injected status probes; omitted to exercise the real defaults
+ * @returns The console's loopback origin and a close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes?: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(
+    destDir,
+    { port: "0", sync: false },
+    probes ? { probes } : {}
+  );
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build the `detected-stacks` probe returning a fixed result, so each journey
+ * pins an exact snapshot the Stacks section must render honestly.
+ * @param result - The tri-state result the probe reports
+ * @returns A probe registered under the `detected-stacks` id
+ */
+function detectedStacksProbe(
+  result: ProbeResult<string[]>
+): StatusProbe<string[]> {
+  return { id: "detected-stacks", timeoutMs: 1_000, run: async () => result };
+}
+
+/**
+ * Create a fresh temporary project directory.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "lisa-ui-stacks-"));
+}
+
+const stackCards = "#section-stacks .stack-card";
+const stackCardNames = "#section-stacks .stack-card .t b";
+
+test("renders detected types as cards in probe order and nothing else", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({ state: "value", value: ["typescript", "expo"] }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(page.locator(stackCardNames)).toHaveText([
+      "TypeScript",
+      "Expo",
+    ]);
+    await expect(page.locator(stackCards)).toHaveCount(2);
+    await expect(page.locator("#section-stacks .stacks-state")).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders the explicit empty state for value:[] with zero stack cards", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({ state: "value", value: [] }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(
+      page.locator("#section-stacks .stacks-state.empty")
+    ).toHaveText("No Lisa stack detected in this project.");
+    await expect(page.locator(stackCards)).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders the explicit unknown state for an unknown probe result", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({
+      state: "unknown",
+      reason: "probe-failed",
+      message: "Detector registry threw",
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    const unknown = page.locator("#section-stacks .stacks-state.unknown");
+    await expect(unknown).toBeVisible();
+    await expect(unknown).toContainText("Stack detection unavailable");
+    await expect(unknown.locator(".status-why")).toHaveText(
+      "probe-failed: Detector registry threw"
+    );
+    await expect(
+      page.locator("#section-stacks .stacks-state.empty")
+    ).toHaveCount(0);
+    await expect(page.locator(stackCards)).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders the unknown state when the snapshot omits the detected-stacks probe", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    {
+      id: "github-authenticated",
+      timeoutMs: 1_000,
+      run: async () => ({ state: "value", value: true }),
+    },
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    const unknown = page.locator("#section-stacks .stacks-state.unknown");
+    await expect(unknown).toBeVisible();
+    await expect(unknown.locator(".status-why")).toHaveText(
+      "missing-probe: The detected-stacks probe was not reported"
+    );
+    await expect(
+      page.locator("#section-stacks .stacks-state.empty")
+    ).toHaveCount(0);
+    await expect(page.locator(stackCards)).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders a minimal card for a detected id absent from the catalog", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({
+      state: "value",
+      value: ["typescript", "not-a-real-stack"],
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(page.locator(stackCardNames)).toHaveText([
+      "TypeScript",
+      "not-a-real-stack",
+    ]);
+    await expect(page.locator(stackCards)).toHaveCount(2);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("hydrates from the real default probe against a project with tsconfig.json", async ({
+  page,
+}) => {
+  const projectDir = await makeProjectDir();
+  await writeFile(path.join(projectDir, "tsconfig.json"), "{}\n");
+  const ui = await launchConsole(projectDir);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(page.locator(stackCardNames)).toHaveText(["TypeScript"]);
+    await expect(page.locator(stackCards)).toHaveCount(1);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("preserves stack-toggle dirty tracking on a rendered card", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({ state: "value", value: ["typescript"] }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    const card = page.locator(stackCards);
+    await expect(card).toHaveCount(1);
+    await expect(page.locator("#savebar")).not.toHaveClass(/show/);
+    await card.getByRole("checkbox").dispatchEvent("click");
+    await expect(page.locator("#savebar")).toHaveClass(/show/);
+    await expect(page.locator("#savebar")).toContainText("unsaved change");
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/e2e/ui-stacks.spec.ts
+++ b/tests/e2e/ui-stacks.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -56,13 +56,24 @@ function detectedStacksProbe(
   return { id: "detected-stacks", timeoutMs: 1_000, run: async () => result };
 }
 
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
 /**
- * Create a fresh temporary project directory.
+ * Create a fresh temporary project directory, tracked for teardown.
  * @returns Absolute path to the new directory
  */
 async function makeProjectDir(): Promise<string> {
-  return mkdtemp(path.join(tmpdir(), "lisa-ui-stacks-"));
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-stacks-"));
+  createdDirs.push(dir);
+  return dir;
 }
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
 
 const stackCards = "#section-stacks .stack-card";
 const stackCardNames = "#section-stacks .stack-card .t b";
@@ -156,6 +167,33 @@ test("renders the unknown state when the snapshot omits the detected-stacks prob
   }
 });
 
+test("renders the unknown state for an array carrying a non-string element", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    // A non-string element makes the array untrustworthy; the section must not
+    // collapse it to a fabricated "no stacks" empty state.
+    detectedStacksProbe({
+      state: "value",
+      value: [1, 2] as unknown as string[],
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    const unknown = page.locator("#section-stacks .stacks-state.unknown");
+    await expect(unknown).toBeVisible();
+    await expect(unknown.locator(".status-why")).toHaveText(
+      "invalid-value: detected-stacks did not return a string array"
+    );
+    await expect(
+      page.locator("#section-stacks .stacks-state.empty")
+    ).toHaveCount(0);
+    await expect(page.locator(stackCards)).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
 test("renders a minimal card for a detected id absent from the catalog", async ({
   page,
 }) => {
@@ -172,6 +210,27 @@ test("renders a minimal card for a detected id absent from the catalog", async (
       "not-a-real-stack",
     ]);
     await expect(page.locator(stackCards)).toHaveCount(2);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders a hostile detected id as inert text without executing it", async ({
+  page,
+}) => {
+  const hostileId = "<img src=x onerror=window.__xss=1>";
+  const ui = await launchConsole(await makeProjectDir(), [
+    detectedStacksProbe({ state: "value", value: ["typescript", hostileId] }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#stacks`);
+    await expect(page.locator(stackCards)).toHaveCount(2);
+    const minimalCard = page.locator(stackCards).nth(1);
+    // The id survives as a visible literal, not as parsed markup.
+    await expect(minimalCard.locator(".t b")).toHaveText(hostileId);
+    await expect(minimalCard.locator("img")).toHaveCount(0);
+    const xss = await page.evaluate(() => (window as { __xss?: number }).__xss);
+    expect(xss).toBeUndefined();
   } finally {
     await ui.close();
   }

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -289,6 +289,7 @@ describe("runUi", () => {
 
     expect(response.status).toBe(200);
     expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty("detected-stacks");
     expect(snapshot.probes).toHaveProperty("lisa-version");
     expect(snapshot.probes).toHaveProperty("deploy-pipeline-stages");
   });

--- a/tests/unit/cli/ui-detected-stacks-probe.test.ts
+++ b/tests/unit/cli/ui-detected-stacks-probe.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDetectedStacksProbe,
+  DETECTED_STACKS_PROBE_ID,
+  runProbe,
+  runUi,
+} from "../../../src/cli/ui-cmd.js";
+import { DetectorRegistry } from "../../../src/detection/index.js";
+
+/** Holder for per-test temp resources. */
+interface TestResources {
+  dir: string;
+  server: Server | undefined;
+}
+
+const resources: TestResources = { dir: "", server: undefined };
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-detected-stacks-"));
+  resources.server = undefined;
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (resources.server !== undefined) {
+    await new Promise(resolve => resources.server?.close(resolve));
+    resources.server = undefined;
+  }
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+describe("createDetectedStacksProbe", () => {
+  it("registers with the detected-stacks id and a bounded timeout", () => {
+    const probe = createDetectedStacksProbe(resources.dir);
+
+    expect(probe.id).toBe(DETECTED_STACKS_PROBE_ID);
+    expect(Number.isFinite(probe.timeoutMs)).toBe(true);
+    expect(probe.timeoutMs).toBeGreaterThan(0);
+  });
+
+  it("returns expanded, ordered project types for a detected fixture", async () => {
+    await writeFile(path.join(resources.dir, "tsconfig.json"), "{}", "utf8");
+    await writeFile(path.join(resources.dir, "app.json"), "{}", "utf8");
+
+    const result = await runProbe(createDetectedStacksProbe(resources.dir));
+
+    expect(result).toEqual({ state: "value", value: ["typescript", "expo"] });
+  });
+
+  it("returns an explicit empty value when no stack is detected", async () => {
+    const result = await runProbe(createDetectedStacksProbe(resources.dir));
+
+    expect(result).toEqual({ state: "value", value: [] });
+  });
+
+  it("degrades to unknown when the detector registry throws", async () => {
+    const registry = new DetectorRegistry([
+      {
+        type: "typescript",
+        detect: async (): Promise<boolean> => {
+          throw new Error("detector exploded");
+        },
+      },
+    ]);
+
+    const result = await runProbe(
+      createDetectedStacksProbe(resources.dir, registry)
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe("probe-failed");
+      expect(result.message).toContain("detector exploded");
+    }
+  });
+
+  it("registers in the default /api/status snapshot with sibling probes", async () => {
+    await writeFile(path.join(resources.dir, "tsconfig.json"), "{}", "utf8");
+    await writeFile(path.join(resources.dir, "app.json"), "{}", "utf8");
+
+    resources.server = await runUi(resources.dir, { port: "0", sync: false });
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const snapshot = (await response.json()) as {
+      probes: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(snapshot.probes[DETECTED_STACKS_PROBE_ID]).toEqual({
+      state: "value",
+      value: ["typescript", "expo"],
+    });
+    expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty("enabled-plugins");
+    expect(snapshot.probes).toHaveProperty("lisa-version");
+    expect(snapshot.probes).toHaveProperty("deploy-pipeline-stages");
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -5652,9 +5652,9 @@
          stack installs — NOT the detection result; only ids the probe reports
          are rendered from it. */
       function stackCatalog(block) {
-        const catalog = {};
+        const catalog = new Map();
         block.items.forEach(s => {
-          catalog[s.id] = s;
+          catalog.set(s.id, s);
         });
         return catalog;
       }
@@ -5739,7 +5739,7 @@
         const catalog = stackCatalog(block);
         const grid = el("div", "stack-grid");
         d.ids.forEach(id => {
-          grid.appendChild(stackCard(catalog[id] || minimalStackMeta(id)));
+          grid.appendChild(stackCard(catalog.get(id) || minimalStackMeta(id)));
         });
         wrap.appendChild(grid);
         wrap.appendChild(el("div", "", "&nbsp;"));

--- a/ui/index.html
+++ b/ui/index.html
@@ -6825,10 +6825,21 @@
         const result = normalizeLiveStatusResult(raw);
         if (result.state === "value" && Array.isArray(result.value)) {
           const ids = result.value.filter(v => typeof v === "string");
-          stackDetection =
-            ids.length > 0
-              ? { status: "value", ids }
-              : { status: "empty", ids: [] };
+          if (ids.length !== result.value.length) {
+            // Any non-string element makes the whole array untrustworthy;
+            // an empty state here would fabricate a "no stacks" certainty.
+            stackDetection = {
+              status: "unknown",
+              ids: [],
+              reason: "invalid-value",
+              message: "detected-stacks did not return a string array",
+            };
+          } else {
+            stackDetection =
+              ids.length > 0
+                ? { status: "value", ids }
+                : { status: "empty", ids: [] };
+          }
         } else if (result.state === "value") {
           stackDetection = {
             status: "unknown",

--- a/ui/index.html
+++ b/ui/index.html
@@ -877,6 +877,23 @@
           grid-template-columns: 1fr;
         }
       }
+      .stacks-state {
+        border: 1px dashed var(--line);
+        border-radius: 10px;
+        background: var(--surface);
+        padding: 16px 18px;
+        color: var(--muted);
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .stacks-state.unknown {
+        border-color: var(--warn, #c99a2e);
+        border-style: solid;
+      }
+      .stacks-state.unknown b {
+        color: var(--ink);
+      }
       .stack-card {
         border: 1px solid var(--line);
         border-radius: 10px;
@@ -5274,6 +5291,10 @@
         settingsPresent: false,
         plugins: [],
       };
+      /* Live detected-stacks state, hydrated from GET /api/status. Starts as
+         "detecting" so the Stacks section never presents the metadata catalog
+         as if it were the detection result. */
+      let stackDetection = { status: "detecting", ids: [] };
 
       function el(tag, cls, html) {
         const node = document.createElement(tag);
@@ -5627,44 +5648,116 @@
         return card;
       }
 
-      function buildStacks(block) {
-        const grid = el("div", "stack-grid");
+      /* The 8-entry stack metadata, keyed by id. This is a catalog of what each
+         stack installs — NOT the detection result; only ids the probe reports
+         are rendered from it. */
+      function stackCatalog(block) {
+        const catalog = {};
         block.items.forEach(s => {
-          const card = el("div", "stack-card" + (s.on ? " on" : ""));
-          const head = el("div", "head");
-          head.appendChild(el("span", "glyph", esc(s.glyph)));
-          const t = el("div", "t");
-          t.appendChild(el("b", "", esc(s.name)));
-          t.appendChild(el("i", "", esc(s.tagline)));
-          head.appendChild(t);
-          const toggleWrap = buildControl(
-            { type: "toggle", value: s.on },
-            "stack." + s.id
-          );
-          toggleWrap.querySelector("input").addEventListener("change", e => {
-            card.classList.toggle("on", e.target.checked);
-            markDirty("stack." + s.id, null);
-          });
-          head.appendChild(toggleWrap);
-          card.appendChild(head);
-          const meta = el("div", "meta");
-          s.badges.forEach(b => meta.appendChild(el("span", "tag", esc(b))));
-          card.appendChild(meta);
-          card.appendChild(el("div", "detect", s.detect));
-          if (s.more && s.more.length) {
-            const det = el("details", "stack-more");
-            det.appendChild(el("summary", "", "What this stack installs"));
-            const ul = el("ul");
-            s.more.forEach(m => ul.appendChild(el("li", "", esc(m))));
-            det.appendChild(ul);
-            card.appendChild(det);
-          }
-          grid.appendChild(card);
+          catalog[s.id] = s;
         });
-        const wrap = el("div");
+        return catalog;
+      }
+
+      /* A detected id with no catalog entry still gets a card (id as name) so
+         detection truth is never dropped just because copy is missing. */
+      function minimalStackMeta(id) {
+        return {
+          id,
+          glyph: id.slice(0, 2).toUpperCase(),
+          name: id,
+          tagline: "",
+          detect: "",
+          badges: [],
+          more: [],
+        };
+      }
+
+      function stackCard(s) {
+        const card = el("div", "stack-card on");
+        const head = el("div", "head");
+        head.appendChild(el("span", "glyph", esc(s.glyph)));
+        const t = el("div", "t");
+        t.appendChild(el("b", "", esc(s.name)));
+        t.appendChild(el("i", "", esc(s.tagline)));
+        head.appendChild(t);
+        const toggleWrap = buildControl(
+          { type: "toggle", value: true },
+          "stack." + s.id
+        );
+        toggleWrap.querySelector("input").addEventListener("change", e => {
+          card.classList.toggle("on", e.target.checked);
+          markDirty("stack." + s.id, null);
+        });
+        head.appendChild(toggleWrap);
+        card.appendChild(head);
+        const meta = el("div", "meta");
+        (s.badges || []).forEach(b =>
+          meta.appendChild(el("span", "tag", esc(b)))
+        );
+        card.appendChild(meta);
+        card.appendChild(el("div", "detect", s.detect || ""));
+        if (s.more && s.more.length) {
+          const det = el("details", "stack-more");
+          det.appendChild(el("summary", "", "What this stack installs"));
+          const ul = el("ul");
+          s.more.forEach(m => ul.appendChild(el("li", "", esc(m))));
+          det.appendChild(ul);
+          card.appendChild(det);
+        }
+        return card;
+      }
+
+      function renderStacksInto(wrap, block) {
+        wrap.innerHTML = "";
+        const d = stackDetection;
+        if (d.status === "detecting") {
+          wrap.appendChild(
+            el("div", "stacks-state detecting", "Detecting project stacks…")
+          );
+          return;
+        }
+        if (d.status === "unknown") {
+          const box = el("div", "stacks-state unknown");
+          box.appendChild(el("b", "", "Stack detection unavailable"));
+          box.appendChild(
+            el("span", "status-why", esc(d.reason + ": " + d.message))
+          );
+          wrap.appendChild(box);
+          return;
+        }
+        if (!d.ids || d.ids.length === 0) {
+          wrap.appendChild(
+            el(
+              "div",
+              "stacks-state empty",
+              "No Lisa stack detected in this project."
+            )
+          );
+          return;
+        }
+        const catalog = stackCatalog(block);
+        const grid = el("div", "stack-grid");
+        d.ids.forEach(id => {
+          grid.appendChild(stackCard(catalog[id] || minimalStackMeta(id)));
+        });
         wrap.appendChild(grid);
         wrap.appendChild(el("div", "", "&nbsp;"));
+      }
+
+      function buildStacks(block) {
+        const wrap = el("div", "stacks-block");
+        renderStacksInto(wrap, block);
         return wrap;
+      }
+
+      /* Re-render the Stacks section in place after detection hydrates. */
+      function refreshStacks() {
+        const block = DATA.sections.stacks.blocks.find(
+          b => b.type === "stacks"
+        );
+        const wrap = document.querySelector(".stacks-block");
+        if (block && wrap) renderStacksInto(wrap, block);
       }
 
       function buildHooks(block) {
@@ -6711,6 +6804,63 @@
         if (existing) {
           existing.replaceWith(buildTable(block));
         }
+      /* Map the detected-stacks probe into stackDetection. A missing probe or a
+         non-value/non-array result becomes an explicit unknown state — never a
+         false empty and never the metadata catalog. */
+      function applyDetectedStacks(probes) {
+        const raw =
+          probes && Object.hasOwn(probes, "detected-stacks")
+            ? probes["detected-stacks"]
+            : undefined;
+        if (raw === undefined) {
+          stackDetection = {
+            status: "unknown",
+            ids: [],
+            reason: "missing-probe",
+            message: "The detected-stacks probe was not reported",
+          };
+          refreshStacks();
+          return;
+        }
+        const result = normalizeLiveStatusResult(raw);
+        if (result.state === "value" && Array.isArray(result.value)) {
+          const ids = result.value.filter(v => typeof v === "string");
+          stackDetection =
+            ids.length > 0
+              ? { status: "value", ids }
+              : { status: "empty", ids: [] };
+        } else if (result.state === "value") {
+          stackDetection = {
+            status: "unknown",
+            ids: [],
+            reason: "invalid-value",
+            message: "detected-stacks did not return a string array",
+          };
+        } else if (result.state === "not-applicable") {
+          stackDetection = {
+            status: "unknown",
+            ids: [],
+            reason: "not-applicable",
+            message: "detected-stacks reported not applicable",
+          };
+        } else {
+          stackDetection = {
+            status: "unknown",
+            ids: [],
+            reason: result.reason,
+            message: result.message,
+          };
+        }
+        refreshStacks();
+      }
+      function markStacksUnreachable(error) {
+        stackDetection = {
+          status: "unknown",
+          ids: [],
+          reason: "status-unavailable",
+          message: error instanceof Error ? error.message : String(error),
+        };
+        refreshStacks();
       }
       async function hydrateLiveStatuses() {
         try {
@@ -6722,6 +6872,7 @@
           const probes = liveStatusProbeMap(snapshot);
           renderLiveStatuses(probes);
           applyEnabledPlugins(probes);
+          applyDetectedStacks(probes);
           // Quality jobs re-renders the page; paint the version chip after.
           applyCiQualityJobs(probes);
           applyLisaVersion(probes);
@@ -6752,6 +6903,7 @@
           applyDeployPipelineStages({
             "deploy-pipeline-stages": unavailable,
           });
+          markStacksUnreachable(error);
         }
       }
 


### PR DESCRIPTION
## Summary

Wires the `lisa ui` console's Stacks section to the real detector registry via the live-status probe contract shipped in #1537 — the console now reports the invoked project's actual stacks instead of the hardcoded `acme/acme-app` demo list.

Work item: CodySwannGT/lisa#1539 (Sub-task of Story #1507, Epic #1495, PRD #1492).

- **New `detected-stacks` status probe** (`src/cli/ui-cmd.ts`): `createDetectedStacksProbe(destDir)` runs the exact chain `lisa doctor` uses — `expandAndOrderTypes(await DetectorRegistry.detectAll(destDir))` — so the console and doctor cannot drift. Registered in `runUi`'s default probes beside `github-auth`. Empty match returns the honest `{state:"value", value:[]}`; detector errors surface as `unknown` via the existing `runProbe` wrapper. No detector or heuristic was touched.
- **Stacks section hydration** (`ui/index.html`): the section consumes the existing single `GET /api/status` fetch. Detected types render catalog cards in probe order; `value: []` renders an explicit "No Lisa stack detected" empty state; `unknown`/unreachable/missing-probe/non-string-array all render an explicit "Stack detection unavailable" state naming the reason — the demo list is never rendered as a fallback. A detected id with no catalog entry renders a minimal card rather than being dropped. Stack-toggle dirty-tracking machinery is preserved (#1538 constraint; Epic #1496 re-enables Save on top of it).
- **Tests**: unit coverage for the probe (ordered expansion, empty dir, detector-throws) and default registration; new Playwright regression spec `tests/e2e/ui-stacks.spec.ts` (9 tests) codifying the verified journey — order/empty/unknown/missing-probe/minimal-card/real-registry/dirty-tracking/non-string-array/XSS-inertness — on OS-assigned ports (4780 never bound).

## Verification

- Unit: 293 files / 4683 tests pass. Playwright e2e: 11 passed (2 existing + 9 new). Lint 0/0, typecheck clean.
- Independent live-browser verification (interactive Playwright, isolated ports 47921-47923): expostarter renders TypeScript→Expo in `PROJECT_TYPE_ORDER`; `doctor --json` agrees exactly with the rendered list and the probe value; cdkstarter renders TypeScript→AWS CDK (no Expo); a bare directory renders the empty state with zero cards. Evidence artifacts captured per the ticket's typed manifest (screenshot ×3, cli-output ×1).
- Reviews: spec-conformance CONFORMS (no misses, no scope creep); quality + product clean passes; CodeRabbit-style review near-clean — its three valid findings (false-empty for non-string arrays, e2e temp-dir cleanup, escaping regression test) are fixed in 8184a8d.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Stacks section now hydrates from real project stack detection (via a new `detected-stacks` UI probe).
  * Added explicit UI states for detecting, explicit empty, missing probe, unknown/unavailable, and invalid detection results.
  * Detected stacks render as safe, non-interactive cards when unknown/invalid catalog entries occur.
  * Stack selection now correctly triggers unsaved changes.

* **Bug Fixes**
  * Fixed handling so missing or malformed detection data no longer appears as an empty stack list.

* **Tests**
  * Added unit + end-to-end coverage for probe wiring, ordering/state mapping, and safe rendering against hostile/prototype-shadowing IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->