### PR TITLE
feat(skills): add convergent review policy

### DIFF
--- a/plugins/lisa-agy/agents/product-specialist.md
+++ b/plugins/lisa-agy/agents/product-specialist.md
@@ -61,3 +61,5 @@ For each acceptance criterion:
 - If the changes are purely internal (refactoring, config, tooling), report "No user-facing impact" and explain why
 - Do not propose UX changes beyond what was described -- flag scope concerns instead
 - Assume the reviewer has no technical background
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and mark lint-owned style or taste feedback as non-blocking.
+- For every finding, state severity, whether it blocks, the concrete user/operator failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-agy/agents/quality-specialist.md
+++ b/plugins/lisa-agy/agents/quality-specialist.md
@@ -24,7 +24,8 @@ For each changed file, evaluate:
 Rank findings by severity:
 
 ### Critical (must fix before merge)
-Broken logic or violates hard project rules.
+Broken logic, security exposure, data loss, or a hard contract violation with a
+concrete failure scenario.
 
 ### Warning (should fix)
 Could cause problems later or reduce maintainability.
@@ -54,3 +55,5 @@ For each finding:
 - Run the task's proof command to confirm the implementation works
 - Never approve code with failing tests
 - If no issues found, say so clearly -- do not invent problems
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and do not block on lint-owned style, formatting, taste, or speculative maintainability improvements.
+- For every finding, state severity, whether it blocks, the concrete failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/lisa-agy/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/lisa-agy/skills/lisa-review-local/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch

--- a/plugins/lisa-copilot/agents/product-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/product-specialist.agent.md
@@ -61,3 +61,5 @@ For each acceptance criterion:
 - If the changes are purely internal (refactoring, config, tooling), report "No user-facing impact" and explain why
 - Do not propose UX changes beyond what was described -- flag scope concerns instead
 - Assume the reviewer has no technical background
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and mark lint-owned style or taste feedback as non-blocking.
+- For every finding, state severity, whether it blocks, the concrete user/operator failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-copilot/agents/quality-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/quality-specialist.agent.md
@@ -24,7 +24,8 @@ For each changed file, evaluate:
 Rank findings by severity:
 
 ### Critical (must fix before merge)
-Broken logic or violates hard project rules.
+Broken logic, security exposure, data loss, or a hard contract violation with a
+concrete failure scenario.
 
 ### Warning (should fix)
 Could cause problems later or reduce maintainability.
@@ -54,3 +55,5 @@ For each finding:
 - Run the task's proof command to confirm the implementation works
 - Never approve code with failing tests
 - If no issues found, say so clearly -- do not invent problems
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and do not block on lint-owned style, formatting, taste, or speculative maintainability improvements.
+- For every finding, state severity, whether it blocks, the concrete failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-copilot/rules/eager/convergent-review.md
+++ b/plugins/lisa-copilot/rules/eager/convergent-review.md
@@ -1,0 +1,19 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+
+- Block only concrete correctness, security, data-loss, or contract-violation
+  failures. Lint-owned style, formatting, taste, and speculative improvements
+  are non-blocking unless the work item or repository rules make them release
+  criteria.
+- Every finding must state severity, blocking yes/no, a concrete failure
+  scenario, evidence, and the smallest actionable fix.
+- A blocking finding without a concrete failure scenario is malformed by
+  contract; downgrade it to non-blocking and ask for evidence.
+- Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer
+  cannot refute a pushback with fresh evidence, the author's disposition stands.
+- After suggestion implementation completes and gates pass, review does not
+  reopen absent new evidence: a relevant new commit, a failed gate, a newly cited
+  failure scenario, or a scope change.
+- Irreconcilable blocking disagreement becomes a blocked work item with both
+  positions summarized for the operator, not an endless loop.

