### PR TITLE
feat(ui): detect connected observability providers (#1545)

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -31,6 +31,7 @@ import {
   type StatusProbe,
 } from "./ui-status.js";
 import { createEnabledPluginsProbe } from "./ui-enabled-plugins.js";
+import { createObservabilityProviderProbes } from "./ui-observability-providers.js";
 import { serveConfigWrite } from "./ui-config-write.js";
 export {
   createGithubAuthProbe,
@@ -69,6 +70,7 @@ export {
   type CiWorkflowInputs,
   type RepoSecretsPresence,
 } from "./ui-ci-quality-jobs.js";
+export { createObservabilityProviderProbes } from "./ui-observability-providers.js";
 export { inspectRemoteEnvironment } from "./remote-environment.js";
 
 /** Default port for the settings console. */
@@ -358,6 +360,7 @@ export async function runUi(
     createLisaVersionProbe(),
     createCiQualityJobsProbe(destDir, config),
     createDeployPipelineProbe(destDir),
+    ...createObservabilityProviderProbes(),
   ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)

--- a/src/cli/ui-observability-checks.ts
+++ b/src/cli/ui-observability-checks.ts
@@ -1,0 +1,204 @@
+/**
+ * Shell-out reachability checks for observability provider probes.
+ *
+ * Reuses the same CLIs/tokens skills already use (SENTRY_AUTH_TOKEN REST,
+ * `aws sts` / `cloudwatch` / `xray`) — no second SDK.
+ * @module cli/ui-observability-checks
+ */
+import { execFile } from "node:child_process";
+import type {
+  AwsCountCheck,
+  SentryReachabilityCheck,
+} from "./ui-observability-providers.js";
+
+const NOT_AUTHENTICATED = "not-authenticated" as const;
+
+/**
+ * Read one env var through a single reviewable process.env exception.
+ * @param name - Environment variable name
+ * @returns Trimmed value, or undefined when unset/blank
+ */
+function readEnv(name: string): string | undefined {
+  // eslint-disable-next-line no-restricted-syntax -- observability probe must read developer-local auth tokens once
+  const value = process.env[name];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Run a fixed argv via execFile without a shell.
+ * @param file - Executable name
+ * @param args - Argument vector
+ * @param timeoutMs - Child-process timeout
+ * @param signal - Probe cancellation signal
+ * @returns stdout on success
+ */
+async function runCommand(
+  file: string,
+  args: readonly string[],
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed aws CLI
+      file,
+      [...args],
+      { signal, timeout: timeoutMs, encoding: "utf8" },
+      (error, stdout) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      }
+    );
+  });
+}
+
+/**
+ * Classify an AWS CLI failure as missing auth vs other probe failure.
+ * @param error - Thrown command error
+ * @returns Whether the failure indicates missing credentials
+ */
+function isAwsAuthFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const lowered = message.toLowerCase();
+  return (
+    lowered.includes("unable to locate credentials") ||
+    lowered.includes("could not load credentials") ||
+    lowered.includes("no credentials") ||
+    lowered.includes("expiredtoken") ||
+    lowered.includes("the security token included in the request is invalid") ||
+    lowered.includes("is not authorized to perform") ||
+    lowered.includes("accessdenied") ||
+    lowered.includes("error loading sso") ||
+    lowered.includes("sso session")
+  );
+}
+
+/**
+ * Confirm AWS identity, mapping credential failures to not-authenticated.
+ * @param timeoutMs - Command budget
+ * @param signal - Abort signal
+ * @returns not-authenticated when credentials are missing; otherwise void
+ */
+async function requireAwsIdentity(
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<typeof NOT_AUTHENTICATED | undefined> {
+  try {
+    await runCommand(
+      "aws",
+      ["sts", "get-caller-identity", "--output", "json"],
+      timeoutMs,
+      signal
+    );
+    return undefined;
+  } catch (error) {
+    if (isAwsAuthFailure(error)) {
+      return NOT_AUTHENTICATED;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Default Sentry reachability: REST when SENTRY_AUTH_TOKEN is set.
+ * @param timeoutMs - Request budget
+ * @param signal - Abort signal
+ * @returns Reachability outcome
+ */
+export const defaultSentryCheck: SentryReachabilityCheck = async (
+  timeoutMs,
+  signal
+) => {
+  const token = readEnv("SENTRY_AUTH_TOKEN");
+  if (token === undefined) {
+    return NOT_AUTHENTICATED;
+  }
+  const response = await fetch("https://sentry.io/api/0/", {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    signal: AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]),
+  });
+  if (response.ok) {
+    return "reachable";
+  }
+  if (response.status === 401 || response.status === 403) {
+    return NOT_AUTHENTICATED;
+  }
+  throw new Error(`Sentry API returned HTTP ${String(response.status)}`);
+};
+
+/**
+ * Count CloudWatch alarms after confirming AWS identity.
+ * @param timeoutMs - Command budget
+ * @param signal - Abort signal
+ * @returns Alarm count, or not-authenticated
+ */
+export const defaultCloudWatchCheck: AwsCountCheck = async (
+  timeoutMs,
+  signal
+) => {
+  const auth = await requireAwsIdentity(timeoutMs, signal);
+  if (auth !== undefined) {
+    return auth;
+  }
+  const stdout = await runCommand(
+    "aws",
+    ["cloudwatch", "describe-alarms", "--output", "json"],
+    timeoutMs,
+    signal
+  );
+  const parsed = JSON.parse(stdout) as {
+    MetricAlarms?: unknown[];
+    CompositeAlarms?: unknown[];
+  };
+  const metric = Array.isArray(parsed.MetricAlarms)
+    ? parsed.MetricAlarms.length
+    : 0;
+  const composite = Array.isArray(parsed.CompositeAlarms)
+    ? parsed.CompositeAlarms.length
+    : 0;
+  return metric + composite;
+};
+
+/**
+ * Count recent X-Ray traces after confirming AWS identity.
+ * @param timeoutMs - Command budget
+ * @param signal - Abort signal
+ * @returns Trace count, or not-authenticated
+ */
+export const defaultXRayCheck: AwsCountCheck = async (timeoutMs, signal) => {
+  const auth = await requireAwsIdentity(timeoutMs, signal);
+  if (auth !== undefined) {
+    return auth;
+  }
+  const end = new Date();
+  const start = new Date(end.getTime() - 60 * 60 * 1000);
+  const stdout = await runCommand(
+    "aws",
+    [
+      "xray",
+      "get-trace-summaries",
+      "--start-time",
+      start.toISOString(),
+      "--end-time",
+      end.toISOString(),
+      "--output",
+      "json",
+    ],
+    timeoutMs,
+    signal
+  );
+  const parsed = JSON.parse(stdout) as { TraceSummaries?: unknown[] };
+  return Array.isArray(parsed.TraceSummaries)
+    ? parsed.TraceSummaries.length
+    : 0;
+};

--- a/src/cli/ui-observability-providers.ts
+++ b/src/cli/ui-observability-providers.ts
@@ -1,0 +1,161 @@
+/**
+ * Live-status probes for connected observability providers.
+ *
+ * READ-ONLY detection by reachability (Sentry auth, CloudWatch alarms, X-Ray
+ * traces). Missing credentials degrade to unknown — never a fabricated
+ * "disconnected" claim.
+ * @module cli/ui-observability-providers
+ */
+import type { JsonValue } from "../sync/json-path.js";
+import type { ProbeResult, StatusProbe } from "./ui-status.js";
+import {
+  defaultCloudWatchCheck,
+  defaultSentryCheck,
+  defaultXRayCheck,
+} from "./ui-observability-checks.js";
+
+/** Structured value for a reachable observability provider. */
+export type ObservabilityProviderValue = {
+  readonly [key: string]: JsonValue;
+  readonly status: "connected" | "connected-but-empty";
+  readonly emptyKind?: "alarms" | "traces";
+};
+
+/** Injectable Sentry reachability check. */
+export type SentryReachabilityCheck = (
+  timeoutMs: number,
+  signal: AbortSignal
+) => Promise<"reachable" | "not-authenticated">;
+
+/** Injectable AWS count check (alarms or traces), or not-authenticated. */
+export type AwsCountCheck = (
+  timeoutMs: number,
+  signal: AbortSignal
+) => Promise<number | "not-authenticated">;
+
+export const SENTRY_PROBE_ID = "sentry";
+export const CLOUDWATCH_ALARMS_PROBE_ID = "cloudwatch-alarms";
+export const XRAY_PROBE_ID = "x-ray";
+
+const PROBE_TIMEOUT_MS = 5_000;
+const NOT_AUTHENTICATED = "not-authenticated";
+const SENTRY_UNKNOWN_MESSAGE =
+  "Sentry auth/MCP is not reachable — authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN";
+const AWS_UNKNOWN_MESSAGE =
+  "AWS credentials are not authenticated for this machine";
+
+/**
+ * Map Sentry reachability onto the live-status tri-state.
+ * @param outcome - Reachability check result
+ * @returns Probe result for the sentry provider
+ */
+export function mapSentryReachability(
+  outcome: "reachable" | "not-authenticated"
+): ProbeResult<ObservabilityProviderValue> {
+  if (outcome === "reachable") {
+    return { state: "value", value: { status: "connected" } };
+  }
+  return {
+    state: "unknown",
+    reason: NOT_AUTHENTICATED,
+    message: SENTRY_UNKNOWN_MESSAGE,
+  };
+}
+
+/**
+ * Map an AWS count check onto connected / empty / unknown.
+ * @param outcome - Count or not-authenticated
+ * @param emptyKind - Whether zero means no alarms or no traces
+ * @returns Probe result for CloudWatch or X-Ray
+ */
+export function mapAwsCountCheck(
+  outcome: number | "not-authenticated",
+  emptyKind: "alarms" | "traces"
+): ProbeResult<ObservabilityProviderValue> {
+  if (outcome === "not-authenticated") {
+    return {
+      state: "unknown",
+      reason: NOT_AUTHENTICATED,
+      message: AWS_UNKNOWN_MESSAGE,
+    };
+  }
+  if (outcome > 0) {
+    return { state: "value", value: { status: "connected" } };
+  }
+  return {
+    state: "value",
+    value: { status: "connected-but-empty", emptyKind },
+  };
+}
+
+/**
+ * Create the Sentry observability probe.
+ * @param options - Injectable collaborators
+ * @param options.check - Optional reachability check for focused tests
+ * @returns Bounded status probe
+ */
+export function createSentryProbe(
+  options: {
+    readonly check?: SentryReachabilityCheck;
+  } = {}
+): StatusProbe<ObservabilityProviderValue> {
+  const check = options.check ?? defaultSentryCheck;
+  return {
+    id: SENTRY_PROBE_ID,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    run: async signal =>
+      mapSentryReachability(await check(PROBE_TIMEOUT_MS + 250, signal)),
+  };
+}
+
+/**
+ * Create the CloudWatch Alarms observability probe.
+ * @param options - Injectable collaborators
+ * @param options.check - Optional alarm-count check for focused tests
+ * @returns Bounded status probe
+ */
+export function createCloudWatchAlarmsProbe(
+  options: {
+    readonly check?: AwsCountCheck;
+  } = {}
+): StatusProbe<ObservabilityProviderValue> {
+  const check = options.check ?? defaultCloudWatchCheck;
+  return {
+    id: CLOUDWATCH_ALARMS_PROBE_ID,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    run: async signal =>
+      mapAwsCountCheck(await check(PROBE_TIMEOUT_MS + 250, signal), "alarms"),
+  };
+}
+
+/**
+ * Create the X-Ray observability probe.
+ * @param options - Injectable collaborators
+ * @param options.check - Optional trace-count check for focused tests
+ * @returns Bounded status probe
+ */
+export function createXRayProbe(
+  options: {
+    readonly check?: AwsCountCheck;
+  } = {}
+): StatusProbe<ObservabilityProviderValue> {
+  const check = options.check ?? defaultXRayCheck;
+  return {
+    id: XRAY_PROBE_ID,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    run: async signal =>
+      mapAwsCountCheck(await check(PROBE_TIMEOUT_MS + 250, signal), "traces"),
+  };
+}
+
+/**
+ * Register all three observability provider probes.
+ * @returns Sentry, CloudWatch Alarms, and X-Ray probes
+ */
+export function createObservabilityProviderProbes(): readonly StatusProbe<ObservabilityProviderValue>[] {
+  return [
+    createSentryProbe(),
+    createCloudWatchAlarmsProbe(),
+    createXRayProbe(),
+  ];
+}

--- a/tests/e2e/ui-observability-providers.spec.ts
+++ b/tests/e2e/ui-observability-providers.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Playwright regression for Monitoring → Connected providers live probes.
+ *
+ * Maestro: this web console surface has no Maestro harness in the repo
+ * (coverage is Playwright-only, same as other `lisa ui` e2e specs).
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  runUi,
+  type ProbeResult,
+  type StatusProbe,
+} from "../../src/cli/ui-cmd.ts";
+import type { ObservabilityProviderValue } from "../../src/cli/ui-observability-providers.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port with sync disabled.
+ * @param destDir - Project root the console serves
+ * @param probes - Injected status probes
+ * @returns The console's loopback origin and a close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(destDir, { port: "0", sync: false }, { probes });
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build a fixed observability provider probe.
+ * @param id - Probe id
+ * @param result - Tri-state result
+ * @returns Status probe
+ */
+function providerProbe(
+  id: string,
+  result: ProbeResult<ObservabilityProviderValue>
+): StatusProbe<ObservabilityProviderValue> {
+  return { id, timeoutMs: 1_000, run: async () => result };
+}
+
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
+/**
+ * Create a fresh temporary project directory, tracked for teardown.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-obs-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+/**
+ * Locator for a Connected providers status cell.
+ * @param page - Playwright page
+ * @param provider - data-provider attribute
+ * @returns Locator
+ */
+function statusCell(
+  page: import("@playwright/test").Page,
+  provider: string
+): import("@playwright/test").Locator {
+  return page.locator(`#section-monitor td[data-provider="${provider}"]`);
+}
+
+test("missing AWS credentials paint unknown, never disconnected", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    providerProbe("sentry", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+    providerProbe("cloudwatch-alarms", {
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "AWS credentials are not authenticated for this machine",
+    }),
+    providerProbe("x-ray", {
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "AWS credentials are not authenticated for this machine",
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#monitor`);
+    await expect(statusCell(page, "cloudwatch-alarms")).toContainText(
+      "unknown"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).toContainText(
+      "not-authenticated"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).not.toContainText(
+      "disconnected"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).not.toContainText(
+      "✗ off"
+    );
+    await expect(statusCell(page, "x-ray")).toContainText("unknown");
+    await expect(statusCell(page, "x-ray")).toContainText("not-authenticated");
+    await expect(statusCell(page, "x-ray")).not.toContainText("disconnected");
+  } finally {
+    await ui.close();
+  }
+});
+
+test("credentials with zero alarms show connected-but-empty", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    providerProbe("sentry", {
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "Sentry auth/MCP is not reachable",
+    }),
+    providerProbe("cloudwatch-alarms", {
+      state: "value",
+      value: { status: "connected-but-empty", emptyKind: "alarms" },
+    }),
+    providerProbe("x-ray", {
+      state: "value",
+      value: { status: "connected-but-empty", emptyKind: "traces" },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#monitor`);
+    await expect(statusCell(page, "cloudwatch-alarms")).toContainText(
+      "connected-but-empty"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).toContainText(
+      "no alarms"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).not.toContainText(
+      "unknown"
+    );
+    await expect(statusCell(page, "x-ray")).toContainText(
+      "connected-but-empty"
+    );
+  } finally {
+    await ui.close();
+  }
+});
+
+test("credentials with a real alarm show connected", async ({ page }) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    providerProbe("sentry", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+    providerProbe("cloudwatch-alarms", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+    providerProbe("x-ray", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#monitor`);
+    await expect(statusCell(page, "cloudwatch-alarms")).toContainText(
+      "✓ connected"
+    );
+    await expect(statusCell(page, "cloudwatch-alarms")).not.toContainText(
+      "connected-but-empty"
+    );
+    await expect(statusCell(page, "sentry")).toContainText("✓ connected");
+  } finally {
+    await ui.close();
+  }
+});
+
+test("unreachable Sentry shows unknown with the reason", async ({ page }) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    providerProbe("sentry", {
+      state: "unknown",
+      reason: "not-authenticated",
+      message:
+        "Sentry auth/MCP is not reachable — authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN",
+    }),
+    providerProbe("cloudwatch-alarms", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+    providerProbe("x-ray", {
+      state: "value",
+      value: { status: "connected" },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#monitor`);
+    await expect(statusCell(page, "sentry")).toContainText("unknown");
+    await expect(statusCell(page, "sentry")).toContainText("not-authenticated");
+    await expect(statusCell(page, "sentry")).toContainText("Sentry");
+    await expect(statusCell(page, "sentry")).not.toContainText("✓ connected");
+    await expect(statusCell(page, "sentry")).not.toContainText("disconnected");
+    await expect(statusCell(page, "sentry")).not.toContainText("✗ off");
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -20,6 +20,8 @@ interface TestResources {
 
 const resources: TestResources = { dir: "", server: undefined };
 
+const GITHUB_AUTH_PROBE_ID = "github-auth";
+
 beforeEach(async () => {
   resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-cmd-"));
   vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -288,7 +290,7 @@ describe("runUi", () => {
     };
 
     expect(response.status).toBe(200);
-    expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty(GITHUB_AUTH_PROBE_ID);
     expect(snapshot.probes).toHaveProperty("lisa-version");
     expect(snapshot.probes).toHaveProperty("deploy-pipeline-stages");
   });
@@ -310,7 +312,7 @@ describe("runUi", () => {
     const snapshot = (await response.json()) as {
       probes: Record<string, unknown>;
     };
-    expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty(GITHUB_AUTH_PROBE_ID);
     expect(snapshot.probes).toHaveProperty("enabled-plugins");
     expect(snapshot.probes["enabled-plugins"]).toEqual({
       state: "value",
@@ -330,10 +332,9 @@ describe("runUi", () => {
     };
 
     expect(response.status).toBe(200);
-    expect(body.probes).toHaveProperty("github-auth");
+    expect(body.probes).toHaveProperty(GITHUB_AUTH_PROBE_ID);
     expect(body.probes).toHaveProperty("sentry");
     expect(body.probes).toHaveProperty("cloudwatch-alarms");
     expect(body.probes).toHaveProperty("x-ray");
   });
-
 });

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -317,4 +317,23 @@ describe("runUi", () => {
       value: { settingsPresent: false, plugins: [] },
     });
   });
+
+  it("registers observability provider probes in the default status snapshot", async () => {
+    resources.server = await runUi(resources.dir, { port: "0", sync: false });
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const body = (await response.json()) as {
+      probes: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.probes).toHaveProperty("github-auth");
+    expect(body.probes).toHaveProperty("sentry");
+    expect(body.probes).toHaveProperty("cloudwatch-alarms");
+    expect(body.probes).toHaveProperty("x-ray");
+  });
+
 });

--- a/tests/unit/cli/ui-observability-providers-probe.test.ts
+++ b/tests/unit/cli/ui-observability-providers-probe.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CLOUDWATCH_ALARMS_PROBE_ID,
+  createCloudWatchAlarmsProbe,
+  createObservabilityProviderProbes,
+  createSentryProbe,
+  createXRayProbe,
+  mapAwsCountCheck,
+  mapSentryReachability,
+  SENTRY_PROBE_ID,
+  XRAY_PROBE_ID,
+  type AwsCountCheck,
+  type SentryReachabilityCheck,
+} from "../../../src/cli/ui-observability-providers.js";
+import { runProbe } from "../../../src/cli/ui-cmd.js";
+
+const NOT_AUTHENTICATED = "not-authenticated" as const;
+const CONNECTED = "connected";
+const CONNECTED_BUT_EMPTY = "connected-but-empty";
+const REACHABLE = "reachable" as const;
+
+/**
+ * Build an injectable Sentry reachability check.
+ * @param outcome - Fixed reachability outcome
+ * @returns Check used by focused probe tests
+ */
+function sentryCheck(
+  outcome: typeof REACHABLE | typeof NOT_AUTHENTICATED
+): SentryReachabilityCheck {
+  return vi.fn(async () => outcome);
+}
+
+/**
+ * Build an injectable AWS count check.
+ * @param outcome - Count outcome or auth failure
+ * @returns Check used by focused probe tests
+ */
+function awsCountCheck(
+  outcome: number | typeof NOT_AUTHENTICATED
+): AwsCountCheck {
+  return vi.fn(async () => outcome);
+}
+
+describe("mapSentryReachability", () => {
+  it("maps reachable auth to connected", () => {
+    expect(mapSentryReachability(REACHABLE)).toEqual({
+      state: "value",
+      value: { status: CONNECTED },
+    });
+  });
+
+  it("maps missing auth to unknown with not-authenticated reason", () => {
+    const result = mapSentryReachability(NOT_AUTHENTICATED);
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NOT_AUTHENTICATED);
+      expect(result.message.length).toBeGreaterThan(0);
+      expect(result.message.toLowerCase()).not.toContain("disconnected");
+    }
+  });
+});
+
+describe("mapAwsCountCheck", () => {
+  it("maps not-authenticated to unknown, never disconnected", () => {
+    const result = mapAwsCountCheck(NOT_AUTHENTICATED, "alarms");
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NOT_AUTHENTICATED);
+      expect(result.message.toLowerCase()).not.toContain("disconnected");
+    }
+  });
+
+  it("maps a positive count to connected", () => {
+    expect(mapAwsCountCheck(3, "alarms")).toEqual({
+      state: "value",
+      value: { status: CONNECTED },
+    });
+  });
+
+  it("maps zero alarms to connected-but-empty", () => {
+    expect(mapAwsCountCheck(0, "alarms")).toEqual({
+      state: "value",
+      value: { status: CONNECTED_BUT_EMPTY, emptyKind: "alarms" },
+    });
+  });
+
+  it("maps zero traces to connected-but-empty", () => {
+    expect(mapAwsCountCheck(0, "traces")).toEqual({
+      state: "value",
+      value: { status: CONNECTED_BUT_EMPTY, emptyKind: "traces" },
+    });
+  });
+});
+
+describe("createSentryProbe", () => {
+  it("registers under the sentry id with a bounded timeout", () => {
+    const probe = createSentryProbe({ check: sentryCheck(REACHABLE) });
+    expect(probe.id).toBe(SENTRY_PROBE_ID);
+    expect(probe.timeoutMs).toBeGreaterThan(0);
+    expect(Number.isFinite(probe.timeoutMs)).toBe(true);
+  });
+
+  it("reports connected when Sentry auth is reachable", async () => {
+    const result = await runProbe(
+      createSentryProbe({ check: sentryCheck(REACHABLE) })
+    );
+    expect(result).toEqual({
+      state: "value",
+      value: { status: CONNECTED },
+    });
+  });
+
+  it("reports unknown with reason when Sentry is unreachable", async () => {
+    const result = await runProbe(
+      createSentryProbe({ check: sentryCheck(NOT_AUTHENTICATED) })
+    );
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NOT_AUTHENTICATED);
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("degrades to unknown when the check throws", async () => {
+    const result = await runProbe(
+      createSentryProbe({
+        check: async () => {
+          throw new Error("sentry substrate exploded");
+        },
+      })
+    );
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe("probe-failed");
+      expect(result.message).toContain("sentry substrate exploded");
+    }
+  });
+});
+
+describe("createCloudWatchAlarmsProbe", () => {
+  it("registers under the cloudwatch-alarms id", () => {
+    expect(createCloudWatchAlarmsProbe({ check: awsCountCheck(1) }).id).toBe(
+      CLOUDWATCH_ALARMS_PROBE_ID
+    );
+  });
+
+  it("reports connected when alarms exist", async () => {
+    const result = await runProbe(
+      createCloudWatchAlarmsProbe({ check: awsCountCheck(2) })
+    );
+    expect(result).toEqual({
+      state: "value",
+      value: { status: CONNECTED },
+    });
+  });
+
+  it("reports connected-but-empty when credentials work but alarms are zero", async () => {
+    const result = await runProbe(
+      createCloudWatchAlarmsProbe({ check: awsCountCheck(0) })
+    );
+    expect(result).toEqual({
+      state: "value",
+      value: { status: CONNECTED_BUT_EMPTY, emptyKind: "alarms" },
+    });
+  });
+
+  it("reports unknown-not-authenticated when AWS credentials are missing", async () => {
+    const result = await runProbe(
+      createCloudWatchAlarmsProbe({
+        check: awsCountCheck(NOT_AUTHENTICATED),
+      })
+    );
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NOT_AUTHENTICATED);
+      expect(result.message.toLowerCase()).not.toContain("disconnected");
+    }
+  });
+});
+
+describe("createXRayProbe", () => {
+  it("registers under the x-ray id", () => {
+    expect(createXRayProbe({ check: awsCountCheck(1) }).id).toBe(XRAY_PROBE_ID);
+  });
+
+  it("reports connected when traces exist", async () => {
+    const result = await runProbe(createXRayProbe({ check: awsCountCheck(5) }));
+    expect(result).toEqual({
+      state: "value",
+      value: { status: CONNECTED },
+    });
+  });
+
+  it("reports connected-but-empty when credentials work but traces are zero", async () => {
+    const result = await runProbe(createXRayProbe({ check: awsCountCheck(0) }));
+    expect(result).toEqual({
+      state: "value",
+      value: { status: CONNECTED_BUT_EMPTY, emptyKind: "traces" },
+    });
+  });
+
+  it("reports unknown-not-authenticated when AWS credentials are missing", async () => {
+    const result = await runProbe(
+      createXRayProbe({ check: awsCountCheck(NOT_AUTHENTICATED) })
+    );
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe(NOT_AUTHENTICATED);
+      expect(result.message.toLowerCase()).not.toContain("disconnected");
+    }
+  });
+});
+
+describe("createObservabilityProviderProbes", () => {
+  it("returns sentry, cloudwatch-alarms, and x-ray probes in that order", () => {
+    const probes = createObservabilityProviderProbes();
+    expect(probes.map(probe => probe.id)).toEqual([
+      SENTRY_PROBE_ID,
+      CLOUDWATCH_ALARMS_PROBE_ID,
+      XRAY_PROBE_ID,
+    ]);
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -3640,7 +3640,7 @@
                   t: "text",
                   v: "Error events, issue volume, release health",
                 },
-                { t: "status", v: true },
+                { t: "status", v: true, provider: "sentry" },
               ],
               [
                 { t: "mono", v: "AWS CloudWatch (Alarms)" },
@@ -3648,7 +3648,11 @@
                   t: "text",
                   v: "Alarm states, error-rate and latency metrics",
                 },
-                { t: "status", v: true },
+                {
+                  t: "status",
+                  v: true,
+                  provider: "cloudwatch-alarms",
+                },
               ],
               [
                 { t: "mono", v: "AWS X-Ray" },
@@ -3656,6 +3660,7 @@
                 {
                   t: "status",
                   v: false,
+                  provider: "x-ray",
                   reason: "no traces found — X-Ray is not instrumented",
                 },
               ],
@@ -5483,9 +5488,48 @@
         return card;
       }
 
