### PR TITLE
feat(ui): populate GitHub repository panel from live gh api probes

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -20,6 +20,7 @@ import {
   inspectRemoteEnvironment,
   type RemoteEnvironmentStatus,
 } from "./remote-environment.js";
+import { createGithubRepoProbe } from "./ui-github-repo.js";
 import { createLisaVersionProbe } from "./ui-lisa-version.js";
 import {
   createGithubAuthProbe,
@@ -37,6 +38,7 @@ export {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+export { createGithubRepoProbe } from "./ui-github-repo.js";
 export {
   createLisaVersionProbe,
   mapLisaVersionCheck,
@@ -328,6 +330,7 @@ export async function runUi(
   const probes = dependencies.probes ?? [
     createGithubAuthProbe(destDir),
     createLisaVersionProbe(),
+    createGithubRepoProbe(destDir, config),
   ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)

--- a/src/cli/ui-github-repo-expected.ts
+++ b/src/cli/ui-github-repo-expected.ts
@@ -1,0 +1,152 @@
+/**
+ * Expected labels and secrets for the GitHub repository live-status panel.
+ * @module cli/ui-github-repo-expected
+ */
+import type { JsonObject, JsonValue } from "../sync/json-path.js";
+
+/** One config-expected lifecycle label. */
+export interface ExpectedLabel {
+  readonly name: string;
+  readonly role: string;
+}
+
+/** One workflow-expected repository secret (presence only). */
+export interface ExpectedSecret {
+  readonly name: string;
+  readonly purpose: string;
+}
+
+/**
+ * Secrets Lisa creates or expects workflows to consume.
+ * Presence is checked via `gh secret list`; values are never read.
+ */
+export const EXPECTED_GITHUB_SECRETS: readonly ExpectedSecret[] = [
+  {
+    name: "DEPLOY_KEY",
+    purpose:
+      "Write deploy key so CI can push version bumps through ruleset bypass",
+  },
+  {
+    name: "CLAUDE_CODE_OAUTH_TOKEN",
+    purpose:
+      "Claude Code Action workflows (nightly, review response, auto-fix)",
+  },
+  {
+    name: "AWS_ACCOUNT_ID_DEV",
+    purpose: "Per-environment AWS account for dev deploys",
+  },
+  {
+    name: "AWS_ACCOUNT_ID_STAGING",
+    purpose: "Per-environment AWS account for staging deploys",
+  },
+  {
+    name: "AWS_ACCOUNT_ID_PRODUCTION",
+    purpose: "Per-environment AWS account for production deploys",
+  },
+  {
+    name: "GITGUARDIAN_API_KEY",
+    purpose: "Secret scanning check",
+  },
+  {
+    name: "SONAR_TOKEN",
+    purpose: "SonarCloud SAST",
+  },
+  {
+    name: "SNYK_TOKEN",
+    purpose: "Snyk dependency scan",
+  },
+  {
+    name: "FOSSA_API_KEY",
+    purpose: "License compliance",
+  },
+  {
+    name: "SENTRY_AUTH_TOKEN",
+    purpose: "Sentry releases and sourcemaps",
+  },
+  {
+    name: "SENTRY_ORG",
+    purpose: "Sentry organization slug",
+  },
+  {
+    name: "SENTRY_PROJECT",
+    purpose: "Sentry project slug",
+  },
+  {
+    name: "EXPO_TOKEN",
+    purpose: "EAS builds",
+  },
+  {
+    name: "MAESTRO_API_KEY",
+    purpose: "Maestro Cloud mobile E2E",
+  },
+  {
+    name: "MAESTRO_SECRET_ENV",
+    purpose:
+      "Native Maestro e2e — newline-separated KEY=VALUE secrets forwarded to flows",
+  },
+];
+
+/**
+ * Walk a nested labels object into role-path entries.
+ * @param value - Nested label map or leaf string
+ * @param pathParts - Role segments accumulated so far
+ * @returns Flattened labels under this node
+ */
+function walkLabels(
+  value: JsonValue,
+  pathParts: readonly string[]
+): readonly ExpectedLabel[] {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [{ name: value, role: pathParts.join(" · ") }];
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, child]) =>
+    walkLabels(child as JsonValue, [...pathParts, key])
+  );
+}
+
+/**
+ * Flatten `github.labels` from merged config into expected label rows.
+ * @param config - Merged Lisa project config
+ * @returns Expected labels with human-readable role paths
+ */
+export function expectedLabelsFromConfig(
+  config: JsonObject
+): readonly ExpectedLabel[] {
+  const github = config.github;
+  if (github === null || typeof github !== "object" || Array.isArray(github)) {
+    return [];
+  }
+  const labels = Reflect.get(github, "labels");
+  if (labels === null || typeof labels !== "object" || Array.isArray(labels)) {
+    return [];
+  }
+  return walkLabels(labels as JsonValue, []);
+}
+
+/**
+ * Read configured github.org / github.repo when both are non-empty strings.
+ * @param config - Merged Lisa project config
+ * @returns Owner and repo, or undefined when either is missing
+ */
+export function configuredGithubRepo(
+  config: JsonObject
+): { readonly owner: string; readonly repo: string } | undefined {
+  const github = config.github;
+  if (github === null || typeof github !== "object" || Array.isArray(github)) {
+    return undefined;
+  }
+  const owner = Reflect.get(github, "org");
+  const repo = Reflect.get(github, "repo");
+  if (
+    typeof owner !== "string" ||
+    owner.trim().length === 0 ||
+    typeof repo !== "string" ||
+    repo.trim().length === 0
+  ) {
+    return undefined;
+  }
+  return { owner: owner.trim(), repo: repo.trim() };
+}

--- a/src/cli/ui-github-repo-gh.ts
+++ b/src/cli/ui-github-repo-gh.ts
@@ -1,0 +1,230 @@
+/**
+ * Injectable `gh` reads for the GitHub repository live-status panel.
+ * @module cli/ui-github-repo-gh
+ */
+import { execFile } from "node:child_process";
+import {
+  mapRepoSettings,
+  mapRulesetRow,
+  requireNamedString,
+} from "./ui-github-repo-map.js";
+
+/** Live repository settings surfaced in the console panel. */
+export interface GithubRepoSettings {
+  readonly allow_merge_commit: boolean;
+  readonly allow_squash_merge: boolean;
+  readonly allow_rebase_merge: boolean;
+  readonly allow_auto_merge: boolean;
+  readonly allow_update_branch: boolean;
+  readonly delete_branch_on_merge: boolean;
+  readonly merge_commit_title: string;
+  readonly has_issues: boolean;
+  readonly has_wiki: boolean;
+  readonly secret_scanning: boolean;
+  readonly default_branch: string;
+}
+
+/** One ruleset row for the panel. */
+export interface GithubRulesetRow {
+  readonly name: string;
+  readonly appliesTo: string;
+  readonly enforces: string;
+  readonly active: boolean;
+}
+
+/** One label present on the remote repository. */
+export interface GithubRemoteLabel {
+  readonly name: string;
+  readonly color: string;
+}
+
+/** Injectable collaborators used by the github-repo probe. */
+export interface GithubRepoGhReads {
+  readonly readSettings: (
+    owner: string,
+    repo: string,
+    cwd: string,
+    timeoutMs: number,
+    signal: AbortSignal
+  ) => Promise<GithubRepoSettings>;
+  readonly listRulesets: (
+    owner: string,
+    repo: string,
+    cwd: string,
+    timeoutMs: number,
+    signal: AbortSignal
+  ) => Promise<readonly GithubRulesetRow[]>;
+  readonly listLabels: (
+    owner: string,
+    repo: string,
+    cwd: string,
+    timeoutMs: number,
+    signal: AbortSignal
+  ) => Promise<readonly GithubRemoteLabel[]>;
+  readonly listSecretNames: (
+    owner: string,
+    repo: string,
+    cwd: string,
+    timeoutMs: number,
+    signal: AbortSignal
+  ) => Promise<readonly string[]>;
+}
+
+/**
+ * Run `gh` without a shell and return stdout.
+ * @param args - gh argv after the executable
+ * @param cwd - Working directory
+ * @param timeoutMs - Child-process timeout
+ * @param signal - Probe cancellation signal
+ * @returns Trimmed stdout
+ */
+function runGh(
+  args: readonly string[],
+  cwd: string,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ghExecutable = "gh";
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed gh executable
+      ghExecutable,
+      [...args],
+      { cwd, signal, timeout: timeoutMs, encoding: "utf8" },
+      (error, stdout) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        resolve(stdout.trim());
+      }
+    );
+  });
+}
+
+/**
+ * Parse JSON from a gh command, rejecting non-JSON payloads.
+ * @param stdout - Command stdout
+ * @returns Parsed JSON value
+ */
+function parseJson(stdout: string): unknown {
+  return JSON.parse(stdout) as unknown;
+}
+
+/**
+ * Load detailed ruleset rows for every ruleset id in the list response.
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param listed - Parsed rulesets list payload
+ * @param cwd - Working directory
+ * @param timeoutMs - Child-process timeout
+ * @param signal - Probe cancellation signal
+ * @returns Panel ruleset rows
+ */
+async function loadRulesetDetails(
+  owner: string,
+  repo: string,
+  listed: unknown,
+  cwd: string,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<readonly GithubRulesetRow[]> {
+  if (!Array.isArray(listed)) {
+    throw new TypeError("Rulesets list was not an array");
+  }
+  return await Promise.all(
+    listed.map(async entry => {
+      if (entry === null || typeof entry !== "object") {
+        throw new TypeError("Ruleset list entry was not an object");
+      }
+      const id = Reflect.get(entry, "id");
+      if (typeof id !== "number") {
+        throw new TypeError("Ruleset list entry omitted numeric id");
+      }
+      const detailStdout = await runGh(
+        ["api", `repos/${owner}/${repo}/rulesets/${String(id)}`],
+        cwd,
+        timeoutMs,
+        signal
+      );
+      return mapRulesetRow(parseJson(detailStdout));
+    })
+  );
+}
+
+/** Default `gh` implementations used by `lisa ui`. */
+export const defaultGithubRepoGhReads: GithubRepoGhReads = {
+  readSettings: async (owner, repo, cwd, timeoutMs, signal) => {
+    const stdout = await runGh(
+      ["api", `repos/${owner}/${repo}`],
+      cwd,
+      timeoutMs,
+      signal
+    );
+    return mapRepoSettings(parseJson(stdout));
+  },
+  listRulesets: async (owner, repo, cwd, timeoutMs, signal) => {
+    const listStdout = await runGh(
+      ["api", `repos/${owner}/${repo}/rulesets`],
+      cwd,
+      timeoutMs,
+      signal
+    );
+    return loadRulesetDetails(
+      owner,
+      repo,
+      parseJson(listStdout),
+      cwd,
+      timeoutMs,
+      signal
+    );
+  },
+  listLabels: async (owner, repo, cwd, timeoutMs, signal) => {
+    const stdout = await runGh(
+      [
+        "label",
+        "list",
+        "--repo",
+        `${owner}/${repo}`,
+        "--limit",
+        "200",
+        "--json",
+        "name,color",
+      ],
+      cwd,
+      timeoutMs,
+      signal
+    );
+    const parsed = parseJson(stdout);
+    if (!Array.isArray(parsed)) {
+      throw new TypeError("Label list was not an array");
+    }
+    return parsed.map(entry => {
+      if (entry === null || typeof entry !== "object") {
+        throw new TypeError("Label entry was not an object");
+      }
+      return {
+        name: requireNamedString(entry, "name"),
+        color: requireNamedString(entry, "color"),
+      };
+    });
+  },
+  listSecretNames: async (owner, repo, cwd, timeoutMs, signal) => {
+    const stdout = await runGh(
+      ["secret", "list", "--repo", `${owner}/${repo}`, "--json", "name"],
+      cwd,
+      timeoutMs,
+      signal
+    );
+    const parsed = parseJson(stdout);
+    if (!Array.isArray(parsed)) {
+      throw new TypeError("Secret list was not an array");
+    }
+    return parsed.map(entry => {
+      if (entry === null || typeof entry !== "object") {
+        throw new TypeError("Secret entry was not an object");
+      }
+      return requireNamedString(entry, "name");
+    });
+  },
+};

--- a/src/cli/ui-github-repo-map.ts
+++ b/src/cli/ui-github-repo-map.ts
@@ -1,0 +1,172 @@
+/**
+ * Pure mappers from GitHub API JSON onto repository panel rows.
+ * @module cli/ui-github-repo-map
+ */
+import type {
+  GithubRepoSettings,
+  GithubRulesetRow,
+} from "./ui-github-repo-gh.js";
+
+/**
+ * Require a boolean field from a plain object.
+ * @param record - Source object
+ * @param key - Property name
+ * @returns Boolean value
+ */
+function requireBoolean(record: object, key: string): boolean {
+  const value = Reflect.get(record, key);
+  if (typeof value !== "boolean") {
+    throw new TypeError(`Repository settings omitted boolean ${key}`);
+  }
+  return value;
+}
+
+/**
+ * Require a string field from a plain object.
+ * @param record - Source object
+ * @param key - Property name
+ * @returns String value
+ */
+function requireString(record: object, key: string): string {
+  const value = Reflect.get(record, key);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`Repository settings omitted string ${key}`);
+  }
+  return value;
+}
+
+/**
+ * Derive secret-scanning enabled from the security_and_analysis payload.
+ * @param record - Repository API object
+ * @returns Whether secret scanning is enabled
+ */
+function secretScanningEnabled(record: object): boolean {
+  const security = Reflect.get(record, "security_and_analysis");
+  if (security === null || typeof security !== "object") {
+    return false;
+  }
+  const scanning = Reflect.get(security, "secret_scanning");
+  if (scanning === null || typeof scanning !== "object") {
+    return false;
+  }
+  return Reflect.get(scanning, "status") === "enabled";
+}
+
+/**
+ * Map repository JSON into the panel settings shape.
+ * @param raw - Parsed `gh api repos/{owner}/{repo}` payload
+ * @returns Settings for the console
+ */
+export function mapRepoSettings(raw: unknown): GithubRepoSettings {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError("Repository settings response was not an object");
+  }
+  return {
+    allow_merge_commit: requireBoolean(raw, "allow_merge_commit"),
+    allow_squash_merge: requireBoolean(raw, "allow_squash_merge"),
+    allow_rebase_merge: requireBoolean(raw, "allow_rebase_merge"),
+    allow_auto_merge: requireBoolean(raw, "allow_auto_merge"),
+    allow_update_branch: requireBoolean(raw, "allow_update_branch"),
+    delete_branch_on_merge: requireBoolean(raw, "delete_branch_on_merge"),
+    merge_commit_title: requireString(raw, "merge_commit_title"),
+    has_issues: requireBoolean(raw, "has_issues"),
+    has_wiki: requireBoolean(raw, "has_wiki"),
+    secret_scanning: secretScanningEnabled(raw),
+    default_branch: requireString(raw, "default_branch"),
+  };
+}
+
+/**
+ * Humanize ruleset ref includes for the Applies-to column.
+ * @param includes - Ruleset condition include list
+ * @returns Display string
+ */
+function formatAppliesTo(includes: readonly string[]): string {
+  if (includes.length === 0) {
+    return "—";
+  }
+  return includes
+    .map(entry =>
+      entry
+        .replace(/^refs\/heads\//u, "")
+        .replace(/^refs\/tags\//u, "")
+        .replace(/^~DEFAULT_BRANCH$/u, "default")
+    )
+    .join(" · ");
+}
+
+/**
+ * Extract ref_name.include strings from a ruleset conditions object.
+ * @param conditions - Ruleset conditions payload
+ * @returns Include list, or empty when absent
+ */
+function rulesetIncludes(conditions: unknown): readonly string[] {
+  if (
+    conditions === null ||
+    typeof conditions !== "object" ||
+    Array.isArray(conditions)
+  ) {
+    return [];
+  }
+  const refName = Reflect.get(conditions, "ref_name");
+  if (
+    refName === null ||
+    typeof refName !== "object" ||
+    Array.isArray(refName)
+  ) {
+    return [];
+  }
+  const include = Reflect.get(refName, "include");
+  if (!Array.isArray(include)) {
+    return [];
+  }
+  return include.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Extract rule type names from a ruleset rules array.
+ * @param rules - Ruleset rules payload
+ * @returns Rule type strings
+ */
+function rulesetRuleTypes(rules: unknown): readonly string[] {
+  if (!Array.isArray(rules)) {
+    return [];
+  }
+  return rules
+    .map(rule => {
+      if (rule === null || typeof rule !== "object") {
+        return undefined;
+      }
+      const type = Reflect.get(rule, "type");
+      return typeof type === "string" ? type : undefined;
+    })
+    .filter((type): type is string => type !== undefined);
+}
+
+/**
+ * Map a detailed ruleset payload into a panel row.
+ * @param raw - One ruleset object from gh api
+ * @returns Panel row
+ */
+export function mapRulesetRow(raw: unknown): GithubRulesetRow {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError("Ruleset entry was not an object");
+  }
+  const ruleTypes = rulesetRuleTypes(Reflect.get(raw, "rules"));
+  return {
+    name: requireString(raw, "name"),
+    appliesTo: formatAppliesTo(rulesetIncludes(Reflect.get(raw, "conditions"))),
+    enforces: ruleTypes.length > 0 ? ruleTypes.join(", ") : "—",
+    active: Reflect.get(raw, "enforcement") === "active",
+  };
+}
+
+/**
+ * Require a non-empty string field (shared by label/secret list parsers).
+ * @param record - Source object
+ * @param key - Property name
+ * @returns String value
+ */
+export function requireNamedString(record: object, key: string): string {
+  return requireString(record, key);
+}

--- a/src/cli/ui-github-repo.ts
+++ b/src/cli/ui-github-repo.ts
@@ -1,0 +1,214 @@
+/**
+ * Live-status probe for the console GitHub repository panel.
+ *
+ * Every input is `gh`-derived. Unauthenticated `gh` takes the whole panel to
+ * unknown — never a partial concrete value. Secret values are never read.
+ * @module cli/ui-github-repo
+ */
+import type { JsonObject } from "../sync/json-path.js";
+import {
+  configuredGithubRepo,
+  EXPECTED_GITHUB_SECRETS,
+  expectedLabelsFromConfig,
+} from "./ui-github-repo-expected.js";
+import {
+  defaultGithubRepoGhReads,
+  type GithubRemoteLabel,
+  type GithubRepoGhReads,
+  type GithubRepoSettings,
+  type GithubRulesetRow,
+} from "./ui-github-repo-gh.js";
+import {
+  createGithubAuthProbe,
+  type ProbeResult,
+  type StatusProbe,
+} from "./ui-status.js";
+
+export type { GithubRepoGhReads } from "./ui-github-repo-gh.js";
+export { expectedLabelsFromConfig } from "./ui-github-repo-expected.js";
+
+const GITHUB_REPO_PROBE_ID = "github-repo";
+const PROBE_TIMEOUT_MS = 15_000;
+const NOT_AUTHENTICATED = "not-authenticated" as const;
+const GITHUB_NOT_AUTHENTICATED = "GitHub CLI is not authenticated";
+
+/** Label row for the panel (presence vs config expectation). */
+export interface GithubRepoLabelRow {
+  readonly name: string;
+  readonly role: string;
+  readonly color: string;
+  readonly present: boolean;
+}
+
+/** Secret row — presence only; never a value. */
+export interface GithubRepoSecretRow {
+  readonly name: string;
+  readonly purpose: string;
+  readonly set: boolean;
+}
+
+/**
+ * Structured value emitted by the github-repo live-status probe.
+ * Stored as JsonObject for the probe transport; shape is validated in tests.
+ */
+export type GithubRepoPanelValue = JsonObject & {
+  readonly owner: string;
+  readonly repo: string;
+  readonly settings: GithubRepoSettings;
+  readonly rulesets: readonly GithubRulesetRow[];
+  readonly labels: readonly GithubRepoLabelRow[];
+  readonly secrets: readonly GithubRepoSecretRow[];
+};
+
+/** Optional overrides for focused unit tests. */
+export interface GithubRepoProbeDependencies {
+  readonly authenticate?: (
+    signal: AbortSignal
+  ) => Promise<"authenticated" | "not-authenticated">;
+  readonly reads?: Partial<GithubRepoGhReads>;
+}
+
+/**
+ * Compare expected labels against the remote label set.
+ * @param expected - Labels from config
+ * @param remote - Labels returned by gh
+ * @returns Panel rows with present/missing
+ */
+function compareLabels(
+  expected: ReturnType<typeof expectedLabelsFromConfig>,
+  remote: readonly GithubRemoteLabel[]
+): readonly GithubRepoLabelRow[] {
+  const byName = new Map(remote.map(label => [label.name, label]));
+  return expected.map(label => {
+    const found = byName.get(label.name);
+    return found === undefined
+      ? { name: label.name, role: label.role, color: "", present: false }
+      : {
+          name: label.name,
+          role: label.role,
+          color: found.color,
+          present: true,
+        };
+  });
+}
+
+/**
+ * Compare expected secrets against names from `gh secret list`.
+ * @param presentNames - Secret names that exist on the repo
+ * @returns Presence-only rows (no values)
+ */
+function compareSecrets(
+  presentNames: readonly string[]
+): readonly GithubRepoSecretRow[] {
+  const present = new Set(presentNames);
+  return EXPECTED_GITHUB_SECRETS.map(secret => ({
+    name: secret.name,
+    purpose: secret.purpose,
+    set: present.has(secret.name),
+  }));
+}
+
+/**
+ * Build the panel value after all gh reads succeed.
+ * @param owner - github.org
+ * @param repo - github.repo
+ * @param settings - Live repository settings
+ * @param rulesets - Live rulesets
+ * @param labels - Compared label rows
+ * @param secrets - Presence-only secret rows
+ * @returns Probe value payload
+ */
+function panelValue(
+  owner: string,
+  repo: string,
+  settings: GithubRepoSettings,
+  rulesets: readonly GithubRulesetRow[],
+  labels: readonly GithubRepoLabelRow[],
+  secrets: readonly GithubRepoSecretRow[]
+): GithubRepoPanelValue {
+  return {
+    owner,
+    repo,
+    settings: { ...settings },
+    rulesets: rulesets.map(row => ({ ...row })),
+    labels: labels.map(row => ({ ...row })),
+    secrets: secrets.map(row => ({ ...row })),
+  } as GithubRepoPanelValue;
+}
+
+/**
+ * Create the probe that populates the GitHub repository panel.
+ * @param cwd - Project root used as the command working directory
+ * @param config - Merged Lisa project config
+ * @param dependencies - Injectable auth and gh reads for focused tests
+ * @returns Live-status probe for GET /api/status
+ */
+export function createGithubRepoProbe(
+  cwd: string,
+  config: JsonObject,
+  dependencies: GithubRepoProbeDependencies = {}
+): StatusProbe<GithubRepoPanelValue> {
+  const reads: GithubRepoGhReads = {
+    ...defaultGithubRepoGhReads,
+    ...dependencies.reads,
+  };
+  const authenticate =
+    dependencies.authenticate ??
+    (async (signal: AbortSignal) => {
+      const auth = await createGithubAuthProbe(cwd).run(signal);
+      return auth.state === "value" && auth.value === true
+        ? "authenticated"
+        : "not-authenticated";
+    });
+
+  return {
+    id: GITHUB_REPO_PROBE_ID,
+    timeoutMs: PROBE_TIMEOUT_MS,
+    run: async signal => {
+      const authState = await authenticate(signal);
+      if (authState !== "authenticated") {
+        return {
+          state: "unknown",
+          reason: NOT_AUTHENTICATED,
+          message: GITHUB_NOT_AUTHENTICATED,
+        };
+      }
+      const target = configuredGithubRepo(config);
+      if (target === undefined) {
+        return {
+          state: "unknown",
+          reason: "repo-not-configured",
+          message: "github.org and github.repo must be set in Lisa config",
+        };
+      }
+      const timeoutMs = PROBE_TIMEOUT_MS + 250;
+      const [settings, rulesets, remoteLabels, secretNames] = await Promise.all(
+        [
+          reads.readSettings(target.owner, target.repo, cwd, timeoutMs, signal),
+          reads.listRulesets(target.owner, target.repo, cwd, timeoutMs, signal),
+          reads.listLabels(target.owner, target.repo, cwd, timeoutMs, signal),
+          reads.listSecretNames(
+            target.owner,
+            target.repo,
+            cwd,
+            timeoutMs,
+            signal
+          ),
+        ]
+      );
+      const value = panelValue(
+        target.owner,
+        target.repo,
+        settings,
+        rulesets,
+        compareLabels(expectedLabelsFromConfig(config), remoteLabels),
+        compareSecrets(secretNames)
+      );
+      const result: ProbeResult<GithubRepoPanelValue> = {
+        state: "value",
+        value,
+      };
+      return result;
+    },
+  };
+}

--- a/tests/e2e/ui-github-repo-panel.spec.ts
+++ b/tests/e2e/ui-github-repo-panel.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** Fixture panel value returned by a successful github-repo probe. */
+const LIVE_PANEL_VALUE = {
+  owner: "acme",
+  repo: "acme-app",
+  settings: {
+    allow_merge_commit: true,
+    allow_squash_merge: false,
+    allow_rebase_merge: false,
+    allow_auto_merge: true,
+    allow_update_branch: true,
+    delete_branch_on_merge: true,
+    merge_commit_title: "MERGE_MESSAGE",
+    has_issues: true,
+    has_wiki: false,
+    secret_scanning: true,
+    default_branch: "main",
+  },
+  rulesets: [
+    {
+      name: "base",
+      appliesTo: "dev · staging · main",
+      enforces: "deletion, non_fast_forward, pull_request",
+      active: true,
+    },
+    {
+      name: "quality checks",
+      appliesTo: "dev · staging · main",
+      enforces: "required_status_checks",
+      active: true,
+    },
+  ],
+  labels: [
+    {
+      name: "status:ready",
+      role: "build · ready",
+      color: "fbca04",
+      present: true,
+    },
+    {
+      name: "status:blocked",
+      role: "build · blocked",
+      color: "",
+      present: false,
+    },
+  ],
+  secrets: [
+    {
+      name: "DEPLOY_KEY",
+      purpose:
+        "Write deploy key so CI can push version bumps through ruleset bypass",
+      set: true,
+    },
+    {
+      name: "SNYK_TOKEN",
+      purpose: "Snyk dependency scan",
+      set: false,
+    },
+  ],
+};
+
+/**
+ * Stub /api/status before navigation so boot hydration sees the fixture.
+ * @param page - Playwright page
+ * @param githubRepo - Probe result for github-repo
+ */
+async function stubStatus(
+  page: Page,
+  githubRepo: Record<string, unknown>
+): Promise<void> {
+  await page.route("**/api/status", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: { "cache-control": "no-store" },
+      body: JSON.stringify({
+        probes: {
+          "github-auth": { state: "value", value: true },
+          "lisa-version": {
+            state: "value",
+            value: { current: "2.234.0", latest: "2.234.0", outdated: false },
+          },
+          "github-repo": githubRepo,
+        },
+      }),
+    });
+  });
+}
+
+test("lists live rulesets and marks a missing expected label", async ({
+  page,
+}) => {
+  await stubStatus(page, { state: "value", value: LIVE_PANEL_VALUE });
+  await page.goto("/#repository");
+
+  const section = page.locator("#section-repository");
+  await expect(section.locator("h1")).toContainText("Repository & protection");
+  await expect(section.getByText("base", { exact: true })).toBeVisible();
+  await expect(
+    section.getByText("quality checks", { exact: true })
+  ).toBeVisible();
+  await expect(
+    section.getByText("status:blocked", { exact: true })
+  ).toBeVisible();
+  await expect(
+    section.locator("tr", { hasText: "status:blocked" }).getByText("missing")
+  ).toBeVisible();
+  await expect(section.getByText("DEPLOY_KEY", { exact: true })).toBeVisible();
+  await expect(
+    section
+      .locator("tr", { hasText: "DEPLOY_KEY" })
+      .locator(".badge.on", { hasText: "set" })
+  ).toBeVisible();
+  await expect(
+    section
+      .locator("tr", { hasText: "SNYK_TOKEN" })
+      .locator(".badge.off", { hasText: "missing" })
+  ).toBeVisible();
+  const html = await page.content();
+  expect(html).not.toMatch(/ghp_|github_pat_|BEGIN (?:RSA |OPENSSH )?PRIVATE/);
+});
+
+test("unauthenticated gh takes the whole panel to unknown", async ({
+  page,
+}) => {
+  await stubStatus(page, {
+    state: "unknown",
+    reason: "not-authenticated",
+    message: "GitHub CLI is not authenticated",
+  });
+  await page.goto("/#repository");
+
+  const section = page.locator("#section-repository");
+  await expect(section).toContainText("unknown");
+  await expect(section).toContainText("not-authenticated");
+  await expect(section).toContainText("GitHub CLI is not authenticated");
+  await expect(section.getByText("base", { exact: true })).toHaveCount(0);
+  await expect(section.getByText("DEPLOY_KEY", { exact: true })).toHaveCount(0);
+  await expect(section.getByText("status:ready", { exact: true })).toHaveCount(
+    0
+  );
+  await expect(section.getByText("Allow merge commits")).toHaveCount(0);
+});

