### PR TITLE
feat: require tracked work before durable changes

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -20,29 +20,15 @@ fi
 # Get the commit message file path
 COMMIT_MSG_FILE=$1
 
-# Get the current branch name
-BRANCH_NAME=$(git branch --show-current)
-
-# Extract Jira key from branch name if present
-# Default pattern matches common Jira project keys (2-10 uppercase letters followed by a hyphen and numbers)
-# Can be overridden with JIRA_PROJECT_KEY environment variable (e.g., JIRA_PROJECT_KEY="SE|PROJ|ABC")
-JIRA_PROJECT_KEY=${JIRA_PROJECT_KEY:-"[A-Z]{2,10}"}
-
-# Extract Jira key from branch name using grep
-# Matches patterns like: feat/SE-2397-description, SE-2397-description, chore/PROJ-123-something
-JIRA_KEY=$(echo "$BRANCH_NAME" | grep -E "(^|/)($JIRA_PROJECT_KEY)-[0-9]+" | grep -E "($JIRA_PROJECT_KEY)-[0-9]+" -o | head -1)
-
-if [ -n "$JIRA_KEY" ]; then
-  # Read the current commit message
-  COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
-  
-  # Check if the Jira key is already in the commit message
-  if ! echo "$COMMIT_MSG" | grep -q "\[$JIRA_KEY\]"; then
-    # Append the Jira key to the commit message
-    echo "$COMMIT_MSG [$JIRA_KEY]" > "$COMMIT_MSG_FILE"
-    echo "🎫 Auto-appended Jira key: [$JIRA_KEY]"
-  fi
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Commit blocked: Node.js is required to validate tracker work items."
+  exit 1
+fi
+node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE" || exit 1
 
 echo "📝 Validating commit message with commitlint..."
 COMMITLINT_OUTPUT=$($EXECUTOR commitlint --edit "$COMMIT_MSG_FILE" 2>&1)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,15 @@
 # BEGIN: AI GUARDRAILS
 
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Push blocked: Node.js is required to validate tracker work items."
+  exit 1
+fi
+node "$WORK_ITEM_SCRIPT" validate-push "${1:-origin}" || exit 1
+
 # Detect package manager (check if tool is available before using it)
 # Priority: bun > yarn > npm (bun first since package.json engines prefer it)
 if ([ -f "bun.lockb" ] || [ -f "bun.lock" ]) && command -v bun >/dev/null 2>&1; then

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,15 @@
+# BEGIN: AI GUARDRAILS
+
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Commit blocked: Node.js is required to link commits to tracker work items."
+  exit 1
+fi
+
+node "$WORK_ITEM_SCRIPT" prepare-commit-msg "$@"
+
+# END: AI GUARDRAILS

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -1,0 +1,1102 @@
+#!/usr/bin/env node
+/**
+ * Provider-neutral work-item binding and Git enforcement for Lisa projects.
+ * State is private to the current linked worktree; durable linkage lives in
+ * commit trailers, pull-request bodies, and the configured tracker.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const RELEASE_SUBJECT =
+  /^chore\(release\): \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \[skip ci\]$/;
+const ZERO_OID = /^0+$/;
+const MARKER = "[lisa-pr-link]";
+const GUIDANCE = [
+  "Mention the ticket this work relates to, or ask Lisa to create one:",
+  "  Work-Item: <configured-project-ticket>",
+].join("\n");
+
+class TrackingError extends Error {}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    input: options.input,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new TrackingError(
+      options.error ?? `${command} ${args.join(" ")} failed`
+    );
+  }
+  return result;
+}
+
+function git(args, options = {}) {
+  return run("git", args, options).stdout.trim();
+}
+
+function projectRoot() {
+  return git(["rev-parse", "--show-toplevel"]);
+}
+
+function statePath() {
+  return resolve(git(["rev-parse", "--git-path", "lisa/work-item.json"]));
+}
+
+function currentBranch() {
+  return git(["branch", "--show-current"]);
+}
+
+function deepMerge(base, override) {
+  if (Array.isArray(base) || Array.isArray(override)) return override;
+  if (
+    base === null ||
+    override === null ||
+    typeof base !== "object" ||
+    typeof override !== "object"
+  ) {
+    return override;
+  }
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    merged[key] = key in merged ? deepMerge(merged[key], value) : value;
+  }
+  return merged;
+}
+
+function readJson(file, required = false) {
+  if (!existsSync(file)) {
+    if (required) throw new TrackingError(`Required file not found: ${file}`);
+    return {};
+  }
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    throw new TrackingError(`Invalid JSON: ${file}`);
+  }
+}
+
+function readConfig() {
+  const override = process.env.LISA_TRACKING_CONFIG_FILE;
+  if (override) return readJson(resolve(process.cwd(), override), true);
+  const root = projectRoot();
+  return deepMerge(
+    readJson(join(root, ".lisa.config.json"), true),
+    readJson(join(root, ".lisa.config.local.json"))
+  );
+}
+
+function values(value) {
+  if (typeof value === "string" && value.trim()) return [value.trim()];
+  if (!value || typeof value !== "object") return [];
+  return Object.values(value).flatMap(values);
+}
+
+function lifecycleContract(config, provider) {
+  const configured =
+    provider === "jira"
+      ? config.jira?.workflow
+      : provider === "github"
+        ? config.github?.labels?.build
+        : config.linear?.labels?.build;
+  const defaults =
+    provider === "jira"
+      ? {
+          ready: "Ready",
+          claimed: "In Progress",
+          review: "Code Review",
+          blocked: "Blocked",
+          done: {
+            dev: "On Dev",
+            staging: "On Stg",
+            production: "Done",
+          },
+        }
+      : {
+          ready: "status:ready",
+          claimed: "status:in-progress",
+          ...(provider === "linear" ? { review: "status:code-review" } : {}),
+          blocked: "status:blocked",
+          done: {
+            dev: "status:on-dev",
+            staging: "status:on-stg",
+            production: "status:done",
+          },
+        };
+  const roles = deepMerge(defaults, configured ?? {});
+  const done = values(roles.done);
+  const terminal =
+    typeof roles.done === "string"
+      ? roles.done
+      : (roles.done?.production ?? done.at(-1));
+  return {
+    active: [roles.claimed, roles.review, roles.blocked, ...done]
+      .filter(value => typeof value === "string" && value !== terminal)
+      .map(value => value.toLowerCase()),
+    claimed: requireString(roles.claimed, `${provider} claimed lifecycle role`),
+    ready: requireString(roles.ready, `${provider} ready lifecycle role`),
+    terminal: String(terminal ?? "").toLowerCase(),
+  };
+}
+
+function requireString(value, path) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TrackingError(`Tracker configuration is missing ${path}`);
+  }
+  return value.trim();
+}
+
+function repoBasename(value) {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/\.git$/, "");
+  return normalized.split(/[/:]/).filter(Boolean).at(-1) ?? "";
+}
+
+function currentRepoIdentity(config) {
+  const configured = repoBasename(config.repo ?? config.github?.repo);
+  if (configured) return configured;
+  const githubRepository = repoBasename(process.env.GITHUB_REPOSITORY);
+  if (githubRepository) return githubRepository;
+  const remote = run("git", ["remote", "get-url", "origin"], {
+    allowFailure: true,
+  });
+  const inferred = remote.status === 0 ? repoBasename(remote.stdout) : "";
+  if (inferred) return inferred;
+  throw new TrackingError(
+    "Cannot resolve the current repository; configure repo or github.repo"
+  );
+}
+
+function trackerContract(config = readConfig()) {
+  const provider = requireString(config.tracker, "tracker").toLowerCase();
+  const identityRepo = currentRepoIdentity(config);
+  if (provider === "github") {
+    const org = requireString(config.github?.org, "github.org");
+    const githubRepo = requireString(config.github?.repo, "github.repo");
+    const queue =
+      typeof config.github?.queueRepo === "string" &&
+      config.github.queueRepo.trim() !== ""
+        ? config.github.queueRepo.trim()
+        : `${org}/${githubRepo}`;
+    const repository = queue.includes("/") ? queue : `${org}/${queue}`;
+    return {
+      provider,
+      repository,
+      identityRepo,
+      lifecycle: lifecycleContract(config, provider),
+      repositoryIsIdentity:
+        repository.toLowerCase() === `${org}/${githubRepo}`.toLowerCase(),
+    };
+  }
+  if (provider === "jira") {
+    return {
+      provider,
+      identityRepo,
+      project: requireString(
+        config.jira?.project,
+        "jira.project"
+      ).toUpperCase(),
+      cloudId: String(config.atlassian?.cloudId ?? "").trim(),
+      site: String(config.atlassian?.site ?? process.env.JIRA_SERVER ?? "")
+        .replace(/^https?:\/\//, "")
+        .replace(/\/$/, ""),
+      email: String(config.atlassian?.email ?? "").trim(),
+      lifecycle: lifecycleContract(config, provider),
+    };
+  }
+  if (provider === "linear") {
+    return {
+      provider,
+      identityRepo,
+      workspace: requireString(config.linear?.workspace, "linear.workspace"),
+      teamKey: requireString(
+        config.linear?.teamKey,
+        "linear.teamKey"
+      ).toUpperCase(),
+      lifecycle: lifecycleContract(config, provider),
+    };
+  }
+  throw new TrackingError(
+    `Unknown tracker '${provider}'. Expected github, jira, or linear`
+  );
+}
+
+function canonicalizeRef(raw, contract = trackerContract()) {
+  const value = String(raw ?? "").trim();
+  if (contract.provider === "github") {
+    const match = /^([^\s/#]+\/[^\s/#]+)#([1-9]\d*)$/.exec(value);
+    if (!match)
+      throw new TrackingError(
+        `Invalid GitHub Work-Item '${value}'; expected owner/repo#123`
+      );
+    const repository = `${match[1]}`;
+    if (repository.toLowerCase() !== contract.repository.toLowerCase()) {
+      throw new TrackingError(
+        `Work-Item '${value}' is outside configured tracker repository ${contract.repository}`
+      );
+    }
+    return `${contract.repository}#${match[2]}`;
+  }
+  const match = /^([A-Z][A-Z0-9]{1,9})-([1-9]\d*)$/.exec(value.toUpperCase());
+  if (!match)
+    throw new TrackingError(
+      `Invalid ${contract.provider} Work-Item '${value}'; expected KEY-123`
+    );
+  const expected =
+    contract.provider === "jira" ? contract.project : contract.teamKey;
+  if (match[1] !== expected) {
+    throw new TrackingError(
+      `Work-Item '${value}' is outside configured ${contract.provider} project ${expected}`
+    );
+  }
+  return `${match[1]}-${match[2]}`;
+}
+
+function readState(optional = true) {
+  const file = statePath();
+  if (!existsSync(file)) {
+    if (optional) return undefined;
+    throw new TrackingError("No work item is bound to this worktree");
+  }
+  const state = readJson(file, true);
+  if (
+    state.version !== 1 ||
+    (state.branch !== null && typeof state.branch !== "string") ||
+    typeof state.provider !== "string" ||
+    typeof state.ref !== "string"
+  ) {
+    throw new TrackingError(`Malformed work-item binding: ${file}`);
+  }
+  return state;
+}
+
+function assertStateBranch(state) {
+  const branch = currentBranch();
+  if (!branch)
+    throw new TrackingError(
+      "Cannot use a work-item binding from detached HEAD"
+    );
+  if (state.branch === null) {
+    throw new TrackingError(
+      "Work-item binding is pending branch attachment; run lisa-work-item.mjs attach-branch"
+    );
+  }
+  if (state.branch !== branch) {
+    throw new TrackingError(
+      `Work-item binding belongs to branch '${state.branch}', not '${branch}'. Re-bind or attach it to this branch`
+    );
+  }
+}
+
+function writeState(ref, provider = trackerContract().provider, options = {}) {
+  const branch = currentBranch();
+  if (!branch && options.requireBranch)
+    throw new TrackingError(
+      "Create or check out a feature branch before binding a work item"
+    );
+  const file = statePath();
+  mkdirSync(dirname(file), { recursive: true });
+  const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(
+      temporary,
+      `${JSON.stringify({ version: 1, branch: branch || null, provider, ref }, null, 2)}\n`,
+      {
+        flag: "wx",
+        mode: 0o600,
+      }
+    );
+    chmodSync(temporary, 0o600);
+    renameSync(temporary, file);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+  return file;
+}
+
+function parseTrailers(message) {
+  const parsed = git(["interpret-trailers", "--parse"], { input: message });
+  return parsed
+    .split("\n")
+    .filter(Boolean)
+    .flatMap(line => {
+      const match = /^Work-Item:\s*(.+?)\s*$/i.exec(line);
+      return match ? [match[1]] : [];
+    });
+}
+
+function exactWorkItem(message, contract = trackerContract()) {
+  const refs = parseTrailers(message);
+  if (refs.length !== 1) {
+    throw new TrackingError(
+      `Expected exactly one Work-Item trailer; found ${refs.length}`
+    );
+  }
+  return canonicalizeRef(refs[0], contract);
+}
+
+function messageSubject(message) {
+  return message.split(/\r?\n/, 1)[0] ?? "";
+}
+
+function isMergeInProgress() {
+  return (
+    run("git", ["rev-parse", "-q", "--verify", "MERGE_HEAD"], {
+      allowFailure: true,
+    }).status === 0
+  );
+}
+
+function commitExemption(sha) {
+  const parents = git(["rev-list", "--parents", "-n", "1", sha]).split(/\s+/);
+  if (parents.length > 2) return "merge";
+  return RELEASE_SUBJECT.test(git(["show", "-s", "--format=%s", sha]))
+    ? "release"
+    : undefined;
+}
+
+function safeJson(text, context) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new TrackingError(`${context} returned malformed JSON`);
+  }
+}
+
+function namesFrom(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(item => (typeof item === "string" ? item : item?.name))
+    .filter(name => typeof name === "string")
+    .map(name => name.toLowerCase());
+}
+
+function assertRepoScope(ref, contract, labels, components = []) {
+  const expected = `repo:${contract.identityRepo}`.toLowerCase();
+  const labelNames = namesFrom(labels);
+  const componentNames = namesFrom(components);
+  if (
+    !labelNames.includes(expected) &&
+    !componentNames.includes(contract.identityRepo.toLowerCase())
+  ) {
+    throw new TrackingError(
+      `Work item ${ref} is not scoped to repository ${contract.identityRepo}; require label ${expected}`
+    );
+  }
+}
+
+function assertClaimedLifecycle(ref, contract, currentRoles) {
+  const roles = namesFrom(currentRoles);
+  if (
+    contract.lifecycle.terminal &&
+    roles.includes(contract.lifecycle.terminal)
+  ) {
+    throw new TrackingError(
+      `Work item ${ref} is in terminal lifecycle role ${contract.lifecycle.terminal}`
+    );
+  }
+  if (!roles.some(role => contract.lifecycle.active.includes(role))) {
+    throw new TrackingError(
+      `Work item ${ref} is not claimed; require ${contract.lifecycle.claimed} or a later non-terminal lifecycle role`
+    );
+  }
+}
+
+function assertLeaf(ref, type, childStates = []) {
+  const normalizedType = String(type ?? "")
+    .replace(/^type:/i, "")
+    .trim()
+    .toLowerCase();
+  const openChildren = childStates.filter(
+    state =>
+      !["closed", "done", "completed", "canceled", "cancelled"].includes(
+        String(state ?? "").toLowerCase()
+      )
+  );
+  if (normalizedType === "epic" || openChildren.length > 0) {
+    throw new TrackingError(
+      `Work item ${ref} is a container; bind a claimed leaf with no open children`
+    );
+  }
+}
+
+function typeFromLabels(labels) {
+  return namesFrom(labels).find(name => name.startsWith("type:"));
+}
+
+function githubHierarchy(ref, contract, number) {
+  const [owner, repo] = contract.repository.split("/");
+  const query =
+    "query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){subIssues(first:100){nodes{state}}}}}";
+  const result = run(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `repo=${repo}`,
+      "-F",
+      `number=${number}`,
+    ],
+    { allowFailure: true }
+  );
+  if (result.status !== 0)
+    throw new TrackingError(`GitHub issue ${ref} hierarchy is inaccessible`);
+  const response = safeJson(result.stdout, `GitHub issue ${ref} hierarchy`);
+  const issue = response.data?.repository?.issue;
+  if (!issue || !Array.isArray(issue.subIssues?.nodes)) {
+    throw new TrackingError(
+      `GitHub issue ${ref} did not expose native sub-issue hierarchy`
+    );
+  }
+  return issue.subIssues.nodes.map(child => child.state);
+}
+
+function githubIssue(ref, contract) {
+  const number = ref.slice(ref.lastIndexOf("#") + 1);
+  const result = run(
+    "gh",
+    [
+      "issue",
+      "view",
+      number,
+      "--repo",
+      contract.repository,
+      "--json",
+      "number,url,state,labels,comments,closedByPullRequestsReferences",
+    ],
+    {
+      allowFailure: true,
+    }
+  );
+  if (result.status !== 0)
+    throw new TrackingError(
+      `GitHub issue ${ref} does not exist or is inaccessible`
+    );
+  const issue = safeJson(result.stdout, `GitHub issue ${ref}`);
+  if (String(issue.number) !== number)
+    throw new TrackingError(`GitHub returned the wrong issue for ${ref}`);
+  if (String(issue.state ?? "").toUpperCase() !== "OPEN") {
+    throw new TrackingError(
+      `GitHub issue ${ref} is closed; bind an open work item`
+    );
+  }
+  if (!contract.repositoryIsIdentity) {
+    assertRepoScope(ref, contract, issue.labels);
+  }
+  assertClaimedLifecycle(ref, contract, issue.labels);
+  assertLeaf(
+    ref,
+    typeFromLabels(issue.labels),
+    githubHierarchy(ref, contract, number)
+  );
+  return issue;
+}
+
+function jiraStatusCategory(issue) {
+  return String(
+    issue.fields?.status?.statusCategory?.key ??
+      issue.status?.statusCategory?.key ??
+      issue.statusCategory?.key ??
+      ""
+  ).toLowerCase();
+}
+
+function jiraCredentials(contract) {
+  const token = process.env.JIRA_API_TOKEN || process.env.ATLASSIAN_API_TOKEN;
+  const login = process.env.JIRA_LOGIN || contract.email;
+  const server = String(contract.site || process.env.JIRA_SERVER || "")
+    .replace(/^https?:\/\//, "")
+    .replace(/\/$/, "");
+  const baseUrl = contract.cloudId
+    ? `https://api.atlassian.com/ex/jira/${encodeURIComponent(contract.cloudId)}`
+    : server
+      ? `https://${server}`
+      : "";
+  return token && login && baseUrl ? { token, login, baseUrl } : undefined;
+}
+
+function jiraIssue(ref, contract) {
+  const credentials = jiraCredentials(contract);
+  if (credentials) {
+    const url = `${credentials.baseUrl}/rest/api/3/issue/${encodeURIComponent(ref)}?fields=project,status,labels,components,issuetype,subtasks,comment`;
+    const result = run(
+      "curl",
+      [
+        "-fsS",
+        "-u",
+        `${credentials.login}:${credentials.token}`,
+        "-H",
+        "Accept: application/json",
+        url,
+      ],
+      { allowFailure: true }
+    );
+    if (result.status !== 0)
+      throw new TrackingError(
+        `Jira ticket ${ref} does not exist or is inaccessible`
+      );
+    const issue = safeJson(result.stdout, `Jira ticket ${ref}`);
+    if (
+      String(issue.key ?? "").toUpperCase() !== ref ||
+      String(issue.fields?.project?.key ?? "").toUpperCase() !==
+        contract.project
+    ) {
+      throw new TrackingError(
+        `Jira ticket ${ref} is outside configured project ${contract.project}`
+      );
+    }
+    const statusCategory = jiraStatusCategory(issue);
+    if (!statusCategory) {
+      throw new TrackingError(
+        `Jira ticket ${ref} did not expose a status category`
+      );
+    }
+    if (statusCategory === "done") {
+      throw new TrackingError(
+        `Jira ticket ${ref} is done; bind an active work item`
+      );
+    }
+    assertRepoScope(
+      ref,
+      contract,
+      issue.fields?.labels,
+      issue.fields?.components
+    );
+    assertClaimedLifecycle(ref, contract, [issue.fields?.status?.name]);
+    assertLeaf(
+      ref,
+      issue.fields?.issuetype?.name,
+      (issue.fields?.subtasks ?? []).map(child =>
+        jiraStatusCategory(child) === "done" ? "done" : "open"
+      )
+    );
+    return issue;
+  }
+
+  if (
+    run("sh", ["-c", "command -v acli >/dev/null 2>&1"], { allowFailure: true })
+      .status === 0
+  ) {
+    if (!contract.site) {
+      throw new TrackingError(
+        "Jira acli validation requires atlassian.site so the active account can be identity-matched"
+      );
+    }
+    const auth = run("acli", ["auth", "status"], { allowFailure: true });
+    if (
+      auth.status !== 0 ||
+      !auth.stdout.toLowerCase().includes(contract.site.toLowerCase())
+    ) {
+      throw new TrackingError(
+        `Jira acli is not authenticated to configured site ${contract.site}`
+      );
+    }
+    const result = run(
+      "acli",
+      ["jira", "workitem", "view", ref, "--fields", "*all", "--json"],
+      { allowFailure: true }
+    );
+    if (result.status !== 0)
+      throw new TrackingError(
+        `Jira ticket ${ref} does not exist or is inaccessible`
+      );
+    const issue = safeJson(result.stdout, `Jira ticket ${ref}`);
+    if (String(issue.key ?? "").toUpperCase() !== ref)
+      throw new TrackingError(`Jira returned the wrong ticket for ${ref}`);
+    const statusCategory = jiraStatusCategory(issue);
+    if (!statusCategory) {
+      throw new TrackingError(
+        `Jira ticket ${ref} did not expose a status category`
+      );
+    }
+    if (statusCategory === "done") {
+      throw new TrackingError(
+        `Jira ticket ${ref} is done; bind an active work item`
+      );
+    }
+    assertRepoScope(
+      ref,
+      contract,
+      issue.fields?.labels ?? issue.labels,
+      issue.fields?.components ?? issue.components
+    );
+    assertClaimedLifecycle(ref, contract, [
+      issue.fields?.status?.name ?? issue.status?.name,
+    ]);
+    assertLeaf(
+      ref,
+      issue.fields?.issuetype?.name ?? issue.issueType?.name,
+      (issue.fields?.subtasks ?? issue.subtasks ?? []).map(child =>
+        jiraStatusCategory(child) === "done" ? "done" : "open"
+      )
+    );
+    return issue;
+  }
+  throw new TrackingError(
+    "Jira validation requires identity-matched acli or ATLASSIAN_API_TOKEN/JIRA_API_TOKEN with JIRA_LOGIN and atlassian.cloudId/site"
+  );
+}
+
+function readLinearKey(workspace) {
+  if (process.env.LINEAR_API_KEY) return process.env.LINEAR_API_KEY;
+  const suffix = workspace.toLowerCase().replace(/-/g, "_");
+  if (process.env[`LINEAR_API_KEY_${suffix}`])
+    return process.env[`LINEAR_API_KEY_${suffix}`];
+  if (process.platform === "darwin") {
+    return (
+      run(
+        "security",
+        ["find-generic-password", "-s", "lisa-linear", "-a", workspace, "-w"],
+        { allowFailure: true }
+      ).stdout.trim() || undefined
+    );
+  }
+  return undefined;
+}
+
+function linearIssue(ref, contract) {
+  const token = readLinearKey(contract.workspace);
+  if (!token)
+    throw new TrackingError(
+      "Linear validation requires LINEAR_API_KEY or a lisa-linear keychain entry"
+    );
+  const query =
+    "query($id:String!){issue(id:$id){id identifier team{key} state{type} labels{nodes{name}} children{nodes{state{type}}} attachments{nodes{url}} comments{nodes{body}}}}";
+  const payload = JSON.stringify({ query, variables: { id: ref } });
+  const result = run(
+    "curl",
+    [
+      "-fsS",
+      "-X",
+      "POST",
+      "-H",
+      "Content-Type: application/json",
+      "-H",
+      `Authorization: ${token}`,
+      "--data-binary",
+      payload,
+      "https://api.linear.app/graphql",
+    ],
+    { allowFailure: true }
+  );
+  if (result.status !== 0)
+    throw new TrackingError(
+      `Linear issue ${ref} does not exist or is inaccessible`
+    );
+  const response = safeJson(result.stdout, `Linear issue ${ref}`);
+  if (Array.isArray(response.errors) && response.errors.length > 0)
+    throw new TrackingError(`Linear issue ${ref} validation failed`);
+  const issue = response.data?.issue;
+  if (
+    !issue ||
+    String(issue.identifier ?? "").toUpperCase() !== ref ||
+    String(issue.team?.key ?? "").toUpperCase() !== contract.teamKey
+  ) {
+    throw new TrackingError(
+      `Linear issue ${ref} does not exist in configured team ${contract.teamKey}`
+    );
+  }
+  const stateType = String(issue.state?.type ?? "").toLowerCase();
+  if (!stateType) {
+    throw new TrackingError(
+      `Linear issue ${ref} did not expose a workflow state`
+    );
+  }
+  if (["completed", "canceled", "cancelled"].includes(stateType)) {
+    throw new TrackingError(
+      `Linear issue ${ref} is terminal; bind an active work item`
+    );
+  }
+  assertRepoScope(ref, contract, issue.labels?.nodes);
+  assertClaimedLifecycle(ref, contract, issue.labels?.nodes);
+  assertLeaf(
+    ref,
+    typeFromLabels(issue.labels?.nodes),
+    (issue.children?.nodes ?? []).map(child => child.state?.type)
+  );
+  return issue;
+}
+
+function validateLive(ref, contract = trackerContract()) {
+  if (contract.provider === "github") return githubIssue(ref, contract);
+  if (contract.provider === "jira") return jiraIssue(ref, contract);
+  return linearIssue(ref, contract);
+}
+
+function textContainsBacklink(value, prUrl) {
+  if (typeof value === "string")
+    return value.includes(MARKER) && value.includes(prUrl);
+  if (Array.isArray(value))
+    return value.some(item => textContainsBacklink(item, prUrl));
+  if (value && typeof value === "object")
+    return Object.values(value).some(item => textContainsBacklink(item, prUrl));
+  return false;
+}
+
+function assertBacklink(
+  ref,
+  prUrl,
+  contract,
+  issue = validateLive(ref, contract)
+) {
+  if (contract.provider === "github") {
+    const native = (issue.closedByPullRequestsReferences ?? []).some(
+      pr => pr.url === prUrl
+    );
+    const fallback = (issue.comments ?? []).some(comment =>
+      textContainsBacklink(comment.body, prUrl)
+    );
+    if (!native && !fallback)
+      throw new TrackingError(
+        `GitHub issue ${ref} has no verified backlink to ${prUrl}`
+      );
+    return;
+  }
+  if (contract.provider === "linear") {
+    const native = (issue.attachments?.nodes ?? []).some(
+      attachment => attachment.url === prUrl
+    );
+    const fallback = (issue.comments?.nodes ?? []).some(comment =>
+      textContainsBacklink(comment.body, prUrl)
+    );
+    if (!native && !fallback)
+      throw new TrackingError(
+        `Linear issue ${ref} has no verified backlink to ${prUrl}`
+      );
+    return;
+  }
+  const fallback = textContainsBacklink(
+    issue.fields?.comment?.comments ?? issue.comments ?? [],
+    prUrl
+  );
+  if (fallback) return;
+  const credentials = jiraCredentials(contract);
+  if (credentials) {
+    const url = `${credentials.baseUrl}/rest/api/3/issue/${encodeURIComponent(ref)}/remotelink`;
+    const result = run(
+      "curl",
+      [
+        "-fsS",
+        "-u",
+        `${credentials.login}:${credentials.token}`,
+        "-H",
+        "Accept: application/json",
+        url,
+      ],
+      { allowFailure: true }
+    );
+    if (result.status === 0) {
+      const links = safeJson(result.stdout, `Jira remote links for ${ref}`);
+      if (
+        Array.isArray(links) &&
+        links.some(link => link.object?.url === prUrl)
+      )
+        return;
+    }
+  }
+  throw new TrackingError(
+    `Jira ticket ${ref} has no verified backlink to ${prUrl}`
+  );
+}
+
+function assertStateMatches(ref, contract) {
+  const state = readState(true);
+  if (!state) return;
+  assertStateBranch(state);
+  if (
+    state.provider !== contract.provider ||
+    canonicalizeRef(state.ref, contract) !== ref
+  ) {
+    throw new TrackingError(
+      `Work-Item ${ref} does not match this worktree's binding ${state.ref}`
+    );
+  }
+}
+
+function validateMessage(message, options = {}) {
+  if (options.allowInProgressMerge && isMergeInProgress())
+    return { exempt: "merge" };
+  if (RELEASE_SUBJECT.test(messageSubject(message)))
+    return { exempt: "release" };
+  const contract = trackerContract();
+  const ref = exactWorkItem(message, contract);
+  assertStateMatches(ref, contract);
+  const issue = validateLive(ref, contract);
+  return { ref, contract, issue };
+}
+
+function commitMessage(sha) {
+  return git(["show", "-s", "--format=%B", sha]);
+}
+
+function validateCommits(commits) {
+  const contract = trackerContract();
+  const refs = new Set();
+  const issues = new Map();
+  let relevant = 0;
+  let mergeExempt = 0;
+  let releaseExempt = 0;
+  for (const sha of new Set(commits)) {
+    const exemption = commitExemption(sha);
+    if (exemption === "merge") {
+      mergeExempt += 1;
+      continue;
+    }
+    if (exemption === "release") {
+      releaseExempt += 1;
+      continue;
+    }
+    relevant += 1;
+    const ref = exactWorkItem(commitMessage(sha), contract);
+    refs.add(ref);
+    if (!issues.has(ref)) issues.set(ref, validateLive(ref, contract));
+  }
+  if (refs.size > 1)
+    throw new TrackingError(
+      `Push/PR contains mixed Work-Item references: ${[...refs].join(", ")}`
+    );
+  const [ref] = refs;
+  if (ref) assertStateMatches(ref, contract);
+  return {
+    contract,
+    ref,
+    issue: ref ? issues.get(ref) : undefined,
+    mergeExempt,
+    releaseExempt,
+    relevant,
+  };
+}
+
+function parsePushLines(input, remote) {
+  const commits = [];
+  for (const line of input.trim().split(/\r?\n/).filter(Boolean)) {
+    const [, localOid, , remoteOid] = line.trim().split(/\s+/);
+    if (!localOid || ZERO_OID.test(localOid)) continue;
+    const args =
+      remoteOid && !ZERO_OID.test(remoteOid)
+        ? ["rev-list", `${remoteOid}..${localOid}`]
+        : ["rev-list", localOid, "--not", `--remotes=${remote}`];
+    commits.push(...git(args).split("\n").filter(Boolean));
+  }
+  if (commits.length === 0 && input.trim() === "") {
+    commits.push(
+      ...git(["rev-list", "HEAD", "--not", `--remotes=${remote}`])
+        .split("\n")
+        .filter(Boolean)
+    );
+  }
+  return commits;
+}
+
+function prWorkItem(body, contract) {
+  const matches = String(body ?? "")
+    .split(/\r?\n/)
+    .flatMap(line => {
+      const match = /^Work-Item:\s*(.+?)\s*$/i.exec(line);
+      return match ? [match[1]] : [];
+    });
+  if (matches.length !== 1)
+    throw new TrackingError(
+      `Pull request must contain exactly one Work-Item line; found ${matches.length}`
+    );
+  return canonicalizeRef(matches[0], contract);
+}
+
+function validatePrData(result, prUrl, prBody) {
+  if (result.relevant === 0) {
+    if (result.releaseExempt > 0 && result.mergeExempt === 0) return;
+    throw new TrackingError(
+      "Pull request has no non-merge commit linked to a work item"
+    );
+  }
+  if (!result.ref)
+    throw new TrackingError(
+      "Pull request commits are not linked to a work item"
+    );
+  const bodyRef = prWorkItem(prBody, result.contract);
+  if (bodyRef !== result.ref)
+    throw new TrackingError(
+      `Pull request Work-Item ${bodyRef} does not match commit Work-Item ${result.ref}`
+    );
+  assertBacklink(result.ref, prUrl, result.contract, result.issue);
+}
+
+function currentRepository() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  const result = run("gh", ["repo", "view", "--json", "nameWithOwner"], {
+    allowFailure: true,
+  });
+  if (result.status !== 0) return undefined;
+  return safeJson(result.stdout, "GitHub repository").nameWithOwner;
+}
+
+function currentPullRequest(number, repository = currentRepository()) {
+  const args = ["pr", "view"];
+  if (number) args.push(String(number));
+  if (repository) args.push("--repo", repository);
+  args.push("--json", "url,body,state");
+  const result = run("gh", args, { allowFailure: true });
+  return result.status === 0
+    ? safeJson(result.stdout, "GitHub pull request")
+    : undefined;
+}
+
+function option(args, name, envName) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : process.env[envName];
+}
+
+function bind(args) {
+  const contract = trackerContract();
+  const ref = canonicalizeRef(args[0], contract);
+  validateLive(ref, contract);
+  const file = writeState(ref, contract.provider);
+  console.log(`work-item bound: ${ref} (${file})`);
+}
+
+function prepareCommitMessage(args) {
+  const [file, source = ""] = args;
+  if (!file)
+    throw new TrackingError(
+      "prepare-commit-msg requires the commit message file"
+    );
+  if (
+    source === "merge" ||
+    RELEASE_SUBJECT.test(messageSubject(readFileSync(file, "utf8")))
+  )
+    return;
+  const state = readState(true);
+  if (!state) return;
+  assertStateBranch(state);
+  const contract = trackerContract();
+  const ref = canonicalizeRef(state.ref, contract);
+  run("git", [
+    "interpret-trailers",
+    "--in-place",
+    "--if-exists=doNothing",
+    "--if-missing=add",
+    "--trailer",
+    `Work-Item: ${ref}`,
+    file,
+  ]);
+}
+
+function validateCommit(args) {
+  const file = args[0];
+  if (!file)
+    throw new TrackingError("validate-commit requires the commit message file");
+  const result = validateMessage(readFileSync(file, "utf8"), {
+    allowInProgressMerge: true,
+  });
+  console.log(`WORK_ITEM_TRACKING_OK ${result.exempt ?? result.ref}`);
+}
+
+function validatePush(args) {
+  const remote = args[0] || "origin";
+  const input = readFileSync(0, "utf8");
+  const result = validateCommits(parsePushLines(input, remote));
+  const pr = currentPullRequest();
+  if (!pr) {
+    console.log(
+      `WORK_ITEM_TRACKING_OK ${result.relevant} commit(s); no pull request exists yet, CI will verify PR linkage`
+    );
+    return;
+  }
+  validatePrData(result, pr.url, pr.body);
+  console.log(
+    `WORK_ITEM_TRACKING_OK ${result.relevant} commit(s), PR body, and tracker backlink`
+  );
+}
+
+function validatePr(args) {
+  const base = option(args, "--base", "LISA_PR_BASE_SHA");
+  const head = option(args, "--head", "LISA_PR_HEAD_SHA") || "HEAD";
+  if (!base)
+    throw new TrackingError("validate-pr requires --base or LISA_PR_BASE_SHA");
+  const commits = git(["rev-list", `${base}..${head}`])
+    .split("\n")
+    .filter(Boolean);
+  const result = validateCommits(commits);
+  const bodyFile = option(args, "--body-file", "LISA_PR_BODY_FILE");
+  const prNumber = option(args, "--pr-number", "LISA_PR_NUMBER");
+  const suppliedUrl =
+    option(args, "--pr-url", "LISA_PR_URL") ??
+    option(args, "--url", "LISA_PR_URL");
+  const repository =
+    option(args, "--repo", "GITHUB_REPOSITORY") ?? currentRepository();
+  const fetched = bodyFile
+    ? undefined
+    : currentPullRequest(prNumber, repository);
+  const pr = bodyFile
+    ? { url: suppliedUrl, body: readFileSync(bodyFile, "utf8") }
+    : fetched && { ...fetched, url: suppliedUrl ?? fetched.url };
+  if (!pr?.url) {
+    throw new TrackingError(
+      "validate-pr requires --pr-number, or --pr-url/--url with --body-file, and an accessible GitHub PR"
+    );
+  }
+  validatePrData(result, pr.url, pr.body);
+  console.log(
+    `WORK_ITEM_TRACKING_OK ${result.relevant} commit(s), PR body, and tracker backlink`
+  );
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "bind") return bind(args);
+  if (command === "current")
+    return console.log(JSON.stringify(readState(false), null, 2));
+  if (command === "attach-branch") {
+    const state = readState(false);
+    const contract = trackerContract();
+    if (state.provider !== contract.provider) {
+      throw new TrackingError(
+        `Work-item binding provider ${state.provider} does not match configured tracker ${contract.provider}`
+      );
+    }
+    const ref = canonicalizeRef(state.ref, contract);
+    validateLive(ref, contract);
+    const file = writeState(ref, contract.provider, { requireBranch: true });
+    return console.log(
+      `work-item binding attached to ${currentBranch()} (${file})`
+    );
+  }
+  if (command === "clear") {
+    rmSync(statePath(), { force: true });
+    return console.log("work-item binding cleared");
+  }
+  if (command === "prepare-commit-msg") return prepareCommitMessage(args);
+  if (command === "validate-commit") return validateCommit(args);
+  if (command === "validate-push") return validatePush(args);
+  if (command === "validate-pr") return validatePr(args);
+  throw new TrackingError(
+    "Usage: lisa-work-item.mjs bind|current|attach-branch|clear|prepare-commit-msg|validate-commit|validate-push|validate-pr"
+  );
+}
+
+try {
+  await main();
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error(
+    `\n❌ Work-item tracking blocked this operation: ${detail}\n\n${GUIDANCE}\n`
+  );
+  process.exitCode = 1;
+}

--- a/plugins/lisa-agy/commands/lisa/track.md
+++ b/plugins/lisa-agy/commands/lisa/track.md
@@ -1,0 +1,6 @@
+---
+description: "Bind this worktree to one live work item in the configured tracker. Accepts an existing Jira, GitHub, or Linear reference, a specification file, or a plain-text description; validates or creates and claims exactly one leaf before persisting the local binding."
+argument-hint: "<work-item-url | key | spec-file | description>"
+---
+
+Use the /lisa-track skill to resolve, live-validate or create, claim, and bind exactly one configured-tracker leaf for this worktree. $ARGUMENTS

--- a/plugins/lisa-agy/skills/lisa-github-claim/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live GitHub leaf issue for direct Lisa work. Reuses github-build-intake Phase 3b semantics: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/lisa-agy/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live Jira leaf ticket for direct Lisa work. Reuses jira-build-intake Phase 3b semantics through lisa-atlassian-access: configured ready-to-claimed transition, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/lisa-agy/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live Linear leaf issue for direct Lisa work. Reuses linear-build-intake Phase 3b semantics through lisa-linear-access: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/lisa-agy/skills/lisa-track/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in worktree-local state. Accepts an existing Jira/GitHub/Linear ref, a spec file, or plain text. Use directly to mention/create the related ticket, and as lisa-implement's mandatory input gate."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/lisa-agy/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item. Reads the required tracker from .lisa.config.json and delegates to lisa-jira-claim, lisa-github-claim, or lisa-linear-claim. The vendor skill owns the post-read leaf/open guard, ready-to-claimed mutation, attributable assignment, and post-write verification."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/plugins/lisa-copilot/commands/lisa/track.md
+++ b/plugins/lisa-copilot/commands/lisa/track.md
@@ -1,0 +1,6 @@
+---
+description: "Bind this worktree to one live work item in the configured tracker. Accepts an existing Jira, GitHub, or Linear reference, a specification file, or a plain-text description; validates or creates and claims exactly one leaf before persisting the local binding."
+argument-hint: "<work-item-url | key | spec-file | description>"
+---
+
+Use the /lisa-track skill to resolve, live-validate or create, claim, and bind exactly one configured-tracker leaf for this worktree. $ARGUMENTS

--- a/plugins/lisa-copilot/rules/eager/tracked-work.md
+++ b/plugins/lisa-copilot/rules/eager/tracked-work.md
@@ -1,0 +1,7 @@
+# Tracked Work
+
+Before the first durable project mutation (code, tests, config, docs, committed research/plans/findings, commits, or PRs), establish exactly one live tracker leaf through `lisa-track`. Read-only discussion and orientation are exempt only while they produce no durable artifact.
+
+The mandatory order is: live-validate an explicit ref, or conservatively search and create exactly one valid leaf through `lisa-tracker-write` when no unique match exists; idempotently claim it through `lisa-tracker-claim`; then persist and verify the worktree-local binding with `node scripts/lisa-work-item.mjs bind <ref>`. Any tracker, claim, or binding failure blocks durable work.
+
+Carry that canonical ref through the branch, every ordinary commit's `Work-Item:` trailer, the PR, usage/evidence, and `lisa-tracker-sync`. Hooks and CI never create tickets. Keep the binding through interruptions or blocked outcomes; run `node scripts/lisa-work-item.mjs clear` only after merge/deploy/verification, two-way linkage/evidence, and the tracker item have all reached true terminal completion.

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -677,6 +677,7 @@ The shim → vendor mapping is fixed:
 | `lisa-tracker-validate` | `lisa-jira-validate-ticket` | `lisa-github-validate-issue` | `lisa-linear-validate-issue` |
 | `lisa-tracker-verify` | `lisa-jira-verify` | `lisa-github-verify` | `lisa-linear-verify` |
 | `lisa-tracker-read` | `lisa-jira-read-ticket` | `lisa-github-read-issue` | `lisa-linear-read-issue` |
+| `lisa-tracker-claim` | `lisa-jira-claim` | `lisa-github-claim` | `lisa-linear-claim` |
 | `lisa-tracker-evidence` | `lisa-jira-evidence` | `lisa-github-evidence` | `lisa-linear-evidence` |
 | `lisa-tracker-sync` | `lisa-jira-sync` | `lisa-github-sync` | `lisa-linear-sync` |
 | `lisa-tracker-add-journey` | `lisa-jira-add-journey` | `lisa-github-add-journey` | `lisa-linear-add-journey` |
@@ -689,7 +690,7 @@ The `tracker-source-artifacts` skill (formerly `tracker-source-artifacts`) is re
 ## Caller responsibilities
 
 - **PRD-source skills** (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST invoke `tracker-write` and `tracker-validate` — never `jira-write-ticket` / `github-write-issue` / `linear-write-issue` directly. This is what makes a project's destination switchable via config.
-- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
+- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-claim`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
 - **Per-vendor PRD intake skills** (`notion-prd-intake`, `confluence-prd-intake`, `linear-prd-intake`, `github-prd-intake`) compose the PRD-source skills (which in turn invoke the shims) — they do not need to read `tracker` themselves.
 - **Vendor-specific destination skills** (`jira-*`, `github-*`, `linear-*`) read their own vendor config section directly. They do NOT consult `tracker` — they are the targets of dispatch, not the dispatchers.
 

--- a/plugins/lisa-copilot/rules/reference/tracked-work.md
+++ b/plugins/lisa-copilot/rules/reference/tracked-work.md
@@ -1,0 +1,26 @@
+# Tracked Work
+
+The project tracker is the durable operator-facing record for project work. Every session that will produce a durable project outcome must establish exactly one live configured-tracker leaf before the first durable mutation. Durable outcomes include code, tests, configuration, documentation, committed research or plans, investigation findings, commits, and pull requests. Read-only questions, discussion, and repository orientation are exempt until they turn into durable work.
+
+## Resolve, claim, bind
+
+Use `lisa-track` as the single entry point:
+
+1. An explicit ticket is live-read through `lisa-tracker-read` and rejected if it is missing, inaccessible, terminal, a container, outside the configured project, or outside the current repository.
+2. A plain-text request or specification file is searched conservatively within the configured project. Reuse only one uniquely high-confidence matching live leaf. If no unique match exists, create exactly one complete single-repository leaf through `lisa-tracker-write`; never create a thin placeholder or a container.
+3. Idempotently claim the resolved leaf through `lisa-tracker-claim`, which reuses the vendor build-intake claim semantics and post-read verifies the claimed-or-later state.
+4. Before any durable repository work, persist the canonical reference with `node scripts/lisa-work-item.mjs bind <ref>` and verify the worktree-local binding.
+
+The sequence is strict: **live validate/create -> claim -> bind -> durable work**. A failed tracker read/write, claim, or binding blocks the work. Tracker availability must be proven; tool presence or stale session text is not access.
+
+## One canonical identity
+
+The binding is authoritative for the worktree. Branches, commits, pull requests, usage accounting, evidence, and tracker-sync operations all carry the same canonical ref. Branch names are helpful discovery metadata but are not authoritative. After branch creation, `node scripts/lisa-work-item.mjs attach-branch` may attach the local branch to the binding.
+
+Linkage is unconditional for an Implement flow because its input gate always establishes a work item. PR creation must pass the ref to `lisa-git-submit-pr`; `lisa-tracker-sync` must prove the reverse native link or its managed fallback.
+
+## Binding lifetime
+
+Binding state is local machine state and must remain untracked. Keep it through interruptions and blocked outcomes. Run `node scripts/lisa-work-item.mjs clear` only after true terminal completion: required merge/deploy/verification is complete, evidence and two-way PR linkage are recorded, and the tracker item is in its terminal state. Verify that no current binding remains before ending the completed flow.
+
+Git hooks and CI enforce this contract but never create work items. Their recovery message directs the operator to mention the related ticket or run `/lisa:track <description>` to create and bind one.

--- a/plugins/lisa-copilot/skills/lisa-github-claim/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live GitHub leaf issue for direct Lisa work. Reuses github-build-intake Phase 3b semantics: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/lisa-copilot/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live Jira leaf ticket for direct Lisa work. Reuses jira-build-intake Phase 3b semantics through lisa-atlassian-access: configured ready-to-claimed transition, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/lisa-copilot/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live Linear leaf issue for direct Lisa work. Reuses linear-build-intake Phase 3b semantics through lisa-linear-access: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/lisa-copilot/skills/lisa-track/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in worktree-local state. Accepts an existing Jira/GitHub/Linear ref, a spec file, or plain text. Use directly to mention/create the related ticket, and as lisa-implement's mandatory input gate."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/lisa-copilot/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item. Reads the required tracker from .lisa.config.json and delegates to lisa-jira-claim, lisa-github-claim, or lisa-linear-claim. The vendor skill owns the post-read leaf/open guard, ready-to-claimed mutation, attributable assignment, and post-write verification."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/plugins/lisa-cursor/commands/lisa/track.md
+++ b/plugins/lisa-cursor/commands/lisa/track.md
@@ -1,0 +1,6 @@
+---
+description: "Bind this worktree to one live work item in the configured tracker. Accepts an existing Jira, GitHub, or Linear reference, a specification file, or a plain-text description; validates or creates and claims exactly one leaf before persisting the local binding."
+argument-hint: "<work-item-url | key | spec-file | description>"
+---
+
+Use the /lisa-track skill to resolve, live-validate or create, claim, and bind exactly one configured-tracker leaf for this worktree. $ARGUMENTS

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -682,6 +682,7 @@ The shim → vendor mapping is fixed:
 | `lisa-tracker-validate` | `lisa-jira-validate-ticket` | `lisa-github-validate-issue` | `lisa-linear-validate-issue` |
 | `lisa-tracker-verify` | `lisa-jira-verify` | `lisa-github-verify` | `lisa-linear-verify` |
 | `lisa-tracker-read` | `lisa-jira-read-ticket` | `lisa-github-read-issue` | `lisa-linear-read-issue` |
+| `lisa-tracker-claim` | `lisa-jira-claim` | `lisa-github-claim` | `lisa-linear-claim` |
 | `lisa-tracker-evidence` | `lisa-jira-evidence` | `lisa-github-evidence` | `lisa-linear-evidence` |
 | `lisa-tracker-sync` | `lisa-jira-sync` | `lisa-github-sync` | `lisa-linear-sync` |
 | `lisa-tracker-add-journey` | `lisa-jira-add-journey` | `lisa-github-add-journey` | `lisa-linear-add-journey` |
@@ -694,7 +695,7 @@ The `tracker-source-artifacts` skill (formerly `tracker-source-artifacts`) is re
 ## Caller responsibilities
 
 - **PRD-source skills** (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST invoke `tracker-write` and `tracker-validate` — never `jira-write-ticket` / `github-write-issue` / `linear-write-issue` directly. This is what makes a project's destination switchable via config.
-- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
+- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-claim`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
 - **Per-vendor PRD intake skills** (`notion-prd-intake`, `confluence-prd-intake`, `linear-prd-intake`, `github-prd-intake`) compose the PRD-source skills (which in turn invoke the shims) — they do not need to read `tracker` themselves.
 - **Vendor-specific destination skills** (`jira-*`, `github-*`, `linear-*`) read their own vendor config section directly. They do NOT consult `tracker` — they are the targets of dispatch, not the dispatchers.
 

--- a/plugins/lisa-cursor/rules/tracked-work-reference.mdc
+++ b/plugins/lisa-cursor/rules/tracked-work-reference.mdc
@@ -1,0 +1,31 @@
+---
+description: "Tracked Work"
+alwaysApply: false
+---
+
+# Tracked Work
+
+The project tracker is the durable operator-facing record for project work. Every session that will produce a durable project outcome must establish exactly one live configured-tracker leaf before the first durable mutation. Durable outcomes include code, tests, configuration, documentation, committed research or plans, investigation findings, commits, and pull requests. Read-only questions, discussion, and repository orientation are exempt until they turn into durable work.
+
+## Resolve, claim, bind
+
+Use `lisa-track` as the single entry point:
+
+1. An explicit ticket is live-read through `lisa-tracker-read` and rejected if it is missing, inaccessible, terminal, a container, outside the configured project, or outside the current repository.
+2. A plain-text request or specification file is searched conservatively within the configured project. Reuse only one uniquely high-confidence matching live leaf. If no unique match exists, create exactly one complete single-repository leaf through `lisa-tracker-write`; never create a thin placeholder or a container.
+3. Idempotently claim the resolved leaf through `lisa-tracker-claim`, which reuses the vendor build-intake claim semantics and post-read verifies the claimed-or-later state.
+4. Before any durable repository work, persist the canonical reference with `node scripts/lisa-work-item.mjs bind <ref>` and verify the worktree-local binding.
+
+The sequence is strict: **live validate/create -> claim -> bind -> durable work**. A failed tracker read/write, claim, or binding blocks the work. Tracker availability must be proven; tool presence or stale session text is not access.
+
+## One canonical identity
+
+The binding is authoritative for the worktree. Branches, commits, pull requests, usage accounting, evidence, and tracker-sync operations all carry the same canonical ref. Branch names are helpful discovery metadata but are not authoritative. After branch creation, `node scripts/lisa-work-item.mjs attach-branch` may attach the local branch to the binding.
+
+Linkage is unconditional for an Implement flow because its input gate always establishes a work item. PR creation must pass the ref to `lisa-git-submit-pr`; `lisa-tracker-sync` must prove the reverse native link or its managed fallback.
+
+## Binding lifetime
+
+Binding state is local machine state and must remain untracked. Keep it through interruptions and blocked outcomes. Run `node scripts/lisa-work-item.mjs clear` only after true terminal completion: required merge/deploy/verification is complete, evidence and two-way PR linkage are recorded, and the tracker item is in its terminal state. Verify that no current binding remains before ending the completed flow.
+
+Git hooks and CI enforce this contract but never create work items. Their recovery message directs the operator to mention the related ticket or run `/lisa:track <description>` to create and bind one.

--- a/plugins/lisa-cursor/rules/tracked-work.mdc
+++ b/plugins/lisa-cursor/rules/tracked-work.mdc
@@ -1,0 +1,12 @@
+---
+description: "Tracked Work"
+alwaysApply: true
+---
+
+# Tracked Work
+
+Before the first durable project mutation (code, tests, config, docs, committed research/plans/findings, commits, or PRs), establish exactly one live tracker leaf through `lisa-track`. Read-only discussion and orientation are exempt only while they produce no durable artifact.
+
+The mandatory order is: live-validate an explicit ref, or conservatively search and create exactly one valid leaf through `lisa-tracker-write` when no unique match exists; idempotently claim it through `lisa-tracker-claim`; then persist and verify the worktree-local binding with `node scripts/lisa-work-item.mjs bind <ref>`. Any tracker, claim, or binding failure blocks durable work.
+
+Carry that canonical ref through the branch, every ordinary commit's `Work-Item:` trailer, the PR, usage/evidence, and `lisa-tracker-sync`. Hooks and CI never create tickets. Keep the binding through interruptions or blocked outcomes; run `node scripts/lisa-work-item.mjs clear` only after merge/deploy/verification, two-way linkage/evidence, and the tracker item have all reached true terminal completion.

--- a/plugins/lisa-cursor/skills/lisa-github-claim/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live GitHub leaf issue for direct Lisa work. Reuses github-build-intake Phase 3b semantics: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/lisa-cursor/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live Jira leaf ticket for direct Lisa work. Reuses jira-build-intake Phase 3b semantics through lisa-atlassian-access: configured ready-to-claimed transition, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/lisa-cursor/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live Linear leaf issue for direct Lisa work. Reuses linear-build-intake Phase 3b semantics through lisa-linear-access: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/lisa-cursor/skills/lisa-track/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in worktree-local state. Accepts an existing Jira/GitHub/Linear ref, a spec file, or plain text. Use directly to mention/create the related ticket, and as lisa-implement's mandatory input gate."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/lisa-cursor/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item. Reads the required tracker from .lisa.config.json and delegates to lisa-jira-claim, lisa-github-claim, or lisa-linear-claim. The vendor skill owns the post-read leaf/open guard, ready-to-claimed mutation, attributable assignment, and post-write verification."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-claim/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live…"
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-claim/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Github Claim"
+short_description: "Idempotently claims one live…"
+default_prompt:
+  - "Use $lisa-github-claim: Idempotently claims one live…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live…"
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-claim/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Jira Claim"
+short_description: "Idempotently claims one live…"
+default_prompt:
+  - "Use $lisa-jira-claim: Idempotently claims one live…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live…"
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-claim/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Linear Claim"
+short_description: "Idempotently claims one live…"
+default_prompt:
+  - "Use $lisa-linear-claim: Idempotently claims one live…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-track/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live…"
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/lisa/.codex-plugin/skills/lisa-track/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-track/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Track"
+short_description: "Resolves exactly one live…"
+default_prompt:
+  - "Use $lisa-track: Resolves exactly one live…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for…"
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/plugins/lisa/.codex-plugin/skills/lisa-tracker-claim/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-tracker-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Tracker Claim"
+short_description: "Vendor-neutral dispatcher for…"
+default_prompt:
+  - "Use $lisa-tracker-claim: Vendor-neutral dispatcher for…."

--- a/plugins/lisa/commands/track.md
+++ b/plugins/lisa/commands/track.md
@@ -1,0 +1,6 @@
+---
+description: "Bind this worktree to one live work item in the configured tracker. Accepts an existing Jira, GitHub, or Linear reference, a specification file, or a plain-text description; validates or creates and claims exactly one leaf before persisting the local binding."
+argument-hint: "<work-item-url | key | spec-file | description>"
+---
+
+Use the /lisa-track skill to resolve, live-validate or create, claim, and bind exactly one configured-tracker leaf for this worktree. $ARGUMENTS

--- a/plugins/lisa/rules/eager/tracked-work.md
+++ b/plugins/lisa/rules/eager/tracked-work.md
@@ -1,0 +1,7 @@
+# Tracked Work
+
+Before the first durable project mutation (code, tests, config, docs, committed research/plans/findings, commits, or PRs), establish exactly one live tracker leaf through `lisa-track`. Read-only discussion and orientation are exempt only while they produce no durable artifact.
+
+The mandatory order is: live-validate an explicit ref, or conservatively search and create exactly one valid leaf through `lisa-tracker-write` when no unique match exists; idempotently claim it through `lisa-tracker-claim`; then persist and verify the worktree-local binding with `node scripts/lisa-work-item.mjs bind <ref>`. Any tracker, claim, or binding failure blocks durable work.
+
+Carry that canonical ref through the branch, every ordinary commit's `Work-Item:` trailer, the PR, usage/evidence, and `lisa-tracker-sync`. Hooks and CI never create tickets. Keep the binding through interruptions or blocked outcomes; run `node scripts/lisa-work-item.mjs clear` only after merge/deploy/verification, two-way linkage/evidence, and the tracker item have all reached true terminal completion.

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -677,6 +677,7 @@ The shim → vendor mapping is fixed:
 | `lisa-tracker-validate` | `lisa-jira-validate-ticket` | `lisa-github-validate-issue` | `lisa-linear-validate-issue` |
 | `lisa-tracker-verify` | `lisa-jira-verify` | `lisa-github-verify` | `lisa-linear-verify` |
 | `lisa-tracker-read` | `lisa-jira-read-ticket` | `lisa-github-read-issue` | `lisa-linear-read-issue` |
+| `lisa-tracker-claim` | `lisa-jira-claim` | `lisa-github-claim` | `lisa-linear-claim` |
 | `lisa-tracker-evidence` | `lisa-jira-evidence` | `lisa-github-evidence` | `lisa-linear-evidence` |
 | `lisa-tracker-sync` | `lisa-jira-sync` | `lisa-github-sync` | `lisa-linear-sync` |
 | `lisa-tracker-add-journey` | `lisa-jira-add-journey` | `lisa-github-add-journey` | `lisa-linear-add-journey` |
@@ -689,7 +690,7 @@ The `tracker-source-artifacts` skill (formerly `tracker-source-artifacts`) is re
 ## Caller responsibilities
 
 - **PRD-source skills** (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST invoke `tracker-write` and `tracker-validate` — never `jira-write-ticket` / `github-write-issue` / `linear-write-issue` directly. This is what makes a project's destination switchable via config.
-- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
+- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-claim`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
 - **Per-vendor PRD intake skills** (`notion-prd-intake`, `confluence-prd-intake`, `linear-prd-intake`, `github-prd-intake`) compose the PRD-source skills (which in turn invoke the shims) — they do not need to read `tracker` themselves.
 - **Vendor-specific destination skills** (`jira-*`, `github-*`, `linear-*`) read their own vendor config section directly. They do NOT consult `tracker` — they are the targets of dispatch, not the dispatchers.
 

--- a/plugins/lisa/rules/reference/tracked-work.md
+++ b/plugins/lisa/rules/reference/tracked-work.md
@@ -1,0 +1,26 @@
+# Tracked Work
+
+The project tracker is the durable operator-facing record for project work. Every session that will produce a durable project outcome must establish exactly one live configured-tracker leaf before the first durable mutation. Durable outcomes include code, tests, configuration, documentation, committed research or plans, investigation findings, commits, and pull requests. Read-only questions, discussion, and repository orientation are exempt until they turn into durable work.
+
+## Resolve, claim, bind
+
+Use `lisa-track` as the single entry point:
+
+1. An explicit ticket is live-read through `lisa-tracker-read` and rejected if it is missing, inaccessible, terminal, a container, outside the configured project, or outside the current repository.
+2. A plain-text request or specification file is searched conservatively within the configured project. Reuse only one uniquely high-confidence matching live leaf. If no unique match exists, create exactly one complete single-repository leaf through `lisa-tracker-write`; never create a thin placeholder or a container.
+3. Idempotently claim the resolved leaf through `lisa-tracker-claim`, which reuses the vendor build-intake claim semantics and post-read verifies the claimed-or-later state.
+4. Before any durable repository work, persist the canonical reference with `node scripts/lisa-work-item.mjs bind <ref>` and verify the worktree-local binding.
+
+The sequence is strict: **live validate/create -> claim -> bind -> durable work**. A failed tracker read/write, claim, or binding blocks the work. Tracker availability must be proven; tool presence or stale session text is not access.
+
+## One canonical identity
+
+The binding is authoritative for the worktree. Branches, commits, pull requests, usage accounting, evidence, and tracker-sync operations all carry the same canonical ref. Branch names are helpful discovery metadata but are not authoritative. After branch creation, `node scripts/lisa-work-item.mjs attach-branch` may attach the local branch to the binding.
+
+Linkage is unconditional for an Implement flow because its input gate always establishes a work item. PR creation must pass the ref to `lisa-git-submit-pr`; `lisa-tracker-sync` must prove the reverse native link or its managed fallback.
+
+## Binding lifetime
+
+Binding state is local machine state and must remain untracked. Keep it through interruptions and blocked outcomes. Run `node scripts/lisa-work-item.mjs clear` only after true terminal completion: required merge/deploy/verification is complete, evidence and two-way PR linkage are recorded, and the tracker item is in its terminal state. Verify that no current binding remains before ending the completed flow.
+
+Git hooks and CI enforce this contract but never create work items. Their recovery message directs the operator to mention the related ticket or run `/lisa:track <description>` to create and bind one.

--- a/plugins/lisa/skills/lisa-github-claim/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live GitHub leaf issue for direct Lisa work. Reuses github-build-intake Phase 3b semantics: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/lisa/skills/lisa-github-claim/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-github-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Github Claim"
+short_description: "Idempotently claims one live GitHub leaf issue for direct Lisa work"
+default_prompt:
+  - "Use $lisa-github-claim: Idempotently claims one live GitHub leaf issue for direct Lisa work."

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/lisa/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/lisa/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live Jira leaf ticket for direct Lisa work. Reuses jira-build-intake Phase 3b semantics through lisa-atlassian-access: configured ready-to-claimed transition, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/lisa/skills/lisa-jira-claim/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-jira-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Jira Claim"
+short_description: "Idempotently claims one live Jira leaf ticket for direct Lisa work"
+default_prompt:
+  - "Use $lisa-jira-claim: Idempotently claims one live Jira leaf ticket for direct Lisa work."

--- a/plugins/lisa/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live Linear leaf issue for direct Lisa work. Reuses linear-build-intake Phase 3b semantics through lisa-linear-access: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/lisa/skills/lisa-linear-claim/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-linear-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Linear Claim"
+short_description: "Idempotently claims one live Linear leaf issue for direct Lisa work"
+default_prompt:
+  - "Use $lisa-linear-claim: Idempotently claims one live Linear leaf issue for direct Lisa work."

--- a/plugins/lisa/skills/lisa-track/SKILL.md
+++ b/plugins/lisa/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in worktree-local state. Accepts an existing Jira/GitHub/Linear ref, a spec file, or plain text. Use directly to mention/create the related ticket, and as lisa-implement's mandatory input gate."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/lisa/skills/lisa-track/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-track/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Track"
+short_description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in…"
+default_prompt:
+  - "Use $lisa-track: Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in…."

--- a/plugins/lisa/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/lisa/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item. Reads the required tracker from .lisa.config.json and delegates to lisa-jira-claim, lisa-github-claim, or lisa-linear-claim. The vendor skill owns the post-read leaf/open guard, ready-to-claimed mutation, attributable assignment, and post-write verification."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/plugins/lisa/skills/lisa-tracker-claim/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-tracker-claim/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Tracker Claim"
+short_description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item"
+default_prompt:
+  - "Use $lisa-tracker-claim: Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item."

--- a/plugins/src/base/commands/track.md
+++ b/plugins/src/base/commands/track.md
@@ -1,0 +1,6 @@
+---
+description: "Bind this worktree to one live work item in the configured tracker. Accepts an existing Jira, GitHub, or Linear reference, a specification file, or a plain-text description; validates or creates and claims exactly one leaf before persisting the local binding."
+argument-hint: "<work-item-url | key | spec-file | description>"
+---
+
+Use the /lisa-track skill to resolve, live-validate or create, claim, and bind exactly one configured-tracker leaf for this worktree. $ARGUMENTS

--- a/plugins/src/base/rules/eager/tracked-work.md
+++ b/plugins/src/base/rules/eager/tracked-work.md
@@ -1,0 +1,7 @@
+# Tracked Work
+
+Before the first durable project mutation (code, tests, config, docs, committed research/plans/findings, commits, or PRs), establish exactly one live tracker leaf through `lisa-track`. Read-only discussion and orientation are exempt only while they produce no durable artifact.
+
+The mandatory order is: live-validate an explicit ref, or conservatively search and create exactly one valid leaf through `lisa-tracker-write` when no unique match exists; idempotently claim it through `lisa-tracker-claim`; then persist and verify the worktree-local binding with `node scripts/lisa-work-item.mjs bind <ref>`. Any tracker, claim, or binding failure blocks durable work.
+
+Carry that canonical ref through the branch, every ordinary commit's `Work-Item:` trailer, the PR, usage/evidence, and `lisa-tracker-sync`. Hooks and CI never create tickets. Keep the binding through interruptions or blocked outcomes; run `node scripts/lisa-work-item.mjs clear` only after merge/deploy/verification, two-way linkage/evidence, and the tracker item have all reached true terminal completion.

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -677,6 +677,7 @@ The shim → vendor mapping is fixed:
 | `lisa-tracker-validate` | `lisa-jira-validate-ticket` | `lisa-github-validate-issue` | `lisa-linear-validate-issue` |
 | `lisa-tracker-verify` | `lisa-jira-verify` | `lisa-github-verify` | `lisa-linear-verify` |
 | `lisa-tracker-read` | `lisa-jira-read-ticket` | `lisa-github-read-issue` | `lisa-linear-read-issue` |
+| `lisa-tracker-claim` | `lisa-jira-claim` | `lisa-github-claim` | `lisa-linear-claim` |
 | `lisa-tracker-evidence` | `lisa-jira-evidence` | `lisa-github-evidence` | `lisa-linear-evidence` |
 | `lisa-tracker-sync` | `lisa-jira-sync` | `lisa-github-sync` | `lisa-linear-sync` |
 | `lisa-tracker-add-journey` | `lisa-jira-add-journey` | `lisa-github-add-journey` | `lisa-linear-add-journey` |
@@ -689,7 +690,7 @@ The `tracker-source-artifacts` skill (formerly `tracker-source-artifacts`) is re
 ## Caller responsibilities
 
 - **PRD-source skills** (`notion-to-tracker`, `confluence-to-tracker`, `linear-to-tracker`, `github-to-tracker`) MUST invoke `tracker-write` and `tracker-validate` — never `jira-write-ticket` / `github-write-issue` / `linear-write-issue` directly. This is what makes a project's destination switchable via config.
-- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
+- **Lifecycle skills** (`implement`, `verify`, `monitor`) MUST invoke `tracker-read`, `tracker-claim`, `tracker-evidence`, `tracker-sync` for ticket interaction — never the vendor-specific equivalents.
 - **Per-vendor PRD intake skills** (`notion-prd-intake`, `confluence-prd-intake`, `linear-prd-intake`, `github-prd-intake`) compose the PRD-source skills (which in turn invoke the shims) — they do not need to read `tracker` themselves.
 - **Vendor-specific destination skills** (`jira-*`, `github-*`, `linear-*`) read their own vendor config section directly. They do NOT consult `tracker` — they are the targets of dispatch, not the dispatchers.
 

--- a/plugins/src/base/rules/reference/tracked-work.md
+++ b/plugins/src/base/rules/reference/tracked-work.md
@@ -1,0 +1,26 @@
+# Tracked Work
+
+The project tracker is the durable operator-facing record for project work. Every session that will produce a durable project outcome must establish exactly one live configured-tracker leaf before the first durable mutation. Durable outcomes include code, tests, configuration, documentation, committed research or plans, investigation findings, commits, and pull requests. Read-only questions, discussion, and repository orientation are exempt until they turn into durable work.
+
+## Resolve, claim, bind
+
+Use `lisa-track` as the single entry point:
+
+1. An explicit ticket is live-read through `lisa-tracker-read` and rejected if it is missing, inaccessible, terminal, a container, outside the configured project, or outside the current repository.
+2. A plain-text request or specification file is searched conservatively within the configured project. Reuse only one uniquely high-confidence matching live leaf. If no unique match exists, create exactly one complete single-repository leaf through `lisa-tracker-write`; never create a thin placeholder or a container.
+3. Idempotently claim the resolved leaf through `lisa-tracker-claim`, which reuses the vendor build-intake claim semantics and post-read verifies the claimed-or-later state.
+4. Before any durable repository work, persist the canonical reference with `node scripts/lisa-work-item.mjs bind <ref>` and verify the worktree-local binding.
+
+The sequence is strict: **live validate/create -> claim -> bind -> durable work**. A failed tracker read/write, claim, or binding blocks the work. Tracker availability must be proven; tool presence or stale session text is not access.
+
+## One canonical identity
+
+The binding is authoritative for the worktree. Branches, commits, pull requests, usage accounting, evidence, and tracker-sync operations all carry the same canonical ref. Branch names are helpful discovery metadata but are not authoritative. After branch creation, `node scripts/lisa-work-item.mjs attach-branch` may attach the local branch to the binding.
+
+Linkage is unconditional for an Implement flow because its input gate always establishes a work item. PR creation must pass the ref to `lisa-git-submit-pr`; `lisa-tracker-sync` must prove the reverse native link or its managed fallback.
+
+## Binding lifetime
+
+Binding state is local machine state and must remain untracked. Keep it through interruptions and blocked outcomes. Run `node scripts/lisa-work-item.mjs clear` only after true terminal completion: required merge/deploy/verification is complete, evidence and two-way PR linkage are recorded, and the tracker item is in its terminal state. Verify that no current binding remains before ending the completed flow.
+
+Git hooks and CI enforce this contract but never create work items. Their recovery message directs the operator to mention the related ticket or run `/lisa:track <description>` to create and bind one.

--- a/plugins/src/base/skills/lisa-github-claim/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-github-claim
+description: "Idempotently claims one live GitHub leaf issue for direct Lisa work. Reuses github-build-intake Phase 3b semantics: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim GitHub Issue: $ARGUMENTS
+
+Claim exactly one canonical `org/repo#<number>` reference. This is the reusable direct-session counterpart of `lisa-github-build-intake` Phase 3b.
+
+1. Resolve merged `.github.org`, `.github.repo`, optional `.github.queueRepo`, and `github.labels.build` values from local-over-global config. Resolve current-repository identity independently using `repo-scope-split` / `config-resolution` (`.repo` -> `.github.repo` -> `git remote get-url origin` basename). The queue repository defaults to `<github.org>/<github.repo>`; it is only the tracker storage/scan target and never replaces current-repository identity. Resolve the ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Require the ref's `org/repo` to equal the resolved queue repository. Invoke `lisa-github-read-issue <ref>` immediately before mutation. When the queue repository differs from the current repository, require exactly the current-repository scope (`repo:<current>`); reject an unlabeled issue, `repo:<other>`, or an ambiguous multi-repo leaf. Also reject a closed issue, an active blocker, any issue with open child work, or a childless Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live build lifecycle labels:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> run `gh issue edit <number> --repo <org>/<repo>`, remove ready when present, and add claimed. This is the idempotency lock.
+   - Terminal label/state -> reject; completed work cannot be rebound as new work.
+4. If and only if the issue is unassigned, add `@me`; leave every existing assignee untouched.
+5. Post the stable marker comment once, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-github-read-issue <ref>` again. Success requires the issue to remain open, leaf/current-repo (including the explicit `repo:<current>` proof for an umbrella queue), and in claimed or a later non-terminal role. If the relabel or verification fails, return failure and do not authorize a binding.
+7. Return `tracker_provider: github`, canonical `work_item_ref: <org>/<repo>#<number>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an issue here. Never call GitHub for a configured Jira or Linear project.

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -34,18 +34,26 @@ Treat the first successful lead-spawn request (or, on the Codex fallback, the fi
 
 ## Resolve the input (first task assigned to the team)
 
-$ARGUMENTS is either a url to a ticket containing the request, a pointer to a file containing the request, or the request in text format.
+$ARGUMENTS is either a URL/key for an existing work item, a pointer to a file containing the request, or the request in text format. Every form must resolve to exactly one live, claimed tracker leaf and a verified worktree binding before the lead may begin durable work.
 
 The team lead does NOT read the input directly. The first task on the team's plan is "resolve the input" — assigned to a bounded input-resolver teammate, which then:
 
-- If it's a ticket, calls `lisa-tracker-read` (preferred — vendor-agnostic; dispatches per `.lisa.config.json` `tracker`). **Mismatch guard**: if the ticket format doesn't match the configured tracker (e.g., a GitHub URL when `tracker` is `jira`), `tracker-read` stops and reports the error — never auto-translates vendors:
-  - JIRA ticket → `lisa-tracker-read` → `lisa-jira-read-ticket`
-  - GitHub Issue → `lisa-tracker-read` → `lisa-github-read-issue`
-  - Linear identifier or project URL → `lisa-tracker-read` → `lisa-linear-read-issue`
-  - Captures comments and metadata, not just the description.
-- If it's a file, reads the entire file without offset or limit.
-- If it's a plain-text request, uses the provided text verbatim as the resolved input.
-- Returns the resolved input to the team lead, who then proceeds to roster selection.
+The input-resolver invokes `lisa-track $ARGUMENTS` and owns its complete resolve -> claim -> bind transaction:
+
+- **Explicit ticket:** call `lisa-tracker-read` against the configured tracker and require a live open/unresolved current-project leaf. **Mismatch guard:** if the ticket format/project does not match the configured tracker (for example, a GitHub URL when `tracker` is `jira`), stop — never auto-translate vendors or trust pasted/stale ticket text. The read captures comments, graph, and metadata, not just the description.
+- **Specification file:** read the entire file without offset or limit, preserve it as the resolved input, and follow the plain-text resolution path below.
+- **Plain text or file contents:** search the configured project conservatively for open leaves describing the same outcome. Live-validate every candidate through `lisa-tracker-read`; reuse only exactly one high-confidence match. When there is no unique match (zero or ambiguous candidates), synthesize one complete single-repository leaf and invoke `lisa-tracker-write` exactly once with `build_ready: true`, then live-read its canonical returned ref. Never create a thin placeholder, hierarchy, or container.
+- **Claim:** invoke `lisa-tracker-claim <canonical-ref>` and require the provider skill's post-read verified `claimed|reused` result. A failed or inaccessible claim blocks the flow.
+- **Bind before durable work:** only after the verified claim, run:
+
+  ```bash
+  node scripts/lisa-work-item.mjs bind <canonical-ref>
+  ```
+
+  Require a successful readback of that worktree-local binding. On detached HEAD, `branch: null` is the expected pending binding; after branch creation the mandatory `attach-branch` step below must replace it before any commit. Tracker or binding failure stops the flow; never continue untracked.
+- Return the full resolved work-item context plus `tracker_provider`, canonical `work_item_ref`, resolution outcome, claim outcome, and verified binding to the team lead, who then proceeds to roster selection.
+
+The input resolver may perform these tracker and local-binding operations before the Roster Decision because they are the mandatory gate that establishes what work the team is allowed to do. No project source, documentation, plan artifact, branch, or task may be created or changed before this transaction succeeds. Read-only discussion/orientation outside an Implement flow remains exempt per the `tracked-work` rule.
 
 The input resolver is the only teammate that may be spawned before the Roster Decision exists. After it returns the resolved input, do not spawn any lifecycle, research, implementation, review, verification, or learning teammate until the Roster Decision has been recorded.
 
@@ -86,13 +94,14 @@ Using the general-purpose agent in Team Lead session, **determine the base branc
    - **Rebase the feature branch onto `origin/<base>` and resolve any merge conflicts BEFORE starting work.** If the conflicts cannot be resolved cleanly and safely, create a fix task for the agent team (with the conflicting file list and current merge state) and resolve it before implementation begins — never start work on stale or conflicted code.
 4. **The PR targets the resolved base branch** — carry it as `target_branch=<base>` into `lisa-git-submit-pr` (Verify flow). `git-submit-pr` already chooses a closing keyword when the base is the production/default branch and a non-closing reference for a non-terminal environment branch. For a bug fixed on a non-integration environment branch, the current flow is not done until the fix is merged and verified there, then forward cherry-picked down to the integration branch via a linked follow-up.
 
-When the request came from a tracker work item, preserve its native identifier for development linkage:
+Every Implement run now has a tracker work item. Preserve its canonical identifier for development linkage unconditionally:
 
-- Capture `tracker_provider` and `work_item_ref` from the resolved input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`.
+- Capture `tracker_provider` and `work_item_ref` from the tracked input before creating or reusing a branch. Examples: `github` + `CodySwannGT/lisa#614`, `linear` + `ENG-123`, `jira` + `ENG-123`. Missing linkage is a workflow failure, never an optional/no-ticket mode.
 - If a new branch is needed and the provider can link branches by identifier, include the identifier in the branch name before the human-readable slug. Linear and JIRA integrations commonly link from branch names; GitHub issue linkage is PR-body driven, but including the issue number in the branch name is still useful. Keep branch names URL-safe, for example `codex/ENG-123-add-checkout-copy` or `codex/614-add-checkout-copy`.
+- After the feature branch exists, run `node scripts/lisa-work-item.mjs attach-branch` so the worktree-local binding records the actual branch without treating the branch name as authority.
 - Pass the work-item ref and target branch to `lisa-git-submit-pr` when opening or updating the PR, for example `work_item_ref=CodySwannGT/lisa#614 target_branch=<base resolved from the ticket's environment above>` (not hardcoded `main`). The PR workflow owns provider-specific body text and must decide whether to use a closing keyword or a non-closing reference.
 - After `lisa-git-submit-pr` returns a PR URL, ensure the reverse backlink is present on the source work item by running `lisa-tracker-sync <work_item_ref> pr-ready pr_url=<url> tracker_provider=<provider>`. The sync path must prefer native provider linkage and fall back to one managed `[lisa-pr-link]` comment when native linkage is unavailable or cannot be verified.
-- If the provider has no native branch or PR development-linkage surface, continue without linkage and mention that the provider was skipped.
+- If the provider has no native branch or PR development-linkage surface, the managed `[lisa-pr-link]` fallback is required; never continue without proven ticket-side linkage.
 
 Using the general-purpose agent in Team Lead session, Determine which flow applies:
 1. Research -- needs a PRD (no specification exists)
@@ -214,12 +223,13 @@ Before shutting down the team, execute the Verify flow:
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).
 6. Push the changes - if any pre-push hook blocks you, create a task for the agent team to fix the error/problem whether it was pre-existing or not
-7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the work-item ref when one exists so the PR can be linked natively to the source issue.
+7. Open a pull request with auto-merge on via `lisa-git-submit-pr`, targeting the **base branch resolved from the ticket's environment** (`target_branch=<base>`, per the branch step above), and including the mandatory work-item ref so the PR can be linked natively to the source issue.
 7a. Confirm two-way linkage before treating PR submission as complete: the PR body/title/branch must reference the work item, and the work item must have either a verified native PR link or a single managed `[lisa-pr-link]` fallback comment from `lisa-tracker-sync`.
 8. PR Watch Loop: Drive the PR to merge via the `drive-pr-to-merge` skill — the single source of truth for clearing every blocker (auto-merge with direct-merge fallback, `BEHIND` re-sync, conflict resolution, failing-check fixes, human + bot review-comment handling with thread resolution, stale `CHANGES_REQUESTED` dismissal, and post-merge ancestry verification). `git-submit-pr` already invokes it; if you reach this step with a PR already open, invoke `drive-pr-to-merge` directly with the PR number. For a large review backlog you may fan the code-fix work out to the agent team, but `drive-pr-to-merge` owns the loop and the terminal conditions — do not re-implement them.
-9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>` when a work item exists.
+9. Merge the PR, then refresh the ticket-side backlink with `lisa-tracker-sync <work_item_ref> pr-merged pr_url=<url> merge_sha=<sha> tracker_provider=<provider>`.
 10. Monitor the deploy action that triggers automatically from the successful merge
 11. If deploy fails, create a task for the agent team to fix the failure, open a new PR and then go back to step 7
 12. Remote verification: `verification-specialist` verifies in target environment (same checks as local verification, but on remote), and refreshes the verdict (step 2a) to reflect the remote result.
 13. `ops-specialist`: post-deploy health check, monitor for errors in first minutes
 14. If remote verification fails, create a task for the agent team to find out why it failed, fix it and return to step 5. **Bound this loop**: after a small number of full fix→deploy→reverify cycles without reaching a passing remote verdict (treat ~3 as the ceiling unless the work item states otherwise), stop retrying — file a build-ready fix ticket, write the verdict with `status: "blocked"` and the diagnosis, and move the work item to blocked rather than looping indefinitely. The completion gate releases on a `blocked` verdict, so the flow ends with a recorded outcome instead of a silent spin or a self-declared success.
+15. After true terminal completion — required merge/deploy/verification passed, usage/evidence and two-way PR linkage are recorded, and the work item is terminal — run `node scripts/lisa-work-item.mjs clear` and verify the worktree has no current binding. Do not clear on an interruption or blocked outcome; preserving the binding is what keeps resumed work attributable.

--- a/plugins/src/base/skills/lisa-jira-claim/SKILL.md
+++ b/plugins/src/base/skills/lisa-jira-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-jira-claim
+description: "Idempotently claims one live Jira leaf ticket for direct Lisa work. Reuses jira-build-intake Phase 3b semantics through lisa-atlassian-access: configured ready-to-claimed transition, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Jira Ticket: $ARGUMENTS
+
+Claim exactly one canonical Jira key. All Jira access goes through `lisa-atlassian-access`; do not call MCP tools or `acli` directly. This is the reusable direct-session counterpart of `lisa-jira-build-intake` Phase 3b.
+
+1. Resolve merged `atlassian.cloudId`, `jira.project`, and `jira.workflow` values from local-over-global config. Require the key's project prefix to equal the configured Jira project. Resolve ready, claimed, review, environment, and terminal roles from config; do not hardcode status decisions.
+2. Invoke `lisa-jira-read-ticket <key>` immediately before mutation. Reject a resolved/terminal ticket, active blocker, `repo:<other>` ticket, any item with open children/subtasks, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect the live workflow role:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or an unlaned backlog leaf -> invoke `lisa-atlassian-access operation: transition key: <key> to: <configured-claimed>` and require success. This is the idempotency lock.
+   - Terminal/resolved -> reject; never regress completed work.
+4. If and only if the ticket is unassigned, assign it to the authenticated account through `lisa-atlassian-access` (prefer the identity-probed account id / `@me` semantics documented by Jira build intake). Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-atlassian-access operation: comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-jira-read-ticket <key>` again. Success requires an unresolved, current-repo leaf in claimed or a later non-terminal role. An unreachable transition or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: jira`, canonical `work_item_ref: <KEY>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create a ticket here. Never bypass `lisa-atlassian-access`.

--- a/plugins/src/base/skills/lisa-linear-claim/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-claim/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: lisa-linear-claim
+description: "Idempotently claims one live Linear leaf issue for direct Lisa work. Reuses linear-build-intake Phase 3b semantics through lisa-linear-access: configured ready-to-claimed relabel, assign-only-if-unassigned, stable managed comment, and post-write verification."
+allowed-tools: ["Bash", "Skill", "Read"]
+---
+
+# Claim Linear Issue: $ARGUMENTS
+
+Claim exactly one canonical Linear identifier such as `ENG-123`. All Linear access goes through `lisa-linear-access`. This is the reusable direct-session counterpart of `lisa-linear-build-intake` Phase 3b.
+
+1. Resolve merged `linear.workspace`, `linear.teamKey`, and Linear build-label roles from local-over-global config. Require the identifier's team key to equal the configured team. Resolve ready and claimed roles from config (defaults `status:ready` and `status:in-progress`); do not hardcode lifecycle decisions.
+2. Invoke `lisa-linear-read-issue <identifier>` immediately before mutation. Reject a completed/canceled issue, active blocker, `repo:<other>` issue, any issue with open sub-Issues, or an Epic per `repo-scope-split` and `leaf-only-lifecycle`.
+3. Inspect live build labels/workflow state:
+   - Already claimed, review, environment-done, or another configured later non-terminal role -> preserve it and set `claim_outcome: reused`.
+   - Ready or no build lifecycle label -> invoke `lisa-linear-access operation: save-issue`, remove ready when present, and add claimed (resolve label IDs with `list-issue-labels`, creating claimed only when missing). This is the idempotency lock.
+   - Terminal/completed -> reject; never regress completed work.
+4. If and only if the Issue is unassigned, resolve the authenticated viewer and set its `assigneeId` through `lisa-linear-access operation: save-issue`. Leave an existing assignee untouched.
+5. Post this stable comment once through `lisa-linear-access operation: save-comment`, deduped against all existing comments:
+
+   ```text
+   [lisa-tracker-claim] Claimed by Lisa. Starting implementation.
+   ```
+
+6. Invoke `lisa-linear-read-issue <identifier>` again. Success requires a non-terminal, current-repo leaf in claimed or a later non-terminal role. A failed relabel or failed verification is a hard failure and must not authorize a binding.
+7. Return `tracker_provider: linear`, canonical `work_item_ref: <IDENTIFIER>`, `claim_outcome: claimed|reused`, assignee outcome, and the post-write status evidence.
+
+Never create an Issue here. Never bypass `lisa-linear-access`.

--- a/plugins/src/base/skills/lisa-track/SKILL.md
+++ b/plugins/src/base/skills/lisa-track/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lisa-track
+description: "Resolves exactly one live configured-tracker leaf for durable project work, claims it idempotently, and persists its canonical reference in worktree-local state. Accepts an existing Jira/GitHub/Linear ref, a spec file, or plain text. Use directly to mention/create the related ticket, and as lisa-implement's mandatory input gate."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Track Work: $ARGUMENTS
+
+Establish the tracked-work invariant before any durable project mutation. Discussion and read-only orientation may proceed without this skill; code, configuration, documentation, research artifacts, plans, investigation findings, tests, commits, and pull requests may not.
+
+This flow must return exactly one canonical `(tracker_provider, work_item_ref)` pair or fail closed. It never returns an unvalidated textual guess.
+
+## Phase 1 — Resolve tracker and classify input
+
+1. Resolve merged `.lisa.config.local.json` over `.lisa.config.json` exactly as `lisa-tracker-read` / `lisa-tracker-write` do. Missing, unknown, or incomplete tracker configuration is a blocking error.
+2. Classify `$ARGUMENTS` as exactly one of:
+   - an explicit reference matching the configured tracker (`KEY-123`, `org/repo#123` or issue URL, Linear team identifier);
+   - an existing file path containing a specification (read the entire file, without offset/limit);
+   - plain-text work description.
+3. Preserve the full resolved specification for the caller. Do not treat a ticket-like token for a different provider/project as plain text; report the mismatch.
+
+## Phase 2 — Resolve one live work item
+
+### Explicit reference
+
+Invoke `lisa-tracker-read <ref>` and require a live result from the configured project. Reject nonexistent, inaccessible, closed/resolved/terminal, wrong-project, wrong-repository, or container items. This live read is mandatory even if caller context already includes ticket text.
+
+### File or plain text
+
+Search conservatively before creating:
+
+1. Normalize the requested outcome and derive a short keyword set; never search with the whole prompt or secrets.
+2. Search only open/non-terminal items in the configured project and current repository through the configured provider's documented read surface:
+   - GitHub: `gh issue list --repo <org>/<repo> --state open --search "<keywords> in:title,body"`.
+   - Jira: `lisa-atlassian-access operation: search-issues` with project-scoped JQL.
+   - Linear: `lisa-linear-access operation: list-issues` scoped to the configured team/workspace.
+3. Treat search results as candidates, never proof. Live-read each plausible candidate through `lisa-tracker-read`, and discard terminal, container, blocked, cross-repo, and materially different outcomes.
+4. Reuse only when **exactly one** live leaf is a high-confidence semantic match for the same requested outcome and repository. A shared keyword or similar title is not enough. Record the search queries, candidates, and rejection reasons in the returned resolution evidence.
+5. If there is no unique high-confidence match (zero or ambiguous candidates), create **exactly one** item by invoking `lisa-tracker-write` once. Synthesize one complete single-repository leaf (`Bug`, `Task`, `Sub-task`, or `Improvement`, never Epic/container) with the writer's required three-audience body, Gherkin acceptance criteria, repository, target environment, relationship search, and executable Validation Journey. Pass `build_ready: true`. Do not create placeholder/thin tickets, do not create a hierarchy, and do not retry creation by making another item if validation fails; repair the proposed spec and retry the same writer operation only if the vendor contract supports idempotent reuse.
+6. Live-read the writer's canonical returned reference with `lisa-tracker-read`. A create response without a verified live leaf is failure.
+
+This is intentionally conservative: ambiguity creates one explicit work item instead of silently attaching work to the wrong existing item. Across the entire invocation, at most one new work item may be created.
+
+## Phase 3 — Claim and bind
+
+1. Invoke `lisa-tracker-claim <canonical-ref>`. Require its post-read verified `claim_outcome: claimed|reused`; no binding may be written after a failed/unverified claim.
+2. Persist only the canonical reference in worktree-local machine state:
+
+   ```bash
+   node scripts/lisa-work-item.mjs bind <canonical-ref>
+   ```
+
+3. Read the binding back through `node scripts/lisa-work-item.mjs current` and require it to equal the canonical reference. If binding fails, stop before durable project work.
+   - A detached-HEAD worktree is valid at this stage: the binding records `branch: null` as a pending state. Create the feature branch only after the gate succeeds, then run `node scripts/lisa-work-item.mjs attach-branch`. Commit preparation and validation fail closed until that attachment succeeds.
+4. Return this structured result plus the full resolved work-item context:
+
+   ```text
+   tracker_provider: jira|github|linear
+   work_item_ref: <canonical-ref>
+   resolution_outcome: explicit|reused|created
+   claim_outcome: claimed|reused
+   binding_outcome: verified
+   ```
+
+## Lifecycle
+
+- The binding is worktree-local, uncommitted machine state. Never write it into tracked source files.
+- Branch setup may call `node scripts/lisa-work-item.mjs attach-branch` after the feature branch exists.
+- Keep the binding across ordinary interruptions and blocked outcomes so resumed work remains attributable.
+- Clear it only after true terminal completion — merged, deployed/verified where required, tracker evidence/backlink complete, and the work item terminal — by running `node scripts/lisa-work-item.mjs clear` and verifying no current binding remains.
+- A tracker outage, invalid item, failed claim, or failed binding blocks durable work. Never continue untracked and never ask a Git hook to create the item.

--- a/plugins/src/base/skills/lisa-tracker-claim/SKILL.md
+++ b/plugins/src/base/skills/lisa-tracker-claim/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lisa-tracker-claim
+description: "Vendor-neutral dispatcher for idempotently claiming one already live-validated leaf work item. Reads the required tracker from .lisa.config.json and delegates to lisa-jira-claim, lisa-github-claim, or lisa-linear-claim. The vendor skill owns the post-read leaf/open guard, ready-to-claimed mutation, attributable assignment, and post-write verification."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Tracker Claim: $ARGUMENTS
+
+Thin dispatcher. `$ARGUMENTS` must contain exactly one canonical work-item reference. The caller must have already fetched it with `lisa-tracker-read`; each vendor claim skill independently repeats the live read before mutation and verifies the claim afterward so stale caller context cannot authorize a write.
+
+## Workflow
+
+1. Resolve merged tracker config exactly as `lisa-tracker-write` does:
+
+   ```bash
+   local_tracker=$(jq -r '.tracker // empty' .lisa.config.local.json 2>/dev/null)
+   global_tracker=$(jq -r '.tracker // empty' .lisa.config.json 2>/dev/null)
+   tracker="${local_tracker:-$global_tracker}"
+   ```
+
+2. Dispatch without changing `$ARGUMENTS`:
+   - Missing / empty -> stop and report `"No tracker configured in .lisa.config.json. Run /lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear first."`
+   - `jira` -> invoke `lisa-jira-claim`.
+   - `github` -> invoke `lisa-github-claim`.
+   - `linear` -> invoke `lisa-linear-claim`.
+   - Anything else -> stop and report `"Unknown tracker '<value>' in .lisa.config.json. Expected 'jira', 'github', or 'linear'."`
+3. Return the vendor result unchanged. Success must include `tracker_provider`, canonical `work_item_ref`, `claim_outcome: claimed|reused`, and the post-write live-read evidence.
+
+## Contract
+
+- Claim only an open/unresolved, current-repository leaf per `leaf-only-lifecycle` and `repo-scope-split`. Never claim a container, terminal item, inaccessible item, or item from a different configured project.
+- Preserve later active lifecycle states. If the item is already in the configured claimed role or a later non-terminal role, return `reused`; never move it backward.
+- A fresh claim uses the same idempotency lock as the three build-intake Phase 3b flows: move configured ready to configured claimed, or place an unlaned backlog leaf directly in claimed; assign to the authenticated user only when unassigned; never replace an existing owner.
+- Fail closed if the mutation or post-write read cannot prove the claimed-or-later state. A tracker outage is a blocker, not permission to work untracked.
+- This skill claims existing work only. It never creates a ticket and never writes the worktree binding.

--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -17,13 +17,23 @@ pre-commit:
       # inside a git worktree (the inherited GIT_DIR points at the wrong repo).
       run: env -u GIT_DIR -u GIT_WORK_TREE bundle exec bundler-audit check --update
 
+prepare-commit-msg:
+  commands:
+    work-item-trailer:
+      run: node scripts/lisa-work-item.mjs prepare-commit-msg {1} {2} {3}
+
 commit-msg:
   commands:
+    work-item:
+      run: node scripts/lisa-work-item.mjs validate-commit {1}
     conventional-commit:
       run: 'head -1 {1} | grep -qE "^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\(.+\))?: .+" || (echo "Commit message must follow conventional format" && exit 1)'
 
 pre-push:
   commands:
+    work-item:
+      run: node scripts/lisa-work-item.mjs validate-push {1}
+      use_stdin: true
     rspec:
       run: bundle exec rspec
     brakeman:

--- a/scripts/lisa-work-item.mjs
+++ b/scripts/lisa-work-item.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+// The installed copy lives under all/copy-overwrite. Keeping this tiny entrypoint
+// makes the exact same implementation available to Lisa's own hooks and CI.
+await import("../all/copy-overwrite/scripts/lisa-work-item.mjs");

--- a/tests/unit/hooks/commit-msg.test.ts
+++ b/tests/unit/hooks/commit-msg.test.ts
@@ -9,6 +9,7 @@
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
+  copyFileSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -17,6 +18,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+
+import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const HOOK_PATH = path.resolve(".husky/commit-msg");
 const BASH_PATH = "/bin/bash";
@@ -27,6 +30,11 @@ const OPENCODE_TRAILER = "Co-authored-by: OpenCode <noreply@opencode.ai>";
 const OPENCODE_AGENT_TRAILER = "AI-Agent: OpenCode";
 const OPENCODE_MODEL_HINT = "AI-Model: <provider/model>";
 const OPENCODE_EFFORT_HINT = "AI-Effort: <effort or runtime value>";
+const WORK_ITEM_REF = "acme/widgets#42";
+const WORK_ITEM_TRAILER = `Work-Item: ${WORK_ITEM_REF}`;
+const TRACKER_SCRIPT = path.resolve(
+  "all/copy-overwrite/scripts/lisa-work-item.mjs"
+);
 
 let tempDirs: string[] = [];
 
@@ -46,7 +54,13 @@ describe("commit-msg hook diagnostics", () => {
         "printf '%s\\n' '✖   subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]'",
         "exit 1",
       ].join("\n"),
-      message: "Fix Bad Subject\n\nCo-authored-by: Codex <codex@openai.com>\n",
+      message: [
+        "Fix Bad Subject",
+        "",
+        WORK_ITEM_TRAILER,
+        "Co-authored-by: Codex <codex@openai.com>",
+        "",
+      ].join("\n"),
     });
 
     const result = runHook(project);
@@ -61,7 +75,7 @@ describe("commit-msg hook diagnostics", () => {
     const project = createProject({
       binName: "npx",
       binBody: PASSING_COMMITLINT_BIN,
-      message: `${VALID_SUBJECT}\n`,
+      message: `${VALID_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n`,
     });
 
     const result = runHook(project);
@@ -85,6 +99,7 @@ describe("commit-msg hook diagnostics", () => {
       message: [
         VALID_SUBJECT,
         "",
+        WORK_ITEM_TRAILER,
         OPENCODE_TRAILER,
         OPENCODE_AGENT_TRAILER,
         "AI-Model: openai/gpt-5.5",
@@ -102,7 +117,13 @@ describe("commit-msg hook diagnostics", () => {
     const project = createProject({
       binName: "npx",
       binBody: PASSING_COMMITLINT_BIN,
-      message: [VALID_SUBJECT, "", OPENCODE_TRAILER, ""].join("\n"),
+      message: [
+        VALID_SUBJECT,
+        "",
+        WORK_ITEM_TRAILER,
+        OPENCODE_TRAILER,
+        "",
+      ].join("\n"),
     });
 
     const result = runHook(project);
@@ -133,15 +154,39 @@ type ProjectOptions = {
  */
 function createProject(options: ProjectOptions): string {
   const project = mkdtempSync(path.join(tmpdir(), "lisa-commit-msg-"));
+  const gitEnv = cleanGitEnv(process.env);
   tempDirs.push(project);
   mkdirSync(path.join(project, "node_modules", ".bin"), { recursive: true });
+  mkdirSync(path.join(project, "scripts"), { recursive: true });
   writeFileSync(path.join(project, "package-lock.json"), "{}\n");
+  writeFileSync(
+    path.join(project, ".lisa.config.json"),
+    '{"tracker":"github","github":{"org":"acme","repo":"widgets"}}\n'
+  );
   writeFileSync(path.join(project, "COMMIT_EDITMSG"), options.message);
+  copyFileSync(
+    TRACKER_SCRIPT,
+    path.join(project, "scripts/lisa-work-item.mjs")
+  );
   writeBin(project, options.binName, options.binBody);
-  spawnSync(GIT_PATH, ["init"], { cwd: project, encoding: "utf8" });
+  writeBin(
+    project,
+    "gh",
+    `if [ "\${1:-} \${2:-}" = "api graphql" ]; then
+  printf '%s\\n' '{"data":{"repository":{"issue":{"subIssues":{"nodes":[]}}}}}'
+else
+  printf '%s\\n' '{"number":42,"url":"https://github.com/acme/widgets/issues/42","state":"OPEN","labels":[{"name":"status:in-progress"},{"name":"type:Task"}],"comments":[],"closedByPullRequestsReferences":[]}'
+fi\n`
+  );
+  spawnSync(GIT_PATH, ["init"], {
+    cwd: project,
+    encoding: "utf8",
+    env: gitEnv,
+  });
   spawnSync(GIT_PATH, ["checkout", "-b", "codex/issue-1264"], {
     cwd: project,
     encoding: "utf8",
+    env: gitEnv,
   });
   return project;
 }