--- a/plugins/lisa-copilot/rules/reference/convergent-review.md
+++ b/plugins/lisa-copilot/rules/reference/convergent-review.md
@@ -1,0 +1,69 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+Apply this contract to every product, quality, local, bot-parity, and suggestion
+implementation pass.
+
+## Severity Bar
+
+Findings block only when they name a concrete failure scenario in one of these
+classes:
+
+- Correctness: shipped behavior violates the work item, breaks an existing
+  contract, or loses required data.
+- Security: the change creates or preserves an exploitable auth, input,
+  secret-handling, permission, or data-exposure flaw.
+- Data loss: a realistic path can delete, corrupt, overwrite, or strand user or
+  operational state.
+- Contract violation: the change breaks a public API, workflow, generated
+  artifact contract, tracker lifecycle, or documented factory invariant.
+
+Lint-owned style, formatting, taste, general maintainability preferences, and
+speculative improvements are non-blocking unless the repository rule or work
+item explicitly makes them release criteria.
+
+## Required Finding Shape
+
+Every finding must state:
+
+- Severity: `critical`, `major`, `minor`, or `nit`.
+- Blocking: `yes` or `no`.
+- Failure scenario: the concrete user, operator, security, or factory outcome
+  that occurs if the change ships as-is.
+- Evidence: the file, command output, observed behavior, ticket text, or
+  external constraint proving the scenario is reachable.
+- Fix: the smallest actionable correction, or the reason no code change is
+  needed.
+
+A finding marked blocking without a concrete failure scenario is malformed by
+contract. Downgrade it to non-blocking and ask for evidence instead of treating
+it as a merge blocker.
+
+## Dispositions
+
+The implementer resolves each finding with exactly one disposition:
+
+- `fixed`: code, tests, docs, or generated artifacts changed to remove the
+  failure scenario.
+- `deferred`: the issue is real but non-blocking; record the rationale and, when
+  useful, the follow-up work item.
+- `pushed-back`: the finding is not valid for this work because evidence,
+  scope, or existing project rules refute it; reply with that rationale.
+
+If a reviewer cannot refute a `pushed-back` disposition with fresh evidence, the
+author's disposition stands.
+
+## Stopping Rule
+
+After suggestion implementation completes and the required quality and
+verification gates pass, review does not reopen unless new evidence appears:
+
+- a new commit changes the reviewed behavior,
+- a gate fails,
+- a reviewer supplies a previously uncited failure scenario, or
+- the work item scope changes.
+
+Irreconcilable blocking disagreement is not an endless review loop. Move the
+work item to the configured blocked state, add the human-needed marker when the
+decision is human-only, and summarize both positions in operator-readable
+language.

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/lisa-copilot/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/lisa-copilot/skills/lisa-review-local/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch

--- a/plugins/lisa-cursor/agents/product-specialist.md
+++ b/plugins/lisa-cursor/agents/product-specialist.md
@@ -61,3 +61,5 @@ For each acceptance criterion:
 - If the changes are purely internal (refactoring, config, tooling), report "No user-facing impact" and explain why
 - Do not propose UX changes beyond what was described -- flag scope concerns instead
 - Assume the reviewer has no technical background
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and mark lint-owned style or taste feedback as non-blocking.
+- For every finding, state severity, whether it blocks, the concrete user/operator failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-cursor/agents/quality-specialist.md
+++ b/plugins/lisa-cursor/agents/quality-specialist.md
@@ -24,7 +24,8 @@ For each changed file, evaluate:
 Rank findings by severity:
 
 ### Critical (must fix before merge)
-Broken logic or violates hard project rules.
+Broken logic, security exposure, data loss, or a hard contract violation with a
+concrete failure scenario.
 
 ### Warning (should fix)
 Could cause problems later or reduce maintainability.
