### PR TITLE
feat(learnings): reroute debrief-apply knowledge categories to the ledger (LLG-4, #1733)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/plugins/lisa-copilot/rules/reference/project-learnings.md
+++ b/plugins/lisa-copilot/rules/reference/project-learnings.md
@@ -36,15 +36,15 @@ Each persisted entry has seven fields:
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
   It is capture-only: it never appends to `PROJECT_RULES.md`, creates skills, or
   files upstream issues — promotion is the gardener's ticket-gated job.
+- **`lisa-debrief-apply`** routes accepted debrief findings in the three
+  knowledge categories — recurring gotcha, process friction, convention drift —
+  to the ledger through the same contract (`persistLearningEntry` /
+  `persistConsolidatedLearning`, with consolidation-at-write), provenance drawn
+  from the triage row's evidence links and a `high` starting confidence because
+  a human Accept is corroboration. It no longer writes to machine-local memory,
+  `PROJECT_RULES.md`, or `CLAUDE.md` for these categories.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-
-**Legacy writer (NOT contract-mediated, pending #1733)**:
-
-- **`lisa-debrief-apply`** still routes debrief findings to machine-local
-  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
-  contract-mediated ledger writer only when #1733 ships its reroute — until
-  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/plugins/lisa-cursor/rules/project-learnings-reference.mdc
+++ b/plugins/lisa-cursor/rules/project-learnings-reference.mdc
@@ -41,15 +41,15 @@ Each persisted entry has seven fields:
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
   It is capture-only: it never appends to `PROJECT_RULES.md`, creates skills, or
   files upstream issues — promotion is the gardener's ticket-gated job.
+- **`lisa-debrief-apply`** routes accepted debrief findings in the three
+  knowledge categories — recurring gotcha, process friction, convention drift —
+  to the ledger through the same contract (`persistLearningEntry` /
+  `persistConsolidatedLearning`, with consolidation-at-write), provenance drawn
+  from the triage row's evidence links and a `high` starting confidence because
+  a human Accept is corroboration. It no longer writes to machine-local memory,
+  `PROJECT_RULES.md`, or `CLAUDE.md` for these categories.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-
-**Legacy writer (NOT contract-mediated, pending #1733)**:
-
-- **`lisa-debrief-apply`** still routes debrief findings to machine-local
-  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
-  contract-mediated ledger writer only when #1733 ships its reroute — until
-  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/plugins/lisa/rules/reference/project-learnings.md
+++ b/plugins/lisa/rules/reference/project-learnings.md
@@ -36,15 +36,15 @@ Each persisted entry has seven fields:
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
   It is capture-only: it never appends to `PROJECT_RULES.md`, creates skills, or
   files upstream issues — promotion is the gardener's ticket-gated job.
+- **`lisa-debrief-apply`** routes accepted debrief findings in the three
+  knowledge categories — recurring gotcha, process friction, convention drift —
+  to the ledger through the same contract (`persistLearningEntry` /
+  `persistConsolidatedLearning`, with consolidation-at-write), provenance drawn
+  from the triage row's evidence links and a `high` starting confidence because
+  a human Accept is corroboration. It no longer writes to machine-local memory,
+  `PROJECT_RULES.md`, or `CLAUDE.md` for these categories.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-
-**Legacy writer (NOT contract-mediated, pending #1733)**:
-
-- **`lisa-debrief-apply`** still routes debrief findings to machine-local
-  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
-  contract-mediated ledger writer only when #1733 ships its reroute — until
-  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/lisa/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/plugins/src/base/rules/reference/project-learnings.md
+++ b/plugins/src/base/rules/reference/project-learnings.md
@@ -36,15 +36,15 @@ Each persisted entry has seven fields:
   (`persistLearningEntry` / `persistConsolidatedLearning`) from task learnings.
   It is capture-only: it never appends to `PROJECT_RULES.md`, creates skills, or
   files upstream issues — promotion is the gardener's ticket-gated job.
+- **`lisa-debrief-apply`** routes accepted debrief findings in the three
+  knowledge categories — recurring gotcha, process friction, convention drift —
+  to the ledger through the same contract (`persistLearningEntry` /
+  `persistConsolidatedLearning`, with consolidation-at-write), provenance drawn
+  from the triage row's evidence links and a `high` starting confidence because
+  a human Accept is corroboration. It no longer writes to machine-local memory,
+  `PROJECT_RULES.md`, or `CLAUDE.md` for these categories.
 - The **build-intake flows** advance `last_confirmed` at claim time
   (`confirmLearningEntry`, below).
-
-**Legacy writer (NOT contract-mediated, pending #1733)**:
-
-- **`lisa-debrief-apply`** still routes debrief findings to machine-local
-  memory and `PROJECT_RULES.md`, entirely outside the contract. It becomes a
-  contract-mediated ledger writer only when #1733 ships its reroute — until
-  then, never treat its output as budgeted/validated ledger content.
 
 Promotion to a higher rung (skill, eager rule, executable control, upstream
 ticket) is never a writer here — it is the gardener's job, gated by a human

--- a/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
+++ b/plugins/src/base/skills/lisa-debrief-apply/SKILL.md
@@ -18,7 +18,7 @@ A path or URL to a Debrief triage document produced by `lisa-debrief`. The docum
 
 1. **Verify the doc exists and parses.** If the file cannot be read or the expected sections are missing, stop and report — do not guess.
 2. **Confirm dispositions exist.** If every row is unmarked, stop and ask the human to triage first. A pristine doc is a no-op, not an error to silently swallow.
-3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), `projectRulesFile` (default: `.claude/rules/PROJECT_RULES.md`), memory directory (per the auto-memory system path), tracker for new tickets.
+3. **Identify the destination map.** Read the project's `.lisa.config.json` (or stack defaults) for: edge-case checklist file (default: `plugins/src/base/rules/intent-routing.md`'s Edge Case Brainstorm sub-flow), the committed learnings ledger path (resolve it — never hardcode — via `resolveProjectLearningsFile` from `@codyswann/lisa/learnings`: the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md`), tracker for new tickets. The three knowledge categories (recurring gotcha, process friction, convention drift) all land in the ledger now; machine-local auto-memory and `PROJECT_RULES.md` / `CLAUDE.md` are no longer knowledge destinations (see [Ledger persistence](#ledger-persistence-knowledge-categories)).
 
 ## Routing rules
 
@@ -27,19 +27,49 @@ For every row marked **Accept**:
 | Category | Destination | Action |
 |----------|-------------|--------|
 | Edge case | Edge Case Brainstorm checklist in `intent-routing.md` | Append the new pattern + question to the matching group (Navigation, Data, Failure, Input, Auth, or a new group if none fit). Use the row's `Summary` and `Evidence` link as a citation comment. |
-| Recurring gotcha | Memory file (`project_*.md`) | Write a new memory entry with `type: project`, structured as: rule, **Why:**, **How to apply:**. Add an index line to `MEMORY.md`. |
-| Process friction | Configured project rules file | Append a one-line guideline to the `.lisa.config.json` `projectRulesFile` destination (default `PROJECT_RULES.md`) under an appropriate heading (or create one). |
+| Recurring gotcha | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the recurring gotcha and the guard against it; `why` is the causal claim. |
+| Process friction | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the friction-avoiding guideline; `why` names the friction it prevents. |
 | Tooling gap | Configured tracker — or upstream Lisa when harness-level | **Split by level.** Project-level (a missing project script, hook, or automation) → create a ticket via `lisa-tracker-write` with `issue_type: Task`, summary derived from the row's `Summary`, description citing the evidence and the originating debrief doc, labeled `type:tooling` / `lifecycle-improvement`. Harness-level (a Lisa skill/gate/agent that should have caught the issue but didn't) → file an upstream Lisa issue exactly per the "Filing upstream" procedure in `lisa-rework-triage` (dedupe search first, three-audience description, evidence chain, `self-hardening` label; repo from `.lisa.config.json` `hardening.upstreamRepo`, default `CodySwannGT/lisa`). |
-| Convention drift | `CLAUDE.md` for project-wide agent operating instructions; otherwise the configured project rules file for codebase conventions | Append the convention as a one-paragraph note under the relevant section. If no relevant section exists, create one. |
+| Convention drift | Committed learnings ledger (via contract) | Persist a ledger entry per [Ledger persistence](#ledger-persistence-knowledge-categories). The `rule` is the correct convention; `why` records the drift it corrects. |
 | Decomposition infidelity | Upstream Lisa repo | File an upstream Lisa issue per the "Filing upstream" procedure in `lisa-rework-triage`, citing the PRD text vs. the distorted ticket AC and naming the gate that passed it. |
 | PRD defect | Source PRD | Comment on the PRD via the `lisa-prd-backlink` lineage quoting the defective requirement and the failure it missed; flag for product review. Never silently edit the spec. |
 | Missing tool access | Configured tracker | Create a provisioning ticket via `lisa-tracker-write` (`issue_type: Task`, `type:tooling`) describing the missing tool/credential/environment and which flow needs it. |
 
 For every row marked **Reject** or **Defer**: no action. Defer is a no-op for `apply` but worth surfacing in the run summary — the human may want to revisit at the next debrief.
 
+## Ledger persistence (knowledge categories)
+
+The three knowledge categories — **recurring gotcha**, **process friction**, and **convention drift** — all persist to the committed learnings ledger through the SAME executable contract the learner uses (`@codyswann/lisa/learnings`). This is the single governed, budgeted, contract-validated, team- and cloud-visible knowledge surface. **Never hand-edit the ledger markdown** — every write goes through the contract, or it is a bug.
+
+For each such Accepted row:
+
+1. **Resolve the ledger path (never hardcode).** Use `resolveProjectLearningsFile` from `@codyswann/lisa/learnings` — the `learnings.file` override, else the default `.lisa/PROJECT_LEARNINGS.md` (a cold path, never an auto-loaded rules tree):
+
+   ```bash
+   LEARNINGS_FILE=$(node -e 'import("@codyswann/lisa/learnings").then(async m => { const c = await m.readProjectConfig(process.cwd()); console.log(m.resolveProjectLearningsFile(c)); })')
+   ```
+
+2. **Consolidation check (mandatory before writing).** Parse the existing entries with `parseLearningsFile` and look for one related to the row (same failure class, overlapping topic, or near-duplicate wording). Then write through the contract:
+   - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug.
+   - **No related entry** → append via `persistLearningEntry(projectRoot, entry)`.
+
+3. **Entry mapping (seven fields).**
+   - `id` — the entry id returned by the contract writer (report it in the run summary).
+   - `rule` / `why` — from the row's `Summary` and the category-specific guidance in the routing table above (≤240 chars, ≤2 lines).
+   - `provenance` — **the triage-doc row's evidence links**. This is the same evidence link that doubles as the idempotency fingerprint below, so the row's provenance is what a later re-apply scans for.
+   - `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`).
+   - `confidence` = **`high`**. A human marking the row **Accept** is corroboration — an independent human judgement that the learning is real — so a debrief-accepted entry starts higher than the learner's single-occurrence auto-capture (which defaults to `low`). The writer re-asserts the entry and token budgets; an over-budget failure means consolidate harder or drop, never truncate by hand.
+
+**Machine-local memory is no longer a knowledge destination.** Auto-memory (`project_*.md`, `MEMORY.md`) remains available only for the assistant's *personal* collaboration notes — it is invisible to cloud runs and to teammates, so it can never hold shared project knowledge. **`CLAUDE.md` is human-authored** agent operating instruction and `PROJECT_RULES.md` is durable human-authored guidance; `apply` never writes to any of the three for these categories.
+
 ## Idempotency
 
-`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint — before writing, check whether the destination already cites that fingerprint. If it does, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
+`apply` is safe to re-run. Each Accepted row carries an evidence link that doubles as a fingerprint. Before writing, check whether the destination already cites that fingerprint:
+
+- **Knowledge categories (gotcha, friction, drift) → ledger.** Parse the ledger once with `parseLearningsFile` from `@codyswann/lisa/learnings` and scan the entries' `provenance` for the row's evidence link. If any entry's provenance already contains it, the row is already persisted — skip the write. This replaces the old scattered-file greps (memory files, `PROJECT_RULES.md`, `CLAUDE.md`): provenance in the single governed ledger is now the one fingerprint surface.
+- **Other categories** keep their existing destination check (the tracker for the ticket marker, the PRD for the defect comment, `intent-routing.md` for the edge-case citation).
+
+If the fingerprint is already present, skip the write and note the row as `already-applied` in the run summary. This lets the human triage a doc incrementally (mark a few, run apply, mark more, run apply again) without producing duplicates.
 
 ## Updating the triage doc
 
@@ -52,11 +82,11 @@ A run summary printed to the user:
 ```text
 Applied <n> learnings:
   <n> edge cases → intent-routing.md
-  <n> gotchas → memory
-  <n> friction → PROJECT_RULES.md
+  <n> gotchas → ledger (<entry-id1>, <entry-id2>, ...)
+  <n> friction → ledger (<entry-id1>, ...)
+  <n> convention drift → ledger (<entry-id1>, ...)
   <n> tooling gaps (project) → <tracker> (<key1>, <key2>, ...)
   <n> tooling gaps (harness) → upstream Lisa (<issue-url1>, ...)
-  <n> convention drift → CLAUDE.md
   <n> decomposition infidelity → upstream Lisa (<issue-url1>, ...)
   <n> PRD defects → PRD comments (<prd-link1>, ...)
   <n> missing tool access → <tracker> (<key1>, ...)
@@ -67,4 +97,4 @@ Failed:
 Triage doc updated in place: <path>
 ```
 
-If anything is written to a tracker, suggest the human commit the local file changes (memory, rules, intent-routing) when ready — `apply` does not commit.
+If anything is written to a tracker, suggest the human commit the local file changes (the learnings ledger, intent-routing) when ready — `apply` does not commit.

--- a/tests/unit/strategies/debrief-reroute-contract.test.ts
+++ b/tests/unit/strategies/debrief-reroute-contract.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Prose contract for debrief-apply's knowledge-category reroute (LLG-4, #1733).
+ *
+ * Before this ticket, `lisa-debrief-apply` routed three accepted knowledge
+ * categories to unmanaged prose surfaces: recurring gotchas → machine-local
+ * auto-memory `project_*.md`, process friction → `PROJECT_RULES.md`, convention
+ * drift → `CLAUDE.md`. None of those are budgeted, validated, expiring, or
+ * shared with cloud runs / teammates. This ticket reroutes all three to the
+ * committed learnings ledger through the SAME executable contract the learner
+ * uses (`@codyswann/lisa/learnings`): consolidation-at-write, resolver-only
+ * paths, provenance from the triage row's evidence links, and a human-Accept
+ * starting confidence of `high` (an Accept is human corroboration).
+ *
+ * The category routes that were never knowledge routing stay byte-for-byte:
+ * edge case → intent-routing checklist; tooling gap → tracker/upstream split;
+ * decomposition infidelity → upstream; PRD defect → PRD comment; missing tool
+ * access → tracker ticket.
+ *
+ * These are agent instructions, so the assertions cover the canonical plugin
+ * source AND every checked-in runtime projection produced by
+ * `bun run build:plugins`. Per-agent parity: the skill fans out to all five
+ * runtimes plus the Codex overlay; the project-learnings reference rule ships to
+ * Claude/Codex-base, Cursor (flattened `.mdc`), and Copilot — Antigravity ships
+ * no `rules/` tree and the Codex overlay is skills-only, so neither carries the
+ * reference projection (matching learner-capture-contract).
+ * @module tests/unit/strategies/debrief-reroute-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const DEBRIEF_APPLY_SKILL_PATHS = [
+  "plugins/src/base/skills/lisa-debrief-apply/SKILL.md",
+  "plugins/lisa/skills/lisa-debrief-apply/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-debrief-apply/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md",
+] as const;
+
+const REFERENCE_RULE_PATHS = [
+  "plugins/src/base/rules/reference/project-learnings.md",
+  "plugins/lisa/rules/reference/project-learnings.md",
+  "plugins/lisa-cursor/rules/project-learnings-reference.mdc",
+  "plugins/lisa-copilot/rules/reference/project-learnings.md",
+] as const;
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+/**
+ * Return the single Markdown routing-table row whose first cell names the given
+ * category. Rows are `| Category | Destination | Action |`. Returns the raw line
+ * so per-cell token assertions can scope to exactly that category's route and
+ * never collide with the prose sections that legitimately mention retired
+ * surfaces (e.g. the "memory is no longer a destination" note).
+ * @param skill The full skill Markdown text to search.
+ * @param category The routing-table category naming the row's first cell.
+ * @returns The raw Markdown line for that category's routing row.
+ */
+const routingRow = (skill: string, category: string): string => {
+  const line = skill
+    .split("\n")
+    .find(l => l.trimStart().startsWith(`| ${category} `));
+  if (line === undefined) {
+    throw new Error(`routing row for "${category}" not found`);
+  }
+  return line;
+};
+
+describe.each(DEBRIEF_APPLY_SKILL_PATHS)(
+  "debrief-apply reroutes knowledge categories to the ledger (%s)",
+  skillPath => {
+    const skill = read(skillPath);
+
+    it("persists the three knowledge categories through the executable contract", () => {
+      // The reroute writes via the same contract the learner uses — no hand-edits.
+      expect(skill).toContain("@codyswann/lisa/learnings");
+      expect(skill).toContain("resolveProjectLearningsFile");
+      expect(skill).toContain("persistLearningEntry");
+      expect(skill).toContain("persistConsolidatedLearning");
+      // Consolidation-at-write: scan existing entries before appending.
+      expect(skill).toContain("parseLearningsFile");
+      expect(skill).toMatch(/consolidat/i);
+    });
+
+    it("documents human-Accept ⇒ high starting confidence and why", () => {
+      expect(skill).toMatch(/confidence/);
+      expect(skill).toMatch(/\bhigh\b/);
+      // A human Accept is corroboration — higher than learner auto-capture.
+      expect(skill).toMatch(/corroborat/i);
+    });
+
+    it.each(["Recurring gotcha", "Process friction", "Convention drift"])(
+      "routes %s to the ledger with no retired destination tokens",
+      category => {
+        const row = routingRow(skill, category);
+        expect(row).toMatch(/ledger/i);
+        // The retired knowledge surfaces must not appear in these rows.
+        expect(row).not.toMatch(/project_\*\.md/);
+        expect(row).not.toMatch(/PROJECT_RULES/);
+        expect(row).not.toMatch(/projectRulesFile/);
+        expect(row).not.toMatch(/CLAUDE\.md/);
+        expect(row).not.toMatch(/\bmemory\b/i);
+      }
+    );
+
+    it("provenance for ledger entries is the triage row's evidence links", () => {
+      expect(skill).toMatch(/provenance/i);
+      expect(skill).toMatch(/evidence/i);
+    });
+
+    it("keeps the non-knowledge routes unchanged", () => {
+      expect(routingRow(skill, "Edge case")).toMatch(
+        /intent-routing|checklist/i
+      );
+      expect(routingRow(skill, "Tooling gap")).toMatch(/upstream/i);
+      expect(routingRow(skill, "Decomposition infidelity")).toMatch(
+        /[Uu]pstream/
+      );
+      expect(routingRow(skill, "PRD defect")).toMatch(/PRD/);
+      expect(routingRow(skill, "Missing tool access")).toMatch(/tracker/i);
+    });
+
+    it("declares machine-local memory retired and CLAUDE.md human-authored", () => {
+      // Auto-memory survives for assistant-personal notes, not project knowledge.
+      expect(skill).toMatch(/no longer.*(destination|knowledge)/i);
+      expect(skill).toMatch(/personal/i);
+      expect(skill).toMatch(/human-authored/i);
+    });
+
+    it("checks idempotency via ledger provenance, not scattered-file greps", () => {
+      const idempotency = skill.slice(skill.indexOf("## Idempotency"));
+      expect(idempotency).toContain("parseLearningsFile");
+      expect(idempotency).toMatch(/provenance/i);
+      expect(idempotency).toMatch(/already-applied/);
+    });
+
+    it("reports ledger destinations with entry ids in the run summary", () => {
+      const summary = skill.slice(skill.indexOf("## Output"));
+      expect(summary).toMatch(/ledger/i);
+      expect(summary).toMatch(/gotchas/);
+      expect(summary).toMatch(/friction/);
+      expect(summary).toMatch(/drift/);
+      // The ledger destinations name the persisted entry ids.
+      expect(summary).toMatch(/\bid/i);
+    });
+  }
+);
+
+describe.each(REFERENCE_RULE_PATHS)(
+  "project-learnings reference rule promotes debrief-apply to a contract writer (%s)",
+  rulePath => {
+    const rule = read(rulePath);
+
+    it("lists debrief-apply among the contract-mediated writers", () => {
+      expect(rule).toContain("Contract-mediated writers");
+      expect(rule).toContain("lisa-debrief-apply");
+      expect(rule).toContain("persistLearningEntry");
+      expect(rule).toContain("persistConsolidatedLearning");
+    });
+
+    it("no longer describes debrief-apply as a pending legacy writer", () => {
+      // The reroute shipped: the "#1733 pending" / "legacy writer" framing is gone.
+      expect(rule).not.toMatch(/pending #1733/);
+      expect(rule).not.toMatch(/Legacy writer/);
+    });
+  }
+);

--- a/tests/unit/strategies/learner-capture-contract.test.ts
+++ b/tests/unit/strategies/learner-capture-contract.test.ts
@@ -132,12 +132,15 @@ describe.each(REFERENCE_RULE_PATHS)(
       expect(rule).toMatch(/learner/);
       expect(rule).toMatch(/capture time/);
       expect(rule).toContain("confirmLearningEntry");
-      // debrief-apply is not a contract writer yet — it becomes one only once
-      // #1733 ships; until then it is a legacy writer outside the contract.
+      // #1733 shipped: debrief-apply is now a contract-mediated ledger writer,
+      // not the pending "legacy writer" it was before the reroute. The old
+      // "#1733 pending" / "legacy writer" / "NOT contract-mediated" framing is
+      // gone; debrief-apply sits in the contract-mediated writers list.
+      expect(rule).toContain("Contract-mediated writers");
       expect(rule).toContain("lisa-debrief-apply");
-      expect(rule).toMatch(/#1733/);
-      expect(rule).toMatch(/legacy writer/i);
-      expect(rule).toMatch(/NOT contract-mediated/);
+      expect(rule).not.toMatch(/pending #1733/);
+      expect(rule).not.toMatch(/Legacy writer/);
+      expect(rule).not.toMatch(/NOT contract-mediated/);
       // Promotion is the gardener's ticket-gated job, not a writer here.
       expect(rule).toContain("gardener");
       expect(rule).toMatch(/status:ready/);


### PR DESCRIPTION
## Summary

- `lisa-debrief-apply`'s three knowledge categories (recurring gotcha, process friction, convention drift) now persist to the committed learnings ledger through the executable contract — consolidation-at-write, provenance = the triage row's evidence links, confidence high (a human Accept is corroboration). Machine-local memory, PROJECT_RULES.md, and CLAUDE.md are retired as knowledge destinations (memory stays personal-notes-only; the human-authored files stay human-authored).
- Non-knowledge routes (edge cases, tooling gaps, PRD defects, decomposition infidelity, missing access) are byte-for-byte unchanged. Idempotency now scans ledger provenance instead of scattered files. The project-learnings reference rule promotes debrief-apply into the contract-mediated writers list.

Closes CodySwannGT/lisa#1733

## Review + verification

Three lanes (quality MERGE, CodeRabbit APPROVE, spec PARTIAL-on-empirical): zero blocking findings. Independent verification PASS on the built dist: three-row synthetic triage apply (entries validated, provenance/confidence proven, retired surfaces asserted absent), byte-identical idempotent re-apply, consolidation-with-supersede proven by parse, tooling-gap row byte-identical to main. 118 contract-test assertions green.

🤖 Generated with Claude Code