### PR TITLE
feat(ui): compute CI quality-jobs Active column from live probes

### DIFF
--- a/src/cli/ui-ci-quality-jobs-compute.ts
+++ b/src/cli/ui-ci-quality-jobs-compute.ts
@@ -1,0 +1,247 @@
+/**
+ * Pure join of ci.yml inputs, Lisa gate config, and secret presence for the
+ * CI Quality jobs Active column.
+ * @module cli/ui-ci-quality-jobs-compute
+ */
+import {
+  isJsonObject,
+  type JsonObject,
+  type JsonValue,
+} from "../sync/json-path.js";
+
+/** Inputs the project's `ci.yml` forwards into Lisa's quality workflow. */
+export interface CiWorkflowInputs {
+  readonly skipJobs: readonly string[];
+  readonly verifyEnforced: boolean;
+  readonly complianceFramework: string;
+  readonly requireApproval: boolean;
+  readonly zapTargetUrl: string;
+}
+
+/** Presence-only secret inventory, or an honest unknown. */
+export type RepoSecretsPresence =
+  | { readonly state: "value"; readonly names: ReadonlySet<string> }
+  | {
+      readonly state: "unknown";
+      readonly reason: string;
+      readonly message: string;
+    };
+
+/** One Quality-jobs row for the Active column. */
+export type CiQualityJobEntry = {
+  readonly [key: string]: JsonValue;
+  readonly id: string;
+  readonly label: string;
+  /** `true` active, `false` off, `null` unknown (never a false off). */
+  readonly active: boolean | null;
+  readonly reason: string;
+};
+
+/** Structured probe value for the Quality jobs table. */
+export type CiQualityJobsValue = {
+  readonly [key: string]: JsonValue;
+  readonly jobs: CiQualityJobEntry[];
+};
+
+/** Catalog entry describing how one Quality job becomes active. */
+interface QualityJobSpec {
+  readonly id: string;
+  readonly label: string;
+  readonly secret?: string;
+  readonly gate?:
+    | "mutation"
+    | "verify_enforced"
+    | "compliance_framework"
+    | "zap_target_url"
+    | "require_approval";
+}
+
+/** Jobs shown in the console Quality jobs table, in display order. */
+const QUALITY_JOB_SPECS: readonly QualityJobSpec[] = [
+  { id: "lint", label: "🧹 Lint" },
+  { id: "lint_slow", label: "🐢 Slow Lint Rules" },
+  { id: "typecheck", label: "🔍 Type Check" },
+  { id: "format", label: "📐 Check Formatting" },
+  { id: "build", label: "🏗️ Build" },
+  { id: "test:unit", label: "🧪 Run Unit Tests" },
+  { id: "test:integration", label: "🧪 Run Integration Tests" },
+  { id: "test:e2e", label: "🧪 Run E2E Tests" },
+  { id: "playwright_e2e", label: "🎭 Playwright E2E Tests" },
+  {
+    id: "maestro_e2e",
+    label: "📱 Maestro Cloud E2E",
+    secret: "MAESTRO_API_KEY",
+  },
+  { id: "e2e_coverage", label: "🧭 E2E Route Coverage" },
+  { id: "test:mutation", label: "🧬 Mutation Testing Gate", gate: "mutation" },
+  {
+    id: "verification_coverage",
+    label: "✅ Verification Coverage",
+    gate: "verify_enforced",
+  },
+  { id: "dead_code", label: "🗑️ Dead Code Detection" },
+  { id: "sg_scan", label: "🔎 AST Grep Scan" },
+  { id: "npm_security_scan", label: "🔒 Security Scan" },
+  {
+    id: "sonarcloud",
+    label: "🔍 SonarCloud SAST",
+    secret: "SONAR_TOKEN",
+  },
+  { id: "snyk", label: "🛡️ Snyk", secret: "SNYK_TOKEN" },
+  {
+    id: "secret_scanning",
+    label: "🔐 GitGuardian",
+    secret: "GITGUARDIAN_API_KEY",
+  },
+  {
+    id: "license_compliance",
+    label: "📜 FOSSA",
+    secret: "FOSSA_API_KEY",
+  },
+  {
+    id: "zap_baseline",
+    label: "🕷️ OWASP ZAP Baseline",
+    gate: "zap_target_url",
+  },
+  {
+    id: "compliance_validation",
+    label: "🧾 Compliance Validation",
+    gate: "compliance_framework",
+  },
+  {
+    id: "approval_gate",
+    label: "🚦 Approval Gate",
+    gate: "require_approval",
+  },
+];
+
+/**
+ * Read whether the mutation gate is enabled in merged Lisa config.
+ * @param config - Merged config
+ * @returns True only when explicitly enabled
+ */
+function mutationGateEnabled(config: JsonObject): boolean {
+  if (!isJsonObject(config.quality)) {
+    return false;
+  }
+  if (!isJsonObject(config.quality.mutation)) {
+    return false;
+  }
+  if (!isJsonObject(config.quality.mutation.gate)) {
+    return false;
+  }
+  return config.quality.mutation.gate.enabled === true;
+}
+
+/**
+ * Resolve a config/workflow gate into an off-reason, or undefined when open.
+ * @param gate - Gate kind on the job spec
+ * @param inputs - ci.yml inputs
+ * @param config - Merged Lisa config
+ * @returns Off reason when the gate closes the job
+ */
+function gateOffReason(
+  gate: QualityJobSpec["gate"],
+  inputs: CiWorkflowInputs,
+  config: JsonObject
+): string | undefined {
+  if (gate === "mutation" && !mutationGateEnabled(config)) {
+    return "mutation gate is disabled";
+  }
+  if (gate === "verify_enforced" && !inputs.verifyEnforced) {
+    return "verify_enforced is off";
+  }
+  if (
+    gate === "compliance_framework" &&
+    (inputs.complianceFramework.length === 0 ||
+      inputs.complianceFramework === "none" ||
+      inputs.complianceFramework === "(none)")
+  ) {
+    return "no compliance_framework configured";
+  }
+  if (gate === "zap_target_url" && inputs.zapTargetUrl.length === 0) {
+    return "zap_target_url is not set";
+  }
+  if (gate === "require_approval" && !inputs.requireApproval) {
+    return "require_approval is off";
+  }
+  return undefined;
+}
+
+/**
+ * Resolve secret presence into active/off/unknown for one job.
+ * @param secretName - Required Actions secret
+ * @param secrets - Presence inventory or unknown
+ * @returns Job active state and reason
+ */
+function secretActiveState(
+  secretName: string,
+  secrets: RepoSecretsPresence
+): Pick<CiQualityJobEntry, "active" | "reason"> {
+  if (secrets.state === "unknown") {
+    return {
+      active: null,
+      reason:
+        secrets.reason === "not-authenticated"
+          ? "not authenticated"
+          : secrets.message,
+    };
+  }
+  if (!secrets.names.has(secretName)) {
+    return {
+      active: false,
+      reason: `${secretName} secret is not set`,
+    };
+  }
+  return { active: true, reason: "" };
+}
+
+/**
+ * Join ci.yml inputs, gate config, and secret presence into Active-column rows.
+ * @param inputs - Parsed ci.yml quality inputs
+ * @param config - Merged Lisa config
+ * @param secrets - Presence-only secret inventory
+ * @returns Probe value for the Quality jobs table
+ */
+export function computeCiQualityJobs(
+  inputs: CiWorkflowInputs,
+  config: JsonObject,
+  secrets: RepoSecretsPresence
+): CiQualityJobsValue {
+  const skipped = new Set(inputs.skipJobs);
+  const jobs = QUALITY_JOB_SPECS.map((spec): CiQualityJobEntry => {
+    if (skipped.has(spec.id)) {
+      return {
+        id: spec.id,
+        label: spec.label,
+        active: false,
+        reason: `ci.yml skip_jobs includes ${spec.id}`,
+      };
+    }
+    const closed = gateOffReason(spec.gate, inputs, config);
+    if (closed !== undefined) {
+      return {
+        id: spec.id,
+        label: spec.label,
+        active: false,
+        reason: closed,
+      };
+    }
+    if (spec.secret !== undefined) {
+      const secretState = secretActiveState(spec.secret, secrets);
+      return {
+        id: spec.id,
+        label: spec.label,
+        active: secretState.active,
+        reason: secretState.reason,
+      };
+    }
+    return {
+      id: spec.id,
+      label: spec.label,
+      active: true,
+      reason: "",
+    };
+  });
+  return { jobs };
+}

