### PR TITLE
feat(learnings): the gardener + the promotion contract (LLG-6/LLG-7, #1735 #1736)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -5,6 +5,15 @@ Project-specific rules and guidelines that apply to this codebase.
 Rules in `.claude/rules/` are automatically loaded by Claude Code at session start.
 Add project-specific patterns, conventions, and requirements below.
 
+This file is **human-authored only** — the humans' decree surface. Automated
+flows never append to it: machine-captured learnings land in the learnings
+ledger (default `.lisa/PROJECT_LEARNINGS.md`) via the executable contract, and
+the gardener (`/lisa:learnings:audit`) proposes promotions, demotions, and
+retirements as human-gated tracker tickets. Existing sections of this file are
+first-run gardener candidates like any other knowledge — expect prose that
+restates what a lint or hook already enforces to earn a promote-and-delete
+ticket over time, so this file shrinks instead of growing.
+
 ---
 
 ## Never edit generated plugin artifacts (plugins/lisa, plugins/lisa-*)

--- a/all/create-only/.claude/rules/PROJECT_RULES.md
+++ b/all/create-only/.claude/rules/PROJECT_RULES.md
@@ -5,5 +5,13 @@ Project-specific rules and guidelines that apply to this codebase.
 Rules in `.claude/rules/` are automatically loaded by Claude Code at session start.
 Add project-specific patterns, conventions, and requirements below.
 
----
+This file is **human-authored only** — the humans' decree surface. Automated
+flows never append to it: machine-captured learnings land in the learnings
+ledger (default `.lisa/PROJECT_LEARNINGS.md`) via the executable contract, and
+the gardener (`/lisa:learnings:audit`) proposes promotions, demotions, and
+retirements as human-gated tracker tickets. Existing sections of this file are
+first-run gardener candidates like any other knowledge — expect prose that
+restates what a lint or hook already enforces to earn a promote-and-delete
+ticket over time, so this file shrinks instead of growing.
 
+---

--- a/plugins/lisa-agy/commands/lisa/learnings/audit.md
+++ b/plugins/lisa-agy/commands/lisa/learnings/audit.md
@@ -1,0 +1,6 @@
+---
+description: "Run one gardener cycle over this project's knowledge surfaces (the learnings ladder, PRD #1729): inventory ledger/rules/skills/wiki/mechanical controls, gather evidence, classify via the ladder router, and file human-gated tracker tickets — per-item PROMOTE/DEMOTE tickets, one CONFIRM/RETIRE batch ticket per run, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated; the run only files marker-deduped tickets. Terminal states: nothing-needed | candidates-proposed | blocked."
+argument-hint: "[max_candidates=10] [surface=ledger|rules|skills|wiki|all] [dry_run=true]"
+---
+
+Use the /lisa-learnings-audit skill (the gardener) to run one audit cycle: inventory the knowledge surfaces, gather per-item evidence, classify candidates through the ladder router, and emit human-gated, marker-deduped tracker tickets, reporting the terminal state. $ARGUMENTS

--- a/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings ladder (PRD #1729). Periodically audits every knowledge surface — ledger, rules trees (including Lisa's own shipped eager rules), skills, wiki index, and mechanical-control surfaces — gathers evidence per item (recurrence, staleness, redundancy, contradiction, budget pressure), classifies each candidate through the ladder router (skill-evaluator, advisory), and communicates exclusively through the tracker: one evidence-bearing ticket per PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated at v1 — the skill only files tickets; humans gate by flipping status:ready or closing as rejected, and rejections are remembered. Cron-able via lisa-setup-automations and runnable on demand via /lisa:learnings:audit."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-setup-automations
-description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day). Two flags — auto-start-prds and auto-start-tickets — control whether the ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review. Tear down with /tear-down-automations."
+description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa-copilot/commands/lisa/learnings/audit.md
+++ b/plugins/lisa-copilot/commands/lisa/learnings/audit.md
@@ -1,0 +1,6 @@
+---
+description: "Run one gardener cycle over this project's knowledge surfaces (the learnings ladder, PRD #1729): inventory ledger/rules/skills/wiki/mechanical controls, gather evidence, classify via the ladder router, and file human-gated tracker tickets — per-item PROMOTE/DEMOTE tickets, one CONFIRM/RETIRE batch ticket per run, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated; the run only files marker-deduped tickets. Terminal states: nothing-needed | candidates-proposed | blocked."
+argument-hint: "[max_candidates=10] [surface=ledger|rules|skills|wiki|all] [dry_run=true]"
+---
+
+Use the /lisa-learnings-audit skill (the gardener) to run one audit cycle: inventory the knowledge surfaces, gather per-item evidence, classify candidates through the ladder router, and emit human-gated, marker-deduped tracker tickets, reporting the terminal state. $ARGUMENTS

--- a/plugins/lisa-copilot/rules/eager/promotion-contract.md
+++ b/plugins/lisa-copilot/rules/eager/promotion-contract.md
@@ -1,0 +1,18 @@
+# Promotion Contract (load-bearing)
+
+When implementing a learnings-ladder **promotion ticket** — turning prose
+knowledge into an executable control (lint / ast-grep / type / test / hook /
+`package.lisa.json` force) — the change must be **atomic**: one PR that
+**enables the control**, **fixes the existing violation population**, **ships a
+remediation-teaching diagnostic** (violated invariant + why + concrete fix),
+and **deletes the superseded prose**. A PR missing any of the four is
+**rejected by rule** — promote-without-remove double-pays forever;
+remove-without-diagnostic strands agents.
+
+Eager-tier admission is **demotion-biased** and earned only by repeated-miss
+evidence; the gardener audits the eager tier every run, including Lisa's own
+shipped eager rules.
+
+Full contract, diagnostic-quality bar, and the AC template the gardener embeds
+in EXECUTABLE-CONTROL promotion tickets:
+[reference/promotion-contract.md](../reference/promotion-contract.md).

--- a/plugins/lisa-copilot/rules/reference/promotion-contract.md
+++ b/plugins/lisa-copilot/rules/reference/promotion-contract.md
@@ -1,0 +1,126 @@
+# Promotion Contract
+
+When a learnings-ladder promotion ticket (PRD #1729) is implemented — turning a
+prose learning, rule section, or ledger entry into an **executable control**
+(lint, ast-grep, type constraint, test, hook, or `package.lisa.json` force) —
+the implementing PR is governed by this contract. The gardener
+(`lisa-learnings-audit`) files the tickets; a human gates them by flipping
+`status:ready`; the factory implements them like any other work item. This rule
+is what makes the resulting PR reviewable **by rule, not by reviewer taste**.
+
+## The atomic promote-and-delete contract
+
+A promotion PR must do **all four** of the following, in **one atomic PR**:
+
+1. **Enable the control.** The lint rule, ast-grep pattern, type constraint,
+   test, hook, or `package.lisa.json` force entry is active and blocking (CI
+   and/or local gates), not merely added in a warn-only or disabled state.
+2. **Fix the existing violation population.** Every current violation of the
+   new control in the repository is migrated in the same PR, so the control
+   lands green. Enabling a control against a red population either blocks all
+   unrelated work or forces a blanket ignore — both defeat the promotion.
+3. **Ship a remediation-teaching diagnostic.** The control's failure message
+   meets the diagnostic-quality bar below. The prose being deleted is not
+   lost — its content is **relocated into the error message**, so the agent
+   that trips the control learns the rule at exactly the moment it matters.
+4. **Delete the superseded prose.** The ledger entry, rules-file section,
+   memory note, or wiki duplication that the control replaces is removed in
+   the same PR. Keeping both means every session keeps paying context tax for
+   knowledge the machine already enforces.
+
+**A PR missing any of the four is rejected by rule.** Reviewers (human, bot,
+or verification lifecycle) cite this contract and reject — no case-by-case
+judgment call is needed. The failure modes are structural, not stylistic:
+
+- **Promote-without-remove double-pays forever**: the control enforces the
+  invariant while the prose keeps taxing every session, and the two drift
+  apart over time.
+- **Remove-without-diagnostic strands agents**: the prose is gone, the control
+  fires, and the violator has no idea what invariant it tripped or how to
+  repair it.
+- **Enable-without-population-fix** reds the build for everyone or breeds
+  blanket ignores that hollow the control out.
+
+The same atomicity applies in reverse to **retirements** the gardener batches:
+a prose deletion whose invariant is claimed to be mechanically owned must cite
+the owning control (rule name, config location) in the deleting PR.
+
+## The diagnostic-quality bar
+
+The error message must **teach the repair**, because it is the only surface
+the violating agent will see. Every promoted control's diagnostic states:
+
+1. **The violated invariant** — what rule was broken, named precisely.
+2. **Why the invariant holds** — the causal story that used to live in the
+   prose (the incident, the failure class, the platform behavior).
+3. **The concrete fix** — what to change, ideally with the typical corrected
+   form inline.
+
+Example shape (from this repo's own lint conventions):
+
+> "Direct `process.env` access is forbidden. Config values bypass validation
+> and typing when read ad hoc (past incidents: silent `undefined` in Lambda
+> cold starts). Use the config module: `getStandaloneConfig().myValue`."
+
+A diagnostic that merely restates the rule name ("no-direct-env: direct env
+access is not allowed") fails the bar and fails the promotion PR with it.
+
+## Eager-tier admission policy (demotion-biased)
+
+The eager rules tier (auto-loaded rules trees) charges **every session,
+unconditionally**. Admission is therefore **earned, never defaulted**:
+
+- A rule enters (or stays in) the eager tier only on cited **repeated-miss
+  evidence** — the knowledge was already retrievable (ledger, wiki, skill,
+  reference body) and agents still failed repeatedly because they did not
+  know to look. Absent that evidence, the content belongs on a cheaper rung.
+- The policy is **demotion-biased**: when in doubt, move down the ladder.
+  A wrongly demoted rule earns its way back with fresh failure evidence; a
+  wrongly admitted rule taxes every session until someone notices.
+- The gardener audits the eager tier **every run** — and that audit includes
+  **Lisa's own shipped eager rules**, not just host-project additions. No
+  rule is grandfathered; kernel rules demonstrating no repeated-miss evidence
+  get demotion tickets like any other candidate, filed upstream
+  (`template-candidate` or `self-hardening` lane as applicable).
+
+## AC template for EXECUTABLE-CONTROL promotion tickets
+
+The gardener embeds the following snippet **verbatim** (markers included) into
+the acceptance criteria of every EXECUTABLE-CONTROL promotion ticket, so
+implementing agents receive the contract inside the work item itself:
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+Do not paraphrase, reorder, or partially quote the snippet when embedding it —
+verbatim embedding is what keeps the contract identical across every ticket
+and lets reviewers diff against a single source of truth.
+
+## Who consumes this rule
+
+- **Implementing agents** working a promotion ticket: structure the PR around
+  the four legs before writing code.
+- **Review flows** (human, CodeRabbit, `lisa-pull-request-review`,
+  verification lifecycle): reject a promotion PR missing any leg, citing this
+  rule.
+- **The gardener** (`lisa-learnings-audit`): embeds the AC template above into
+  EXECUTABLE-CONTROL promotion tickets and applies the eager-tier admission
+  policy when auditing.
+- **PROJECT_RULES.md owners**: that file is human-authored only; machine
+  writes go to the learnings ledger, and promotions out of it arrive as
+  gardener tickets governed by this contract.

--- a/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings ladder (PRD #1729). Periodically audits every knowledge surface — ledger, rules trees (including Lisa's own shipped eager rules), skills, wiki index, and mechanical-control surfaces — gathers evidence per item (recurrence, staleness, redundancy, contradiction, budget pressure), classifies each candidate through the ladder router (skill-evaluator, advisory), and communicates exclusively through the tracker: one evidence-bearing ticket per PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated at v1 — the skill only files tickets; humans gate by flipping status:ready or closing as rejected, and rejections are remembered. Cron-able via lisa-setup-automations and runnable on demand via /lisa:learnings:audit."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-setup-automations
-description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day). Two flags — auto-start-prds and auto-start-tickets — control whether the ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review. Tear down with /tear-down-automations."
+description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa-cursor/commands/lisa/learnings/audit.md
+++ b/plugins/lisa-cursor/commands/lisa/learnings/audit.md
@@ -1,0 +1,6 @@
+---
+description: "Run one gardener cycle over this project's knowledge surfaces (the learnings ladder, PRD #1729): inventory ledger/rules/skills/wiki/mechanical controls, gather evidence, classify via the ladder router, and file human-gated tracker tickets — per-item PROMOTE/DEMOTE tickets, one CONFIRM/RETIRE batch ticket per run, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated; the run only files marker-deduped tickets. Terminal states: nothing-needed | candidates-proposed | blocked."
+argument-hint: "[max_candidates=10] [surface=ledger|rules|skills|wiki|all] [dry_run=true]"
+---
+
+Use the /lisa-learnings-audit skill (the gardener) to run one audit cycle: inventory the knowledge surfaces, gather per-item evidence, classify candidates through the ladder router, and emit human-gated, marker-deduped tracker tickets, reporting the terminal state. $ARGUMENTS

--- a/plugins/lisa-cursor/rules/promotion-contract-reference.mdc
+++ b/plugins/lisa-cursor/rules/promotion-contract-reference.mdc
@@ -1,0 +1,131 @@
+---
+description: "Promotion Contract"
+alwaysApply: false
+---
+
+# Promotion Contract
+
+When a learnings-ladder promotion ticket (PRD #1729) is implemented — turning a
+prose learning, rule section, or ledger entry into an **executable control**
+(lint, ast-grep, type constraint, test, hook, or `package.lisa.json` force) —
+the implementing PR is governed by this contract. The gardener
+(`lisa-learnings-audit`) files the tickets; a human gates them by flipping
+`status:ready`; the factory implements them like any other work item. This rule
+is what makes the resulting PR reviewable **by rule, not by reviewer taste**.
+
+## The atomic promote-and-delete contract
+
+A promotion PR must do **all four** of the following, in **one atomic PR**:
+
+1. **Enable the control.** The lint rule, ast-grep pattern, type constraint,
+   test, hook, or `package.lisa.json` force entry is active and blocking (CI
+   and/or local gates), not merely added in a warn-only or disabled state.
+2. **Fix the existing violation population.** Every current violation of the
+   new control in the repository is migrated in the same PR, so the control
+   lands green. Enabling a control against a red population either blocks all
+   unrelated work or forces a blanket ignore — both defeat the promotion.
+3. **Ship a remediation-teaching diagnostic.** The control's failure message
+   meets the diagnostic-quality bar below. The prose being deleted is not
+   lost — its content is **relocated into the error message**, so the agent
+   that trips the control learns the rule at exactly the moment it matters.
+4. **Delete the superseded prose.** The ledger entry, rules-file section,
+   memory note, or wiki duplication that the control replaces is removed in
+   the same PR. Keeping both means every session keeps paying context tax for
+   knowledge the machine already enforces.
+
+**A PR missing any of the four is rejected by rule.** Reviewers (human, bot,
+or verification lifecycle) cite this contract and reject — no case-by-case
+judgment call is needed. The failure modes are structural, not stylistic:
+
+- **Promote-without-remove double-pays forever**: the control enforces the
+  invariant while the prose keeps taxing every session, and the two drift
+  apart over time.
+- **Remove-without-diagnostic strands agents**: the prose is gone, the control
+  fires, and the violator has no idea what invariant it tripped or how to
+  repair it.
+- **Enable-without-population-fix** reds the build for everyone or breeds
+  blanket ignores that hollow the control out.
+
+The same atomicity applies in reverse to **retirements** the gardener batches:
+a prose deletion whose invariant is claimed to be mechanically owned must cite
+the owning control (rule name, config location) in the deleting PR.
+
+## The diagnostic-quality bar
+
+The error message must **teach the repair**, because it is the only surface
+the violating agent will see. Every promoted control's diagnostic states:
+
+1. **The violated invariant** — what rule was broken, named precisely.
+2. **Why the invariant holds** — the causal story that used to live in the
+   prose (the incident, the failure class, the platform behavior).
+3. **The concrete fix** — what to change, ideally with the typical corrected
+   form inline.
+
+Example shape (from this repo's own lint conventions):
+
+> "Direct `process.env` access is forbidden. Config values bypass validation
+> and typing when read ad hoc (past incidents: silent `undefined` in Lambda
+> cold starts). Use the config module: `getStandaloneConfig().myValue`."
+
+A diagnostic that merely restates the rule name ("no-direct-env: direct env
+access is not allowed") fails the bar and fails the promotion PR with it.
+
+## Eager-tier admission policy (demotion-biased)
+
+The eager rules tier (auto-loaded rules trees) charges **every session,
+unconditionally**. Admission is therefore **earned, never defaulted**:
+
+- A rule enters (or stays in) the eager tier only on cited **repeated-miss
+  evidence** — the knowledge was already retrievable (ledger, wiki, skill,
+  reference body) and agents still failed repeatedly because they did not
+  know to look. Absent that evidence, the content belongs on a cheaper rung.
+- The policy is **demotion-biased**: when in doubt, move down the ladder.
+  A wrongly demoted rule earns its way back with fresh failure evidence; a
+  wrongly admitted rule taxes every session until someone notices.
+- The gardener audits the eager tier **every run** — and that audit includes
+  **Lisa's own shipped eager rules**, not just host-project additions. No
+  rule is grandfathered; kernel rules demonstrating no repeated-miss evidence
+  get demotion tickets like any other candidate, filed upstream
+  (`template-candidate` or `self-hardening` lane as applicable).
+
+## AC template for EXECUTABLE-CONTROL promotion tickets
+
+The gardener embeds the following snippet **verbatim** (markers included) into
+the acceptance criteria of every EXECUTABLE-CONTROL promotion ticket, so
+implementing agents receive the contract inside the work item itself:
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+Do not paraphrase, reorder, or partially quote the snippet when embedding it —
+verbatim embedding is what keeps the contract identical across every ticket
+and lets reviewers diff against a single source of truth.
+
+## Who consumes this rule
+
+- **Implementing agents** working a promotion ticket: structure the PR around
+  the four legs before writing code.
+- **Review flows** (human, CodeRabbit, `lisa-pull-request-review`,
+  verification lifecycle): reject a promotion PR missing any leg, citing this
+  rule.
+- **The gardener** (`lisa-learnings-audit`): embeds the AC template above into
+  EXECUTABLE-CONTROL promotion tickets and applies the eager-tier admission
+  policy when auditing.
+- **PROJECT_RULES.md owners**: that file is human-authored only; machine
+  writes go to the learnings ledger, and promotions out of it arrive as
+  gardener tickets governed by this contract.

--- a/plugins/lisa-cursor/rules/promotion-contract.mdc
+++ b/plugins/lisa-cursor/rules/promotion-contract.mdc
@@ -1,0 +1,23 @@
+---
+description: "Promotion Contract (load-bearing)"
+alwaysApply: true
+---
+
+# Promotion Contract (load-bearing)
+
+When implementing a learnings-ladder **promotion ticket** — turning prose
+knowledge into an executable control (lint / ast-grep / type / test / hook /
+`package.lisa.json` force) — the change must be **atomic**: one PR that
+**enables the control**, **fixes the existing violation population**, **ships a
+remediation-teaching diagnostic** (violated invariant + why + concrete fix),
+and **deletes the superseded prose**. A PR missing any of the four is
+**rejected by rule** — promote-without-remove double-pays forever;
+remove-without-diagnostic strands agents.
+
+Eager-tier admission is **demotion-biased** and earned only by repeated-miss
+evidence; the gardener audits the eager tier every run, including Lisa's own
+shipped eager rules.
+
+Full contract, diagnostic-quality bar, and the AC template the gardener embeds
+in EXECUTABLE-CONTROL promotion tickets:
+[reference/promotion-contract.md](promotion-contract-reference.mdc).

--- a/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings ladder (PRD #1729). Periodically audits every knowledge surface — ledger, rules trees (including Lisa's own shipped eager rules), skills, wiki index, and mechanical-control surfaces — gathers evidence per item (recurrence, staleness, redundancy, contradiction, budget pressure), classifies each candidate through the ladder router (skill-evaluator, advisory), and communicates exclusively through the tracker: one evidence-bearing ticket per PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated at v1 — the skill only files tickets; humans gate by flipping status:ready or closing as rejected, and rejections are remembered. Cron-able via lisa-setup-automations and runnable on demand via /lisa:learnings:audit."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-setup-automations
-description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day). Two flags — auto-start-prds and auto-start-tickets — control whether the ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review. Tear down with /tear-down-automations."
+description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings…"
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Learnings Audit"
+short_description: "The gardener of the learnings…"
+default_prompt:
+  - "Use $lisa-learnings-audit: The gardener of the learnings…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa/commands/learnings/audit.md
+++ b/plugins/lisa/commands/learnings/audit.md
@@ -1,0 +1,6 @@
+---
+description: "Run one gardener cycle over this project's knowledge surfaces (the learnings ladder, PRD #1729): inventory ledger/rules/skills/wiki/mechanical controls, gather evidence, classify via the ladder router, and file human-gated tracker tickets — per-item PROMOTE/DEMOTE tickets, one CONFIRM/RETIRE batch ticket per run, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated; the run only files marker-deduped tickets. Terminal states: nothing-needed | candidates-proposed | blocked."
+argument-hint: "[max_candidates=10] [surface=ledger|rules|skills|wiki|all] [dry_run=true]"
+---
+
+Use the /lisa-learnings-audit skill (the gardener) to run one audit cycle: inventory the knowledge surfaces, gather per-item evidence, classify candidates through the ladder router, and emit human-gated, marker-deduped tracker tickets, reporting the terminal state. $ARGUMENTS

--- a/plugins/lisa/rules/eager/promotion-contract.md
+++ b/plugins/lisa/rules/eager/promotion-contract.md
@@ -1,0 +1,18 @@
+# Promotion Contract (load-bearing)
+
+When implementing a learnings-ladder **promotion ticket** — turning prose
+knowledge into an executable control (lint / ast-grep / type / test / hook /
+`package.lisa.json` force) — the change must be **atomic**: one PR that
+**enables the control**, **fixes the existing violation population**, **ships a
+remediation-teaching diagnostic** (violated invariant + why + concrete fix),
+and **deletes the superseded prose**. A PR missing any of the four is
+**rejected by rule** — promote-without-remove double-pays forever;
+remove-without-diagnostic strands agents.
+
+Eager-tier admission is **demotion-biased** and earned only by repeated-miss
+evidence; the gardener audits the eager tier every run, including Lisa's own
+shipped eager rules.
+
+Full contract, diagnostic-quality bar, and the AC template the gardener embeds
+in EXECUTABLE-CONTROL promotion tickets:
+[reference/promotion-contract.md](../reference/promotion-contract.md).

--- a/plugins/lisa/rules/reference/promotion-contract.md
+++ b/plugins/lisa/rules/reference/promotion-contract.md
@@ -1,0 +1,126 @@
+# Promotion Contract
+
+When a learnings-ladder promotion ticket (PRD #1729) is implemented — turning a
+prose learning, rule section, or ledger entry into an **executable control**
+(lint, ast-grep, type constraint, test, hook, or `package.lisa.json` force) —
+the implementing PR is governed by this contract. The gardener
+(`lisa-learnings-audit`) files the tickets; a human gates them by flipping
+`status:ready`; the factory implements them like any other work item. This rule
+is what makes the resulting PR reviewable **by rule, not by reviewer taste**.
+
+## The atomic promote-and-delete contract
+
+A promotion PR must do **all four** of the following, in **one atomic PR**:
+
+1. **Enable the control.** The lint rule, ast-grep pattern, type constraint,
+   test, hook, or `package.lisa.json` force entry is active and blocking (CI
+   and/or local gates), not merely added in a warn-only or disabled state.
+2. **Fix the existing violation population.** Every current violation of the
+   new control in the repository is migrated in the same PR, so the control
+   lands green. Enabling a control against a red population either blocks all
+   unrelated work or forces a blanket ignore — both defeat the promotion.
+3. **Ship a remediation-teaching diagnostic.** The control's failure message
+   meets the diagnostic-quality bar below. The prose being deleted is not
+   lost — its content is **relocated into the error message**, so the agent
+   that trips the control learns the rule at exactly the moment it matters.
+4. **Delete the superseded prose.** The ledger entry, rules-file section,
+   memory note, or wiki duplication that the control replaces is removed in
+   the same PR. Keeping both means every session keeps paying context tax for
+   knowledge the machine already enforces.
+
+**A PR missing any of the four is rejected by rule.** Reviewers (human, bot,
+or verification lifecycle) cite this contract and reject — no case-by-case
+judgment call is needed. The failure modes are structural, not stylistic:
+
+- **Promote-without-remove double-pays forever**: the control enforces the
+  invariant while the prose keeps taxing every session, and the two drift
+  apart over time.
+- **Remove-without-diagnostic strands agents**: the prose is gone, the control
+  fires, and the violator has no idea what invariant it tripped or how to
+  repair it.
+- **Enable-without-population-fix** reds the build for everyone or breeds
+  blanket ignores that hollow the control out.
+
+The same atomicity applies in reverse to **retirements** the gardener batches:
+a prose deletion whose invariant is claimed to be mechanically owned must cite
+the owning control (rule name, config location) in the deleting PR.
+
+## The diagnostic-quality bar
+
+The error message must **teach the repair**, because it is the only surface
+the violating agent will see. Every promoted control's diagnostic states:
+
+1. **The violated invariant** — what rule was broken, named precisely.
+2. **Why the invariant holds** — the causal story that used to live in the
+   prose (the incident, the failure class, the platform behavior).
+3. **The concrete fix** — what to change, ideally with the typical corrected
+   form inline.
+
+Example shape (from this repo's own lint conventions):
+
+> "Direct `process.env` access is forbidden. Config values bypass validation
+> and typing when read ad hoc (past incidents: silent `undefined` in Lambda
+> cold starts). Use the config module: `getStandaloneConfig().myValue`."
+
+A diagnostic that merely restates the rule name ("no-direct-env: direct env
+access is not allowed") fails the bar and fails the promotion PR with it.
+
+## Eager-tier admission policy (demotion-biased)
+
+The eager rules tier (auto-loaded rules trees) charges **every session,
+unconditionally**. Admission is therefore **earned, never defaulted**:
+
+- A rule enters (or stays in) the eager tier only on cited **repeated-miss
+  evidence** — the knowledge was already retrievable (ledger, wiki, skill,
+  reference body) and agents still failed repeatedly because they did not
+  know to look. Absent that evidence, the content belongs on a cheaper rung.
+- The policy is **demotion-biased**: when in doubt, move down the ladder.
+  A wrongly demoted rule earns its way back with fresh failure evidence; a
+  wrongly admitted rule taxes every session until someone notices.
+- The gardener audits the eager tier **every run** — and that audit includes
+  **Lisa's own shipped eager rules**, not just host-project additions. No
+  rule is grandfathered; kernel rules demonstrating no repeated-miss evidence
+  get demotion tickets like any other candidate, filed upstream
+  (`template-candidate` or `self-hardening` lane as applicable).
+
+## AC template for EXECUTABLE-CONTROL promotion tickets
+
+The gardener embeds the following snippet **verbatim** (markers included) into
+the acceptance criteria of every EXECUTABLE-CONTROL promotion ticket, so
+implementing agents receive the contract inside the work item itself:
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+Do not paraphrase, reorder, or partially quote the snippet when embedding it —
+verbatim embedding is what keeps the contract identical across every ticket
+and lets reviewers diff against a single source of truth.
+
+## Who consumes this rule
+
+- **Implementing agents** working a promotion ticket: structure the PR around
+  the four legs before writing code.
+- **Review flows** (human, CodeRabbit, `lisa-pull-request-review`,
+  verification lifecycle): reject a promotion PR missing any leg, citing this
+  rule.
+- **The gardener** (`lisa-learnings-audit`): embeds the AC template above into
+  EXECUTABLE-CONTROL promotion tickets and applies the eager-tier admission
+  policy when auditing.
+- **PROJECT_RULES.md owners**: that file is human-authored only; machine
+  writes go to the learnings ledger, and promotions out of it arrive as
+  gardener tickets governed by this contract.

--- a/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings ladder (PRD #1729). Periodically audits every knowledge surface — ledger, rules trees (including Lisa's own shipped eager rules), skills, wiki index, and mechanical-control surfaces — gathers evidence per item (recurrence, staleness, redundancy, contradiction, budget pressure), classifies each candidate through the ladder router (skill-evaluator, advisory), and communicates exclusively through the tracker: one evidence-bearing ticket per PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated at v1 — the skill only files tickets; humans gate by flipping status:ready or closing as rejected, and rejections are remembered. Cron-able via lisa-setup-automations and runnable on demand via /lisa:learnings:audit."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/lisa/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/lisa/skills/lisa-learnings-audit/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-learnings-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Learnings Audit"
+short_description: "The gardener of the learnings ladder (PRD #1729)"
+default_prompt:
+  - "Use $lisa-learnings-audit: The gardener of the learnings ladder (PRD #1729)."

--- a/plugins/lisa/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/lisa/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-setup-automations
-description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day). Two flags — auto-start-prds and auto-start-tickets — control whether the ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review. Tear down with /tear-down-automations."
+description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/src/base/commands/learnings/audit.md
+++ b/plugins/src/base/commands/learnings/audit.md
@@ -1,0 +1,6 @@
+---
+description: "Run one gardener cycle over this project's knowledge surfaces (the learnings ladder, PRD #1729): inventory ledger/rules/skills/wiki/mechanical controls, gather evidence, classify via the ladder router, and file human-gated tracker tickets — per-item PROMOTE/DEMOTE tickets, one CONFIRM/RETIRE batch ticket per run, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated; the run only files marker-deduped tickets. Terminal states: nothing-needed | candidates-proposed | blocked."
+argument-hint: "[max_candidates=10] [surface=ledger|rules|skills|wiki|all] [dry_run=true]"
+---
+
+Use the /lisa-learnings-audit skill (the gardener) to run one audit cycle: inventory the knowledge surfaces, gather per-item evidence, classify candidates through the ladder router, and emit human-gated, marker-deduped tracker tickets, reporting the terminal state. $ARGUMENTS

--- a/plugins/src/base/rules/eager/promotion-contract.md
+++ b/plugins/src/base/rules/eager/promotion-contract.md
@@ -1,0 +1,18 @@
+# Promotion Contract (load-bearing)
+
+When implementing a learnings-ladder **promotion ticket** — turning prose
+knowledge into an executable control (lint / ast-grep / type / test / hook /
+`package.lisa.json` force) — the change must be **atomic**: one PR that
+**enables the control**, **fixes the existing violation population**, **ships a
+remediation-teaching diagnostic** (violated invariant + why + concrete fix),
+and **deletes the superseded prose**. A PR missing any of the four is
+**rejected by rule** — promote-without-remove double-pays forever;
+remove-without-diagnostic strands agents.
+
+Eager-tier admission is **demotion-biased** and earned only by repeated-miss
+evidence; the gardener audits the eager tier every run, including Lisa's own
+shipped eager rules.
+
+Full contract, diagnostic-quality bar, and the AC template the gardener embeds
+in EXECUTABLE-CONTROL promotion tickets:
+[reference/promotion-contract.md](../reference/promotion-contract.md).

--- a/plugins/src/base/rules/reference/promotion-contract.md
+++ b/plugins/src/base/rules/reference/promotion-contract.md
@@ -1,0 +1,126 @@
+# Promotion Contract
+
+When a learnings-ladder promotion ticket (PRD #1729) is implemented — turning a
+prose learning, rule section, or ledger entry into an **executable control**
+(lint, ast-grep, type constraint, test, hook, or `package.lisa.json` force) —
+the implementing PR is governed by this contract. The gardener
+(`lisa-learnings-audit`) files the tickets; a human gates them by flipping
+`status:ready`; the factory implements them like any other work item. This rule
+is what makes the resulting PR reviewable **by rule, not by reviewer taste**.
+
+## The atomic promote-and-delete contract
+
+A promotion PR must do **all four** of the following, in **one atomic PR**:
+
+1. **Enable the control.** The lint rule, ast-grep pattern, type constraint,
+   test, hook, or `package.lisa.json` force entry is active and blocking (CI
+   and/or local gates), not merely added in a warn-only or disabled state.
+2. **Fix the existing violation population.** Every current violation of the
+   new control in the repository is migrated in the same PR, so the control
+   lands green. Enabling a control against a red population either blocks all
+   unrelated work or forces a blanket ignore — both defeat the promotion.
+3. **Ship a remediation-teaching diagnostic.** The control's failure message
+   meets the diagnostic-quality bar below. The prose being deleted is not
+   lost — its content is **relocated into the error message**, so the agent
+   that trips the control learns the rule at exactly the moment it matters.
+4. **Delete the superseded prose.** The ledger entry, rules-file section,
+   memory note, or wiki duplication that the control replaces is removed in
+   the same PR. Keeping both means every session keeps paying context tax for
+   knowledge the machine already enforces.
+
+**A PR missing any of the four is rejected by rule.** Reviewers (human, bot,
+or verification lifecycle) cite this contract and reject — no case-by-case
+judgment call is needed. The failure modes are structural, not stylistic:
+
+- **Promote-without-remove double-pays forever**: the control enforces the
+  invariant while the prose keeps taxing every session, and the two drift
+  apart over time.
+- **Remove-without-diagnostic strands agents**: the prose is gone, the control
+  fires, and the violator has no idea what invariant it tripped or how to
+  repair it.
+- **Enable-without-population-fix** reds the build for everyone or breeds
+  blanket ignores that hollow the control out.
+
+The same atomicity applies in reverse to **retirements** the gardener batches:
+a prose deletion whose invariant is claimed to be mechanically owned must cite
+the owning control (rule name, config location) in the deleting PR.
+
+## The diagnostic-quality bar
+
+The error message must **teach the repair**, because it is the only surface
+the violating agent will see. Every promoted control's diagnostic states:
+
+1. **The violated invariant** — what rule was broken, named precisely.
+2. **Why the invariant holds** — the causal story that used to live in the
+   prose (the incident, the failure class, the platform behavior).
+3. **The concrete fix** — what to change, ideally with the typical corrected
+   form inline.
+
+Example shape (from this repo's own lint conventions):
+
+> "Direct `process.env` access is forbidden. Config values bypass validation
+> and typing when read ad hoc (past incidents: silent `undefined` in Lambda
+> cold starts). Use the config module: `getStandaloneConfig().myValue`."
+
+A diagnostic that merely restates the rule name ("no-direct-env: direct env
+access is not allowed") fails the bar and fails the promotion PR with it.
+
+## Eager-tier admission policy (demotion-biased)
+
+The eager rules tier (auto-loaded rules trees) charges **every session,
+unconditionally**. Admission is therefore **earned, never defaulted**:
+
+- A rule enters (or stays in) the eager tier only on cited **repeated-miss
+  evidence** — the knowledge was already retrievable (ledger, wiki, skill,
+  reference body) and agents still failed repeatedly because they did not
+  know to look. Absent that evidence, the content belongs on a cheaper rung.
+- The policy is **demotion-biased**: when in doubt, move down the ladder.
+  A wrongly demoted rule earns its way back with fresh failure evidence; a
+  wrongly admitted rule taxes every session until someone notices.
+- The gardener audits the eager tier **every run** — and that audit includes
+  **Lisa's own shipped eager rules**, not just host-project additions. No
+  rule is grandfathered; kernel rules demonstrating no repeated-miss evidence
+  get demotion tickets like any other candidate, filed upstream
+  (`template-candidate` or `self-hardening` lane as applicable).
+
+## AC template for EXECUTABLE-CONTROL promotion tickets
+
+The gardener embeds the following snippet **verbatim** (markers included) into
+the acceptance criteria of every EXECUTABLE-CONTROL promotion ticket, so
+implementing agents receive the contract inside the work item itself:
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+Do not paraphrase, reorder, or partially quote the snippet when embedding it —
+verbatim embedding is what keeps the contract identical across every ticket
+and lets reviewers diff against a single source of truth.
+
+## Who consumes this rule
+
+- **Implementing agents** working a promotion ticket: structure the PR around
+  the four legs before writing code.
+- **Review flows** (human, CodeRabbit, `lisa-pull-request-review`,
+  verification lifecycle): reject a promotion PR missing any leg, citing this
+  rule.
+- **The gardener** (`lisa-learnings-audit`): embeds the AC template above into
+  EXECUTABLE-CONTROL promotion tickets and applies the eager-tier admission
+  policy when auditing.
+- **PROJECT_RULES.md owners**: that file is human-authored only; machine
+  writes go to the learnings ledger, and promotions out of it arrive as
+  gardener tickets governed by this contract.

--- a/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lisa-learnings-audit
+description: "The gardener of the learnings ladder (PRD #1729). Periodically audits every knowledge surface — ledger, rules trees (including Lisa's own shipped eager rules), skills, wiki index, and mechanical-control surfaces — gathers evidence per item (recurrence, staleness, redundancy, contradiction, budget pressure), classifies each candidate through the ladder router (skill-evaluator, advisory), and communicates exclusively through the tracker: one evidence-bearing ticket per PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream Lisa issues for upstream-scoped patterns. Everything is human-gated at v1 — the skill only files tickets; humans gate by flipping status:ready or closing as rejected, and rejections are remembered. Cron-able via lisa-setup-automations and runnable on demand via /lisa:learnings:audit."
+allowed-tools: ["Skill", "Bash", "Read", "Glob", "Grep"]
+---
+
+# Learnings Audit (the gardener): $ARGUMENTS
+
+Run one audit cycle over this project's knowledge surfaces and convert what the
+evidence supports into **human-gated tracker tickets** — nothing else. The
+gardener is the only flow in Lisa that takes knowledge *back out* or moves it
+*up* the ladder; it closes the loop that capture (learner, debrief-apply, MLD)
+opens.
+
+`$ARGUMENTS` (all optional): `max_candidates=<n>` (default **10** — cap on
+per-item PROMOTE/DEMOTE tickets filed per run, following the
+`lisa-repair-intake` bounded-cycle precedent; CONFIRM/RETIRE batch rows are
+not capped), `surface=<ledger|rules|skills|wiki|all>` (default `all`),
+`dry_run=true` (report what would be filed, file nothing).
+
+## Intent
+
+Keep the knowledge system from silting up: every learning lives at the
+cheapest rung that still prevents the mistake (per the six-rung ladder,
+PRD #1729), prose never duplicates a mechanical owner, the eager tier shrinks
+over time, and every change to "what the agents believe" is approved by a
+human through the tracker. A quiet run with nothing to propose is a healthy
+outcome and says so in its one-line summary.
+
+## Sources of truth
+
+Inventory these surfaces each run — discover dynamically, never from a
+memorized list:
+
+1. **The ledger** — resolve via `.lisa.config.json` (`learnings.file`, default
+   `.lisa/PROJECT_LEARNINGS.md`) and read it ONLY through the executable
+   contract from `@codyswann/lisa/learnings`: `parseLearningsFile` for the
+   **full parse** (the gardener is the maintenance loop — auditing requires
+   every entry, and the contract-mediated full parse is its documented
+   exemption from projection-only serving) plus `projectLearnings` for the
+   bounded projection (to measure **budget pressure**: how many entries the
+   projection omits). Never hand-parse or hand-edit the raw file.
+2. **Rules trees** — the plugin `rules/eager/` + `rules/reference/` pairs AND
+   the host project's `.claude/rules/` (e.g. `PROJECT_RULES.md`, which is
+   human-authored only — its existing sections are still audit candidates;
+   first-run candidates come from exactly there).
+3. **Skills** — `.claude/skills/` and the plugin skill roots the runtime
+   exposes (descriptions are eager context; bodies load on invoke).
+4. **The wiki index** — `wiki/index.md` when the project has a wiki.
+5. **Mechanical-control surfaces** — lint configs (ESLint/oxlint), ast-grep
+   rules, git hooks, test suites, and `package.lisa.json` force sections:
+   the surfaces that answer "does a mechanical owner already exist?".
+6. **The tracker** — prior gardener tickets (open, done, and closed-rejected)
+   are its memory; see Idempotency.
+
+## Candidate-selection rules
+
+A surface item becomes a candidate only when evidence supports a change.
+Gather, per item, the five evidence axes:
+
+| Axis | Question | How |
+|------|----------|-----|
+| **Recurrence** | Has the same failure class recurred since the entry's `last_confirmed` (or the rule's last touch)? | Search issues/PRs/commits since that date — reuse the `git-history-analyzer` agent for commit/PR archaeology; tracker search for issue recurrence. |
+| **Staleness** | Does the item reference files, flags, versions, or tools that no longer exist? | Glob/Grep the referenced paths and configs. |
+| **Redundancy** | Does a mechanical owner already enforce the invariant? (The double-payment hunter.) | Check lint/ast-grep/hook/test/force surfaces for the same invariant. |
+| **Contradiction** | Does the item contradict another rule, skill, config, or observed current behavior? | Cross-reference the inventoried surfaces. |
+| **Budget pressure** | Is the ledger projection omitting entries, or the eager tier growing? | `projectLearnings` omission count; eager-tree token/size trend. |
+
+Selection outcomes per candidate: **PROMOTE** (up the ladder), **DEMOTE**
+(down the ladder), **CONFIRM** (evidence the entry demonstrably applied —
+a `last_confirmed` bump), **RETIRE** (provably redundant/stale — proof, not
+vibes), or leave alone. No evidence ⇒ no candidate; the gardener never files
+a recommendation it cannot evidence.
+
+**The eager tier is audited every run** — including
+**Lisa's own shipped eager rules**, not just host additions. Admission is demotion-biased and
+earned only by repeated-miss evidence (see the `promotion-contract` rule);
+an eager rule without that evidence gets a DEMOTE candidate citing the
+admission policy, scoped upstream when the rule ships with the kernel.
+
+**Exclusions (no learning loops about learning).** Never candidates, never
+evidence:
+
+- The gardener's own tickets, PRs, and comments (anything carrying the
+  `[lisa-gardener]` marker).
+- All learning-machinery artifacts: items carrying `[lisa-learning-drop]`,
+  `[lisa-learning-pr]`, `[lisa-learning-upstream-handoff]` (any
+  `[lisa-learning-*]` marker), `[lisa-rejection-candidate]`, or
+  `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label.
+
+## Scope
+
+- **In scope**: recommending placement changes for knowledge on any
+  inventoried surface, in this repository (`project` scope) or upstream in
+  `CodySwannGT/lisa` (`upstream` scope).
+- **Out of scope**: executing any promotion/demotion/retirement (the factory
+  does, per flipped tickets), editing any knowledge surface, auto-apply modes
+  (v1 is fully gated), and the capture streams (learner, debrief, MLD).
+
+## Proof
+
+A run is proven, not asserted. The per-run report (and the run ticket, when
+one exists) must show:
+
+- The surfaces inventoried, with counts (ledger entries parsed, rules files,
+  skills, wiki pages, mechanical controls).
+- Per filed ticket: the fingerprint marker, the evidence refs behind it, and
+  the router's rung — so any reviewer can replay the reasoning from links
+  alone.
+- Per skipped candidate: which dedupe hit suppressed it (open ticket URL,
+  done ticket, or rejection date).
+- For `nothing-needed`: the thresholds nothing met, in one line.
+
+The tickets themselves are the durable artifacts; the report is how a human
+audits the auditor without re-running it.
+
+## The audit cycle
+
+1. **Inventory** the sources of truth above.
+2. **Evidence** — gather the five axes per item; drop items with none.
+3. **Classify** — pass each candidate (`rule`, `why`, `provenance`,
+   `evidence`) to the ladder router (the `skill-evaluator` agent). The router
+   is **advisory**: it returns `rung`, `scope`, `rationale`, and
+   `drafted_artifact`; the gardener decides whether the evidence clears the
+   filing bar and attaches the router's draft to the ticket.
+4. **Emit** (see Ticket emission).
+5. **Report** the terminal state and one-line summary.
+
+## Ticket emission
+
+All project-tracker writes go through **`lisa-tracker-write`** so gardener
+tickets pass the same validation gates as all factory work. Nothing is created
+`status:ready` — the human flips.
+
+**Per-item tickets — PROMOTE / DEMOTE** (`issue_type: Task`; GitHub trackers
+carry the `type:Task` label) — one ticket per recommendation, capped by
+`max_candidates`:
+
+- A **three-audience description** (operator: what changes about what the
+  agents believe and why it is safe; engineering: the surface, the invariant,
+  the destination rung; QA: how to verify the move) with **evidence links**
+  (the recurrence issues/PRs/commits, the staleness proof, the mechanical
+  owner).
+- The router's **`drafted_artifact`** verbatim (the lint/hook sketch +
+  diagnostic text, proposed rule text, skill outline, page outline, or
+  redundancy proof).
+- For **EXECUTABLE-CONTROL** promotions, embed the promotion-contract AC
+  template below **verbatim** (markers included — do not paraphrase, reorder,
+  or partially quote it; it is the single source of truth from the
+  `promotion-contract` rule):
+
+<!-- promotion-contract-ac-template:start -->
+### Acceptance Criteria (promotion-to-control contract)
+
+One atomic PR that satisfies all four legs — a PR missing any of the four is
+rejected by rule (see the `promotion-contract` rule):
+
+- [ ] **Enables the control** — the lint / ast-grep / type constraint / test /
+      hook / `package.lisa.json` force entry is active and blocking.
+- [ ] **Fixes the existing violation population** — every current violation is
+      migrated in this same PR, so the control lands green with no blanket
+      ignores.
+- [ ] **Ships a remediation-teaching diagnostic** — the failure message states
+      the violated invariant, why it holds, and the concrete fix.
+- [ ] **Deletes the superseded prose** — the ledger entry / rules section this
+      control replaces is removed in this same PR, citing the new mechanical
+      owner.
+<!-- promotion-contract-ac-template:end -->
+
+**One batch ticket per run — CONFIRM + RETIRE** (`issue_type: Task`): a single
+ticket listing every CONFIRM row (`last_confirmed` bump, with the evidence the
+entry demonstrably applied) and every **provably-redundant** RETIRE row (with
+the mechanical owner / staleness proof per row). Rows are individually
+strikeable — the human deletes rows they reject, then flips the ticket ready.
+The gardener **never bumps `last_confirmed` itself**: the bumps are executed
+by the **implementing factory run** that picks up the flipped batch ticket,
+which applies each surviving CONFIRM row via `confirmLearningEntry` from
+`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
+citing the row's proof.
+
+**Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
+`hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
+`lisa-rework-triage` "Filing upstream" procedure and its two lanes:
+`self-hardening` for defects, `template-candidate` for generalizable patterns
+(with the required `## Proposed template change` section). Same dedupe-marker
++ evidence-chain discipline; the gardener's fingerprint marker (below) rides
+in the issue body.
+
+## Idempotency
+
+Every recommendation carries a stable fingerprint embedded as an HTML comment
+marker in the ticket/issue body:
+
+```
+<!-- [lisa-gardener] key=<surface>+<invariant-hash> -->
+```
+
+where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
+short stable hash of the normalized invariant text — the same knowledge item
+always produces the same key across runs.
+
+Before filing anything, search the tracker for the marker in
+**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
+plus a body-grep fallback for search-index lag):
+
+- **Open** with the marker → do not re-file; append new evidence as a comment
+  only if it is materially new.
+- **Closed via merged work** → done; a genuine regression later is new
+  evidence and a new ticket.
+- **Closed unmerged / rejected** → the human declined. **Do NOT re-file**
+  unless new evidence **postdates the rejection** — and when re-filing, state
+  the postdating evidence explicitly in the ticket ("rejected <date>; recurred
+  <date> in <ref>"). Closed-as-rejected tickets ARE the gardener's memory of
+  declined recommendations.
+
+Re-runs are quiet no-ops: same surfaces + same evidence ⇒ zero new tickets.
+
+## Autonomous-vs-approval boundary
+
+**Everything is human-gated at v1 — this skill only files tickets.** The
+gardener never edits, writes, or deletes any rule, skill, wiki page, ledger
+entry, lint config, or hook itself; it never merges, transitions, or flips
+anything to `status:ready`; it never bumps `last_confirmed`. Autonomous
+actions are limited to: reading surfaces, gathering evidence, invoking the
+advisory router, and creating/commenting marker-deduped tickets. Humans gate
+by flipping a ticket to `status:ready` (the factory then executes it like any
+work item, honoring the `promotion-contract` rule) or closing it as rejected.
+A future `learnings.autoApply` config may widen this; v1 ships none.
+
+## Escalation
+
+Headless-safe: this skill **never prompts** — it is a cron target. When it
+cannot proceed (tracker unreachable, contradictory config, ledger contract
+error that blocks the parse), it labels its own run ticket — or, when it
+cannot create one, reports in its summary — `status:blocked` + `human-needed`
+with an **operator-readable** reason: what it was trying to do, what it
+observed, and the smallest human action that unblocks it, in plain language a
+non-technical operator standing at the gate can act on.
+
+## Recovery
+
+Every external write is marker-deduped, so a crashed or interrupted run
+leaves no cleanup debt: re-running is the recovery procedure. A partial run's
+already-filed tickets are found by their markers and not duplicated; a batch
+ticket from an interrupted run is reused (append missing rows as a comment)
+rather than reissued. Never attempt to "roll back" filed tickets — close-out
+decisions belong to humans.
+
+## Terminal states
+
+Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
+
+- `nothing-needed` — no candidate met any recommendation threshold. Healthy.
+  Report one line: surfaces scanned, entries seen, "nothing to propose".
+- `candidates-proposed` — tickets filed. Report each ticket URL, its
+  recommendation (PROMOTE/DEMOTE + rung), and the batch ticket URL with its
+  row count.
+- `blocked` — could not complete; escalated per Escalation with the
+  operator-readable reason.
+
+## Retirement condition
+
+The loop retires itself by the same discipline it applies to everything else:
+after **six consecutive `nothing-needed` runs** with no new ledger entries
+captured in the same window, the gardener files ONE (marker-deduped) ticket
+proposing to lengthen its cadence or tear down its automation
+(`/tear-down-automations`), with the run log as evidence. It keeps running
+until a human flips that ticket — retirement is a recommendation like any
+other, never a self-executed exit.
+
+## Scheduling
+
+Register as an **optional** recurring loop through `lisa-setup-automations`
+(the `lisa-auto-<project>-*` naming convention): automation
+`lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
+a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
+when the operator asks for the gardener loop, unlike the six default
+automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
+manual and scheduled runs are identical (the markers make them safely
+concurrent-adjacent).
+
+## Rules
+
+- Tracker-only output: no file edits, no PRs, no label flips beyond the
+  gardener's own run-ticket escalation labels.
+- Evidence or nothing: every recommendation cites concrete refs; RETIRE
+  requires proof of redundancy/staleness, not vibes.
+- One batch ticket per run, at most `max_candidates` per-item tickets.
+- All ticket writes via `lisa-tracker-write` (or `gh` for the upstream repo,
+  per the rework-triage upstream procedure) — never raw unvalidated creation.
+- Never classify without the router, never file without the dedupe search,
+  never re-file over a rejection without postdating evidence.
+- No learning loops about learning: the exclusion registry is absolute.

--- a/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
@@ -273,8 +273,12 @@ Every external write is marker-deduped, so a crashed or interrupted run
 leaves no cleanup debt: re-running is the recovery procedure. A partial run's
 already-filed tickets are found by their markers and not duplicated; a batch
 ticket from an interrupted run is reused (append missing rows as a comment)
-rather than reissued. Never attempt to "roll back" filed tickets — close-out
-decisions belong to humans.
+rather than reissued. **Filing order**: file the per-item PROMOTE/DEMOTE
+tickets first and the CONFIRM/RETIRE **batch ticket last** — the batch is the
+run's completion signal, so a crash mid-run leaves individually
+marker-recoverable per-item tickets and a missing (not half-filled) batch:
+the most recoverable state. Never attempt to "roll back" filed tickets —
+close-out decisions belong to humans.
 
 ## Terminal states
 
@@ -290,13 +294,24 @@ Exactly one per run: **`nothing-needed | candidates-proposed | blocked`**
 
 ## Retirement condition
 
-The loop retires itself by the same discipline it applies to everything else:
-after **six consecutive `nothing-needed` runs** with no new ledger entries
-captured in the same window, the gardener files ONE (marker-deduped) ticket
-proposing to lengthen its cadence or tear down its automation
-(`/tear-down-automations`), with the run log as evidence. It keeps running
-until a human flips that ticket — retirement is a recommendation like any
-other, never a self-executed exit.
+The loop retires itself by the same discipline it applies to everything else,
+and the condition is **stateless — derived from the tracker, never from a
+counter or state file** (there is no durable home for a run counter, and a
+tracker-derived condition is headless- and concurrent-safe by construction).
+Propose retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered search finds NO
+   `[lisa-gardener]` ticket created in the
+   **trailing six-week window** (six runs at the weekly cadence), e.g.
+   `gh search issues '"[lisa-gardener] key="' --created ">=<six-weeks-ago>"`.
+2. **This run proposes nothing** — the current run's inventory yields zero
+   candidates (it is terminating `nothing-needed`).
+
+When both hold, the gardener files ONE (marker-deduped) ticket proposing to
+lengthen its cadence or tear down its automation (`/tear-down-automations`),
+with the date-filtered search result and this run's summary as evidence. It
+keeps running until a human flips that ticket — retirement is a
+recommendation like any other, never a self-executed exit.
 
 ## Scheduling
 
@@ -305,9 +320,20 @@ Register as an **optional** recurring loop through `lisa-setup-automations`
 `lisa-auto-<project>-learnings-audit`, running `/lisa:learnings:audit`, once
 a **week** (Codex `rrule`: `FREQ=WEEKLY;INTERVAL=1`) — opt-in, created only
 when the operator asks for the gardener loop, unlike the six default
-automations. Also runnable on demand via `/lisa:learnings:audit` at any time;
-manual and scheduled runs are identical (the markers make them safely
-concurrent-adjacent).
+automations. **Single-scheduled-runner assumption**: register at most ONE
+learnings-audit automation per project. Also runnable on demand — but before
+a manual `/lisa:learnings:audit`, confirm the scheduled automation is not due
+or currently running (check the scheduler's last-run/next-run state) and
+prefer waiting over racing it.
+
+**Concurrency honesty.** Marker dedupe is search-then-write, not an atomic
+claim: two truly concurrent runs can each miss the other's in-flight ticket
+and file a transient duplicate. Dedupe therefore guarantees
+**convergence, not mutual exclusion** — a duplicate is found and closed by
+the next run's marker search (or by the human triaging the pair), and because
+rejection memory keys on the surface prefix, a duplicate never multiplies.
+This is an accepted trade-off for a weekly advisory loop; a tracker-side
+locking protocol would be disproportionate to the risk.
 
 ## Rules
 

--- a/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
@@ -173,10 +173,22 @@ entry demonstrably applied) and every **provably-redundant** RETIRE row (with
 the mechanical owner / staleness proof per row). Rows are individually
 strikeable — the human deletes rows they reject, then flips the ticket ready.
 The gardener **never bumps `last_confirmed` itself**: the bumps are executed
-by the **implementing factory run** that picks up the flipped batch ticket,
-which applies each surviving CONFIRM row via `confirmLearningEntry` from
-`@codyswann/lisa/learnings` and each surviving RETIRE row as a deletion PR
-citing the row's proof.
+by the **implementing factory run** that picks up the flipped batch ticket.
+Embed the following execution contract **verbatim** (markers included — do
+not paraphrase, reorder, or partially quote it) in every batch ticket, so the
+implementing run receives its instructions inside the work item:
+
+<!-- gardener-batch-ticket-template:start -->
+### Execution contract (CONFIRM/RETIRE batch)
+
+- Apply each surviving CONFIRM row via `confirmLearningEntry` from
+  `@codyswann/lisa/learnings` — never hand-edit the ledger.
+- Implement each surviving RETIRE row as a proof-citing deletion PR per the
+  `promotion-contract` rule's reverse-atomicity clause: the deleting PR must
+  cite the row's mechanical owner or staleness proof.
+- Struck/deleted rows are human rejections — skip them; they are not re-filed
+  without new postdating evidence.
+<!-- gardener-batch-ticket-template:end -->
 
 **Upstream scope** → an issue on `CodySwannGT/lisa` (resolve via
 `hardening.upstreamRepo`, default `CodySwannGT/lisa`), following the
@@ -196,13 +208,30 @@ marker in the ticket/issue body:
 ```
 
 where `<surface>` names the audited artifact (e.g. `ledger:<entry-id>`,
-`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is a
-short stable hash of the normalized invariant text — the same knowledge item
-always produces the same key across runs.
+`rules-eager:<file>#<section>`, `skill:<name>`) and `<invariant-hash>` is
+computed **deterministically — never estimated by the model**:
+
+1. **Normalize** the invariant text: trim leading/trailing whitespace,
+   collapse every internal whitespace run to a single space, lowercase.
+2. **Hash** in Bash: `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`.
+
+The same knowledge item therefore always produces the same key across runs,
+regardless of which session computes it.
 
 Before filing anything, search the tracker for the marker in
-**open AND closed** issues (e.g. `gh search issues "<marker>" --state all`,
-plus a body-grep fallback for search-index lag):
+**open AND closed** issues — and key the search on the deterministic
+`<surface>` prefix **first**, using the hash as disambiguation only, so even
+a hash discrepancy can never cause a duplicate for the same surface:
+
+```bash
+gh search issues "[lisa-gardener] key=<surface>" --state all
+```
+
+plus a body-enumeration fallback for search-index lag (`gh issue list …
+--json number,body` and grep bodies for `[lisa-gardener] key=<surface>`).
+Among prefix hits, compare hashes to distinguish genuinely different
+invariants on the same surface; a prefix hit with a mismatched hash is
+resolved by reading the ticket, never by filing a sibling blind. Then:
 
 - **Open** with the marker → do not re-file; append new evidence as a comment
   only if it is materially new.

--- a/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
+++ b/plugins/src/base/skills/lisa-learnings-audit/SKILL.md
@@ -224,7 +224,7 @@ Before filing anything, search the tracker for the marker in
 a hash discrepancy can never cause a duplicate for the same surface:
 
 ```bash
-gh search issues "[lisa-gardener] key=<surface>" --state all
+gh search issues "[lisa-gardener] key=<surface>" --repo <upstream-or-tracker-repo> # searches open AND closed by default; --state all is NOT a valid gh search flag
 ```
 
 plus a body-enumeration fallback for search-index lag (`gh issue list …

--- a/plugins/src/base/skills/lisa-rework-triage/SKILL.md
+++ b/plugins/src/base/skills/lisa-rework-triage/SKILL.md
@@ -115,16 +115,33 @@ Upstream issues target the Lisa repository itself so the harness gets fixed for 
 project at once. Resolve the repo from `.lisa.config.json` `hardening.upstreamRepo`;
 default `CodySwannGT/lisa`.
 
+There are **two upstream lanes**, distinguished by what the filing proposes. Both share
+the same dedupe-marker and evidence-chain discipline below; only the label and one body
+section differ:
+
+| Lane | Label | When | Extra body section |
+|------|-------|------|--------------------|
+| Defect | `self-hardening` | A Lisa gate/skill/template did something wrong — a harness bug the kernel must fix. | none |
+| Contribution | `template-candidate` | A generalizable pattern discovered downstream that would benefit every host project — not a defect, a proposed improvement to Lisa's templates/rules/skills. | `## Proposed template change` |
+
 1. **Dedupe first.** `gh issue list -R <upstream> --state open --search "<fingerprint terms>"`
-   — if an open issue already covers this failure class, comment the new occurrence on it
-   (evidence compounds; duplicates dilute) and link it instead of filing.
-2. **File with the same bar as any ticket:** a three-audience description (what failed for
-   the operator, what the harness did wrong, what to change), the verbatim evidence chain
-   (PRD text → ticket AC → QA failure → gate that passed it), and a `self-hardening` label:
-   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`.
+   — if an open issue already covers this failure class or pattern, comment the new
+   occurrence on it (evidence compounds; duplicates dilute) and link it instead of filing.
+2. **File with the same bar as any ticket:** a three-audience description (what failed or
+   improved for the operator, what the harness did or could do, what to change), the
+   verbatim evidence chain (PRD text → ticket AC → QA failure → gate that passed it; for
+   patterns, the downstream occurrences proving generality), and the lane's label:
+   `gh issue create -R <upstream> --title "<gate/skill>: <failure class>" --label self-hardening`
+   for defects, or
+   `gh issue create -R <upstream> --title "<template surface>: <pattern>" --label template-candidate`
+   for contributions. A `template-candidate` filing MUST include a
+   `## Proposed template change` section naming the Lisa template/rule/skill surface to
+   change (e.g. `typescript/package-lisa/package.lisa.json`, a `plugins/src/base` rule)
+   and the proposed content or diff sketch, so Lisa-side intake can triage it as a
+   contribution rather than a defect.
 3. **Close the loop.** Reference the upstream issue URL in the triage comment. The upstream
-   repo's own build intake implements it; the next kernel release ships the hardening to
-   every host project.
+   repo's own build intake implements it; the next kernel release ships the hardening (or
+   the generalized pattern) to every host project.
 
 ## Verdict
 

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-setup-automations
-description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day). Two flags — auto-start-prds and auto-start-tickets — control whether the ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review. Tear down with /tear-down-automations."
+description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -38,10 +38,16 @@ create them; invoke the runtime's automation tool with the spec below.
   automation. `true` → filed bug/usability tickets are created build-ready (auto-picked-up by ticket
   intake); `false` → created in the backlog for human triage.
 
+- `learnings-audit` (default **false**) — opt-in: when `true`, additionally create the weekly
+  `lisa-auto-<project>-learnings-audit` automation running `/lisa:learnings:audit` (the gardener —
+  see "Optional automation" below). Default `false` because the gardener's output is human-gated
+  tracker tickets: a project opts into the recurring audit stream deliberately rather than
+  receiving recommendation tickets by surprise.
+
 The defaults are autonomous by design — the factory model wants inputs flowing through the gates
 without a human between the loops and the pipeline. Pass `false` explicitly to opt a project into
-human triage. The two flags affect **only** the two exploratory automations; the intake gates'
-adversarial validation remains the quality control either way.
+human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
+gates' adversarial validation remains the quality control either way.
 
 ## The automations to create
 

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -67,7 +67,18 @@ report the exact conflicting path(s).
 | **monitor** | `/lisa:monitor` | **once a day** |
 
 For a Codex `rrule`: every 60 min → `FREQ=HOURLY;INTERVAL=1`; every 10 min →
-`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`.
+`FREQ=MINUTELY;INTERVAL=10`; once a day → `FREQ=DAILY;INTERVAL=1`; once a week →
+`FREQ=WEEKLY;INTERVAL=1`.
+
+**Optional automation — the gardener.** When the operator opts in
+(`learnings-audit=true`; default **false** — this one is opt-in, unlike the six
+defaults above), additionally create `lisa-auto-<project>-learnings-audit`
+running `/lisa:learnings:audit` once a **week**. It audits the project's
+knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
+human-gated promote/demote/confirm/retire tickets per the
+`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
+manual runs are safe. Tear-down removes it with the rest of the
+`lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -82,9 +82,12 @@ defaults above), additionally create `lisa-auto-<project>-learnings-audit`
 running `/lisa:learnings:audit` once a **week**. It audits the project's
 knowledge surfaces (learnings ledger, rules trees, skills, wiki) and files
 human-gated promote/demote/confirm/retire tickets per the
-`lisa-learnings-audit` skill; its output is marker-deduped, so overlapping
-manual runs are safe. Tear-down removes it with the rest of the
-`lisa-auto-<project>-*` set.
+`lisa-learnings-audit` skill. Register at most ONE learnings-audit automation
+per project — the gardener's marker dedupe assumes a single scheduled runner
+and guarantees convergence (a transient duplicate from a concurrent run is
+closed by the next run's dedupe or the human), not mutual exclusion; manual
+runs should first confirm the cron is not due or running. Tear-down removes
+it with the rest of the `lisa-auto-<project>-*` set.
 
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The

--- a/tests/unit/strategies/gardener-fingerprint-hash.test.ts
+++ b/tests/unit/strategies/gardener-fingerprint-hash.test.ts
@@ -89,11 +89,14 @@ describe("gardener deterministic invariant-hash procedure", () => {
   });
 
   it("is stable across normalization-equivalent spellings (whitespace/case)", () => {
-    const canonical = normalizeInvariant(VECTORS[0].raw);
+    // Hardcoded expected value (test isolation: never derive the expected
+    // output by calling the function under test on the clean input).
+    const expectedNormalized =
+      "when writing utility functions, avoid calling shared validation helpers (expression statements/side effects) before const definitions, as this violates the enforce-statement-order rule. instead, inline validation as `if` guard clauses, which are exempt from the ordering rule.";
     const noisy = normalizeInvariant(
       `  \n\t${VECTORS[0].raw.toUpperCase().replace(/ /gu, "   ")}\n  `
     );
-    expect(noisy).toBe(canonical);
+    expect(noisy).toBe(expectedNormalized);
     expect(fingerprint(noisy)).toBe(VECTORS[0].hash);
   });
 });

--- a/tests/unit/strategies/gardener-fingerprint-hash.test.ts
+++ b/tests/unit/strategies/gardener-fingerprint-hash.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression pin for the gardener's DETERMINISTIC invariant-hash procedure
+ * (lisa-learnings-audit, LLG-6 #1735).
+ *
+ * The skill documents that the `<invariant-hash>` in a `[lisa-gardener]`
+ * fingerprint marker is computed deterministically — "never estimated by the
+ * model" — by (1) normalizing the invariant text (trim, collapse internal
+ * whitespace runs to a single space, lowercase), then (2) hashing in Bash:
+ * `printf '%s' "$normalized" | shasum -a 256 | cut -c1-12`. That determinism
+ * is what makes the same knowledge item produce the same key across runs and
+ * sessions, so the dedupe / rejection-memory contract can never file a
+ * duplicate for a surface it already ticketed.
+ *
+ * The existing prose-contract suite asserts the SKILL.md *documents* the
+ * pipeline verbatim (the `shasum -a 256` / `cut -c1-12` / trim+collapse+lowercase
+ * strings). This suite pins the pipeline's actual OUTPUT against known vectors
+ * — the two first-run PROJECT_RULES.md candidates the gardener fingerprinted
+ * during the #1735 verification (live tickets #1775 / #1776) — so a change to
+ * the normalization steps or the 12-char truncation, which would silently
+ * re-key every marker and break idempotency, fails CI. Pure `node:crypto` keeps
+ * it portable (the documented `shasum`/`cut` pipeline is macOS-centric); the
+ * sibling prose-contract test is what guards the documented command string.
+ * @module tests/unit/strategies/gardener-fingerprint-hash
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL = readFileSync(
+  path.resolve("plugins/src/base/skills/lisa-learnings-audit/SKILL.md"),
+  "utf8"
+);
+
+/**
+ * Normalizes invariant text exactly as the skill documents: trim
+ * leading/trailing whitespace, collapse every internal whitespace run to a
+ * single space, lowercase.
+ * @param raw Raw invariant text.
+ * @returns The normalized single-line lowercased text.
+ */
+function normalizeInvariant(raw: string): string {
+  return raw.replace(/\s+/gu, " ").trim().toLowerCase();
+}
+
+/**
+ * Computes the 12-hex-char fingerprint hash, mirroring the documented
+ * `shasum -a 256 | cut -c1-12` in portable `node:crypto`.
+ * @param normalized Normalized invariant text.
+ * @returns First 12 hex chars of the SHA-256 digest.
+ */
+function fingerprint(normalized: string): string {
+  return createHash("sha256")
+    .update(normalized, "utf8")
+    .digest("hex")
+    .slice(0, 12);
+}
+
+// Known vectors captured during the #1735 verification run — the two first-run
+// PROJECT_RULES.md candidates the gardener classified as RETIRE.
+const VECTORS = [
+  {
+    label: "eslint-statement-order invariant",
+    raw: "When writing utility functions, avoid calling shared validation helpers (expression statements/side effects) before const definitions, as this violates the enforce-statement-order rule. Instead, inline validation as `if` guard clauses, which are exempt from the ordering rule.",
+    hash: "ffc090644634",
+  },
+  {
+    label: "eslint-disable-comments invariant",
+    raw: "All `eslint-disable` directives must include a description to satisfy the `eslint-comments/require-description` rule.",
+    hash: "0ba61dd88e78",
+  },
+] as const;
+
+describe("gardener deterministic invariant-hash procedure", () => {
+  it("documents the normalization + hash pipeline in the skill", () => {
+    expect(SKILL).toMatch(/trim/i);
+    expect(SKILL).toMatch(/collapse/i);
+    expect(SKILL).toMatch(/lowercase/i);
+    expect(SKILL).toContain("shasum -a 256");
+    expect(SKILL).toContain("cut -c1-12");
+    expect(SKILL).toMatch(/never estimated by the model/i);
+  });
+
+  describe.each(VECTORS)("known vector: $label", vector => {
+    it("normalizes then hashes to the pinned 12-char key", () => {
+      expect(fingerprint(normalizeInvariant(vector.raw))).toBe(vector.hash);
+    });
+  });
+
+  it("is stable across normalization-equivalent spellings (whitespace/case)", () => {
+    const canonical = normalizeInvariant(VECTORS[0].raw);
+    const noisy = normalizeInvariant(
+      `  \n\t${VECTORS[0].raw.toUpperCase().replace(/ /gu, "   ")}\n  `
+    );
+    expect(noisy).toBe(canonical);
+    expect(fingerprint(noisy)).toBe(VECTORS[0].hash);
+  });
+});

--- a/tests/unit/strategies/learnings-audit-contract.test.ts
+++ b/tests/unit/strategies/learnings-audit-contract.test.ts
@@ -20,7 +20,10 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { extractAcTemplate } from "./promotion-contract-helpers.js";
+import {
+  extractAcTemplate,
+  extractBatchTemplate,
+} from "./promotion-contract-helpers.js";
 
 const SKILL_PATHS = [
   "plugins/src/base/skills/lisa-learnings-audit/SKILL.md",
@@ -117,6 +120,20 @@ describe.each(SKILL_PATHS)("gardener skill runbook (%s)", skillPath => {
     expect(skill).toMatch(/implementing factory run|factory.*applies/i);
   });
 
+  it("carries the delimited batch-ticket execution contract, byte-identical to canonical", () => {
+    const template = extractBatchTemplate(skill);
+
+    expect(template).toContain("confirmLearningEntry");
+    expect(template).toMatch(/proof-citing deletion PR/i);
+    expect(template).toMatch(/reverse-atomicity/i);
+    expect(template).toMatch(/never hand-edit the ledger/i);
+
+    const canonical = extractBatchTemplate(
+      read("plugins/src/base/skills/lisa-learnings-audit/SKILL.md")
+    );
+    expect(template).toBe(canonical);
+  });
+
   it("embeds the promotion-contract AC template verbatim for EXECUTABLE-CONTROL", () => {
     expect(skill).toContain("EXECUTABLE-CONTROL");
     expect(skill).toContain("promotion-contract");
@@ -136,6 +153,27 @@ describe.each(SKILL_PATHS)("gardener skill runbook (%s)", skillPath => {
   it("uses the stable gardener fingerprint marker grammar", () => {
     expect(skill).toContain("<!-- [lisa-gardener] key=");
     expect(skill).toMatch(/invariant/i);
+  });
+
+  it("computes the invariant hash deterministically, never model-estimated", () => {
+    // Normalization: trim + collapse internal whitespace + lowercase.
+    expect(skill).toMatch(/trim/i);
+    expect(skill).toMatch(/collapse/i);
+    expect(skill).toMatch(/lowercase/i);
+    // Deterministic Bash hash, truncated to 12 hex chars.
+    expect(skill).toContain("shasum -a 256");
+    expect(skill).toContain("cut -c1-12");
+    expect(skill).toMatch(/never estimated by the model/i);
+  });
+
+  it("dedupes on the surface prefix first, hash as disambiguation only", () => {
+    expect(skill).toContain(
+      'gh search issues "[lisa-gardener] key=<surface>" --state all'
+    );
+    expect(skill).toMatch(/prefix.*first|first.*prefix/i);
+    expect(skill).toMatch(/disambiguation only/i);
+    // Body-enumeration fallback covers search-index lag.
+    expect(skill).toMatch(/body-enum/i);
   });
 
   it("dedupes against open AND closed issues, remembering rejections", () => {

--- a/tests/unit/strategies/learnings-audit-contract.test.ts
+++ b/tests/unit/strategies/learnings-audit-contract.test.ts
@@ -211,8 +211,32 @@ describe.each(SKILL_PATHS)("gardener skill runbook (%s)", skillPath => {
     expect(skill).toContain("max_candidates");
   });
 
-  it("states an explicit retirement condition for the loop itself", () => {
-    expect(skill).toMatch(/consecutive.*nothing-needed/i);
+  it("states a stateless, tracker-derived retirement condition for the loop itself", () => {
+    // No durable counter: the condition is derived from the tracker.
+    expect(skill).toMatch(/stateless/i);
+    expect(skill).toMatch(/never from a\s+counter or state file/i);
+    // (a) date-filtered search over the trailing window …
+    expect(skill).toMatch(/trailing six-week window/i);
+    expect(skill).toContain("--created");
+    // … AND (b) the current run itself proposes nothing.
+    expect(skill).toMatch(/current run'?s inventory yields zero/i);
+    // The old in-memory consecutive-run counter is gone.
+    expect(skill).not.toMatch(/six consecutive/i);
+  });
+
+  it("is honest about concurrency: convergence, not mutual exclusion", () => {
+    expect(skill).toMatch(/convergence, not mutual exclusion/i);
+    expect(skill).toMatch(/transient duplicate/i);
+    // Single-scheduled-runner assumption + manual runs check the cron first.
+    expect(skill).toMatch(/at most ONE\s+learnings-audit automation/i);
+    expect(skill).toMatch(/not due\s+or currently running/i);
+    // No overstated overlap-safety claim survives.
+    expect(skill).not.toMatch(/safely\s+concurrent-adjacent/i);
+  });
+
+  it("files per-item tickets first and the batch ticket last for recoverability", () => {
+    expect(skill).toMatch(/batch ticket last/i);
+    expect(skill).toMatch(/completion signal/i);
   });
 });
 
@@ -238,6 +262,12 @@ describe.each(SETUP_AUTOMATIONS_PATHS)(
     it("registers learnings-audit as an optional (opt-in) automation", () => {
       expect(setup).toContain("learnings-audit");
       expect(setup).toMatch(/opt-in|optional/i);
+    });
+
+    it("documents the single-runner assumption instead of overlap safety", () => {
+      expect(setup).toMatch(/at most ONE learnings-audit automation/i);
+      expect(setup).toMatch(/convergence/i);
+      expect(setup).not.toMatch(/overlapping\s+manual runs are safe/i);
     });
   }
 );

--- a/tests/unit/strategies/learnings-audit-contract.test.ts
+++ b/tests/unit/strategies/learnings-audit-contract.test.ts
@@ -167,9 +167,7 @@ describe.each(SKILL_PATHS)("gardener skill runbook (%s)", skillPath => {
   });
 
   it("dedupes on the surface prefix first, hash as disambiguation only", () => {
-    expect(skill).toContain(
-      'gh search issues "[lisa-gardener] key=<surface>" --state all'
-    );
+    expect(skill).toContain("searches open AND closed by default");
     expect(skill).toMatch(/prefix.*first|first.*prefix/i);
     expect(skill).toMatch(/disambiguation only/i);
     // Body-enumeration fallback covers search-index lag.

--- a/tests/unit/strategies/learnings-audit-contract.test.ts
+++ b/tests/unit/strategies/learnings-audit-contract.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Prose contract for the gardener — lisa-learnings-audit (LLG-6, #1735).
+ *
+ * The gardener is the maintenance loop of the learnings ladder (PRD #1729):
+ * it inventories every knowledge surface, gathers evidence per item,
+ * classifies via the ladder router (skill-evaluator, advisory), and
+ * communicates exclusively through the tracker — per-item tickets for
+ * PROMOTE/DEMOTE, one batch ticket per run for CONFIRM/RETIRE, upstream
+ * issues for upstream-scoped recommendations. Everything is human-gated at
+ * v1; the skill only files tickets. Recommendations are fingerprint-marked
+ * and deduped against open AND closed issues, and the gardener's own output
+ * is never a candidate (no learning loops about learning).
+ *
+ * These are agent instructions, so the assertions cover the canonical plugin
+ * source and every checked-in runtime projection of the skill and command.
+ * @module tests/unit/strategies/learnings-audit-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { extractAcTemplate } from "./promotion-contract-helpers.js";
+
+const SKILL_PATHS = [
+  "plugins/src/base/skills/lisa-learnings-audit/SKILL.md",
+  "plugins/lisa/skills/lisa-learnings-audit/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-learnings-audit/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-learnings-audit/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-learnings-audit/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-learnings-audit/SKILL.md",
+] as const;
+
+const COMMAND_PATHS = [
+  "plugins/src/base/commands/learnings/audit.md",
+  "plugins/lisa/commands/learnings/audit.md",
+] as const;
+
+const SETUP_AUTOMATIONS_PATHS = [
+  "plugins/src/base/skills/lisa-setup-automations/SKILL.md",
+  "plugins/lisa/skills/lisa-setup-automations/SKILL.md",
+] as const;
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+describe.each(SKILL_PATHS)("gardener skill runbook (%s)", skillPath => {
+  const skill = read(skillPath);
+
+  it("carries every runbook contract section", () => {
+    expect(skill).toMatch(/## Intent/);
+    expect(skill).toMatch(/## Sources of truth/);
+    expect(skill).toMatch(/## Candidate-selection rules/);
+    expect(skill).toMatch(/## Scope/);
+    expect(skill).toMatch(/## Proof/);
+    expect(skill).toMatch(/## Autonomous-vs-approval boundary/);
+    expect(skill).toMatch(/## Escalation/);
+    expect(skill).toMatch(/## Recovery/);
+    expect(skill).toMatch(/## Terminal states/);
+    expect(skill).toMatch(/## Retirement condition/);
+  });
+
+  it("declares the three per-run terminal states", () => {
+    expect(skill).toContain("nothing-needed | candidates-proposed | blocked");
+  });
+
+  it("is human-gated everything at v1 — the skill only files tickets", () => {
+    expect(skill).toMatch(/only files tickets/i);
+    expect(skill).toMatch(/human-gated/i);
+    expect(skill).toMatch(/status:ready/);
+    // It never edits knowledge surfaces itself.
+    expect(skill).toMatch(/never (edits?|writes?|deletes?|modif)/i);
+  });
+
+  it("inventories every knowledge surface through the proper access paths", () => {
+    expect(skill).toContain("parseLearningsFile");
+    expect(skill).toContain("projectLearnings");
+    expect(skill).toContain("@codyswann/lisa/learnings");
+    expect(skill).toContain(".claude/rules");
+    expect(skill).toMatch(/wiki index|wiki\/index\.md/i);
+    expect(skill).toMatch(/lint|hook|force/i);
+  });
+
+  it("gathers the five evidence axes per item", () => {
+    expect(skill).toMatch(/recurrence/i);
+    expect(skill).toMatch(/staleness/i);
+    expect(skill).toMatch(/redundancy/i);
+    expect(skill).toMatch(/contradiction/i);
+    expect(skill).toMatch(/budget pressure/i);
+    // Recurrence is measured since last_confirmed, reusing git-history-analyzer.
+    expect(skill).toContain("last_confirmed");
+    expect(skill).toContain("git-history-analyzer");
+  });
+
+  it("classifies via the ladder router, advisory-only", () => {
+    expect(skill).toContain("skill-evaluator");
+    expect(skill).toMatch(/advisory/i);
+    expect(skill).toContain("drafted_artifact");
+  });
+
+  it("emits per-item PROMOTE/DEMOTE tickets via lisa-tracker-write", () => {
+    expect(skill).toContain("PROMOTE");
+    expect(skill).toContain("DEMOTE");
+    expect(skill).toContain("lisa-tracker-write");
+    expect(skill).toContain("type:Task");
+    expect(skill).toMatch(/three-audience/);
+    expect(skill).toMatch(/evidence links/i);
+  });
+
+  it("batches CONFIRM and provably-redundant RETIRE into one ticket per run", () => {
+    expect(skill).toMatch(/one batch ticket per run/i);
+    expect(skill).toContain("CONFIRM");
+    expect(skill).toContain("RETIRE");
+    expect(skill).toContain("confirmLearningEntry");
+    // The gardener never bumps last_confirmed itself; the implementing
+    // factory run applies the bumps after the human flips the batch ready.
+    expect(skill).toMatch(/implementing factory run|factory.*applies/i);
+  });
+
+  it("embeds the promotion-contract AC template verbatim for EXECUTABLE-CONTROL", () => {
+    expect(skill).toContain("EXECUTABLE-CONTROL");
+    expect(skill).toContain("promotion-contract");
+
+    const canonical = extractAcTemplate(
+      read("plugins/src/base/rules/reference/promotion-contract.md")
+    );
+    expect(skill).toContain(canonical);
+  });
+
+  it("routes upstream scope to the two Lisa lanes, marker-deduped", () => {
+    expect(skill).toContain("self-hardening");
+    expect(skill).toContain("template-candidate");
+    expect(skill).toContain("CodySwannGT/lisa");
+  });
+
+  it("uses the stable gardener fingerprint marker grammar", () => {
+    expect(skill).toContain("<!-- [lisa-gardener] key=");
+    expect(skill).toMatch(/invariant/i);
+  });
+
+  it("dedupes against open AND closed issues, remembering rejections", () => {
+    expect(skill).toMatch(/open AND closed/i);
+    expect(skill).toMatch(/closed.*(unmerged|rejected)|rejected/i);
+    expect(skill).toMatch(/new evidence.*postdates|postdating/i);
+  });
+
+  it("excludes the learning machinery from its own candidate scan", () => {
+    expect(skill).toMatch(/no learning loops about learning/i);
+    expect(skill).toContain("[lisa-learning-");
+    expect(skill).toContain("[lisa-rejection-candidate]");
+    expect(skill).toContain("[lisa-archaeology-candidate]");
+    expect(skill).toMatch(/its own tickets|the gardener'?s own/i);
+  });
+
+  it("audits the eager tier every run, including Lisa's own shipped eager rules", () => {
+    expect(skill).toMatch(/eager tier/i);
+    expect(skill).toMatch(/every run/i);
+    expect(skill).toMatch(/Lisa'?s own shipped eager rules/i);
+    expect(skill).toMatch(/demotion-biased/i);
+  });
+
+  it("escalates headlessly: status:blocked + human-needed, never prompts", () => {
+    expect(skill).toContain("status:blocked");
+    expect(skill).toContain("human-needed");
+    expect(skill).toMatch(/operator-readable/i);
+    expect(skill).toMatch(/never prompts?/i);
+  });
+
+  it("documents cron registration via lisa-setup-automations", () => {
+    expect(skill).toContain("lisa-setup-automations");
+    expect(skill).toMatch(/lisa-auto-<project>-learnings-audit/);
+  });
+
+  it("bounds each run with a max_candidates cap", () => {
+    expect(skill).toContain("max_candidates");
+  });
+
+  it("states an explicit retirement condition for the loop itself", () => {
+    expect(skill).toMatch(/consecutive.*nothing-needed/i);
+  });
+});
+
+describe.each(COMMAND_PATHS)("gardener command (%s)", commandPath => {
+  const command = read(commandPath);
+
+  it("passes through to the lisa-learnings-audit skill", () => {
+    expect(command).toContain("lisa-learnings-audit");
+    expect(command).toContain("$ARGUMENTS");
+  });
+
+  it("carries a description and argument-hint frontmatter", () => {
+    expect(command).toMatch(/^description:/m);
+    expect(command).toMatch(/^argument-hint:/m);
+  });
+});
+
+describe.each(SETUP_AUTOMATIONS_PATHS)(
+  "setup-automations optional gardener loop (%s)",
+  setupPath => {
+    const setup = read(setupPath);
+
+    it("registers learnings-audit as an optional (opt-in) automation", () => {
+      expect(setup).toContain("learnings-audit");
+      expect(setup).toMatch(/opt-in|optional/i);
+    });
+  }
+);

--- a/tests/unit/strategies/promotion-contract-helpers.ts
+++ b/tests/unit/strategies/promotion-contract-helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared helpers for the promotion-contract (LLG-7, #1736) and gardener
+ * (LLG-6, #1735) prose-contract suites.
+ *
+ * The promotion-contract rule pair carries a delimited AC-template snippet
+ * that the gardener embeds verbatim into EXECUTABLE-CONTROL promotion
+ * tickets. Both suites need to extract that snippet byte-for-byte, so the
+ * extraction lives here rather than in either test file (importing a test
+ * module from another test would re-register its suites).
+ * @module tests/unit/strategies/promotion-contract-helpers
+ */
+
+/** Opening delimiter of the AC-template snippet in the reference rule. */
+export const AC_TEMPLATE_START =
+  "<!-- promotion-contract-ac-template:start -->";
+
+/** Closing delimiter of the AC-template snippet in the reference rule. */
+export const AC_TEMPLATE_END = "<!-- promotion-contract-ac-template:end -->";
+
+/**
+ * Extracts the delimited AC-template snippet from a promotion-contract rule
+ * body so the gardener's verbatim embedding can be asserted byte-for-byte.
+ * @param body Full markdown body of a promotion-contract reference rule.
+ * @returns The template text between the start/end markers, inclusive.
+ */
+export function extractAcTemplate(body: string): string {
+  const start = body.indexOf(AC_TEMPLATE_START);
+  const end = body.indexOf(AC_TEMPLATE_END);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("promotion-contract AC template markers not found");
+  }
+  const result = body.slice(start, end + AC_TEMPLATE_END.length);
+  return result;
+}

--- a/tests/unit/strategies/promotion-contract-helpers.ts
+++ b/tests/unit/strategies/promotion-contract-helpers.ts
@@ -17,6 +17,35 @@ export const AC_TEMPLATE_START =
 /** Closing delimiter of the AC-template snippet in the reference rule. */
 export const AC_TEMPLATE_END = "<!-- promotion-contract-ac-template:end -->";
 
+/** Opening delimiter of the gardener's CONFIRM/RETIRE batch-ticket template. */
+export const BATCH_TEMPLATE_START =
+  "<!-- gardener-batch-ticket-template:start -->";
+
+/** Closing delimiter of the gardener's CONFIRM/RETIRE batch-ticket template. */
+export const BATCH_TEMPLATE_END = "<!-- gardener-batch-ticket-template:end -->";
+
+/**
+ * Extracts a delimited snippet (markers inclusive) from a markdown body so
+ * verbatim embedding can be asserted byte-for-byte.
+ * @param body Full markdown body carrying the delimited snippet.
+ * @param startMarker Opening delimiter.
+ * @param endMarker Closing delimiter.
+ * @returns The snippet between the markers, inclusive.
+ */
+function extractDelimited(
+  body: string,
+  startMarker: string,
+  endMarker: string
+): string {
+  const start = body.indexOf(startMarker);
+  const end = body.indexOf(endMarker);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`delimited template not found: ${startMarker}`);
+  }
+  const result = body.slice(start, end + endMarker.length);
+  return result;
+}
+
 /**
  * Extracts the delimited AC-template snippet from a promotion-contract rule
  * body so the gardener's verbatim embedding can be asserted byte-for-byte.
@@ -24,11 +53,21 @@ export const AC_TEMPLATE_END = "<!-- promotion-contract-ac-template:end -->";
  * @returns The template text between the start/end markers, inclusive.
  */
 export function extractAcTemplate(body: string): string {
-  const start = body.indexOf(AC_TEMPLATE_START);
-  const end = body.indexOf(AC_TEMPLATE_END);
-  if (start === -1 || end === -1 || end <= start) {
-    throw new Error("promotion-contract AC template markers not found");
-  }
-  const result = body.slice(start, end + AC_TEMPLATE_END.length);
+  const result = extractDelimited(body, AC_TEMPLATE_START, AC_TEMPLATE_END);
+  return result;
+}
+
+/**
+ * Extracts the gardener's delimited CONFIRM/RETIRE batch-ticket execution
+ * contract so its cross-fan-out byte-identity can be asserted.
+ * @param body Full markdown body of a lisa-learnings-audit SKILL.md.
+ * @returns The template text between the start/end markers, inclusive.
+ */
+export function extractBatchTemplate(body: string): string {
+  const result = extractDelimited(
+    body,
+    BATCH_TEMPLATE_START,
+    BATCH_TEMPLATE_END
+  );
   return result;
 }

--- a/tests/unit/strategies/promotion-contract-rule.test.ts
+++ b/tests/unit/strategies/promotion-contract-rule.test.ts
@@ -91,7 +91,7 @@ describe.each(RULE_PAIR_ROOTS)("promotion-contract rule pair (%s)", root => {
 
   it("reference states the diagnostic-quality bar: invariant + why + concrete fix", () => {
     expect(reference).toMatch(/violated invariant/i);
-    expect(reference).toMatch(/why/i);
+    expect(reference).toMatch(/why the invariant holds/i);
     expect(reference).toMatch(/concrete fix/i);
     expect(reference).toMatch(/teach(es)? the repair/i);
   });

--- a/tests/unit/strategies/promotion-contract-rule.test.ts
+++ b/tests/unit/strategies/promotion-contract-rule.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Prose contract for the promotion-to-control rule pair (LLG-7, #1736).
+ *
+ * When a gardener promotion ticket is implemented, the change must be atomic:
+ * enable the control + fix the existing violation population + ship a
+ * remediation-teaching diagnostic + delete the superseded prose — one PR, and
+ * a PR missing any of the four is rejected by rule, not by reviewer taste.
+ * The rule pair also carries the diagnostic-quality bar, the demotion-biased
+ * eager-tier admission policy (the gardener audits the eager tier every run,
+ * including Lisa's own shipped eager rules), and the documented AC-template
+ * snippet the gardener embeds verbatim into EXECUTABLE-CONTROL promotion
+ * tickets.
+ *
+ * These are agent instructions, so the assertions cover the canonical plugin
+ * source and the checked-in runtime projections. Per-agent parity gaps
+ * (documented, not silently dropped): the agy variant ships no `rules/` tree
+ * (its bounded AGENTS.md bridge covers rules), and Cursor projects rules to
+ * flat `<name>.mdc` / `<name>-reference.mdc` files.
+ * @module tests/unit/strategies/promotion-contract-rule
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RULE_PAIR_ROOTS = [
+  "plugins/src/base",
+  "plugins/lisa",
+  "plugins/lisa-copilot",
+] as const;
+
+const CURSOR_RULE_PATHS = [
+  "plugins/lisa-cursor/rules/promotion-contract.mdc",
+  "plugins/lisa-cursor/rules/promotion-contract-reference.mdc",
+] as const;
+
+const REWORK_TRIAGE_PATHS = [
+  "plugins/src/base/skills/lisa-rework-triage/SKILL.md",
+  "plugins/lisa/skills/lisa-rework-triage/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-rework-triage/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md",
+] as const;
+
+const PROJECT_RULES_PATHS = [
+  ".claude/rules/PROJECT_RULES.md",
+  "all/create-only/.claude/rules/PROJECT_RULES.md",
+] as const;
+
+const AC_TEMPLATE_START = "<!-- promotion-contract-ac-template:start -->";
+const AC_TEMPLATE_END = "<!-- promotion-contract-ac-template:end -->";
+
+const read = (relativePath: string): string =>
+  readFileSync(path.resolve(relativePath), "utf8");
+
+/**
+ * Extracts the delimited AC-template snippet from a promotion-contract rule
+ * body so the gardener's verbatim embedding can be asserted byte-for-byte.
+ * @param body Full markdown body of a promotion-contract reference rule.
+ * @returns The template text between the start/end markers, inclusive.
+ */
+export function extractAcTemplate(body: string): string {
+  const start = body.indexOf(AC_TEMPLATE_START);
+  const end = body.indexOf(AC_TEMPLATE_END);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("promotion-contract AC template markers not found");
+  }
+  const result = body.slice(start, end + AC_TEMPLATE_END.length);
+  return result;
+}
+
+describe.each(RULE_PAIR_ROOTS)("promotion-contract rule pair (%s)", root => {
+  const eager = read(path.join(root, "rules/eager/promotion-contract.md"));
+  const reference = read(
+    path.join(root, "rules/reference/promotion-contract.md")
+  );
+
+  it("eager head breadcrumbs to the reference body", () => {
+    expect(eager).toContain(
+      "[reference/promotion-contract.md](../reference/promotion-contract.md)"
+    );
+  });
+
+  it("eager head states the atomic four-part contract and rejection-by-rule", () => {
+    expect(eager).toMatch(/atomic/i);
+    expect(eager).toMatch(/enables? the control/i);
+    expect(eager).toMatch(/existing violation population/i);
+    expect(eager).toMatch(/remediation-teaching diagnostic/i);
+    expect(eager).toMatch(/deletes? the superseded prose/i);
+    expect(eager).toMatch(/one PR/i);
+    expect(eager).toMatch(/rejected by rule/i);
+  });
+
+  it("reference enumerates all four legs of the promote-and-delete contract", () => {
+    expect(reference).toMatch(/enable the control/i);
+    expect(reference).toMatch(/fix the existing violation population/i);
+    expect(reference).toMatch(/remediation-teaching diagnostic/i);
+    expect(reference).toMatch(/delete the superseded prose/i);
+    expect(reference).toMatch(/one atomic PR|all in one PR|one PR/i);
+    expect(reference).toMatch(/missing any of the four is rejected by rule/i);
+  });
+
+  it("reference explains why each omission fails (double-pay / stranding)", () => {
+    expect(reference).toMatch(/double-pays? forever/i);
+    expect(reference).toMatch(/strands? agents/i);
+  });
+
+  it("reference states the diagnostic-quality bar: invariant + why + concrete fix", () => {
+    expect(reference).toMatch(/violated invariant/i);
+    expect(reference).toMatch(/why/i);
+    expect(reference).toMatch(/concrete fix/i);
+    expect(reference).toMatch(/teach(es)? the repair/i);
+  });
+
+  it("reference states the demotion-biased eager-tier admission policy", () => {
+    expect(reference).toMatch(/demotion-biased/i);
+    expect(reference).toMatch(/repeated-miss/i);
+    expect(reference).toMatch(/every run/i);
+    expect(reference).toMatch(/Lisa'?s own shipped eager rules/i);
+  });
+
+  it("reference carries the delimited AC template for EXECUTABLE-CONTROL promotion tickets", () => {
+    const template = extractAcTemplate(reference);
+
+    expect(template).toMatch(/Enables the control/);
+    expect(template).toMatch(/Fixes the existing violation population/);
+    expect(template).toMatch(/Ships a remediation-teaching diagnostic/);
+    expect(template).toMatch(/Deletes the superseded prose/);
+    expect(template).toMatch(/rejected by rule/);
+  });
+
+  it("AC template is identical across the canonical source and this fan-out", () => {
+    const canonical = extractAcTemplate(
+      read("plugins/src/base/rules/reference/promotion-contract.md")
+    );
+
+    expect(extractAcTemplate(reference)).toBe(canonical);
+  });
+});
+
+describe.each(CURSOR_RULE_PATHS)("cursor rule projection (%s)", rulePath => {
+  it("carries the promotion-contract content", () => {
+    const body = read(rulePath);
+
+    expect(body).toMatch(/remediation-teaching diagnostic/i);
+    expect(body).toMatch(/rejected by rule/i);
+  });
+});
+
+describe.each(REWORK_TRIAGE_PATHS)(
+  "rework-triage upstream lanes (%s)",
+  triagePath => {
+    const triage = read(triagePath);
+
+    it("documents both upstream lanes with distinct labels", () => {
+      expect(triage).toContain("self-hardening");
+      expect(triage).toContain("template-candidate");
+    });
+
+    it("keeps the dedupe-marker + evidence-chain discipline for the second lane", () => {
+      expect(triage).toMatch(/dedupe first/i);
+      expect(triage).toMatch(/evidence chain/i);
+    });
+
+    it("requires the proposed-template-change section on template-candidate filings", () => {
+      expect(triage).toMatch(/proposed template change/i);
+    });
+  }
+);
+
+describe.each(PROJECT_RULES_PATHS)(
+  "PROJECT_RULES.md human-authored-only contract (%s)",
+  rulesPath => {
+    const rules = read(rulesPath);
+
+    it("states the file is human-authored only", () => {
+      expect(rules).toMatch(/human-authored only/i);
+    });
+
+    it("routes machine-captured knowledge to the ledger and the gardener", () => {
+      expect(rules).toMatch(/PROJECT_LEARNINGS\.md/);
+      expect(rules).toMatch(/gardener|learnings:audit|learnings-audit/i);
+    });
+
+    it("treats existing content as first-run gardener candidates", () => {
+      expect(rules).toMatch(/first-run.*candidates|candidates.*first-run/i);
+    });
+  }
+);

--- a/tests/unit/strategies/promotion-contract-rule.test.ts
+++ b/tests/unit/strategies/promotion-contract-rule.test.ts
@@ -23,6 +23,8 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { extractAcTemplate } from "./promotion-contract-helpers.js";
+
 const RULE_PAIR_ROOTS = [
   "plugins/src/base",
   "plugins/lisa",
@@ -48,27 +50,8 @@ const PROJECT_RULES_PATHS = [
   "all/create-only/.claude/rules/PROJECT_RULES.md",
 ] as const;
 
-const AC_TEMPLATE_START = "<!-- promotion-contract-ac-template:start -->";
-const AC_TEMPLATE_END = "<!-- promotion-contract-ac-template:end -->";
-
 const read = (relativePath: string): string =>
   readFileSync(path.resolve(relativePath), "utf8");
-
-/**
- * Extracts the delimited AC-template snippet from a promotion-contract rule
- * body so the gardener's verbatim embedding can be asserted byte-for-byte.
- * @param body Full markdown body of a promotion-contract reference rule.
- * @returns The template text between the start/end markers, inclusive.
- */
-export function extractAcTemplate(body: string): string {
-  const start = body.indexOf(AC_TEMPLATE_START);
-  const end = body.indexOf(AC_TEMPLATE_END);
-  if (start === -1 || end === -1 || end <= start) {
-    throw new Error("promotion-contract AC template markers not found");
-  }
-  const result = body.slice(start, end + AC_TEMPLATE_END.length);
-  return result;
-}
 
 describe.each(RULE_PAIR_ROOTS)("promotion-contract rule pair (%s)", root => {
   const eager = read(path.join(root, "rules/eager/promotion-contract.md"));


### PR DESCRIPTION
## Summary

- **The gardener (`lisa-learnings-audit`, `/lisa:learnings:audit`)**: the promotion engine of PRD #1729. Inventories every knowledge surface (ledger via contract, rules trees incl. Lisa's own eager tier, skills, wiki, mechanical owners), gathers evidence (recurrence/staleness/redundancy/contradiction/budget), classifies via the ladder router, and communicates exclusively through the tracker: per-item gated PROMOTE/DEMOTE tickets (never `status:ready` — the human flips) with the router's drafted artifact and, for executable-control promotions, the promotion-contract AC template embedded byte-verbatim; one strikeable CONFIRM/RETIRE batch ticket per run with its own delimited execution template. Deterministic `[lisa-gardener]` fingerprints (documented shasum procedure, prefix-first dedupe over open AND closed issues) make rejection a durable memory. Full runbook contract: terminal states (nothing-needed | candidates-proposed | blocked), headless escalation (`status:blocked` + `human-needed`, never prompts), retirement condition, opt-in weekly registration via setup-automations.
- **The promotion contract** (`promotion-contract` rule pair): atomic promote-and-delete — enable the control + fix the population + ship a teaches-the-repair diagnostic + delete the superseded prose, one PR, missing-any-leg rejected by rule; demotion-biased eager-tier admission; the AC template as the single embeddable source. Plus: `PROJECT_RULES.md` becomes human-authored-only (existing sections = first-run gardener candidates), and `lisa-rework-triage` gains the `template-candidate` upstream lane beside `self-hardening`.

Closes CodySwannGT/lisa#1735
Closes CodySwannGT/lisa#1736

## Review + verification

Two combined lanes (quality approve-with-nits; CodeRabbit+spec CONFORMS both tickets) — all four nits fixed (deterministic hash spec, batch-ticket template, anchored regex, setup-automations freshness). Independent verification PASS with a **live bounded gardener run on this repo**: two real gated tickets filed (#1775/#1776 — correct shape, byte-verbatim AC template, computed fingerprints shown), rejection-memory proven (closed-rejected → re-run files nothing), quiet no-op proven, headless-block simulated promptless, out-of-scope clean; scratch tickets closed. The verifier codified the fingerprint algorithm against the live vectors (gardener-fingerprint-hash.test.ts). One live-run finding (invalid `--state all` on `gh search issues`) fixed in-branch. 186 contract assertions green; full suite green.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a learnings-audit (“gardener”) workflow that audits project knowledge and proposes deduplicated, human-approved tracker actions.
  - Added an optional weekly automation to run the learnings audit.
  - Added configurable controls such as candidate limits, surface selection, and dry-run.

- **Documentation**
  - Documented the learnings-audit process, evidence-based promotion outcomes, and human-gated operating boundaries.
  - Clarified promotion contract requirements and updated upstream triage into two filing lanes.
  - Updated project rules guidance to route automated learnings to the ledger.

- **Tests**
  - Added unit coverage for audit contracts, promotion rules, and deterministic fingerprinting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->