--- a/tests/unit/cli/ui-github-repo-map.test.ts
+++ b/tests/unit/cli/ui-github-repo-map.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapRepoSettings,
+  mapRulesetRow,
+} from "../../../src/cli/ui-github-repo-map.js";
+
+describe("mapRepoSettings", () => {
+  it("maps repository JSON including secret scanning status", () => {
+    expect(
+      mapRepoSettings({
+        allow_merge_commit: true,
+        allow_squash_merge: false,
+        allow_rebase_merge: false,
+        allow_auto_merge: true,
+        allow_update_branch: true,
+        delete_branch_on_merge: true,
+        merge_commit_title: "MERGE_MESSAGE",
+        has_issues: true,
+        has_wiki: false,
+        default_branch: "main",
+        security_and_analysis: {
+          secret_scanning: { status: "enabled" },
+        },
+      })
+    ).toMatchObject({
+      allow_merge_commit: true,
+      secret_scanning: true,
+      default_branch: "main",
+    });
+  });
+
+  it("treats missing security_and_analysis as secret scanning off", () => {
+    expect(
+      mapRepoSettings({
+        allow_merge_commit: false,
+        allow_squash_merge: true,
+        allow_rebase_merge: true,
+        allow_auto_merge: false,
+        allow_update_branch: false,
+        delete_branch_on_merge: false,
+        merge_commit_title: "PR_TITLE",
+        has_issues: false,
+        has_wiki: true,
+        default_branch: "dev",
+      }).secret_scanning
+    ).toBe(false);
+  });
+});
+
+describe("mapRulesetRow", () => {
+  it("humanizes ref includes and joins rule types", () => {
+    expect(
+      mapRulesetRow({
+        name: "base",
+        enforcement: "active",
+        conditions: {
+          ref_name: {
+            include: ["~DEFAULT_BRANCH", "refs/heads/main", "refs/tags/v*"],
+          },
+        },
+        rules: [{ type: "deletion" }, { type: "pull_request" }],
+      })
+    ).toEqual({
+      name: "base",
+      appliesTo: "default · main · v*",
+      enforces: "deletion, pull_request",
+      active: true,
+    });
+  });
+});

