### PR TITLE
docs(rules): split contract-mediated vs legacy ledger writers (follow-up to #1771)

### DIFF
--- a/plugins/lisa-copilot/rules/reference/project-learnings.md
+++ b/plugins/lisa-copilot/rules/reference/project-learnings.md
@@ -29,8 +29,8 @@ Each persisted entry has seven fields:
 
 ## Who writes the ledger
 
-The ledger's contract-mediated writers — all going through the executable
-contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
+**Contract-mediated writers** — all going through the executable contract
+(`@codyswann/lisa/learnings`), never a hand-edit:
 
 - The **learner agent** at capture time appends or consolidates new entries
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
@@ -38,9 +38,13 @@ contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
   files upstream issues — promotion is the gardener's ticket-gated job.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-- **`lisa-debrief-apply`** reroutes debrief findings into the ledger once #1733
-  ships; until then it is a legacy writer outside the contract (it still routes
-  to machine-local memory and `PROJECT_RULES.md`).
+
+**Legacy writer (NOT contract-mediated, pending #1733)**:
+
+- **`lisa-debrief-apply`** still routes debrief findings to machine-local
+  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
+  contract-mediated ledger writer only when #1733 ships its reroute — until
+  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/lisa-cursor/rules/project-learnings-reference.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings-reference.mdc
@@ -34,8 +34,8 @@ Each persisted entry has seven fields:
 
 ## Who writes the ledger
 
-The ledger's contract-mediated writers — all going through the executable
-contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
+**Contract-mediated writers** — all going through the executable contract
+(`@codyswann/lisa/learnings`), never a hand-edit:
 
 - The **learner agent** at capture time appends or consolidates new entries
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
@@ -43,9 +43,13 @@ contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
   files upstream issues — promotion is the gardener's ticket-gated job.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-- **`lisa-debrief-apply`** reroutes debrief findings into the ledger once #1733
-  ships; until then it is a legacy writer outside the contract (it still routes
-  to machine-local memory and `PROJECT_RULES.md`).
+
+**Legacy writer (NOT contract-mediated, pending #1733)**:
+
+- **`lisa-debrief-apply`** still routes debrief findings to machine-local
+  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
+  contract-mediated ledger writer only when #1733 ships its reroute — until
+  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/lisa/rules/reference/project-learnings.md
+++ b/plugins/lisa/rules/reference/project-learnings.md
@@ -29,8 +29,8 @@ Each persisted entry has seven fields:
 
 ## Who writes the ledger
 
-The ledger's contract-mediated writers — all going through the executable
-contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
+**Contract-mediated writers** — all going through the executable contract
+(`@codyswann/lisa/learnings`), never a hand-edit:
 
 - The **learner agent** at capture time appends or consolidates new entries
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
@@ -38,9 +38,13 @@ contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
   files upstream issues — promotion is the gardener's ticket-gated job.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-- **`lisa-debrief-apply`** reroutes debrief findings into the ledger once #1733
-  ships; until then it is a legacy writer outside the contract (it still routes
-  to machine-local memory and `PROJECT_RULES.md`).
+
+**Legacy writer (NOT contract-mediated, pending #1733)**:
+
+- **`lisa-debrief-apply`** still routes debrief findings to machine-local
+  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
+  contract-mediated ledger writer only when #1733 ships its reroute — until
+  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/src/base/rules/reference/project-learnings.md
+++ b/plugins/src/base/rules/reference/project-learnings.md
@@ -29,8 +29,8 @@ Each persisted entry has seven fields:
 
 ## Who writes the ledger
 
-The ledger's contract-mediated writers — all going through the executable
-contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
+**Contract-mediated writers** — all going through the executable contract
+(`@codyswann/lisa/learnings`), never a hand-edit:
 
 - The **learner agent** at capture time appends or consolidates new entries
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
@@ -38,9 +38,13 @@ contract (`@codyswann/lisa/learnings`), never a hand-edit — are:
   files upstream issues — promotion is the gardener's ticket-gated job.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-- **`lisa-debrief-apply`** reroutes debrief findings into the ledger once #1733
-  ships; until then it is a legacy writer outside the contract (it still routes
-  to machine-local memory and `PROJECT_RULES.md`).
+
+**Legacy writer (NOT contract-mediated, pending #1733)**:
+
+- **`lisa-debrief-apply`** still routes debrief findings to machine-local
+  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
+  contract-mediated ledger writer only when #1733 ships its reroute — until
+  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/tests/unit/strategies/learner-capture-contract.test.ts
+++ b/tests/unit/strategies/learner-capture-contract.test.ts
@@ -136,7 +136,8 @@ describe.each(REFERENCE_RULE_PATHS)(
       // #1733 ships; until then it is a legacy writer outside the contract.
       expect(rule).toContain("lisa-debrief-apply");
       expect(rule).toMatch(/#1733/);
-      expect(rule).toMatch(/legacy writer/);
+      expect(rule).toMatch(/legacy writer/i);
+      expect(rule).toMatch(/NOT contract-mediated/);
       // Promotion is the gardener's ticket-gated job, not a writer here.
       expect(rule).toContain("gardener");
       expect(rule).toMatch(/status:ready/);


### PR DESCRIPTION
Follow-up carrying the CodeRabbit-requested writer-boundary split that PR #1771's auto-merge raced past (the stale-review dismissal fired auto-merge on the prior head before the fix commit landed — the exact ancestry race the repo's own rule documents; caught by the post-merge ancestry check). Two explicit sub-lists in the project-learnings reference: contract-mediated writers vs the legacy NOT-contract-mediated debrief-apply path pending #1733, with the never-treat-as-validated warning; contract test pins the boundary. Refs CodySwannGT/lisa#1731.