@@ -54,3 +55,5 @@ For each finding:
 - Run the task's proof command to confirm the implementation works
 - Never approve code with failing tests
 - If no issues found, say so clearly -- do not invent problems
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and do not block on lint-owned style, formatting, taste, or speculative maintainability improvements.
+- For every finding, state severity, whether it blocks, the concrete failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa-cursor/rules/convergent-review-reference.mdc
+++ b/plugins/lisa-cursor/rules/convergent-review-reference.mdc
@@ -1,0 +1,74 @@
+---
+description: "Convergent Review"
+alwaysApply: false
+---
+
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+Apply this contract to every product, quality, local, bot-parity, and suggestion
+implementation pass.
+
+## Severity Bar
+
+Findings block only when they name a concrete failure scenario in one of these
+classes:
+
+- Correctness: shipped behavior violates the work item, breaks an existing
+  contract, or loses required data.
+- Security: the change creates or preserves an exploitable auth, input,
+  secret-handling, permission, or data-exposure flaw.
+- Data loss: a realistic path can delete, corrupt, overwrite, or strand user or
+  operational state.
+- Contract violation: the change breaks a public API, workflow, generated
+  artifact contract, tracker lifecycle, or documented factory invariant.
+
+Lint-owned style, formatting, taste, general maintainability preferences, and
+speculative improvements are non-blocking unless the repository rule or work
+item explicitly makes them release criteria.
+
+## Required Finding Shape
+
+Every finding must state:
+
+- Severity: `critical`, `major`, `minor`, or `nit`.
+- Blocking: `yes` or `no`.
+- Failure scenario: the concrete user, operator, security, or factory outcome
+  that occurs if the change ships as-is.
+- Evidence: the file, command output, observed behavior, ticket text, or
+  external constraint proving the scenario is reachable.
+- Fix: the smallest actionable correction, or the reason no code change is
+  needed.
+
+A finding marked blocking without a concrete failure scenario is malformed by
+contract. Downgrade it to non-blocking and ask for evidence instead of treating
+it as a merge blocker.
+
+## Dispositions
+
+The implementer resolves each finding with exactly one disposition:
+
+- `fixed`: code, tests, docs, or generated artifacts changed to remove the
+  failure scenario.
+- `deferred`: the issue is real but non-blocking; record the rationale and, when
+  useful, the follow-up work item.
+- `pushed-back`: the finding is not valid for this work because evidence,
+  scope, or existing project rules refute it; reply with that rationale.
+
+If a reviewer cannot refute a `pushed-back` disposition with fresh evidence, the
+author's disposition stands.
+
+## Stopping Rule
+
+After suggestion implementation completes and the required quality and
+verification gates pass, review does not reopen unless new evidence appears:
+
+- a new commit changes the reviewed behavior,
+- a gate fails,
+- a reviewer supplies a previously uncited failure scenario, or
+- the work item scope changes.
+
+Irreconcilable blocking disagreement is not an endless review loop. Move the
+work item to the configured blocked state, add the human-needed marker when the
+decision is human-only, and summarize both positions in operator-readable
+language.

--- a/plugins/lisa-cursor/rules/convergent-review.mdc
+++ b/plugins/lisa-cursor/rules/convergent-review.mdc
@@ -1,0 +1,24 @@
+---
+description: "Convergent Review"
+alwaysApply: true
+---
+
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+
+- Block only concrete correctness, security, data-loss, or contract-violation
+  failures. Lint-owned style, formatting, taste, and speculative improvements
+  are non-blocking unless the work item or repository rules make them release
+  criteria.
+- Every finding must state severity, blocking yes/no, a concrete failure
+  scenario, evidence, and the smallest actionable fix.
+- A blocking finding without a concrete failure scenario is malformed by
+  contract; downgrade it to non-blocking and ask for evidence.
+- Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer
+  cannot refute a pushback with fresh evidence, the author's disposition stands.
+- After suggestion implementation completes and gates pass, review does not
+  reopen absent new evidence: a relevant new commit, a failed gate, a newly cited
+  failure scenario, or a scope change.
+- Irreconcilable blocking disagreement becomes a blocked work item with both
+  positions summarized for the operator, not an endless loop.

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/lisa-cursor/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/lisa-cursor/skills/lisa-review-local/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/lisa/.codex-plugin/skills/lisa-review-local/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch

