### PR TITLE
feat(learnings): MLD task-end telemetry — kind-tagged capture contract, never injected (LLG-3, #1732)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/plugins/lisa-copilot/rules/reference/intent-routing.md
+++ b/plugins/lisa-copilot/rules/reference/intent-routing.md
@@ -166,6 +166,8 @@ Determine the work type and execute the matching variant:
 3. Recommend next action (Research, Plan, Implement, or escalate)
 4. `learner` -- capture discoveries
 
+In every work type above, before a task completes -- immediately ahead of the closing `learner` step -- the implementing agent records concise kind-tagged MLD (Mistakes / Learnings / Desires) into that task's `metadata.learnings`: one line per item, empty is valid, never re-prompted or scored. See the `lisa-implement` skill for the full `{ kind, note, evidence? }` schema and routing (change the schema there, not here).
+
 Output: Code passing all quality gates + local empirical verification + codified regression test for each verification (except for spikes, which produce findings only, and non-behavioral verification types — PR / Documentation / Deploy — which carry their own proof).
 
 ### Verify

--- a/plugins/lisa-copilot/rules/reference/project-learnings.md
+++ b/plugins/lisa-copilot/rules/reference/project-learnings.md
@@ -57,6 +57,19 @@ Precedence:
 3. Project learnings add recent operational knowledge, but never rewrite or
    append to `PROJECT_RULES.md`.
 
+## Task telemetry (MLD) is not context
+
+Raw task-end MLD telemetry — the Mistakes / Learnings / Desires an implementing
+agent records into `metadata.learnings`, and the raw yield of debrief mining — is
+rung-1 capture only: it is never read into a later session's instruction surface,
+never required of an agent (empty is valid), and never graded or scored. It reaches
+a durable surface only indirectly — through the learner's validation into the
+ledger (which sessions still consume solely as the bounded projection above), and
+from there through the gardener's ticket-gated promotion a human approved. Injecting
+raw self-reports, or treating their volume as a quality signal, would reward
+plausible commentary over good outcomes and bypass the very budget and validation
+this contract exists to enforce.
+
 Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
 a bounded `AGENTS.md` bridge that points agy at this same file without copying
 learning bodies or restoring the retired full rules bake.

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/plugins/lisa-cursor/rules/intent-routing-reference.mdc
+++ b/plugins/lisa-cursor/rules/intent-routing-reference.mdc
@@ -171,6 +171,8 @@ Determine the work type and execute the matching variant:
 3. Recommend next action (Research, Plan, Implement, or escalate)
 4. `learner` -- capture discoveries
 
+In every work type above, before a task completes -- immediately ahead of the closing `learner` step -- the implementing agent records concise kind-tagged MLD (Mistakes / Learnings / Desires) into that task's `metadata.learnings`: one line per item, empty is valid, never re-prompted or scored. See the `lisa-implement` skill for the full `{ kind, note, evidence? }` schema and routing (change the schema there, not here).
+
 Output: Code passing all quality gates + local empirical verification + codified regression test for each verification (except for spikes, which produce findings only, and non-behavioral verification types — PR / Documentation / Deploy — which carry their own proof).
 
 ### Verify

--- a/plugins/lisa-cursor/rules/project-learnings-reference.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings-reference.mdc
@@ -62,6 +62,19 @@ Precedence:
 3. Project learnings add recent operational knowledge, but never rewrite or
    append to `PROJECT_RULES.md`.
 
+## Task telemetry (MLD) is not context
+
+Raw task-end MLD telemetry — the Mistakes / Learnings / Desires an implementing
+agent records into `metadata.learnings`, and the raw yield of debrief mining — is
+rung-1 capture only: it is never read into a later session's instruction surface,
+never required of an agent (empty is valid), and never graded or scored. It reaches
+a durable surface only indirectly — through the learner's validation into the
+ledger (which sessions still consume solely as the bounded projection above), and
+from there through the gardener's ticket-gated promotion a human approved. Injecting
+raw self-reports, or treating their volume as a quality signal, would reward
+plausible commentary over good outcomes and bypass the very budget and validation
+this contract exists to enforce.
+
 Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
 a bounded `AGENTS.md` bridge that points agy at this same file without copying
 learning bodies or restoring the retired full rules bake.

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/plugins/lisa/rules/reference/intent-routing.md
+++ b/plugins/lisa/rules/reference/intent-routing.md
@@ -166,6 +166,8 @@ Determine the work type and execute the matching variant:
 3. Recommend next action (Research, Plan, Implement, or escalate)
 4. `learner` -- capture discoveries
 
+In every work type above, before a task completes -- immediately ahead of the closing `learner` step -- the implementing agent records concise kind-tagged MLD (Mistakes / Learnings / Desires) into that task's `metadata.learnings`: one line per item, empty is valid, never re-prompted or scored. See the `lisa-implement` skill for the full `{ kind, note, evidence? }` schema and routing (change the schema there, not here).
+
 Output: Code passing all quality gates + local empirical verification + codified regression test for each verification (except for spikes, which produce findings only, and non-behavioral verification types — PR / Documentation / Deploy — which carry their own proof).
 
 ### Verify

--- a/plugins/lisa/rules/reference/project-learnings.md
+++ b/plugins/lisa/rules/reference/project-learnings.md
@@ -57,6 +57,19 @@ Precedence:
 3. Project learnings add recent operational knowledge, but never rewrite or
    append to `PROJECT_RULES.md`.
 
+## Task telemetry (MLD) is not context
+
+Raw task-end MLD telemetry — the Mistakes / Learnings / Desires an implementing
+agent records into `metadata.learnings`, and the raw yield of debrief mining — is
+rung-1 capture only: it is never read into a later session's instruction surface,
+never required of an agent (empty is valid), and never graded or scored. It reaches
+a durable surface only indirectly — through the learner's validation into the
+ledger (which sessions still consume solely as the bounded projection above), and
+from there through the gardener's ticket-gated promotion a human approved. Injecting
+raw self-reports, or treating their volume as a quality signal, would reward
+plausible commentary over good outcomes and bypass the very budget and validation
+this contract exists to enforce.
+
 Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
 a bounded `AGENTS.md` bridge that points agy at this same file without copying
 learning bodies or restoring the retired full rules bake.

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/plugins/src/base/rules/reference/intent-routing.md
+++ b/plugins/src/base/rules/reference/intent-routing.md
@@ -166,6 +166,8 @@ Determine the work type and execute the matching variant:
 3. Recommend next action (Research, Plan, Implement, or escalate)
 4. `learner` -- capture discoveries
 
+In every work type above, before a task completes -- immediately ahead of the closing `learner` step -- the implementing agent records concise kind-tagged MLD (Mistakes / Learnings / Desires) into that task's `metadata.learnings`: one line per item, empty is valid, never re-prompted or scored. See the `lisa-implement` skill for the full `{ kind, note, evidence? }` schema and routing (change the schema there, not here).
+
 Output: Code passing all quality gates + local empirical verification + codified regression test for each verification (except for spikes, which produce findings only, and non-behavioral verification types — PR / Documentation / Deploy — which carry their own proof).
 
 ### Verify

--- a/plugins/src/base/rules/reference/project-learnings.md
+++ b/plugins/src/base/rules/reference/project-learnings.md
@@ -57,6 +57,19 @@ Precedence:
 3. Project learnings add recent operational knowledge, but never rewrite or
    append to `PROJECT_RULES.md`.
 
+## Task telemetry (MLD) is not context
+
+Raw task-end MLD telemetry — the Mistakes / Learnings / Desires an implementing
+agent records into `metadata.learnings`, and the raw yield of debrief mining — is
+rung-1 capture only: it is never read into a later session's instruction surface,
+never required of an agent (empty is valid), and never graded or scored. It reaches
+a durable surface only indirectly — through the learner's validation into the
+ledger (which sessions still consume solely as the bounded projection above), and
+from there through the gardener's ticket-gated promotion a human approved. Injecting
+raw self-reports, or treating their volume as a quality signal, would reward
+plausible commentary over good outcomes and bypass the very budget and validation
+this contract exists to enforce.
+
 Antigravity note: agy does not receive the plugin `rules/` tree. Lisa reconciles
 a bounded `AGENTS.md` bridge that points agy at this same file without copying
 learning bodies or restoring the retired full rules bake.

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -173,11 +173,16 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 
 For Fix tasks and user-visible Build tasks, `testing_requirements` must include the highest-practical-observation regression requirement above, including the selected harness or the recorded absence/blocker path. The completion condition must include the proof command and the required CI execution evidence for the new spec.
 
 Each task must be reviewed by the team to make sure their verification passes.
+
+Before marking a task complete, the implementing agent records concise MLD into `metadata.learnings` — mistakes (errors in its own trajectory), learnings (environment facts it discovered the hard way), and desires (context or tools it wished it had). Empty (`learnings: []`) is a valid result: never re-prompt for content, and never grade or score self-reports — a scored MLD would reward plausible self-commentary over good outcomes.
+
 Each task must have their learnings reviewed by the learner subagent.
 
 Before shutting down the team, execute the Verify flow:

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -161,7 +161,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
   "relevant_documentation": "",
   "testing_requirements": ["..."],
   "skills": ["..."],
-  "learnings": ["..."],
+  "learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }],
   "required_access": [
     { "tool": "<external tool/system this task or its verification needs>", "probe": "<the read-only command or *-access check that proves access>", "status": "pass|fail" }
   ],
@@ -173,7 +173,7 @@ Every task MUST include this JSON metadata block. Do NOT omit `skills` (use `[]`
 }
 ```
 
-The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as `kind: "learning"` for backward compatibility with older flows) or a structured object `{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }`: a `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
+The `learnings` array is task-end MLD telemetry (Mistakes / Learnings / Desires) — a low-trust self-report for the harness builder, never instructions for a later agent. Each entry is either a plain string (treated as kind `learning` for backward compatibility with older flows) or an object, exactly like the example entry in the block above: a `kind` of `mistake`, `learning`, or `desire`; a one-line `note`; and an optional `evidence` pointer. A `mistake` is an error in the agent's own trajectory, a `learning` is an environment fact discovered the hard way, a `desire` is context or tooling the agent wished it had. Keep each to one line — no essays. `mistake`/`learning` entries are ledger candidates; `desire` entries are tooling-gap candidates that the learner (#1731) records for the gardener's human-gated tooling-gap lane.
 
 Before any task is implemented, the agent team must explore the codebase for relevant research (documentation, code, git history, etc) and update each task's `metadata.relevant_documentation` with the findings.
 

--- a/tests/unit/strategies/mld-telemetry-contract.test.ts
+++ b/tests/unit/strategies/mld-telemetry-contract.test.ts
@@ -20,6 +20,16 @@ const IMPLEMENT_FANOUTS = [
 
 const REFERENCE_RULE = "plugins/src/base/rules/reference/project-learnings.md";
 
+// The canonical Implement step sequence is dual-homed (lisa-implement +
+// intent-routing). The task-end MLD step is threaded into the intent-routing
+// reference rule as a pointer to the lisa-implement contract (schema is NOT
+// duplicated here). These are every built fan-out of that reference rule.
+const INTENT_ROUTING_FANOUTS = [
+  "plugins/lisa/rules/reference/intent-routing.md",
+  "plugins/lisa-copilot/rules/reference/intent-routing.md",
+  "plugins/lisa-cursor/rules/intent-routing-reference.mdc",
+];
+
 describe("MLD task-end telemetry contract (LLG-3)", () => {
   describe.each(IMPLEMENT_FANOUTS)("lisa-implement fan-out %s", path => {
     const skill = readFileSync(path, "utf8");
@@ -66,6 +76,29 @@ describe("MLD task-end telemetry contract (LLG-3)", () => {
     it("promotes only through the learner's ledger capture and the gardener's gated promotion", () => {
       expect(reference).toMatch(/learner's validation into the\s+ledger/);
       expect(reference).toMatch(/gardener's ticket-gated promotion/);
+    });
+  });
+
+  describe.each(INTENT_ROUTING_FANOUTS)("intent-routing fan-out %s", path => {
+    const rule = readFileSync(path, "utf8");
+
+    it("threads the task-end MLD step into the Implement sequence", () => {
+      expect(rule).toMatch(
+        /before a task completes .*ahead of the closing `learner` step.*records concise kind-tagged MLD/s
+      );
+      expect(rule).toContain("`metadata.learnings`");
+    });
+
+    it("points at lisa-implement for the schema instead of duplicating it", () => {
+      expect(rule).toContain("`lisa-implement`");
+      expect(rule).toContain("change the schema there, not here");
+      // The full kind-union schema must live only in lisa-implement, not be copied here.
+      expect(rule).not.toContain('"kind": "mistake" | "learning" | "desire"');
+    });
+
+    it("preserves the empty-is-valid / never-scored discipline", () => {
+      expect(rule).toContain("empty is valid");
+      expect(rule).toContain("never re-prompted or scored");
     });
   });
 });

--- a/tests/unit/strategies/mld-telemetry-contract.test.ts
+++ b/tests/unit/strategies/mld-telemetry-contract.test.ts
@@ -18,7 +18,15 @@ const IMPLEMENT_FANOUTS = [
   "plugins/lisa-copilot/skills/lisa-implement/SKILL.md",
 ];
 
-const REFERENCE_RULE = "plugins/src/base/rules/reference/project-learnings.md";
+// The anti-injection discipline is authored in base and fanned out to every
+// agent variant. The suite binds the BUILT copies (what actually ships) so it
+// catches generator drift, keeping base as one additional root.
+const PROJECT_LEARNINGS_REFERENCE_ROOTS = [
+  "plugins/lisa/rules/reference/project-learnings.md",
+  "plugins/lisa-copilot/rules/reference/project-learnings.md",
+  "plugins/lisa-cursor/rules/project-learnings-reference.mdc",
+  "plugins/src/base/rules/reference/project-learnings.md",
+];
 
 // The canonical Implement step sequence is dual-homed (lisa-implement +
 // intent-routing). The task-end MLD step is threaded into the intent-routing
@@ -34,15 +42,29 @@ describe("MLD task-end telemetry contract (LLG-3)", () => {
   describe.each(IMPLEMENT_FANOUTS)("lisa-implement fan-out %s", path => {
     const skill = readFileSync(path, "utf8");
 
-    it("documents the kind-tagged MLD schema", () => {
+    it("ships a literal, parseable JSON example entry for the kind-tagged schema", () => {
+      // CodeRabbit #1770: the shape must be a literal parseable example inside a
+      // block mandated as JSON — never a TS-style union an agent could copy verbatim.
       expect(skill).toContain(
-        '{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }'
+        '"learnings": [{ "kind": "mistake", "note": "one line", "evidence": "optional ref" }]'
       );
+      expect(skill).not.toContain('"kind": "mistake" | "learning" | "desire"');
+      expect(skill).not.toContain('"evidence"?:');
+    });
+
+    it("keeps the whole task-metadata block valid, parseable JSON", () => {
+      const block = /```json\n([\s\S]*?)\n```/.exec(skill);
+      expect(block).not.toBeNull();
+      expect(() => JSON.parse(block![1] as string)).not.toThrow();
+    });
+
+    it("documents the allowed kind values in prose", () => {
+      expect(skill).toContain("a `kind` of `mistake`, `learning`, or `desire`");
     });
 
     it("keeps plain strings valid for backward compatibility", () => {
       expect(skill).toContain(
-        'treated as `kind: "learning"` for backward compatibility'
+        "treated as kind `learning` for backward compatibility"
       );
     });
 
@@ -58,26 +80,29 @@ describe("MLD task-end telemetry contract (LLG-3)", () => {
     });
   });
 
-  describe("project-learnings reference rule", () => {
-    const reference = readFileSync(REFERENCE_RULE, "utf8");
+  describe.each(PROJECT_LEARNINGS_REFERENCE_ROOTS)(
+    "project-learnings reference rule %s",
+    path => {
+      const reference = readFileSync(path, "utf8");
 
-    it("carries the anti-injection paragraph", () => {
-      expect(reference).toContain("## Task telemetry (MLD) is not context");
-      expect(reference).toMatch(
-        /never read into a later session's instruction surface/
-      );
-    });
+      it("carries the anti-injection paragraph", () => {
+        expect(reference).toContain("Task telemetry (MLD) is not context");
+        expect(reference).toMatch(
+          /never read into a later session's instruction surface/
+        );
+      });
 
-    it("states that raw MLD is never required and never scored", () => {
-      expect(reference).toContain("empty is valid");
-      expect(reference).toContain("never graded or scored");
-    });
+      it("states that raw MLD is never required and never scored", () => {
+        expect(reference).toContain("empty is valid");
+        expect(reference).toContain("never graded or scored");
+      });
 
-    it("promotes only through the learner's ledger capture and the gardener's gated promotion", () => {
-      expect(reference).toMatch(/learner's validation into the\s+ledger/);
-      expect(reference).toMatch(/gardener's ticket-gated promotion/);
-    });
-  });
+      it("promotes only through the learner's ledger capture and the gardener's gated promotion", () => {
+        expect(reference).toMatch(/learner's validation into the\s+ledger/);
+        expect(reference).toMatch(/gardener's ticket-gated promotion/);
+      });
+    }
+  );
 
   describe.each(INTENT_ROUTING_FANOUTS)("intent-routing fan-out %s", path => {
     const rule = readFileSync(path, "utf8");

--- a/tests/unit/strategies/mld-telemetry-contract.test.ts
+++ b/tests/unit/strategies/mld-telemetry-contract.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// LLG-3 (#1732): MLD task-end telemetry. The task-metadata `learnings` contract
+// is authored once in base and fanned out to every agent variant by
+// `bun run build:plugins`; the anti-injection discipline is authored in the
+// project-learnings reference rule. These assertions pin the shipped prose so a
+// future edit that drops the kind-tagged schema, the backward-compat escape
+// hatch, the "empty is valid / never scored" guarantee, or the anti-injection
+// paragraph fails loudly.
+
+// Every built fan-out of lisa-implement that must carry the MLD schema.
+const IMPLEMENT_FANOUTS = [
+  "plugins/lisa/skills/lisa-implement/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-implement/SKILL.md",
+];
+
+const REFERENCE_RULE = "plugins/src/base/rules/reference/project-learnings.md";
+
+describe("MLD task-end telemetry contract (LLG-3)", () => {
+  describe.each(IMPLEMENT_FANOUTS)("lisa-implement fan-out %s", path => {
+    const skill = readFileSync(path, "utf8");
+
+    it("documents the kind-tagged MLD schema", () => {
+      expect(skill).toContain(
+        '{ "kind": "mistake" | "learning" | "desire", "note": "<one line>", "evidence"?: "<optional pointer>" }'
+      );
+    });
+
+    it("keeps plain strings valid for backward compatibility", () => {
+      expect(skill).toContain(
+        'treated as `kind: "learning"` for backward compatibility'
+      );
+    });
+
+    it("records MLD before task completion and never re-prompts or scores it", () => {
+      expect(skill).toContain("Before marking a task complete");
+      expect(skill).toContain("`learnings: []`) is a valid result");
+      expect(skill).toContain("never grade or score self-reports");
+    });
+
+    it("routes desires to the gardener's tooling-gap lane via the learner", () => {
+      expect(skill).toContain("tooling-gap candidates");
+      expect(skill).toContain("learner (#1731)");
+    });
+  });
+
+  describe("project-learnings reference rule", () => {
+    const reference = readFileSync(REFERENCE_RULE, "utf8");
+
+    it("carries the anti-injection paragraph", () => {
+      expect(reference).toContain("## Task telemetry (MLD) is not context");
+      expect(reference).toMatch(
+        /never read into a later session's instruction surface/
+      );
+    });
+
+    it("states that raw MLD is never required and never scored", () => {
+      expect(reference).toContain("empty is valid");
+      expect(reference).toContain("never graded or scored");
+    });
+
+    it("promotes only through the learner's ledger capture and the gardener's gated promotion", () => {
+      expect(reference).toMatch(/learner's validation into the\s+ledger/);
+      expect(reference).toMatch(/gardener's ticket-gated promotion/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extends the implement task-metadata contract: `learnings` entries are kind-tagged `{ kind: mistake | learning | desire, note, evidence? }` — plain strings remain valid (treated as `kind: learning`). Task-end instruction: record concise MLD before completing a task; empty is valid; never re-prompted, never graded or scored.
- Threads the task-end step into the canonical Implement sequence in the intent-routing reference rule (dual-homed per repo convention; schema pointer only, no duplication).
- Documents the anti-injection discipline in the project-learnings reference rule: raw task telemetry is never read into a later session's context — it reaches durable surfaces only through the learner's ledger capture (#1731) and the future gardener's gated promotion (#1735). Desires are tooling-gap candidates for the gardener.

Closes CodySwannGT/lisa#1732

## Review + verification

Combined lanes with #1731: quality/CodeRabbit SHIP; spec-conformance's one PARTIAL (intent-routing threading conditional resolved TRUE) fixed in-branch. Spec adjudicated no runtime legs needed beyond static + fan-out proofs: 32-assertion contract suite green across all fan-outs, check:plugins/check:rules-pairing green, task-metadata JSON block verified still parseable, zero operator-facing surface changes.

## Test plan

2698 strategy-suite tests green incl. the 32 MLD assertions; typecheck/lint/pre-commit hooks green; merges before #1731 (whose branch resolves the known one-line SKILL.md overlap on rebase).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified task-end learning telemetry requirements, including supported formats, one-line entries, and optional empty submissions.
  * Added guidance for recording mistakes, learnings, and desires before task completion.
  * Clarified that telemetry is low-trust, not scored, and does not directly influence future session instructions.
  * Reinforced documentation discovery, regression testing, CI evidence, and team review requirements.

* **Tests**
  * Added coverage validating telemetry formats, routing guidance, completion rules, and promotion safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->