### PR TITLE
fix(ci): learnings budget gate — bump pin to a headless-capable CLI and assert the check ran

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -390,11 +390,15 @@ jobs:
       # Pinned for reproducibility: the gate must not change behavior under
       # unchanged host commits. Bump deliberately when the learnings contract
       # changes. (Publishing npm and pushing this @main workflow are the same
-      # trust domain; the pin buys determinism, not a trust boundary.) When a
-      # future release moves the ledger default path, a stale pin degrades to
-      # the missing-file silent PASS — never a false failure.
+      # trust domain; the pin buys determinism, not a trust boundary.) The pin
+      # must be >= 2.237.0: earlier CLIs lack this subcommand AND self-skip in
+      # non-interactive environments with exit 0, silently voiding the gate —
+      # which is why the marker grep below asserts the check actually ran.
       - name: 📚 Check learnings budget
-        run: bunx @codyswann/lisa@2.236.0 check-learnings-budget
+        run: |
+          set -o pipefail
+          bunx @codyswann/lisa@2.239.0 check-learnings-budget | tee learnings-budget.out
+          grep -qE "learnings budget passed|no learnings file" learnings-budget.out
 
   license_compliance:
     name: 📜 FOSSA License Check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -557,11 +557,15 @@ jobs:
       # Pinned for reproducibility: the gate must not change behavior under
       # unchanged host commits. Bump deliberately when the learnings contract
       # changes. (Publishing npm and pushing this @main workflow are the same
-      # trust domain; the pin buys determinism, not a trust boundary.) When a
-      # future release moves the ledger default path, a stale pin degrades to
-      # the missing-file silent PASS — never a false failure.
+      # trust domain; the pin buys determinism, not a trust boundary.) The pin
+      # must be >= 2.237.0: earlier CLIs lack this subcommand AND self-skip in
+      # non-interactive environments with exit 0, silently voiding the gate —
+      # which is why the marker grep below asserts the check actually ran.
       - name: 📚 Check learnings budget
-        run: bunx @codyswann/lisa@2.236.0 check-learnings-budget
+        run: |
+          set -o pipefail
+          bunx @codyswann/lisa@2.239.0 check-learnings-budget | tee learnings-budget.out
+          grep -qE "learnings budget passed|no learnings file" learnings-budget.out
         working-directory: ${{ inputs.working_directory || '.' }}
 
   test_unit:


### PR DESCRIPTION
The learnings_budget job was vacuous: pinned to 2.236.0, which lacks the subcommand AND self-skips non-interactively with exit 0 (proved by scratch PR #1753 passing against a 25-entry over-budget file — job 88202478892, 14s 'pass'). This bumps the pin to 2.239.0 (locally verified: exit 1 + remediation diagnostic on the same file, runs headless) and adds a success-marker grep so a silently-skipping CLI can never green the gate again. Caught by #1581's bounded-claims red-leg validation. Refs CodySwannGT/lisa#1581. After merge, #1753's re-run must go RED on this job — completing the [real-ci-run-fails-on-budget-step] leg for real.