--- a/src/cli/ui-ci-quality-jobs-parse.ts
+++ b/src/cli/ui-ci-quality-jobs-parse.ts
@@ -1,0 +1,130 @@
+/**
+ * Parse the project's calling `ci.yml` quality workflow inputs.
+ * @module cli/ui-ci-quality-jobs-parse
+ */
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import yaml from "js-yaml";
+import { isJsonObject } from "../sync/json-path.js";
+import type { CiWorkflowInputs } from "./ui-ci-quality-jobs-compute.js";
+
+/**
+ * Read `ci.yml` from the project workflows directory.
+ * @param cwd - Project root
+ * @returns File contents
+ */
+export async function readCiYmlFile(cwd: string): Promise<string> {
+  return await readFile(
+    path.join(cwd, ".github", "workflows", "ci.yml"),
+    "utf8"
+  );
+}
+
+/**
+ * Split a comma-separated skip_jobs string into trimmed non-empty ids.
+ * @param raw - Raw skip_jobs value from YAML
+ * @returns Normalized job ids
+ */
+function parseSkipJobs(raw: unknown): readonly string[] {
+  if (typeof raw !== "string") {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map(part => part.trim())
+    .filter(part => part.length > 0);
+}
+
+/**
+ * Coerce a YAML scalar to boolean with an explicit default.
+ * @param value - Candidate YAML value
+ * @param fallback - Default when absent or unreadable
+ * @returns Boolean
+ */
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return fallback;
+}
+
+/**
+ * Coerce a YAML scalar to a trimmed string with a default.
+ * @param value - Candidate YAML value
+ * @param fallback - Default when absent
+ * @returns String
+ */
+function asString(value: unknown, fallback: string): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return fallback;
+}
+
+/**
+ * Find the `with:` map on the job that calls Lisa's quality workflow.
+ * @param document - Parsed ci.yml root
+ * @returns The with-block object, or undefined
+ */
+function qualityWithBlock(
+  document: unknown
+): Record<string, unknown> | undefined {
+  if (!isJsonObject(document) || !isJsonObject(document.jobs)) {
+    return undefined;
+  }
+  for (const job of Object.values(document.jobs)) {
+    if (!isJsonObject(job) || typeof job.uses !== "string") {
+      continue;
+    }
+    if (
+      !job.uses.includes("quality.yml") &&
+      !job.uses.includes("quality-rails.yml")
+    ) {
+      continue;
+    }
+    if (isJsonObject(job.with)) {
+      return job.with as Record<string, unknown>;
+    }
+    return {};
+  }
+  return undefined;
+}
+
+/**
+ * Parse the project's calling `ci.yml` into quality workflow inputs.
+ * @param cwd - Project root
+ * @param readCiYml - Injectable file reader
+ * @returns Normalized inputs
+ */
+export async function parseCiWorkflowInputs(
+  cwd: string,
+  readCiYml: (projectRoot: string) => Promise<string> = readCiYmlFile
+): Promise<CiWorkflowInputs> {
+  const source = await readCiYml(cwd);
+  const document: unknown = yaml.load(source);
+  const withBlock = qualityWithBlock(document);
+  if (withBlock === undefined) {
+    throw new Error(
+      "ci.yml does not call quality.yml or quality-rails.yml with a with-block"
+    );
+  }
+  return {
+    skipJobs: parseSkipJobs(withBlock.skip_jobs),
+    verifyEnforced: asBoolean(withBlock.verify_enforced, false),
+    complianceFramework: asString(
+      withBlock.compliance_framework,
+      "none"
+    ).toLowerCase(),
+    requireApproval: asBoolean(withBlock.require_approval, false),
+    zapTargetUrl: asString(withBlock.zap_target_url, ""),
+  };
+}