+      function paintProviderStatus(td, cell) {
+        td.innerHTML = "";
+        if (cell.v === true || cell.v === "connected") {
+          td.appendChild(el("span", "badge pass", "✓ connected"));
+          return;
+        }
+        if (cell.v === "connected-but-empty") {
+          td.appendChild(el("span", "badge warn", "◐ connected-but-empty"));
+          if (cell.reason) {
+            td.appendChild(el("span", "status-why", esc(cell.reason)));
+          }
+          return;
+        }
+        if (cell.v === "pending") {
+          td.appendChild(el("span", "badge default", "checking…"));
+          return;
+        }
+        if (cell.v === "unknown") {
+          td.appendChild(el("span", "badge warn", "unknown"));
+          if (cell.reason) {
+            td.appendChild(el("span", "status-why", esc(cell.reason)));
+          }
+          return;
+        }
+        if (cell.v) {
+          td.appendChild(el("span", "badge pass", "✓ active"));
+          return;
+        }
+        td.appendChild(el("span", "badge fail", "✗ off"));
+        if (cell.reason) {
+          td.appendChild(el("span", "status-why", esc(cell.reason)));
+        }
+      }
       function buildStatusCell(cell) {
         const td = el("td");
-        if (cell.v === "unknown") {
+        if (cell.provider) td.dataset.provider = cell.provider;
+        if (cell.jobId) td.dataset.jobId = cell.jobId;
+        if (cell.provider) {
+          paintProviderStatus(td, cell);
+          return td;
+        }
+        if (cell.v === "unknown" || cell.v === null || cell.v === undefined) {
           td.appendChild(el("span", "badge warn", "unknown"));
           if (cell.reason) {
             td.appendChild(el("span", "status-why", esc(cell.reason)));
@@ -6132,6 +6176,7 @@
               if (value !== undefined) hydrateControl(row.control, value);
             });
           });
