### PR TITLE
fix: surface worker epoch drift in doctor

### DIFF
--- a/src/cli/doctor-worker-epoch.ts
+++ b/src/cli/doctor-worker-epoch.ts
@@ -1,0 +1,321 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import * as path from "node:path";
+import type { DoctorCheck } from "./doctor.js";
+
+const WORKER_EPOCH_CHECK_NAME = "Worker epoch qualified?";
+
+/** One worker entry from `.lisa/worker-config.json`. */
+interface WorkerEpochAgentRecord {
+  id?: unknown;
+  host?: unknown;
+  version?: unknown;
+  model?: unknown;
+  modelId?: unknown;
+  qualificationEvidence?: unknown;
+  evidence?: unknown;
+}
+
+/** Supported top-level worker epoch record shapes. */
+interface WorkerEpochRecord {
+  agents?: unknown;
+  workers?: unknown;
+}
+
+/** Current runtime identity used for epoch comparison. */
+interface RuntimeWorkerSignature {
+  host: string;
+  model: string;
+  version: string;
+}
+
+/**
+ * Report whether the project has a worker-epoch record and whether the current
+ * runtime signature still matches it. This is intentionally read-only: doctor
+ * tells the operator when requalification is needed; lifecycle/repair flows own
+ * filing any build-ready tickets from failed representative journeys.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+export async function checkWorkerEpoch(
+  targetPath: string
+): Promise<DoctorCheck> {
+  const recordPath = path.join(targetPath, ".lisa", "worker-config.json");
+  if (!existsSync(recordPath)) {
+    if (!looksLikeLisaProject(targetPath)) {
+      return {
+        name: WORKER_EPOCH_CHECK_NAME,
+        status: "ok",
+        detail: "Not a Lisa project; skipped worker epoch qualification",
+      };
+    }
+    return {
+      name: WORKER_EPOCH_CHECK_NAME,
+      status: "warn",
+      detail:
+        "No .lisa/worker-config.json found; record the qualified model/agent-host epoch and representative journey evidence before relying on unattended factory runs",
+    };
+  }
+
+  try {
+    const record = JSON.parse(
+      await readFile(recordPath, "utf8")
+    ) as WorkerEpochRecord;
+    return evaluateWorkerEpochRecord(
+      targetPath,
+      record,
+      currentRuntimeWorkerSignature()
+    );
+  } catch (error) {
+    return {
+      name: WORKER_EPOCH_CHECK_NAME,
+      status: "fail",
+      detail: `.lisa/worker-config.json is not parseable JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
+/**
+ * Determine whether a project should carry a Lisa worker epoch record.
+ * @param targetPath - Project path to inspect
+ * @returns True when Lisa project markers are present
+ */
+function looksLikeLisaProject(targetPath: string): boolean {
+  return [".lisa.config.json", ".lisa.config.local.json", ".lisa"].some(
+    fileName => existsSync(path.join(targetPath, fileName))
+  );
+}
+
+/**
+ * Compare a parsed worker record against the current runtime signature.
+ * @param targetPath - Project path to inspect for subtraction candidates
+ * @param record - Parsed worker epoch record
+ * @param signature - Current runtime worker signature
+ * @returns Doctor check result
+ */
+async function evaluateWorkerEpochRecord(
+  targetPath: string,
+  record: WorkerEpochRecord,
+  signature: RuntimeWorkerSignature
+): Promise<DoctorCheck> {
+  const agents = normalizeWorkerAgents(record);
+  if (agents.length === 0) {
+    return {
+      name: WORKER_EPOCH_CHECK_NAME,
+      status: "warn",
+      detail:
+        ".lisa/worker-config.json does not list any qualified workers; add agent host, model, version, and evidence entries",
+    };
+  }
+
+  const currentRecord = agents.find(agent => {
+    return (
+      typeof agent.host === "string" &&
+      agent.host.toLowerCase() === signature.host
+    );
+  });
+  if (!currentRecord) {
+    return {
+      name: WORKER_EPOCH_CHECK_NAME,
+      status: "warn",
+      detail:
+        `Worker epoch record exists, but current host ${signature.host} is not recorded; ` +
+        "run representative journeys, save evidence, and list any scaffolding-subtraction candidates in the report",
+    };
+  }
+
+  return renderWorkerEpochMatch(targetPath, currentRecord, signature);
+}
+
+/**
+ * Render the doctor check for the matched worker host.
+ * @param targetPath - Project path to inspect for subtraction candidates
+ * @param currentRecord - Recorded worker for the current host
+ * @param signature - Current runtime worker signature
+ * @returns Doctor check result
+ */
+async function renderWorkerEpochMatch(
+  targetPath: string,
+  currentRecord: WorkerEpochAgentRecord,
+  signature: RuntimeWorkerSignature
+): Promise<DoctorCheck> {
+  const recordedModel = stringField(
+    currentRecord.modelId ?? currentRecord.model
+  );
+  const recordedVersion = stringField(currentRecord.version);
+  const drift = [
+    compareWorkerField("model", recordedModel, signature.model),
+    compareWorkerField("version", recordedVersion, signature.version),
+  ].filter((entry): entry is string => entry !== null);
+  const subtractionCount = await countWorkerWorkaroundCandidates(targetPath);
+  const evidence = stringField(
+    currentRecord.qualificationEvidence ?? currentRecord.evidence
+  );
+
+  if (drift.length > 0) {
+    return {
+      name: WORKER_EPOCH_CHECK_NAME,
+      status: "warn",
+      detail:
+        `Worker epoch drift detected for ${signature.host}: ${drift.join(", ")}. ` +
+        "Re-run representative journeys headlessly; passing journeys update qualification evidence, failing journeys file build-ready tickets. " +
+        `Scaffolding-subtraction candidates surfaced: ${subtractionCount}.`,
+    };
+  }
+
+  return {
+    name: WORKER_EPOCH_CHECK_NAME,
+    status: evidence ? "ok" : "warn",
+    detail: evidence
+      ? `Worker epoch matches ${signature.host}; qualification evidence: ${evidence}. Scaffolding-subtraction candidates surfaced: ${subtractionCount}.`
+      : `Worker epoch matches ${signature.host}, but no qualification evidence is recorded. Scaffolding-subtraction candidates surfaced: ${subtractionCount}.`,
+  };
+}
+
+/**
+ * Normalize object- and array-shaped worker records into one array.
+ * @param record - Parsed worker epoch record
+ * @returns Normalized worker entries
+ */
+function normalizeWorkerAgents(
+  record: WorkerEpochRecord
+): WorkerEpochAgentRecord[] {
+  if (Array.isArray(record.agents)) {
+    return record.agents.filter(isRecord) as WorkerEpochAgentRecord[];
+  }
+  if (Array.isArray(record.workers)) {
+    return record.workers.filter(isRecord) as WorkerEpochAgentRecord[];
+  }
+  if (isRecord(record.agents)) {
+    return Object.entries(record.agents).map(([id, value]) => ({
+      ...(isRecord(value) ? value : {}),
+      id,
+    }));
+  }
+  if (isRecord(record.workers)) {
+    return Object.entries(record.workers).map(([id, value]) => ({
+      ...(isRecord(value) ? value : {}),
+      id,
+    }));
+  }
+  return [];
+}
+
+/**
+ * Infer a stable worker signature from explicit Lisa variables first.
+ * @returns Current runtime signature
+ */
+function currentRuntimeWorkerSignature(): RuntimeWorkerSignature {
+  const env = process["env"];
+  const host =
+    env.LISA_WORKER_HOST ??
+    (env.CODEX_HOME || env.CODEX_SANDBOX
+      ? "codex"
+      : env.CLAUDECODE
+        ? "claude"
+        : "unknown");
+  return {
+    host: host.toLowerCase(),
+    model: env.LISA_WORKER_MODEL ?? env.CODEX_MODEL ?? "unknown",
+    version: env.LISA_WORKER_VERSION ?? env.CODEX_VERSION ?? "unknown",
+  };
+}
+
+/**
+ * Return a human-readable drift fragment for one worker field.
+ * @param name - Field name
+ * @param recorded - Recorded value
+ * @param current - Current value
+ * @returns Drift fragment, or null when unchanged/unobservable
+ */
+function compareWorkerField(
+  name: string,
+  recorded: string | null,
+  current: string
+): string | null {
+  if (!recorded || current === "unknown" || recorded === current) {
+    return null;
+  }
+  return `${name} recorded ${recorded} now ${current}`;
+}
+
+/**
+ * Count local rules/skills whose rationale mentions worker-specific workarounds.
+ * @param targetPath - Project path to scan
+ * @returns Number of candidate files
+ */
+async function countWorkerWorkaroundCandidates(
+  targetPath: string
+): Promise<number> {
+  const roots = [
+    path.join(targetPath, "plugins", "src", "base", "rules"),
+    path.join(targetPath, "plugins", "src", "base", "skills"),
+  ];
+  const counts = await Promise.all(
+    roots.map(root => countMatchingMarkdownFiles(root, isWorkerWorkaround))
+  );
+  return counts.reduce((total, count) => total + count, 0);
+}
+
+/**
+ * Determine whether a markdown file describes a worker workaround.
+ * @param content - Markdown content
+ * @returns True when content is a subtraction-pass candidate
+ */
+function isWorkerWorkaround(content: string): boolean {
+  return /\b(model|worker|host|epoch|claude|codex|cursor|opencode|copilot|agy)\b[\s\S]{0,160}\b(workaround|limitation|quirk|scaffold|temporary|native capability)\b/iu.test(
+    content
+  );
+}
+
+/**
+ * Recursively count markdown files matching a predicate.
+ * @param directory - Directory to scan
+ * @param predicate - Markdown content predicate
+ * @returns Number of matching files
+ */
+async function countMatchingMarkdownFiles(
+  directory: string,
+  predicate: (content: string) => boolean
+): Promise<number> {
+  if (!existsSync(directory)) {
+    return 0;
+  }
+  const counts = await Promise.all(
+    (await readdir(directory)).map(async entry => {
+      const entryPath = path.join(directory, entry);
+      const entryStat = await stat(entryPath);
+      if (entryStat.isDirectory()) {
+        return countMatchingMarkdownFiles(entryPath, predicate);
+      }
+      if (
+        entry.endsWith(".md") &&
+        predicate(await readFile(entryPath, "utf8"))
+      ) {
+        return 1;
+      }
+      return 0;
+    })
+  );
+  return counts.reduce((total, count) => total + count, 0);
+}
+
+/**
+ * Narrow unknown JSON values to plain records.
+ * @param value - Value to inspect
+ * @returns True for plain object records
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize a possibly empty string field.
+ * @param value - Value to normalize
+ * @returns Trimmed string or null
+ */
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/src/cli/doctor-worker-epoch.ts
+++ b/src/cli/doctor-worker-epoch.ts
@@ -204,13 +204,17 @@ function normalizeWorkerAgents(
 }
 
 /**
- * Infer a stable worker signature from explicit Lisa variables first.
+ * Infer a stable worker signature from explicit Lisa variables first,
+ * falling back to `LISA_REMOTE_AGENT` (set by the remote-agent bootstrap for
+ * Cursor, Copilot, OpenCode, and Antigravity) and then Codex/Claude-specific
+ * markers.
  * @returns Current runtime signature
  */
 function currentRuntimeWorkerSignature(): RuntimeWorkerSignature {
   const env = process["env"];
   const host =
     env.LISA_WORKER_HOST ??
+    env.LISA_REMOTE_AGENT ??
     (env.CODEX_HOME || env.CODEX_SANDBOX
       ? "codex"
       : env.CLAUDECODE
@@ -265,7 +269,7 @@ async function countWorkerWorkaroundCandidates(
  * @returns True when content is a subtraction-pass candidate
  */
 function isWorkerWorkaround(content: string): boolean {
-  return /\b(model|worker|host|epoch|claude|codex|cursor|opencode|copilot|agy)\b[\s\S]{0,160}\b(workaround|limitation|quirk|scaffold|temporary|native capability)\b/iu.test(
+  return /\b(model|worker|host|epoch|claude|codex|cursor|opencode|copilot|agy|antigravity)\b[\s\S]{0,160}\b(workaround|limitation|quirk|scaffold|temporary|native capability)\b/iu.test(
     content
   );
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,7 @@ import { CLAUDE_MD_FILENAME } from "../claude/claude-md-installer.js";
 import { migrateInstructionFiles } from "../core/instruction-files-migration.js";
 import { createDetectorRegistry } from "../detection/index.js";
 import { checkLegacyMonitorThresholds } from "./doctor-monitor-thresholds.js";
+import { checkWorkerEpoch } from "./doctor-worker-epoch.js";
 import { STARTERS } from "./starters.js";
 import { runUpdateCheck } from "./update-check.js";
 
@@ -369,6 +370,7 @@ export async function runDoctor(
     await checkLegacyMonitorThresholds(resolvedTarget),
     await checkProjectType(resolvedTarget),
     await checkInstructionFiles(resolvedTarget),
+    await checkWorkerEpoch(resolvedTarget),
     checkLegacyCodexOverlay(resolvedTarget),
     await checkStarterHealth(deps, options.offline === true),
     checkWiki(resolvedTarget),

--- a/tests/unit/cli/doctor-worker-epoch.test.ts
+++ b/tests/unit/cli/doctor-worker-epoch.test.ts
@@ -1,0 +1,144 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkWorkerEpoch } from "../../../src/cli/doctor-worker-epoch.js";
+
+const LISA_CONFIG_FILE = ".lisa.config.json";
+const WORKER_EPOCH_CHECK = "Worker epoch qualified?";
+const CODEX_HOST = "codex";
+const CURRENT_MODEL = "gpt-5.2";
+const CURRENT_VERSION = "26.8.0";
+
+let tempDir: string | undefined;
+let envRestores: Array<() => void> = [];
+
+/**
+ * Resolve the temporary directory for one worker epoch test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-worker-epoch-"));
+  return tempDir;
+}
+
+afterEach(async () => {
+  for (const restore of envRestores.toReversed()) {
+    restore();
+  }
+  envRestores = [];
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("checkWorkerEpoch", () => {
+  it("warns when a Lisa project has no worker epoch record", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, LISA_CONFIG_FILE), "{}\n");
+
+    await expect(checkWorkerEpoch(cwd)).resolves.toMatchObject({
+      name: WORKER_EPOCH_CHECK,
+      status: "warn",
+      detail: expect.stringContaining(".lisa/worker-config.json"),
+    });
+  });
+
+  it("warns on worker epoch drift and surfaces subtraction candidates", async () => {
+    const cwd = await getTempDir();
+    setWorkerEnv();
+    await seedWorkerRecord(cwd, {
+      agents: [
+        {
+          host: CODEX_HOST,
+          model: "gpt-5.1",
+          version: "26.7.0",
+          qualificationEvidence: "runs/previous.md",
+        },
+      ],
+    });
+    await mkdir(path.join(cwd, "plugins", "src", "base", "rules"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(cwd, "plugins", "src", "base", "rules", "worker.md"),
+      "This rule is a Codex model workaround for a worker limitation.\n"
+    );
+
+    const check = await checkWorkerEpoch(cwd);
+
+    expect(check.name).toBe(WORKER_EPOCH_CHECK);
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain("Worker epoch drift detected");
+    expect(check.detail).toContain(
+      "Scaffolding-subtraction candidates surfaced: 1"
+    );
+  });
+
+  it("passes when the current worker epoch matches recorded evidence", async () => {
+    const cwd = await getTempDir();
+    setWorkerEnv();
+    await seedWorkerRecord(cwd, {
+      agents: {
+        codex: {
+          host: CODEX_HOST,
+          modelId: CURRENT_MODEL,
+          version: CURRENT_VERSION,
+          evidence: "runs/current.md",
+        },
+      },
+    });
+
+    await expect(checkWorkerEpoch(cwd)).resolves.toMatchObject({
+      name: WORKER_EPOCH_CHECK,
+      status: "ok",
+      detail: expect.stringContaining(
+        "qualification evidence: runs/current.md"
+      ),
+    });
+  });
+});
+
+/**
+ * Set the worker environment variables used by the doctor epoch check.
+ */
+function setWorkerEnv(): void {
+  setEnv("LISA_WORKER_HOST", CODEX_HOST);
+  setEnv("LISA_WORKER_MODEL", CURRENT_MODEL);
+  setEnv("LISA_WORKER_VERSION", CURRENT_VERSION);
+}
+
+/**
+ * Set one environment variable and restore it after the test.
+ * @param name - Environment variable name
+ * @param value - Environment variable value
+ */
+function setEnv(name: string, value: string): void {
+  const previous = process["env"][name];
+  process["env"][name] = value;
+  envRestores.push(() => {
+    if (previous === undefined) {
+      delete process["env"][name];
+    } else {
+      process["env"][name] = previous;
+    }
+  });
+}
+
+/**
+ * Seed a worker epoch record in a temporary Lisa project.
+ * @param cwd - Temporary project root
+ * @param record - Worker epoch record body
+ */
+async function seedWorkerRecord(
+  cwd: string,
+  record: Record<string, unknown>
+): Promise<void> {
+  await writeFile(path.join(cwd, LISA_CONFIG_FILE), "{}\n");
+  await mkdir(path.join(cwd, ".lisa"), { recursive: true });
+  await writeFile(
+    path.join(cwd, ".lisa", "worker-config.json"),
+    JSON.stringify(record)
+  );
+}

--- a/tests/unit/cli/doctor-worker-epoch.test.ts
+++ b/tests/unit/cli/doctor-worker-epoch.test.ts
@@ -98,6 +98,57 @@ describe("checkWorkerEpoch", () => {
       ),
     });
   });
+
+  it("recognizes non-Codex/Claude hosts via LISA_REMOTE_AGENT", async () => {
+    const cwd = await getTempDir();
+    setEnv("LISA_REMOTE_AGENT", "cursor");
+    setEnv("LISA_WORKER_MODEL", CURRENT_MODEL);
+    setEnv("LISA_WORKER_VERSION", CURRENT_VERSION);
+    await seedWorkerRecord(cwd, {
+      agents: {
+        cursor: {
+          host: "cursor",
+          modelId: CURRENT_MODEL,
+          version: CURRENT_VERSION,
+          evidence: "runs/cursor.md",
+        },
+      },
+    });
+
+    await expect(checkWorkerEpoch(cwd)).resolves.toMatchObject({
+      name: WORKER_EPOCH_CHECK,
+      status: "ok",
+      detail: expect.stringContaining("qualification evidence: runs/cursor.md"),
+    });
+  });
+
+  it("counts a rationale mentioning Antigravity (without the agy token) as a subtraction candidate", async () => {
+    const cwd = await getTempDir();
+    setWorkerEnv();
+    await seedWorkerRecord(cwd, {
+      agents: [
+        {
+          host: CODEX_HOST,
+          model: "gpt-5.1",
+          version: "26.7.0",
+          qualificationEvidence: "runs/previous.md",
+        },
+      ],
+    });
+    await mkdir(path.join(cwd, "plugins", "src", "base", "rules"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(cwd, "plugins", "src", "base", "rules", "worker.md"),
+      "Antigravity needs a scaffold to package skills for its runtime.\n"
+    );
+
+    const check = await checkWorkerEpoch(cwd);
+
+    expect(check.detail).toContain(
+      "Scaffolding-subtraction candidates surfaced: 1"
+    );
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
- add a worker-epoch doctor check for `.lisa/worker-config.json`
- report missing records, host/model/version drift, and recorded qualification evidence
- surface scaffolding-subtraction candidates from worker-workaround rule/skill rationale without deleting anything

Closes #1742

## Verification
- bun test tests/unit/cli/doctor.test.ts tests/unit/cli/doctor-worker-epoch.test.ts
- bun run typecheck
- bun run lint
- bun run build:dist
- pre-push hook: slow lint, knip, full unit coverage, integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI “doctor” check that validates a Lisa project’s worker-epoch qualification record against the current runtime worker identity.
  * Reports when the record is missing, malformed, evidence is missing, or drift is detected, including actionable diagnostic details.
  * Diagnostic output now includes detected worker workaround references for the current host-matched path.

* **Tests**
  * Added unit coverage for missing records, drift detection, evidence present/absent cases, and host recognition via runtime environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->