### PR TITLE
fix(ci): collapse learnings budget bridge

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -428,24 +428,15 @@ jobs:
       # unchanged host commits. Bump deliberately when the learnings contract
       # changes. (Publishing npm and pushing this @main workflow are the same
       # trust domain; the pin buys determinism, not a trust boundary.) The pin
-      # must be >= 2.237.0: earlier CLIs lack this subcommand AND self-skip in
-      # non-interactive environments with exit 0, silently voiding the gate —
-      # which is why the marker grep below asserts the check actually ran.
-      # Transition bridge: the pinned CLI's resolver predates the .lisa/ default,
-      # so the no-arg leg still resolves the OLD .claude/rules/ path — which is
-      # empty once the ledger relocates, silently voiding the gate. The
-      # explicit-arg leg (explicit-path mode ships in the pinned CLI; a missing
-      # file is a silent pass) keeps the relocated .lisa/ ledger gated. Collapse
-      # to a single no-arg leg at the next deliberate pin bump (>= the release
-      # containing #1730). Each leg has its own marker grep so neither can be
-      # silently voided (same class as PR #1754).
+      # must be >= 2.243.0: earlier CLIs lack the relocated .lisa/ resolver or
+      # this subcommand, and pre-2.237.0 CLIs self-skip in non-interactive
+      # environments with exit 0, silently voiding the gate — which is why the
+      # marker grep below asserts the check actually ran.
       - name: 📚 Check learnings budget
         run: |
           set -o pipefail
-          bunx @codyswann/lisa@2.239.0 check-learnings-budget | tee learnings-budget.out
+          bunx @codyswann/lisa@2.243.0 check-learnings-budget | tee learnings-budget.out
           grep -qE "learnings budget passed|no learnings file" learnings-budget.out
-          bunx @codyswann/lisa@2.239.0 check-learnings-budget .lisa/PROJECT_LEARNINGS.md | tee learnings-budget-relocated.out
-          grep -qE "learnings budget passed|no learnings file" learnings-budget-relocated.out
 
   license_compliance:
     name: 📜 FOSSA License Check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -558,24 +558,15 @@ jobs:
       # unchanged host commits. Bump deliberately when the learnings contract
       # changes. (Publishing npm and pushing this @main workflow are the same
       # trust domain; the pin buys determinism, not a trust boundary.) The pin
-      # must be >= 2.237.0: earlier CLIs lack this subcommand AND self-skip in
-      # non-interactive environments with exit 0, silently voiding the gate —
-      # which is why the marker grep below asserts the check actually ran.
-      # Transition bridge: the pinned CLI's resolver predates the .lisa/ default,
-      # so the no-arg leg still resolves the OLD .claude/rules/ path — which is
-      # empty once the ledger relocates, silently voiding the gate. The
-      # explicit-arg leg (explicit-path mode ships in the pinned CLI; a missing
-      # file is a silent pass) keeps the relocated .lisa/ ledger gated. Collapse
-      # to a single no-arg leg at the next deliberate pin bump (>= the release
-      # containing #1730). Each leg has its own marker grep so neither can be
-      # silently voided (same class as PR #1754).
+      # must be >= 2.243.0: earlier CLIs lack the relocated .lisa/ resolver or
+      # this subcommand, and pre-2.237.0 CLIs self-skip in non-interactive
+      # environments with exit 0, silently voiding the gate — which is why the
+      # marker grep below asserts the check actually ran.
       - name: 📚 Check learnings budget
         run: |
           set -o pipefail
-          bunx @codyswann/lisa@2.239.0 check-learnings-budget | tee learnings-budget.out
+          bunx @codyswann/lisa@2.243.0 check-learnings-budget | tee learnings-budget.out
           grep -qE "learnings budget passed|no learnings file" learnings-budget.out
-          bunx @codyswann/lisa@2.239.0 check-learnings-budget .lisa/PROJECT_LEARNINGS.md | tee learnings-budget-relocated.out
-          grep -qE "learnings budget passed|no learnings file" learnings-budget-relocated.out
         working-directory: ${{ inputs.working_directory || '.' }}
 
   test_unit:

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -371,26 +371,24 @@ describe("quality.yml reusable workflow", () => {
   });
 });
 
-describe("learnings-budget transition bridge (#1730)", () => {
-  // Both the no-arg leg (legacy path under the pinned CLI's old resolver) and
-  // the explicit .lisa/ leg must be present, each with its OWN marker grep, so
-  // a relocated ledger cannot silently pass an empty legacy gate (PR #1754).
+describe("learnings-budget gate (#1730)", () => {
+  // The post-relocation pin must use the resolver-aware CLI and keep the marker
+  // assertion so the gate cannot silently pass through a self-skipping CLI.
   it.each([QUALITY_YML, QUALITY_RAILS_YML])(
-    "%s gates both the legacy and the relocated ledger",
+    "%s gates the resolved project learnings ledger",
     file => {
       const workflow = fs.readFileSync(file, "utf8");
 
       expect(workflow).toContain(
-        "bunx @codyswann/lisa@2.239.0 check-learnings-budget | tee learnings-budget.out"
+        "bunx @codyswann/lisa@2.243.0 check-learnings-budget | tee learnings-budget.out"
       );
-      expect(workflow).toContain(
-        "bunx @codyswann/lisa@2.239.0 check-learnings-budget .lisa/PROJECT_LEARNINGS.md | tee learnings-budget-relocated.out"
-      );
-      // Each leg is asserted by its own marker grep — two greps, two out files.
       expect(
         workflow.match(/grep -qE "learnings budget passed\|no learnings file"/g)
-      ).toHaveLength(2);
-      expect(workflow).toContain("learnings-budget-relocated.out");
+      ).toHaveLength(1);
+      expect(workflow).not.toContain(
+        "check-learnings-budget .lisa/PROJECT_LEARNINGS.md"
+      );
+      expect(workflow).not.toContain("learnings-budget-relocated.out");
     }
   );
 });


### PR DESCRIPTION
## Summary
- bump the reusable learnings-budget CLI pin to the first resolver-aware release, `2.243.0`
- remove the temporary explicit `.lisa/PROJECT_LEARNINGS.md` bridge leg from both quality workflows
- keep the success-marker grep on the remaining no-arg leg and update the workflow contract test

Closes #1767

## Verification
- `git merge-base --is-ancestor e3b4df73ce6dcf548ab8cb920125db0aeb08178a v2.243.0`
- `bun test tests/integration/quality-workflow.test.ts`
- `bunx prettier --check .github/workflows/quality.yml .github/workflows/quality-rails.yml tests/integration/quality-workflow.test.ts`
- `bunx @codyswann/lisa@2.243.0 check-learnings-budget`
- temp-host red leg: over-budget `.lisa/PROJECT_LEARNINGS.md` fails with `maxTokens exceeded`
- pre-push hook: security audit, slow lint, knip, unit tests with coverage, integration tests

Co-authored-by: Codex <codex@openai.com>