--- a/plugins/lisa/agents/product-specialist.md
+++ b/plugins/lisa/agents/product-specialist.md
@@ -61,3 +61,5 @@ For each acceptance criterion:
 - If the changes are purely internal (refactoring, config, tooling), report "No user-facing impact" and explain why
 - Do not propose UX changes beyond what was described -- flag scope concerns instead
 - Assume the reviewer has no technical background
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and mark lint-owned style or taste feedback as non-blocking.
+- For every finding, state severity, whether it blocks, the concrete user/operator failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa/agents/quality-specialist.md
+++ b/plugins/lisa/agents/quality-specialist.md
@@ -24,7 +24,8 @@ For each changed file, evaluate:
 Rank findings by severity:
 
 ### Critical (must fix before merge)
-Broken logic or violates hard project rules.
+Broken logic, security exposure, data loss, or a hard contract violation with a
+concrete failure scenario.
 
 ### Warning (should fix)
 Could cause problems later or reduce maintainability.
@@ -54,3 +55,5 @@ For each finding:
 - Run the task's proof command to confirm the implementation works
 - Never approve code with failing tests
 - If no issues found, say so clearly -- do not invent problems
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and do not block on lint-owned style, formatting, taste, or speculative maintainability improvements.
+- For every finding, state severity, whether it blocks, the concrete failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/lisa/rules/eager/convergent-review.md
+++ b/plugins/lisa/rules/eager/convergent-review.md
@@ -1,0 +1,19 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+
+- Block only concrete correctness, security, data-loss, or contract-violation
+  failures. Lint-owned style, formatting, taste, and speculative improvements
+  are non-blocking unless the work item or repository rules make them release
+  criteria.
+- Every finding must state severity, blocking yes/no, a concrete failure
+  scenario, evidence, and the smallest actionable fix.
+- A blocking finding without a concrete failure scenario is malformed by
+  contract; downgrade it to non-blocking and ask for evidence.
+- Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer
+  cannot refute a pushback with fresh evidence, the author's disposition stands.
+- After suggestion implementation completes and gates pass, review does not
+  reopen absent new evidence: a relevant new commit, a failed gate, a newly cited
+  failure scenario, or a scope change.
+- Irreconcilable blocking disagreement becomes a blocked work item with both
+  positions summarized for the operator, not an endless loop.

--- a/plugins/lisa/rules/reference/convergent-review.md
+++ b/plugins/lisa/rules/reference/convergent-review.md
@@ -1,0 +1,69 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+Apply this contract to every product, quality, local, bot-parity, and suggestion
+implementation pass.
+
+## Severity Bar
+
+Findings block only when they name a concrete failure scenario in one of these
+classes:
+
+- Correctness: shipped behavior violates the work item, breaks an existing
+  contract, or loses required data.
+- Security: the change creates or preserves an exploitable auth, input,
+  secret-handling, permission, or data-exposure flaw.
+- Data loss: a realistic path can delete, corrupt, overwrite, or strand user or
+  operational state.
+- Contract violation: the change breaks a public API, workflow, generated
+  artifact contract, tracker lifecycle, or documented factory invariant.
+
+Lint-owned style, formatting, taste, general maintainability preferences, and
+speculative improvements are non-blocking unless the repository rule or work
+item explicitly makes them release criteria.
+
+## Required Finding Shape
+
+Every finding must state:
+
+- Severity: `critical`, `major`, `minor`, or `nit`.
+- Blocking: `yes` or `no`.
+- Failure scenario: the concrete user, operator, security, or factory outcome
+  that occurs if the change ships as-is.
+- Evidence: the file, command output, observed behavior, ticket text, or
+  external constraint proving the scenario is reachable.
+- Fix: the smallest actionable correction, or the reason no code change is
+  needed.
+
+A finding marked blocking without a concrete failure scenario is malformed by
+contract. Downgrade it to non-blocking and ask for evidence instead of treating
+it as a merge blocker.
+
+## Dispositions
+
+The implementer resolves each finding with exactly one disposition:
+
+- `fixed`: code, tests, docs, or generated artifacts changed to remove the
+  failure scenario.
+- `deferred`: the issue is real but non-blocking; record the rationale and, when
+  useful, the follow-up work item.
+- `pushed-back`: the finding is not valid for this work because evidence,
+  scope, or existing project rules refute it; reply with that rationale.
+
+If a reviewer cannot refute a `pushed-back` disposition with fresh evidence, the
+author's disposition stands.
+
+## Stopping Rule
+
+After suggestion implementation completes and the required quality and
+verification gates pass, review does not reopen unless new evidence appears:
+
+- a new commit changes the reviewed behavior,
+- a gate fails,
+- a reviewer supplies a previously uncited failure scenario, or
+- the work item scope changes.
+
+Irreconcilable blocking disagreement is not an endless review loop. Move the
+work item to the configured blocked state, add the human-needed marker when the
+decision is human-only, and summarize both positions in operator-readable
+language.

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/lisa/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/lisa/skills/lisa-review-local/SKILL.md
+++ b/plugins/lisa/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch

