### PR TITLE
fix(ui): restore applyDeployPipelineStages closing brace lost in merge

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -6711,11 +6711,6 @@
        * Never leaves demo hold/no-hold claims in place.
        * @param probes - Live-status probe map from /api/status
        */
-      /**
-       * Replace the Deploy pipeline stages table from the live probe.
-       * Never leaves demo hold/no-hold claims in place.
-       * @param probes - Live-status probe map from /api/status
-       */
       function applyDeployPipelineStages(probes) {
         const section = DATA.sections.deploy;
         if (!section || !Array.isArray(section.blocks)) return;
@@ -6806,6 +6801,7 @@
         if (existing) {
           existing.replaceWith(buildTable(block));
         }
+      }
       /* Map the detected-stacks probe into stackDetection. A missing probe or a
          non-value/non-array result becomes an explicit unknown state — never a
          false empty and never the metadata catalog. */


### PR DESCRIPTION
## Main-breaking regression — all releases red

The Cursor rebase of #1714 reconstructed the `ui/index.html` live-status hydration region and **dropped the closing `}` of `applyDeployPipelineStages`**. As a result `applyDetectedStacks` and everything after it became nested inside that function, and the entire inline console `<script>` failed to parse with `Unexpected end of input`.

Effects:
- The console rendered nothing dynamic (no probe hydration).
- Every page-driven Playwright test failed — the Release run **[29662031873](https://github.com/CodySwannGT/lisa/actions/runs/29662031873)** for merge `3894ba9da` failed exactly this way (ui-ci-quality-jobs.spec.ts first), leaving npm stranded at **2.235.0**.

## Fix

- Add the missing `}` closing `applyDeployPipelineStages` before the `detected-stacks` comment.
- Dedupe the JSDoc block above the function, which the same merge duplicated verbatim.

Two-line change, no behavior change — it only restores the brace balance the merge lost.

## Verification

- Inline `<script>` now parses clean (acorn) — was `Unexpected end of input`.
- `node dist/index.js ui --no-sync` serves `200`; `/api/status` returns working `detected-stacks` and `deploy-pipeline-stages` probes.
- **Full e2e suite: 43/43 pass** (ui-ci-quality-jobs, ui-deploy-pipeline, ui-version-status, ui-stacks ×9, ui-automations-scheduler, ui-plugins, ui-observability-providers, ui-github-repo-panel, ui-live-status, ui-readonly-affordance).
- `bun run lint` and `bun run typecheck` green.

This unblocks all releases.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent live status updates and deployment pipeline stages from rendering correctly.
  * Improved script stability by correcting a JavaScript syntax error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->