--- a/tests/unit/cli/ui-github-repo.test.ts
+++ b/tests/unit/cli/ui-github-repo.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGithubRepoProbe,
+  expectedLabelsFromConfig,
+  type GithubRepoGhReads,
+} from "../../../src/cli/ui-github-repo.js";
+import type { JsonObject } from "../../../src/sync/json-path.js";
+import { runProbe } from "../../../src/cli/ui-status.js";
+
+const OWNER = "acme";
+const REPO = "acme-app";
+const AUTHENTICATED = "authenticated" as const;
+const STATUS_READY = "status:ready";
+const STATUS_BLOCKED = "status:blocked";
+const CONFIG: JsonObject = {
+  github: {
+    org: OWNER,
+    repo: REPO,
+    labels: {
+      build: {
+        ready: STATUS_READY,
+        claimed: "status:in-progress",
+        blocked: STATUS_BLOCKED,
+        human_needed: "human-needed",
+        done: {
+          dev: "status:on-dev",
+          staging: "status:on-stg",
+          production: "status:done",
+        },
+      },
+      prd: {
+        draft: "prd-draft",
+        ready: "prd-ready",
+      },
+    },
+  },
+};
+
+/**
+ * Build injectable gh reads for focused probe tests.
+ * @param overrides - Partial collaborators to replace
+ * @returns Complete injectable read surface
+ */
+function reads(overrides: Partial<GithubRepoGhReads> = {}): GithubRepoGhReads {
+  return {
+    readSettings: async () => ({
+      allow_merge_commit: true,
+      allow_squash_merge: false,
+      allow_rebase_merge: false,
+      allow_auto_merge: true,
+      allow_update_branch: true,
+      delete_branch_on_merge: true,
+      merge_commit_title: "MERGE_MESSAGE",
+      has_issues: true,
+      has_wiki: false,
+      secret_scanning: true,
+      default_branch: "main",
+    }),
+    listRulesets: async () => [
+      {
+        name: "base",
+        appliesTo: "dev · staging · main",
+        enforces: "deletion, non_fast_forward, pull_request",
+        active: true,
+      },
+    ],
+    listLabels: async () => [
+      { name: STATUS_READY, color: "fbca04" },
+      { name: "status:in-progress", color: "0e8a16" },
+    ],
+    listSecretNames: async () => ["DEPLOY_KEY", "CLAUDE_CODE_OAUTH_TOKEN"],
+    ...overrides,
+  };
+}
+
+describe("expectedLabelsFromConfig", () => {
+  it("flattens nested github.labels into role paths", () => {
+    const labels = expectedLabelsFromConfig(CONFIG);
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        { name: STATUS_READY, role: "build · ready" },
+        { name: "status:on-dev", role: "build · done · dev" },
+        { name: "prd-draft", role: "prd · draft" },
+      ])
+    );
+  });
+});
+
+describe("createGithubRepoProbe", () => {
+  it("returns unknown not-authenticated without calling any repo reads", async () => {
+    const readSettings = vi.fn();
+    const listRulesets = vi.fn();
+    const listLabels = vi.fn();
+    const listSecretNames = vi.fn();
+
+    const result = await runProbe(
+      createGithubRepoProbe(".", CONFIG, {
+        authenticate: async () => "not-authenticated",
+        reads: {
+          readSettings,
+          listRulesets,
+          listLabels,
+          listSecretNames,
+        },
+      })
+    );
+
+    expect(result).toEqual({
+      state: "unknown",
+      reason: "not-authenticated",
+      message: "GitHub CLI is not authenticated",
+    });
+    expect(result).not.toHaveProperty("value");
+    expect(readSettings).not.toHaveBeenCalled();
+    expect(listRulesets).not.toHaveBeenCalled();
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listSecretNames).not.toHaveBeenCalled();
+  });
+
+  it("returns unknown when github.org/repo are missing", async () => {
+    const result = await runProbe(
+      createGithubRepoProbe(
+        ".",
+        { tracker: "github" },
+        {
+          authenticate: async () => AUTHENTICATED,
+          reads: reads(),
+        }
+      )
+    );
+
+    expect(result).toMatchObject({
+      state: "unknown",
+      reason: "repo-not-configured",
+    });
+    expect(result).not.toHaveProperty("value");
+  });
+
+  it("lists live rulesets and marks expected-but-absent labels missing", async () => {
+    const result = await runProbe(
+      createGithubRepoProbe(".", CONFIG, {
+        authenticate: async () => AUTHENTICATED,
+        reads: reads(),
+      })
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const labels = result.value.labels as readonly {
+      readonly name: string;
+      readonly present: boolean;
+      readonly color: string;
+    }[];
+    expect(result.value.rulesets).toEqual([
+      {
+        name: "base",
+        appliesTo: "dev · staging · main",
+        enforces: "deletion, non_fast_forward, pull_request",
+        active: true,
+      },
+    ]);
+    const ready = labels.find(label => label.name === STATUS_READY);
+    const blocked = labels.find(label => label.name === STATUS_BLOCKED);
+    expect(ready).toMatchObject({ present: true, color: "fbca04" });
+    expect(blocked).toMatchObject({ present: false });
+  });
+
+  it("reports secret presence only and never includes a secret value field", async () => {
+    const result = await runProbe(
+      createGithubRepoProbe(".", CONFIG, {
+        authenticate: async () => AUTHENTICATED,
+        reads: reads(),
+      })
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const secrets = result.value.secrets as readonly {
+      readonly name: string;
+      readonly purpose: string;
+      readonly set: boolean;
+    }[];
+    const deploy = secrets.find(secret => secret.name === "DEPLOY_KEY");
+    const snyk = secrets.find(secret => secret.name === "SNYK_TOKEN");
+    expect(deploy).toEqual({
+      name: "DEPLOY_KEY",
+      purpose:
+        "Write deploy key so CI can push version bumps through ruleset bypass",
+      set: true,
+    });
+    expect(snyk).toMatchObject({ name: "SNYK_TOKEN", set: false });
+    for (const secret of secrets) {
+      expect(
+        Object.keys(secret).toSorted((left, right) => left.localeCompare(right))
+      ).toEqual(["name", "purpose", "set"]);
+      expect(JSON.stringify(secret)).not.toMatch(/ghp_|github_pat_|-----BEGIN/);
+    }
+  });
+
+  it("surfaces live repository settings in the value payload", async () => {
+    const result = await runProbe(
+      createGithubRepoProbe(".", CONFIG, {
+        authenticate: async () => AUTHENTICATED,
+        reads: reads({
+          readSettings: async () => ({
+            allow_merge_commit: true,
+            allow_squash_merge: false,
+            allow_rebase_merge: false,
+            allow_auto_merge: true,
+            allow_update_branch: true,
+            delete_branch_on_merge: true,
+            merge_commit_title: "PR_TITLE",
+            has_issues: false,
+            has_wiki: false,
+            secret_scanning: false,
+            default_branch: "staging",
+          }),
+        }),
+      })
+    );
+
+    expect(result).toMatchObject({
+      state: "value",
+      value: {
+        owner: OWNER,
+        repo: REPO,
+        settings: {
+          merge_commit_title: "PR_TITLE",
+          has_issues: false,
+          default_branch: "staging",
+          secret_scanning: false,
+        },
+      },
+    });
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -4746,9 +4746,10 @@
       };
 
       /* ---------------------------------- GitHub repo ---------------------------------- */
+      /* Demo values are never shown — the panel hydrates from the github-repo probe. */
       DATA.sections.repository = {
         title: "Repository & protection",
-        desc: "Repo-level governance on the git host: merge policy, branch protection with required status checks, lifecycle labels, deploy key and expected secrets. The controls below are those of the configured host — GitHub is the only one implemented today, so they are GitHub’s rulesets and settings.",
+        desc: "Repo-level governance on the git host: merge policy, branch protection with required status checks, lifecycle labels, deploy key and expected secrets. Values come from live gh api reads against the configured github.org / github.repo — never from demo data.",
         src: "scripts/lisa-github-repo-setup.sh · all/github-rulesets/",
         blocks: [
           {
@@ -4763,253 +4764,9 @@
             ],
           },
           {
-            card: "Repository settings",
-            note: "github.settings.* overrides the baseline per key",
-            rows: [
-              {
-                key: "allow_merge_commit",
-                label: "Allow merge commits",
-                desc: "The fleet is merge-only — squash and rebase are disabled because squashing flattens release commits and breaks promotion.",
-                control: tog(true),
-              },
-              {
-                key: "allow_squash_merge",
-                label: "Allow squash merge",
-                desc: "",
-                control: tog(false),
-              },
-              {
-                key: "allow_rebase_merge",
-                label: "Allow rebase merge",
-                desc: "",
-                control: tog(false),
-              },
-              {
-                key: "allow_auto_merge",
-                label: "Auto-merge",
-                desc: "Lisa PRs enable auto-merge and drive themselves to green.",
-                control: tog(true),
-              },
-              {
-                key: "allow_update_branch",
-                label: "Suggest updating PR branches",
-                desc: "",
-                control: tog(true),
-              },
-              {
-                key: "delete_branch_on_merge",
-                label: "Delete head branch on merge",
-                desc: "Environment branches survive via the prevent-delete ruleset.",
-                control: tog(true),
-              },
-              {
-                key: "merge_commit_title",
-                label: "Merge commit title",
-                desc: "",
-                control: sel("MERGE_MESSAGE", ["MERGE_MESSAGE", "PR_TITLE"]),
-              },
-              {
-                key: "has_issues",
-                label: "Issues tab",
-                desc: "",
-                control: tog(true),
-              },
-              {
-                key: "has_wiki",
-                label: "Wiki tab",
-                desc: "Off — Lisa uses the in-repo wiki/ directory instead.",
-                control: tog(false),
-              },
-              {
-                key: "secret_scanning",
-                label: "Secret scanning + push protection",
-                desc: "Best-effort; skipped when the plan lacks GitHub Advanced Security.",
-                control: tog(true),
-              },
-              {
-                key: "github.settings.default_branch",
-                label: "Default branch",
-                desc: "Lowest-tier existing environment branch wins: dev, then staging, then main.",
-                control: txt("dev", { mono: true }),
-              },
-            ],
-          },
-          {
-            type: "table",
-            card: "Rulesets",
-            note: "Bypass: deploy key + repo admins (prevent-delete has no bypass)",
-            cols: ["Ruleset", "Applies to", "Enforces", "Active"],
-            rows: [
-              [
-                { t: "mono", v: "base" },
-                { t: "text", v: "dev · staging · main" },
-                {
-                  t: "text",
-                  v: "No deletion/force-push; PRs with thread resolution; CodeRabbit + GitGuardian required",
-                },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "quality checks" },
-                { t: "text", v: "dev · staging · main" },
-                {
-                  t: "text",
-                  v: "Lint, Type Check, Build, Formatting, Security Scan, Unit + Integration Tests",
-                },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "playwright" },
-                { t: "text", v: "staging" },
-                { t: "text", v: "Playwright E2E required (expo stacks)" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "prevent delete" },
-                { t: "text", v: "dev · staging · main" },
-                { t: "text", v: "Deletion + force-push blocked, no bypass" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "protect tags" },
-                { t: "text", v: "refs/tags/v*" },
-                { t: "text", v: "Tag deletion + moves blocked" },
-                { t: "toggle", v: true },
-              ],
-            ],
-          },
-          {
-            card: "Ruleset adjustments",
-            rows: [
-              {
-                key: "github.rulesets.dropRequiredChecks",
-                label: "Dropped required checks",
-                desc: "Contexts removed from required checks for this repo — e.g. an app integration not installed here.",
-                control: tags([]),
-              },
-              {
-                key: "pull_request.required_review_thread_resolution",
-                label: "Require review-thread resolution",
-                desc: "PRs stay blocked until every conversation (including CodeRabbit’s) is resolved.",
-                control: tog(true),
-              },
-              {
-                key: "pull_request.required_approving_review_count",
-                label: "Required approvals",
-                desc: "Zero — quality is enforced by checks and reviews-by-agents rather than human approval count.",
-                control: num(0),
-              },
-            ],
-          },
-          {
-            type: "table",
-            card: "Lifecycle labels",
-            note: "Created idempotently by /lisa:setup:github",
-            cols: ["Label", "Role", "Color"],
-            rows: [
-              [
-                { t: "mono", v: "status:ready" },
-                { t: "text", v: "build · ready" },
-                { t: "color", v: "#FBCA04" },
-              ],
-              [
-                { t: "mono", v: "status:in-progress" },
-                { t: "text", v: "build · claimed" },
-                { t: "color", v: "#0E8A16" },
-              ],
-              [
-                { t: "mono", v: "status:blocked" },
-                { t: "text", v: "build · blocked" },
-                { t: "color", v: "#D93F0B" },
-              ],
-              [
-                { t: "mono", v: "status:on-dev / status:on-stg" },
-                { t: "text", v: "build · done (dev/staging)" },
-                { t: "color", v: "#1D76DB" },
-              ],
-              [
-                { t: "mono", v: "status:done" },
-                { t: "text", v: "build · done (production)" },
-                { t: "color", v: "#0E8A16" },
-              ],
-              [
-                { t: "mono", v: "prd-draft → prd-verified" },
-                { t: "text", v: "PRD lifecycle (8 labels)" },
-                { t: "color", v: "#5319E7" },
-              ],
-            ],
-          },
-          {
-            type: "table",
-            card: "Secrets",
-            note: "DEPLOY_KEY is the only secret Lisa creates; the rest are expected by workflows",
-            cols: ["Secret", "Purpose", "Status"],
-            rows: [
-              [
-                { t: "mono", v: "DEPLOY_KEY" },
-                {
-                  t: "text",
-                  v: "Write deploy key so CI can push version bumps through ruleset bypass",
-                },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "CLAUDE_CODE_OAUTH_TOKEN" },
-                {
-                  t: "text",
-                  v: "Claude Code Action workflows (nightly, review response, auto-fix)",
-                },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "AWS_ACCOUNT_ID_DEV / _STAGING / _PRODUCTION" },
-                { t: "text", v: "Per-environment AWS accounts for deploys" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "GITGUARDIAN_API_KEY" },
-                { t: "text", v: "Secret scanning check" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "SONAR_TOKEN" },
-                { t: "text", v: "SonarCloud SAST" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "SNYK_TOKEN" },
-                { t: "text", v: "Snyk dependency scan" },
-                { t: "badge", v: "missing", cls: "off" },
-              ],
-              [
-                { t: "mono", v: "FOSSA_API_KEY" },
-                { t: "text", v: "License compliance" },
-                { t: "badge", v: "missing", cls: "off" },
-              ],
-              [
-                { t: "mono", v: "SENTRY_AUTH_TOKEN / ORG / PROJECT" },
-                { t: "text", v: "Sentry releases and sourcemaps" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "EXPO_TOKEN" },
-                { t: "text", v: "EAS builds" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "MAESTRO_API_KEY" },
-                { t: "text", v: "Maestro Cloud mobile E2E" },
-                { t: "badge", v: "set", cls: "on" },
-              ],
-              [
-                { t: "mono", v: "MAESTRO_SECRET_ENV" },
-                {
-                  t: "text",
-                  v: "Native Maestro e2e — newline-separated KEY=VALUE secrets forwarded to flows (test-account passwords)",
-                },
-                { t: "badge", v: "missing", cls: "off" },
-              ],
-            ],
+            type: "callout",
+            variant: "warn",
+            text: "<b>Live repository status</b> — waiting for gh api probe…",
           },
         ],
       };