+          markObservabilityProvidersPending();
         }
         configureRemoteEnvironment(cfg);
         const repoEl = document.querySelector(".project-switch .repo");
@@ -6190,6 +6235,115 @@
           throw new TypeError("Status response omitted a valid probes map");
         }
         return snapshot.probes;
+      }
+      function connectedProvidersBlock() {
+        const blocks = DATA.sections.monitor && DATA.sections.monitor.blocks;
+        if (!Array.isArray(blocks)) return null;
+        return (
+          blocks.find(
+            block =>
+              block &&
+              block.type === "table" &&
+              block.card === "Connected providers"
+          ) || null
+        );
+      }
+      function setProviderStatusCell(provider, cell) {
+        const block = connectedProvidersBlock();
+        if (!block || !Array.isArray(block.rows)) return;
+        block.rows.forEach(row => {
+          if (!Array.isArray(row)) return;
+          row.forEach((entry, index) => {
+            if (entry && entry.t === "status" && entry.provider === provider) {
+              row[index] = cell;
+            }
+          });
+        });
+        const td = document.querySelector(
+          'td[data-provider="' + provider + '"]'
+        );
+        if (td) paintProviderStatus(td, cell);
+      }
+      function markObservabilityProvidersPending() {
+        ["sentry", "cloudwatch-alarms", "x-ray"].forEach(provider => {
+          setProviderStatusCell(provider, {
+            t: "status",
+            v: "pending",
+            provider,
+          });
+        });
+      }
+      /**
+       * Paint Connected providers from sentry / cloudwatch-alarms / x-ray probes.
+       * unknown ≠ disconnected — never invent an unevidenced "off" claim.
+       * @param probes - Live-status probe map from /api/status
+       */
+      function applyObservabilityProviders(probes) {
+        const specs = [
+          {
+            id: "sentry",
+            emptyReason: "reachable — no Sentry data observed",
+          },
+          {
+            id: "cloudwatch-alarms",
+            emptyReason: "connected — no alarms",
+          },
+          {
+            id: "x-ray",
+            emptyReason: "connected — no traces",
+          },
+        ];
+        specs.forEach(spec => {
+          const raw =
+            probes && Object.hasOwn(probes, spec.id)
+              ? probes[spec.id]
+              : undefined;
+          const result =
+            raw === undefined
+              ? {
+                  state: "unknown",
+                  reason: "missing-probe",
+                  message: "The " + spec.id + " probe was not reported",
+                }
+              : normalizeLiveStatusResult(raw);
+          if (
+            result.state === "value" &&
+            result.value &&
+            typeof result.value === "object" &&
+            result.value.status === "connected"
+          ) {
+            setProviderStatusCell(spec.id, {
+              t: "status",
+              v: "connected",
+              provider: spec.id,
+            });
+            return;
+          }
+          if (
+            result.state === "value" &&
+            result.value &&
+            typeof result.value === "object" &&
+            result.value.status === "connected-but-empty"
+          ) {
+            setProviderStatusCell(spec.id, {
+              t: "status",
+              v: "connected-but-empty",
+              provider: spec.id,
+              reason: spec.emptyReason,
+            });
+            return;
+          }
+          const reason =
+            result.state === "unknown"
+              ? result.reason + ": " + result.message
+              : "invalid-value: provider probe returned an unusable value";
+          setProviderStatusCell(spec.id, {
+            t: "status",
+            v: "unknown",
+            provider: spec.id,
+            reason,
+          });
+        });
       }
       function renderLiveStatuses(probes) {
         const list = document.getElementById("liveStatusList");
@@ -6549,6 +6703,7 @@
           applyCiQualityJobs(probes);
           applyLisaVersion(probes);
           applyDeployPipelineStages(probes);
+          applyObservabilityProviders(probes);
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -6563,6 +6718,11 @@
           applyLisaVersion({ "lisa-version": unavailable });
           applyDeployPipelineStages({
             "deploy-pipeline-stages": unavailable,
+          });
+          applyObservabilityProviders({
+            sentry: unavailable,
+            "cloudwatch-alarms": unavailable,
+            "x-ray": unavailable,
           });
         }
       }


### PR DESCRIPTION
## Summary
- Add READ-ONLY live-status probes for Sentry, CloudWatch Alarms, and X-Ray that detect by reachability (never invent a disconnected claim when credentials/tools are missing).
- Wire Monitoring → Connected providers to those probes via `hydrateLiveStatuses`, with distinct connected / connected-but-empty / unknown-not-authenticated UI states.
- Cover probe mapping and UI states with unit tests and Playwright e2e (mirrors the github-auth / lisa-version probe pattern).

Closes #1545.

## Test plan
- [x] `bunx vitest run tests/unit/cli/ui-observability-providers-probe.test.ts tests/unit/cli/ui-cmd.test.ts`
- [x] `bunx playwright test tests/e2e/ui-observability-providers.spec.ts`
- [ ] With AWS credentials unset, open `lisa ui` → CloudWatch/X-Ray show unknown (not disconnected)
- [ ] With AWS creds + alarms → CloudWatch shows connected; zero alarms → connected-but-empty
- [ ] With Sentry unreachable → unknown with reason


Made with [Cursor](https://cursor.com)