--- a/plugins/src/base/agents/product-specialist.md
+++ b/plugins/src/base/agents/product-specialist.md
@@ -61,3 +61,5 @@ For each acceptance criterion:
 - If the changes are purely internal (refactoring, config, tooling), report "No user-facing impact" and explain why
 - Do not propose UX changes beyond what was described -- flag scope concerns instead
 - Assume the reviewer has no technical background
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and mark lint-owned style or taste feedback as non-blocking.
+- For every finding, state severity, whether it blocks, the concrete user/operator failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/src/base/agents/quality-specialist.md
+++ b/plugins/src/base/agents/quality-specialist.md
@@ -24,7 +24,8 @@ For each changed file, evaluate:
 Rank findings by severity:
 
 ### Critical (must fix before merge)
-Broken logic or violates hard project rules.
+Broken logic, security exposure, data loss, or a hard contract violation with a
+concrete failure scenario.
 
 ### Warning (should fix)
 Could cause problems later or reduce maintainability.
@@ -54,3 +55,5 @@ For each finding:
 - Run the task's proof command to confirm the implementation works
 - Never approve code with failing tests
 - If no issues found, say so clearly -- do not invent problems
+- Apply the `convergent-review` rule: bias toward merge, block only concrete correctness/security/data-loss/contract failures, and do not block on lint-owned style, formatting, taste, or speculative maintainability improvements.
+- For every finding, state severity, whether it blocks, the concrete failure scenario, evidence, and the smallest fix. A blocker without a failure scenario is malformed.

--- a/plugins/src/base/rules/eager/convergent-review.md
+++ b/plugins/src/base/rules/eager/convergent-review.md
@@ -1,0 +1,19 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+
+- Block only concrete correctness, security, data-loss, or contract-violation
+  failures. Lint-owned style, formatting, taste, and speculative improvements
+  are non-blocking unless the work item or repository rules make them release
+  criteria.
+- Every finding must state severity, blocking yes/no, a concrete failure
+  scenario, evidence, and the smallest actionable fix.
+- A blocking finding without a concrete failure scenario is malformed by
+  contract; downgrade it to non-blocking and ask for evidence.
+- Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer
+  cannot refute a pushback with fresh evidence, the author's disposition stands.
+- After suggestion implementation completes and gates pass, review does not
+  reopen absent new evidence: a relevant new commit, a failed gate, a newly cited
+  failure scenario, or a scope change.
+- Irreconcilable blocking disagreement becomes a blocked work item with both
+  positions summarized for the operator, not an endless loop.