--- a/src/cli/ui-ci-quality-jobs.ts
+++ b/src/cli/ui-ci-quality-jobs.ts
@@ -1,0 +1,226 @@
+/**
+ * Live-status probe for the CI Quality jobs Active column.
+ *
+ * Three-input join: `ci.yml` skip/gate inputs, Lisa gate config, and
+ * presence-only `gh secret list`. READ-ONLY — never fabricates "off" for
+ * secrets when authentication is unavailable.
+ * @module cli/ui-ci-quality-jobs
+ */
+import { execFile } from "node:child_process";
+import { isJsonObject, type JsonObject } from "../sync/json-path.js";
+import {
+  computeCiQualityJobs,
+  type CiQualityJobsValue,
+  type RepoSecretsPresence,
+} from "./ui-ci-quality-jobs-compute.js";
+import {
+  parseCiWorkflowInputs,
+  readCiYmlFile,
+} from "./ui-ci-quality-jobs-parse.js";
+import type { StatusProbe } from "./ui-status.js";
+
+export {
+  computeCiQualityJobs,
+  type CiQualityJobEntry,
+  type CiQualityJobsValue,
+  type CiWorkflowInputs,
+  type RepoSecretsPresence,
+} from "./ui-ci-quality-jobs-compute.js";
+export { parseCiWorkflowInputs } from "./ui-ci-quality-jobs-parse.js";
+
+/** Stable probe id consumed by the console Active-column hydrator. */
+export const CI_QUALITY_JOBS_PROBE_ID = "ci-quality-jobs";
+
+/** Injectable collaborators for focused unit tests. */
+export interface CiQualityJobsDependencies {
+  readonly listSecrets?: (
+    cwd: string,
+    timeoutMs: number,
+    signal: AbortSignal,
+    repo: string | undefined
+  ) => Promise<RepoSecretsPresence>;
+  readonly readCiYml?: (cwd: string) => Promise<string>;
+  readonly resolveRepo?: (
+    cwd: string,
+    config: JsonObject
+  ) => string | undefined;
+}
+
+/**
+ * Resolve `owner/repo` from Lisa config when both fields are non-empty strings.
+ * @param config - Merged Lisa config
+ * @returns Repo slug, or undefined when absent
+ */
+function repoFromConfig(config: JsonObject): string | undefined {
+  if (!isJsonObject(config.github)) {
+    return undefined;
+  }
+  const org = config.github.org;
+  const repo = config.github.repo;
+  if (
+    typeof org === "string" &&
+    org.trim().length > 0 &&
+    typeof repo === "string" &&
+    repo.trim().length > 0
+  ) {
+    return `${org.trim()}/${repo.trim()}`;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a failed `gh secret list` into not-authenticated vs other unknown.
+ * @param error - Child-process or parse error
+ * @returns Unknown secrets presence
+ */
+function classifySecretListError(error: unknown): RepoSecretsPresence {
+  const message =
+    error instanceof Error && error.message.trim().length > 0
+      ? error.message
+      : "Unable to list repository secrets";
+  const lower = message.toLowerCase();
+  const notAuthenticated =
+    lower.includes("401") ||
+    lower.includes("bad credentials") ||
+    lower.includes("not logged in") ||
+    lower.includes("authentication required") ||
+    lower.includes("to re-authenticate") ||
+    lower.includes("gh auth login");
+  return {
+    state: "unknown",
+    reason: notAuthenticated ? "not-authenticated" : "secret-list-failed",
+    message: notAuthenticated ? "GitHub CLI is not authenticated" : message,
+  };
+}
+
+/**
+ * Parse `gh secret list --json name` stdout into a presence set.
+ * @param stdout - Command stdout
+ * @returns Presence-only secret names
+ */
+function secretNamesFromJson(stdout: string): ReadonlySet<string> {
+  const parsed: unknown = JSON.parse(stdout);
+  if (!Array.isArray(parsed)) {
+    throw new TypeError("gh secret list did not return an array");
+  }
+  return new Set(
+    parsed.flatMap(entry => {
+      if (typeof entry !== "object" || entry === null) {
+        return [];
+      }
+      const name = Reflect.get(entry, "name");
+      return typeof name === "string" && name.trim().length > 0 ? [name] : [];
+    })
+  );
+}
+
+/**
+ * List Actions secret *names* only via `gh secret list --json name`.
+ * @param cwd - Project root
+ * @param timeoutMs - Child-process timeout
+ * @param signal - Probe cancellation
+ * @param repo - Optional `owner/repo` for `-R`
+ * @returns Presence set or unknown
+ */
+const listRepoSecretNames: NonNullable<
+  CiQualityJobsDependencies["listSecrets"]
+> = async (cwd, timeoutMs, signal, repo) =>
+  await new Promise((resolve, reject) => {
+    const args =
+      repo !== undefined && repo.length > 0
+        ? (["secret", "list", "--json", "name", "-R", repo] as const)
+        : (["secret", "list", "--json", "name"] as const);
+    const ghExecutable = "gh";
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed gh executable
+      ghExecutable,
+      [...args],
+      { cwd, signal, timeout: timeoutMs, encoding: "utf8" },
+      (error, stdout) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        try {
+          resolve({ state: "value", names: secretNamesFromJson(stdout) });
+        } catch (parseError) {
+          reject(parseError);
+        }
+      }
+    );
+  });
+
+/**
+ * Load secret presence, mapping command failures to honest unknown states.
+ * @param listSecrets - Injectable secret lister
+ * @param cwd - Project root
+ * @param timeoutMs - Child-process timeout
+ * @param signal - Probe cancellation
+ * @param repo - Optional repo slug
+ * @returns Presence inventory or unknown
+ */
+async function loadSecretsPresence(
+  listSecrets: NonNullable<CiQualityJobsDependencies["listSecrets"]>,
+  cwd: string,
+  timeoutMs: number,
+  signal: AbortSignal,
+  repo: string | undefined
+): Promise<RepoSecretsPresence> {
+  try {
+    return await listSecrets(cwd, timeoutMs + 250, signal, repo);
+  } catch (error) {
+    return classifySecretListError(error);
+  }
+}
+
+/**
+ * Create the CI quality-jobs Active-column probe.
+ * @param cwd - Project root
+ * @param config - Merged Lisa config (mutation gate, github slug)
+ * @param dependencies - Injectable readers for tests
+ * @returns Live-status probe
+ */
+export function createCiQualityJobsProbe(
+  cwd: string,
+  config: JsonObject,
+  dependencies: CiQualityJobsDependencies = {}
+): StatusProbe<CiQualityJobsValue> {
+  const timeoutMs = 5_000;
+  const listSecrets = dependencies.listSecrets ?? listRepoSecretNames;
+  const readCiYml = dependencies.readCiYml ?? readCiYmlFile;
+  const resolveRepo =
+    dependencies.resolveRepo ?? ((_projectRoot, cfg) => repoFromConfig(cfg));
+  return {
+    id: CI_QUALITY_JOBS_PROBE_ID,
+    timeoutMs,
+    run: async signal => {
+      try {
+        const inputs = await parseCiWorkflowInputs(cwd, readCiYml);
+        const secrets = await loadSecretsPresence(
+          listSecrets,
+          cwd,
+          timeoutMs,
+          signal,
+          resolveRepo(cwd, config)
+        );
+        return {
+          state: "value",
+          value: computeCiQualityJobs(inputs, config, secrets),
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : "Unable to read ci.yml quality inputs";
+        const missing =
+          message.includes("ENOENT") ||
+          message.toLowerCase().includes("no such file");
+        return {
+          state: "unknown",
+          reason: missing ? "ci-yml-missing" : "ci-yml-unreadable",
+          message,
+        };
+      }
+    },
+  };
+}

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -20,6 +20,7 @@ import {
   inspectRemoteEnvironment,
   type RemoteEnvironmentStatus,
 } from "./remote-environment.js";
+import { createCiQualityJobsProbe } from "./ui-ci-quality-jobs.js";
 import { createLisaVersionProbe } from "./ui-lisa-version.js";
 import {
   createGithubAuthProbe,
@@ -42,6 +43,16 @@ export {
   mapLisaVersionCheck,
   type LisaVersionValue,
 } from "./ui-lisa-version.js";
+export {
+  createCiQualityJobsProbe,
+  computeCiQualityJobs,
+  parseCiWorkflowInputs,
+  CI_QUALITY_JOBS_PROBE_ID,
+  type CiQualityJobEntry,
+  type CiQualityJobsValue,
+  type CiWorkflowInputs,
+  type RepoSecretsPresence,
+} from "./ui-ci-quality-jobs.js";
 export { inspectRemoteEnvironment } from "./remote-environment.js";
 
 /** Default port for the settings console. */
@@ -328,6 +339,7 @@ export async function runUi(
   const probes = dependencies.probes ?? [
     createGithubAuthProbe(destDir),
     createLisaVersionProbe(),
+    createCiQualityJobsProbe(destDir, config),
   ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)

--- a/tests/e2e/ui-ci-quality-jobs.spec.ts
+++ b/tests/e2e/ui-ci-quality-jobs.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * Playwright regression for the CI Quality jobs Active column.
+ *
+ * Maestro: this web console surface has no Maestro harness in the repo
+ * (coverage is Playwright-only, same as other `lisa ui` e2e specs).
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  CI_QUALITY_JOBS_PROBE_ID,
+  runUi,
+  type CiQualityJobsValue,
+  type ProbeResult,
+  type StatusProbe,
+} from "../../src/cli/ui-cmd.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
+/**
+ * Create a fresh temporary project directory, tracked for teardown.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-ci-quality-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port with sync disabled.
+ * @param destDir - Project root the console serves
+ * @param probes - Injected status probes
+ * @returns The console's loopback origin and a close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(destDir, { port: "0", sync: false }, { probes });
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build the ci-quality-jobs probe returning a fixed result.
+ * @param result - Tri-state result the probe reports
+ * @returns Probe registered under the ci-quality-jobs id
+ */
+function ciQualityProbe(
+  result: ProbeResult<CiQualityJobsValue>
+): StatusProbe<CiQualityJobsValue> {
+  return {
+    id: CI_QUALITY_JOBS_PROBE_ID,
+    timeoutMs: 1_000,
+    run: async () => result,
+  };
+}
+
+/**
+ * Seed a minimal project config used only for HTML injection.
+ * @param destDir - Project root
+ */
+async function seedProject(destDir: string): Promise<void> {
+  await writeFile(
+    path.join(destDir, ".lisa.config.json"),
+    JSON.stringify({
+      github: { org: "acme", repo: "acme-app" },
+      quality: { mutation: { gate: { enabled: false } } },
+    }),
+    "utf8"
+  );
+  await mkdir(path.join(destDir, ".github", "workflows"), { recursive: true });
+  await writeFile(
+    path.join(destDir, ".github", "workflows", "ci.yml"),
+    [
+      "name: CI",
+      "on: pull_request",
+      "jobs:",
+      "  quality:",
+      "    uses: ./.github/workflows/quality.yml",
+      "    with:",
+      "      skip_jobs: ''",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+/**
+ * Locate the Active-column cell for a Quality job by jobId.
+ * @param page - Playwright page
+ * @param jobId - Stable job identifier
+ * @returns Locator for the Active td
+ */
+function activeCell(
+  page: import("@playwright/test").Page,
+  jobId: string
+): import("@playwright/test").Locator {
+  return page.locator(`#section-ci td[data-job-id="${jobId}"]`);
+}
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+test("Snyk and Mutation Testing Gate show real off reasons", async ({
+  page,
+}) => {
+  const destDir = await makeProjectDir();
+  await seedProject(destDir);
+  const ui = await launchConsole(destDir, [
+    ciQualityProbe({
+      state: "value",
+      value: {
+        jobs: [
+          {
+            id: "snyk",
+            label: "🛡️ Snyk",
+            active: false,
+            reason: "SNYK_TOKEN secret is not set",
+          },
+          {
+            id: "test:mutation",
+            label: "🧬 Mutation Testing Gate",
+            active: false,
+            reason: "mutation gate is disabled",
+          },
+          {
+            id: "lint",
+            label: "🧹 Lint",
+            active: true,
+            reason: "",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#ci`);
+    await expect(page.locator("#section-ci h1")).toContainText("Quality gates");
+    await expect(activeCell(page, "snyk")).toContainText("✗ off");
+    await expect(activeCell(page, "snyk")).toContainText(
+      "SNYK_TOKEN secret is not set"
+    );
+    await expect(activeCell(page, "test:mutation")).toContainText("✗ off");
+    await expect(activeCell(page, "test:mutation")).toContainText(
+      "mutation gate is disabled"
+    );
+  } finally {
+    await ui.close();
+  }
+});
+
+test("unauthenticated secret state never renders a false off", async ({
+  page,
+}) => {
+  const destDir = await makeProjectDir();
+  await seedProject(destDir);
+  const ui = await launchConsole(destDir, [
+    ciQualityProbe({
+      state: "value",
+      value: {
+        jobs: [
+          {
+            id: "snyk",
+            label: "🛡️ Snyk",
+            active: null,
+            reason: "not authenticated",
+          },
+          {
+            id: "test:mutation",
+            label: "🧬 Mutation Testing Gate",
+            active: false,
+            reason: "mutation gate is disabled",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#ci`);
+    const snyk = activeCell(page, "snyk");
+    await expect(snyk).toContainText("unknown");
+    await expect(snyk).toContainText("not authenticated");
+    await expect(snyk).not.toContainText("✗ off");
+    await expect(snyk).not.toContainText("secret is not set");
+    await expect(activeCell(page, "test:mutation")).toContainText("✗ off");
+  } finally {
+    await ui.close();
+  }
+});
+
+test("skip_jobs from ci.yml is reported off with that reason", async ({
+  page,
+}) => {
+  const destDir = await makeProjectDir();
+  await seedProject(destDir);
+  const ui = await launchConsole(destDir, [
+    ciQualityProbe({
+      state: "value",
+      value: {
+        jobs: [
+          {
+            id: "lint",
+            label: "🧹 Lint",
+            active: false,
+            reason: "ci.yml skip_jobs includes lint",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#ci`);
+    await expect(activeCell(page, "lint")).toContainText("✗ off");
+    await expect(activeCell(page, "lint")).toContainText(
+      "ci.yml skip_jobs includes lint"
+    );
+  } finally {
+    await ui.close();
+  }
+});
+
+test("served CI section never renders secret values", async ({
+  page,
+  request,
+}) => {
+  const destDir = await makeProjectDir();
+  await seedProject(destDir);
+  const planted = "planted-secret-value-should-never-appear";
+  const ui = await launchConsole(destDir, [
+    ciQualityProbe({
+      state: "value",
+      value: {
+        jobs: [
+          {
+            id: "snyk",
+            label: "🛡️ Snyk",
+            active: false,
+            reason: "SNYK_TOKEN secret is not set",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    const htmlResponse = await request.get(`${ui.base}/`);
+    expect(htmlResponse.ok()).toBe(true);
+    const html = await htmlResponse.text();
+    expect(html).not.toContain(planted);
+    expect(html).not.toMatch(/gho_[A-Za-z0-9]+/u);
+    expect(html).not.toMatch(/ghp_[A-Za-z0-9]+/u);
+
+    await page.goto(`${ui.base}/#ci`);
+    await expect(activeCell(page, "snyk")).toContainText(
+      "SNYK_TOKEN secret is not set"
+    );
+    const bodyText = await page.locator("body").innerText();
+    expect(bodyText).not.toContain(planted);
+    // Presence-only: the secret *name* may appear; never a value payload.
+    expect(bodyText).not.toMatch(/SNYK_TOKEN\s*=\s*\S+/u);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("initial Quality jobs Active column does not flash false-green active", async ({
+  page,
+  request,
+}) => {
+  const destDir = await makeProjectDir();
+  await seedProject(destDir);
+  const ui = await launchConsole(destDir, [
+    ciQualityProbe({
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "GitHub CLI is not authenticated",
+    }),
+  ]);
+  try {
+    const htmlResponse = await request.get(`${ui.base}/`);
+    const html = await htmlResponse.text();
+    // Demo data must not ship ✓ active for quality jobs before the probe.
+    expect(html).toContain('jobId: "snyk"');
+    expect(html).toContain("checking…");
+    const qualityBlock = html.slice(
+      html.indexOf('card: "Quality jobs"'),
+      html.indexOf("Rails calls quality-rails.yml")
+    );
+    expect(qualityBlock).not.toMatch(/t:\s*"status",\s*v:\s*true/u);
+
+    await page.goto(`${ui.base}/#ci`);
+    await expect(activeCell(page, "snyk")).toContainText("unknown");
+    await expect(activeCell(page, "snyk")).not.toContainText("✓ active");
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/unit/cli/ui-ci-quality-jobs.test.ts
+++ b/tests/unit/cli/ui-ci-quality-jobs.test.ts
@@ -1,0 +1,309 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CI_QUALITY_JOBS_PROBE_ID,
+  computeCiQualityJobs,
+  createCiQualityJobsProbe,
+  parseCiWorkflowInputs,
+  type CiWorkflowInputs,
+  type RepoSecretsPresence,
+} from "../../../src/cli/ui-ci-quality-jobs.js";
+import { runProbe } from "../../../src/cli/ui-cmd.js";
+import type { JsonObject } from "../../../src/sync/json-path.js";
+
+/** Per-test temp directory. */
+interface Resources {
+  dir: string;
+}
+
+const resources: Resources = { dir: "" };
+const MUTATION_GATE_DISABLED = "mutation gate is disabled";
+const MUTATION_JOB_ID = "test:mutation";
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-ci-quality-"));
+});
+
+afterEach(async () => {
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+/**
+ * Write a minimal calling `ci.yml` that forwards quality inputs.
+ * @param withBlock - YAML fragment for the quality job `with:` map
+ */
+async function writeCiYml(withBlock: string): Promise<void> {
+  const workflows = path.join(resources.dir, ".github", "workflows");
+  await mkdir(workflows, { recursive: true });
+  await writeFile(
+    path.join(workflows, "ci.yml"),
+    [
+      "name: CI",
+      "on: pull_request",
+      "jobs:",
+      "  quality:",
+      "    uses: ./.github/workflows/quality.yml",
+      "    with:",
+      withBlock,
+      "    secrets: inherit",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+/**
+ * Locate one job entry by id inside a computed value.
+ * @param jobs - Computed job list
+ * @param id - Stable job id
+ * @returns The matching job
+ */
+function jobOf(
+  jobs: ReturnType<typeof computeCiQualityJobs>["jobs"],
+  id: string
+): (typeof jobs)[number] {
+  const found = jobs.find(entry => entry.id === id);
+  if (found === undefined) {
+    throw new Error(`Missing job ${id}`);
+  }
+  return found;
+}
+
+describe("parseCiWorkflowInputs", () => {
+  it("reads skip_jobs and gate inputs from the quality caller with-block", async () => {
+    await writeCiYml(
+      [
+        "      skip_jobs: 'snyk,sonarcloud'",
+        "      verify_enforced: true",
+        "      compliance_framework: soc2",
+        "      require_approval: true",
+        "      zap_target_url: 'https://example.test'",
+      ].join("\n")
+    );
+
+    const inputs = await parseCiWorkflowInputs(resources.dir);
+
+    expect(inputs).toEqual({
+      skipJobs: ["snyk", "sonarcloud"],
+      verifyEnforced: true,
+      complianceFramework: "soc2",
+      requireApproval: true,
+      zapTargetUrl: "https://example.test",
+    } satisfies CiWorkflowInputs);
+  });
+
+  it("returns empty skip list and defaults when with-block omits optional keys", async () => {
+    await writeCiYml("      skip_jobs: ''\n");
+
+    const inputs = await parseCiWorkflowInputs(resources.dir);
+
+    expect(inputs.skipJobs).toEqual([]);
+    expect(inputs.verifyEnforced).toBe(false);
+    expect(inputs.complianceFramework).toBe("none");
+    expect(inputs.requireApproval).toBe(false);
+    expect(inputs.zapTargetUrl).toBe("");
+  });
+});
+
+describe("computeCiQualityJobs", () => {
+  const baseInputs: CiWorkflowInputs = {
+    skipJobs: [],
+    verifyEnforced: false,
+    complianceFramework: "none",
+    requireApproval: false,
+    zapTargetUrl: "",
+  };
+  const secretsPresent: RepoSecretsPresence = {
+    state: "value",
+    names: new Set(["GITGUARDIAN_API_KEY"]),
+  };
+  const configMutationOff: JsonObject = {
+    quality: { mutation: { gate: { enabled: false } } },
+  };
+
+  it("marks Snyk off naming SNYK_TOKEN when the secret is absent", () => {
+    const value = computeCiQualityJobs(
+      baseInputs,
+      configMutationOff,
+      secretsPresent
+    );
+
+    expect(jobOf(value.jobs, "snyk")).toEqual({
+      id: "snyk",
+      label: "🛡️ Snyk",
+      active: false,
+      reason: "SNYK_TOKEN secret is not set",
+    });
+  });
+
+  it("marks Mutation Testing Gate off when the gate config is disabled", () => {
+    const value = computeCiQualityJobs(
+      baseInputs,
+      configMutationOff,
+      secretsPresent
+    );
+
+    expect(jobOf(value.jobs, MUTATION_JOB_ID)).toMatchObject({
+      active: false,
+      reason: MUTATION_GATE_DISABLED,
+    });
+  });
+
+  it("marks a skip_jobs entry off with a ci.yml reason", () => {
+    const value = computeCiQualityJobs(
+      { ...baseInputs, skipJobs: ["lint"] },
+      configMutationOff,
+      secretsPresent
+    );
+
+    expect(jobOf(value.jobs, "lint")).toMatchObject({
+      active: false,
+      reason: "ci.yml skip_jobs includes lint",
+    });
+  });
+
+  it("never claims a secret is missing when gh is unauthenticated", () => {
+    const value = computeCiQualityJobs(baseInputs, configMutationOff, {
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "GitHub CLI is not authenticated",
+    });
+
+    const snyk = jobOf(value.jobs, "snyk");
+    expect(snyk.active).toBeNull();
+    expect(snyk.reason).toMatch(/not authenticated/iu);
+    expect(snyk.reason.toLowerCase()).not.toContain("not set");
+    expect(snyk.reason).not.toMatch(/\boff\b/iu);
+
+    const mutation = jobOf(value.jobs, MUTATION_JOB_ID);
+    expect(mutation.active).toBe(false);
+    expect(mutation.reason).toBe(MUTATION_GATE_DISABLED);
+  });
+
+  it("reports secret-backed jobs active only when the secret name is present", () => {
+    const value = computeCiQualityJobs(baseInputs, configMutationOff, {
+      state: "value",
+      names: new Set(["SNYK_TOKEN", "GITGUARDIAN_API_KEY"]),
+    });
+
+    expect(jobOf(value.jobs, "snyk").active).toBe(true);
+    expect(jobOf(value.jobs, "snyk").reason).toBe("");
+    expect(jobOf(value.jobs, "license_compliance")).toMatchObject({
+      active: false,
+      reason: "FOSSA_API_KEY secret is not set",
+    });
+  });
+
+  it("never embeds secret values in reasons or labels", () => {
+    const secretValue = "super-secret-token-value-9f3a";
+    const value = computeCiQualityJobs(baseInputs, configMutationOff, {
+      state: "value",
+      names: new Set(["SNYK_TOKEN"]),
+    });
+    const serialized = JSON.stringify(value);
+
+    expect(serialized).not.toContain(secretValue);
+    expect(serialized).not.toMatch(/"value"\s*:\s*"[^"]*token/iu);
+    for (const entry of value.jobs) {
+      expect(entry.reason).not.toContain("=");
+      expect(entry.reason).not.toMatch(/gho_|ghp_|github_pat_/u);
+    }
+  });
+});
+
+describe("createCiQualityJobsProbe", () => {
+  it("registers under the ci-quality-jobs id with a bounded timeout", () => {
+    const probe = createCiQualityJobsProbe(resources.dir, {});
+
+    expect(probe.id).toBe(CI_QUALITY_JOBS_PROBE_ID);
+    expect(probe.timeoutMs).toBeGreaterThan(0);
+    expect(Number.isFinite(probe.timeoutMs)).toBe(true);
+  });
+
+  it("joins filesystem inputs with injectable secret presence", async () => {
+    await writeCiYml(
+      ["      skip_jobs: 'snyk'", "      verify_enforced: false"].join("\n")
+    );
+    const listSecrets = vi.fn(async () => ({
+      state: "value" as const,
+      names: new Set<string>(),
+    }));
+
+    const result = await runProbe(
+      createCiQualityJobsProbe(
+        resources.dir,
+        { quality: { mutation: { gate: { enabled: false } } } },
+        { listSecrets }
+      )
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const jobs = result.value.jobs as readonly {
+      readonly id: string;
+      readonly active: boolean | null;
+      readonly reason: string;
+    }[];
+    expect(jobOf(jobs, "snyk")).toMatchObject({
+      active: false,
+      reason: "ci.yml skip_jobs includes snyk",
+    });
+    expect(jobOf(jobs, MUTATION_JOB_ID)).toMatchObject({
+      active: false,
+      reason: MUTATION_GATE_DISABLED,
+    });
+    expect(listSecrets).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces secret-derived unknown when the secret lister is unauthenticated", async () => {
+    await writeCiYml("      skip_jobs: ''\n");
+    const result = await runProbe(
+      createCiQualityJobsProbe(
+        resources.dir,
+        { quality: { mutation: { gate: { enabled: true } } } },
+        {
+          listSecrets: async () => ({
+            state: "unknown",
+            reason: "not-authenticated",
+            message: "GitHub CLI is not authenticated",
+          }),
+        }
+      )
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const jobs = result.value.jobs as readonly {
+      readonly id: string;
+      readonly active: boolean | null;
+      readonly reason: string;
+    }[];
+    const snyk = jobOf(jobs, "snyk");
+    expect(snyk.active).toBeNull();
+    expect(snyk.reason.toLowerCase()).toContain("not authenticated");
+  });
+
+  it("degrades to unknown when ci.yml cannot be read", async () => {
+    const result = await runProbe(
+      createCiQualityJobsProbe(
+        resources.dir,
+        {},
+        {
+          listSecrets: async () => ({ state: "value", names: new Set() }),
+        }
+      )
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toMatch(/ci-yml|missing|not found/iu);
+      expect(result.message.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -4454,7 +4454,12 @@
                   t: "text",
                   v: "oxlint then ESLint over the whole repo — the fast rule set",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "lint",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🐢 Slow Lint Rules" },
@@ -4462,22 +4467,42 @@
                   t: "text",
                   v: "The expensive rules deferred from local lint (import cycles, namespace checks)",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "lint_slow",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🔍 Type Check" },
                 { t: "text", v: "tsc --noEmit across the project" },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "typecheck",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "📐 Check Formatting" },
                 { t: "text", v: "Prettier in check mode — no writes" },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "format",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🏗️ Build" },
                 { t: "text", v: "Compiles the project to catch build breaks" },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "build",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧪 Run Unit Tests" },
@@ -4485,12 +4510,22 @@
                   t: "text",
                   v: "Unit suite with the coverage floors from Testing & coverage enforced",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "test:unit",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧪 Run Integration Tests" },
                 { t: "text", v: "Integration suite (30-minute timeout)" },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "test:integration",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧪 Run E2E Tests" },
@@ -4498,7 +4533,12 @@
                   t: "text",
                   v: "Playwright end-to-end tests, auto-detected from playwright.config + a test:e2e script",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "test:e2e",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🎭 Playwright E2E Tests" },
@@ -4506,7 +4546,12 @@
                   t: "text",
                   v: "Web-export e2e run — a required check on staging via ruleset",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "playwright_e2e",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "📱 Maestro Cloud E2E" },
@@ -4514,7 +4559,12 @@
                   t: "text",
                   v: "Mobile end-to-end flows on Maestro Cloud",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "maestro_e2e",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧭 E2E Route Coverage" },
@@ -4522,7 +4572,12 @@
                   t: "text",
                   v: "Static gate: % of expo-router routes reached by Playwright specs and Maestro flows, against the floors in e2e.thresholds.json — auto-enabled on Expo projects, a no-op elsewhere",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "e2e_coverage",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧬 Mutation Testing Gate" },
@@ -4532,9 +4587,9 @@
                 },
                 {
                   t: "status",
-                  v: false,
-                  reason:
-                    "mutation gate is disabled (quality.mutation.gate.enabled)",
+                  jobId: "test:mutation",
+                  v: null,
+                  reason: "checking…",
                 },
               ],
               [
@@ -4543,7 +4598,12 @@
                   t: "text",
                   v: "Requires feat/fix PRs to add or extend an e2e verification spec",
                 },
-                { t: "status", v: false, reason: "verify_enforced is off" },
+                {
+                  t: "status",
+                  jobId: "verification_coverage",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🗑️ Dead Code Detection" },
@@ -4551,7 +4611,12 @@
                   t: "text",
                   v: "knip — unused files, exports, and dependencies",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "dead_code",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🔎 AST Grep Scan" },
@@ -4559,7 +4624,12 @@
                   t: "text",
                   v: "Structural code rules from sgconfig.yml",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "sg_scan",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🔒 Security Scan" },
@@ -4567,20 +4637,31 @@
                   t: "text",
                   v: "Dependency audit — high and critical advisories in production dependencies",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "npm_security_scan",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🔍 SonarCloud SAST" },
                 { t: "text", v: "Static analysis via SonarCloud" },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "sonarcloud",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🛡️ Snyk" },
                 { t: "text", v: "Snyk dependency vulnerability scan" },
                 {
                   t: "status",
-                  v: false,
-                  reason: "SNYK_TOKEN secret is not set",
+                  jobId: "snyk",
+                  v: null,
+                  reason: "checking…",
                 },
               ],
               [
@@ -4589,15 +4670,21 @@
                   t: "text",
                   v: "Secret scanning — also a required check via the base ruleset",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "secret_scanning",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "📜 FOSSA" },
                 { t: "text", v: "License compliance check" },
                 {
                   t: "status",
-                  v: false,
-                  reason: "FOSSA_API_KEY secret is not set",
+                  jobId: "license_compliance",
+                  v: null,
+                  reason: "checking…",
                 },
               ],
               [
@@ -4606,7 +4693,12 @@
                   t: "text",
                   v: "DAST baseline scan against zap_target_url with per-rule IGNORE/WARN/FAIL decisions",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "zap_baseline",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
               [
                 { t: "mono", v: "🧾 Compliance Validation" },
@@ -4616,8 +4708,9 @@
                 },
                 {
                   t: "status",
-                  v: false,
-                  reason: "no compliance_framework configured",
+                  jobId: "compliance_validation",
+                  v: null,
+                  reason: "checking…",
                 },
               ],
               [
@@ -4626,7 +4719,12 @@
                   t: "text",
                   v: "Pauses the run until the target GitHub environment’s reviewers approve",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  jobId: "approval_gate",
+                  v: null,
+                  reason: "checking…",
+                },
               ],
             ],
           },
@@ -5546,10 +5644,17 @@
               chip.appendChild(el("span", "", esc(cell.v)));
               td.appendChild(chip);
             } else if (cell.t === "status") {
-              if (cell.v) {
+              if (cell.jobId) td.dataset.jobId = cell.jobId;
+              if (cell.v === true) {
                 td.appendChild(el("span", "badge pass", "✓ active"));
-              } else {
+              } else if (cell.v === false) {
                 td.appendChild(el("span", "badge fail", "✗ off"));
+                if (cell.reason) {
+                  td.appendChild(el("span", "status-why", esc(cell.reason)));
+                }
+              } else {
+                // null/undefined = unknown — never fabricate "off" or "active"
+                td.appendChild(el("span", "badge warn", "unknown"));
                 if (cell.reason) {
                   td.appendChild(el("span", "status-why", esc(cell.reason)));
                 }
@@ -6152,6 +6257,58 @@
           "@codyswann/lisa · unknown (invalid-value: lisa-version probe returned an unusable value)"
         );
       }
+      /**
+       * Paint the CI Quality jobs Active column from the ci-quality-jobs probe.
+       * Never leaves a fabricated active/off value when the probe is unknown.
+       * @param probes - Live-status probe map from /api/status
+       */
+      function applyCiQualityJobs(probes) {
+        const table = (DATA.sections.ci.blocks || []).find(
+          block => block.type === "table" && block.card === "Quality jobs"
+        );
+        if (!table) return;
+        const result = normalizeLiveStatusResult(
+          probes && Object.hasOwn(probes, "ci-quality-jobs")
+            ? probes["ci-quality-jobs"]
+            : {
+                state: "unknown",
+                reason: "missing-probe",
+                message: "The ci-quality-jobs probe was not reported",
+              }
+        );
+        const byId = new Map();
+        if (
+          result.state === "value" &&
+          result.value &&
+          typeof result.value === "object" &&
+          Array.isArray(result.value.jobs)
+        ) {
+          result.value.jobs.forEach(job => {
+            if (job && typeof job.id === "string") byId.set(job.id, job);
+          });
+        }
+        table.rows.forEach(cells => {
+          const status = cells.find(cell => cell.t === "status" && cell.jobId);
+          if (!status) return;
+          if (result.state !== "value") {
+            status.v = null;
+            status.reason =
+              result.reason + (result.message ? ": " + result.message : "");
+            return;
+          }
+          const job = byId.get(status.jobId);
+          if (!job) {
+            status.v = null;
+            status.reason = "missing-job: probe omitted " + status.jobId;
+            return;
+          }
+          status.v = job.active;
+          status.reason = typeof job.reason === "string" ? job.reason : "";
+        });
+        const current = activeSection;
+        renderAll();
+        showSection(current);
+      }
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {
@@ -6161,14 +6318,19 @@
           const snapshot = await response.json();
           const probes = liveStatusProbeMap(snapshot);
           renderLiveStatuses(probes);
+          // Quality jobs re-renders the page; paint the version chip after.
+          applyCiQualityJobs(probes);
           applyLisaVersion(probes);
         } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
           const unavailable = {
             state: "unknown",
             reason: "status-unavailable",
-            message: error instanceof Error ? error.message : String(error),
+            message,
           };
           renderLiveStatuses({ transport: unavailable });
+          applyCiQualityJobs({ "ci-quality-jobs": unavailable });
           applyLisaVersion({ "lisa-version": unavailable });
         }
       }


### PR DESCRIPTION
## Summary
- Add a `ci-quality-jobs` live-status probe that joins `ci.yml` skip/gate inputs, Lisa mutation-gate config, and presence-only `gh secret list` results.
- Hydrate the Quality gates Active column from that probe so Snyk/mutation/skip reasons are real, secret-derived rows stay `unknown` when `gh` is unauthenticated (never a false `off`), and secret values are never rendered.
- Cover the acceptance scenarios with unit tests and Playwright e2e; keep the first paint on `checking…` so the console cannot false-green before the probe returns.

Closes #1541

## Test plan
- [x] `bunx vitest run tests/unit/cli/ui-ci-quality-jobs.test.ts` (12 passed)
- [x] `bunx playwright test tests/e2e/ui-ci-quality-jobs.spec.ts` (5 passed)
- [x] Compatibility with lisa-version probe: unit + e2e still green after rebase onto main
- [ ] CI green on the PR


Made with [Cursor](https://cursor.com)