### PR TITLE
feat(quality): threshold ratchet — gates may tighten, never weaken

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -99,7 +99,10 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
+          # fetch-depth 0 brings all branches, so the base ref is available
+          # without a credentialed fetch later in the job.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 📐 Compare thresholds against merge-base
         env:
@@ -113,7 +116,10 @@ jobs:
             echo "scripts/check-threshold-ratchet.mjs not present — project not yet on the ratchet template; skipping."
             exit 0
           fi
-          git fetch origin "$BASE_REF"
+          if ! git rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1; then
+            echo "Base ref origin/$BASE_REF is not available in this checkout — cannot evaluate the ratchet."
+            exit 1
+          fi
           node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
 
   security:

--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -43,7 +43,7 @@ on:
         type: string
         default: 'test'
       skip_jobs:
-        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, learnings_budget, license_compliance, zap_baseline)'
+        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, learnings_budget, threshold_ratchet, license_compliance, zap_baseline)'
         required: false
         type: string
         default: ''
@@ -84,6 +84,37 @@ jobs:
 
       - name: 🔍 Run RuboCop
         run: bundle exec rubocop --format github
+
+  # Threshold ratchet: quality thresholds (simplecov minimums, rubocop Metrics
+  # maximums) may tighten, never weaken. Same deterministic comparator as the
+  # agent-time hooks and the lefthook pre-commit layer; this is the
+  # non-bypassable layer. Human-approved exceptions live in .lisa.config.json
+  # (thresholdRatchet.allow) and are honored only once merged into the base.
+  threshold_ratchet:
+    name: 📐 Threshold Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !contains(inputs.skip_jobs, 'threshold_ratchet') }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 📐 Compare thresholds against merge-base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -z "$BASE_REF" ]; then
+            echo "Not a pull request — nothing to ratchet against."
+            exit 0
+          fi
+          if [ ! -f scripts/check-threshold-ratchet.mjs ]; then
+            echo "scripts/check-threshold-ratchet.mjs not present — project not yet on the ratchet template; skipping."
+            exit 0
+          fi
+          git fetch origin "$BASE_REF"
+          node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
 
   security:
     name: Security

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,7 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,threshold_ratchet,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -1330,6 +1330,41 @@ jobs:
             out
           retention-days: 1
           if-no-files-found: ignore
+
+  # Threshold ratchet: quality thresholds may tighten, never weaken. Compares
+  # every watched gate file (coverage/e2e/eslint thresholds, stryker break,
+  # k6 bounds, audit-ignore lists) against the PR's merge-base with the same
+  # deterministic comparator the agent-time hooks and pre-commit run. This is
+  # the non-bypassable layer: agent hooks can be absent (headless runtimes) and
+  # local git hooks can be uninstalled, but nothing weakened lands in a PR.
+  # Human-approved exceptions live in .lisa.config.json (thresholdRatchet.allow)
+  # and are honored only once merged into the base branch.
+  threshold_ratchet:
+    name: 📐 Threshold Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !contains(inputs.skip_jobs, 'threshold_ratchet') }}
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 📐 Compare thresholds against merge-base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -z "$BASE_REF" ]; then
+            echo "Not a pull request — nothing to ratchet against."
+            exit 0
+          fi
+          if [ ! -f scripts/check-threshold-ratchet.mjs ]; then
+            echo "scripts/check-threshold-ratchet.mjs not present — project not yet on the ratchet template; skipping."
+            exit 0
+          fi
+          git fetch origin "$BASE_REF"
+          node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
 
   dead_code:
     name: 🗑️ Dead Code Detection

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1349,7 +1349,10 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
+          # fetch-depth 0 brings all branches, so the base ref is available
+          # without a credentialed fetch later in the job.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 📐 Compare thresholds against merge-base
         env:
@@ -1363,7 +1366,10 @@ jobs:
             echo "scripts/check-threshold-ratchet.mjs not present — project not yet on the ratchet template; skipping."
             exit 0
           fi