--- a/plugins/src/base/rules/reference/convergent-review.md
+++ b/plugins/src/base/rules/reference/convergent-review.md
@@ -1,0 +1,69 @@
+# Convergent Review
+
+Review exists to get correct work merged, not to keep a PR in review orbit.
+Apply this contract to every product, quality, local, bot-parity, and suggestion
+implementation pass.
+
+## Severity Bar
+
+Findings block only when they name a concrete failure scenario in one of these
+classes:
+
+- Correctness: shipped behavior violates the work item, breaks an existing
+  contract, or loses required data.
+- Security: the change creates or preserves an exploitable auth, input,
+  secret-handling, permission, or data-exposure flaw.
+- Data loss: a realistic path can delete, corrupt, overwrite, or strand user or
+  operational state.
+- Contract violation: the change breaks a public API, workflow, generated
+  artifact contract, tracker lifecycle, or documented factory invariant.
+
+Lint-owned style, formatting, taste, general maintainability preferences, and
+speculative improvements are non-blocking unless the repository rule or work
+item explicitly makes them release criteria.
+
+## Required Finding Shape
+
+Every finding must state:
+
+- Severity: `critical`, `major`, `minor`, or `nit`.
+- Blocking: `yes` or `no`.
+- Failure scenario: the concrete user, operator, security, or factory outcome
+  that occurs if the change ships as-is.
+- Evidence: the file, command output, observed behavior, ticket text, or
+  external constraint proving the scenario is reachable.
+- Fix: the smallest actionable correction, or the reason no code change is
+  needed.
+
+A finding marked blocking without a concrete failure scenario is malformed by
+contract. Downgrade it to non-blocking and ask for evidence instead of treating
+it as a merge blocker.
+
+## Dispositions
+
+The implementer resolves each finding with exactly one disposition:
+
+- `fixed`: code, tests, docs, or generated artifacts changed to remove the
+  failure scenario.
+- `deferred`: the issue is real but non-blocking; record the rationale and, when
+  useful, the follow-up work item.
+- `pushed-back`: the finding is not valid for this work because evidence,
+  scope, or existing project rules refute it; reply with that rationale.
+
+If a reviewer cannot refute a `pushed-back` disposition with fresh evidence, the
+author's disposition stands.
+
+## Stopping Rule
+
+After suggestion implementation completes and the required quality and
+verification gates pass, review does not reopen unless new evidence appears:
+
+- a new commit changes the reviewed behavior,
+- a gate fails,
+- a reviewer supplies a previously uncited failure scenario, or
+- the work item scope changes.
+
+Irreconcilable blocking disagreement is not an endless review loop. Move the
+work item to the configured blocked state, add the human-needed marker when the
+decision is human-only, and summarize both positions in operator-readable
+language.

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -185,6 +185,32 @@ Before marking a task complete, the implementing agent records concise MLD into 
 
 Each task must have their learnings captured to the ledger by the learner subagent.
 
+## Implement valid suggestions
+
+When review, CodeRabbit, local-review, product, quality, security, or specialist
+feedback arrives, apply the `convergent-review` rule before changing code:
+
+1. Normalize each finding into severity, blocking yes/no, concrete failure
+   scenario, evidence, and proposed smallest fix.
+2. Treat a blocker with no concrete correctness, security, data-loss, or
+   contract-violation scenario as malformed. Reply with the missing-evidence
+   reason and handle it as non-blocking.
+3. Resolve each finding with one disposition:
+   - `fixed`: make the smallest code, test, docs, or generated-artifact change
+     that removes the failure scenario.
+   - `deferred`: record why the issue is real but non-blocking, and file or link
+     follow-up work when useful.
+   - `pushed-back`: cite the evidence, scope boundary, or repository rule that
+     refutes the finding.
+4. If a reviewer cannot refute a pushback with fresh evidence, the author's
+   disposition stands.
+5. After the suggestion-implementation task completes and required gates pass,
+   do not reopen review unless new evidence appears: a relevant new commit, a
+   failed gate, a newly cited failure scenario, or a scope change.
+6. If a blocking disagreement remains irreconcilable, stop the review loop:
+   move the work item to the configured blocked state, add `human-needed` when
+   the decision is human-only, and summarize both positions in plain language.
+
 Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.

