### PR TITLE
feat(ui): wire top-bar version status to checkVersion (#1546)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -277,3 +277,8 @@ Before declaring any auto-merge PR done — do NOT rely on "pushed + thread reso
 3. Confirm the merge commit's parent is your fixed commit, not a stale head.
 
 If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confirm the merged head includes it.
+
+## Local `lisa ui` verification
+
+- CLI entrypoint is `bun src/index.ts ui` (or `bun dist/index.js ui` after build). Do not use `bun src/cli/index.ts ui` — that module has no `main()`.
+- After source changes that register new `/api/status` probes, rebuild (`bun run build:dist`) or run via the source entrypoint before trusting live `dist/` output; a stale `dist/` can omit newly added probe modules.

--- a/.lisa/plan-1546.md
+++ b/.lisa/plan-1546.md
@@ -1,0 +1,109 @@
+# Plan: implement-ready-queue-1546
+
+Work item: CodySwannGT/lisa#1546
+Type: Build (sub-task)
+Base branch: main (ticket `dev` = local-only; no deploy.branches.dev)
+Branch: cursor/1546-top-bar-version-status
+Roster: `.lisa/roster.md`
+
+## Effective completion condition
+
+Observable end state: after `lisa ui --no-sync --port <isolated>` serves the console,
+
+1. Injected/probe `lisa-version` up-to-date → `#healthChip` has `.dot.ok` and “up to date” + current version
+2. Behind → `#healthChip` has `.dot.warn` and both current and latest version strings visible
+3. Unknown / registry fail → `#healthChip` has no `.dot.ok` and shows unknown + reason
+
+Proof commands:
+
+- `curl -s http://127.0.0.1:<port>/api/status | jq '.probes["lisa-version"]'`
+- `bunx playwright test tests/e2e/ui-version-status.spec.ts --reporter=list`
+
+## Tool access preflight
+
+| tool | probe | status |
+|------|-------|--------|
+| local bun/node CLI | `bun --version` / `node --version` | pass (assumed present) |
+| Playwright e2e | existing `tests/e2e/ui-stacks.spec.ts` harness | pass |
+| npm registry (optional real) | unit stubs preferred; real smoke optional | pass via injectable stub |
+| GitHub gh | `gh issue view 1546` | pass |
+
+## Tasks
+
+### T1 — Export checkVersion + createLisaVersionProbe (TDD)
+
+```json
+{
+  "plan": "implement-ready-queue-1546",
+  "type": "task",
+  "acceptance_criteria": [
+    "checkVersion is exported without semantic change",
+    "createLisaVersionProbe id lisa-version maps up-to-date/behind/unknown correctly",
+    "offline doctor ok path never produces green value when latest missing"
+  ],
+  "relevant_documentation": "src/cli/doctor.ts checkVersion; src/cli/ui-cmd.ts createDetectedStacksProbe; src/cli/ui-status.ts StatusProbe",
+  "testing_requirements": [
+    "tests/unit/cli/ui-lisa-version-probe.test.ts covering up-to-date, behind, unknown, throw"
+  ],
+  "skills": ["lisa-implement"],
+  "learnings": [],
+  "required_access": [],
+  "verification": {
+    "type": "cli-test",
+    "command": "bun test tests/unit/cli/ui-lisa-version-probe.test.ts",
+    "expected": "all tests pass; mapper never emits value+ok for unavailable latest"
+  }
+}
+```
+
+### T2 — Register probe in runUi defaults
+
+```json
+{
+  "plan": "implement-ready-queue-1546",
+  "type": "task",
+  "acceptance_criteria": [
+    "Default /api/status includes probes['lisa-version']"
+  ],
+  "relevant_documentation": "src/cli/ui-cmd.ts runUi probes array",
+  "testing_requirements": ["tests/unit/cli/ui-cmd.test.ts asserts lisa-version key"],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": {
+    "type": "cli-test",
+    "command": "bun test tests/unit/cli/ui-cmd.test.ts",
+    "expected": "default snapshot includes lisa-version"
+  }
+}
+```
+
+### T3 — Wire #healthChip hydrate + Playwright regression
+
+```json
+{
+  "plan": "implement-ready-queue-1546",
+  "type": "task",
+  "acceptance_criteria": [
+    "Up-to-date green",
+    "Behind amber with both versions",
+    "Unknown never green with reason",
+    "No false-green demo flash on served UI"
+  ],
+  "relevant_documentation": "ui/index.html applyDetectedStacks / hydrateLiveStatuses; tests/e2e/ui-stacks.spec.ts",
+  "testing_requirements": [
+    "Playwright tests/e2e/ui-version-status.spec.ts dual cases + anti-false-green",
+    "Maestro: record absence if project has no Maestro for this web console surface"
+  ],
+  "skills": [],
+  "learnings": [],
+  "required_access": [
+    { "tool": "Playwright", "probe": "bunx playwright --version", "status": "pass" }
+  ],
+  "verification": {
+    "type": "ui-recording",
+    "command": "bunx playwright test tests/e2e/ui-version-status.spec.ts --reporter=list",
+    "expected": "named specs pass for green/amber/unknown; no .dot.ok on unknown fixtures"
+  }
+}
+```

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -1,38 +1,56 @@
 # Lisa Implement Roster Decision
 
-Work item: `CodySwannGT/lisa#1537`
+Work item: queue campaign starting `CodySwannGT/lisa#1546`
+Plan: `implement-ready-queue-1546`
+Runtime: Cursor (Task tool specialists)
+Recorded: 2026-07-18T20:55:00Z
 
-Runtime delegation inventory:
+## Queue (status:ready)
 
-`INCLUDE - general-purpose collaboration agent - Codex exposes no enumerated specialist agent types; this available type is constrained by role-specific prompts.`
+1. #1546 Wire the top-bar version status to the existing npm update check
+2. #1545 Detect connected observability providers
+3. #1544 Populate the automations section from the harness scheduler
+4. #1543 Populate the GitHub repository panel from live gh api reads
+5. #1542 Compute deploy pipeline stages from deploy.yml and github.environments
+6. #1541 Compute the CI quality-jobs Active column from ci.yml
+7. #1540 Wire the plugins & MCP section to .claude/settings.json enabledPlugins
 
-Assigned fresh specialist roles:
+SKIP this session: #1539 (status:in-progress, other branch). BLOCKED/human-needed and unlabeled self-hardening issues are out of the formal ready queue.
 
-- `INCLUDE - input resolver - Reconciled the complete issue, comments, target environment, prior browser block, and recoverable WIP before claim.`
-- `INCLUDE - architecture/security auditor - Reviews tri-state correctness, timeout isolation, child-process safety, HTTP transport, JSON safety, and UI accessibility; read-only.`
-- `INCLUDE - test specialist - Owns focused unit/integration tests, records a pre-fix failure for discovered gaps, and does not edit production code.`
-- `INCLUDE - browser verification specialist - Proves controller-neutral interactive browser access and designs/runs the live unauthenticated, failure, timeout, all-unknown, and authenticated journey without mutating the user's credentials.`
-- `INCLUDE - implementation owner - Integrates fixes after specialist findings and preserves issue scope.`
-- `INCLUDE - independent review/learning/verifier/ops roles - Required after implementation for correctness, durable learning, empirical verdict, PR/CI/merge, and release evidence.`
+## Base branch assumption
 
-No available delegation type is excluded. Implementation/review/verification responsibilities remain separated by bounded prompts and fresh agents where the runtime permits.
+Ticket #1546 names target environment `dev` (local-only UI on 127.0.0.1). `.lisa.config.json` `deploy.branches` only maps `production → main`. Interpreting `dev` as local verification (not a missing deploy branch); PR base = remote default `main`.
 
----
+## Runtime agent inventory
 
-Work item: `CodySwannGT/lisa#1550` (post-release compatibility repair)
+INCLUDE|EXCLUDE - agent type - reason
 
-Runtime delegation inventory:
+INCLUDE - generalPurpose - Explore/research equivalent; plan naming, branch sync, task planning when no narrower specialist fits
+INCLUDE - architecture-specialist - design approach, file map, reuse of checkVersion / live-status probe
+INCLUDE - builder - TDD implementation of #1546 and subsequent ready items
+INCLUDE - test-specialist - unit + Playwright regression for version status surface
+INCLUDE - product-specialist - acceptance criteria / Validation Journey alignment
+INCLUDE - verification-specialist - local empirical proof + verification-status.json
+INCLUDE - quality-specialist - correctness / coverage / philosophy review
+INCLUDE - code-reviewer - PR-oriented code review before merge drive
+INCLUDE - code-simplifier - clarify recently modified code after green tests
+INCLUDE - security-specialist - threat pass on live probe / npm registry reads
+INCLUDE - learner - post-task learnings review (required by implement skill)
+INCLUDE - github-agent - claim/sync issue labels, PR linkage, done transitions between queue items
+INCLUDE - debug-specialist - only if reproduction or verification fails
+INCLUDE - performance-specialist - only if version probe or UI polling shows latency issues
+INCLUDE - spec-conformance-specialist - verify shipped work matches ticket AC before done
+EXCLUDE - bug-fixer - work type is Build, not Fix; builder covers TDD
+EXCLUDE - bugbot - only when explicitly requested
+EXCLUDE - security-review - only when explicitly requested; security-specialist covers inline
+EXCLUDE - best-of-n-runner - no parallel experiment need
+EXCLUDE - cursor-guide - not a Cursor product question
+EXCLUDE - *-prd-intake / *-build-intake - this is implement, not intake
+EXCLUDE - jira-agent / linear-agent / confluence-* / notion-* - tracker is github
+EXCLUDE - pr-mining-specialist / tracker-mining-specialist / learnings-synthesizer - debrief-only
+EXCLUDE - skill-evaluator - no new skill authoring in this flow
+EXCLUDE - git-history-analyzer - architecture-specialist + generalPurpose cover needed history
 
-`INCLUDE - general-purpose collaboration agent - Codex exposes one delegation type, constrained here by fresh role-specific prompts.`
+## Effective completion (queue)
 
-`INCLUDE - input resolver - Confirmed #1550 was initially ready and later reopened after empirical npm verification.`
-
-`INCLUDE - reproducer and parity mapper - Reproduced the original gap, mapped canonical/generated surfaces, and now pins the released backward-compatibility regression.`
-
-`INCLUDE - implementer - Repairs the released 2.222.0 compatibility failure and mixed-rollup semantics from clean main.`
-
-`INCLUDE - reviewer and learner - Independently gate contract correctness, source compatibility, and maintainability.`
-
-`INCLUDE - verifier and release operations - Validate local behavior, merged CI, release, and public npm artifact before terminal closeout.`
-
-No available delegation type is excluded.
+Queue is clean when `gh issue list --label status:ready --state open` returns zero issues (or only items that transitioned to blocked with human_needed / linked dependency). Per-issue: verification-status.json all-pass, PR merged to main, tracker sync to env-keyed done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,13 @@ The factories run on the current runtime's native scheduler (Claude Routines, Co
 **Brownfield projects earn their way in.** Greenfield projects start agent-ready; an existing codebase must be made ready first, in two steps. First, **knowledge convergence**: `/lisa:agent-ready` builds the initial knowledge wiki from everything the agent can reach (repository, git history, connected systems) under the premise "starting tomorrow you maintain this with zero human input — today is your only chance to ask questions," and writes `wiki/gaps.md` with the questions only a human can answer. Humans answer inline, a fresh session re-runs the skill, answers are absorbed into the wiki, and the loop repeats until zero gaps remain. Second, **standards adoption**: apply Lisa's full lint rules, guardrails, and thresholds — expect the project to go red — then agents refactor to conform **without changing business logic or functionality**, proving behavior is preserved. Only then does the automation fleet run unattended.
 
 Everything else in Lisa — the skills, hooks, quality checks, and guardrails — exists to enforce enterprise-grade quality and verification standards that keep the software maintainable, across every major coding agent platform. When executed properly, end users have zero direct contact with coding agents.
+
+<!-- LISA_PROJECT_LEARNINGS_START -->
+Antigravity startup bridge: before normal task work, resolve the canonical
+project-learnings file from `.lisa.config.json` (`projectRulesFile`'s sibling
+`PROJECT_LEARNINGS.md`; default `.claude/rules/PROJECT_LEARNINGS.md`). If it
+exists and satisfies the Lisa learnings contract, read and apply its entries.
+If it is absent, continue silently. If it is malformed, warn once and ignore it.
+
+Resolved path for this project: `.claude/rules/PROJECT_LEARNINGS.md`.
+<!-- LISA_PROJECT_LEARNINGS_END -->

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -59,11 +59,13 @@ const DEFAULT_DEPENDENCIES: DoctorDependencies = {
 
 /**
  * Check Lisa's installed version against npm.
+ * Exported so the console live-status probe can reuse the same check as
+ * `lisa doctor` — never invent a second npm update-check path.
  * @param deps - Runtime dependencies
  * @param offline - Skip network check
  * @returns Doctor check result
  */
-async function checkVersion(
+export async function checkVersion(
   deps: DoctorDependencies,
   offline: boolean
 ): Promise<DoctorCheck> {

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -20,6 +20,7 @@ import {
   inspectRemoteEnvironment,
   type RemoteEnvironmentStatus,
 } from "./remote-environment.js";
+import { createLisaVersionProbe } from "./ui-lisa-version.js";
 import {
   createGithubAuthProbe,
   readStatusSnapshot,
@@ -36,6 +37,11 @@ export {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+export {
+  createLisaVersionProbe,
+  mapLisaVersionCheck,
+  type LisaVersionValue,
+} from "./ui-lisa-version.js";
 export { inspectRemoteEnvironment } from "./remote-environment.js";
 
 /** Default port for the settings console. */
@@ -319,7 +325,10 @@ export async function runUi(
     getProcessEnvironment()
   );
   const page = injectLiveConfig(html, config, remoteEnvironment);
-  const probes = dependencies.probes ?? [createGithubAuthProbe(destDir)];
+  const probes = dependencies.probes ?? [
+    createGithubAuthProbe(destDir),
+    createLisaVersionProbe(),
+  ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)
   );

--- a/src/cli/ui-lisa-version.ts
+++ b/src/cli/ui-lisa-version.ts
@@ -1,0 +1,110 @@
+/**
+ * Live-status probe for the console top-bar Lisa version chip.
+ *
+ * Reuses doctor `checkVersion` so `/api/status` and `lisa doctor` cannot drift.
+ * @module cli/ui-lisa-version
+ */
+import {
+  checkVersion,
+  type DoctorCheck,
+  type DoctorDependencies,
+} from "./doctor.js";
+import { runUpdateCheck } from "./update-check.js";
+import type { JsonValue } from "../sync/json-path.js";
+import type { ProbeResult, StatusProbe } from "./ui-status.js";
+
+/** Structured value emitted by the lisa-version live-status probe. */
+export type LisaVersionValue = {
+  readonly [key: string]: JsonValue;
+  readonly current: string;
+  readonly latest: string;
+  readonly outdated: boolean;
+};
+
+const LISA_VERSION_PROBE_ID = "lisa-version";
+const INSTALLED_LATEST_DETAIL = /^Installed (.+); latest is (.+)$/u;
+const LATEST_UNAVAILABLE_DETAIL = /^Latest version unavailable(?: \((.+)\))?$/u;
+const OFFLINE_SKIP_DETAIL = "Skipped network check in offline mode";
+const UNRECOGNIZED_MESSAGE = "Version check returned an unrecognized result";
+
+/**
+ * Default doctor collaborators for the version probe.
+ * checkVersion only reads `runUpdateCheck`; the rest satisfy the type.
+ */
+const DEFAULT_VERSION_PROBE_DEPS: DoctorDependencies = {
+  fetchImpl: fetch,
+  runUpdateCheck,
+  setExitCode: () => undefined,
+  write: () => undefined,
+};
+
+/**
+ * Map a `checkVersion` doctor result onto the live-status tri-state contract.
+ *
+ * Doctor's offline skip returns status "ok" — that must become unknown here so
+ * the top bar never shows a false green when latest was never fetched.
+ * Latest-unavailable is also doctor "warn"; surface it as unknown, not amber.
+ * @param check - Result from the shared doctor version check
+ * @returns Probe result for `#healthChip`
+ */
+export function mapLisaVersionCheck(
+  check: DoctorCheck
+): ProbeResult<LisaVersionValue> {
+  if (check.detail === OFFLINE_SKIP_DETAIL) {
+    return {
+      state: "unknown",
+      reason: "offline-skipped",
+      message: check.detail,
+    };
+  }
+  const unavailable = LATEST_UNAVAILABLE_DETAIL.exec(check.detail);
+  if (unavailable !== null) {
+    return {
+      state: "unknown",
+      reason: unavailable[1] ?? "latest-unavailable",
+      message: check.detail,
+    };
+  }
+  const installed = INSTALLED_LATEST_DETAIL.exec(check.detail);
+  if (
+    installed !== null &&
+    (check.status === "ok" || check.status === "warn")
+  ) {
+    return {
+      state: "value",
+      value: {
+        current: installed[1] ?? "",
+        latest: installed[2] ?? "",
+        outdated: check.status === "warn",
+      },
+    };
+  }
+  return {
+    state: "unknown",
+    reason: "unrecognized-version-check",
+    message:
+      check.detail.trim().length > 0 ? check.detail : UNRECOGNIZED_MESSAGE,
+  };
+}
+
+/**
+ * Create the probe that reports whether the installed Lisa matches npm latest.
+ *
+ * Always calls `checkVersion(deps, false)` — never offline:true, which would
+ * produce doctor's false-green "Skipped network check in offline mode" ok.
+ * @param dependencies - Injectable doctor collaborators for focused tests
+ * @returns Probe emitting current/latest/outdated or an honest unknown
+ */
+export function createLisaVersionProbe(
+  dependencies: Partial<DoctorDependencies> = {}
+): StatusProbe<LisaVersionValue> {
+  const deps = { ...DEFAULT_VERSION_PROBE_DEPS, ...dependencies };
+  return {
+    id: LISA_VERSION_PROBE_ID,
+    timeoutMs: 5_000,
+    run: async () => {
+      const check = await checkVersion(deps, false);
+      return mapLisaVersionCheck(check);
+    },
+  };
+}

--- a/tests/e2e/ui-version-status.spec.ts
+++ b/tests/e2e/ui-version-status.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Playwright regression for the top-bar `#healthChip` lisa-version probe.
+ *
+ * Maestro: this web console surface has no Maestro harness in the repo
+ * (coverage is Playwright-only, same as other `lisa ui` e2e specs). Do not
+ * invent Maestro flows for a surface that is not Maestro-covered.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  runUi,
+  type LisaVersionValue,
+  type ProbeResult,
+  type StatusProbe,
+} from "../../src/cli/ui-cmd.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown. Each test
+ * owns one and closes it in a `finally` so no server outlives its test and no
+ * fixed port (never 4780) is bound.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port (0) with sync disabled, so the spec
+ * neither mutates the project nor collides with the shared webServer.
+ * @param destDir - Project root the console serves
+ * @param probes - Injected status probes; omitted to exercise the real defaults
+ * @returns The console's loopback origin and a close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes?: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(
+    destDir,
+    { port: "0", sync: false },
+    probes ? { probes } : {}
+  );
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build the `lisa-version` probe returning a fixed result.
+ * @param result - The tri-state result the probe reports
+ * @returns A probe registered under the `lisa-version` id
+ */
+function lisaVersionProbe(
+  result: ProbeResult<LisaVersionValue>
+): StatusProbe<LisaVersionValue> {
+  return { id: "lisa-version", timeoutMs: 1_000, run: async () => result };
+}
+
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
+/**
+ * Create a fresh temporary project directory, tracked for teardown.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-version-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+const healthChip = "#healthChip";
+const healthDot = "#healthChip .dot";
+
+test("up-to-date lisa-version paints green up-to-date on #healthChip", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    lisaVersionProbe({
+      state: "value",
+      value: { current: "2.233.1", latest: "2.233.1", outdated: false },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/`);
+    await expect(page.locator(healthChip)).toContainText("2.233.1");
+    await expect(page.locator(healthChip)).toContainText("up to date");
+    await expect(page.locator(healthDot)).toHaveClass(/ok/);
+    await expect(page.locator(healthDot)).not.toHaveClass(/warn/);
+    await expect(page.locator(healthDot)).not.toHaveClass(/unknown/);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("behind lisa-version paints amber with both current and latest", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    lisaVersionProbe({
+      state: "value",
+      value: { current: "2.199.0", latest: "2.233.1", outdated: true },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/`);
+    await expect(page.locator(healthChip)).toContainText("2.199.0");
+    await expect(page.locator(healthChip)).toContainText("2.233.1");
+    await expect(page.locator(healthDot)).toHaveClass(/warn/);
+    await expect(page.locator(healthDot)).not.toHaveClass(/ok/);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("unknown lisa-version never shows green and carries the reason", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    lisaVersionProbe({
+      state: "unknown",
+      reason: "network-error",
+      message: "Latest version unavailable (network-error)",
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/`);
+    await expect(page.locator(healthChip)).toContainText("unknown");
+    await expect(page.locator(healthChip)).toContainText("network-error");
+    await expect(page.locator(healthDot)).toHaveClass(/unknown/);
+    await expect(page.locator(healthDot)).not.toHaveClass(/ok/);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("served HTML does not flash a false-green demo on #healthChip", async ({
+  page,
+  request,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    lisaVersionProbe({
+      state: "unknown",
+      reason: "network-error",
+      message: "Latest version unavailable (network-error)",
+    }),
+  ]);
+  try {
+    const htmlResponse = await request.get(`${ui.base}/`);
+    expect(htmlResponse.ok()).toBe(true);
+    const html = await htmlResponse.text();
+    expect(html).toContain('id="healthChip"');
+    expect(html).toContain("checking…");
+    expect(html).not.toMatch(/id="healthChip"[\s\S]*?<span class="dot ok"/u);
+
+    await page.goto(`${ui.base}/`);
+    await expect(page.locator(healthDot)).not.toHaveClass(/ok/);
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createLisaVersionProbe,
   findUiHtml,
   injectLiveConfig,
   inspectRemoteEnvironment,
@@ -241,6 +242,54 @@ describe("runUi", () => {
     expect(body).toContain("window.LISA_REMOTE_ENVIRONMENT");
     const missing = await fetch(`http://127.0.0.1:${port}/nope`);
     expect(missing.status).toBe(404);
+  });
+
+  it("registers the lisa-version probe in the default status snapshot", async () => {
+    resources.server = await runUi(
+      resources.dir,
+      { port: "0", sync: false },
+      {
+        probes: [
+          createLisaVersionProbe({
+            runUpdateCheck: vi.fn(async () => ({
+              current: "2.200.0",
+              latest: "2.200.0",
+              isOutdated: false,
+            })),
+          }),
+        ],
+      }
+    );
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const snapshot = (await response.json()) as {
+      probes: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(snapshot.probes["lisa-version"]).toEqual({
+      state: "value",
+      value: { current: "2.200.0", latest: "2.200.0", outdated: false },
+    });
+  });
+
+  it("includes lisa-version among the default runUi probes", async () => {
+    resources.server = await runUi(resources.dir, { port: "0", sync: false });
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const snapshot = (await response.json()) as {
+      probes: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(snapshot.probes).toHaveProperty("lisa-version");
+    expect(snapshot.probes).toHaveProperty("github-auth");
   });
 
   it("rejects an invalid port", async () => {

--- a/tests/unit/cli/ui-lisa-version-probe.test.ts
+++ b/tests/unit/cli/ui-lisa-version-probe.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createLisaVersionProbe,
+  mapLisaVersionCheck,
+  runProbe,
+} from "../../../src/cli/ui-cmd.js";
+import type {
+  DoctorCheck,
+  DoctorDependencies,
+} from "../../../src/cli/doctor.js";
+import { checkVersion } from "../../../src/cli/doctor.js";
+
+const LISA_VERSION_PROBE_ID = "lisa-version";
+const VERSION_CHECK_NAME = "Lisa version current?";
+const LATEST_UNAVAILABLE_PREFIX = "Latest version unavailable";
+const NETWORK_ERROR_REASON = "network-error";
+const CURRENT_MATCHING = "2.200.0";
+const CURRENT_BEHIND = "2.199.0";
+const LATEST_AHEAD = "2.233.1";
+
+/**
+ * Build injectable doctor deps with a stubbed update check.
+ * @param runUpdateCheck - Stubbed npm update check
+ * @returns Partial doctor dependencies for the probe
+ */
+function depsWith(
+  runUpdateCheck: DoctorDependencies["runUpdateCheck"]
+): Partial<DoctorDependencies> {
+  return {
+    runUpdateCheck,
+    fetchImpl: vi.fn<typeof fetch>(),
+    setExitCode: vi.fn(),
+    write: vi.fn(),
+  };
+}
+
+describe("checkVersion export", () => {
+  it("remains callable for the live-status probe without semantic change", async () => {
+    const check = await checkVersion(
+      {
+        fetchImpl: vi.fn<typeof fetch>(),
+        runUpdateCheck: vi.fn(async () => ({
+          current: CURRENT_MATCHING,
+          latest: CURRENT_MATCHING,
+          isOutdated: false,
+        })),
+        setExitCode: vi.fn(),
+        write: vi.fn(),
+      },
+      false
+    );
+
+    expect(check).toEqual({
+      name: VERSION_CHECK_NAME,
+      status: "ok",
+      detail: `Installed ${CURRENT_MATCHING}; latest is ${CURRENT_MATCHING}`,
+    });
+  });
+});
+
+describe("mapLisaVersionCheck", () => {
+  it("maps an up-to-date doctor check to a non-outdated value", () => {
+    const check: DoctorCheck = {
+      name: VERSION_CHECK_NAME,
+      status: "ok",
+      detail: `Installed ${CURRENT_MATCHING}; latest is ${CURRENT_MATCHING}`,
+    };
+
+    expect(mapLisaVersionCheck(check)).toEqual({
+      state: "value",
+      value: {
+        current: CURRENT_MATCHING,
+        latest: CURRENT_MATCHING,
+        outdated: false,
+      },
+    });
+  });
+
+  it("maps a behind doctor check to an outdated value with both versions", () => {
+    const check: DoctorCheck = {
+      name: VERSION_CHECK_NAME,
+      status: "warn",
+      detail: `Installed ${CURRENT_BEHIND}; latest is ${CURRENT_MATCHING}`,
+    };
+
+    expect(mapLisaVersionCheck(check)).toEqual({
+      state: "value",
+      value: {
+        current: CURRENT_BEHIND,
+        latest: CURRENT_MATCHING,
+        outdated: true,
+      },
+    });
+  });
+
+  it("maps latest-unavailable to unknown, never a green value", () => {
+    const check: DoctorCheck = {
+      name: VERSION_CHECK_NAME,
+      status: "warn",
+      detail: `${LATEST_UNAVAILABLE_PREFIX} (${NETWORK_ERROR_REASON})`,
+    };
+
+    const result = mapLisaVersionCheck(check);
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NETWORK_ERROR_REASON);
+      expect(result.message).toContain(LATEST_UNAVAILABLE_PREFIX);
+    }
+  });
+
+  it("maps offline skip (doctor ok) to unknown so it cannot become green", () => {
+    const check: DoctorCheck = {
+      name: VERSION_CHECK_NAME,
+      status: "ok",
+      detail: "Skipped network check in offline mode",
+    };
+
+    const result = mapLisaVersionCheck(check);
+
+    expect(result).toEqual({
+      state: "unknown",
+      reason: "offline-skipped",
+      message: "Skipped network check in offline mode",
+    });
+  });
+});
+
+describe("createLisaVersionProbe", () => {
+  it("registers with the lisa-version id and a bounded timeout", () => {
+    const probe = createLisaVersionProbe();
+
+    expect(probe.id).toBe(LISA_VERSION_PROBE_ID);
+    expect(Number.isFinite(probe.timeoutMs)).toBe(true);
+    expect(probe.timeoutMs).toBeGreaterThan(0);
+  });
+
+  it("reports up-to-date when checkVersion finds matching latest", async () => {
+    const result = await runProbe(
+      createLisaVersionProbe(
+        depsWith(
+          vi.fn(async () => ({
+            current: CURRENT_MATCHING,
+            latest: CURRENT_MATCHING,
+            isOutdated: false,
+          }))
+        )
+      )
+    );
+
+    expect(result).toEqual({
+      state: "value",
+      value: {
+        current: CURRENT_MATCHING,
+        latest: CURRENT_MATCHING,
+        outdated: false,
+      },
+    });
+  });
+
+  it("reports behind with both versions when checkVersion warns outdated", async () => {
+    const result = await runProbe(
+      createLisaVersionProbe(
+        depsWith(
+          vi.fn(async () => ({
+            current: CURRENT_BEHIND,
+            latest: LATEST_AHEAD,
+            isOutdated: true,
+          }))
+        )
+      )
+    );
+
+    expect(result).toEqual({
+      state: "value",
+      value: {
+        current: CURRENT_BEHIND,
+        latest: LATEST_AHEAD,
+        outdated: true,
+      },
+    });
+  });
+
+  it("reports unknown when latest is unavailable", async () => {
+    const result = await runProbe(
+      createLisaVersionProbe(
+        depsWith(
+          vi.fn(async () => ({
+            current: CURRENT_MATCHING,
+            latest: null,
+            isOutdated: false,
+            reason: NETWORK_ERROR_REASON,
+          }))
+        )
+      )
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NETWORK_ERROR_REASON);
+      expect(result.message).toContain(LATEST_UNAVAILABLE_PREFIX);
+    }
+  });
+
+  it("always calls checkVersion with offline:false (never the false-green skip)", async () => {
+    const runUpdateCheck = vi.fn(async () => ({
+      current: CURRENT_MATCHING,
+      latest: CURRENT_MATCHING,
+      isOutdated: false,
+    }));
+
+    await runProbe(createLisaVersionProbe(depsWith(runUpdateCheck)));
+
+    expect(runUpdateCheck).toHaveBeenCalled();
+  });
+
+  it("degrades to unknown when the update check throws", async () => {
+    const result = await runProbe(
+      createLisaVersionProbe(
+        depsWith(
+          vi.fn(async () => {
+            throw new Error("registry exploded");
+          })
+        )
+      )
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe("probe-failed");
+      expect(result.message).toContain("registry exploded");
+    }
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -260,6 +260,7 @@
         height: 8px;
         border-radius: 50%;
         flex: none;
+        background: var(--muted);
       }
       .dot.ok {
         background: var(--good);
@@ -269,6 +270,9 @@
       }
       .dot.fail {
         background: var(--crit);
+      }
+      .dot.unknown {
+        background: var(--muted);
       }
       .badge.pass {
         background: var(--good-soft);
@@ -1252,8 +1256,7 @@
         type="button"
         title="Lisa health — click for details"
       >
-        <span class="dot ok" aria-hidden="true"></span> @codyswann/lisa 2.199.0
-        · up to date
+        <span class="dot" aria-hidden="true"></span> @codyswann/lisa · checking…
       </button>
       <button
         class="icon-btn"
@@ -6082,6 +6085,73 @@
           list.appendChild(item);
         });
       }
+      /**
+       * Paint `#healthChip` from the lisa-version probe.
+       * green=ok (up to date), amber=warn (behind), unknown≠ok.
+       * READ-ONLY — never offers an upgrade action.
+       * @param probes - Live-status probe map from /api/status
+       */
+      function applyLisaVersion(probes) {
+        const chip = document.getElementById("healthChip");
+        if (!chip) return;
+        const raw =
+          probes && Object.hasOwn(probes, "lisa-version")
+            ? probes["lisa-version"]
+            : undefined;
+        const result =
+          raw === undefined
+            ? {
+                state: "unknown",
+                reason: "missing-probe",
+                message: "The lisa-version probe was not reported",
+              }
+            : normalizeLiveStatusResult(raw);
+        const setChip = (dotClass, label) => {
+          chip.innerHTML = "";
+          const dot = el("span", "dot" + (dotClass ? " " + dotClass : ""));
+          dot.setAttribute("aria-hidden", "true");
+          chip.appendChild(dot);
+          chip.appendChild(document.createTextNode(" " + label));
+        };
+        if (
+          result.state === "value" &&
+          result.value &&
+          typeof result.value === "object"
+        ) {
+          const current = result.value.current;
+          const latest = result.value.latest;
+          const outdated = result.value.outdated === true;
+          if (
+            typeof current === "string" &&
+            typeof latest === "string" &&
+            current.length > 0 &&
+            latest.length > 0
+          ) {
+            if (outdated) {
+              setChip(
+                "warn",
+                "@codyswann/lisa " + current + " · latest " + latest
+              );
+              return;
+            }
+            setChip("ok", "@codyswann/lisa " + current + " · up to date");
+            return;
+          }
+        }
+        if (result.state === "unknown") {
+          const reason = result.reason || "unknown";
+          const message = result.message || "Version status unavailable";
+          setChip(
+            "unknown",
+            "@codyswann/lisa · unknown (" + reason + ": " + message + ")"
+          );
+          return;
+        }
+        setChip(
+          "unknown",
+          "@codyswann/lisa · unknown (invalid-value: lisa-version probe returned an unusable value)"
+        );
+      }
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {
@@ -6089,15 +6159,17 @@
           });
           if (!response.ok) throw new Error("HTTP " + response.status);
           const snapshot = await response.json();