@@ -6152,6 +5909,178 @@
           "@codyswann/lisa · unknown (invalid-value: lisa-version probe returned an unusable value)"
         );
       }
+      function githubRepoHostBlock() {
+        return {
+          card: "Host",
+          rows: [
+            {
+              key: "",
+              label: "Git host",
+              desc: "Which host this repository lives on. GitHub is the only host Lisa provisions today.",
+              control: sel("GitHub", ["GitHub", "GitLab", "Bitbucket"]),
+            },
+          ],
+        };
+      }
+      function githubRepoSettingsRows(settings) {
+        return [
+          {
+            label: "Allow merge commits",
+            desc: "The fleet is merge-only — squash and rebase are disabled because squashing flattens release commits and breaks promotion.",
+            control: tog(!!settings.allow_merge_commit),
+          },
+          {
+            label: "Allow squash merge",
+            desc: "",
+            control: tog(!!settings.allow_squash_merge),
+          },
+          {
+            label: "Allow rebase merge",
+            desc: "",
+            control: tog(!!settings.allow_rebase_merge),
+          },
+          {
+            label: "Auto-merge",
+            desc: "Lisa PRs enable auto-merge and drive themselves to green.",
+            control: tog(!!settings.allow_auto_merge),
+          },
+          {
+            label: "Suggest updating PR branches",
+            desc: "",
+            control: tog(!!settings.allow_update_branch),
+          },
+          {
+            label: "Delete head branch on merge",
+            desc: "Environment branches survive via the prevent-delete ruleset.",
+            control: tog(!!settings.delete_branch_on_merge),
+          },
+          {
+            label: "Merge commit title",
+            desc: "",
+            control: sel(String(settings.merge_commit_title || ""), [
+              "MERGE_MESSAGE",
+              "PR_TITLE",
+            ]),
+          },
+          {
+            label: "Issues tab",
+            desc: "",
+            control: tog(!!settings.has_issues),
+          },
+          {
+            label: "Wiki tab",
+            desc: "Off — Lisa uses the in-repo wiki/ directory instead.",
+            control: tog(!!settings.has_wiki),
+          },
+          {
+            label: "Secret scanning + push protection",
+            desc: "Best-effort; skipped when the plan lacks GitHub Advanced Security.",
+            control: tog(!!settings.secret_scanning),
+          },
+          {
+            label: "Default branch",
+            desc: "Live default branch from the repository.",
+            control: txt(String(settings.default_branch || ""), {
+              mono: true,
+            }),
+          },
+        ];
+      }
+      function applyGithubRepoPanel(result) {
+        const host = githubRepoHostBlock();
+        if (result.state !== "value") {
+          const reason =
+            result.state === "unknown"
+              ? result.reason + ": " + result.message
+              : "not applicable";
+          DATA.sections.repository.blocks = [
+            host,
+            {
+              type: "callout",
+              variant: "warn",
+              text:
+                "<b>unknown — not authenticated / unavailable</b> — " +
+                esc(reason) +
+                ". No setting, ruleset, label, or secret state is shown as a concrete value.",
+            },
+          ];
+          return;
+        }
+        const value = result.value || {};
+        const settings = value.settings || {};
+        const rulesets = Array.isArray(value.rulesets) ? value.rulesets : [];
+        const labels = Array.isArray(value.labels) ? value.labels : [];
+        const secrets = Array.isArray(value.secrets) ? value.secrets : [];
+        DATA.sections.repository.blocks = [
+          host,
+          {
+            card: "Repository settings",
+            note:
+              "Live from gh api repos/" +
+              String(value.owner || "") +
+              "/" +
+              String(value.repo || ""),
+            rows: githubRepoSettingsRows(settings),
+          },
+          {
+            type: "table",
+            card: "Rulesets",
+            note: "Live from gh api repos/{owner}/{repo}/rulesets",
+            cols: ["Ruleset", "Applies to", "Enforces", "Active"],
+            rows: rulesets.map(row => [
+              { t: "mono", v: String(row.name || "") },
+              { t: "text", v: String(row.appliesTo || "—") },
+              { t: "text", v: String(row.enforces || "—") },
+              {
+                t: "badge",
+                v: row.active ? "active" : "disabled",
+                cls: row.active ? "on" : "off",
+              },
+            ]),
+          },
+          {
+            type: "table",
+            card: "Lifecycle labels",
+            note: "Config-expected labels vs live gh label list",
+            cols: ["Label", "Role", "Color", "Status"],
+            rows: labels.map(row => [
+              { t: "mono", v: String(row.name || "") },
+              { t: "text", v: String(row.role || "") },
+              row.present && row.color
+                ? {
+                    t: "color",
+                    v: "#" + String(row.color).replace(/^#/u, ""),
+                  }
+                : { t: "text", v: "—" },
+              {
+                t: "badge",
+                v: row.present ? "present" : "missing",
+                cls: row.present ? "on" : "off",
+              },
+            ]),
+          },
+          {
+            type: "table",
+            card: "Secrets",
+            note: "Presence only from gh secret list — values are never read",
+            cols: ["Secret", "Purpose", "Status"],
+            rows: secrets.map(row => [
+              { t: "mono", v: String(row.name || "") },
+              { t: "text", v: String(row.purpose || "") },
+              {
+                t: "badge",
+                v: row.set ? "set" : "missing",
+                cls: row.set ? "on" : "off",
+              },
+            ]),
+          },
+        ];
+      }
+      function reRenderAfterGithubRepoHydration() {
+        const current = activeSection;
+        renderAll();
+        showSection(current || "overview");
+      }
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {
@@ -6162,6 +6091,15 @@
           const probes = liveStatusProbeMap(snapshot);
           renderLiveStatuses(probes);
           applyLisaVersion(probes);
+          const repoResult = normalizeLiveStatusResult(
+            probes["github-repo"] || {
+              state: "unknown",
+              reason: "probe-missing",
+              message: "GitHub repository probe did not run",
+            }
+          );
+          applyGithubRepoPanel(repoResult);
+          reRenderAfterGithubRepoHydration();
         } catch (error) {
           const unavailable = {
             state: "unknown",
@@ -6170,6 +6108,8 @@
           };
           renderLiveStatuses({ transport: unavailable });
           applyLisaVersion({ "lisa-version": unavailable });
+          applyGithubRepoPanel(unavailable);
+          reRenderAfterGithubRepoHydration();
         }
       }
 


### PR DESCRIPTION
## Summary
- Add a `github-repo` live-status probe that reads repository settings, rulesets, expected labels, and secret presence via authenticated `gh` / `gh api` calls
- Hydrate the Repository & protection panel from that probe so demo values never render, and unauthenticated `gh` takes the entire panel to unknown
- Secret rows expose set/missing only — values are never read, logged, or rendered

## Test plan
- [x] `bunx vitest run tests/unit/cli/ui-github-repo.test.ts tests/unit/cli/ui-github-repo-map.test.ts`
- [x] `bunx playwright test tests/e2e/ui-github-repo-panel.spec.ts`
- [x] Existing UI e2e (`ui-live-status`, `ui-readonly-affordance`, `ui-version-status`) still green
- [x] Push hook: security audit, slow lint, knip, full unit coverage (4700), integration tests

Closes #1543

Made with [Cursor](https://cursor.com)