@@ -155,10 +200,9 @@ function runHook(project: string): ReturnType<typeof spawnSync> {
   return spawnSync(BASH_PATH, [HOOK_PATH, "COMMIT_EDITMSG"], {
     cwd: project,
     encoding: "utf8",
-    env: {
-      ...process.env,
+    env: cleanGitEnv(process.env, {
       PATH: `${path.join(project, "node_modules", ".bin")}:${process.env.PATH}`,
-    },
+    }),
   });
 }
 

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (file: string): string => readFileSync(path.resolve(file), "utf8");
+
+describe("work-item Git enforcement wiring", () => {
+  it.each([".husky", "typescript/copy-contents/.husky"])(
+    "%s prepares, validates, and checks pushes through the shared validator",
+    directory => {
+      const prepare = path.join(directory, "prepare-commit-msg");
+      expect(statSync(prepare).mode & 0o111).not.toBe(0);
+      expect(read(prepare)).toContain(
+        'node "$WORK_ITEM_SCRIPT" prepare-commit-msg "$@"'
+      );
+      expect(read(path.join(directory, "commit-msg"))).toContain(
+        'node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE"'
+      );
+      expect(read(path.join(directory, "pre-push"))).toContain(
+        'node "$WORK_ITEM_SCRIPT" validate-push "${1:-origin}"'
+      );
+      expect(read(path.join(directory, "commit-msg"))).not.toContain(
+        "Auto-appended Jira key"
+      );
+    }
+  );
+
+  it("ships the validator to Lisa itself and downstream projects", () => {
+    expect(read("scripts/lisa-work-item.mjs")).toContain(
+      "../all/copy-overwrite/scripts/lisa-work-item.mjs"
+    );
+    const installed = read("all/copy-overwrite/scripts/lisa-work-item.mjs");
+    for (const command of [
+      "bind",
+      "current",
+      "attach-branch",
+      "clear",
+      "prepare-commit-msg",
+      "validate-commit",
+      "validate-push",
+      "validate-pr",
+    ]) {
+      expect(installed).toContain(`command === "${command}"`);
+    }
+    expect(installed).toContain("WORK_ITEM_TRACKING_OK");
+  });
+
+  it("gives Rails the same gates and a single stdin consumer", () => {
+    const lefthook = read("rails/copy-overwrite/lefthook.yml");
+    expect(lefthook).toContain(
+      "node scripts/lisa-work-item.mjs prepare-commit-msg {1} {2} {3}"
+    );
+    expect(lefthook).toContain(
+      "node scripts/lisa-work-item.mjs validate-commit {1}"
+    );
+    expect(lefthook).toContain(
+      "node scripts/lisa-work-item.mjs validate-push {1}"
+    );
+    expect(lefthook.match(/use_stdin: true/g)).toHaveLength(1);
+  });
+});

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -1,0 +1,692 @@
+/* eslint-disable max-lines, sonarjs/no-duplicate-string, jsdoc/require-param, jsdoc/require-returns, @eslint-community/eslint-comments/disable-enable-pair -- one hermetic fake-provider fixture exercises the full local tracking contract */
+/**
+ * Hermetic tests for Lisa's provider-neutral work-item Git gate.
+ *
+ * Every case runs in a disposable repository and resolves tracker access through
+ * fake gh/acli/curl executables, so a developer's credentials cannot affect the
+ * result.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { cleanGitEnv } from "../../helpers/test-utils.js";
+
+const SCRIPT = path.resolve("scripts/lisa-work-item.mjs");
+const GIT = "/usr/bin/git";
+const ZERO_OID = "0".repeat(40);
+const IDENTITY = {
+  GIT_AUTHOR_NAME: "Lisa Test",
+  GIT_AUTHOR_EMAIL: "lisa@example.test",
+  GIT_COMMITTER_NAME: "Lisa Test",
+  GIT_COMMITTER_EMAIL: "lisa@example.test",
+};
+
+/** Captured validator process result. */
+interface CommandResult {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+/** Disposable repository and its isolated executable environment. */
+interface Fixture {
+  bin: string;
+  env: NodeJS.ProcessEnv;
+  root: string;
+}
+
+let fixtures: string[] = [];
+
+afterEach(() => {
+  for (const fixture of fixtures)
+    rmSync(fixture, { force: true, recursive: true });
+  fixtures = [];
+});
+
+/** Write an executable fake CLI. */
+function executable(file: string, body: string): void {
+  writeFileSync(file, `#!/bin/sh\nset -eu\n${body}\n`);
+  chmodSync(file, 0o755);
+}
+
+/** Run Git inside a disposable fixture. */
+function git(root: string, args: string[], env: NodeJS.ProcessEnv): string {
+  const result = spawnSync(GIT, args, { cwd: root, encoding: "utf8", env });
+  if (result.status !== 0)
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  return result.stdout.trim();
+}
+
+/** Run the validator entrypoint inside a disposable fixture. */
+function command(
+  fixture: Fixture,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; input?: string } = {}
+): CommandResult {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: fixture.root,
+    encoding: "utf8",
+    env: { ...fixture.env, ...options.env },
+    input: options.input,
+  });
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+/** Create an initialized repository with fake tracker transports. */
+function createFixture(config: object = githubConfig()): Fixture {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-work-item-"));
+  const bin = path.join(root, "fake-bin");
+  const env = cleanGitEnv(process.env, {
+    ...IDENTITY,
+    FAKE_ACLI_JSON:
+      '{"key":"LAS-12","fields":{"project":{"key":"LAS"},"status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},"labels":["repo:widgets"],"issuetype":{"name":"Task"},"subtasks":[],"comment":{"comments":[]}}}',
+    FAKE_CURL_JSON:
+      '{"data":{"issue":{"id":"id-12","identifier":"LIN-12","team":{"key":"LIN"},"state":{"type":"started"},"labels":{"nodes":[{"name":"repo:widgets"},{"name":"status:in-progress"},{"name":"type:Task"}]},"children":{"nodes":[]},"attachments":{"nodes":[]},"comments":{"nodes":[]}}}}',
+    FAKE_GH_ISSUE_JSON:
+      '{"number":42,"url":"https://github.com/acme/widgets/issues/42","state":"OPEN","labels":[{"name":"repo:identity"},{"name":"status:in-progress"},{"name":"type:Bug"}],"comments":[],"closedByPullRequestsReferences":[]}',
+    FAKE_GH_HIERARCHY_JSON:
+      '{"data":{"repository":{"issue":{"subIssues":{"nodes":[]}}}}}',
+    FAKE_GH_PR_JSON:
+      '{"url":"https://github.com/acme/code/pull/7","body":"Work-Item: acme/widgets#42","state":"OPEN"}',
+    GITHUB_REPOSITORY: "acme/code",
+    LINEAR_API_KEY: "fake-linear-key",
+    PATH: `${bin}:${process.env.PATH ?? ""}`,
+  });
+
+  fixtures.push(root);
+  mkdirSync(bin);
+
+  executable(
+    path.join(bin, "gh"),
+    `
+if [ -n "\${FAKE_GH_LOG:-}" ]; then printf '%s\\n' "$*" >> "$FAKE_GH_LOG"; fi
+case "\${1:-} \${2:-}" in
+  "issue view")
+    if [ "\${3:-}" = "43" ]; then
+      printf '%s\\n' '{"number":43,"state":"OPEN","labels":[{"name":"status:in-progress"},{"name":"type:Bug"}],"comments":[],"closedByPullRequestsReferences":[]}'
+    else
+      printf '%s\\n' "$FAKE_GH_ISSUE_JSON"
+    fi
+    ;;
+  "api graphql") printf '%s\\n' "$FAKE_GH_HIERARCHY_JSON" ;;
+  "pr view")
+    [ "\${FAKE_GH_PR_MISSING:-0}" != "1" ] || exit 1
+    printf '%s\\n' "$FAKE_GH_PR_JSON"
+    ;;
+  "repo view") printf '%s\\n' '{"nameWithOwner":"acme/code"}' ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 70 ;;
+esac`
+  );
+  executable(
+    path.join(bin, "acli"),
+    `
+[ "\${FAKE_ACLI_FAIL:-0}" != "1" ] || exit 1
+if [ "\${1:-} \${2:-}" = "auth status" ]; then
+  printf 'Site: %s\\n' "\${FAKE_ACLI_SITE:-acme.atlassian.net}"
+  exit 0
+fi
+printf '%s\\n' "$FAKE_ACLI_JSON"`
+  );
+  executable(
+    path.join(bin, "curl"),
+    `
+[ "\${FAKE_CURL_FAIL:-0}" != "1" ] || exit 1
+printf '%s\\n' "$FAKE_CURL_JSON"`
+  );
+
+  git(root, ["init", "-q", "-b", "main"], env);
+  writeFileSync(
+    path.join(root, ".lisa.config.json"),
+    `${JSON.stringify(config, null, 2)}\n`
+  );
+  git(root, ["add", ".lisa.config.json"], env);
+  git(root, ["commit", "-q", "-m", "test fixture"], env);
+  git(root, ["switch", "-q", "-c", "feature/tracked"], env);
+  return { bin, env, root };
+}
+
+/** Build the minimal GitHub tracker config. */
+function githubConfig(repository = "widgets"): object {
+  return { tracker: "github", github: { org: "acme", repo: repository } };
+}
+
+/** Add one empty fixture commit and return its object ID. */
+function commit(fixture: Fixture, message: string): string {
+  git(
+    fixture.root,
+    ["commit", "-q", "--allow-empty", "-m", message],
+    fixture.env
+  );
+  return git(fixture.root, ["rev-parse", "HEAD"], fixture.env);
+}
+
+describe("work-item binding and commit messages", () => {
+  it("merges local config, writes worktree-private state atomically, and preserves the subject", () => {
+    const fixture = createFixture(githubConfig("identity"));
+    writeFileSync(
+      path.join(fixture.root, ".lisa.config.local.json"),
+      '{"github":{"queueRepo":"acme/widgets"}}\n'
+    );
+
+    const bound = command(fixture, ["bind", "acme/widgets#42"]);
+    expect(bound.status).toBe(0);
+    const stateFile = path.join(fixture.root, ".git", "lisa", "work-item.json");
+    expect(JSON.parse(readFileSync(stateFile, "utf8"))).toMatchObject({
+      branch: "feature/tracked",
+      provider: "github",
+      ref: "acme/widgets#42",
+      version: 1,
+    });
+    expect(statSync(stateFile).mode & 0o777).toBe(0o600);
+    expect(readdirSync(path.dirname(stateFile))).toEqual(["work-item.json"]);
+
+    const messageFile = path.join(fixture.root, "COMMIT_EDITMSG");
+    writeFileSync(
+      messageFile,
+      "feat: preserve this subject\n\nLonger context.\n"
+    );
+    expect(
+      command(fixture, ["prepare-commit-msg", messageFile, "message"]).status
+    ).toBe(0);
+    expect(
+      command(fixture, ["prepare-commit-msg", messageFile, "message"]).status
+    ).toBe(0);
+
+    const prepared = readFileSync(messageFile, "utf8");
+    expect(prepared.split("\n")[0]).toBe("feat: preserve this subject");
+    expect(prepared.match(/^Work-Item: acme\/widgets#42$/gm)).toHaveLength(1);
+    const validated = command(fixture, ["validate-commit", messageFile]);
+    expect(validated.status).toBe(0);
+    expect(validated.stdout).toContain("WORK_ITEM_TRACKING_OK acme/widgets#42");
+  });
+
+  it("fails closed for missing, duplicate, mismatched, and closed GitHub work items", () => {
+    const fixture = createFixture();
+    expect(command(fixture, ["bind", "acme/widgets#42"]).status).toBe(0);
+    const messageFile = path.join(fixture.root, "COMMIT_EDITMSG");
+
+    for (const message of [
+      "fix: missing trailer\n",
+      "fix: duplicate\n\nWork-Item: acme/widgets#42\nWork-Item: acme/widgets#42\n",
+      "fix: wrong repo\n\nWork-Item: acme/elsewhere#42\n",
+    ]) {
+      writeFileSync(messageFile, message);
+      const result = command(fixture, ["validate-commit", messageFile]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "Mention the ticket this work relates to"
+      );
+    }
+
+    writeFileSync(messageFile, "fix: closed\n\nWork-Item: acme/widgets#42\n");
+    const closed = command(fixture, ["validate-commit", messageFile], {
+      env: {
+        FAKE_GH_ISSUE_JSON:
+          '{"number":42,"state":"CLOSED","comments":[],"closedByPullRequestsReferences":[]}',
+      },
+    });
+    expect(closed.status).toBe(1);
+    expect(closed.stderr).toContain("is closed");
+  });
+
+  it("binds before branch creation in detached HEAD, then requires attachment", () => {
+    const fixture = createFixture();
+    git(fixture.root, ["checkout", "-q", "--detach"], fixture.env);
+
+    expect(command(fixture, ["bind", "acme/widgets#42"]).status).toBe(0);
+    const current = command(fixture, ["current"]);
+    expect(JSON.parse(current.stdout).branch).toBeNull();
+
+    const messageFile = path.join(fixture.root, "COMMIT_EDITMSG");
+    writeFileSync(messageFile, "fix: detached\n\nWork-Item: acme/widgets#42\n");
+    expect(command(fixture, ["validate-commit", messageFile]).status).toBe(1);
+
+    git(
+      fixture.root,
+      ["switch", "-q", "-c", "feature/from-detached"],
+      fixture.env
+    );
+    expect(command(fixture, ["attach-branch"]).status).toBe(0);
+    expect(command(fixture, ["validate-commit", messageFile]).status).toBe(0);
+  });
+
+  it("honors an explicit trusted config without merging head-local overrides", () => {
+    const fixture = createFixture();
+    const trusted = path.join(fixture.root, "trusted-config.json");
+    writeFileSync(trusted, `${JSON.stringify(githubConfig())}\n`);
+    writeFileSync(
+      path.join(fixture.root, ".lisa.config.local.json"),
+      '{"github":{"queueRepo":"acme/attacker"}}\n'
+    );
+
+    const result = command(fixture, ["bind", "acme/widgets#42"], {
+      env: { LISA_TRACKING_CONFIG_FILE: trusted },
+    });
+    expect(result.status).toBe(0);
+  });
+
+  it("rejects unclaimed, cross-repo, and container GitHub issues", () => {
+    const fixture = createFixture({
+      tracker: "github",
+      github: { org: "acme", repo: "identity", queueRepo: "acme/widgets" },
+    });
+    const issue = (labels: string[]) =>
+      JSON.stringify({
+        number: 42,
+        state: "OPEN",
+        labels: labels.map(name => ({ name })),
+        comments: [],
+        closedByPullRequestsReferences: [],
+      });
+
+    const unclaimed = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: issue([
+          "repo:identity",
+          "status:ready",
+          "type:Bug",
+        ]),
+      },
+    });
+    expect(unclaimed.status).toBe(1);
+    expect(unclaimed.stderr).toContain("is not claimed");
+
+    const wrongRepo = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: issue([
+          "repo:other",
+          "status:in-progress",
+          "type:Bug",
+        ]),
+      },
+    });
+    expect(wrongRepo.status).toBe(1);
+    expect(wrongRepo.stderr).toContain("not scoped to repository identity");
+
+    const epic = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: issue([
+          "repo:identity",
+          "status:in-progress",
+          "type:Epic",
+        ]),
+      },
+    });
+    expect(epic.status).toBe(1);
+    expect(epic.stderr).toContain("is a container");
+
+    const parent = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: issue([
+          "repo:identity",
+          "status:in-progress",
+          "type:Task",
+        ]),
+        FAKE_GH_HIERARCHY_JSON:
+          '{"data":{"repository":{"issue":{"subIssues":{"nodes":[{"state":"OPEN"}]}}}}}',
+      },
+    });
+    expect(parent.status).toBe(1);
+    expect(parent.stderr).toContain("is a container");
+  });
+
+  it("exempts only the exact release subject", () => {
+    const fixture = createFixture();
+    const messageFile = path.join(fixture.root, "COMMIT_EDITMSG");
+    writeFileSync(messageFile, "chore(release): 1.2.3 [skip ci]\n");
+    expect(command(fixture, ["validate-commit", messageFile]).stdout).toContain(
+      "WORK_ITEM_TRACKING_OK release"
+    );
+
+    writeFileSync(messageFile, "chore(release): prepare 1.2.3 [skip ci]\n");
+    expect(command(fixture, ["validate-commit", messageFile]).status).toBe(1);
+  });
+});
+
+describe("push and pull-request proof", () => {
+  it("allows the first push for CI follow-up, but rejects mixed references", () => {
+    const fixture = createFixture();
+    const base = git(fixture.root, ["rev-parse", "main"], fixture.env);
+    git(
+      fixture.root,
+      ["update-ref", "refs/remotes/origin/main", base],
+      fixture.env
+    );
+    expect(command(fixture, ["bind", "acme/widgets#42"]).status).toBe(0);
+    const head = commit(
+      fixture,
+      "feat: tracked change\n\nWork-Item: acme/widgets#42"
+    );
+    const pushLine = `refs/heads/feature/tracked ${head} refs/heads/feature/tracked ${ZERO_OID}\n`;
+    const firstPush = command(fixture, ["validate-push", "origin"], {
+      env: { FAKE_GH_PR_MISSING: "1" },
+      input: pushLine,
+    });
+    expect(firstPush.status).toBe(0);
+    expect(firstPush.stdout).toContain(
+      "no pull request exists yet, CI will verify"
+    );
+
+    commit(fixture, "fix: another ticket\n\nWork-Item: acme/widgets#43");
+    const mixedHead = git(fixture.root, ["rev-parse", "HEAD"], fixture.env);
+    const mixed = command(fixture, ["validate-push", "origin"], {
+      env: {
+        FAKE_GH_PR_MISSING: "1",
+      },
+      input: `refs/heads/feature/tracked ${mixedHead} refs/heads/feature/tracked ${ZERO_OID}\n`,
+    });
+    expect(mixed.status).toBe(1);
+    expect(mixed.stderr).toContain("mixed Work-Item references");
+  });
+
+  it("fetches a numbered PR deterministically and requires body and tracker backlinks", () => {
+    const fixture = createFixture();
+    const base = git(fixture.root, ["rev-parse", "main"], fixture.env);
+    expect(command(fixture, ["bind", "acme/widgets#42"]).status).toBe(0);
+    const head = commit(
+      fixture,
+      "feat: tracked change\n\nWork-Item: acme/widgets#42"
+    );
+    const log = path.join(fixture.root, "gh.log");
+    const prUrl = "https://github.com/acme/code/pull/7";
+    const issue = JSON.stringify({
+      number: 42,
+      state: "OPEN",
+      labels: [{ name: "status:in-progress" }, { name: "type:Bug" }],
+      comments: [{ body: `[lisa-pr-link] ${prUrl}` }],
+      closedByPullRequestsReferences: [],
+    });
+
+    const validated = command(
+      fixture,
+      [
+        "validate-pr",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--pr-number",
+        "7",
+        "--pr-url",
+        prUrl,
+      ],
+      { env: { FAKE_GH_ISSUE_JSON: issue, FAKE_GH_LOG: log } }
+    );
+    expect(validated.status).toBe(0);
+    expect(validated.stdout).toContain("WORK_ITEM_TRACKING_OK");
+    expect(readFileSync(log, "utf8")).toContain(
+      "pr view 7 --repo acme/code --json url,body,state"
+    );
+
+    const absentBacklink = command(
+      fixture,
+      [
+        "validate-pr",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--pr-number",
+        "7",
+        "--pr-url",
+        prUrl,
+      ],
+      {
+        env: {
+          FAKE_GH_ISSUE_JSON:
+            '{"number":42,"state":"OPEN","labels":[{"name":"status:in-progress"},{"name":"type:Bug"}],"comments":[],"closedByPullRequestsReferences":[]}',
+        },
+      }
+    );
+    expect(absentBacklink.status).toBe(1);
+    expect(absentBacklink.stderr).toContain("no verified backlink");
+  });
+
+  it("permits an exact release-only PR without inventing a work item", () => {
+    const fixture = createFixture();
+    const base = git(fixture.root, ["rev-parse", "main"], fixture.env);
+    const head = commit(fixture, "chore(release): 1.2.3 [skip ci]");
+    const result = command(fixture, [
+      "validate-pr",
+      "--base",
+      base,
+      "--head",
+      head,
+      "--pr-number",
+      "7",
+      "--pr-url",
+      "https://github.com/acme/code/pull/7",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("WORK_ITEM_TRACKING_OK 0 commit(s)");
+  });
+
+  it("rejects a merge-only PR with no linked non-merge commit", () => {
+    const fixture = createFixture();
+    git(fixture.root, ["switch", "-q", "main"], fixture.env);
+    commit(fixture, "chore: extend base");
+    const base = git(fixture.root, ["rev-parse", "HEAD"], fixture.env);
+    const ancestor = git(fixture.root, ["rev-parse", "HEAD^"], fixture.env);
+    const tree = git(fixture.root, ["rev-parse", "HEAD^{tree}"], fixture.env);
+    const merge = spawnSync(
+      GIT,
+      ["commit-tree", tree, "-p", base, "-p", ancestor],
+      {
+        cwd: fixture.root,
+        encoding: "utf8",
+        env: fixture.env,
+        input: "Merge branch 'already-in-base'\n",
+      }
+    );
+    expect(merge.status).toBe(0);
+
+    const result = command(fixture, [
+      "validate-pr",
+      "--base",
+      base,
+      "--head",
+      merge.stdout.trim(),
+      "--pr-number",
+      "7",
+      "--pr-url",
+      "https://github.com/acme/code/pull/7",
+    ]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("no non-merge commit linked");
+  });
+});
+
+describe("provider liveness", () => {
+  it("accepts active Jira work and rejects done Jira work through acli", () => {
+    const fixture = createFixture({
+      tracker: "jira",
+      repo: "widgets",
+      jira: { project: "LAS" },
+      atlassian: { site: "acme.atlassian.net" },
+    });
+    expect(command(fixture, ["bind", "LAS-12"]).status).toBe(0);
+    const done = command(fixture, ["bind", "LAS-12"], {
+      env: {
+        FAKE_ACLI_JSON:
+          '{"key":"LAS-12","fields":{"status":{"name":"Done","statusCategory":{"key":"done"}}}}',
+      },
+    });
+    expect(done.status).toBe(1);
+    expect(done.stderr).toContain("is done");
+  });
+
+  it("fails Jira closed for an identity mismatch, wrong repo, unclaimed role, or container", () => {
+    const fixture = createFixture({
+      tracker: "jira",
+      repo: "widgets",
+      jira: { project: "LAS" },
+      atlassian: { site: "acme.atlassian.net" },
+    });
+    const fields = (overrides: object) =>
+      JSON.stringify({
+        key: "LAS-12",
+        fields: {
+          project: { key: "LAS" },
+          status: {
+            name: "In Progress",
+            statusCategory: { key: "indeterminate" },
+          },
+          labels: ["repo:widgets"],
+          issuetype: { name: "Task" },
+          subtasks: [],
+          comment: { comments: [] },
+          ...overrides,
+        },
+      });
+
+    const identity = command(fixture, ["bind", "LAS-12"], {
+      env: { FAKE_ACLI_SITE: "attacker.atlassian.net" },
+    });
+    expect(identity.status).toBe(1);
+    expect(identity.stderr).toContain("is not authenticated");
+
+    const wrongRepo = command(fixture, ["bind", "LAS-12"], {
+      env: { FAKE_ACLI_JSON: fields({ labels: ["repo:other"] }) },
+    });
+    expect(wrongRepo.status).toBe(1);
+    expect(wrongRepo.stderr).toContain("not scoped to repository widgets");
+
+    const unclaimed = command(fixture, ["bind", "LAS-12"], {
+      env: {
+        FAKE_ACLI_JSON: fields({
+          status: {
+            name: "Ready",
+            statusCategory: { key: "indeterminate" },
+          },
+        }),
+      },
+    });
+    expect(unclaimed.status).toBe(1);
+    expect(unclaimed.stderr).toContain("is not claimed");
+
+    const epic = command(fixture, ["bind", "LAS-12"], {
+      env: { FAKE_ACLI_JSON: fields({ issuetype: { name: "Epic" } }) },
+    });
+    expect(epic.status).toBe(1);
+    expect(epic.stderr).toContain("is a container");
+  });
+
+  it("uses canonical Atlassian credentials and requests Jira status in curl fallback", () => {
+    const fixture = createFixture({
+      tracker: "jira",
+      repo: "widgets",
+      jira: { project: "LAS" },
+      atlassian: { cloudId: "cloud-123", email: "agent@acme.test" },
+    });
+    rmSync(path.join(fixture.bin, "acli"));
+    const log = path.join(fixture.root, "curl.log");
+    executable(
+      path.join(fixture.bin, "curl"),
+      `printf '%s\\n' "$*" > "\${FAKE_CURL_LOG}"\nprintf '%s\\n' '{"key":"LAS-12","fields":{"project":{"key":"LAS"},"status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},"labels":["repo:widgets"],"issuetype":{"name":"Task"},"subtasks":[],"comment":{"comments":[]}}}'`
+    );
+
+    const result = command(fixture, ["bind", "LAS-12"], {
+      env: {
+        ATLASSIAN_API_TOKEN: "fake-atlassian-key",
+        FAKE_CURL_LOG: log,
+        PATH: `${fixture.bin}:/usr/bin:/bin`,
+      },
+    });
+    expect(result.status).toBe(0);
+    const invocation = readFileSync(log, "utf8");
+    expect(invocation).toContain("agent@acme.test:fake-atlassian-key");
+    expect(invocation).toContain("api.atlassian.com/ex/jira/cloud-123");
+    expect(invocation).toContain(
+      "fields=project,status,labels,components,issuetype,subtasks,comment"
+    );
+  });
+
+  it("accepts active Linear work and rejects terminal Linear work through curl", () => {
+    const fixture = createFixture({
+      tracker: "linear",
+      repo: "widgets",
+      linear: { workspace: "acme", teamKey: "LIN" },
+    });
+    expect(command(fixture, ["bind", "LIN-12"]).status).toBe(0);
+    const terminal = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON:
+          '{"data":{"issue":{"identifier":"LIN-12","team":{"key":"LIN"},"state":{"type":"completed"}}}}',
+      },
+    });
+    expect(terminal.status).toBe(1);
+    expect(terminal.stderr).toContain("is terminal");
+  });
+
+  it("rejects wrong-repo, unclaimed, and container Linear issues", () => {
+    const fixture = createFixture({
+      tracker: "linear",
+      repo: "widgets",
+      linear: { workspace: "acme", teamKey: "LIN" },
+    });
+    const response = (labels: string[], children: object[] = []) =>
+      JSON.stringify({
+        data: {
+          issue: {
+            id: "id-12",
+            identifier: "LIN-12",
+            team: { key: "LIN" },
+            state: { type: "started" },
+            labels: { nodes: labels.map(name => ({ name })) },
+            children: { nodes: children },
+            attachments: { nodes: [] },
+            comments: { nodes: [] },
+          },
+        },
+      });
+
+    const wrongRepo = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: response([
+          "repo:other",
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(wrongRepo.status).toBe(1);
+    expect(wrongRepo.stderr).toContain("not scoped to repository widgets");
+
+    const unclaimed = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: response(["repo:widgets", "status:ready", "type:Task"]),
+      },
+    });
+    expect(unclaimed.status).toBe(1);
+    expect(unclaimed.stderr).toContain("is not claimed");
+
+    const parent = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: response(
+          ["repo:widgets", "status:in-progress", "type:Task"],
+          [{ state: { type: "started" } }]
+        ),
+      },
+    });
+    expect(parent.status).toBe(1);
+    expect(parent.stderr).toContain("is a container");
+  });
+});

