### PR TITLE
fix(ui): restore applyCiQualityJobs close after deploy-pipeline merge

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5628,7 +5628,8 @@
                 if (cell.reason) {
                   td.appendChild(el("span", "status-why", esc(cell.reason)));
                 }
-              }            } else if (cell.t === "run") {
+              }
+            } else if (cell.t === "run") {
               const cls =
                 cell.ok === true
                   ? "pass"
@@ -6277,7 +6278,8 @@
         const current = activeSection;
         renderAll();
         showSection(current);
-
+      }
+      /**
        * Replace the Deploy pipeline stages table from the live probe.
        * Never leaves demo hold/no-hold claims in place.
        * @param probes - Live-status probe map from /api/status
@@ -6371,7 +6373,8 @@
         const existing = document.getElementById("deploy-pipeline-stages");
         if (existing) {
           existing.replaceWith(buildTable(block));
-        }      }
+        }
+      }
       async function hydrateLiveStatuses() {
         try {
           const response = await fetch("/api/status", {


### PR DESCRIPTION
## Summary
- Restore the missing `applyCiQualityJobs` function terminator / JSDoc opener that was dropped when #1720 merged onto main
- Without this, `lisa ui` fails to boot (empty console) and Deploy pipeline hydration never runs

## Test plan
- [x] `bunx playwright test tests/e2e/ui-deploy-pipeline.spec.ts`
- [ ] Confirm `lisa ui` renders Deploy + CI sections after reload

Follow-up to #1720 / #1542

Made with [Cursor](https://cursor.com)