### PR TITLE
feat(ui): compute deploy pipeline stages from deploy.yml and GitHub environments (#1542)

### DIFF
--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -21,6 +21,7 @@ import {
   type RemoteEnvironmentStatus,
 } from "./remote-environment.js";
 import { createCiQualityJobsProbe } from "./ui-ci-quality-jobs.js";
+import { createDeployPipelineProbe } from "./ui-deploy-pipeline.js";
 import { createLisaVersionProbe } from "./ui-lisa-version.js";
 import {
   createGithubAuthProbe,
@@ -38,6 +39,12 @@ export {
   type ProbeResult,
   type StatusProbe,
 } from "./ui-status.js";
+export {
+  createDeployPipelineProbe,
+  DEPLOY_PIPELINE_PROBE_ID,
+  type DeployPipelineStage,
+  type DeployPipelineValue,
+} from "./ui-deploy-pipeline.js";
 export {
   createLisaVersionProbe,
   mapLisaVersionCheck,
@@ -340,6 +347,7 @@ export async function runUi(
     createGithubAuthProbe(destDir),
     createLisaVersionProbe(),
     createCiQualityJobsProbe(destDir, config),
+    createDeployPipelineProbe(destDir),
   ];
   const server = http.createServer(
     createUiRequestHandler(page, probes, destDir)

--- a/src/cli/ui-deploy-pipeline-model.ts
+++ b/src/cli/ui-deploy-pipeline-model.ts
@@ -1,0 +1,191 @@
+/**
+ * Pure model for Deploy pipeline stages — parse deploy.yml, map holds, assemble.
+ * @module cli/ui-deploy-pipeline-model
+ */
+import yaml from "js-yaml";
+import { isJsonObject, type JsonValue } from "../sync/json-path.js";
+import type { ProbeResult } from "./ui-status.js";
+
+/** Stable probe id consumed by the Deploy section hydration. */
+export const DEPLOY_PIPELINE_PROBE_ID = "deploy-pipeline-stages";
+
+const NOT_AUTHENTICATED_REASON = "not-authenticated";
+const ENVIRONMENT_NOT_FOUND_REASON = "environment-not-found";
+
+/** One row in the Deploy pipeline stages table. */
+export type DeployPipelineStage = {
+  readonly [key: string]: JsonValue;
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  /** Configured GitHub environment name, or empty for workflow jobs. */
+  readonly environment: string;
+  /**
+   * Active column: `true` = hold/job present, `false` = no hold,
+   * `"unknown"` = cannot claim hold/no-hold without lying.
+   */
+  readonly active: boolean | "unknown";
+  /** Required when `active` is false or unknown; empty otherwise. */
+  readonly reason: string;
+};
+
+/** Structured value emitted by the deploy-pipeline-stages probe. */
+export type DeployPipelineValue = {
+  readonly [key: string]: JsonValue;
+  readonly stages: DeployPipelineStage[];
+};
+
+/** One GitHub environment as returned by the Environments API. */
+export type GithubEnvironmentInfo = {
+  readonly name: string;
+  readonly hasRequiredReviewers: boolean;
+};
+
+/** Result of listing GitHub environments — never invents a concrete hold. */
+export type GithubEnvironmentsLookup =
+  | {
+      readonly status: "ok";
+      readonly environments: readonly GithubEnvironmentInfo[];
+    }
+  | {
+      readonly status: "not-authenticated";
+      readonly message: string;
+    }
+  | { readonly status: "error"; readonly message: string };
+
+/**
+ * Extract ordered job stages from a deploy.yml document.
+ * @param contents - Raw YAML text
+ * @returns Workflow job stages in document order
+ */
+export function parseDeployWorkflowStages(
+  contents: string
+): readonly DeployPipelineStage[] {
+  try {
+    const loaded = yaml.load(contents) as unknown;
+    if (!isJsonObject(loaded)) {
+      return [];
+    }
+    const jobs = loaded.jobs;
+    if (!isJsonObject(jobs)) {
+      return [];
+    }
+    return Object.entries(jobs).map(([id, job]) => {
+      const name =
+        isJsonObject(job) && typeof job.name === "string" && job.name.length > 0
+          ? job.name
+          : id;
+      return {
+        id: `job:${id}`,
+        name,
+        description: `Workflow job \`${id}\` from deploy.yml`,
+        environment: "",
+        active: true,
+        reason: "",
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Map one configured environment onto a hold stage using live GH evidence.
+ * @param environment - Configured environment name
+ * @param lookup - Live environments API result
+ * @returns Approval-hold stage that never false-greens
+ */
+export function mapEnvironmentHoldStage(
+  environment: string,
+  lookup: GithubEnvironmentsLookup
+): DeployPipelineStage {
+  const base = {
+    id: `hold:${environment}`,
+    name: `Release approval — ${environment}`,
+    description: `Pauses at the release_approval job until a configured reviewer approves the GitHub environment \`${environment}\``,
+    environment,
+  };
+  if (lookup.status === "not-authenticated") {
+    return {
+      ...base,
+      active: "unknown",
+      reason: `${NOT_AUTHENTICATED_REASON}: ${lookup.message}`,
+    };
+  }
+  if (lookup.status === "error") {
+    return {
+      ...base,
+      active: "unknown",
+      reason: `environments-api-error: ${lookup.message}`,
+    };
+  }
+  const match = lookup.environments.find(entry => entry.name === environment);
+  if (match === undefined) {
+    return {
+      ...base,
+      active: "unknown",
+      reason: `${ENVIRONMENT_NOT_FOUND_REASON}: GitHub environment '${environment}' is named in github.environments but was not found on the repository`,
+    };
+  }
+  if (match.hasRequiredReviewers) {
+    return { ...base, active: true, reason: "" };
+  }
+  return {
+    ...base,
+    active: false,
+    reason: `No required reviewers on GitHub environment '${environment}'`,
+  };
+}
+
+/**
+ * Interleave approval holds before the first release job (or append).
+ * @param jobStages - Stages parsed from deploy.yml
+ * @param holdStages - Per-environment approval hold stages
+ * @returns Ordered pipeline stages for the console table
+ */
+export function assembleDeployPipelineStages(
+  jobStages: readonly DeployPipelineStage[],
+  holdStages: readonly DeployPipelineStage[]
+): readonly DeployPipelineStage[] {
+  if (holdStages.length === 0) {
+    return jobStages;
+  }
+  if (jobStages.length === 0) {
+    return holdStages;
+  }
+  const releaseIndex = jobStages.findIndex(
+    stage => /release/iu.test(stage.id) || /release/iu.test(stage.name)
+  );
+  if (releaseIndex === -1) {
+    return [...jobStages, ...holdStages];
+  }
+  return [
+    ...jobStages.slice(0, releaseIndex),
+    ...holdStages,
+    ...jobStages.slice(releaseIndex),
+  ];
+}
+
+/**
+ * Build the tri-state probe result from filesystem + live environment inputs.
+ * @param workflow - deploy.yml contents, or null when absent
+ * @param configuredEnvironments - Keys from github.environments
+ * @param lookup - Live GitHub environments lookup
+ * @returns Probe result — value, not-applicable, or unknown
+ */
+export function buildDeployPipelineResult(
+  workflow: string | null,
+  configuredEnvironments: readonly string[],
+  lookup: GithubEnvironmentsLookup
+): ProbeResult<DeployPipelineValue> {
+  const jobStages =
+    workflow === null ? [] : parseDeployWorkflowStages(workflow);
+  const holdStages = configuredEnvironments.map(name =>
+    mapEnvironmentHoldStage(name, lookup)
+  );
+  const stages = assembleDeployPipelineStages(jobStages, holdStages);
+  if (stages.length === 0) {
+    return { state: "not-applicable" };
+  }
+  return { state: "value", value: { stages: [...stages] } };
+}

--- a/src/cli/ui-deploy-pipeline.ts
+++ b/src/cli/ui-deploy-pipeline.ts
@@ -1,0 +1,267 @@
+/**
+ * Live-status probe for Deploy pipeline stages in `lisa ui`.
+ *
+ * Combines the project's `.github/workflows/deploy.yml` job sequence with
+ * live GitHub environment protection rules for each `github.environments`
+ * entry. READ-ONLY — never fabricates a hold/no-hold claim.
+ * @module cli/ui-deploy-pipeline
+ */
+import { execFile } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { isJsonObject, type JsonObject } from "../sync/json-path.js";
+import { deepMerge, readJsonOrNull } from "../utils/index.js";
+import type { StatusProbe } from "./ui-status.js";
+import {
+  buildDeployPipelineResult,
+  DEPLOY_PIPELINE_PROBE_ID,
+  type DeployPipelineValue,
+  type GithubEnvironmentInfo,
+  type GithubEnvironmentsLookup,
+} from "./ui-deploy-pipeline-model.js";
+
+export {
+  assembleDeployPipelineStages,
+  buildDeployPipelineResult,
+  DEPLOY_PIPELINE_PROBE_ID,
+  mapEnvironmentHoldStage,
+  parseDeployWorkflowStages,
+  type DeployPipelineStage,
+  type DeployPipelineValue,
+  type GithubEnvironmentInfo,
+  type GithubEnvironmentsLookup,
+} from "./ui-deploy-pipeline-model.js";
+
+const DEPLOY_YML_RELATIVE = path.join(".github", "workflows", "deploy.yml");
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+/** Injectable collaborators for focused unit tests. */
+export type DeployPipelineDependencies = {
+  readonly readDeployWorkflow?: (cwd: string) => Promise<string | null>;
+  readonly readConfiguredEnvironments?: (
+    cwd: string
+  ) => Promise<readonly string[]>;
+  readonly listGithubEnvironments?: (
+    cwd: string,
+    signal: AbortSignal,
+    timeoutMs: number
+  ) => Promise<GithubEnvironmentsLookup>;
+};
+
+/**
+ * Read deploy.yml when present; null when the project has no deploy workflow.
+ * @param cwd - Project root
+ * @returns File contents or null
+ */
+async function readDeployWorkflowDefault(cwd: string): Promise<string | null> {
+  const filePath = path.join(cwd, DEPLOY_YML_RELATIVE);
+  try {
+    await access(filePath);
+  } catch {
+    return null;
+  }
+  return await readFile(filePath, "utf8");
+}
+
+/**
+ * Read configured environment names from merged Lisa config.
+ * @param cwd - Project root
+ * @returns Stable key order from the merged `github.environments` map
+ */
+async function readConfiguredEnvironmentsDefault(
+  cwd: string
+): Promise<readonly string[]> {
+  const committed = await readJsonOrNull<unknown>(
+    path.join(cwd, ".lisa.config.json")
+  );
+  const local = await readJsonOrNull<unknown>(
+    path.join(cwd, ".lisa.config.local.json")
+  );
+  const merged = deepMerge(
+    isJsonObject(committed) ? committed : {},
+    isJsonObject(local) ? local : {}
+  ) as JsonObject;
+  const github = merged.github;
+  if (!isJsonObject(github)) {
+    return [];
+  }
+  const environments = github.environments;
+  if (!isJsonObject(environments)) {
+    return [];
+  }
+  return Object.keys(environments);
+}
+
+/**
+ * Detect whether a gh failure means the CLI is not authenticated.
+ * @param stderr - Combined stderr/stdout from the failed command
+ * @returns Whether the failure is an authentication problem
+ */
+function isNotAuthenticatedFailure(stderr: string): boolean {
+  const text = stderr.toLowerCase();
+  return (
+    text.includes("not logged into") ||
+    text.includes("not authenticated") ||
+    text.includes("gh auth login") ||
+    text.includes("http 401") ||
+    text.includes("401 unauthorized") ||
+    text.includes("to re-authenticate") ||
+    text.includes("authentication required")
+  );
+}
+
+/**
+ * Parse a required-reviewers protection rule into a boolean hold signal.
+ * @param rules - Protection rules from one environment payload
+ * @returns True when at least one required reviewer is configured
+ */
+function protectionHasRequiredReviewers(rules: unknown): boolean {
+  if (!Array.isArray(rules)) {
+    return false;
+  }
+  return rules.some(rule => {
+    if (!isJsonObject(rule) || rule.type !== "required_reviewers") {
+      return false;
+    }
+    const reviewers = rule.reviewers;
+    return Array.isArray(reviewers) && reviewers.length > 0;
+  });
+}
+
+/**
+ * Classify a failed `gh api` invocation without fabricating hold state.
+ * @param stderr - Command stderr
+ * @param errorMessage - Error message from execFile
+ * @returns not-authenticated or generic error lookup
+ */
+function classifyGithubEnvironmentsFailure(
+  stderr: string,
+  errorMessage: string
+): GithubEnvironmentsLookup {
+  const detail = `${stderr}\n${errorMessage}`.trim();
+  if (isNotAuthenticatedFailure(detail)) {
+    return {
+      status: "not-authenticated",
+      message: detail.length > 0 ? detail : "GitHub CLI is not authenticated",
+    };
+  }
+  return {
+    status: "error",
+    message: detail.length > 0 ? detail : "Failed to list GitHub environments",
+  };
+}
+
+/**
+ * Parse the jq-shaped environments array from `gh api`.
+ * @param stdout - Command stdout
+ * @returns ok lookup or parse error
+ */
+function parseGithubEnvironmentsStdout(
+  stdout: string
+): GithubEnvironmentsLookup {
+  try {
+    const parsed = JSON.parse(stdout) as unknown;
+    if (!Array.isArray(parsed)) {
+      return {
+        status: "error",
+        message: "GitHub environments response was not an array",
+      };
+    }
+    const environments = parsed.flatMap((entry): GithubEnvironmentInfo[] => {
+      if (!isJsonObject(entry) || typeof entry.name !== "string") {
+        return [];
+      }
+      return [
+        {
+          name: entry.name,
+          hasRequiredReviewers: protectionHasRequiredReviewers(
+            entry.protection_rules
+          ),
+        },
+      ];
+    });
+    return { status: "ok", environments };
+  } catch (parseError) {
+    return {
+      status: "error",
+      message:
+        parseError instanceof Error
+          ? parseError.message
+          : "Failed to parse GitHub environments response",
+    };
+  }
+}
+
+/**
+ * List GitHub Environments for the project's origin repo via `gh api`.
+ * @param cwd - Project root
+ * @param signal - Probe cancellation signal
+ * @param timeoutMs - Child-process timeout
+ * @returns Authenticated list, not-authenticated, or error
+ */
+export async function listGithubEnvironmentsViaGh(
+  cwd: string,
+  signal: AbortSignal,
+  timeoutMs: number
+): Promise<GithubEnvironmentsLookup> {
+  return await new Promise(resolve => {
+    const ghExecutable = "gh";
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed gh executable
+      ghExecutable,
+      [
+        "api",
+        "repos/{owner}/{repo}/environments",
+        "--paginate",
+        "--jq",
+        "[.environments[]? | {name, protection_rules}]",
+      ],
+      { cwd, signal, timeout: timeoutMs, encoding: "utf8" },
+      (error, stdout, stderr) => {
+        if (error !== null) {
+          resolve(classifyGithubEnvironmentsFailure(stderr, error.message));
+          return;
+        }
+        resolve(parseGithubEnvironmentsStdout(stdout));
+      }
+    );
+  });
+}
+
+/**
+ * Create the probe that reports Deploy pipeline stages for `lisa ui`.
+ * @param cwd - Project root the console is serving
+ * @param dependencies - Injectable IO for focused tests
+ * @returns Status probe registered as `deploy-pipeline-stages`
+ */
+export function createDeployPipelineProbe(
+  cwd: string,
+  dependencies: DeployPipelineDependencies = {}
+): StatusProbe<DeployPipelineValue> {
+  const readDeployWorkflow =
+    dependencies.readDeployWorkflow ?? readDeployWorkflowDefault;
+  const readConfiguredEnvironments =
+    dependencies.readConfiguredEnvironments ??
+    readConfiguredEnvironmentsDefault;
+  const listGithubEnvironments =
+    dependencies.listGithubEnvironments ?? listGithubEnvironmentsViaGh;
+  return {
+    id: DEPLOY_PIPELINE_PROBE_ID,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    run: async signal => {
+      const [workflow, configuredEnvironments] = await Promise.all([
+        readDeployWorkflow(cwd),
+        readConfiguredEnvironments(cwd),
+      ]);
+      const lookup =
+        configuredEnvironments.length === 0
+          ? { status: "ok" as const, environments: [] }
+          : await listGithubEnvironments(cwd, signal, DEFAULT_TIMEOUT_MS + 250);
+      return buildDeployPipelineResult(
+        workflow,
+        configuredEnvironments,
+        lookup
+      );
+    },
+  };
+}

--- a/tests/e2e/ui-deploy-pipeline.spec.ts
+++ b/tests/e2e/ui-deploy-pipeline.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Playwright regression for Deploy pipeline stages live-status probe.
+ *
+ * Maestro: this web console surface has no Maestro harness in the repo
+ * (coverage is Playwright-only, same as other `lisa ui` e2e specs).
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  runUi,
+  type DeployPipelineValue,
+  type ProbeResult,
+  type StatusProbe,
+} from "../../src/cli/ui-cmd.ts";
+
+/**
+ * A running console rooted at an isolated origin, plus its teardown.
+ */
+interface LiveConsole {
+  readonly base: string;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Launch `lisa ui` on an OS-assigned port with sync disabled.
+ * @param destDir - Project root the console serves
+ * @param probes - Injected status probes
+ * @returns Loopback origin and close handle
+ */
+async function launchConsole(
+  destDir: string,
+  probes: readonly StatusProbe[]
+): Promise<LiveConsole> {
+  const server = await runUi(destDir, { port: "0", sync: false }, { probes });
+  const address = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Build the deploy-pipeline-stages probe returning a fixed result.
+ * @param result - Tri-state probe result
+ * @returns Probe registered under deploy-pipeline-stages
+ */
+function deployPipelineProbe(
+  result: ProbeResult<DeployPipelineValue>
+): StatusProbe<DeployPipelineValue> {
+  return {
+    id: "deploy-pipeline-stages",
+    timeoutMs: 1_000,
+    run: async () => result,
+  };
+}
+
+/** Temp project dirs created this test, removed in afterEach. */
+const createdDirs: string[] = [];
+
+/**
+ * Create a fresh temporary project directory, tracked for teardown.
+ * @returns Absolute path to the new directory
+ */
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "lisa-ui-deploy-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+test.afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+const table = "#deploy-pipeline-stages";
+
+/**
+ * Open the Deploy section and wait for the live pipeline table.
+ * @param page - Playwright page
+ * @param base - Console origin
+ */
+async function openDeployPipeline(
+  page: import("@playwright/test").Page,
+  base: string
+): Promise<void> {
+  await page.goto(`${base}/#deploy`);
+  await expect(page.locator(`${table} h2`)).toContainText(
+    "Deploy pipeline stages"
+  );
+}
+
+test("environment with required reviewers shows an approval hold", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    deployPipelineProbe({
+      state: "value",
+      value: {
+        stages: [
+          {
+            id: "hold:production",
+            name: "Release approval — production",
+            description:
+              "Pauses at the release_approval job until a configured reviewer approves the GitHub environment `production`",
+            environment: "production",
+            active: true,
+            reason: "",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await openDeployPipeline(page, ui.base);
+    const row = page.locator(`${table} tbody tr`, {
+      hasText: "Release approval — production",
+    });
+    await expect(row).toBeVisible();
+    await expect(row.locator(".badge.pass")).toContainText("✓ active");
+    await expect(row.locator(".badge.fail")).toHaveCount(0);
+    await expect(row.locator(".badge.warn")).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("environment without required reviewers shows no hold", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    deployPipelineProbe({
+      state: "value",
+      value: {
+        stages: [
+          {
+            id: "hold:staging",
+            name: "Release approval — staging",
+            description: "Approval hold before staging deploys",
+            environment: "staging",
+            active: false,
+            reason: "No required reviewers on GitHub environment 'staging'",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await openDeployPipeline(page, ui.base);
+    const row = page.locator(`${table} tbody tr`, {
+      hasText: "Release approval — staging",
+    });
+    await expect(row.locator(".badge.fail")).toContainText("✗ off");
+    await expect(row.locator(".status-why")).toContainText(
+      "No required reviewers"
+    );
+    await expect(row.locator(".badge.pass")).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("configured-but-absent environment is unknown with reason, not unprotected", async ({
+  page,
+}) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    deployPipelineProbe({
+      state: "value",
+      value: {
+        stages: [
+          {
+            id: "hold:ghost",
+            name: "Release approval — ghost",
+            description: "Configured environment missing from GitHub",
+            environment: "ghost",
+            active: "unknown",
+            reason:
+              "environment-not-found: GitHub environment 'ghost' is named in github.environments but was not found on the repository",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await openDeployPipeline(page, ui.base);
+    const row = page.locator(`${table} tbody tr`, {
+      hasText: "Release approval — ghost",
+    });
+    await expect(row.locator(".badge.warn")).toContainText("unknown");
+    await expect(row.locator(".status-why")).toContainText(
+      "environment-not-found"
+    );
+    await expect(row.locator(".badge.fail")).toHaveCount(0);
+    await expect(row.locator(".badge.pass")).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});
+
+test("unauthenticated gh never fabricates a hold state", async ({ page }) => {
+  const ui = await launchConsole(await makeProjectDir(), [
+    deployPipelineProbe({
+      state: "value",
+      value: {
+        stages: [
+          {
+            id: "hold:production",
+            name: "Release approval — production",
+            description: "Environment-derived hold state",
+            environment: "production",
+            active: "unknown",
+            reason: "not-authenticated: GitHub CLI is not authenticated",
+          },
+        ],
+      },
+    }),
+  ]);
+  try {
+    await openDeployPipeline(page, ui.base);
+    const row = page.locator(`${table} tbody tr`, {
+      hasText: "Release approval — production",
+    });
+    await expect(row.locator(".badge.warn")).toContainText("unknown");
+    await expect(row.locator(".status-why")).toContainText("not-authenticated");
+    await expect(row.locator(".badge.pass")).toHaveCount(0);
+    await expect(row.locator(".badge.fail")).toHaveCount(0);
+  } finally {
+    await ui.close();
+  }
+});

--- a/tests/unit/cli/ui-cmd.test.ts
+++ b/tests/unit/cli/ui-cmd.test.ts
@@ -276,7 +276,7 @@ describe("runUi", () => {
     });
   });
 
-  it("includes lisa-version among the default runUi probes", async () => {
+  it("includes lisa-version and deploy-pipeline-stages among default probes", async () => {
     resources.server = await runUi(resources.dir, { port: "0", sync: false });
 
     const address = resources.server.address();
@@ -288,8 +288,9 @@ describe("runUi", () => {
     };
 
     expect(response.status).toBe(200);
-    expect(snapshot.probes).toHaveProperty("lisa-version");
     expect(snapshot.probes).toHaveProperty("github-auth");
+    expect(snapshot.probes).toHaveProperty("lisa-version");
+    expect(snapshot.probes).toHaveProperty("deploy-pipeline-stages");
   });
 
   it("rejects an invalid port", async () => {

--- a/tests/unit/cli/ui-deploy-pipeline-probe.test.ts
+++ b/tests/unit/cli/ui-deploy-pipeline-probe.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assembleDeployPipelineStages,
+  buildDeployPipelineResult,
+  createDeployPipelineProbe,
+  DEPLOY_PIPELINE_PROBE_ID,
+  mapEnvironmentHoldStage,
+  parseDeployWorkflowStages,
+  type DeployPipelineStage,
+  type GithubEnvironmentsLookup,
+} from "../../../src/cli/ui-deploy-pipeline.js";
+import { runProbe } from "../../../src/cli/ui-cmd.js";
+
+const PRODUCTION = "production";
+const STAGING = "staging";
+const MISSING = "missing-env";
+const NOT_AUTHENTICATED = "not-authenticated" as const;
+const GITHUB_NOT_AUTHENTICATED = "GitHub CLI is not authenticated";
+
+const SAMPLE_DEPLOY_YML = `
+name: Release and Deploy
+jobs:
+  determine_environment:
+    name: Determine Environment
+    runs-on: ubuntu-latest
+  release:
+    name: Release
+    uses: ./.github/workflows/release.yml
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+`;
+
+/**
+ * Build a hold stage fixture for assemble tests.
+ * @param environment - Environment name
+ * @param active - Active column value
+ * @returns Stage row
+ */
+function hold(
+  environment: string,
+  active: DeployPipelineStage["active"]
+): DeployPipelineStage {
+  return {
+    id: `hold:${environment}`,
+    name: `Release approval — ${environment}`,
+    description: "hold",
+    environment,
+    active,
+    reason: active === true ? "" : "reason",
+  };
+}
+
+/**
+ * Build a job stage fixture for assemble tests.
+ * @param id - Job id
+ * @param name - Display name
+ * @returns Stage row
+ */
+function job(id: string, name: string): DeployPipelineStage {
+  return {
+    id: `job:${id}`,
+    name,
+    description: "job",
+    environment: "",
+    active: true,
+    reason: "",
+  };
+}
+
+describe("parseDeployWorkflowStages", () => {
+  it("emits job stages in deploy.yml order with name fields", () => {
+    expect(parseDeployWorkflowStages(SAMPLE_DEPLOY_YML)).toEqual([
+      {
+        id: "job:determine_environment",
+        name: "Determine Environment",
+        description: "Workflow job `determine_environment` from deploy.yml",
+        environment: "",
+        active: true,
+        reason: "",
+      },
+      {
+        id: "job:release",
+        name: "Release",
+        description: "Workflow job `release` from deploy.yml",
+        environment: "",
+        active: true,
+        reason: "",
+      },
+      {
+        id: "job:deploy",
+        name: "Deploy",
+        description: "Workflow job `deploy` from deploy.yml",
+        environment: "",
+        active: true,
+        reason: "",
+      },
+    ]);
+  });
+
+  it("returns an empty list for invalid YAML documents", () => {
+    expect(parseDeployWorkflowStages("not: a: workflow")).toEqual([]);
+  });
+});
+
+describe("mapEnvironmentHoldStage", () => {
+  it("shows an approval hold when GitHub has required reviewers", () => {
+    const lookup: GithubEnvironmentsLookup = {
+      status: "ok",
+      environments: [{ name: PRODUCTION, hasRequiredReviewers: true }],
+    };
+    const stage = mapEnvironmentHoldStage(PRODUCTION, lookup);
+    expect(stage.active).toBe(true);
+    expect(stage.reason).toBe("");
+    expect(stage.name).toContain(PRODUCTION);
+  });
+
+  it("shows no hold when the environment exists without reviewers", () => {
+    const lookup: GithubEnvironmentsLookup = {
+      status: "ok",
+      environments: [{ name: STAGING, hasRequiredReviewers: false }],
+    };
+    const stage = mapEnvironmentHoldStage(STAGING, lookup);
+    expect(stage.active).toBe(false);
+    expect(stage.reason).toContain("No required reviewers");
+  });
+
+  it("reports unknown with environment-not-found for configured-but-absent envs", () => {
+    const lookup: GithubEnvironmentsLookup = {
+      status: "ok",
+      environments: [{ name: PRODUCTION, hasRequiredReviewers: true }],
+    };
+    const stage = mapEnvironmentHoldStage(MISSING, lookup);
+    expect(stage.active).toBe("unknown");
+    expect(stage.reason).toContain("environment-not-found");
+    expect(stage.reason).toContain(MISSING);
+    expect(stage.active).not.toBe(false);
+  });
+
+  it("never fabricates a hold state when gh is not authenticated", () => {
+    const lookup: GithubEnvironmentsLookup = {
+      status: NOT_AUTHENTICATED,
+      message: GITHUB_NOT_AUTHENTICATED,
+    };
+    const stage = mapEnvironmentHoldStage(PRODUCTION, lookup);
+    expect(stage.active).toBe("unknown");
+    expect(stage.reason).toContain(NOT_AUTHENTICATED);
+    expect(stage.active).not.toBe(true);
+    expect(stage.active).not.toBe(false);
+  });
+});
+
+describe("assembleDeployPipelineStages", () => {
+  it("inserts approval holds before the release job", () => {
+    const stages = assembleDeployPipelineStages(
+      [
+        job("determine_environment", "Determine Environment"),
+        job("release", "Release"),
+        job("deploy", "Deploy"),
+      ],
+      [hold(PRODUCTION, true)]
+    );
+    expect(stages.map(stage => stage.id)).toEqual([
+      "job:determine_environment",
+      "hold:production",
+      "job:release",
+      "job:deploy",
+    ]);
+  });
+
+  it("does not assume a fixed env triple when only one hold exists", () => {
+    const stages = assembleDeployPipelineStages(
+      [job("release", "Release")],
+      [hold(PRODUCTION, true)]
+    );
+    expect(stages.filter(stage => stage.environment.length > 0)).toHaveLength(
+      1
+    );
+    expect(stages.map(stage => stage.environment)).toEqual([PRODUCTION, ""]);
+  });
+});
+
+describe("buildDeployPipelineResult", () => {
+  it("returns not-applicable when there is no workflow and no environments", () => {
+    expect(
+      buildDeployPipelineResult(null, [], {
+        status: "ok",
+        environments: [],
+      })
+    ).toEqual({ state: "not-applicable" });
+  });
+
+  it("keeps job stages when environments are absent", () => {
+    const result = buildDeployPipelineResult(SAMPLE_DEPLOY_YML, [], {
+      status: "ok",
+      environments: [],
+    });
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    expect(result.value.stages.every(stage => stage.environment === "")).toBe(
+      true
+    );
+    expect(result.value.stages.length).toBeGreaterThan(0);
+  });
+
+  it("marks environment-derived stages unknown when unauthenticated", () => {
+    const result = buildDeployPipelineResult(SAMPLE_DEPLOY_YML, [PRODUCTION], {
+      status: NOT_AUTHENTICATED,
+      message: GITHUB_NOT_AUTHENTICATED,
+    });
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const holdStage = result.value.stages.find(
+      stage => stage.id === "hold:production"
+    );
+    expect(holdStage?.active).toBe("unknown");
+    expect(holdStage?.reason).toContain(NOT_AUTHENTICATED);
+    const jobStage = result.value.stages.find(stage =>
+      stage.id.startsWith("job:")
+    );
+    expect(jobStage?.active).toBe(true);
+  });
+});
+
+describe("createDeployPipelineProbe", () => {
+  it("registers under the stable deploy-pipeline-stages id", () => {
+    expect(createDeployPipelineProbe("/tmp").id).toBe(DEPLOY_PIPELINE_PROBE_ID);
+  });
+
+  it("joins deploy.yml jobs with live environment holds", async () => {
+    const listGithubEnvironments = vi.fn(
+      async (): Promise<GithubEnvironmentsLookup> => ({
+        status: "ok",
+        environments: [
+          { name: PRODUCTION, hasRequiredReviewers: true },
+          { name: STAGING, hasRequiredReviewers: false },
+        ],
+      })
+    );
+    const result = await runProbe(
+      createDeployPipelineProbe("/project", {
+        readDeployWorkflow: async () => SAMPLE_DEPLOY_YML,
+        readConfiguredEnvironments: async () => [PRODUCTION, STAGING, MISSING],
+        listGithubEnvironments,
+      })
+    );
+    expect(result.state).toBe("value");
+    if (result.state !== "value") {
+      return;
+    }
+    const byId = Object.fromEntries(
+      result.value.stages.map(stage => [stage.id, stage])
+    );
+    expect(byId["hold:production"]?.active).toBe(true);
+    expect(byId["hold:staging"]?.active).toBe(false);
+    expect(byId["hold:missing-env"]?.active).toBe("unknown");
+    expect(byId["hold:missing-env"]?.reason).toContain("environment-not-found");
+    expect(listGithubEnvironments).toHaveBeenCalledOnce();
+  });
+
+  it("skips the GitHub API when no environments are configured", async () => {
+    const listGithubEnvironments = vi.fn(
+      async (): Promise<GithubEnvironmentsLookup> => ({
+        status: "ok",
+        environments: [],
+      })
+    );
+    await runProbe(
+      createDeployPipelineProbe("/project", {
+        readDeployWorkflow: async () => SAMPLE_DEPLOY_YML,
+        readConfiguredEnvironments: async () => [],
+        listGithubEnvironments,
+      })
+    );
+    expect(listGithubEnvironments).not.toHaveBeenCalled();
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -3134,77 +3134,22 @@
           },
           {
             type: "table",
+            id: "deploy-pipeline-stages",
             card: "Deploy pipeline stages",
-            note: "Runs when an environment branch (dev / staging / main) receives a merge",
+            note: "Live from deploy.yml + GitHub environment protection rules — never fabricated",
             cols: ["Stage", "What it does", "Active"],
             rows: [
               [
-                { t: "mono", v: "🏗️ Build & package" },
+                { t: "mono", v: "…" },
                 {
                   t: "text",
-                  v: "Builds the artifacts for the environment mapped to the pushed branch",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "🚦 Release approval — production" },
-                {
-                  t: "text",
-                  v: "Pauses at the release_approval job until a configured reviewer approves the GitHub environment",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "🚦 Release approval — staging" },
-                {
-                  t: "text",
-                  v: "Approval hold before staging deploys",
+                  v: "Loading live deploy pipeline stages…",
                 },
                 {
                   t: "status",
-                  v: false,
-                  reason: "require_approval is off for staging",
+                  v: "unknown",
+                  reason: "waiting for deploy-pipeline-stages probe",
                 },
-              ],
-              [
-                { t: "mono", v: "🚀 Deploy" },
-                {
-                  t: "text",
-                  v: "Runs the stack’s deploy (EAS / Serverless / CDK / Fabric) against the target environment",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "📝 Version bump & changelog" },
-                {
-                  t: "text",
-                  v: "standard-version tags the release and pushes the chore(release) commit through the deploy key’s ruleset bypass",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "🔄 Sync-down branches" },
-                {
-                  t: "text",
-                  v: "After a promotion merges, back-merges higher environment branches into lower ones",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "🧯 Deploy auto-fix" },
-                {
-                  t: "text",
-                  v: "On a failed deploy, a Claude workflow investigates and opens a fix PR",
-                },
-                { t: "status", v: true },
-              ],
-              [
-                { t: "mono", v: "🎫 Issue on failure" },
-                {
-                  t: "text",
-                  v: "Files a tracker issue when a deploy run fails",
-                },
-                { t: "status", v: true },
               ],
             ],
           },
@@ -5599,8 +5544,29 @@
         return card;
       }
 
+      function buildStatusCell(cell) {
+        const td = el("td");
+        if (cell.v === "unknown") {
+          td.appendChild(el("span", "badge warn", "unknown"));
+          if (cell.reason) {
+            td.appendChild(el("span", "status-why", esc(cell.reason)));
+          }
+          return td;
+        }
+        if (cell.v) {
+          td.appendChild(el("span", "badge pass", "✓ active"));
+          return td;
+        }
+        td.appendChild(el("span", "badge fail", "✗ off"));
+        if (cell.reason) {
+          td.appendChild(el("span", "status-why", esc(cell.reason)));
+        }
+        return td;
+      }
+
       function buildTable(block) {
         const card = el("div", "card");
+        if (block.id) card.id = block.id;
         if (block.card) {
           const head = el("div", "card-head");
           head.appendChild(el("h2", "", esc(block.card)));
@@ -5628,6 +5594,10 @@
         block.rows.forEach(cells => {
           const tr = el("tr");
           cells.forEach(cell => {
+            if (cell.t === "status") {
+              tr.appendChild(buildStatusCell(cell));
+              return;
+            }
             const td = el("td");
             if (cell.t === "mono") td.className = "mono";
             if (cell.t === "text" || cell.t === "mono") {
@@ -5658,8 +5628,7 @@
                 if (cell.reason) {
                   td.appendChild(el("span", "status-why", esc(cell.reason)));
                 }
-              }
-            } else if (cell.t === "run") {
+              }            } else if (cell.t === "run") {
               const cls =
                 cell.ok === true
                   ? "pass"
@@ -6308,7 +6277,101 @@
         const current = activeSection;
         renderAll();
         showSection(current);
-      }
+
+       * Replace the Deploy pipeline stages table from the live probe.
+       * Never leaves demo hold/no-hold claims in place.
+       * @param probes - Live-status probe map from /api/status
+       */
+      function applyDeployPipelineStages(probes) {
+        const section = DATA.sections.deploy;
+        if (!section || !Array.isArray(section.blocks)) return;
+        const block = section.blocks.find(
+          candidate =>
+            candidate &&
+            candidate.type === "table" &&
+            candidate.id === "deploy-pipeline-stages"
+        );
+        if (!block) return;
+        const raw =
+          probes && Object.hasOwn(probes, "deploy-pipeline-stages")
+            ? probes["deploy-pipeline-stages"]
+            : undefined;
+        const result =
+          raw === undefined
+            ? {
+                state: "unknown",
+                reason: "missing-probe",
+                message: "The deploy-pipeline-stages probe was not reported",
+              }
+            : normalizeLiveStatusResult(raw);
+        if (result.state === "not-applicable") {
+          block.rows = [
+            [
+              { t: "mono", v: "—" },
+              {
+                t: "text",
+                v: "No deploy.yml or github.environments configured for this project",
+              },
+              { t: "status", v: "unknown", reason: "not-applicable" },
+            ],
+          ];
+        } else if (
+          result.state === "value" &&
+          result.value &&
+          typeof result.value === "object" &&
+          Array.isArray(result.value.stages)
+        ) {
+          block.rows = result.value.stages.map(stage => [
+            {
+              t: "mono",
+              v: String(stage.name || stage.id || "stage"),
+            },
+            {
+              t: "text",
+              v: String(stage.description || ""),
+            },
+            {
+              t: "status",
+              v: stage.active === "unknown" ? "unknown" : stage.active === true,
+              reason:
+                typeof stage.reason === "string" && stage.reason.length > 0
+                  ? stage.reason
+                  : undefined,
+            },
+          ]);
+          if (block.rows.length === 0) {
+            block.rows = [
+              [
+                { t: "mono", v: "—" },
+                { t: "text", v: "Deploy pipeline reported zero stages" },
+                {
+                  t: "status",
+                  v: "unknown",
+                  reason: "empty-stages",
+                },
+              ],
+            ];
+          }
+        } else {
+          const reason =
+            result.state === "unknown"
+              ? result.reason + ": " + result.message
+              : "invalid-value: deploy-pipeline-stages probe returned an unusable value";
+          block.rows = [
+            [
+              { t: "mono", v: "—" },
+              {
+                t: "text",
+                v: "Deploy pipeline stages unavailable",
+              },
+              { t: "status", v: "unknown", reason: reason },
+            ],
+          ];
+        }
+        const existing = document.getElementById("deploy-pipeline-stages");
+        if (existing) {
+          existing.replaceWith(buildTable(block));
+        }      }
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {
@@ -6321,6 +6384,7 @@
           // Quality jobs re-renders the page; paint the version chip after.
           applyCiQualityJobs(probes);
           applyLisaVersion(probes);
+          applyDeployPipelineStages(probes);
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -6332,6 +6396,9 @@
           renderLiveStatuses({ transport: unavailable });
           applyCiQualityJobs({ "ci-quality-jobs": unavailable });
           applyLisaVersion({ "lisa-version": unavailable });
+          applyDeployPipelineStages({
+            "deploy-pipeline-stages": unavailable,
+          });
         }
       }
 


### PR DESCRIPTION
## Summary
- Add a `deploy-pipeline-stages` live-status probe joining `.github/workflows/deploy.yml` job order with live `gh api` environment protection rules
- Hydrate the Deploy pipeline stages table so approval holds / no-hold / missing env / unauthenticated `gh` never false-green
- Unit + Playwright coverage for the acceptance scenarios

Closes #1542

## Test plan
- [x] `bunx vitest run tests/unit/cli/ui-deploy-pipeline-probe.test.ts tests/unit/cli/ui-cmd.test.ts`
- [x] Pre-push unit/integration suite green after rebase onto main (includes #1541/#1546 probes)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)