--- a/tests/unit/strategies/tracked-work-contract.test.ts
+++ b/tests/unit/strategies/tracked-work-contract.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Contract tests for issue #1783's session-side tracked-work invariant.
+ *
+ * Base is the sole authored source. `build:plugins` fans base skills into the
+ * Claude/OpenCode, Codex, Cursor, Antigravity, and Copilot artifacts below; all
+ * shipped Implement surfaces must retain the same resolve -> claim -> bind gate.
+ * @module tests/unit/strategies/tracked-work-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const BASE_SKILLS = "plugins/src/base/skills";
+const IMPLEMENT_PATHS = [
+  `${BASE_SKILLS}/lisa-implement/SKILL.md`,
+  "plugins/lisa/skills/lisa-implement/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-implement/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-implement/SKILL.md",
+] as const;
+const TRACK_SKILL_PATHS = [
+  `${BASE_SKILLS}/lisa-track/SKILL.md`,
+  "plugins/lisa/skills/lisa-track/SKILL.md",
+  "plugins/lisa/.codex-plugin/skills/lisa-track/SKILL.md",
+  "plugins/lisa-cursor/skills/lisa-track/SKILL.md",
+  "plugins/lisa-agy/skills/lisa-track/SKILL.md",
+  "plugins/lisa-copilot/skills/lisa-track/SKILL.md",
+] as const;
+const PROVIDERS = ["github", "jira", "linear"] as const;
+const TRACKER_WRITE = "lisa-tracker-write";
+const CLEAR_BINDING = "node scripts/lisa-work-item.mjs clear";
+const CONFIG_RULE_PATHS = [
+  "plugins/src/base/rules/reference/config-resolution.md",
+  "plugins/lisa/rules/reference/config-resolution.md",
+  "plugins/lisa-cursor/rules/config-resolution-reference.mdc",
+  "plugins/lisa-copilot/rules/reference/config-resolution.md",
+] as const;
+
+const read = (file: string): string => readFileSync(path.resolve(file), "utf8");
+
+describe("public lisa-track entry point", () => {
+  it("ships a public command backed by lisa-track", () => {
+    const command = read("plugins/src/base/commands/track.md");
+
+    expect(command).toContain("/lisa-track");
+    expect(command).toMatch(
+      /existing.*reference.*specification file.*plain-text/is
+    );
+  });
+
+  describe.each(TRACK_SKILL_PATHS)("%s", file => {
+    it("live-validates or conservatively searches before one create", () => {
+      const skill = read(file);
+
+      expect(skill).toContain("lisa-tracker-read");
+      expect(skill).toMatch(/exactly one.*high-confidence/is);
+      expect(skill).toMatch(/create \*\*exactly one\*\*/i);
+      expect(skill).toContain(TRACKER_WRITE);
+      expect(skill).toContain("build_ready: true");
+      expect(skill).toMatch(/single-repository leaf/i);
+    });
+
+    it("claims before persisting and verifies the binding", () => {
+      const skill = read(file);
+      const claim = skill.indexOf("lisa-tracker-claim <canonical-ref>");
+      const bind = skill.indexOf(
+        "node scripts/lisa-work-item.mjs bind <canonical-ref>"
+      );
+      const current = skill.indexOf("node scripts/lisa-work-item.mjs current");
+
+      expect(claim).toBeGreaterThan(-1);
+      expect(bind).toBeGreaterThan(claim);
+      expect(current).toBeGreaterThan(bind);
+      expect(skill).toMatch(/failed\/unverified claim/i);
+      expect(skill).toMatch(/stop before durable project work/i);
+    });
+
+    it("keeps interrupted work bound and clears only at terminal completion", () => {
+      const skill = read(file);
+
+      expect(skill).toContain(CLEAR_BINDING);
+      expect(skill).toMatch(/Keep the binding across ordinary interruptions/i);
+      expect(skill).toMatch(/only after true terminal completion/i);
+    });
+  });
+});
+
+describe("vendor-neutral tracker claim", () => {
+  const dispatcher = read(`${BASE_SKILLS}/lisa-tracker-claim/SKILL.md`);
+
+  it("dispatches all configured providers without inventing a default", () => {
+    for (const provider of PROVIDERS) {
+      expect(dispatcher).toContain(
+        `\`${provider}\` -> invoke \`lisa-${provider}-claim\``
+      );
+    }
+    expect(dispatcher).toContain("No tracker configured in .lisa.config.json");
+    expect(dispatcher).not.toContain("default: jira");
+  });
+
+  it("requires a live leaf, idempotent claim, and post-write proof", () => {
+    expect(dispatcher).toContain("leaf-only-lifecycle");
+    expect(dispatcher).toContain("repo-scope-split");
+    expect(dispatcher).toMatch(/claimed role or a later non-terminal role/i);
+    expect(dispatcher).toMatch(/assign.*only when unassigned/i);
+    expect(dispatcher).toMatch(/post-write read/i);
+    expect(dispatcher).toMatch(/fail closed/i);
+  });
+
+  it.each(PROVIDERS)(
+    "%s claim reuses the build-intake claim contract",
+    provider => {
+      const skill = read(`${BASE_SKILLS}/lisa-${provider}-claim/SKILL.md`);
+
+      expect(skill).toMatch(/build-intake.*Phase 3b/i);
+      expect(skill).toContain("leaf-only-lifecycle");
+      expect(skill).toContain("repo-scope-split");
+      expect(skill).toMatch(/immediately before mutation/i);
+      expect(skill).toMatch(/only if.*unassigned/i);
+      expect(skill).toContain("[lisa-tracker-claim]");
+      expect(skill).toMatch(/deduped/i);
+      expect(skill).toMatch(/again.*Success requires/is);
+      expect(skill).toMatch(/claim_outcome: claimed\|reused/);
+    }
+  );
+
+  it.each(CONFIG_RULE_PATHS)(
+    "%s maps the claim dispatcher for every provider",
+    file => {
+      const rule = read(file);
+
+      expect(rule).toMatch(
+        /lisa-tracker-claim.*lisa-jira-claim.*lisa-github-claim.*lisa-linear-claim/
+      );
+    }
+  );
+});
+
+describe("Implement tracked-work gate", () => {
+  describe.each(IMPLEMENT_PATHS)("%s", file => {
+    it("makes resolve-create-claim-bind mandatory before durable work", () => {
+      const skill = read(file);
+
+      expect(skill).toContain("lisa-track $ARGUMENTS");
+      expect(skill).toContain("lisa-tracker-read");
+      expect(skill).toContain(TRACKER_WRITE);
+      expect(skill).toContain("lisa-tracker-claim <canonical-ref>");
+      expect(skill).toContain(
+        "node scripts/lisa-work-item.mjs bind <canonical-ref>"
+      );
+      expect(skill).toMatch(/No project source.*may be created or changed/is);
+    });
+
+    it("makes development and PR linkage unconditional", () => {
+      const skill = read(file);
+
+      expect(skill).toMatch(/Every Implement run now has a tracker work item/i);
+      expect(skill).toMatch(/Missing linkage is a workflow failure/i);
+      expect(skill).toContain("node scripts/lisa-work-item.mjs attach-branch");
+      expect(skill).toMatch(/mandatory work-item ref/i);
+      expect(skill).not.toMatch(/including the work-item ref when one exists/i);
+      expect(skill).not.toMatch(/when a work item exists/i);
+    });
+
+    it("clears only after terminal completion", () => {
+      const skill = read(file);
+      const terminal = skill.lastIndexOf("true terminal completion");
+      const clear = skill.lastIndexOf(CLEAR_BINDING);
+
+      expect(terminal).toBeGreaterThan(-1);
+      expect(clear).toBeGreaterThan(terminal);
+      expect(skill).toMatch(
+        /Do not clear on an interruption or blocked outcome/i
+      );
+    });
+  });
+});
+
+describe("tracked-work rules", () => {
+  it.each(["eager", "reference"] as const)(
+    "%s rule pins the invariant",
+    group => {
+      const rule = read(`plugins/src/base/rules/${group}/tracked-work.md`);
+
+      expect(rule).toMatch(/Before.*durable/is);
+      expect(rule).toMatch(/exactly one.*leaf/is);
+      expect(rule).toContain(TRACKER_WRITE);
+      expect(rule).toContain("lisa-tracker-claim");
+      expect(rule).toContain("node scripts/lisa-work-item.mjs bind <ref>");
+      expect(rule).toContain(CLEAR_BINDING);
+      expect(rule).toMatch(/only after.*terminal completion/is);
+    }
+  );
+});

