### PR TITLE
feat(learnings): upstream attribution, automatic self-hardening filing, and applied-learning confirmation (SLL-5 + #1579)

### DIFF
--- a/plugins/lisa-agy/commands/lisa/attribute-failure.md
+++ b/plugins/lisa-agy/commands/lisa/attribute-failure.md
@@ -1,0 +1,6 @@
+---
+description: "Attribute an arbitrary failure event to Lisa or the project with cited evidence. Evaluates three ordered signals — Lisa-managed surface ownership, shipped rule/skill/hook behavior, and the upstream Lisa change-history window — and returns lisa | project | ambiguous. Read-only; inconclusive cases stay local as ambiguous."
+argument-hint: "<failure event: defect description, implicated files, rule/skill/hook in play>"
+---
+
+Use the /lisa-attribute-failure skill to attribute the given failure event to Lisa or the project and return the verdict with its cited evidence. $ARGUMENTS

--- a/plugins/lisa-agy/commands/lisa/persist-learning.md
+++ b/plugins/lisa-agy/commands/lisa/persist-learning.md
@@ -1,5 +1,5 @@
 ---
-description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), emit an upstream handoff marker (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
+description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), file the upstream Lisa ticket automatically with marker dedupe, evidence, and a per-run cap (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
 argument-hint: "<candidate-json-or-fields>"
 ---
 

--- a/plugins/lisa-agy/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-agy/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the project's. Accepts a failure event (defect description, implicated files, rule/skill/hook in play) and returns a verdict of lisa | project | ambiguous plus the evidence relied on. Read-only — it never files, writes, or remediates; callers (lisa-doctor findings, the learning judgment gate, rework triage) consume the verdict. Extracted from lisa-doctor's upstream Lisa change-history diagnosis (#1494) so the same attribution procedure can run on ANY failure event, not only doctor config-audit findings."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-persist-learning
-description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an upstream handoff marker (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
+description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an automatically filed upstream Lisa ticket with marker dedupe, evidence, and a per-run cap (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
 ---
 
 # Persist Learning
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/plugins/lisa-copilot/commands/lisa/attribute-failure.md
+++ b/plugins/lisa-copilot/commands/lisa/attribute-failure.md
@@ -1,0 +1,6 @@
+---
+description: "Attribute an arbitrary failure event to Lisa or the project with cited evidence. Evaluates three ordered signals — Lisa-managed surface ownership, shipped rule/skill/hook behavior, and the upstream Lisa change-history window — and returns lisa | project | ambiguous. Read-only; inconclusive cases stay local as ambiguous."
+argument-hint: "<failure event: defect description, implicated files, rule/skill/hook in play>"
+---
+
+Use the /lisa-attribute-failure skill to attribute the given failure event to Lisa or the project and return the verdict with its cited evidence. $ARGUMENTS

--- a/plugins/lisa-copilot/commands/lisa/persist-learning.md
+++ b/plugins/lisa-copilot/commands/lisa/persist-learning.md
@@ -1,5 +1,5 @@
 ---
-description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), emit an upstream handoff marker (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
+description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), file the upstream Lisa ticket automatically with marker dedupe, evidence, and a per-run cap (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
 argument-hint: "<candidate-json-or-fields>"
 ---
 

--- a/plugins/lisa-copilot/rules/reference/project-learnings.md
+++ b/plugins/lisa-copilot/rules/reference/project-learnings.md
@@ -20,6 +20,24 @@ Each persisted entry has seven fields:
 - `last_confirmed`
 - `confidence`
 
+## Claim-time confirmation (`last_confirmed`)
+
+`last_confirmed` is advanced at claim time by the build-intake flows (step
+3c.2 of `lisa-{jira,github,linear}-build-intake`) when an entry's rule
+**demonstrably applied** during a claim — the rule was explicitly cited or
+observably followed in the claim's plan or diff. Presence in the eagerly
+loaded context is NOT application: every entry is present in every session,
+so counting mere presence would confirm everything on every claim and defeat
+decay entirely.
+
+The bump goes only through `confirmLearningEntry` from
+`@codyswann/lisa/learnings`: a surgical, lock-protected, atomic write that
+advances only `last_confirmed` (re-validated against the
+`>= first_learned` invariant), returns a structured no-op for a missing
+entry or file instead of throwing, and is idempotent within a claim (a
+same-date repeat returns `unchanged`). A failed bump is reported and never
+blocks the build.
+
 Only entries accepted by the executable contract may influence the session. A
 missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
 paths, non-canonical content, or over-budget documents produce one readable

--- a/plugins/lisa-copilot/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-copilot/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the project's. Accepts a failure event (defect description, implicated files, rule/skill/hook in play) and returns a verdict of lisa | project | ambiguous plus the evidence relied on. Read-only — it never files, writes, or remediates; callers (lisa-doctor findings, the learning judgment gate, rework triage) consume the verdict. Extracted from lisa-doctor's upstream Lisa change-history diagnosis (#1494) so the same attribution procedure can run on ANY failure event, not only doctor config-audit findings."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-persist-learning
-description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an upstream handoff marker (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
+description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an automatically filed upstream Lisa ticket with marker dedupe, evidence, and a per-run cap (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
 ---
 
 # Persist Learning
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/plugins/lisa-cursor/commands/lisa/attribute-failure.md
+++ b/plugins/lisa-cursor/commands/lisa/attribute-failure.md
@@ -1,0 +1,6 @@
+---
+description: "Attribute an arbitrary failure event to Lisa or the project with cited evidence. Evaluates three ordered signals — Lisa-managed surface ownership, shipped rule/skill/hook behavior, and the upstream Lisa change-history window — and returns lisa | project | ambiguous. Read-only; inconclusive cases stay local as ambiguous."
+argument-hint: "<failure event: defect description, implicated files, rule/skill/hook in play>"
+---
+
+Use the /lisa-attribute-failure skill to attribute the given failure event to Lisa or the project and return the verdict with its cited evidence. $ARGUMENTS

--- a/plugins/lisa-cursor/commands/lisa/persist-learning.md
+++ b/plugins/lisa-cursor/commands/lisa/persist-learning.md
@@ -1,5 +1,5 @@
 ---
-description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), emit an upstream handoff marker (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
+description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), file the upstream Lisa ticket automatically with marker dedupe, evidence, and a per-run cap (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
 argument-hint: "<candidate-json-or-fields>"
 ---
 

--- a/plugins/lisa-cursor/rules/project-learnings-reference.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings-reference.mdc
@@ -25,6 +25,24 @@ Each persisted entry has seven fields:
 - `last_confirmed`
 - `confidence`
 
+## Claim-time confirmation (`last_confirmed`)
+
+`last_confirmed` is advanced at claim time by the build-intake flows (step
+3c.2 of `lisa-{jira,github,linear}-build-intake`) when an entry's rule
+**demonstrably applied** during a claim — the rule was explicitly cited or
+observably followed in the claim's plan or diff. Presence in the eagerly
+loaded context is NOT application: every entry is present in every session,
+so counting mere presence would confirm everything on every claim and defeat
+decay entirely.
+
+The bump goes only through `confirmLearningEntry` from
+`@codyswann/lisa/learnings`: a surgical, lock-protected, atomic write that
+advances only `last_confirmed` (re-validated against the
+`>= first_learned` invariant), returns a structured no-op for a missing
+entry or file instead of throwing, and is idempotent within a claim (a
+same-date repeat returns `unchanged`). A failed bump is reported and never
+blocks the build.
+
 Only entries accepted by the executable contract may influence the session. A
 missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
 paths, non-canonical content, or over-budget documents produce one readable

--- a/plugins/lisa-cursor/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-cursor/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the project's. Accepts a failure event (defect description, implicated files, rule/skill/hook in play) and returns a verdict of lisa | project | ambiguous plus the evidence relied on. Read-only — it never files, writes, or remediates; callers (lisa-doctor findings, the learning judgment gate, rework triage) consume the verdict. Extracted from lisa-doctor's upstream Lisa change-history diagnosis (#1494) so the same attribution procedure can run on ANY failure event, not only doctor config-audit findings."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-persist-learning
-description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an upstream handoff marker (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
+description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an automatically filed upstream Lisa ticket with marker dedupe, evidence, and a per-run cap (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
 ---
 
 # Persist Learning
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause…"
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-attribute-failure/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Attribute Failure"
+short_description: "Event-triggered root-cause…"
+default_prompt:
+  - "Use $lisa-attribute-failure: Event-triggered root-cause…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/plugins/lisa/commands/attribute-failure.md
+++ b/plugins/lisa/commands/attribute-failure.md
@@ -1,0 +1,6 @@
+---
+description: "Attribute an arbitrary failure event to Lisa or the project with cited evidence. Evaluates three ordered signals — Lisa-managed surface ownership, shipped rule/skill/hook behavior, and the upstream Lisa change-history window — and returns lisa | project | ambiguous. Read-only; inconclusive cases stay local as ambiguous."
+argument-hint: "<failure event: defect description, implicated files, rule/skill/hook in play>"
+---
+
+Use the /lisa-attribute-failure skill to attribute the given failure event to Lisa or the project and return the verdict with its cited evidence. $ARGUMENTS

--- a/plugins/lisa/commands/persist-learning.md
+++ b/plugins/lisa/commands/persist-learning.md
@@ -1,5 +1,5 @@
 ---
-description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), emit an upstream handoff marker (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
+description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), file the upstream Lisa ticket automatically with marker dedupe, evidence, and a per-run cap (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
 argument-hint: "<candidate-json-or-fields>"
 ---
 

--- a/plugins/lisa/rules/reference/project-learnings.md
+++ b/plugins/lisa/rules/reference/project-learnings.md
@@ -20,6 +20,24 @@ Each persisted entry has seven fields:
 - `last_confirmed`
 - `confidence`
 
+## Claim-time confirmation (`last_confirmed`)
+
+`last_confirmed` is advanced at claim time by the build-intake flows (step
+3c.2 of `lisa-{jira,github,linear}-build-intake`) when an entry's rule
+**demonstrably applied** during a claim — the rule was explicitly cited or
+observably followed in the claim's plan or diff. Presence in the eagerly
+loaded context is NOT application: every entry is present in every session,
+so counting mere presence would confirm everything on every claim and defeat
+decay entirely.
+
+The bump goes only through `confirmLearningEntry` from
+`@codyswann/lisa/learnings`: a surgical, lock-protected, atomic write that
+advances only `last_confirmed` (re-validated against the
+`>= first_learned` invariant), returns a structured no-op for a missing
+entry or file instead of throwing, and is idempotent within a claim (a
+same-date repeat returns `unchanged`). A failed bump is reported and never
+blocks the build.
+
 Only entries accepted by the executable contract may influence the session. A
 missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
 paths, non-canonical content, or over-budget documents produce one readable

--- a/plugins/lisa/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/lisa/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the project's. Accepts a failure event (defect description, implicated files, rule/skill/hook in play) and returns a verdict of lisa | project | ambiguous plus the evidence relied on. Read-only — it never files, writes, or remediates; callers (lisa-doctor findings, the learning judgment gate, rework triage) consume the verdict. Extracted from lisa-doctor's upstream Lisa change-history diagnosis (#1494) so the same attribution procedure can run on ANY failure event, not only doctor config-audit findings."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/lisa/skills/lisa-attribute-failure/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-attribute-failure/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Attribute Failure"
+short_description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the…"
+default_prompt:
+  - "Use $lisa-attribute-failure: Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the…."

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/lisa/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/skills/lisa-persist-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-persist-learning
-description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an upstream handoff marker (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
+description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an automatically filed upstream Lisa ticket with marker dedupe, evidence, and a per-run cap (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
 ---
 
 # Persist Learning
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/lisa/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/plugins/src/base/commands/attribute-failure.md
+++ b/plugins/src/base/commands/attribute-failure.md
@@ -1,0 +1,6 @@
+---
+description: "Attribute an arbitrary failure event to Lisa or the project with cited evidence. Evaluates three ordered signals — Lisa-managed surface ownership, shipped rule/skill/hook behavior, and the upstream Lisa change-history window — and returns lisa | project | ambiguous. Read-only; inconclusive cases stay local as ambiguous."
+argument-hint: "<failure event: defect description, implicated files, rule/skill/hook in play>"
+---
+
+Use the /lisa-attribute-failure skill to attribute the given failure event to Lisa or the project and return the verdict with its cited evidence. $ARGUMENTS

--- a/plugins/src/base/commands/persist-learning.md
+++ b/plugins/src/base/commands/persist-learning.md
@@ -1,5 +1,5 @@
 ---
-description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), emit an upstream handoff marker (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
+description: "Route a candidate learning through the hostile-default learning-judge gate and act on the verdict: leave a dropped-with-reason note on the triggering issue (drop), file the upstream Lisa ticket automatically with marker dedupe, evidence, and a per-run cap (lisa-upstream), or persist a durable learning via a confidence-routed PR that touches only the learnings surface — auto-merge on for high confidence, auto-merge off plus the learning:needs-triage label for low confidence. Idempotent via marker dedupe."
 argument-hint: "<candidate-json-or-fields>"
 ---
 

--- a/plugins/src/base/rules/reference/project-learnings.md
+++ b/plugins/src/base/rules/reference/project-learnings.md
@@ -20,6 +20,24 @@ Each persisted entry has seven fields:
 - `last_confirmed`
 - `confidence`
 
+## Claim-time confirmation (`last_confirmed`)
+
+`last_confirmed` is advanced at claim time by the build-intake flows (step
+3c.2 of `lisa-{jira,github,linear}-build-intake`) when an entry's rule
+**demonstrably applied** during a claim — the rule was explicitly cited or
+observably followed in the claim's plan or diff. Presence in the eagerly
+loaded context is NOT application: every entry is present in every session,
+so counting mere presence would confirm everything on every claim and defeat
+decay entirely.
+
+The bump goes only through `confirmLearningEntry` from
+`@codyswann/lisa/learnings`: a surgical, lock-protected, atomic write that
+advances only `last_confirmed` (re-validated against the
+`>= first_learned` invariant), returns a structured no-op for a missing
+entry or file instead of throwing, and is idempotent within a claim (a
+same-date repeat returns `unchanged`). A failed bump is reported and never
+blocks the build.
+
 Only entries accepted by the executable contract may influence the session. A
 missing file is expected and silent. Malformed Markdown, invalid JSONL, unsafe
 paths, non-canonical content, or over-budget documents produce one readable

--- a/plugins/src/base/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/src/base/skills/lisa-attribute-failure/SKILL.md
@@ -137,6 +137,6 @@ This is the #1494 doctor procedure, unchanged in behavior — here it is the thi
 
 - **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
 - **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
-- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead. Evidence destined for upstream surfaces quotes ONLY Lisa-owned surface text (never host env values, tokens/credentials, PII, or proprietary host code — link the host issue instead of quoting it); the binding redaction procedure lives in `lisa-persist-learning`'s `handoff-upstream` step.
 - **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
 - **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/src/base/skills/lisa-attribute-failure/SKILL.md
+++ b/plugins/src/base/skills/lisa-attribute-failure/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lisa-attribute-failure
+description: "Event-triggered root-cause attribution for an arbitrary failure: decide, with cited evidence, whether the defect is Lisa's fault or the project's. Accepts a failure event (defect description, implicated files, rule/skill/hook in play) and returns a verdict of lisa | project | ambiguous plus the evidence relied on. Read-only — it never files, writes, or remediates; callers (lisa-doctor findings, the learning judgment gate, rework triage) consume the verdict. Extracted from lisa-doctor's upstream Lisa change-history diagnosis (#1494) so the same attribution procedure can run on ANY failure event, not only doctor config-audit findings."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Attribute Failure
+
+Attribute ONE failure event to Lisa or the project, with cited evidence. Failure event: $ARGUMENTS
+
+Before a Lisa-caused failure can be routed upstream, something has to say — with evidence — "this was Lisa's fault, not the project's." A failure has two possible causes: the project drifted, or **Lisa itself changed or shipped the defect**. This skill must distinguish them instead of blaming the project by default, and equally must never blame Lisa without conclusive evidence. Wrong attribution in either direction is the failure mode; **inconclusive evidence is always `ambiguous`, and ambiguous stays local and low-confidence — never upstream.**
+
+## Input — the failure event
+
+Accept the event as JSON or `key=value` fields. This procedure is **event-triggered, not version-window-keyed**: any failure can be attributed, not only a doctor config-audit finding.
+
+- `defect` — what went wrong, in plain language (required)
+- `implicated_files` — the file paths where the defect lives or manifests (required when known)
+- `surface_in_play` — the Lisa rule / skill / hook / template / workflow involved, if any
+- `installed_version` / `latest_version` — the Lisa version window, when the caller knows it; otherwise resolve it as signal 3 describes
+- `failure_class` — a short slug naming the class of failure (used by downstream filing for the root-cause key)
+
+## Output — the verdict
+
+Return exactly one verdict — `lisa` | `project` | `ambiguous` — plus the evidence it relied on:
+
+```text
+## Attribution: [lisa | project | ambiguous]
+
+**Signal:** [managed-surface | shipped-artifact-behavior | upstream-history | none-conclusive]
+**Lisa surface at fault:** [path or rule/skill/hook name | n/a]
+**Cited evidence:**
+- [each item names the signal it came from and the concrete citation: file path + ownership proof, shipped artifact text, or commit sha/subject/version]
+**Confidence note:** [why the evidence is conclusive, or exactly what was inconclusive]
+```
+
+Verdict rules:
+
+- **`lisa`** — at least one signal conclusively pins the defect on a Lisa-shipped surface or upstream change, and the evidence names that surface. Never emit `lisa` from degraded, truncated, or unverified history.
+- **`project`** — the implicated files are project-owned, no shipped Lisa artifact drove the behavior, and the upstream-history window shows no relevant Lisa change. Cite the absence explicitly (which paths were checked, which window showed no relevant change).
+- **`ambiguous`** — anything else: unresolvable version window, unreachable history, partial ownership, conflicting signals. Ambiguous is treated as local and low-confidence; nothing is escalated upstream from it.
+
+## The three signals (evaluate in order)
+
+### Signal 1 — the defect lives in a Lisa-managed surface
+
+Resolve ownership of each implicated file the way doctor's config audit does:
+
+- **Copy-overwrite / managed**: the path is populated by `lisa apply` from a stack template (`typescript/`, `expo/`, `nestjs/`, `cdk/`, `harper-fabric/`, `rails/` copy-overwrite trees), is a plugin-distributed rule/skill/hook/agent/command surface, carries Lisa governance markers or a Lisa version stamp, or is governed by `package.lisa.json` `force` keys. A defect in the shipped content of such a surface is **Lisa's fault** — any local edit would be overwritten on the next `lisa apply`.
+- **Create-only**: the local copy is project-owned after scaffolding, but if the defect is faithful to the template as shipped, the template is still Lisa's fault (every newly scaffolded repo inherits it). Cite the template origin, and note the local copy will not be overwritten.
+- **Project-owned**: not from a Lisa template and not Lisa-managed — signal 1 is negative; continue.
+
+If the project locally modified a managed surface and the defect lives in the local modification, that is project drift, not a Lisa defect — signal 1 is negative for `lisa` and positive evidence for `project`.
+
+### Signal 2 — a shipped Lisa rule/skill/hook drove the wrong behavior
+
+Read the shipped artifact named in `surface_in_play` (the plugin-distributed rule, skill, hook, agent, or CI workflow as Lisa ships it — not a local fork). If following its instructions or configuration as shipped produces the observed defect, the verdict is `lisa`: cite the artifact path and the specific shipped text or configuration that drove the behavior. If the artifact is shipped correct and was misapplied locally, that is evidence for `project`.
+
+### Signal 3 — the upstream-history window shows Lisa changed the relevant contract
+
+This is the #1494 doctor procedure, unchanged in behavior — here it is the third signal, not the trigger. Whenever signals 1-2 are not conclusive on their own — and always before a definitive `project` verdict — pull Lisa's own git history for the version window and read what actually changed:
+
+1. **Resolve the version window.** Use the caller-supplied `installed_version`/`latest_version` when present; otherwise determine the project's installed Lisa version (the `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update check's cached result). An unresolvable window makes this signal inconclusive — it can support `ambiguous`, never `lisa`.
+2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is available):
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
+     --paginate --slurp |
+     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
+   ```
+
+   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
+   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
+   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
+   are not one merged input. `total_commits` and `files` only need the first page
+   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
+   while retaining each commit SHA and URLs needed for accurate follow-up.
+
+   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
+   the retained SHA rather than attributing from the subject alone:
+
+   ```bash
+   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
+     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
+   ```
+
+   Preserve the returned filename, status, counts, and available patch with the SHA in the
+   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
+   use the compare diff fallback below or downgrade the attribution to `ambiguous` when
+   commit-level context cannot be established.
+
+   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
+   on the first page, capped at 300 total — a large version window can silently drop commits or
+   files. If `total_commits` or the file count looks truncated, re-run with the
+   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
+   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
+   still can't be established, say so in the evidence and return `ambiguous` rather than attributing
+   with unverified confidence.
+
+   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
+   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
+   window, so treat its output as best-effort context only, not authoritative attribution; a
+   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
+   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
+   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
+
+   ```bash
+   lisa_history_dir="$(mktemp -d)"
+   git init "$lisa_history_dir"
+   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
+   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
+     refs/tags/v<installed>:refs/tags/v<installed> \
+     refs/tags/v<latest>:refs/tags/v<latest>
+   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
+   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
+   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
+   ```
+
+   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
+   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
+   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
+   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
+   reachable, report the gap in the evidence and return `ambiguous` — never fail the caller's flow
+   because history was unavailable or incomplete, and never let a degraded history produce `lisa`.
+3. **Scope the reading to what the failure touches.** Filter the commit list to the paths that
+   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
+   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
+   config factories (`src/configs/`). A failure about a lint rule reads the lint-config commits,
+   not the whole log.
+4. **Attribute.** When the upstream history shows Lisa changed the relevant contract (a tightened
+   lint rule, a renamed check context, a new required config key), the verdict is `lisa` — cite the
+   commit subject/version. When history shows no relevant upstream change and signals 1-2 are also
+   negative, the project drifted — the verdict is `project`, citing the absence of a relevant
+   upstream change as the evidence.
+
+## Rules
+
+- **Read-only.** This skill reads the project and Lisa's repository; it never writes to either, never files issues, and never remediates. Filing the upstream ticket on a `lisa` verdict is the caller's flow (`lisa-persist-learning`, `handoff-upstream` disposition); doctor maps verdicts into its findings; remediation stays with whoever called.
+- **Never block.** Attribution failure, missing tooling (`gh` unavailable), or degraded history degrades to `ambiguous` with the gap named in the evidence — it never raises an error that stops the caller's build or audit.
+- **Every verdict cites its evidence.** An attribution without a named signal and concrete citation is invalid — return `ambiguous` instead.
+- **Ambiguous never escalates.** `ambiguous` is a terminal local verdict: low-confidence, no upstream filing, no durable local rule derived from it.
+- **Headless-safe and idempotent**: no prompts, no side effects, same event in → same verdict out.

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -296,88 +296,39 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed
 upstream** since this project last updated. Doctor must distinguish them instead of blaming the
 project by default. Whenever findings need explanation — and always before proposing repairs —
-pull Lisa's own git history and read what actually changed:
+attribute the finding with real evidence.
+
+The attribution procedure itself is shared: it lives in the `lisa-attribute-failure` skill
+(extracted from this section so any failure event can be attributed, not only doctor findings).
+Doctor invokes it per finding:
 
 1. **Resolve the version window.** Determine the project's installed Lisa version (the
    `@codyswann/lisa` entry in `package.json`/lockfile, or the plugin version stamp on the active
    runtime) and the latest published version (`npm view @codyswann/lisa version`, or the update
    check's cached result).
-2. **Pull the upstream history for that window** (read-only; no clone required when `gh` is
-   available):
+2. **Invoke `lisa-attribute-failure`** with the finding as the failure event: the defect
+   description, the implicated template/config paths, the rule/skill/hook in play, and the
+   resolved version window. The skill evaluates its three ordered signals — Lisa-managed surface
+   ownership, shipped rule/skill/hook behavior, and the upstream change-history window (the
+   version-window compare procedure formerly documented inline here, preserved verbatim in that
+   skill: pagination/`--slurp` handling, targeted per-SHA diff context, truncation caveats, and
+   the bounded explicit-tag fetch fallback) — and returns `lisa` | `project` | `ambiguous` plus
+   the cited evidence.
+3. **Map the verdict into the finding.**
+   - `lisa` — Lisa changed the contract (a tightened lint rule, a renamed check context, a new
+     required config key) or shipped the defective surface. Say so in `Observed:` with the cited
+     evidence (commit subject/version or managed-surface proof), and let `Remediation:` point at
+     the sanctioned adoption path (e.g. `lisa update` + re-apply, a documented config opt-out)
+     rather than hand-editing managed files.
+   - `project` — history shows no relevant upstream change and the surface is project-owned: the
+     project drifted, so remediate on the project side.
+   - `ambiguous` — history was unavailable, truncated, or otherwise inconclusive: report the gap
+     as a `WARN`-level observability note with the evidence gap named — never fail the audit
+     because history was unavailable or incomplete, and never attribute drift with unverified
+     confidence.
 
-   ```bash
-   gh api "repos/CodySwannGT/lisa/compare/v<installed>...v<latest>" \
-     --paginate --slurp |
-     jq '{total_commits: .[0].total_commits, files: [.[0].files[]?.filename], commits: [.[].commits[]? | {sha, subject: (.commit.message | split("\n")[0]), api_url: .url, html_url, parents: [.parents[]?.sha]}]}'
-   ```
-
-   `--paginate` fetches every page of commits, and `--slurp` gathers those pages into a single
-   array before the external `jq` projection runs. GitHub CLI does not permit its built-in `--jq`
-   flag together with `--slurp`, so keep the pipe as shown; without `--slurp`, paginated responses
-   are not one merged input. `total_commits` and `files` only need the first page
-   (files are capped at 300 and not repeated on later pages); `commits` flattens across all pages
-   while retaining each commit SHA and URLs needed for accurate follow-up.
-
-   After path-scoping identifies a candidate commit, fetch its targeted file-level diff context by
-   the retained SHA rather than attributing from the subject alone:
-
-   ```bash
-   gh api "repos/CodySwannGT/lisa/commits/<sha>" \
-     --jq '{sha, files: [.files[]? | select(.filename == "<relevant-path>" or (.filename | startswith("<relevant-prefix>/"))) | {filename, status, additions, deletions, changes, patch}]}'
-   ```
-
-   Preserve the returned filename, status, counts, and available patch with the SHA in the
-   upstream-history projection. A missing or truncated `patch` is not proof of no relevant change;
-   use the compare diff fallback below or downgrade attribution to `WARN` when commit-level context
-   cannot be established.
-
-   The compare endpoint paginates commits (250 without `--paginate`) and only lists changed files
-   on the first page, capped at 300 total — a large version window can silently drop commits or
-   files. If `total_commits` or the file count looks truncated, re-run with the
-   `application/vnd.github.diff` accept header (`gh api ... -H "Accept: application/vnd.github.diff"`)
-   to pull the full patch text, or fall back to the bounded-fetch `git log` below. When completeness
-   still can't be established, say so in the finding and mark it `WARN` rather than attributing
-   drift with unverified confidence.
-
-   Fallbacks, in order: `gh api repos/CodySwannGT/lisa/commits?path=<template-path>` for a
-   path-scoped view — note this endpoint has no way to bound results to the `v<installed>..v<latest>`
-   window, so treat its output as best-effort context only, not authoritative attribution; a
-   finite-depth, explicit-tag fetch, which is bounded to the two version refs and should be preferred
-   for definitive attribution; or the local marketplace/plugin cache checkout when the runtime has
-   one. For the fetch fallback, use a temporary directory and a fixed history ceiling:
-
-   ```bash
-   lisa_history_dir="$(mktemp -d)"
-   git init "$lisa_history_dir"
-   git -C "$lisa_history_dir" remote add origin https://github.com/CodySwannGT/lisa.git
-   git -C "$lisa_history_dir" fetch --no-tags --filter=blob:none --depth=256 origin \
-     refs/tags/v<installed>:refs/tags/v<installed> \
-     refs/tags/v<latest>:refs/tags/v<latest>
-   git -C "$lisa_history_dir" merge-base --is-ancestor v<installed> v<latest>
-   git -C "$lisa_history_dir" log --format='%H%x09%s' v<installed>..v<latest> -- <paths>
-   git -C "$lisa_history_dir" show --format=fuller --stat --patch <relevant-sha> -- <paths>
-   ```
-
-   The explicit tag refspecs, `--no-tags`, and finite `--depth=256` make this fetch bounded. Do not
-   silently deepen beyond that ceiling. If `merge-base --is-ancestor` fails, the shallow window is
-   incomplete (or the tags are not on one ancestry line): do not make definitive attribution from
-   it. If none of the bounded sources are reachable, or only the unbounded path-scoped fallback is
-   reachable, report the gap as a `WARN`-level observability note — never fail the audit because
-   history was unavailable or incomplete.
-3. **Scope the reading to what the finding touches.** Filter the commit list to the paths that
-   generate the failing surface: the detected stacks' template dirs (`typescript/`, `expo/`, …),
-   `plugins/src/base/` for skills/hooks/rules, `scripts/` for governance scripts, and the shipped
-   config factories (`src/configs/`). A finding about a lint rule failure reads the lint-config
-   commits, not the whole log.
-4. **Attribute the finding.** When the upstream history shows Lisa changed the contract (a
-   tightened lint rule, a renamed check context, a new required config key), say so in `Observed:`
-   with the commit subject/version, and let `Remediation:` point at the sanctioned adoption path
-   (e.g. `lisa update` + re-apply, a documented config opt-out) rather than hand-editing managed
-   files. When history shows no relevant upstream change, the project drifted — remediate on the
-   project side.
-
-This history pull is part of doctor's read-only contract: it reads Lisa's repository, never writes
-to it, and repair suggestions stay suggestions.
+This diagnosis remains part of doctor's read-only contract: the attribution skill reads Lisa's
+repository, never writes to it, and repair suggestions stay suggestions.
 
 ## Output contract
 

--- a/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
@@ -333,8 +333,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.

--- a/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
@@ -325,6 +325,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the issue always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
@@ -257,6 +257,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.
+
 #### 3d. Transition to $DONE (only after the PR is merged)
 
 A `done` env status (`On Dev`, `On Stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Setting `On Stg` on an open PR makes a ticket *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
@@ -265,8 +265,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the ticket always outranks confirming a learning about it.

--- a/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
@@ -258,8 +258,10 @@ Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d
 2. **Bump each applied entry exactly once** via the surgical writer:
 
    ```bash
-   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); }).catch(error => { console.log(JSON.stringify({ status: "error", id: process.argv[1], message: String(error) })); })' <entry-id> || true
    ```
+
+   The invocation is failure-safe by construction: a rejected import or write resolves to a structured `error` result instead of a crash, and the trailing `|| true` absorbs any remaining non-zero exit (missing `node`, unresolvable package). Record an `error` or non-zero outcome in the cycle summary and continue — the bump must never abort the lifecycle.
 
    `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
 3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.

--- a/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
@@ -250,6 +250,20 @@ If the canonical fix is merged but not yet present on the production branch, app
 
 This path is distinct from `BLOCKED`: ambiguity, open blockers, and duplicate-of-open findings remain held for human action and must not be auto-closed.
 
+#### 3c.2 Confirm applied learnings (last_confirmed bump)
+
+Run this at the end of 3c, after the lifecycle outcome is recorded and before 3d. It keeps the decay pass safe: a genuinely useful learning that keeps applying stays fresh, while dead weight ages out.
+
+1. **Identify which learnings demonstrably applied.** Resolve the learnings surface with `resolveProjectLearningsFile` and parse it with `parseLearningsFile` from `@codyswann/lisa/learnings` (never hardcode the path; a missing file skips this step silently). An entry counts as applied ONLY when its rule was explicitly cited or observably followed in this claim's plan, diff, or review responses — the plan quotes the rule or its id, or the diff does specifically what the rule mandates where the default behavior would have differed. **Presence in context is NOT application**: the ledger is loaded eagerly into every session, so counting "it was loaded" would confirm every entry on every claim and defeat decay entirely. A run that produced no plan or diff has nothing to confirm.
+2. **Bump each applied entry exactly once** via the surgical writer:
+
+   ```bash
+   node -e 'import("@codyswann/lisa/learnings").then(async m => { const r = await m.confirmLearningEntry(process.cwd(), process.argv[1], new Date().toISOString().slice(0, 10)); console.log(JSON.stringify(r)); })' <entry-id>
+   ```
+
+   `confirmLearningEntry` advances ONLY `last_confirmed` — rule text, why, provenance, `first_learned`, and confidence are untouched — and is idempotent within a claim: a repeat same-date bump returns `unchanged`, so an entry that applied repeatedly during one claim is bumped once, not once per application.
+3. **Never block on it.** A failed bump, an unwritable file, or a `not-found` result (the entry was pruned) is recorded under the cycle summary and the claim proceeds — shipping the Issue always outranks confirming a learning about it.
+
 #### 3d. Relabel to $DONE (only after the PR is merged)
 
 A `done` env state (`status:on-dev`, `status:on-stg`, or the terminal value) asserts that the code has actually reached that environment. Never set it for a PR that is merely open: auto-merge can be blocked indefinitely (a required rebase / `BEHIND` branch, failing checks, an unaddressed review), and the change may never land. Relabeling an Issue `status:on-stg` on an open PR makes it *claim* a deploy that never happened. Transition only after confirming the PR merged.

--- a/plugins/src/base/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/src/base/skills/lisa-persist-learning/SKILL.md
@@ -62,22 +62,27 @@ The note is one line naming the classification (with its fixed plain-language gl
 |----------------|-------|
 | `one-off` | a one-time fluke, not a recurring pattern |
 | `misunderstanding/spec-gap` | traced to an unclear requirement, not a durable lesson |
-| `lisa-upstream` | root cause is Lisa itself; routed upstream |
+| `lisa-upstream` | root cause suspected in Lisa; routed for upstream attribution |
 
-(The `lisa-upstream` gloss is used by the handoff note below, not by a drop note.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
+(A `lisa-upstream` classification never produces a drop note — it routes through the `handoff-upstream` flow below, whose step-1 note uses this pre-attribution wording because filing only happens after attribution confirms the Lisa surface.) Dedupe before posting: if any comment on the triggering issue already carries `[lisa-learning-drop] key=<fingerprint>`, do not post again — report the existing note.
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
 This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
+1. **Post the handoff marker** on the triggering issue (same one-comment marker dedupe; the marker key is unchanged). The visible line must not claim a filing that has not happened yet — attribution and filing come after this step:
 
    ```markdown
    <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
+   ```
 
 3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
 
@@ -91,7 +96,14 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
 4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
 
-5. **Dedupe by marker, then file or update.** The upstream marker is:
+5. **Evidence redaction (binding).** The upstream repo is PUBLIC by default (`hardening.upstreamRepo` → `CodySwannGT/lisa`) and this filing runs headless on crons — treat every drafted upstream body and comment as world-readable:
+
+   - Quote ONLY Lisa-owned surface text: template/rule/skill/hook excerpts and upstream commit references. The reproduction must be REDACTED — generic placeholders, never the host project's real values.
+   - Never paste host environment values, tokens/credentials, connection strings, API keys, PII (names, emails, customer data), or proprietary host code/payloads.
+   - The evidence chain names the Lisa surface and the failure class — never project payloads. When host context is essential to understand the failure, LINK the host-project issue instead of quoting it.
+   - Before filing or commenting, scan the drafted body for common secret shapes — `key=value` pairs with high-entropy values, token prefixes (`AKIA`, `ghp_`, `xox`), email addresses — and strip on match. When in doubt, leave it out: a thinner upstream ticket is recoverable; a leaked secret is not.
+
+6. **Dedupe by marker, then file or update.** The upstream marker is:
 
    ```markdown
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
@@ -102,7 +114,7 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
    - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
 
-6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
    ```markdown
    <!-- [lisa-upstream-filed] key=<fingerprint> -->
@@ -111,7 +123,12 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
+   ```
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/src/base/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/src/base/skills/lisa-persist-learning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-persist-learning
-description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an upstream handoff marker (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
+description: This skill should be used when a candidate learning (from a failure signal, rejection, or debrief) needs to be judged and routed. It computes a stable fingerprint, runs the candidate through the hostile-default learning-judge gate, and performs exactly the verdict's side effects — a dropped-with-reason note on the triggering issue (drop), an automatically filed upstream Lisa ticket with marker dedupe, evidence, and a per-run cap (lisa-upstream), or a confidence-routed pull request that touches only the learnings surface (durable-learning). Idempotent via marker dedupe; headless-safe; never blocks the primary build flow.
 ---
 
 # Persist Learning
@@ -68,14 +68,50 @@ The note is one line naming the classification (with its fixed plain-language gl
 
 ### `handoff-upstream` (classification `lisa-upstream`)
 
-Emit the handoff marker only — file **nothing** (no upstream issue, no local rule; the upstream filing flow [SLL-5] consumes this marker later):
+This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure the upstream Lisa ticket is filed **automatically**. Filing lives here — not in `lisa-attribute-failure` — because that skill is deliberately read-only (doctor delegates to it inside its own read-only contract), while this skill already owns exactly the verdict's side effects and the marker-dedupe discipline. Never persist a local rule for a Lisa-attributed failure; the host project's only durable trace is the brief linking note in step 6.
 
-```markdown
-<!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
-Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>. Nothing persisted locally; upstream filing is a separate flow.
-```
+1. **Post the handoff marker** on the triggering issue (unchanged behavior; same one-comment marker dedupe):
 
-Same one-comment marker dedupe on the triggering issue.
+   ```markdown
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint> -->
+   Upstream handoff (lisa-upstream — root cause is Lisa itself; routed upstream): <reason>.
+   ```
+
+2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, and the run summary says attribution was inconclusive.
+
+3. **Derive the root-cause key from the LISA SURFACE, never the host project or the local issue.** Two projects hitting the same Lisa bug MUST collide on the same key — that collision is the design (update, not duplicate):
+
+   ```text
+   root-cause-key = <lisa-surface>#<failure-class>
+   ```
+
+   - `<lisa-surface>` — the Lisa-relative path of the surface at fault (e.g. `plugins/src/base/skills/lisa-doctor/SKILL.md`, `typescript/copy-overwrite/.github/workflows/quality.yml`), or the canonical rule/skill/hook name when no single file applies (e.g. `lisa-doctor`, `block-no-verify`).
+   - `<failure-class>` — a short lowercase hyphen-slug for the class of failure (e.g. `pagination-truncation`, `stale-artifact-overwrite`).
+   - Normalize: lowercase, trim, collapse every whitespace run to a single `-`. The key must contain no host-project name, no local issue number, and no fingerprint — those vary per project and would defeat fleet-wide dedupe.
+
+4. **Enforce the per-run cap.** Resolve `hardening.maxUpstreamFilingsPerRun` from `.lisa.config.json` (default `5` — a conservative bound modeled on `lisa-repair-intake`'s `max_candidates` precedent). Count every upstream create **and** update this run performs; once the cap is reached, drop the remaining candidates and **note each dropped candidate visibly** (in the run summary, naming its root-cause key) — never queue a spam burst and never drop silently. A later run picks the dropped candidates up idempotently.
+
+5. **Dedupe by marker, then file or update.** The upstream marker is:
+
+   ```markdown
+   <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
+   ```
+
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+
+6. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
+
+   ```markdown
+   <!-- [lisa-upstream-filed] key=<fingerprint> -->
+   Upstream ticket: <url> (root-cause key `<root-cause-key>`). No local rule persisted — the fix ships fleet-wide through Lisa.
+   ```
+
+   The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
+
+7. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — the handoff marker still stands and a later run retries idempotently. Never block the primary build flow.
 
 ### `persist` (classification `durable-learning`)
 

--- a/plugins/src/base/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/src/base/skills/lisa-persist-learning/SKILL.md
@@ -77,10 +77,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    Candidate routed for upstream attribution (root cause suspected in Lisa): <reason>.
    ```
 
-2. **Confirm the attribution names the Lisa surface at fault.** The filing keys off that surface. If the judge's `cited_evidence` already pins it (a shipped file / rule / skill / hook path, or an upstream commit range), use it. Otherwise run the `lisa-attribute-failure` skill on the failure event and file **only on a `lisa` verdict**. An `ambiguous` verdict — or any attribution that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it):
+2. **Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always.** Run the `lisa-attribute-failure` skill on the failure event before any filing. The judge's `cited_evidence` seeds the event (implicated files, surface in play, failure class) but never substitutes for the verdict — a path or commit reference alone is not attribution. File **only** when the skill returns a conclusive `lisa` verdict that names the Lisa surface with cited evidence. Any other outcome — `ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files **NOTHING** upstream: the candidate stays local and low-confidence, the run summary says attribution was inconclusive, and the step-1 note is resolved with one corrective follow-up comment on the triggering issue (marker-deduped so re-runs never repeat it; the suffix is distinct from the filing-failure marker in step 8 so one outcome never suppresses the other):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive -->
    Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally.
    ```
 
@@ -109,10 +109,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
    <!-- [lisa-upstream-attribution] key=<root-cause-key> -->
    ```
 
-   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search for an existing issue carrying the marker — match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state open --search '"<marker>" in:body' --json number,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state open --json number,body` and grep the bodies for the marker before concluding no ticket exists).
+   Resolve the upstream repo from `.lisa.config.json` `hardening.upstreamRepo` (default `CodySwannGT/lisa`). Search **all issue states** for an existing issue carrying the marker — a closed marker-bearing ticket still owns this root cause, and searching only open issues would mint a duplicate the moment the original closes. Match on the **MARKER, never the title** — with the same eventual-consistency guard as above (`gh issue list -R <upstream> --state all --search '"<marker>" in:body' --json number,state,url`, and when the search index returns nothing, also `gh issue list -R <upstream> --state all --json number,state,body` and grep the bodies for the marker before concluding no ticket exists).
 
-   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the verbatim evidence chain (defect → Lisa surface → attribution evidence → reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
-   - **Existing ticket** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket.
+   - **No existing ticket** → file via `lisa-github-write-issue` targeting the upstream repo, following the `lisa-rework-triage` "Filing upstream" discipline: a three-audience description (what failed for the operator, what the harness did wrong, what to change), the redacted evidence chain (Lisa-owned text only, per step 5: defect → Lisa surface → attribution evidence → redacted reproduction), the affected project named, and the `self-hardening` label. The body carries **exactly one** dedupe marker; **never write a markerless body** — it permanently breaks all future dedupe.
+   - **Existing ticket (open or closed)** → this is a repeat encounter: comment the new occurrence on the existing issue with this project's evidence, marker-deduped per occurrence via `<!-- [lisa-upstream-attribution-occurrence] key=<fingerprint> -->` so re-runs never duplicate the occurrence comment. Never open a second issue, and never match on the title — evidence compounds on one ticket. When the match is **CLOSED**, still comment the occurrence there and reference it in the local trace instead of filing a duplicate; do not reopen it yourself — recurrence evidence on a closed ticket signals the shipped fix may not cover this case, and reopening is the upstream maintainer's call.
 
 7. **Leave the local trace — a note, never a rule.** Post one follow-up comment on the triggering issue linking the upstream ticket:
 
@@ -123,10 +123,10 @@ This disposition completes the SLL-5 loop (#1583): on a Lisa-attributed failure 
 
    The learnings surface gains **no durable local rule** for a Lisa-attributed failure. Agents avoid the trap via the upstream ticket link until the fix ships.
 
-8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post the same marker-deduped corrective follow-up on the triggering issue with a filing-failure wording:
+8. **Degrade gracefully.** If filing fails (auth, rate limit, network), report the failure in the run summary and continue shipping the host issue — a later run retries idempotently. Never block the primary build flow. So the step-1 note is not left dangling, post a marker-deduped corrective follow-up on the triggering issue — with its own suffix, distinct from step 2's `-inconclusive`, so an earlier inconclusive note can never suppress a filing-failure note (or vice versa):
 
    ```markdown
-   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-resolution -->
+   <!-- [lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed -->
    Upstream filing did not complete — nothing was filed upstream and nothing was persisted locally; a later run retries.
    ```
 

--- a/src/core/learnings-entry.ts
+++ b/src/core/learnings-entry.ts
@@ -253,12 +253,14 @@ function requireNonBlankText(value: unknown, field: string): string {
 }
 
 /**
- * Require a real calendar date in ISO date form.
+ * Require a real calendar date in ISO date form. Exported so the surgical
+ * `last_confirmed` writer can validate a caller-supplied date up front instead
+ * of duplicating the calendar check.
  * @param value - Untrusted date value
  * @param field - Field name for errors
  * @returns Valid ISO date
  */
-function requireIsoDate(value: unknown, field: string): string {
+export function requireIsoDate(value: unknown, field: string): string {
   const result = requireNonEmptyString(value, field);
   const date = new Date(`${result}T00:00:00.000Z`);
   if (

--- a/src/core/learnings-writer.ts
+++ b/src/core/learnings-writer.ts
@@ -98,7 +98,11 @@ export interface ConfirmLearningResult {
   readonly status: ConfirmLearningStatus;
   /** The entry id the caller asked to confirm. */
   readonly id: string;
-  /** Absolute learnings file path when the file exists. */
+  /**
+   * Absolute learnings file path whenever the file exists — including an
+   * in-file `not-found` id — so callers can report a consistent target.
+   * Absent only when the learnings file itself does not exist.
+   */
   readonly file?: string;
   /** Previous `last_confirmed` value when the entry was advanced. */
   readonly previous?: string;
@@ -143,7 +147,7 @@ export async function confirmLearningEntry(
     const entries = existing === undefined ? [] : parseLearningsFile(existing);
     const current = entries.find(entry => entry.id === id);
     if (current === undefined) {
-      return { status: "not-found", id };
+      return { status: "not-found", id, file: target };
     }
     if (confirmedDate <= current.last_confirmed) {
       return { status: "unchanged", id, file: target };

--- a/src/core/learnings-writer.ts
+++ b/src/core/learnings-writer.ts
@@ -8,7 +8,7 @@ import {
   parseLearningsFile,
   renderLearningsFile,
 } from "./learnings-document.js";
-import { validateLearningEntry } from "./learnings-entry.js";
+import { requireIsoDate, validateLearningEntry } from "./learnings-entry.js";
 import {
   assertSafeLearningParents,
   readExistingLearnings,
@@ -89,11 +89,110 @@ export async function persistConsolidatedLearning(
   });
 }
 
+/** Outcome vocabulary for {@link confirmLearningEntry}. */
+export type ConfirmLearningStatus = "confirmed" | "unchanged" | "not-found";
+
+/** Structured no-throw outcome of a surgical `last_confirmed` bump. */
+export interface ConfirmLearningResult {
+  /** What happened: written, already-current no-op, or missing-target no-op. */
+  readonly status: ConfirmLearningStatus;
+  /** The entry id the caller asked to confirm. */
+  readonly id: string;
+  /** Absolute learnings file path when the file exists. */
+  readonly file?: string;
+  /** Previous `last_confirmed` value when the entry was advanced. */
+  readonly previous?: string;
+}
+
+/**
+ * Surgically advance ONLY one entry's `last_confirmed` timestamp — the
+ * claim-time "this rule demonstrably applied" confirmation (#1579). Uses the
+ * same lock/safety/atomic machinery as the persist writers, but is monotonic
+ * and non-blocking by design: a missing file or unknown id returns a
+ * structured no-op result instead of throwing, and a date at or before the
+ * stored `last_confirmed` never rewrites the file (idempotent within a claim,
+ * never regresses). Every other entry field is preserved byte-for-byte; the
+ * updated entry is re-validated so the `last_confirmed >= first_learned`
+ * invariant and all budgets still hold.
+ * @param projectRoot - Absolute path to the host project root
+ * @param id - Stable id of the entry to confirm
+ * @param date - Confirmation date (real ISO `YYYY-MM-DD`)
+ * @returns Structured outcome; never throws for a missing entry or file
+ */
+export async function confirmLearningEntry(
+  projectRoot: string,
+  id: string,
+  date: string
+): Promise<ConfirmLearningResult> {
+  if (typeof id !== "string" || id.trim() === "") {
+    throw new Error("Invalid learning id: expected a non-empty string");
+  }
+  const confirmedDate = requireIsoDate(date, "last_confirmed");
+  const config = await readProjectConfig(projectRoot);
+  const relativeFile = resolveProjectLearningsFile(config);
+  const { root, target } = resolveSafeLearningTarget(projectRoot, relativeFile);
+  await assertSafeLearningParents(root, path.dirname(target));
+  // Probe outside the lock so a missing file creates no directories or locks.
+  const probe = await readExistingLearnings(target);
+  if (probe === undefined) {
+    return { status: "not-found", id };
+  }
+  return withLearningTargetLock(target, async () => {
+    await assertSafeLearningParents(root, path.dirname(target));
+    const existing = await readExistingLearnings(target);
+    const entries = existing === undefined ? [] : parseLearningsFile(existing);
+    const current = entries.find(entry => entry.id === id);
+    if (current === undefined) {
+      return { status: "not-found", id };
+    }
+    if (confirmedDate <= current.last_confirmed) {
+      return { status: "unchanged", id, file: target };
+    }
+    const confirmed = validateLearningEntry({
+      ...current,
+      last_confirmed: confirmedDate,
+    });
+    const nextEntries = entries.map(entry =>
+      entry.id === id ? confirmed : entry
+    );
+    const rendered = renderConfirmedDocument(nextEntries);
+    const temporary = path.join(
+      path.dirname(target),
+      `.${path.basename(target)}.${process.pid}.${crypto.randomUUID()}.tmp`
+    );
+    try {
+      await writeFile(temporary, rendered, { encoding: "utf8", flag: "wx" });
+      await assertSafeLearningParents(root, path.dirname(target));
+      await rename(temporary, target);
+    } finally {
+      await fse.remove(temporary);
+    }
+    return {
+      status: "confirmed",
+      id,
+      file: target,
+      previous: current.last_confirmed,
+    };
+  });
+}
+
 export {
   parseLearningsFile,
   renderLearningsFile,
 } from "./learnings-document.js";
 export { validateLearningEntry } from "./learnings-entry.js";
+
+/**
+ * Render and budget-check the post-confirmation document so the write path
+ * stays a pure definitions-then-write sequence.
+ * @param entries - Entries with the confirmed entry already substituted
+ * @returns Next canonical document
+ */
+function renderConfirmedDocument(entries: readonly LearningEntry[]): string {
+  const rendered = renderLearningsFile(entries);
+  assertDocumentBudget(rendered, entries.length, "Learnings file");
+  return rendered;
+}
 
 /**
  * Build and budget-check the next canonical document, dropping superseded

--- a/tests/unit/core/learnings-barrel.test.ts
+++ b/tests/unit/core/learnings-barrel.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  confirmLearningEntry,
   parseLearningsFile,
   persistConsolidatedLearning,
   persistLearningEntry,
@@ -22,6 +23,7 @@ const REQUIRED_BARREL_FUNCTIONS = [
   ["parseLearningsFile", parseLearningsFile],
   ["persistLearningEntry", persistLearningEntry],
   ["persistConsolidatedLearning", persistConsolidatedLearning],
+  ["confirmLearningEntry", confirmLearningEntry],
 ] as const;
 
 describe("learnings barrel surface", () => {

--- a/tests/unit/core/learnings-confirm.test.ts
+++ b/tests/unit/core/learnings-confirm.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Surgical `last_confirmed` bump tests (#1579).
+ *
+ * `confirmLearningEntry` advances ONLY the `last_confirmed` timestamp of one
+ * existing entry — never the rule text, why, provenance, `first_learned`, or
+ * confidence — using the same lock/safety/atomic machinery as the persist
+ * writers. A missing id or missing file is a structured no-op result, never a
+ * throw, so claim-time callers can bump without risking the build.
+ * @module tests/unit/core/learnings-confirm
+ */
+import * as fs from "fs-extra";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  confirmLearningEntry,
+  parseLearningsFile,
+  persistLearningEntry,
+} from "../../../src/core/learnings-writer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const LEARNINGS_FILENAME = "PROJECT_LEARNINGS.md";
+const APPLIED_ID = "learning-applied";
+const BYSTANDER_ID = "learning-bystander";
+const ORIGIN_DATE = "2026-07-01";
+const CONFIRM_DATE = "2026-07-19";
+const APPLIED_ENTRY = {
+  id: APPLIED_ID,
+  rule: "Always run the resolver before hardcoding the learnings path.",
+  why: "Hardcoded paths break when projectRulesFile is overridden.",
+  provenance: ["issue:#1579"],
+  first_learned: ORIGIN_DATE,
+  last_confirmed: ORIGIN_DATE,
+  confidence: "high",
+} as const;
+const BYSTANDER_ENTRY = {
+  id: BYSTANDER_ID,
+  rule: "Prefer jq over grep for JSON in shell scripts.",
+  why: "Ad-hoc text parsing corrupts structured data.",
+  provenance: ["issue:#1000"],
+  first_learned: "2026-06-01",
+  last_confirmed: "2026-06-15",
+  confidence: "medium",
+} as const;
+
+describe("confirmLearningEntry", () => {
+  let tempDir: string;
+  let learningsPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    learningsPath = path.join(tempDir, ".claude", "rules", LEARNINGS_FILENAME);
+    await persistLearningEntry(tempDir, APPLIED_ENTRY);
+    await persistLearningEntry(tempDir, BYSTANDER_ENTRY);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("advances only last_confirmed of the targeted entry", async () => {
+    const result = await confirmLearningEntry(
+      tempDir,
+      APPLIED_ID,
+      CONFIRM_DATE
+    );
+    expect(result.status).toBe("confirmed");
+    expect(result.id).toBe(APPLIED_ID);
+    expect(result.previous).toBe(ORIGIN_DATE);
+    expect(result.file).toBe(learningsPath);
+    const entries = parseLearningsFile(await readFile(learningsPath, "utf8"));
+    expect(entries).toEqual([
+      { ...APPLIED_ENTRY, last_confirmed: CONFIRM_DATE },
+      BYSTANDER_ENTRY,
+    ]);
+  });
+
+  it("leaves untargeted entries byte-identical", async () => {
+    const before = await readFile(learningsPath, "utf8");
+    const bystanderBlock = before
+      .split("\n")
+      .filter(line => line.includes(BYSTANDER_ID));
+    await confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE);
+    const after = await readFile(learningsPath, "utf8");
+    const bystanderAfter = after
+      .split("\n")
+      .filter(line => line.includes(BYSTANDER_ID));
+    expect(bystanderAfter).toEqual(bystanderBlock);
+  });
+
+  it("returns a structured no-op for an unknown id without throwing", async () => {
+    const before = await readFile(learningsPath, "utf8");
+    const result = await confirmLearningEntry(
+      tempDir,
+      "learning-missing",
+      CONFIRM_DATE
+    );
+    expect(result).toEqual({ status: "not-found", id: "learning-missing" });
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("returns a structured no-op when the learnings file does not exist", async () => {
+    const emptyRoot = await createTempDir();
+    try {
+      const result = await confirmLearningEntry(
+        emptyRoot,
+        APPLIED_ID,
+        CONFIRM_DATE
+      );
+      expect(result).toEqual({ status: "not-found", id: APPLIED_ID });
+      expect(await fs.pathExists(path.join(emptyRoot, ".claude"))).toBe(false);
+    } finally {
+      await cleanupTempDir(emptyRoot);
+    }
+  });
+
+  it("is idempotent: re-confirming the same date is an unchanged no-op", async () => {
+    await confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE);
+    const afterFirst = await readFile(learningsPath, "utf8");
+    const result = await confirmLearningEntry(
+      tempDir,
+      APPLIED_ID,
+      CONFIRM_DATE
+    );
+    expect(result.status).toBe("unchanged");
+    expect(await readFile(learningsPath, "utf8")).toBe(afterFirst);
+  });
+
+  it("never regresses last_confirmed to an earlier date", async () => {
+    await confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE);
+    const before = await readFile(learningsPath, "utf8");
+    const result = await confirmLearningEntry(
+      tempDir,
+      APPLIED_ID,
+      "2026-07-05"
+    );
+    expect(result.status).toBe("unchanged");
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("keeps the last_confirmed >= first_learned invariant valid on write", async () => {
+    await confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE);
+    const entries = parseLearningsFile(await readFile(learningsPath, "utf8"));
+    const applied = entries.find(entry => entry.id === APPLIED_ID);
+    expect(applied).toBeDefined();
+    expect(applied!.last_confirmed >= applied!.first_learned).toBe(true);
+  });
+
+  it.each(["July 19", "2026-13-01", "2026-02-30", ""])(
+    "rejects the malformed confirmation date %j",
+    async date => {
+      await expect(
+        confirmLearningEntry(tempDir, APPLIED_ID, date)
+      ).rejects.toThrow(/date|last_confirmed/i);
+    }
+  );
+
+  it("rejects a non-string id without touching the file", async () => {
+    const before = await readFile(learningsPath, "utf8");
+    await expect(
+      confirmLearningEntry(tempDir, 42 as never, CONFIRM_DATE)
+    ).rejects.toThrow(/id/i);
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("propagates malformed-document failures without mutating the file", async () => {
+    await fs.outputFile(learningsPath, "# Project Learnings\n\nnot-jsonl\n");
+    const before = await readFile(learningsPath, "utf8");
+    await expect(
+      confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE)
+    ).rejects.toThrow(/format|json/i);
+    expect(await readFile(learningsPath, "utf8")).toBe(before);
+  });
+
+  it("rejects a symlinked learnings file before reading it", async () => {
+    const external = path.join(tempDir, "external.md");
+    await fs.move(learningsPath, external);
+    await fs.symlink(external, learningsPath);
+    await expect(
+      confirmLearningEntry(tempDir, APPLIED_ID, CONFIRM_DATE)
+    ).rejects.toThrow(/not a regular file/i);
+  });
+});

--- a/tests/unit/core/learnings-confirm.test.ts
+++ b/tests/unit/core/learnings-confirm.test.ts
@@ -95,7 +95,11 @@ describe("confirmLearningEntry", () => {
       "learning-missing",
       CONFIRM_DATE
     );
-    expect(result).toEqual({ status: "not-found", id: "learning-missing" });
+    expect(result).toEqual({
+      status: "not-found",
+      id: "learning-missing",
+      file: learningsPath,
+    });
     expect(await readFile(learningsPath, "utf8")).toBe(before);
   });
 

--- a/tests/unit/strategies/distributed-content-round2-contract.test.ts
+++ b/tests/unit/strategies/distributed-content-round2-contract.test.ts
@@ -83,29 +83,62 @@ describe.each(SKILL_ROOTS)("distributed F5 contract (%s)", skillRoot => {
 });
 
 describe.each(SKILL_ROOTS)("distributed doctor history contract (%s)", root => {
+  // #1582 extracted the upstream-history procedure out of lisa-doctor into the
+  // shared, event-triggered lisa-attribute-failure skill. The #1622 hardening
+  // contract now binds wherever the procedure lives; doctor must delegate.
+  const attribution = read(`${root}/lisa-attribute-failure/SKILL.md`);
   const doctor = read(`${root}/lisa-doctor/SKILL.md`);
 
   it("retains commit identity and targeted diff context", () => {
-    expect(doctor).toContain("--paginate --slurp |");
-    expect(doctor).toMatch(/jq '\{total_commits:/);
-    expect(doctor).not.toMatch(/--slurp \\\n\s+--jq/);
-    expect(doctor).toContain("commits: [.[].commits[]? | {sha, subject:");
-    expect(doctor).toContain("repos/CodySwannGT/lisa/commits/<sha>");
-    expect(doctor).toMatch(
+    expect(attribution).toContain("--paginate --slurp |");
+    expect(attribution).toMatch(/jq '\{total_commits:/);
+    expect(attribution).not.toMatch(/--slurp \\\n\s+--jq/);
+    expect(attribution).toContain("commits: [.[].commits[]? | {sha, subject:");
+    expect(attribution).toContain("repos/CodySwannGT/lisa/commits/<sha>");
+    expect(attribution).toMatch(
       /filename, status, additions, deletions, changes, patch/
     );
-    expect(doctor).toMatch(/rather than attributing from the subject alone/);
+    expect(attribution).toMatch(
+      /rather than attributing from the subject alone/
+    );
   });
 
   it("uses a finite, explicit-ref history fallback", () => {
-    expect(doctor).toMatch(/fetch --no-tags --filter=blob:none --depth=256/);
-    expect(doctor).toContain('lisa_history_dir="$(mktemp -d)"');
-    expect(doctor).toContain("refs/tags/v<installed>:refs/tags/v<installed>");
-    expect(doctor).toContain("refs/tags/v<latest>:refs/tags/v<latest>");
-    expect(doctor).toMatch(/merge-base --is-ancestor/);
-    expect(doctor).toMatch(/Do not\s+silently deepen beyond that ceiling/);
-    expect(doctor).not.toContain("git clone --filter=blob:none --no-checkout");
-    expect(doctor).not.toContain("shallow-clone");
+    expect(attribution).toMatch(
+      /fetch --no-tags --filter=blob:none --depth=256/
+    );
+    expect(attribution).toContain('lisa_history_dir="$(mktemp -d)"');
+    expect(attribution).toContain(
+      "refs/tags/v<installed>:refs/tags/v<installed>"
+    );
+    expect(attribution).toContain("refs/tags/v<latest>:refs/tags/v<latest>");
+    expect(attribution).toMatch(/merge-base --is-ancestor/);
+    expect(attribution).toMatch(/Do not\s+silently deepen beyond that ceiling/);
+    expect(attribution).not.toContain(
+      "git clone --filter=blob:none --no-checkout"
+    );
+    expect(attribution).not.toContain("shallow-clone");
+  });
+
+  it("returns the event-triggered verdict vocabulary with cited evidence", () => {
+    expect(attribution).toMatch(/`lisa` \| `project` \| `ambiguous`/);
+    expect(attribution).toMatch(/event-triggered, not version-window-keyed/);
+    expect(attribution).toMatch(/never let a degraded history produce `lisa`/);
+    expect(attribution).toMatch(/ambiguous stays local and low-confidence/i);
+  });
+
+  it("keeps doctor's diagnosis as a thin delegation without regressing it", () => {
+    expect(doctor).toContain("### Upstream Lisa change-history diagnosis");
+    expect(doctor).toMatch(
+      /distinguish them instead of blaming the\s+project by default/
+    );
+    expect(doctor).toContain("lisa-attribute-failure");
+    expect(doctor).toMatch(/Resolve the version window/);
+    expect(doctor).toMatch(/`lisa` \| `project` \| `ambiguous`/);
+    expect(doctor).toMatch(
+      /never fail the audit\s+because history was unavailable/
+    );
+    expect(doctor).toMatch(/read-only contract/);
   });
 });
 

--- a/tests/unit/strategies/learnings-confirmation-contract.test.ts
+++ b/tests/unit/strategies/learnings-confirmation-contract.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 const PLUGIN_ROOTS = [
   "plugins/src/base",
   "plugins/lisa",
+  "plugins/lisa/.codex-plugin",
   "plugins/lisa-cursor",
   "plugins/lisa-agy",
   "plugins/lisa-copilot",
@@ -28,9 +29,12 @@ const BUILD_INTAKE_SKILLS = [
   "lisa-linear-build-intake",
 ] as const;
 
-// Antigravity ships no rules/ tree (AGENTS.md bridge instead), and Cursor
-// flattens the eager+reference pair into .mdc files — assert each projection
-// where the reference body actually lives.
+// Per-agent parity gaps (documented, not silently dropped): Antigravity ships
+// no rules/ tree (Lisa reconciles a bounded AGENTS.md bridge instead), and the
+// Codex overlay (`plugins/lisa/.codex-plugin`) distributes skills only — its
+// SKILL.md pointer surface has no rules projection — so neither appears below.
+// Cursor flattens the eager+reference pair into .mdc files. Assert each
+// projection where the reference body actually lives.
 const REFERENCE_RULE_PATHS = [
   "plugins/src/base/rules/reference/project-learnings.md",
   "plugins/lisa/rules/reference/project-learnings.md",
@@ -59,6 +63,9 @@ describe.each(PLUGIN_ROOTS)("claim-time confirmation contract (%s)", root => {
       expect(section).toMatch(/advances ONLY `last_confirmed`/);
       expect(section).toMatch(/idempotent within a claim/);
       expect(section).toMatch(/bumped once, not once per application/);
+      expect(section).toMatch(/failure-safe by construction/);
+      expect(section).toMatch(/\|\| true/);
+      expect(section).toMatch(/never abort the lifecycle/);
       expect(section).toMatch(/Never block on it/);
     }
   );

--- a/tests/unit/strategies/learnings-confirmation-contract.test.ts
+++ b/tests/unit/strategies/learnings-confirmation-contract.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Prose contract for the claim-time `last_confirmed` bump (#1579).
+ *
+ * Every build-intake flow must confirm demonstrably-applied learnings at the
+ * end of step 3c through the surgical `confirmLearningEntry` writer, with the
+ * "presence in context is NOT application" bar and the never-block guarantee.
+ * The project-learnings reference rule documents the same contract. These are
+ * agent instructions, so the assertions cover the canonical source and every
+ * checked-in runtime projection.
+ * @module tests/unit/strategies/learnings-confirmation-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_ROOTS = [
+  "plugins/src/base",
+  "plugins/lisa",
+  "plugins/lisa-cursor",
+  "plugins/lisa-agy",
+  "plugins/lisa-copilot",
+] as const;
+
+const BUILD_INTAKE_SKILLS = [
+  "lisa-jira-build-intake",
+  "lisa-github-build-intake",
+  "lisa-linear-build-intake",
+] as const;
+
+// Antigravity ships no rules/ tree (AGENTS.md bridge instead), and Cursor
+// flattens the eager+reference pair into .mdc files — assert each projection
+// where the reference body actually lives.
+const REFERENCE_RULE_PATHS = [
+  "plugins/src/base/rules/reference/project-learnings.md",
+  "plugins/lisa/rules/reference/project-learnings.md",
+  "plugins/lisa-cursor/rules/project-learnings-reference.mdc",
+  "plugins/lisa-copilot/rules/reference/project-learnings.md",
+] as const;
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+describe.each(PLUGIN_ROOTS)("claim-time confirmation contract (%s)", root => {
+  it.each(BUILD_INTAKE_SKILLS)(
+    "%s hooks the last_confirmed bump into the end of step 3c",
+    skillName => {
+      const skill = read(`${root}/skills/${skillName}/SKILL.md`);
+      const section = skill.slice(
+        skill.indexOf("#### 3c.2 Confirm applied learnings"),
+        skill.indexOf("#### 3d.")
+      );
+
+      expect(section).toContain("confirmLearningEntry");
+      expect(section).toContain("@codyswann/lisa/learnings");
+      expect(section).toContain("resolveProjectLearningsFile");
+      expect(section).toMatch(/Presence in context is NOT application/);
+      expect(section).toMatch(/explicitly cited or observably followed/);
+      expect(section).toMatch(/advances ONLY `last_confirmed`/);
+      expect(section).toMatch(/idempotent within a claim/);
+      expect(section).toMatch(/bumped once, not once per application/);
+      expect(section).toMatch(/Never block on it/);
+    }
+  );
+});
+
+describe.each(REFERENCE_RULE_PATHS)(
+  "project-learnings reference rule (%s)",
+  rulePath => {
+    it("documents the claim-time confirmation bar", () => {
+      const rule = read(rulePath);
+
+      expect(rule).toContain("## Claim-time confirmation (`last_confirmed`)");
+      expect(rule).toContain("confirmLearningEntry");
+      expect(rule).toMatch(/demonstrably applied/);
+      expect(rule).toMatch(/NOT application/);
+      expect(rule).toMatch(/never\s+blocks the build/);
+    });
+  }
+);

--- a/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
+++ b/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Prose contract for the automatic upstream Lisa filing loop (#1583).
+ *
+ * lisa-persist-learning's `handoff-upstream` disposition must file the
+ * upstream ticket with root-cause marker dedupe (keyed on the Lisa surface,
+ * never the host project), an evidence-rich body, a per-run cap, and only a
+ * brief local linking note — never a durable local rule. These are agent
+ * instructions, so the assertions cover the canonical source and every
+ * checked-in runtime projection.
+ * @module tests/unit/strategies/upstream-attribution-filing-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa/.codex-plugin/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+describe.each(SKILL_ROOTS)("upstream filing contract (%s)", skillRoot => {
+  const skill = read(`${skillRoot}/lisa-persist-learning/SKILL.md`);
+  const handoff = skill.slice(
+    skill.indexOf("### `handoff-upstream`"),
+    skill.indexOf("### `persist`")
+  );
+
+  it("files automatically on the lisa verdict with the attribution marker", () => {
+    expect(handoff).toContain(
+      "[lisa-upstream-attribution] key=<root-cause-key>"
+    );
+    expect(handoff).toMatch(/filed \*\*automatically\*\*/);
+    expect(handoff).toContain("lisa-github-write-issue");
+    expect(handoff).toContain("`self-hardening` label");
+    expect(handoff).toMatch(/three-audience description/);
+    expect(handoff).toMatch(/evidence chain/);
+  });
+
+  it("keys dedupe on the Lisa surface, never the host project or title", () => {
+    expect(handoff).toMatch(/root-cause-key = <lisa-surface>#<failure-class>/);
+    expect(handoff).toMatch(/never the host project or the local issue/i);
+    expect(handoff).toMatch(/MUST collide on the same key/);
+    expect(handoff).toMatch(/MARKER, never the title/);
+    expect(handoff).toMatch(/never write a markerless body/);
+  });
+
+  it("updates the existing ticket on repeat encounters instead of duplicating", () => {
+    expect(handoff).toMatch(/repeat encounter/);
+    expect(handoff).toContain(
+      "[lisa-upstream-attribution-occurrence] key=<fingerprint>"
+    );
+    expect(handoff).toMatch(/Never open a second issue/);
+  });
+
+  it("enforces the configurable per-run cap with visible drops", () => {
+    expect(handoff).toContain("hardening.maxUpstreamFilingsPerRun");
+    expect(handoff).toMatch(/default `5`/);
+    expect(handoff).toMatch(/note each dropped candidate visibly/);
+    expect(handoff).toMatch(/never drop silently/);
+  });
+
+  it("files nothing on ambiguous and keeps the local trace a note, not a rule", () => {
+    expect(handoff).toMatch(/`ambiguous` verdict[\s\S]*files \*\*NOTHING\*\*/);
+    expect(handoff).toMatch(/stays local and low-confidence/);
+    expect(handoff).toMatch(/no durable local rule/);
+    expect(handoff).toContain("[lisa-upstream-filed] key=<fingerprint>");
+    expect(handoff).toContain("hardening.upstreamRepo");
+    expect(handoff).toMatch(/Never block the primary build flow/);
+  });
+});

--- a/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
+++ b/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
@@ -52,6 +52,24 @@ describe.each(SKILL_ROOTS)("upstream filing contract (%s)", skillRoot => {
     expect(handoff).toMatch(/never write a markerless body/);
   });
 
+  it("dedupes across all issue states and handles the closed-ticket branch", () => {
+    expect(handoff).toMatch(/Search \*\*all issue states\*\*/);
+    expect(handoff).toMatch(/--state all/);
+    expect(handoff).not.toMatch(/--state open/);
+    expect(handoff).toMatch(/\*\*Existing ticket \(open or closed\)\*\*/);
+    expect(handoff).toMatch(/do not reopen it yourself/);
+    expect(handoff).toMatch(/upstream maintainer's call/);
+  });
+
+  it("requires the attribution skill's lisa verdict and a redacted chain", () => {
+    expect(handoff).toMatch(
+      /Require a confirmed `lisa` verdict from `lisa-attribute-failure` — always/
+    );
+    expect(handoff).toMatch(/never substitutes for the verdict/);
+    expect(handoff).toMatch(/redacted evidence chain \(Lisa-owned text only/);
+    expect(handoff).not.toMatch(/verbatim evidence chain/);
+  });
+
   it("updates the existing ticket on repeat encounters instead of duplicating", () => {
     expect(handoff).toMatch(/repeat encounter/);
     expect(handoff).toContain(
@@ -86,8 +104,12 @@ describe.each(SKILL_ROOTS)("upstream filing contract (%s)", skillRoot => {
     );
     expect(handoff).not.toMatch(/routed upstream\)/);
     expect(handoff).toContain(
-      "[lisa-learning-upstream-handoff] key=<fingerprint>-resolution"
+      "[lisa-learning-upstream-handoff] key=<fingerprint>-inconclusive"
     );
+    expect(handoff).toContain(
+      "[lisa-learning-upstream-handoff] key=<fingerprint>-filing-failed"
+    );
+    expect(handoff).not.toContain("key=<fingerprint>-resolution");
     expect(handoff).toMatch(
       /Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally\./
     );
@@ -97,7 +119,9 @@ describe.each(SKILL_ROOTS)("upstream filing contract (%s)", skillRoot => {
   });
 
   it("files nothing on ambiguous and keeps the local trace a note, not a rule", () => {
-    expect(handoff).toMatch(/`ambiguous` verdict[\s\S]*files \*\*NOTHING\*\*/);
+    expect(handoff).toMatch(
+      /`ambiguous`, `project`, or a verdict that cannot name a concrete Lisa surface — files \*\*NOTHING\*\*/
+    );
     expect(handoff).toMatch(/stays local and low-confidence/);
     expect(handoff).toMatch(/no durable local rule/);
     expect(handoff).toContain("[lisa-upstream-filed] key=<fingerprint>");

--- a/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
+++ b/tests/unit/strategies/upstream-attribution-filing-contract.test.ts
@@ -67,6 +67,35 @@ describe.each(SKILL_ROOTS)("upstream filing contract (%s)", skillRoot => {
     expect(handoff).toMatch(/never drop silently/);
   });
 
+  it("binds evidence redaction for the public upstream repo", () => {
+    expect(handoff).toMatch(/\*\*Evidence redaction \(binding\)\.\*\*/);
+    expect(handoff).toMatch(/world-readable/);
+    expect(handoff).toMatch(/Quote ONLY Lisa-owned surface text/);
+    expect(handoff).toMatch(/must be REDACTED/);
+    expect(handoff).toMatch(
+      /Never paste host environment values, tokens\/credentials/
+    );
+    expect(handoff).toMatch(/LINK the host-project issue instead of quoting/);
+    expect(handoff).toMatch(/high-entropy values/);
+    expect(handoff).toMatch(/strip on match/);
+  });
+
+  it("never claims a filing before attribution and resolves inconclusive paths", () => {
+    expect(handoff).toMatch(
+      /Candidate routed for upstream attribution \(root cause suspected in Lisa\)/
+    );
+    expect(handoff).not.toMatch(/routed upstream\)/);
+    expect(handoff).toContain(
+      "[lisa-learning-upstream-handoff] key=<fingerprint>-resolution"
+    );
+    expect(handoff).toMatch(
+      /Attribution was inconclusive — nothing was filed upstream and nothing was persisted locally\./
+    );
+    expect(handoff).toMatch(
+      /Upstream filing did not complete — nothing was filed upstream/
+    );
+  });
+
   it("files nothing on ambiguous and keeps the local trace a note, not a rule", () => {
     expect(handoff).toMatch(/`ambiguous` verdict[\s\S]*files \*\*NOTHING\*\*/);
     expect(handoff).toMatch(/stays local and low-confidence/);


### PR DESCRIPTION
## Summary

- **Event-triggered failure attribution (#1582):** new `lisa-attribute-failure` skill extracted from doctor's upstream-history diagnosis — takes an arbitrary failure event, returns `lisa | project | ambiguous` with cited evidence via three ordered signals (managed-surface ownership, shipped rule/skill/hook, upstream-history window — the old version compare demoted to signal 3). `lisa-doctor` now delegates thinly, behavior preserved (contract test moved + strengthened).
- **Automatic upstream filing (#1583):** `lisa-persist-learning`'s `handoff-upstream` completes the loop — on a `lisa` verdict it files on `hardening.upstreamRepo` with the rework-triage discipline upgraded to marker dedupe (`[lisa-upstream-attribution]`, root-cause key derived from the Lisa surface so cross-project encounters collide → update-not-duplicate), a per-run cap with visible drops, ambiguous-files-nothing, and a **binding evidence-redaction step** (Lisa-owned text only, redacted repro, secret-shape scan — the default upstream repo is public).
- **Surgical `last_confirmed` confirmation (#1579):** `confirmLearningEntry(projectRoot, id, date)` in the executable contract (advance-only, byte-identical bystanders, confirmed|unchanged|not-found, never blocks) + build-intake `3c.2` hooks it where "demonstrably applied" is observable (presence in context ≠ application).

Closes CodySwannGT/lisa#1582
Closes CodySwannGT/lisa#1583
Closes CodySwannGT/lisa#1579

## Review + verification

Four lanes pre-PR (quality APPROVE; product/CodeRabbit approve-with-nits; spec-conformance PARTIAL + a MEDIUM-HIGH security finding — the redaction gap — fixed in-branch along with the dangling "routed upstream" marker claim and a result-shape nit). Independent empirical verification PASS on all legs: dist-level bump matrix (confirmed/unchanged/not-found/never-regresses, sibling entries byte-identical); real attribution runs against this repo (staged managed-file defect → `lisa` with citations; host-only file → `project`; degraded history → `ambiguous`, never `lisa`); **real upstream filing** exercised end-to-end on scratch issues (#1759 filed with marker + self-hardening, re-run → occurrence comment not duplicate, ambiguous candidate filed nothing + corrective note, 5 canary secrets stripped by the redaction scan — all scratch artifacts closed).

## Test plan

146 tests across the five batch suites green; full unit suite 4805; `check:plugins`/`check:rules-pairing` green; rebased onto v2.239.1 with 3b/3c composition verified.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only failure attribution that classifies issues as Lisa-related, project-related, or ambiguous with cited evidence.
  * Learning workflows now record when documented learnings are demonstrably applied during build intake.
  * Lisa-related learning findings can automatically create or update upstream tickets with deduplication, evidence handling, and filing limits.

* **Improvements**
  * Diagnostic workflows now use consistent attribution results and safely report inconclusive history without blocking progress.
  * Learning confirmation and upstream filing failures are recorded without interrupting build completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->