-          renderLiveStatuses(liveStatusProbeMap(snapshot));
+          const probes = liveStatusProbeMap(snapshot);
+          renderLiveStatuses(probes);
+          applyLisaVersion(probes);
         } catch (error) {
-          renderLiveStatuses({
-            transport: {
-              state: "unknown",
-              reason: "status-unavailable",
-              message: error instanceof Error ? error.message : String(error),
-            },
-          });
+          const unavailable = {
+            state: "unknown",
+            reason: "status-unavailable",
+            message: error instanceof Error ? error.message : String(error),
+          };
+          renderLiveStatuses({ transport: unavailable });
+          applyLisaVersion({ "lisa-version": unavailable });
         }
       }
 


### PR DESCRIPTION
## Summary
- Add `lisa-version` live-status probe that reuses exported `checkVersion` (no second npm check)
- Hydrate top-bar `#healthChip` to green (up-to-date), amber (behind with both versions), or unknown (never false green)
- Codify Playwright regression `tests/e2e/ui-version-status.spec.ts` (Maestro N/A for web console)

Closes #1546

## Test plan
- [x] `bun test tests/unit/cli/ui-lisa-version-probe.test.ts tests/unit/cli/ui-cmd.test.ts`
- [x] `bunx playwright test tests/e2e/ui-version-status.spec.ts`
- [x] Live `bun src/index.ts ui --no-sync --port <isolated>` + `curl /api/status` shows `probes["lisa-version"]`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)