--- a/plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md
@@ -34,6 +34,12 @@ For each changed file, `Read` the surrounding code and use `Grep`/`Glob` to foll
 
 ## Step 3: Review across all dimensions
 
+Apply the `convergent-review` rule before deciding severity or whether a finding
+blocks merge. Bias toward merge: block only concrete correctness, security,
+data-loss, or contract-violation failures with evidence. Lint-owned style,
+formatting, taste, and speculative maintainability improvements are non-blocking
+unless the work item or repository rules explicitly make them release criteria.
+
 Walk every meaningful hunk and evaluate each dimension. A finding in any dimension is fair game.
 
 1. **Correctness / bugs** — Logic errors, off-by-one, inverted conditions, missing `await`, null/undefined handling, type coercion, broken control flow, incorrect defaults, mutation of shared state, race conditions, broken or missing tests for new behavior.
@@ -59,6 +65,9 @@ Group as **Critical → Major → Minor → Nit**. Every finding includes:
 - **What** — the issue, and which dimension it falls under (bug / security / perf / maintainability / tests).
 - **Where** — `path/to/file.ts:line`.
 - **Why** — the concrete consequence, with a triggering example where relevant.
+- **Blocking** — `yes` only for concrete correctness/security/data-loss/contract failures; otherwise `no`.
+- **Failure scenario** — the concrete user, operator, security, or factory outcome if the change ships as-is.
+- **Evidence** — the cited file, observed behavior, command output, or contract that proves the scenario is reachable.
 - **Fix** — a concrete suggestion or code snippet.
 
 ### Walkthrough (optional but encouraged)
@@ -71,6 +80,7 @@ Call out what's done well. A credible review is balanced, not only critical.
 
 - **Cover the whole diff.** If you deprioritize anything for size, say which files and why — never imply full coverage you didn't give.
 - **Ground every finding in the code.** No generic checklists detached from the actual change; no speculative findings you can't point to.
+- **Malformed blockers do not block.** If you cannot name a concrete failure scenario and evidence, report it as non-blocking context or omit it.
 - **Concrete fixes only.** "Consider improving error handling" is not a finding; "wrap the `fetch` in try/catch and return a 502 on network error at `api/proxy.ts:31`" is.
 - **No external review service.** Use only local git/tooling and the model — this is an independent review, not a CodeRabbit proxy.
 - **Review-only.** Report findings; do not edit files. Route fixes through the implementation flow, `parity-code-simplifier` (quality), or a follow-up.

--- a/plugins/src/base/skills/lisa-review-local/SKILL.md
+++ b/plugins/src/base/skills/lisa-review-local/SKILL.md
@@ -6,6 +6,14 @@ disable-model-invocation: false
 
 Provide a code review for the local changes on the current branch compared to the main branch.
 
+Apply the `convergent-review` rule throughout this skill: reviewers bias toward
+merge, block only concrete correctness/security/data-loss/contract failures, and
+must label every finding with severity, blocking status, failure scenario,
+evidence, and fix. Lint-owned style, formatting, taste, and speculative
+maintainability feedback are non-blocking unless a repository rule or work item
+explicitly makes them release criteria. A blocking finding without a concrete
+failure scenario is malformed and must be filtered out.
+
 To do this, follow these steps precisely:
 
 1. Use a Haiku agent to check the current git state:
@@ -24,6 +32,7 @@ To do this, follow these steps precisely:
    c. Agent #3: Read the git blame and history of the code modified, to identify any bugs in light of that historical context
    d. Agent #4: Read previous pull requests that touched these files, and check for any comments on those pull requests that may also apply to the current changes.
    e. Agent #5: Read code comments in the modified files, and make sure the changes comply with any guidance in the comments.
