### PR TITLE
feat(ui): wire Plugins & MCP section to enabledPlugins (#1540)

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -27,6 +27,7 @@ import {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+import { createEnabledPluginsProbe } from "./ui-enabled-plugins.js";
 import { serveConfigWrite } from "./ui-config-write.js";
 export {
   createGithubAuthProbe,
@@ -36,6 +37,14 @@ export {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+export {
+  createEnabledPluginsProbe,
+  buildEnabledPluginsValue,
+  listMarketplacePluginsFromDisk,
+  type EnabledPluginRow,
+  type EnabledPluginsValue,
+  type MarketplacePlugin,
+} from "./ui-enabled-plugins.js";
 export { inspectRemoteEnvironment } from "./remote-environment.js";
 
 /** Default port for the settings console. */
@@ -319,7 +328,10 @@ export async function runUi(
     getProcessEnvironment()
   );
   const page = injectLiveConfig(html, config, remoteEnvironment);
-  const probes = dependencies.probes ?? [createGithubAuthProbe(destDir)];
+  const probes = dependencies.probes ?? [
+    createGithubAuthProbe(destDir),
+    createEnabledPluginsProbe(destDir),
+  ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)
   );

--- a/src/cli/ui-enabled-plugins.ts
+++ b/src/cli/ui-enabled-plugins.ts
@@ -1,0 +1,365 @@
+/**
+ * Live-status probe for the console Plugins & MCP section.
+ *
+ * Reads project `.claude/settings.json` `enabledPlugins` and joins against
+ * marketplace catalogs on disk. READ-ONLY — never fabricates enablement.
+ * @module cli/ui-enabled-plugins
+ */
+import { readFile } from "node:fs/promises";
+import { homedir as defaultHomedir } from "node:os";
+import * as path from "node:path";
+import type { JsonValue } from "../sync/json-path.js";
+import type { ProbeResult, StatusProbe } from "./ui-status.js";
+
+/** One plugin entry from a marketplace.json catalog. */
+export type MarketplacePlugin = {
+  readonly name: string;
+  readonly description?: string;
+};
+
+/** One plugin row emitted by the enabled-plugins probe. */
+export type EnabledPluginRow = {
+  readonly [key: string]: JsonValue;
+  readonly id: string;
+  readonly status: "enabled" | "available";
+  readonly description: string;
+};
+
+/** Structured value emitted by the enabled-plugins live-status probe. */
+export type EnabledPluginsValue = {
+  readonly [key: string]: JsonValue;
+  /** False when `.claude/settings.json` is absent (empty-state trigger). */
+  readonly settingsPresent: boolean;
+  /** Enabled and available-not-enabled plugins; never demo data. */
+  readonly plugins: EnabledPluginRow[];
+};
+
+/** Injectable collaborators for focused tests. */
+export type EnabledPluginsProbeDependencies = {
+  /** Home directory used to locate `~/.claude/plugins/known_marketplaces.json`. */
+  readonly homedir?: () => string;
+  /** Override marketplace discovery for unit tests. */
+  readonly listMarketplacePlugins?: (
+    cwd: string,
+    home: string
+  ) => Promise<ReadonlyMap<string, string>>;
+};
+
+const ENABLED_PLUGINS_PROBE_ID = "enabled-plugins";
+const SETTINGS_RELATIVE = path.join(".claude", "settings.json");
+const MARKETPLACE_JSON = path.join(".claude-plugin", "marketplace.json");
+
+/**
+ * Read and parse JSON with a real parser; never hand-roll.
+ * @param filePath - Absolute path to a JSON file
+ * @returns Parsed value
+ */
+async function readJsonFile(filePath: string): Promise<unknown> {
+  const content = await readFile(filePath, "utf8");
+  return JSON.parse(content) as unknown;
+}
+
+/**
+ * Extract `plugin@marketplace` → description pairs from one marketplace.json.
+ * @param marketplacePath - Absolute path to marketplace.json
+ * @param fallbackName - Name used when the file omits `name`
+ * @returns Catalog entries (may be empty on read/parse failure)
+ */
+async function readMarketplaceEntries(
+  marketplacePath: string,
+  fallbackName: string
+): Promise<readonly (readonly [string, string])[]> {
+  try {
+    const parsed = await readJsonFile(marketplacePath);
+    if (typeof parsed !== "object" || parsed === null) {
+      return [];
+    }
+    const nameRaw = Reflect.get(parsed, "name");
+    const marketplaceName =
+      typeof nameRaw === "string" && nameRaw.trim().length > 0
+        ? nameRaw.trim()
+        : fallbackName;
+    const plugins = Reflect.get(parsed, "plugins");
+    if (!Array.isArray(plugins)) {
+      return [];
+    }
+    return plugins.flatMap(entry => {
+      if (typeof entry !== "object" || entry === null) {
+        return [];
+      }
+      const pluginName = Reflect.get(entry, "name");
+      if (typeof pluginName !== "string" || pluginName.trim().length === 0) {
+        return [];
+      }
+      const descriptionRaw = Reflect.get(entry, "description");
+      const description =
+        typeof descriptionRaw === "string" ? descriptionRaw : "";
+      return [
+        [`${pluginName.trim()}@${marketplaceName}`, description],
+      ] as const;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read install locations from `~/.claude/plugins/known_marketplaces.json`.
+ * @param home - Home directory
+ * @returns Marketplace name → installLocation pairs
+ */
+async function readKnownMarketplaceInstalls(
+  home: string
+): Promise<readonly (readonly [string, string])[]> {
+  const knownPath = path.join(
+    home,
+    ".claude",
+    "plugins",
+    "known_marketplaces.json"
+  );
+  try {
+    const known = await readJsonFile(knownPath);
+    if (typeof known !== "object" || known === null || Array.isArray(known)) {
+      return [];
+    }
+    return Object.entries(known).flatMap(([marketplaceName, entry]) => {
+      if (typeof entry !== "object" || entry === null) {
+        return [];
+      }
+      const installLocation = Reflect.get(entry, "installLocation");
+      if (typeof installLocation !== "string" || installLocation.length === 0) {
+        return [];
+      }
+      return [[marketplaceName, installLocation]] as const;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect plugin id → description from known Claude marketplaces on disk.
+ * @param cwd - Project root (checked for a local `.claude-plugin/marketplace.json`)
+ * @param home - Home directory containing `~/.claude/plugins`
+ * @returns Map of `plugin@marketplace` ids to descriptions
+ */
+export async function listMarketplacePluginsFromDisk(
+  cwd: string,
+  home: string
+): Promise<ReadonlyMap<string, string>> {
+  const localEntries = await readMarketplaceEntries(
+    path.join(cwd, MARKETPLACE_JSON),
+    "lisa"
+  );
+  const installs = await readKnownMarketplaceInstalls(home);
+  const knownEntries = (
+    await Promise.all(
+      installs.map(async ([marketplaceName, installLocation]) =>
+        readMarketplaceEntries(
+          path.join(installLocation, MARKETPLACE_JSON),
+          marketplaceName
+        )
+      )
+    )
+  ).flat();
+  // Later entries win so the project's local marketplace takes precedence.
+  return new Map([...knownEntries, ...localEntries]);
+}
+
+/**
+ * Sort enabled rows before available, then by id.
+ * @param left - First row
+ * @param right - Second row
+ * @returns Comparator result
+ */
+function comparePluginRows(
+  left: EnabledPluginRow,
+  right: EnabledPluginRow
+): number {
+  if (left.status !== right.status) {
+    return left.status === "enabled" ? -1 : 1;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+/**
+ * Build the probe value from settings + marketplace catalog.
+ * @param settingsPresent - Whether settings.json existed
+ * @param enabledPlugins - Parsed enabledPlugins map (true = enabled)
+ * @param marketplace - Plugin id → description catalog
+ * @returns Structured probe value
+ */
+export function buildEnabledPluginsValue(
+  settingsPresent: boolean,
+  enabledPlugins: Readonly<Record<string, boolean>>,
+  marketplace: ReadonlyMap<string, string>
+): EnabledPluginsValue {
+  if (!settingsPresent) {
+    return { settingsPresent: false, plugins: [] };
+  }
+
+  const enabledRows: EnabledPluginRow[] = Object.entries(enabledPlugins)
+    .filter(
+      (entry): entry is [string, true] =>
+        typeof entry[0] === "string" &&
+        entry[0].trim().length > 0 &&
+        entry[1] === true
+    )
+    .map(([id]) => ({
+      id,
+      status: "enabled" as const,
+      description: marketplace.get(id) ?? "",
+    }));
+
+  const enabledIds = new Set(enabledRows.map(row => row.id));
+  const availableRows: EnabledPluginRow[] = [...marketplace.entries()]
+    .filter(([id]) => !enabledIds.has(id))
+    .map(([id, description]) => ({
+      id,
+      status: "available" as const,
+      description,
+    }));
+
+  return {
+    settingsPresent: true,
+    plugins: [...enabledRows, ...availableRows].sort(comparePluginRows),
+  };
+}
+
+/**
+ * Parse `enabledPlugins` from a settings document.
+ * @param settings - Parsed settings.json root
+ * @returns Map of plugin id → enabled, or an error reason
+ */
+function parseEnabledPluginsMap(
+  settings: unknown
+):
+  | { readonly ok: true; readonly map: Record<string, boolean> }
+  | { readonly ok: false; readonly reason: string; readonly message: string } {
+  if (
+    typeof settings !== "object" ||
+    settings === null ||
+    Array.isArray(settings)
+  ) {
+    return {
+      ok: false,
+      reason: "invalid-settings",
+      message: ".claude/settings.json did not contain a JSON object",
+    };
+  }
+  if (!Object.hasOwn(settings, "enabledPlugins")) {
+    return { ok: true, map: {} };
+  }
+  const enabledPlugins = Reflect.get(settings, "enabledPlugins");
+  if (
+    typeof enabledPlugins !== "object" ||
+    enabledPlugins === null ||
+    Array.isArray(enabledPlugins)
+  ) {
+    return {
+      ok: false,
+      reason: "invalid-enabled-plugins",
+      message:
+        "enabledPlugins must be a JSON object map of plugin id → boolean",
+    };
+  }
+  const map = Object.fromEntries(
+    Object.entries(enabledPlugins).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === "boolean"
+    )
+  );
+  return { ok: true, map };
+}
+
+/**
+ * Classify a settings.json read failure into empty vs unknown.
+ * @param error - Thrown value from read/parse
+ * @returns Probe outcome when the file cannot be used
+ */
+function classifySettingsReadError(
+  error: unknown
+): ProbeResult<EnabledPluginsValue> | { readonly missing: true } {
+  const code =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof Reflect.get(error, "code") === "string"
+      ? (Reflect.get(error, "code") as string)
+      : undefined;
+  if (code === "ENOENT") {
+    return { missing: true };
+  }
+  if (error instanceof SyntaxError) {
+    return {
+      state: "unknown",
+      reason: "unparseable-settings",
+      message:
+        error.message.trim().length > 0
+          ? error.message
+          : ".claude/settings.json could not be parsed as JSON",
+    };
+  }
+  const message =
+    error instanceof Error && error.message.trim().length > 0
+      ? error.message
+      : "Failed to read .claude/settings.json";
+  return {
+    state: "unknown",
+    reason: "settings-read-failed",
+    message,
+  };
+}
+
+/**
+ * Create the probe that reports project plugin enablement vs marketplace availability.
+ * @param cwd - Project root containing `.claude/settings.json`
+ * @param dependencies - Injectable collaborators for focused tests
+ * @returns Probe emitting enabled / available-not-enabled rows, or unknown
+ */
+export function createEnabledPluginsProbe(
+  cwd: string,
+  dependencies: EnabledPluginsProbeDependencies = {}
+): StatusProbe<EnabledPluginsValue> {
+  const resolveHome = dependencies.homedir ?? defaultHomedir;
+  const listMarketplace =
+    dependencies.listMarketplacePlugins ?? listMarketplacePluginsFromDisk;
+
+  return {
+    id: ENABLED_PLUGINS_PROBE_ID,
+    timeoutMs: 5_000,
+    run: async (): Promise<ProbeResult<EnabledPluginsValue>> => {
+      const settingsPath = path.join(cwd, SETTINGS_RELATIVE);
+      const loaded = await readJsonFile(settingsPath).then(
+        settings => ({ ok: true as const, settings }),
+        (error: unknown) => ({ ok: false as const, error })
+      );
+
+      if (!loaded.ok) {
+        const classified = classifySettingsReadError(loaded.error);
+        if (!("missing" in classified)) {
+          return classified;
+        }
+        const marketplace = await listMarketplace(cwd, resolveHome());
+        return {
+          state: "value",
+          value: buildEnabledPluginsValue(false, {}, marketplace),
+        };
+      }
+
+      const parsed = parseEnabledPluginsMap(loaded.settings);
+      if (!parsed.ok) {
+        return {
+          state: "unknown",
+          reason: parsed.reason,
+          message: parsed.message,
+        };
+      }
+
+      const marketplace = await listMarketplace(cwd, resolveHome());
+      return {
+        state: "value",
+        value: buildEnabledPluginsValue(true, parsed.map, marketplace),
+      };
+    },
+  };
+}

--- a/tests/e2e/ui-plugins.spec.ts
+++ b/tests/e2e/ui-plugins.spec.ts
@@ -1,0 +1,363 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  createEnabledPluginsProbe,
+  runUi,
+  type ProbeResult,
+  type StatusProbe,
+  type EnabledPluginsValue,
+} from "../../src/cli/ui-cmd.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port with sync disabled.
+ * @param destDir - Project root the console serves
+ * @param probes - Injected status probes; omitted to exercise real defaults
+ * @returns The console's loopback origin and a close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes?: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(
+    destDir,
+    { port: "0", sync: false },
+    probes ? { probes } : {}
+  );
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build the `enabled-plugins` probe returning a fixed result.
+ * @param result - Tri-state result the probe reports
+ * @returns A probe registered under the `enabled-plugins` id
+ */
+function enabledPluginsProbe(
+  result: ProbeResult<EnabledPluginsValue>
+): StatusProbe<EnabledPluginsValue> {
+  return { id: "enabled-plugins", timeoutMs: 1_000, run: async () => result };
+}
+
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
+/**
+ * Create a fresh temporary project directory, tracked for teardown.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-plugins-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+const demoPluginIds = [
+  "lisa-nestjs@lisa",
+  "code-review@claude-plugins-official",
+  "impeccable@impeccable",
+];
+
+test("lists exactly the enabled plugins and marks available-not-enabled", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    enabledPluginsProbe({
+      state: "value",
+      value: {
+        settingsPresent: true,
+        plugins: [
+          {
+            id: "lisa@lisa",
+            status: "enabled",
+            description: "Base governance",
+          },
+          {
+            id: "lisa-nestjs@lisa",
+            status: "available",
+            description: "NestJS skills",
+          },
+          {
+            id: "playwright@claude-plugins-official",
+            status: "enabled",
+            description: "Browser automation",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    await expect(page.locator("#section-plugins h1")).toHaveText(
+      "Plugins & MCP"
+    );
+
+    const live = page.locator("#section-plugins .plugins-live-block");
+    await expect(live.locator(".plugins-state")).toHaveCount(0);
+
+    await expect(live.getByText("lisa@lisa", { exact: true })).toBeVisible();
+    await expect(
+      live.getByText("lisa-nestjs@lisa", { exact: true })
+    ).toBeVisible();
+    await expect(
+      live.getByText("playwright@claude-plugins-official", { exact: true })
+    ).toBeVisible();
+
+    const lisaRow = live.locator("tr", { hasText: "lisa@lisa" });
+    await expect(lisaRow.getByText("enabled", { exact: true })).toBeVisible();
+    await expect(lisaRow.locator(".badge.on")).toHaveCount(1);
+
+    const nestRow = live.locator("tr", { hasText: "lisa-nestjs@lisa" });
+    await expect(
+      nestRow.getByText("available, not enabled", { exact: true })
+    ).toBeVisible();
+    await expect(nestRow.locator(".badge.on")).toHaveCount(0);
+
+    // Demo-only curated ids that were not in the probe must not appear.
+    await expect(
+      live.getByText("impeccable@impeccable", { exact: true })
+    ).toHaveCount(0);
+    await expect(
+      live.getByText("code-review@claude-plugins-official", { exact: true })
+    ).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders the empty state when settings.json is absent", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    enabledPluginsProbe({
+      state: "value",
+      value: { settingsPresent: false, plugins: [] },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    await expect(
+      page.locator("#section-plugins .plugins-state.empty")
+    ).toHaveText(/No \.claude\/settings\.json in this project/);
+    for (const id of demoPluginIds) {
+      await expect(
+        page.locator("#section-plugins .plugins-live-block").getByText(id, {
+          exact: true,
+        })
+      ).toHaveCount(0);
+    }
+    await expect(
+      page.locator("#section-plugins .plugins-live-block tr")
+    ).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders unknown when the probe is missing", async ({ page }) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    {
+      id: "github-authenticated",
+      timeoutMs: 1_000,
+      run: async () => ({ state: "value", value: true }),
+    },
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    const unknown = page.locator("#section-plugins .plugins-state.unknown");
+    await expect(unknown).toBeVisible();
+    await expect(unknown).toContainText("Plugin enablement unavailable");
+    await expect(unknown.locator(".status-why")).toHaveText(
+      "missing-probe: The enabled-plugins probe was not reported"
+    );
+    await expect(
+      page
+        .locator("#section-plugins .plugins-live-block")
+        .getByText("lisa@lisa", {
+          exact: true,
+        })
+    ).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders unknown for an unparseable-settings probe result", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    enabledPluginsProbe({
+      state: "unknown",
+      reason: "unparseable-settings",
+      message: "Unexpected token in JSON",
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    const unknown = page.locator("#section-plugins .plugins-state.unknown");
+    await expect(unknown).toBeVisible();
+    await expect(unknown.locator(".status-why")).toHaveText(
+      "unparseable-settings: Unexpected token in JSON"
+    );
+    await expect(
+      page.locator("#section-plugins .plugins-state.empty")
+    ).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("renders a hostile plugin id as inert text without executing it", async ({
+  page,
+}) => {
+  const hostileId = "<img src=x onerror=window.__xss=1>@lisa";
+  const ui = await launchConsole(await makeProjectDir(), [
+    enabledPluginsProbe({
+      state: "value",
+      value: {
+        settingsPresent: true,
+        plugins: [{ id: hostileId, status: "enabled", description: "hostile" }],
+      },
+    }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    const live = page.locator("#section-plugins .plugins-live-block");
+    await expect(live.getByText(hostileId, { exact: true })).toBeVisible();
+    await expect(live.locator("img")).toHaveCount(0);
+    const xss = await page.evaluate(() => (window as { __xss?: number }).__xss);
+    expect(xss).toBeUndefined();
+  } finally {
+    await ui.close();
+  }
+});
+
+test("hydrates from the real probe against a settings.json fixture", async ({
+  page,
+}) => {
+  const projectDir = await makeProjectDir();
+  const isolatedHome = await makeProjectDir();
+  await mkdir(path.join(projectDir, ".claude"), { recursive: true });
+  await writeFile(
+    path.join(projectDir, ".claude", "settings.json"),
+    `${JSON.stringify(
+      {
+        enabledPlugins: {
+          "lisa@lisa": true,
+          "unique-e2e-plugin@lisa": true,
+        },
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await mkdir(path.join(projectDir, ".claude-plugin"), { recursive: true });
+  await writeFile(
+    path.join(projectDir, ".claude-plugin", "marketplace.json"),
+    `${JSON.stringify(
+      {
+        name: "lisa",
+        plugins: [
+          { name: "lisa", description: "Base" },
+          { name: "unique-e2e-plugin", description: "Fixture only" },
+          { name: "available-only", description: "Not enabled" },
+        ],
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  // Use the real probe implementation with an empty HOME so the developer's
+  // machine marketplaces cannot leak demo-adjacent ids into the assertion.
+  const ui = await launchConsole(projectDir, [
+    createEnabledPluginsProbe(projectDir, { homedir: () => isolatedHome }),
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    const live = page.locator("#section-plugins .plugins-live-block");
+    await expect(
+      live.getByText("unique-e2e-plugin@lisa", { exact: true })
+    ).toBeVisible();
+    await expect(
+      live.getByText("available-only@lisa", { exact: true })
+    ).toBeVisible();
+    const availableRow = live.locator("tr", { hasText: "available-only@lisa" });
+    await expect(
+      availableRow.getByText("available, not enabled", { exact: true })
+    ).toBeVisible();
+    await expect(
+      live.getByText("impeccable@impeccable", { exact: true })
+    ).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("never flashes demo plugin ids before hydration completes", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    {
+      id: "enabled-plugins",
+      timeoutMs: 1_000,
+      run: async () => {
+        await new Promise(resolve => setTimeout(resolve, 250));
+        return {
+          state: "value",
+          value: {
+            settingsPresent: true,
+            plugins: [
+              {
+                id: "lisa@lisa",
+                status: "enabled",
+                description: "Base",
+              },
+            ],
+          },
+        } satisfies ProbeResult<EnabledPluginsValue>;
+      },
+    },
+  ]);
+  try {
+    await page.goto(`${ui.base}/#plugins`);
+    // Immediately after navigation, demo curated ids must not be present.
+    await expect(
+      page
+        .locator("#section-plugins .plugins-live-block")
+        .getByText("impeccable@impeccable", { exact: true })
+    ).toHaveCount(0);
+    await expect(
+      page
+        .locator("#section-plugins .plugins-live-block")
+        .getByText("lisa@lisa", {
+          exact: true,
+        })
+    ).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -248,4 +248,23 @@ describe("runUi", () => {
       runUi(resources.dir, { port: "not-a-port", sync: false })
     ).rejects.toThrow("Invalid --port value");
   });
+
+  it("includes enabled-plugins among the default /api/status probes", async () => {
+    resources.server = await runUi(resources.dir, { port: "0", sync: false });
+
+    const address = resources.server.address();
+    const port =
+      typeof address === "object" && address !== null ? address.port : 0;
+    const response = await fetch(`http://127.0.0.1:${port}/api/status`);
+    expect(response.status).toBe(200);
+    const snapshot = (await response.json()) as {
+      probes: Record<string, unknown>;
+    };
+    expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty("enabled-plugins");
+    expect(snapshot.probes["enabled-plugins"]).toEqual({
+      state: "value",
+      value: { settingsPresent: false, plugins: [] },
+    });
+  });
 });

--- a/tests/unit/cli/ui-enabled-plugins-probe.test.ts
+++ b/tests/unit/cli/ui-enabled-plugins-probe.test.ts
@@ -1,0 +1,227 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createEnabledPluginsProbe,
+  type MarketplacePlugin,
+} from "../../../src/cli/ui-enabled-plugins.js";
+import { runProbe } from "../../../src/cli/ui-cmd.js";
+
+/** Holder for per-test temp resources. */
+interface TestResources {
+  dir: string;
+  home: string;
+}
+
+const resources: TestResources = { dir: "", home: "" };
+const ENABLED_PLUGINS_PROBE_ID = "enabled-plugins";
+const BASE_GOVERNANCE = "Base governance";
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-enabled-plugins-"));
+  resources.home = await mkdtemp(
+    path.join(tmpdir(), "lisa-enabled-plugins-home-")
+  );
+});
+
+afterEach(async () => {
+  await rm(resources.dir, { recursive: true, force: true });
+  await rm(resources.home, { recursive: true, force: true });
+});
+
+/**
+ * Write a project `.claude/settings.json`.
+ * @param settings - Settings object to serialize
+ */
+async function writeSettings(settings: unknown): Promise<void> {
+  await mkdir(path.join(resources.dir, ".claude"), { recursive: true });
+  await writeFile(
+    path.join(resources.dir, ".claude", "settings.json"),
+    `${JSON.stringify(settings, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * Seed a marketplace under the fake home directory.
+ * @param marketplaceName - Marketplace name used in `plugin@marketplace` ids
+ * @param plugins - Marketplace plugin entries
+ */
+async function seedMarketplace(
+  marketplaceName: string,
+  plugins: readonly MarketplacePlugin[]
+): Promise<void> {
+  const installLocation = path.join(
+    resources.home,
+    ".claude",
+    "plugins",
+    "marketplaces",
+    marketplaceName
+  );
+  await mkdir(path.join(installLocation, ".claude-plugin"), {
+    recursive: true,
+  });
+  await writeFile(
+    path.join(installLocation, ".claude-plugin", "marketplace.json"),
+    `${JSON.stringify({ name: marketplaceName, plugins }, null, 2)}\n`,
+    "utf8"
+  );
+  const knownPath = path.join(
+    resources.home,
+    ".claude",
+    "plugins",
+    "known_marketplaces.json"
+  );
+  await mkdir(path.dirname(knownPath), { recursive: true });
+  let known: Record<string, { installLocation: string }> = {};
+  try {
+    const existing = await readFile(knownPath, "utf8");
+    known = JSON.parse(existing) as Record<string, { installLocation: string }>;
+  } catch {
+    known = {};
+  }
+  known[marketplaceName] = { installLocation };
+  await writeFile(knownPath, `${JSON.stringify(known, null, 2)}\n`, "utf8");
+}
+
+describe("createEnabledPluginsProbe", () => {
+  it("registers with the enabled-plugins id and a bounded timeout", () => {
+    const probe = createEnabledPluginsProbe(resources.dir, {
+      homedir: () => resources.home,
+    });
+
+    expect(probe.id).toBe(ENABLED_PLUGINS_PROBE_ID);
+    expect(Number.isFinite(probe.timeoutMs)).toBe(true);
+    expect(probe.timeoutMs).toBeGreaterThan(0);
+  });
+
+  it("returns settingsPresent:false and empty plugins when settings.json is absent", async () => {
+    await seedMarketplace("lisa", [
+      { name: "lisa", description: BASE_GOVERNANCE },
+    ]);
+
+    const result = await runProbe(
+      createEnabledPluginsProbe(resources.dir, {
+        homedir: () => resources.home,
+      })
+    );
+
+    expect(result).toEqual({
+      state: "value",
+      value: { settingsPresent: false, plugins: [] },
+    });
+  });
+
+  it("lists enabled plugins exactly and distinguishes available-not-enabled", async () => {
+    await seedMarketplace("lisa", [
+      { name: "lisa", description: BASE_GOVERNANCE },
+      { name: "lisa-nestjs", description: "NestJS skills" },
+      { name: "lisa-wiki", description: "LLM wiki" },
+    ]);
+    await writeSettings({
+      enabledPlugins: {
+        "lisa@lisa": true,
+        "lisa-wiki@lisa": false,
+      },
+    });
+
+    const result = await runProbe(
+      createEnabledPluginsProbe(resources.dir, {
+        homedir: () => resources.home,
+      })
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      throw new Error("expected value");
+    }
+    expect(result.value.settingsPresent).toBe(true);
+    expect(result.value.plugins).toEqual([
+      {
+        id: "lisa@lisa",
+        status: "enabled",
+        description: BASE_GOVERNANCE,
+      },
+      {
+        id: "lisa-nestjs@lisa",
+        status: "available",
+        description: "NestJS skills",
+      },
+      {
+        id: "lisa-wiki@lisa",
+        status: "available",
+        description: "LLM wiki",
+      },
+    ]);
+  });
+
+  it("includes enabled plugins absent from the marketplace catalog", async () => {
+    await seedMarketplace("lisa", [
+      { name: "lisa", description: BASE_GOVERNANCE },
+    ]);
+    await writeSettings({
+      enabledPlugins: {
+        "lisa@lisa": true,
+        "custom@elsewhere": true,
+      },
+    });
+
+    const result = await runProbe(
+      createEnabledPluginsProbe(resources.dir, {
+        homedir: () => resources.home,
+      })
+    );
+
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      throw new Error("expected value");
+    }
+    expect(result.value.plugins).toEqual(
+      expect.arrayContaining([
+        {
+          id: "custom@elsewhere",
+          status: "enabled",
+          description: "",
+        },
+      ])
+    );
+  });
+
+  it("degrades to unknown when settings.json is unparseable", async () => {
+    await mkdir(path.join(resources.dir, ".claude"), { recursive: true });
+    await writeFile(
+      path.join(resources.dir, ".claude", "settings.json"),
+      "{ not json\n",
+      "utf8"
+    );
+
+    const result = await runProbe(
+      createEnabledPluginsProbe(resources.dir, {
+        homedir: () => resources.home,
+      })
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe("unparseable-settings");
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("degrades to unknown when enabledPlugins is not an object map", async () => {
+    await writeSettings({ enabledPlugins: ["lisa@lisa"] });
+
+    const result = await runProbe(
+      createEnabledPluginsProbe(resources.dir, {
+        homedir: () => resources.home,
+      })
+    );
+
+    expect(result.state).toBe("unknown");
+    if (result.state === "unknown") {
+      expect(result.reason).toBe("invalid-enabled-plugins");
+      expect(result.message).toContain("enabledPlugins");
+    }
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -322,6 +322,29 @@
         font-family: var(--mono);
         font-size: 11px;
       }
+      .plugins-state {
+        padding: 18px 20px;
+        border: 1px dashed var(--line);
+        border-radius: 10px;
+        background: var(--surface2);
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.45;
+      }
+      .plugins-state.unknown {
+        border-style: solid;
+        border-color: var(--warn, #c9872a);
+      }
+      .plugins-state.unknown b {
+        display: block;
+        color: var(--text);
+        margin-bottom: 4px;
+      }
+      .plugins-live-block .plugin-status-badge.available {
+        background: transparent;
+        border: 1px solid var(--line);
+        color: var(--muted);
+      }
       .live-status-item .status-why {
         display: inline;
         margin: 0;
@@ -5012,175 +5035,83 @@
       };
 
       /* ---------------------------------- Plugins ---------------------------------- */
+      /* Catalog copy only — enablement comes from the enabled-plugins probe.
+         Demo toggles are never rendered as a fallback. */
       DATA.sections.plugins = {
         title: "Plugins & MCP",
         desc: "Lisa’s own plugin set (base + one per detected stack), curated third-party plugins, and the MCP servers each one carries. Non-Claude agents receive generated equivalents of everything here.",
         src: ".claude/settings.json enabledPlugins · plugins/src/",
         blocks: [
           {
-            type: "table",
-            card: "Lisa plugins",
-            cols: ["Plugin", "Bundles", "Enabled"],
-            rows: [
-              [
-                { t: "mono", v: "lisa@lisa" },
-                {
-                  t: "text",
-                  v: "Base governance: ~145 skills, 26 agents, 12 hooks, /lisa:* commands, rules, Sentry MCP",
-                },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "lisa-typescript@lisa" },
-                {
-                  t: "text",
-                  v: "format-on-edit, lint-on-edit, ast-grep-on-edit, suppress-directive blocking",
-                },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "lisa-expo@lisa" },
-                {
-                  t: "text",
-                  v: "~40 skills (EAS, expo-router, gluestack), ops-specialist agent, Expo MCP",
-                },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "lisa-nestjs@lisa" },
-                {
-                  t: "text",
-                  v: "GraphQL/TypeORM skills, migration-edit blocking",
-                },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "lisa-phaser@lisa" },
-                { t: "text", v: "8 skills, 20 game-dev agents, Phaser rules" },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "lisa-rails@lisa" },
-                {
-                  t: "text",
-                  v: "20 skills, rubocop-on-edit, Rails conventions",
-                },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "lisa-harper-fabric@lisa" },
-                { t: "text", v: "12 skills, generated-artifact protection" },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "lisa-wiki@lisa" },
-                {
-                  t: "text",
-                  v: "In-repo LLM wiki: 22 skills, ingestion connectors (default-on for phaser only)",
-                },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "lisa-openclaw@lisa" },
-                {
-                  t: "text",
-                  v: "Telegram/Slack routing via OpenClaw (opt-in)",
-                },
-                { t: "toggle", v: false },
-              ],
-            ],
-          },
-          {
-            type: "table",
-            card: "Curated third-party plugins",
-            note: "Flip an entry to enable or disable; Lisa never touches third-party keys on re-apply",
-            cols: ["Plugin", "Purpose", "Enabled"],
-            rows: [
-              [
-                { t: "mono", v: "code-review@claude-plugins-official" },
-                { t: "text", v: "Pre-ship diff defect hunt" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "code-simplifier@claude-plugins-official" },
-                { t: "text", v: "Behavior-preserving cleanup" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "coderabbit@claude-plugins-official" },
-                { t: "text", v: "AI PR review (also a required check)" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "sentry@claude-plugins-official" },
-                { t: "text", v: "Issue debugging, Seer, instrumentation" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "safety-net@cc-marketplace" },
-                { t: "text", v: "Guardrail rulebooks" },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "typescript-lsp@claude-plugins-official" },
-                { t: "text", v: "TypeScript language server" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "playwright@claude-plugins-official" },
-                { t: "text", v: "Browser automation MCP" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "posthog@claude-plugins-official" },
-                { t: "text", v: "Product analytics" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "impeccable@impeccable" },
-                { t: "text", v: "UI design polish" },
-                { t: "toggle", v: true },
-              ],
-              [
-                { t: "mono", v: "skill-creator@claude-plugins-official" },
-                { t: "text", v: "Author and optimize skills" },
-                { t: "toggle", v: false },
-              ],
-              [
-                { t: "mono", v: "ruby-lsp@claude-plugins-official" },
-                { t: "text", v: "Ruby language server (rails stacks)" },
-                { t: "toggle", v: false },
-              ],
-            ],
+            type: "plugins-live",
+            lisaCatalog: {
+              "lisa@lisa":
+                "Base governance: ~145 skills, 26 agents, 12 hooks, /lisa:* commands, rules, Sentry MCP",
+              "lisa-typescript@lisa":
+                "format-on-edit, lint-on-edit, ast-grep-on-edit, suppress-directive blocking",
+              "lisa-expo@lisa":
+                "~40 skills (EAS, expo-router, gluestack), ops-specialist agent, Expo MCP",
+              "lisa-nestjs@lisa":
+                "GraphQL/TypeORM skills, migration-edit blocking",
+              "lisa-phaser@lisa": "8 skills, 20 game-dev agents, Phaser rules",
+              "lisa-rails@lisa":
+                "20 skills, rubocop-on-edit, Rails conventions",
+              "lisa-harper-fabric@lisa":
+                "12 skills, generated-artifact protection",
+              "lisa-wiki@lisa":
+                "In-repo LLM wiki: 22 skills, ingestion connectors (default-on for phaser only)",
+              "lisa-openclaw@lisa":
+                "Telegram/Slack routing via OpenClaw (opt-in)",
+              "lisa-cdk@lisa": "AWS CDK plugin",
+            },
+            thirdPartyCatalog: {
+              "code-review@claude-plugins-official":
+                "Pre-ship diff defect hunt",
+              "code-simplifier@claude-plugins-official":
+                "Behavior-preserving cleanup",
+              "coderabbit@claude-plugins-official":
+                "AI PR review (also a required check)",
+              "sentry@claude-plugins-official":
+                "Issue debugging, Seer, instrumentation",
+              "safety-net@cc-marketplace": "Guardrail rulebooks",
+              "typescript-lsp@claude-plugins-official":
+                "TypeScript language server",
+              "playwright@claude-plugins-official": "Browser automation MCP",
+              "posthog@claude-plugins-official": "Product analytics",
+              "impeccable@impeccable": "UI design polish",
+              "skill-creator@claude-plugins-official":
+                "Author and optimize skills",
+              "ruby-lsp@claude-plugins-official":
+                "Ruby language server (rails stacks)",
+              "atlassian@claude-plugins-official": "Jira / Confluence access",
+              "hookify@claude-plugins-official": "Custom hook authoring",
+            },
           },
           {
             type: "table",
             card: "MCP servers",
-            cols: ["Server", "Transport", "Enablement", "Enabled"],
+            note: "Catalog of MCP servers commonly carried by plugins — enablement follows the hosting plugin (read-only in this phase).",
+            cols: ["Server", "Transport", "Enablement"],
             rows: [
               [
                 { t: "mono", v: "sentry" },
                 { t: "mono", v: "http" },
                 { t: "text", v: "always-on via base plugin" },
-                { t: "toggle", v: true },
               ],
               [
                 { t: "mono", v: "expo" },
                 { t: "mono", v: "http" },
                 { t: "text", v: "on when the expo stack is detected" },
-                { t: "toggle", v: true },
               ],
               [
                 { t: "mono", v: "linear-server" },
                 { t: "mono", v: "http" },
                 { t: "text", v: "project-level .mcp.json" },
-                { t: "toggle", v: false },
               ],
               [
                 { t: "mono", v: "phaser-editor" },
                 { t: "mono", v: "stdio" },
                 { t: "text", v: "shipped disabled (disabledMcpjsonServers)" },
-                { t: "toggle", v: false },
               ],
             ],
           },
@@ -5289,6 +5220,14 @@
       const $savebar = document.getElementById("savebar");
       const $toast = document.getElementById("toast");
       const dirty = new Set();
+
+      /* Live enabled-plugins state, hydrated from GET /api/status. Starts as
+         "loading" so the Plugins section never presents demo toggles as truth. */
+      let pluginsLive = {
+        status: "loading",
+        settingsPresent: false,
+        plugins: [],
+      };
 
       function el(tag, cls, html) {
         const node = document.createElement(tag);
@@ -5789,6 +5728,131 @@
         return card;
       }
 
+      function pluginDescription(id, probeDescription, catalog) {
+        if (Object.hasOwn(catalog, id) && typeof catalog[id] === "string") {
+          return catalog[id];
+        }
+        return typeof probeDescription === "string" ? probeDescription : "";
+      }
+
+      function pluginTableRows(entries, catalog) {
+        return entries.map(plugin => {
+          const enabled = plugin.status === "enabled";
+          return [
+            { t: "mono", v: plugin.id },
+            {
+              t: "text",
+              v: pluginDescription(plugin.id, plugin.description, catalog),
+            },
+            {
+              t: "badge",
+              v: enabled ? "enabled" : "available, not enabled",
+              cls: enabled ? "on" : "plugin-status-badge available",
+            },
+          ];
+        });
+      }
+
+      function renderPluginsInto(wrap, block) {
+        wrap.innerHTML = "";
+        const state = pluginsLive;
+        if (state.status === "loading") {
+          wrap.appendChild(
+            el("div", "plugins-state loading", "Loading plugin enablement…")
+          );
+          return;
+        }
+        if (state.status === "unknown") {
+          const box = el("div", "plugins-state unknown");
+          box.appendChild(el("b", "", "Plugin enablement unavailable"));
+          box.appendChild(
+            el(
+              "span",
+              "status-why",
+              esc((state.reason || "unknown") + ": " + (state.message || ""))
+            )
+          );
+          wrap.appendChild(box);
+          return;
+        }
+        if (!state.settingsPresent) {
+          wrap.appendChild(
+            el(
+              "div",
+              "plugins-state empty",
+              "No .claude/settings.json in this project — plugin enablement is not configured."
+            )
+          );
+          return;
+        }
+        const plugins = Array.isArray(state.plugins) ? state.plugins : [];
+        const lisaCatalog =
+          block.lisaCatalog && typeof block.lisaCatalog === "object"
+            ? block.lisaCatalog
+            : {};
+        const thirdPartyCatalog =
+          block.thirdPartyCatalog && typeof block.thirdPartyCatalog === "object"
+            ? block.thirdPartyCatalog
+            : {};
+        const lisa = [];
+        const thirdParty = [];
+        plugins.forEach(plugin => {
+          if (!plugin || typeof plugin !== "object") return;
+          const id = plugin.id;
+          if (typeof id !== "string" || id.trim().length === 0) return;
+          if (id.endsWith("@lisa") || Object.hasOwn(lisaCatalog, id)) {
+            lisa.push(plugin);
+          } else {
+            thirdParty.push(plugin);
+          }
+        });
+        if (lisa.length === 0 && thirdParty.length === 0) {
+          wrap.appendChild(
+            el(
+              "div",
+              "plugins-state empty",
+              "No plugins enabled or available in the marketplace catalog."
+            )
+          );
+          return;
+        }
+        if (lisa.length > 0) {
+          wrap.appendChild(
+            buildTable({
+              type: "table",
+              card: "Lisa plugins",
+              cols: ["Plugin", "Bundles", "Status"],
+              rows: pluginTableRows(lisa, lisaCatalog),
+            })
+          );
+        }
+        if (thirdParty.length > 0) {
+          wrap.appendChild(
+            buildTable({
+              type: "table",
+              card: "Third-party plugins",
+              note: "Read-only: enablement comes from .claude/settings.json enabledPlugins",
+              cols: ["Plugin", "Purpose", "Status"],
+              rows: pluginTableRows(thirdParty, thirdPartyCatalog),
+            })
+          );
+        }
+      }
+
+      function buildPluginsLive(block) {
+        const wrap = el("div", "plugins-live-block");
+        renderPluginsInto(wrap, block);
+        return wrap;
+      }
+
+      function refreshPlugins() {
+        const block = DATA.sections.plugins.blocks.find(
+          b => b.type === "plugins-live"
+        );
+        const wrap = document.querySelector(".plugins-live-block");
+        if (block && wrap) renderPluginsInto(wrap, block);
+      }
+
       function buildBlock(block) {
         if (block.type === "tiles") return buildTiles(block);
         if (block.type === "flow") return buildFlow(block);
@@ -5798,6 +5862,7 @@
         if (block.type === "table") return buildTable(block);
         if (block.type === "tabs") return buildTabs(block);
         if (block.type === "checklist") return buildChecklist(block);
+        if (block.type === "plugins-live") return buildPluginsLive(block);
         return buildCard(block);
       }
 
@@ -6082,6 +6147,102 @@
           list.appendChild(item);
         });
       }
+      /**
+       * Map the enabled-plugins probe into pluginsLive. A missing probe or an
+       * unusable value becomes an explicit unknown state — never demo toggles.
+       * @param probes - Live-status probe map from /api/status
+       */
+      function applyEnabledPlugins(probes) {
+        const raw =
+          probes && Object.hasOwn(probes, "enabled-plugins")
+            ? probes["enabled-plugins"]
+            : undefined;
+        if (raw === undefined) {
+          pluginsLive = {
+            status: "unknown",
+            settingsPresent: false,
+            plugins: [],
+            reason: "missing-probe",
+            message: "The enabled-plugins probe was not reported",
+          };
+          refreshPlugins();
+          return;
+        }
+        const result = normalizeLiveStatusResult(raw);
+        if (
+          result.state === "value" &&
+          result.value &&
+          typeof result.value === "object"
+        ) {
+          const settingsPresent = result.value.settingsPresent === true;
+          const plugins = result.value.plugins;
+          if (!Array.isArray(plugins)) {
+            pluginsLive = {
+              status: "unknown",
+              settingsPresent: false,
+              plugins: [],
+              reason: "invalid-value",
+              message: "enabled-plugins did not return a plugins array",
+            };
+          } else {
+            const rows = [];
+            let invalid = false;
+            for (const entry of plugins) {
+              if (
+                !entry ||
+                typeof entry !== "object" ||
+                typeof entry.id !== "string" ||
+                entry.id.trim().length === 0 ||
+                (entry.status !== "enabled" && entry.status !== "available")
+              ) {
+                invalid = true;
+                break;
+              }
+              rows.push({
+                id: entry.id,
+                status: entry.status,
+                description:
+                  typeof entry.description === "string"
+                    ? entry.description
+                    : "",
+              });
+            }
+            if (invalid) {
+              pluginsLive = {
+                status: "unknown",
+                settingsPresent: false,
+                plugins: [],
+                reason: "invalid-value",
+                message: "enabled-plugins returned an unusable plugin row",
+              };
+            } else {
+              pluginsLive = {
+                status: "value",
+                settingsPresent,
+                plugins: rows,
+              };
+            }
+          }
+        } else if (result.state === "not-applicable") {
+          pluginsLive = {
+            status: "unknown",
+            settingsPresent: false,
+            plugins: [],
+            reason: "not-applicable",
+            message: "enabled-plugins reported not applicable",
+          };
+        } else {
+          pluginsLive = {
+            status: "unknown",
+            settingsPresent: false,
+            plugins: [],
+            reason: result.reason || "unknown",
+            message: result.message || "Plugin enablement unavailable",
+          };
+        }
+        refreshPlugins();
+      }
+
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {
@@ -6089,15 +6250,17 @@
           });
           if (!response.ok) throw new Error("HTTP " + response.status);
           const snapshot = await response.json();
-          renderLiveStatuses(liveStatusProbeMap(snapshot));
+          const probes = liveStatusProbeMap(snapshot);
+          renderLiveStatuses(probes);
+          applyEnabledPlugins(probes);
         } catch (error) {
-          renderLiveStatuses({
-            transport: {
-              state: "unknown",
-              reason: "status-unavailable",
-              message: error instanceof Error ? error.message : String(error),
-            },
-          });
+          const unavailable = {
+            state: "unknown",
+            reason: "status-unavailable",
+            message: error instanceof Error ? error.message : String(error),
+          };
+          renderLiveStatuses({ transport: unavailable });
+          applyEnabledPlugins({ "enabled-plugins": unavailable });
         }
       }
 


### PR DESCRIPTION
## Summary

- Add `enabled-plugins` live-status probe (`src/cli/ui-enabled-plugins.ts`) that JSON-parses project `.claude/settings.json` `enabledPlugins` and joins marketplace catalogs on disk (`~/.claude/plugins/known_marketplaces.json` + project `.claude-plugin/marketplace.json`).
- Hydrate the Plugins & MCP section from `GET /api/status` via `applyEnabledPlugins` — enabled vs available-not-enabled badges, explicit empty state when settings are absent, unknown with reason when missing/unparseable; demo plugin toggles are never rendered as a fallback.
- Unit coverage for the probe + default registration; Playwright `tests/e2e/ui-plugins.spec.ts` (7 tests) codifies the validation journey on OS-assigned ports.

Closes #1540

## Test plan

- [x] `bun test tests/unit/cli/ui-enabled-plugins-probe.test.ts tests/unit/cli/ui-cmd.test.ts`
- [x] `bunx playwright test tests/e2e/ui-plugins.spec.ts --reporter=list`
- [x] Existing `ui-live-status` + `ui-readonly-affordance` e2e still pass
- [ ] Cross-check `lisa ui` against `jq '.enabledPlugins' .claude/settings.json` on a real project


Made with [Cursor](https://cursor.com)