--- a/typescript/copy-contents/.husky/commit-msg
+++ b/typescript/copy-contents/.husky/commit-msg
@@ -20,29 +20,15 @@ fi
 # Get the commit message file path
 COMMIT_MSG_FILE=$1
 
-# Get the current branch name
-BRANCH_NAME=$(git branch --show-current)
-
-# Extract Jira key from branch name if present
-# Default pattern matches common Jira project keys (2-10 uppercase letters followed by a hyphen and numbers)
-# Can be overridden with JIRA_PROJECT_KEY environment variable (e.g., JIRA_PROJECT_KEY="SE|PROJ|ABC")
-JIRA_PROJECT_KEY=${JIRA_PROJECT_KEY:-"[A-Z]{2,10}"}
-
-# Extract Jira key from branch name using grep
-# Matches patterns like: feat/SE-2397-description, SE-2397-description, chore/PROJ-123-something
-JIRA_KEY=$(echo "$BRANCH_NAME" | grep -E "(^|/)($JIRA_PROJECT_KEY)-[0-9]+" | grep -E "($JIRA_PROJECT_KEY)-[0-9]+" -o | head -1)
-
-if [ -n "$JIRA_KEY" ]; then
-  # Read the current commit message
-  COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
-  
-  # Check if the Jira key is already in the commit message
-  if ! echo "$COMMIT_MSG" | grep -q "\[$JIRA_KEY\]"; then
-    # Append the Jira key to the commit message
-    echo "$COMMIT_MSG [$JIRA_KEY]" > "$COMMIT_MSG_FILE"
-    echo "🎫 Auto-appended Jira key: [$JIRA_KEY]"
-  fi
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Commit blocked: Node.js is required to validate tracker work items."
+  exit 1
+fi
+node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE" || exit 1
 
 echo "📝 Validating commit message with commitlint..."
 $EXECUTOR commitlint --edit $1

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -1,5 +1,15 @@
 # BEGIN: AI GUARDRAILS
 
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Push blocked: Node.js is required to validate tracker work items."
+  exit 1
+fi
+node "$WORK_ITEM_SCRIPT" validate-push "${1:-origin}" || exit 1
+
 # Detect package manager (check if tool is available before using it)
 # Priority: bun > yarn > npm (bun first since package.json engines prefer it)
 if ([ -f "bun.lockb" ] || [ -f "bun.lock" ]) && command -v bun >/dev/null 2>&1; then

--- a/typescript/copy-contents/.husky/prepare-commit-msg
+++ b/typescript/copy-contents/.husky/prepare-commit-msg
@@ -1,0 +1,15 @@
+# BEGIN: AI GUARDRAILS
+
+WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Commit blocked: Node.js is required to link commits to tracker work items."
+  exit 1
+fi
+
+node "$WORK_ITEM_SCRIPT" prepare-commit-msg "$@"
+
+# END: AI GUARDRAILS


### PR DESCRIPTION
## Summary

- require every durable Lisa session to resolve, claim, and bind one live tracker leaf
- add exact `Work-Item:` commit trailers plus commit and pre-push validation
- mirror the behavior across Claude, Codex, Cursor, OpenCode, Antigravity, and Copilot surfaces

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test:cov` (5,585 passed)
- integration suite (151 passed)
- independent implementation review: PASS

Work-Item: CodySwannGT/lisa#1783

Refs #1783