+   Each agent must apply the severity bar from `convergent-review` and return only findings that include a concrete failure scenario and evidence. Non-blocking observations may be summarized separately, but must not be presented as required changes.
 5. For each issue found in #4, launch a parallel Haiku agent that takes the diff, issue description, and list of CLAUDE.md files (from step 2), and returns a score to indicate the agent's level of confidence for whether the issue is real or false positive. To do that, the agent should score each issue on a scale from 0-100, indicating its level of confidence. For issues that were flagged due to CLAUDE.md instructions, the agent should double check that the CLAUDE.md actually calls out that issue specifically. The scale is (give this rubric to the agent verbatim):
    a. 0: Not confident at all. This is a false positive that doesn't stand up to light scrutiny, or is a pre-existing issue.
    b. 25: Somewhat confident. This might be a real issue, but may also be a false positive. The agent wasn't able to verify that it's a real issue. If the issue is stylistic, it is one that was not explicitly called out in the relevant CLAUDE.md.
@@ -31,6 +40,7 @@ To do this, follow these steps precisely:
    d. 75: Highly confident. The agent double checked the issue, and verified that it is very likely it is a real issue that will be hit in practice. The existing approach is insufficient. The issue is very important and will directly impact the code's functionality, or it is an issue that is directly mentioned in the relevant CLAUDE.md.
    e. 100: Absolutely certain. The agent double checked the issue, and confirmed that it is definitely a real issue, that will happen frequently in practice. The evidence directly confirms this.
 6. Filter out any issues with a score less than 80.
+6a. Filter out any blocking issue that does not name a concrete failure scenario in one of the `convergent-review` blocker classes. Keep it only as non-blocking context if it is useful.
 7. Write the review to claude-review.md. When writing your review, keep in mind to:
    a. Keep your output brief
    b. Avoid emojis
@@ -44,6 +54,7 @@ Examples of false positives, for steps 4 and 5:
 - Pedantic nitpicks that a senior engineer wouldn't call out
 - Issues that a linter, typechecker, or compiler would catch (eg. missing or incorrect imports, type errors, broken tests, formatting issues, pedantic style issues like newlines). No need to run these build steps yourself -- it is safe to assume that they will be run separately as part of CI.
 - General code quality issues (eg. lack of test coverage, general security issues, poor documentation), unless explicitly required in CLAUDE.md
+- Findings that restate lint-owned style, formatting, taste, or speculative cleanup as blockers without a concrete failure scenario
 - Issues that are called out in CLAUDE.md, but explicitly silenced in the code (eg. due to a lint ignore comment)
 - Changes in functionality that are likely intentional or are directly related to the broader change
 - Real issues, but on lines that were not modified in the current branch


### PR DESCRIPTION
## Summary

- Add a shared `convergent-review` eager/reference rule that defines the blocker severity bar, finding shape, dispositions, and stopping rule.
- Wire the policy into product and quality reviewer agents, local review, parity CodeRabbit review, and the implement valid-suggestions flow.
- Regenerate Lisa plugin variants for Claude/Codex, Cursor, Copilot, and agy surfaces.

## Verification

- `bun run build:plugins`
- `bun run check:rules-pairing`
- `bun run typecheck`
- `bun run test:unit -- tests/unit/codex/skill-agents-walk.test.ts tests/unit/strategies/harness-parity-council-fixture-smoke.test.ts`
- `bun run test:unit -- tests/unit/core/skill-frontmatter-contract.test.ts tests/unit/codex/committed-openai-yaml-in-sync.test.ts tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts tests/unit/scripts/generate-agy-plugin-artifacts.test.ts tests/unit/codex/lifecycle-skill-orchestration.test.ts tests/unit/strategies/implement-env-base-branch.test.ts`
- `bun run check:plugins`
- pre-push hook: security audit, slow lint, knip, `vitest run --coverage`, integration tests

Closes #1743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standardized “Convergent Review” process across review and implementation workflows.
  - Review findings now include severity, blocking status, failure scenario, evidence, and the smallest actionable fix.
  - Defined clear outcomes for suggestions: fixed, deferred, or pushed back.

- **Documentation**
  - Clarified that only concrete correctness, security, data-loss, or contract failures can block progress.
  - Added guidance for handling unsupported blockers, preventing unnecessary review loops, and resolving irreconcilable disagreements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->