-          git fetch origin "$BASE_REF"
+          if ! git rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1; then
+            echo "Base ref origin/$BASE_REF is not available in this checkout — cannot evaluate the ratchet."
+            exit 1
+          fi
           node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
 
   dead_code:

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -26,6 +26,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/threshold-ratchet.sh"
+          }
+        ]
       }
     ],
     "preToolUse": [

--- a/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.sh
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
+# Quality thresholds (coverage minimums, complexity maximums, mutation break
+# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
+# shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
+# so this hook is fast feedback — not the only line of defense.
+#
+# Exit 2 on weakening (soft block: the agent gets the report on stderr and can
+# fix the code or escalate to a human). Every infrastructure gap — no node, no
+# git repo, unreadable stdin — exits 0: the CI layer still guarantees the gate,
+# and a broken hook must never wedge an agent session.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v node >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf '%s' "$input" | node "$script_dir/threshold-ratchet.mjs" --hook

--- a/plugins/lisa-cursor/hooks/hooks.json
+++ b/plugins/lisa-cursor/hooks/hooks.json
@@ -10,6 +10,10 @@
       {
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/shell-write-nudge.sh",
         "matcher": "Bash"
+      },
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/threshold-ratchet.sh",
+        "matcher": "Edit|Write|NotebookEdit|Bash"
       }
     ],
     "preToolUse": [

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.sh
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
+# Quality thresholds (coverage minimums, complexity maximums, mutation break
+# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
+# shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
+# so this hook is fast feedback — not the only line of defense.
+#
+# Exit 2 on weakening (soft block: the agent gets the report on stderr and can
+# fix the code or escalate to a human). Every infrastructure gap — no node, no
+# git repo, unreadable stdin — exits 0: the CI layer still guarantees the gate,
+# and a broken hook must never wedge an agent session.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v node >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf '%s' "$input" | node "$script_dir/threshold-ratchet.mjs" --hook

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -64,6 +64,15 @@
         ]
       },
       {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/threshold-ratchet.sh"
+          }
+        ]
+      },
+      {
         "matcher": "TeamCreate|Agent",
         "hooks": [
           {

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -20,6 +20,15 @@
             "command": "${PLUGIN_ROOT}/hooks/shell-write-nudge.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/threshold-ratchet.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/plugins/lisa/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/plugins/lisa/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/plugins/lisa/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/plugins/lisa/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/plugins/lisa/hooks/threshold-ratchet.sh
+++ b/plugins/lisa/hooks/threshold-ratchet.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
+# Quality thresholds (coverage minimums, complexity maximums, mutation break
+# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
+# shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
+# so this hook is fast feedback — not the only line of defense.
+#
+# Exit 2 on weakening (soft block: the agent gets the report on stderr and can
+# fix the code or escalate to a human). Every infrastructure gap — no node, no
+# git repo, unreadable stdin — exits 0: the CI layer still guarantees the gate,
+# and a broken hook must never wedge an agent session.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v node >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf '%s' "$input" | node "$script_dir/threshold-ratchet.mjs" --hook

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -64,6 +64,15 @@
         ]
       },
       {
+        "matcher": "Edit|Write|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/threshold-ratchet.sh"
+          }
+        ]
+      },
+      {
         "matcher": "TeamCreate|Agent",
         "hooks": [
           {

--- a/plugins/src/base/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/plugins/src/base/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/plugins/src/base/hooks/threshold-ratchet-families.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/plugins/src/base/hooks/threshold-ratchet-families.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/plugins/src/base/hooks/threshold-ratchet.sh
+++ b/plugins/src/base/hooks/threshold-ratchet.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
+# Quality thresholds (coverage minimums, complexity maximums, mutation break
+# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
+# shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
+# so this hook is fast feedback — not the only line of defense.
+#
+# Exit 2 on weakening (soft block: the agent gets the report on stderr and can
+# fix the code or escalate to a human). Every infrastructure gap — no node, no
+# git repo, unreadable stdin — exits 0: the CI layer still guarantees the gate,
+# and a broken hook must never wedge an agent session.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v node >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf '%s' "$input" | node "$script_dir/threshold-ratchet.mjs" --hook

--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -4,6 +4,12 @@ pre-commit:
     rubocop:
       glob: '*.rb'
       run: bundle exec rubocop --force-exclusion {staged_files}
+    threshold-ratchet:
+      # Quality thresholds (simplecov minimums, rubocop Metrics maximums, …)
+      # may tighten, never weaken. Same deterministic comparator as the
+      # agent-time hooks and CI; self-skips when node or the script is absent
+      # (CI still enforces the gate).
+      run: sh -c 'command -v node >/dev/null 2>&1 || exit 0; [ -f scripts/check-threshold-ratchet.mjs ] || exit 0; node scripts/check-threshold-ratchet.mjs --staged'
     bundler-audit:
       # Unset GIT_DIR/GIT_WORK_TREE so `--update`'s internal git pull of the
       # ruby-advisory-db (~/.local/share/ruby-advisory-db) does not inherit the

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -70,6 +70,26 @@ build_per_agent_variant() {
 # Base plugin
 build_plugin base lisa
 
+# Threshold-ratchet comparator: the canonical implementation lives in the base
+# plugin's hooks/ (agent-time layer). The pre-commit (husky/lefthook) and CI
+# layers in downstream projects run the same file as scripts/
+# check-threshold-ratchet.mjs, delivered via the stack templates. Sync the
+# copies here so they can never drift; a unit test asserts byte-equality.
+if [ -f "$SRC_DIR/base/hooks/threshold-ratchet.mjs" ]; then
+  for ratchet_scripts_dir in \
+    "$ROOT_DIR/typescript/copy-overwrite/scripts" \
+    "$ROOT_DIR/rails/copy-overwrite/scripts"; do
+    mkdir -p "$ratchet_scripts_dir"
+    # The entry point takes the template check-* naming; its relative imports
+    # (threshold-ratchet-*.mjs) keep their canonical names in both trees.
+    cp "$SRC_DIR/base/hooks/threshold-ratchet.mjs" \
+      "$ratchet_scripts_dir/check-threshold-ratchet.mjs"
+    cp "$SRC_DIR/base/hooks/threshold-ratchet-families.mjs" \
+      "$SRC_DIR/base/hooks/threshold-ratchet-compare.mjs" \
+      "$ratchet_scripts_dir/"
+  done
+fi
+
 # Stack-specific plugins (NO base copy)
 STACKS=(typescript expo nestjs cdk harper-fabric phaser rails)
 for stack in "${STACKS[@]}"; do

--- a/scripts/lib/per-agent-hook-filter.mjs
+++ b/scripts/lib/per-agent-hook-filter.mjs
@@ -78,6 +78,13 @@ const SCRIPT_RULES = {
     agy: true,
     copilot: true,
   },
+  "threshold-ratchet.sh": {
+    claude: true,
+    codex: true,
+    cursor: true,
+    agy: false, // agy hooks ship only via AGY_PLUGIN_HOOKS (root hooks.json) and don't fire headless; the pre-commit + CI ratchet layers carry parity there
+    copilot: true,
+  },
   // Unregistered scripts — exclude by default until classified.
   "ticket-sync-reminder.sh": {
     claude: false,

--- a/tests/unit/scripts/threshold-ratchet-gates.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-gates.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the threshold ratchet, part 2: Tier 2 gate configs (stryker
+ * break score, k6 bounds), Tier 3 exemption additions (audit ignores,
+ * mutate exclusions, allow-list self-service), the baseline-side allow
+ * list, and the wiring of all three enforcement layers (plugin hook
+ * manifest, husky/lefthook pre-commit, reusable CI workflows, template
+ * copy parity). Tier 1 comparator behavior lives in
+ * threshold-ratchet.test.ts.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HOOKS_REL = "plugins/src/base/hooks";
+const RATCHET_MODULES = [
+  "threshold-ratchet-families.mjs",
+  "threshold-ratchet-compare.mjs",
+];
+const TEMPLATE_SCRIPT_DIRS = [
+  "typescript/copy-overwrite/scripts",
+  "rails/copy-overwrite/scripts",
+];
+const ENTRY_TEMPLATE_NAME = "check-threshold-ratchet.mjs";
+
+const STRYKER_FILE = "stryker.conf.json";
+const K6_FILE = ".github/k6/thresholds/normal.json";
+const LISA_CONFIG_FILE = ".lisa.config.json";
+const VITEST_FILE = "vitest.thresholds.json";
+const KEY_LINES = "global.lines";
+const SRC_GLOB = "src/**/*.ts";
+const SPEC_NEGATION = "!src/**/*.spec.ts";
+const P95_BOUND = "p(95)<1000";
+const RATE_UPPER = "rate<0.05";
+const RATE_LOWER = "rate>=0.99";
+const TYPE_EXEMPTION = "exemption-added";
+
+/** One reported ratchet violation. */
+interface Finding {
+  readonly file: string;
+  readonly key: string;
+  readonly type: string;
+  readonly message: string;
+}
+
+/**
+ * Read a repo-relative text file.
+ * @param relativePath - Repo-relative path
+ * @returns File contents
+ */
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+describe("threshold-ratchet tiers 2 and 3", () => {
+  let compareFile: (
+    relPath: string,
+    baselineText: string | null,
+    currentText: string | null
+  ) => Finding[];
+  let applyAllowList: (
+    findings: Finding[],
+    allowEntries: ReadonlyArray<{ file: string; key: string }>
+  ) => { blocked: Finding[]; allowed: Finding[] };
+  let extractAllowEntries: (
+    config: unknown
+  ) => Array<{ file: string; key: string }>;
+
+  beforeAll(async () => {
+    const families = await import(
+      pathToFileURL(path.join(REPO_ROOT, HOOKS_REL, RATCHET_MODULES[0])).href
+    );
+    const compare = await import(
+      pathToFileURL(path.join(REPO_ROOT, HOOKS_REL, RATCHET_MODULES[1])).href
+    );
+    compareFile = compare.compareFile;
+    applyAllowList = compare.applyAllowList;
+    extractAllowEntries = families.extractAllowEntries;
+  });
+
+  describe("stryker", () => {
+    const base = JSON.stringify({
+      thresholds: { high: 80, low: 60, break: 60 },
+      mutate: [SRC_GLOB, SPEC_NEGATION],
+    });
+
+    it("blocks lowering thresholds.break", () => {
+      const current = base.replace('"break":60', '"break":40');
+      const findings = compareFile(STRYKER_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        key: "thresholds.break",
+        type: "weakened",
+      });
+    });
+
+    it("ignores the reporting-only high/low bands", () => {
+      const current = JSON.stringify({
+        thresholds: { high: 70, low: 50, break: 60 },
+        mutate: [SRC_GLOB, SPEC_NEGATION],
+      });
+      expect(compareFile(STRYKER_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("flags a new mutate exclusion", () => {
+      const current = JSON.stringify({
+        thresholds: { high: 80, low: 60, break: 60 },
+        mutate: [SRC_GLOB, SPEC_NEGATION, "!src/hard-stuff/**"],
+      });
+      const findings = compareFile(STRYKER_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe(TYPE_EXEMPTION);
+    });
+
+    it("flags removing a mutate target", () => {
+      const current = JSON.stringify({
+        thresholds: { high: 80, low: 60, break: 60 },
+        mutate: [SPEC_NEGATION],
+      });
+      const findings = compareFile(STRYKER_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe(TYPE_EXEMPTION);
+    });
+  });
+
+  describe("k6 bounds", () => {
+    const base = JSON.stringify({
+      thresholds: {
+        http_req_failed: { threshold: RATE_UPPER, abortOnFail: true },
+        http_req_duration: { threshold: P95_BOUND },
+        checks: { threshold: RATE_LOWER },
+      },
+    });
+
+    it("blocks loosening an upper bound", () => {
+      const current = base.replace(P95_BOUND, "p(95)<3000");
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("weakened");
+    });
+
+    it("allows tightening an upper bound", () => {
+      const current = base.replace(P95_BOUND, "p(95)<500");
+      expect(compareFile(K6_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("blocks loosening a lower bound", () => {
+      const current = base.replace(RATE_LOWER, "rate>=0.9");
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("weakened");
+    });
+
+    it("blocks turning off abortOnFail", () => {
+      const current = base.replace('"abortOnFail":true', '"abortOnFail":false');
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].key).toBe("http_req_failed.abortOnFail");
+    });
+
+    it("blocks deleting a gated metric", () => {
+      const current = JSON.stringify({
+        thresholds: {
+          http_req_failed: { threshold: RATE_UPPER, abortOnFail: true },
+          checks: { threshold: RATE_LOWER },
+        },
+      });
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("removed");
+    });
+  });
+
+  describe("audit ignore lists", () => {
+    it("flags a newly ignored advisory", () => {
+      const base = JSON.stringify({ "GHSA-aaaa": "known, patched upstream" });
+      const current = JSON.stringify({
+        "GHSA-aaaa": "known, patched upstream",
+        "GHSA-bbbb": "new ignore",
+      });
+      const findings = compareFile("audit.ignore.local.json", base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        key: "GHSA-bbbb",
+        type: TYPE_EXEMPTION,
+      });
+    });
+
+    it("allows removing an ignore (tightening)", () => {
+      const base = JSON.stringify({ "GHSA-aaaa": "x", "GHSA-bbbb": "y" });
+      const current = JSON.stringify({ "GHSA-aaaa": "x" });
+      expect(
+        compareFile("audit.ignore.config.json", base, current)
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("allow-list", () => {
+    it("flags new thresholdRatchet.allow entries", () => {
+      const base = JSON.stringify({ thresholdRatchet: { allow: [] } });
+      const current = JSON.stringify({
+        thresholdRatchet: {
+          allow: [
+            {
+              file: VITEST_FILE,
+              key: KEY_LINES,
+              reason: "legacy module onboarding",
+            },
+          ],
+        },
+      });
+      const findings = compareFile(LISA_CONFIG_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("allow-added");
+    });
+
+    it("ignores unrelated .lisa.config.json changes", () => {
+      const base = JSON.stringify({ tracker: "jira" });
+      const current = JSON.stringify({ tracker: "github" });
+      expect(compareFile(LISA_CONFIG_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("suppresses findings matched by a baseline allow entry", () => {
+      const findings = compareFile(
+        `packages/api/${VITEST_FILE}`,
+        JSON.stringify({ global: { lines: 70 } }),
+        JSON.stringify({ global: { lines: 50 } })
+      );
+      const { blocked, allowed } = applyAllowList(findings, [
+        { file: VITEST_FILE, key: KEY_LINES },
+      ]);
+      expect(blocked).toHaveLength(0);
+      expect(allowed).toHaveLength(1);
+    });
+
+    it("supports the wildcard key", () => {
+      const findings = compareFile(
+        VITEST_FILE,
+        JSON.stringify({ global: { lines: 70, branches: 70 } }),
+        JSON.stringify({ global: { lines: 50, branches: 40 } })
+      );
+      const { blocked } = applyAllowList(findings, [
+        { file: VITEST_FILE, key: "*" },
+      ]);
+      expect(blocked).toHaveLength(0);
+    });
+
+    it("never lets an allow entry approve its own creation", () => {
+      const findings = compareFile(
+        LISA_CONFIG_FILE,
+        JSON.stringify({}),
+        JSON.stringify({
+          thresholdRatchet: { allow: [{ file: VITEST_FILE, key: "*" }] },
+        })
+      );
+      const { blocked } = applyAllowList(findings, [
+        { file: LISA_CONFIG_FILE, key: "*" },
+      ]);
+      expect(blocked).toHaveLength(1);
+    });
+
+    it("extracts only well-formed allow entries", () => {
+      expect(
+        extractAllowEntries({
+          thresholdRatchet: {
+            allow: [
+              { file: "a.json", key: "x" },
+              { file: 42, key: "y" },
+              "nope",
+              null,
+            ],
+          },
+        })
+      ).toEqual([{ file: "a.json", key: "x" }]);
+      expect(extractAllowEntries(undefined)).toEqual([]);
+    });
+  });
+});
+
+describe("threshold-ratchet wiring", () => {
+  it("template copies are byte-identical to the canonical modules", () => {
+    for (const dir of TEMPLATE_SCRIPT_DIRS) {
+      expect(
+        read(`${dir}/${ENTRY_TEMPLATE_NAME}`),
+        `${dir}/${ENTRY_TEMPLATE_NAME}`
+      ).toBe(read(`${HOOKS_REL}/threshold-ratchet.mjs`));
+      for (const module of RATCHET_MODULES) {
+        expect(read(`${dir}/${module}`), `${dir}/${module}`).toBe(
+          read(`${HOOKS_REL}/${module}`)
+        );
+      }
+    }
+  });
+
+  it("registers the PostToolUse hook in the base plugin manifest", () => {
+    const manifest = JSON.parse(
+      read("plugins/src/base/.claude-plugin/plugin.json")
+    );
+    const postToolUse: Array<{
+      matcher?: string;
+      hooks: Array<{ command: string }>;
+    }> = manifest.hooks.PostToolUse;
+    const entry = postToolUse.find(e =>
+      e.hooks.some(h => h.command.includes("threshold-ratchet.sh"))
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.matcher).toBe("Edit|Write|NotebookEdit|Bash");
+  });
+
+  it("wires the husky pre-commit backstop", () => {
+    const preCommit = read("typescript/copy-contents/.husky/pre-commit");
+    expect(preCommit).toContain(ENTRY_TEMPLATE_NAME);
+    expect(preCommit).toContain("--staged");
+  });
+
+  it("wires the rails lefthook backstop", () => {
+    const lefthook = read("rails/copy-overwrite/lefthook.yml");
+    expect(lefthook).toContain(ENTRY_TEMPLATE_NAME);
+    expect(lefthook).toContain("--staged");
+  });
+
+  it("wires the CI gate into both reusable quality workflows", () => {
+    for (const workflow of [
+      ".github/workflows/quality.yml",
+      ".github/workflows/quality-rails.yml",
+    ]) {
+      const text = read(workflow);
+      expect(text, workflow).toContain("threshold_ratchet:");
+      expect(text, workflow).toContain(`${ENTRY_TEMPLATE_NAME} --base`);
+    }
+  });
+
+  it("ships the hook wrapper alongside the comparator in the base plugin", () => {
+    expect(
+      fs.existsSync(path.join(REPO_ROOT, HOOKS_REL, "threshold-ratchet.sh"))
+    ).toBe(true);
+  });
+});

--- a/tests/unit/scripts/threshold-ratchet-gates.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-gates.test.ts
@@ -2,13 +2,10 @@
  * Tests for the threshold ratchet, part 2: Tier 2 gate configs (stryker
  * break score, k6 bounds), Tier 3 exemption additions (audit ignores,
  * mutate exclusions, allow-list self-service), the baseline-side allow
- * list, and the wiring of all three enforcement layers (plugin hook
- * manifest, husky/lefthook pre-commit, reusable CI workflows, template
- * copy parity). Tier 1 comparator behavior lives in
- * threshold-ratchet.test.ts.
+ * list. Tier 1 comparator behavior lives in threshold-ratchet.test.ts;
+ * enforcement-layer wiring lives in threshold-ratchet-wiring.test.ts.
  */
 import { beforeAll, describe, expect, it } from "vitest";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -18,12 +15,6 @@ const RATCHET_MODULES = [
   "threshold-ratchet-families.mjs",
   "threshold-ratchet-compare.mjs",
 ];
-const TEMPLATE_SCRIPT_DIRS = [
-  "typescript/copy-overwrite/scripts",
-  "rails/copy-overwrite/scripts",
-];
-const ENTRY_TEMPLATE_NAME = "check-threshold-ratchet.mjs";
-
 const STRYKER_FILE = "stryker.conf.json";
 const K6_FILE = ".github/k6/thresholds/normal.json";
 const LISA_CONFIG_FILE = ".lisa.config.json";
@@ -42,15 +33,6 @@ interface Finding {
   readonly key: string;
   readonly type: string;
   readonly message: string;
-}
-
-/**
- * Read a repo-relative text file.
- * @param relativePath - Repo-relative path
- * @returns File contents
- */
-function read(relativePath: string): string {
-  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
 }
 
 describe("threshold-ratchet tiers 2 and 3", () => {
@@ -157,6 +139,42 @@ describe("threshold-ratchet tiers 2 and 3", () => {
       const findings = compareFile(K6_FILE, base, current);
       expect(findings).toHaveLength(1);
       expect(findings[0].key).toBe("http_req_failed.abortOnFail");
+    });
+
+    it("blocks removing an explicit abortOnFail entirely", () => {
+      const current = JSON.stringify({
+        thresholds: {
+          http_req_failed: { threshold: RATE_UPPER },
+          http_req_duration: { threshold: P95_BOUND },
+          checks: { threshold: RATE_LOWER },
+        },
+      });
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].key).toBe("http_req_failed.abortOnFail");
+    });
+
+    it("handles long-format arrays without crashing and per item", () => {
+      const arrayBase = JSON.stringify({
+        thresholds: {
+          http_req_duration: [
+            "p(99)<2000",
+            { threshold: P95_BOUND, abortOnFail: true },
+          ],
+        },
+      });
+      const weakened = JSON.stringify({
+        thresholds: {
+          http_req_duration: [
+            "p(99)<2000",
+            { threshold: P95_BOUND, abortOnFail: false },
+          ],
+        },
+      });
+      expect(compareFile(K6_FILE, arrayBase, arrayBase)).toHaveLength(0);
+      const findings = compareFile(K6_FILE, arrayBase, weakened);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].key).toBe("http_req_duration.abortOnFail[1]");
     });
 
     it("blocks deleting a gated metric", () => {
@@ -275,65 +293,5 @@ describe("threshold-ratchet tiers 2 and 3", () => {
       ).toEqual([{ file: "a.json", key: "x" }]);
       expect(extractAllowEntries(undefined)).toEqual([]);
     });
-  });
-});
-
-describe("threshold-ratchet wiring", () => {
-  it("template copies are byte-identical to the canonical modules", () => {
-    for (const dir of TEMPLATE_SCRIPT_DIRS) {
-      expect(
-        read(`${dir}/${ENTRY_TEMPLATE_NAME}`),
-        `${dir}/${ENTRY_TEMPLATE_NAME}`
-      ).toBe(read(`${HOOKS_REL}/threshold-ratchet.mjs`));
-      for (const module of RATCHET_MODULES) {
-        expect(read(`${dir}/${module}`), `${dir}/${module}`).toBe(
-          read(`${HOOKS_REL}/${module}`)
-        );
-      }
-    }
-  });
-
-  it("registers the PostToolUse hook in the base plugin manifest", () => {
-    const manifest = JSON.parse(
-      read("plugins/src/base/.claude-plugin/plugin.json")
-    );
-    const postToolUse: Array<{
-      matcher?: string;
-      hooks: Array<{ command: string }>;
-    }> = manifest.hooks.PostToolUse;
-    const entry = postToolUse.find(e =>
-      e.hooks.some(h => h.command.includes("threshold-ratchet.sh"))
-    );
-    expect(entry).toBeDefined();
-    expect(entry?.matcher).toBe("Edit|Write|NotebookEdit|Bash");
-  });
-
-  it("wires the husky pre-commit backstop", () => {
-    const preCommit = read("typescript/copy-contents/.husky/pre-commit");
-    expect(preCommit).toContain(ENTRY_TEMPLATE_NAME);
-    expect(preCommit).toContain("--staged");
-  });
-
-  it("wires the rails lefthook backstop", () => {
-    const lefthook = read("rails/copy-overwrite/lefthook.yml");
-    expect(lefthook).toContain(ENTRY_TEMPLATE_NAME);
-    expect(lefthook).toContain("--staged");
-  });
-
-  it("wires the CI gate into both reusable quality workflows", () => {
-    for (const workflow of [
-      ".github/workflows/quality.yml",
-      ".github/workflows/quality-rails.yml",
-    ]) {
-      const text = read(workflow);
-      expect(text, workflow).toContain("threshold_ratchet:");
-      expect(text, workflow).toContain(`${ENTRY_TEMPLATE_NAME} --base`);
-    }
-  });
-
-  it("ships the hook wrapper alongside the comparator in the base plugin", () => {
-    expect(
-      fs.existsSync(path.join(REPO_ROOT, HOOKS_REL, "threshold-ratchet.sh"))
-    ).toBe(true);
   });
 });

--- a/tests/unit/scripts/threshold-ratchet-wiring.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-wiring.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the threshold ratchet's enforcement-layer wiring: the plugin
+ * hook manifest registration, husky/lefthook pre-commit backstops, the CI
+ * gate in both reusable quality workflows, and byte-identical parity
+ * between the canonical modules and their stack-template copies.
+ * Comparator behavior lives in threshold-ratchet.test.ts (Tier 1) and
+ * threshold-ratchet-gates.test.ts (Tiers 2/3).
+ */
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HOOKS_REL = "plugins/src/base/hooks";
+const RATCHET_MODULES = [
+  "threshold-ratchet-families.mjs",
+  "threshold-ratchet-compare.mjs",
+];
+const TEMPLATE_SCRIPT_DIRS = [
+  "typescript/copy-overwrite/scripts",
+  "rails/copy-overwrite/scripts",
+];
+const ENTRY_TEMPLATE_NAME = "check-threshold-ratchet.mjs";
+
+/**
+ * Read a repo-relative text file.
+ * @param relativePath - Repo-relative path
+ * @returns File contents
+ */
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+describe("threshold-ratchet wiring", () => {
+  it("template copies are byte-identical to the canonical modules", () => {
+    for (const dir of TEMPLATE_SCRIPT_DIRS) {
+      expect(
+        read(`${dir}/${ENTRY_TEMPLATE_NAME}`),
+        `${dir}/${ENTRY_TEMPLATE_NAME}`
+      ).toBe(read(`${HOOKS_REL}/threshold-ratchet.mjs`));
+      for (const module of RATCHET_MODULES) {
+        expect(read(`${dir}/${module}`), `${dir}/${module}`).toBe(
+          read(`${HOOKS_REL}/${module}`)
+        );
+      }
+    }
+  });
+
+  it("registers the PostToolUse hook in the base plugin manifest", () => {
+    const manifest = JSON.parse(
+      read("plugins/src/base/.claude-plugin/plugin.json")
+    );
+    const postToolUse: Array<{
+      matcher?: string;
+      hooks: Array<{ command: string }>;
+    }> = manifest.hooks.PostToolUse;
+    const entry = postToolUse.find(e =>
+      e.hooks.some(h => h.command.includes("threshold-ratchet.sh"))
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.matcher).toBe("Edit|Write|NotebookEdit|Bash");
+  });
+
+  it("wires the husky pre-commit backstop", () => {
+    const preCommit = read("typescript/copy-contents/.husky/pre-commit");
+    expect(preCommit).toContain(ENTRY_TEMPLATE_NAME);
+    expect(preCommit).toContain("--staged");
+  });
+
+  it("wires the rails lefthook backstop", () => {
+    const lefthook = read("rails/copy-overwrite/lefthook.yml");
+    expect(lefthook).toContain(ENTRY_TEMPLATE_NAME);
+    expect(lefthook).toContain("--staged");
+  });
+
+  it("wires the CI gate into both reusable quality workflows", () => {
+    for (const workflow of [
+      ".github/workflows/quality.yml",
+      ".github/workflows/quality-rails.yml",
+    ]) {
+      const text = read(workflow);
+      expect(text, workflow).toContain("threshold_ratchet:");
+      expect(text, workflow).toContain(`${ENTRY_TEMPLATE_NAME} --base`);
+    }
+  });
+
+  it("ships the hook wrapper alongside the comparator in the base plugin", () => {
+    expect(
+      fs.existsSync(path.join(REPO_ROOT, HOOKS_REL, "threshold-ratchet.sh"))
+    ).toBe(true);
+  });
+});

--- a/tests/unit/scripts/threshold-ratchet.test.ts
+++ b/tests/unit/scripts/threshold-ratchet.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the threshold ratchet comparator, Tier 1: the designed tunable
+ * files. Coverage/e2e minimums may only rise; eslint/rubocop maximums may
+ * only fall; removals and file deletions are conservative weakenings.
+ * Tier 2/3 families and enforcement-layer wiring are covered in
+ * threshold-ratchet-gates.test.ts.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const FAMILIES_REL = "plugins/src/base/hooks/threshold-ratchet-families.mjs";
+const COMPARE_REL = "plugins/src/base/hooks/threshold-ratchet-compare.mjs";
+
+const VITEST_FILE = "vitest.thresholds.json";
+const ESLINT_FILE = "eslint.thresholds.json";
+const RUBOCOP_FILE = "rubocop.thresholds.yml";
+const E2E_FILE = "e2e.thresholds.json";
+const KEY_LINES = "global.lines";
+const METHOD_LENGTH_SECTION = "Metrics/MethodLength:";
+const ABC_SIZE_SECTION = "Metrics/AbcSize:";
+const MAX_20 = "  Max: 20";
+
+/** One reported ratchet violation. */
+interface Finding {
+  readonly file: string;
+  readonly key: string;
+  readonly type: string;
+  readonly message: string;
+}
+
+describe("threshold-ratchet tier 1", () => {
+  let familyFor: (relPath: string) => { id: string } | undefined;
+  let compareFile: (
+    relPath: string,
+    baselineText: string | null,
+    currentText: string | null
+  ) => Finding[];
+  let formatReport: (findings: Finding[]) => string;
+
+  beforeAll(async () => {
+    const families = await import(
+      pathToFileURL(path.join(REPO_ROOT, FAMILIES_REL)).href
+    );
+    const compare = await import(
+      pathToFileURL(path.join(REPO_ROOT, COMPARE_REL)).href
+    );
+    familyFor = families.familyFor;
+    compareFile = compare.compareFile;
+    formatReport = compare.formatReport;
+  });
+
+  describe("familyFor", () => {
+    it("watches every Tier 1/2/3 family", () => {
+      expect(familyFor(VITEST_FILE)?.id).toBe("coverage");
+      expect(familyFor("packages/api/jest.thresholds.json")?.id).toBe(
+        "coverage"
+      );
+      expect(familyFor(E2E_FILE)?.id).toBe("e2e");
+      expect(familyFor(ESLINT_FILE)?.id).toBe("eslint");
+      expect(familyFor("simplecov.thresholds.json")?.id).toBe("simplecov");
+      expect(familyFor(RUBOCOP_FILE)?.id).toBe("rubocop");
+      expect(familyFor("stryker.conf.json")?.id).toBe("stryker");
+      expect(familyFor(".github/k6/thresholds/normal.json")?.id).toBe("k6");
+      expect(familyFor("audit.ignore.local.json")?.id).toBe("audit-ignore");
+      expect(familyFor(".lisa.config.json")?.id).toBe("lisa-config");
+    });
+
+    it("ignores unrelated files", () => {
+      expect(familyFor("package.json")).toBeUndefined();
+      expect(familyFor("src/thresholds.json.ts")).toBeUndefined();
+      expect(familyFor("docs/e2e.thresholds.json.md")).toBeUndefined();
+    });
+  });
+
+  describe("coverage minimums (vitest/jest/simplecov/e2e)", () => {
+    const base = JSON.stringify({ global: { lines: 70, branches: 70 } });
+
+    it("blocks lowering a minimum", () => {
+      const current = JSON.stringify({ global: { lines: 50, branches: 70 } });
+      const findings = compareFile(VITEST_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({ key: KEY_LINES, type: "weakened" });
+    });
+
+    it("allows raising and keeping minimums", () => {
+      const current = JSON.stringify({ global: { lines: 80, branches: 70 } });
+      expect(compareFile("jest.thresholds.json", base, current)).toHaveLength(
+        0
+      );
+    });
+
+    it("blocks removing a tuned key", () => {
+      const current = JSON.stringify({ global: { lines: 70 } });
+      const findings = compareFile(VITEST_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("removed");
+    });
+
+    it("allows adding a new key", () => {
+      const current = JSON.stringify({
+        global: { lines: 70, branches: 70, functions: 60 },
+      });
+      expect(compareFile(VITEST_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("ignores underscore-prefixed documentation keys", () => {
+      const withComment = JSON.stringify({
+        _comment: "docs",
+        playwright: { routes: 80 },
+      });
+      const changedComment = JSON.stringify({
+        _comment: "different docs",
+        playwright: { routes: 80 },
+      });
+      expect(compareFile(E2E_FILE, withComment, changedComment)).toHaveLength(
+        0
+      );
+    });
+
+    it("blocks deleting the whole file", () => {
+      const findings = compareFile(VITEST_FILE, base, null);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("file-deleted");
+    });
+
+    it("allows a brand-new file", () => {
+      expect(compareFile(VITEST_FILE, null, base)).toHaveLength(0);
+    });
+
+    it("blocks replacing the file with invalid JSON", () => {
+      const findings = compareFile(VITEST_FILE, base, "{oops");
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("unparseable");
+    });
+  });
+
+  describe("complexity maximums (eslint/rubocop)", () => {
+    it("blocks raising an eslint maximum", () => {
+      const base = JSON.stringify({ maxLines: 300, cognitiveComplexity: 10 });
+      const current = JSON.stringify({
+        maxLines: 500,
+        cognitiveComplexity: 10,
+      });
+      const findings = compareFile(ESLINT_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({ key: "maxLines", type: "weakened" });
+    });
+
+    it("allows lowering an eslint maximum (tightening)", () => {
+      const base = JSON.stringify({ maxLines: 300 });
+      const current = JSON.stringify({ maxLines: 200 });
+      expect(compareFile(ESLINT_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("blocks raising a rubocop Metrics maximum", () => {
+      const base = [
+        "# comment",
+        METHOD_LENGTH_SECTION,
+        MAX_20,
+        "",
+        ABC_SIZE_SECTION,
+        "  Max: 25",
+      ].join("\n");
+      const current = base.replace("Max: 20", "Max: 40");
+      const findings = compareFile(RUBOCOP_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        key: "Metrics/MethodLength.Max",
+        type: "weakened",
+      });
+    });
+
+    it("allows the nightly tightening of a rubocop maximum", () => {
+      const base = [METHOD_LENGTH_SECTION, MAX_20].join("\n");
+      const current = [METHOD_LENGTH_SECTION, "  Max: 15"].join("\n");
+      expect(compareFile(RUBOCOP_FILE, base, current)).toHaveLength(0);
+    });
+
+    it("tolerates trailing comments on rubocop scalar lines", () => {
+      const base = [ABC_SIZE_SECTION, "  Max: 25 # tuned"].join("\n");
+      const current = [ABC_SIZE_SECTION, "  Max: 30"].join("\n");
+      const findings = compareFile(RUBOCOP_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].key).toBe("Metrics/AbcSize.Max");
+    });
+  });
+
+  describe("report", () => {
+    it("explains the ratchet in operator-readable language", () => {
+      const findings = compareFile(
+        VITEST_FILE,
+        JSON.stringify({ global: { lines: 70 } }),
+        JSON.stringify({ global: { lines: 50 } })
+      );
+      const report = formatReport(findings);
+      expect(report).toContain("one-way ratchet");
+      expect(report).toContain("70 → 50");
+      expect(report).toContain("thresholdRatchet.allow");
+    });
+  });
+});

--- a/tests/unit/scripts/threshold-ratchet.test.ts
+++ b/tests/unit/scripts/threshold-ratchet.test.ts
@@ -185,6 +185,17 @@ describe("threshold-ratchet tier 1", () => {
       expect(findings).toHaveLength(1);
       expect(findings[0].key).toBe("Metrics/AbcSize.Max");
     });
+
+    it("skips empty-value rubocop lines instead of reading them as 0", () => {
+      const base = [
+        METHOD_LENGTH_SECTION,
+        MAX_20,
+        "  Exclude:",
+        "    - 'db/**/*'",
+      ].join("\n");
+      const current = [METHOD_LENGTH_SECTION, MAX_20].join("\n");
+      expect(compareFile(RUBOCOP_FILE, base, current)).toHaveLength(0);
+    });
   });
 
   describe("report", () => {

--- a/typescript/copy-contents/.husky/pre-commit
+++ b/typescript/copy-contents/.husky/pre-commit
@@ -102,6 +102,23 @@ fi
 #   exit 1
 # fi
 
+# Threshold ratchet: quality thresholds may tighten, never weaken. The staged
+# change is compared against HEAD by the same deterministic comparator the
+# agent-time hooks and CI run; human-approved exceptions live in
+# .lisa.config.json under thresholdRatchet.allow.
+if [ -f "scripts/check-threshold-ratchet.mjs" ] && command -v node >/dev/null 2>&1; then
+  echo "📐 Checking threshold ratchet..."
+  node scripts/check-threshold-ratchet.mjs --staged
+  if [ $? -ne 0 ]; then
+    echo ""
+    echo "❌ A quality threshold was weakened. Thresholds may only tighten."
+    echo "   Fix the code to meet the current gate, or ask a human to record a"
+    echo "   documented exception in .lisa.config.json (thresholdRatchet.allow)."
+    echo ""
+    exit 1
+  fi
+fi
+
 # Run type check on entire project (can't be done incrementally)
 echo "🔍 Running type check..."
 $RUNNER typecheck

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Threshold ratchet gate — quality thresholds may tighten, never weaken.
+ *
+ * Deterministic comparator shared by three enforcement layers:
+ *   1. Agent-time soft block: PostToolUse hook via threshold-ratchet.sh
+ *      (`--hook`, exit 2 on weakening so the agent gets actionable feedback).
+ *   2. Pre-commit backstop: husky / lefthook (`--staged`, exit 1).
+ *   3. CI gate: reusable quality workflows (`--base <ref>`, exit 1),
+ *      comparing against the merge-base so nothing weakened lands in a PR.
+ *
+ * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
+ * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
+ * break score and k6 expression bounds. Tier 3 — exemption additions
+ * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
+ * entries) which weaken a gate without touching a number.
+ *
+ * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
+ * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /
+ * merge-base), never from the change under review — an agent cannot grant
+ * itself an exception in the same change that weakens a gate. `key: "*"`
+ * allows every key in the file.
+ *
+ * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
+ * threshold-ratchet-compare.mjs. Zero dependencies.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractAllowEntries,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+import {
+  applyAllowList,
+  compareFile,
+  formatReport,
+} from "./threshold-ratchet-compare.mjs";
+
+/**
+ * Standard git locations, checked in order so the executable comes from a
+ * fixed, unwriteable directory rather than a PATH lookup. The bare "git"
+ * fallback keeps unusual layouts (e.g. Windows git-bash) working.
+ */
+const GIT_LOCATIONS = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+];
+const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
+
+/** Git flag shared by every changed-file listing. */
+const NAME_ONLY = "--name-only";
+
+/**
+ * Run git, returning stdout or null on any failure.
+ * @param {string[]} args Git arguments
+ * @param {string} [cwd] Working directory
+ * @returns {string | null} Captured stdout, or null when git failed
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync(GIT, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve mode-specific candidate files and content readers.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} root Repo root
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string[] | undefined} onlyFiles Restrict to these repo-relative
+ *   paths (hook mode with a known edited file)
+ * @returns {{ files: string[], baselineRef: string, readCurrent: (f: string) => string | null } | null}
+ *   The comparison plan, or null when git state can't support the mode
+ */
+function resolvePlan(mode, root, baseRef, onlyFiles) {
+  if (mode === "staged") {
+    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: "HEAD",
+      readCurrent: f => git(["show", `:${f}`], root),
+    };
+  }
+  if (mode === "base") {
+    if (!baseRef) return null;
+    const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
+    if (!mergeBase) return null;
+    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    if (diff === null) return null;
+    return {
+      files: diff.split("\n").filter(Boolean),
+      baselineRef: mergeBase,
+      readCurrent: f => git(["show", `HEAD:${f}`], root),
+    };
+  }
+  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  if (diff === null) return null;
+  return {
+    files: onlyFiles ?? diff.split("\n").filter(Boolean),
+    baselineRef: "HEAD",
+    readCurrent: f => {
+      try {
+        return fs.readFileSync(path.join(root, f), "utf-8");
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Run the ratchet for a mode, print the report, and return the exit code.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} [baseRef] Base ref (base mode only)
+ * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
+ */
+function run(mode, baseRef, onlyFiles) {
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const plan = resolvePlan(mode, root, baseRef, onlyFiles);
+  if (!plan) return 0;
+
+  const watched = plan.files.filter(f => familyFor(f));
+  if (watched.length === 0) return 0;
+
+  const findings = watched.flatMap(f =>
+    compareFile(
+      f,
+      git(["show", `${plan.baselineRef}:${f}`], root),
+      plan.readCurrent(f)
+    )
+  );
+  if (findings.length === 0) return 0;
+
+  const baselineConfig = parseJson(
+    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  );
+  const { blocked, allowed } = applyAllowList(
+    findings,
+    extractAllowEntries(baselineConfig)
+  );
+  for (const finding of allowed) {
+    process.stdout.write(
+      `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
+    );
+  }
+  if (blocked.length === 0) return 0;
+  process.stderr.write(`${formatReport(blocked)}\n`);
+  return mode === "hook" ? 2 : 1;
+}
+
+/**
+ * Handle `--hook` mode: parse the tool-use event from stdin and scope the
+ * check to the edited file (Edit/Write/NotebookEdit) or every changed
+ * watched file (Bash).
+ * @returns {number} Process exit code
+ */
+function runHookMode() {
+  const state = { stdin: "" };
+  try {
+    state.stdin = fs.readFileSync(0, "utf-8");
+  } catch {
+    return 0;
+  }
+  const input = parseJson(state.stdin);
+  if (!input || typeof input !== "object") return 0;
+  if (input.tool_name === "Bash") return run("hook");
+  if (!["Edit", "Write", "NotebookEdit"].includes(input.tool_name)) return 0;
+  const filePath = input.tool_input?.file_path;
+  if (typeof filePath !== "string") return 0;
+  const root = git(["rev-parse", "--show-toplevel"])?.trim();
+  if (!root) return 0;
+  const rel = path
+    .relative(root, path.resolve(filePath))
+    .split(path.sep)
+    .join("/");
+  if (rel.startsWith("..") || !familyFor(rel)) return 0;
+  return run("hook", undefined, [rel]);
+}
+
+/**
+ * CLI entrypoint.
+ * @returns {number} Process exit code
+ */
+function main() {
+  const args = process.argv.slice(2);
+  if (args[0] === "--staged") return run("staged");
+  if (args[0] === "--base") return run("base", args[1]);
+  if (args[0] === "--hook") return runHookMode();
+  process.stderr.write(
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  process.exit(main());
+}

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -1,0 +1,313 @@
+/**
+ * Threshold ratchet — comparison rules and reporting.
+ *
+ * Pure comparison layer: given a watched file's baseline and current
+ * contents, report every weakening. No filesystem or git access. See
+ * threshold-ratchet-families.mjs for extraction and threshold-ratchet.mjs
+ * for the CLI.
+ */
+import {
+  extractAllowEntries,
+  extractExemptionEntries,
+  extractK6Constraints,
+  extractNumericLeaves,
+  extractRubocopThresholds,
+  extractStrykerConstraints,
+  extractStrykerMutate,
+  familyFor,
+  parseJson,
+} from "./threshold-ratchet-families.mjs";
+
+/** Finding type: a numeric bound or boolean gate moved the weakening way. */
+const TYPE_WEAKENED = "weakened";
+/** Finding type: an exemption entry was added (Tier 3). */
+const TYPE_EXEMPTION_ADDED = "exemption-added";
+/** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
+const KIND_ALLOW_LIST = "allow-list";
+
+/**
+ * @typedef {object} Finding
+ * @property {string} file Repo-relative path of the gate file
+ * @property {string} key Dotted key path within the file
+ * @property {"weakened"|"removed"|"exemption-added"|"file-deleted"|"allow-added"|"unparseable"} type
+ *   Which ratchet rule the change violated
+ * @property {number|string} [base] Baseline value
+ * @property {number|string} [current] Current value
+ * @property {string} message Operator-readable explanation
+ */
+
+/**
+ * Build the "file could not be parsed" finding.
+ * @param {string} relPath Repo-relative path
+ * @returns {Finding} The unparseable-file finding
+ */
+function unparseable(relPath) {
+  return {
+    file: relPath,
+    key: "*",
+    type: "unparseable",
+    message: `${relPath} is no longer valid JSON — a broken gate file disables the gate.`,
+  };
+}
+
+/**
+ * Compare two constraint maps: report removals and direction violations.
+ * @param {string} relPath Repo-relative path the constraints came from
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} base
+ *   Baseline constraints
+ * @param {Map<string, { value: number, direction: "min"|"max" }>} current
+ *   Current constraints
+ * @returns {Finding[]} One finding per removed or weakened constraint
+ */
+export function compareConstraints(relPath, base, current) {
+  const findings = [];
+  for (const [key, baseC] of base) {
+    const currentC = current.get(key);
+    if (!currentC) {
+      findings.push({
+        file: relPath,
+        key,
+        type: "removed",
+        base: baseC.value,
+        message: `${relPath}: ${key} was removed — the tuned floor would silently fall back to a default.`,
+      });
+      continue;
+    }
+    const weakened =
+      baseC.direction === "min"
+        ? currentC.value < baseC.value
+        : currentC.value > baseC.value;
+    if (weakened) {
+      const verb =
+        baseC.direction === "min" ? "may only increase" : "may only decrease";
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed ${baseC.value} → ${currentC.value} (this value ${verb}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a stryker.conf.json pair: the break threshold plus mutate-list
+ * exemptions (new negations or removed targets shrink the gate).
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} Break-threshold and mutate-scope findings
+ */
+function compareStryker(relPath, base, current) {
+  const findings = compareConstraints(
+    relPath,
+    extractStrykerConstraints(base),
+    extractStrykerConstraints(current)
+  );
+  const baseMutate = extractStrykerMutate(base);
+  const currentMutate = extractStrykerMutate(current);
+  for (const negation of currentMutate.negations) {
+    if (!baseMutate.negations.has(negation)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${negation}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new mutation-testing exclusion "${negation}" — excluding files from a gate is a weakening.`,
+      });
+    }
+  }
+  for (const positive of baseMutate.positives) {
+    if (!currentMutate.positives.has(positive)) {
+      findings.push({
+        file: relPath,
+        key: `mutate ${positive}`,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: mutation-testing target "${positive}" was removed — shrinking a gate's coverage is a weakening.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare a k6 thresholds pair: numeric bounds plus abortOnFail downgrades.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline thresholds
+ * @param {unknown} current Parsed current thresholds
+ * @returns {Finding[]} Bound and abortOnFail findings
+ */
+function compareK6(relPath, base, current) {
+  const baseC = extractK6Constraints(base);
+  const currentC = extractK6Constraints(current);
+  const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
+  for (const [key, wasOn] of baseC.booleans) {
+    if (wasOn && currentC.booleans.get(key) === false) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: "true",
+        current: "false",
+        message: `${relPath}: ${key} turned off — the gate no longer stops the run on failure.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare an exemption-list pair (audit ignore files): report added entries.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline list
+ * @param {unknown} current Parsed current list
+ * @returns {Finding[]} One finding per newly added ignore entry
+ */
+function compareExemptions(relPath, base, current) {
+  const baseEntries = extractExemptionEntries(base);
+  const findings = [];
+  for (const entry of extractExemptionEntries(current)) {
+    if (!baseEntries.has(entry)) {
+      findings.push({
+        file: relPath,
+        key: entry,
+        type: TYPE_EXEMPTION_ADDED,
+        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare .lisa.config.json allow lists: report added exception entries so a
+ * change can never grant itself an exception.
+ * @param {string} relPath Repo-relative path
+ * @param {unknown} base Parsed baseline config
+ * @param {unknown} current Parsed current config
+ * @returns {Finding[]} One finding per newly added allow entry
+ */
+function compareAllowList(relPath, base, current) {
+  const baseKeys = new Set(
+    extractAllowEntries(base).map(e => `${e.file} ${e.key}`)
+  );
+  const findings = [];
+  for (const entry of extractAllowEntries(current)) {
+    if (!baseKeys.has(`${entry.file} ${entry.key}`)) {
+      findings.push({
+        file: relPath,
+        key: `thresholdRatchet.allow ${entry.file}#${entry.key}`,
+        type: "allow-added",
+        message: `${relPath}: new threshold exception for ${entry.file} → ${entry.key}. Exceptions are a human decision: land this entry in its own human-approved change first, then make the threshold change.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare one watched file's baseline and current contents and report every
+ * weakening. Pure: no filesystem or git access.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @param {string | null} baselineText Baseline contents (null = file is new)
+ * @param {string | null} currentText Current contents (null = file deleted)
+ * @returns {Finding[]} Every ratchet violation in the change (empty = clean)
+ */
+export function compareFile(relPath, baselineText, currentText) {
+  const family = familyFor(relPath);
+  if (!family || baselineText === null || baselineText === undefined) return [];
+
+  if (currentText === null || currentText === undefined) {
+    if (family.kind === KIND_ALLOW_LIST) return [];
+    return [
+      {
+        file: relPath,
+        key: "*",
+        type: "file-deleted",
+        message: `${relPath} was deleted — deleting a quality gate is a weakening.`,
+      },
+    ];
+  }
+
+  if (family.kind === "rubocop-yaml") {
+    return compareConstraints(
+      relPath,
+      extractRubocopThresholds(baselineText, family.direction),
+      extractRubocopThresholds(currentText, family.direction)
+    );
+  }
+
+  const base = parseJson(baselineText);
+  const current = parseJson(currentText);
+  if (base === undefined) return [];
+  if (current === undefined) {
+    return family.kind === KIND_ALLOW_LIST ? [] : [unparseable(relPath)];
+  }
+  switch (family.kind) {
+    case "json-num":
+      return compareConstraints(
+        relPath,
+        extractNumericLeaves(base, family.direction),
+        extractNumericLeaves(current, family.direction)
+      );
+    case "stryker":
+      return compareStryker(relPath, base, current);
+    case "k6":
+      return compareK6(relPath, base, current);
+    case "exemption-list":
+      return compareExemptions(relPath, base, current);
+    case KIND_ALLOW_LIST:
+      return compareAllowList(relPath, base, current);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Drop findings covered by baseline-side allow entries. `allow-added`
+ * findings are never dropped — an exception cannot approve its own creation.
+ * @param {Finding[]} findings All findings from the change
+ * @param {Array<{ file: string, key: string }>} allowEntries Baseline
+ *   (already-merged) allow list
+ * @returns {{ blocked: Finding[], allowed: Finding[] }} Findings that still
+ *   block vs. findings covered by a recorded exception
+ */
+export function applyAllowList(findings, allowEntries) {
+  const blocked = [];
+  const allowed = [];
+  for (const finding of findings) {
+    const isAllowed =
+      finding.type !== "allow-added" &&
+      allowEntries.some(
+        e =>
+          (finding.file === e.file || finding.file.endsWith(`/${e.file}`)) &&
+          (e.key === "*" || e.key === finding.key)
+      );
+    if (isAllowed) allowed.push(finding);
+    else blocked.push(finding);
+  }
+  return { blocked, allowed };
+}
+
+/**
+ * Render the operator-facing block message.
+ * @param {Finding[]} findings Blocked findings
+ * @returns {string} Multi-line report explaining what weakened and the
+ *   human-approved exception path
+ */
+export function formatReport(findings) {
+  return [
+    "⛔ Quality gate weakened — blocked by the threshold ratchet.",
+    "",
+    ...findings.map(f => `  • ${f.message}`),
+    "",
+    "Quality thresholds are a one-way ratchet: they may tighten but never",
+    "loosen. Fix the code so it meets the current gate instead of lowering the",
+    "gate. If a human decides an exception is genuinely correct, they record it",
+    "in .lisa.config.json under thresholdRatchet.allow (with a reason) in a",
+    "separate human-approved change; this check honors exceptions only after",
+    "they are merged.",
+  ].join("\n");
+}

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -144,7 +144,9 @@ function compareK6(relPath, base, current) {
   const currentC = extractK6Constraints(current);
   const findings = compareConstraints(relPath, baseC.numeric, currentC.numeric);
   for (const [key, wasOn] of baseC.booleans) {
-    if (wasOn && currentC.booleans.get(key) === false) {
+    // k6 defaults abortOnFail to false, so DELETING an explicit `true` is as
+    // much a weakening as flipping it — anything but a current `true` blocks.
+    if (wasOn && currentC.booleans.get(key) !== true) {
       findings.push({
         file: relPath,
         key,

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -1,0 +1,285 @@
+/**
+ * Threshold ratchet — watched file families and value extractors.
+ *
+ * Pure extraction layer: given file contents, produce comparable constraint
+ * maps. No filesystem or git access. See threshold-ratchet.mjs for the CLI
+ * and threshold-ratchet-compare.mjs for the comparison rules.
+ */
+
+/**
+ * File families the ratchet watches. `kind` selects the extractor;
+ * `direction` applies to numeric-leaf kinds ("min" values may only rise,
+ * "max" values may only fall).
+ */
+export const FAMILIES = [
+  {
+    id: "coverage",
+    match: /(^|\/)(vitest|jest)\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "simplecov",
+    match: /(^|\/)simplecov\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "e2e",
+    match: /(^|\/)e2e\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "min",
+  },
+  {
+    id: "eslint",
+    match: /(^|\/)eslint\.thresholds\.json$/,
+    kind: "json-num",
+    direction: "max",
+  },
+  {
+    id: "rubocop",
+    match: /(^|\/)rubocop\.thresholds\.yml$/,
+    kind: "rubocop-yaml",
+    direction: "max",
+  },
+  { id: "stryker", match: /(^|\/)stryker\.conf\.json$/, kind: "stryker" },
+  {
+    id: "k6",
+    match: /(^|\/)\.github\/k6\/thresholds\/[^/]+\.json$/,
+    kind: "k6",
+  },
+  {
+    id: "audit-ignore",
+    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
+    kind: "exemption-list",
+  },
+  {
+    id: "lisa-config",
+    match: /(^|\/)\.lisa\.config\.json$/,
+    kind: "allow-list",
+  },
+];
+
+/**
+ * Find the family a repo-relative path belongs to.
+ * @param {string} relPath Repo-relative path (forward slashes)
+ * @returns {(typeof FAMILIES)[number] | undefined} The matching family, or
+ *   undefined when the path is not a watched gate file
+ */
+export function familyFor(relPath) {
+  return FAMILIES.find(f => f.match.test(relPath));
+}
+
+/**
+ * Safe JSON parse.
+ * @param {string | null | undefined} text JSON text
+ * @returns {unknown | undefined} Parsed value, or undefined on failure
+ */
+export function parseJson(text) {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk a JSON object and collect numeric leaves as dotted-path constraints.
+ * Keys starting with "_" (e.g. `_comment`) are documentation, not thresholds.
+ * @param {unknown} node Parsed JSON value
+ * @param {"min"|"max"} direction Ratchet direction for every leaf
+ * @param {string} [prefix] Dotted path accumulated so far
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   path → numeric constraint for every finite numeric leaf
+ */
+export function extractNumericLeaves(node, direction, prefix = "") {
+  const out = new Map();
+  if (node === null || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith("_")) continue;
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out.set(p, { value, direction });
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [cp, c] of extractNumericLeaves(value, direction, p)) {
+        out.set(cp, c);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Minimal parser for rubocop.thresholds.yml — a two-level document of
+ * `Section:` headers with indented `Key: <number>` scalars (comments and
+ * blank lines ignored). Deliberately NOT a general YAML parser: the file is
+ * Lisa-authored with this exact shape, and hand-parsing keeps the gate
+ * dependency-free with no backtracking-prone regexes.
+ * @param {string} text File contents
+ * @param {"min"|"max"} direction Ratchet direction for every scalar
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} Dotted
+ *   `Section.Key` path → numeric constraint
+ */
+export function extractRubocopThresholds(text, direction) {
+  const out = new Map();
+  const state = { section: "" };
+  for (const rawLine of text.split("\n")) {
+    const hash = rawLine.indexOf("#");
+    const line = (hash >= 0 ? rawLine.slice(0, hash) : rawLine).trimEnd();
+    if (!line.trim()) continue;
+    const indented = line.startsWith(" ") || line.startsWith("\t");
+    if (!indented && line.endsWith(":")) {
+      state.section = line.slice(0, -1).trim();
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (!indented || colon < 0 || !state.section) continue;
+    const key = line.slice(0, colon).trim();
+    const value = Number(line.slice(colon + 1).trim());
+    if (key && Number.isFinite(value)) {
+      out.set(`${state.section}.${key}`, { value, direction });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the gating constraint from stryker.conf.json: only
+ * `thresholds.break` fails a run (`high`/`low` are reporting bands).
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {Map<string, { value: number, direction: "min"|"max" }>} The
+ *   `thresholds.break` constraint when present, otherwise an empty map
+ */
+export function extractStrykerConstraints(conf) {
+  const out = new Map();
+  const breakValue = conf?.thresholds?.break;
+  if (typeof breakValue === "number" && Number.isFinite(breakValue)) {
+    out.set("thresholds.break", { value: breakValue, direction: "min" });
+  }
+  return out;
+}
+
+/**
+ * Split a stryker `mutate` array into positive globs and negations.
+ * @param {unknown} conf Parsed stryker.conf.json
+ * @returns {{ positives: Set<string>, negations: Set<string> }} Globs that
+ *   include files vs. `!`-prefixed globs that exclude them
+ */
+export function extractStrykerMutate(conf) {
+  const positives = new Set();
+  const negations = new Set();
+  const mutate = Array.isArray(conf?.mutate) ? conf.mutate : [];
+  for (const glob of mutate) {
+    if (typeof glob !== "string") continue;
+    if (glob.startsWith("!")) negations.add(glob);
+    else positives.add(glob);
+  }
+  return { positives, negations };
+}
+
+/**
+ * Parse one k6 threshold expression (`p(95)<1000`, `rate>=0.99`, …) into a
+ * ratchet constraint. Upper bounds (`<`, `<=`) may only decrease; lower
+ * bounds (`>`, `>=`) may only increase. Hand-parsed — no regex.
+ * @param {string} expr Threshold expression
+ * @returns {{ value: number, direction: "min"|"max" } | undefined} The bound
+ *   as a constraint, or undefined when the expression has no numeric bound
+ */
+export function parseK6Expression(expr) {
+  for (const op of ["<=", ">=", "<", ">"]) {
+    const idx = expr.indexOf(op);
+    if (idx < 0) continue;
+    const value = Number(expr.slice(idx + op.length).trim());
+    if (!Number.isFinite(value)) return undefined;
+    return { value, direction: op.startsWith("<") ? "max" : "min" };
+  }
+  return undefined;
+}
+
+/**
+ * Extract constraints from a k6 thresholds file. Each metric contributes its
+ * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * @param {unknown} conf Parsed k6 thresholds JSON
+ * @returns {{
+ *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
+ *   booleans: Map<string, boolean>,
+ * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
+ *   keyed by `<metric>.abortOnFail`
+ */
+export function extractK6Constraints(conf) {
+  const numeric = new Map();
+  const booleans = new Map();
+  const thresholds = conf?.thresholds;
+  if (thresholds && typeof thresholds === "object") {
+    for (const [metric, spec] of Object.entries(thresholds)) {
+      const exprs =
+        typeof spec === "string"
+          ? [spec]
+          : Array.isArray(spec)
+            ? spec
+            : typeof spec?.threshold === "string"
+              ? [spec.threshold]
+              : [];
+      exprs.forEach((expr, i) => {
+        const c = parseK6Expression(expr);
+        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      });
+      if (
+        spec &&
+        typeof spec === "object" &&
+        !Array.isArray(spec) &&
+        typeof spec.abortOnFail === "boolean"
+      ) {
+        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
+      }
+    }
+  }
+  return { numeric, booleans };
+}
+
+/**
+ * Flatten an exemption file (audit ignore list) into a set of entry tokens.
+ * Arrays contribute their string items; objects contribute their keys.
+ * @param {unknown} conf Parsed JSON
+ * @returns {Set<string>} One token per exemption entry
+ */
+export function extractExemptionEntries(conf) {
+  const out = new Set();
+  if (Array.isArray(conf)) {
+    for (const item of conf) {
+      if (typeof item === "string") out.add(item);
+      else if (item && typeof item === "object") out.add(JSON.stringify(item));
+    }
+  } else if (conf && typeof conf === "object") {
+    for (const [key, value] of Object.entries(conf)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          out.add(
+            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
+          );
+        }
+      } else {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract thresholdRatchet.allow entries from parsed .lisa.config.json.
+ * @param {unknown} config Parsed config (may be undefined)
+ * @returns {Array<{ file: string, key: string, reason?: string }>} The
+ *   well-formed allow entries; malformed entries are dropped
+ */
+export function extractAllowEntries(config) {
+  const raw = config?.thresholdRatchet?.allow;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    e => e && typeof e.file === "string" && typeof e.key === "string"
+  );
+}

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -138,8 +138,11 @@ export function extractRubocopThresholds(text, direction) {
     const colon = line.indexOf(":");
     if (!indented || colon < 0 || !state.section) continue;
     const key = line.slice(0, colon).trim();
-    const value = Number(line.slice(colon + 1).trim());
-    if (key && Number.isFinite(value)) {
+    const rawValue = line.slice(colon + 1).trim();
+    // Number("") is 0, so an empty value (e.g. a nested `Exclude:` list
+    // header) must be skipped, not recorded as a zero threshold.
+    const value = Number(rawValue);
+    if (key && rawValue !== "" && Number.isFinite(value)) {
       out.set(`${state.section}.${key}`, { value, direction });
     }
   }
@@ -201,14 +204,16 @@ export function parseK6Expression(expr) {
 
 /**
  * Extract constraints from a k6 thresholds file. Each metric contributes its
- * expression bound plus (when present) an `abortOnFail` boolean constraint —
+ * expression bound(s) plus (when present) `abortOnFail` boolean constraints —
  * turning abortOnFail off makes the gate advisory, which is a weakening.
+ * Handles every documented k6 shape: a bare expression string, a single long
+ * form `{ threshold, abortOnFail }` object, and arrays mixing both.
  * @param {unknown} conf Parsed k6 thresholds JSON
  * @returns {{
  *   numeric: Map<string, { value: number, direction: "min"|"max" }>,
  *   booleans: Map<string, boolean>,
  * }} Numeric bounds keyed by `<metric>.threshold[i]` and abortOnFail flags
- *   keyed by `<metric>.abortOnFail`
+ *   keyed by `<metric>.abortOnFail` (`[i]`-suffixed for array items)
  */
 export function extractK6Constraints(conf) {
   const numeric = new Map();
@@ -216,26 +221,31 @@ export function extractK6Constraints(conf) {
   const thresholds = conf?.thresholds;
   if (thresholds && typeof thresholds === "object") {
     for (const [metric, spec] of Object.entries(thresholds)) {
-      const exprs =
-        typeof spec === "string"
-          ? [spec]
-          : Array.isArray(spec)
-            ? spec
-            : typeof spec?.threshold === "string"
-              ? [spec.threshold]
-              : [];
-      exprs.forEach((expr, i) => {
-        const c = parseK6Expression(expr);
-        if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+      const isArray = Array.isArray(spec);
+      const items = isArray ? spec : [spec];
+      items.forEach((item, i) => {
+        const expr =
+          typeof item === "string"
+            ? item
+            : item && typeof item === "object" && !Array.isArray(item)
+              ? item.threshold
+              : undefined;
+        if (typeof expr === "string") {
+          const c = parseK6Expression(expr);
+          if (c) numeric.set(`${metric}.threshold[${i}]`, c);
+        }
+        if (
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          typeof item.abortOnFail === "boolean"
+        ) {
+          booleans.set(
+            isArray ? `${metric}.abortOnFail[${i}]` : `${metric}.abortOnFail`,
+            item.abortOnFail
+          );
+        }
       });
-      if (
-        spec &&
-        typeof spec === "object" &&
-        !Array.isArray(spec) &&
-        typeof spec.abortOnFail === "boolean"
-      ) {
-        booleans.set(`${metric}.abortOnFail`, spec.abortOnFail);
-      }
     }
   }
   return { numeric, booleans };


### PR DESCRIPTION
## Summary

Implements the **threshold ratchet**: quality thresholds may tighten but never weaken — agents (Claude, Codex, Cursor, Copilot, humans with hooks installed) get a deterministic soft block when they try to lower a configured gate, with a human-approved exception path. No LLM judgment anywhere in the enforcement path.

### Three enforcement layers, one comparator

| Layer | Surface | Mode | On weakening |
|---|---|---|---|
| Agent-time | PostToolUse hook (`Edit\|Write\|NotebookEdit\|Bash`) in the base plugin, fanned out to Claude/Codex/Cursor/Copilot | `--hook` | exit 2 + operator-readable report |
| Pre-commit | husky (typescript family) / lefthook (rails) | `--staged` | commit blocked |
| CI | `threshold_ratchet` job in reusable `quality.yml` + `quality-rails.yml`, vs. PR merge-base | `--base <ref>` | check fails (non-bypassable layer) |

The comparator (`plugins/src/base/hooks/threshold-ratchet{,-families,-compare}.mjs`, zero dependencies) is synced byte-identically into `typescript/copy-overwrite/scripts/` and `rails/copy-overwrite/scripts/` by `build-plugins.sh`; a unit test asserts parity. agy is a documented gap (headless hooks don't fire) covered by layers 2–3.

### Watched families

- **Tier 1 minimums** (may only rise): `vitest.thresholds.json`, `jest.thresholds.json`, `simplecov.thresholds.json`, `e2e.thresholds.json`
- **Tier 1 maximums** (may only fall): `eslint.thresholds.json`, `rubocop.thresholds.yml`
- **Tier 2**: `stryker.conf.json` `thresholds.break` (reporting-only `high`/`low` ignored); `.github/k6/thresholds/*.json` expression bounds (direction inferred from operator) and `abortOnFail` downgrades
- **Tier 3 exemption additions** (weaken without touching a number): `audit.ignore.{config,local}.json` entries, stryker `mutate` exclusions/removed targets, and new `thresholdRatchet.allow` entries themselves
- Key removal and gate-file deletion are conservatively treated as weakenings

### Human override

`.lisa.config.json` → `thresholdRatchet.allow: [{file, key, reason}]` (`key: "*"` for the whole file). Honored **only from the baseline side** (HEAD / merge-base) — a change can never grant itself an exception; the allow entry must land in its own human-approved change first. The agent-time hook flags self-service allow additions.

## Verification

- 5,022 unit tests pass (39 new across two ratchet test files), lint 0 errors, typecheck clean, `check:plugins` in sync.
- End-to-end smoke in a throwaway repo: hook mode exit 2 (Bash + Edit inputs), `--staged` exit 1, `--base` exit 1 vs. merge-base, scoped allow entry on the base branch permits exactly its key and nothing else, raise-instead-of-lower exits 0 — all via the built plugin artifact.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added threshold-ratchet checks to pull requests, pre-commit workflows, and supported editor hooks.
  * Detects weakened quality, security, coverage, performance, and complexity thresholds across supported configurations.
  * Provides clear reports for blocked changes and supports documented baseline exceptions.
  * Added coverage for threshold enforcement, exception handling, hook integration, and template parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->