### PR TITLE
feat: execute first gardener run — 2 promotions, 1 wiki demotion, 5 retirements (#1787–#1790)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -285,33 +285,3 @@ Before declaring any auto-merge PR done — do NOT rely on "pushed + thread reso
 
 If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confirm the merged head includes it.
 
-## Local `lisa ui` verification
-
-- CLI entrypoint is `bun src/index.ts ui` (or `bun dist/index.js ui` after build). Do not use `bun src/cli/index.ts ui` — that module has no `main()`.
-- After source changes that register new `/api/status` probes, rebuild (`bun run build:dist`) or run via the source entrypoint before trusting live `dist/` output; a stale `dist/` can omit newly added probe modules.
-
-## Lisa Console UI (`ui/`)
-
-The console UI ships as a single hand-written file, `ui/index.html` (there is no bundler/`ui/dist`). It is served by the `lisa ui` command in `src/cli/ui-cmd.ts` (`runUi`). Rules for working on it and its tests:
-
-### Built CLI entry is `dist/index.js`, not `dist/src/...`
-
-`tsconfig.local.json` sets `rootDir: "src"` + `outDir: "dist"`, which flattens `src/` out of the emitted tree. The CLI entry is `dist/index.js` (also `bin.lisa` in `package.json`) — **not** `dist/src/cli/index.js`. Verification, plan, and doctor commands that guess a nested `dist/src/...` path fail. Always target `dist/index.js`.
-
-### `runUi(..., { sync: false })` in tests
-
-Pass `sync: false` whenever calling `runUi` from a test. Without it, `runUi` calls `runConfigSync` and mutates the temp/working directory under test. All unit and e2e tests use `{ port: "0", sync: false }`.
-
-### e2e tests run under Playwright's own TS pipeline
-
-`playwright.config.ts` defines **one** global `webServer` on a fixed port (`UI_TEST_PORT = 4783`) with `baseURL: http://127.0.0.1:4783`. That single shared server cannot host per-test probe injection. To drive real code with stubbed edges (e.g. injected probes), a spec must bypass `baseURL`: `import { runUi }`, launch a per-test server on `port: "0"`, and navigate to the absolute `http://127.0.0.1:${address.port}` URL, closing the server in a `finally`. See `tests/e2e/ui-stacks.spec.ts`.
-
-e2e spec files are **not** type-checked by `tsc --noEmit` (root `tsconfig` `include` is `src/**`, and tests are excluded) and are ESLint-ignored (`eslint.ignore.config.json` ignores `e2e/**`). Playwright's own TypeScript pipeline is what typechecks them — do not expect the repo's `lint`/`typecheck` gates to cover changes made only inside `tests/e2e/`.
-
-### Toggle checkboxes need `dispatchEvent("click")`
-
-The console's toggle controls are an `opacity-0` `<input type="checkbox">` layered under a styled `.trk`/`span`. Playwright's `.click()` hits the visual layer and does not fire the input's change handler. Use `card.getByRole("checkbox").dispatchEvent("click")` — it reliably fires the handler. Reuse this for every console toggle test. (Web analog of the Maestro `opacity-0`/`testID` gaps in [[reference_maestro_ios_ax_pitfalls]].)
-
-### `esc()` / `el()` are a text-context escaper and a raw-HTML sink
-
-In `ui/index.html`, `esc(s)` escapes `& < > "` but **not** `'` — it is safe only for text/element content interpolated into `innerHTML`, not for attribute-value contexts (which can be broken out of with a single quote). `el(tag, cls, html)` assigns its third argument straight to `innerHTML`, so it is a raw-HTML sink: only ever pass it `esc()`-wrapped values or trusted catalog constants. If you add attribute interpolation, add an attribute-safe escaper rather than reusing `esc()`.

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -290,10 +290,6 @@ If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confir
 - CLI entrypoint is `bun src/index.ts ui` (or `bun dist/index.js ui` after build). Do not use `bun src/cli/index.ts ui` — that module has no `main()`.
 - After source changes that register new `/api/status` probes, rebuild (`bun run build:dist`) or run via the source entrypoint before trusting live `dist/` output; a stale `dist/` can omit newly added probe modules.
 
-## Committing in this repo: use `git commit -F`, never a heredoc
-
-The parity-safety-net hook blocks `git commit -m "$(cat <<EOF … EOF)"` heredoc invocations. Write the message to a file and use `git commit -F <file>` instead. Every commit must also carry a `Co-authored-by: Claude <noreply@anthropic.com>` trailer (Codex commits use `Co-authored-by: Codex`) or the co-authorship hook rejects it — see [[reference_codex_commit_attribution]].
-
 ## Lisa Console UI (`ui/`)
 
 The console UI ships as a single hand-written file, `ui/index.html` (there is no bundler/`ui/dist`). It is served by the `lisa ui` command in `src/cli/ui-cmd.ts` (`runUi`). Rules for working on it and its tests:

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -68,8 +68,6 @@ When updating a project file, always check to see if it has a corresponding temp
 
 When upstreaming a governance pattern discovered in a downstream project (e.g., frontend-v2, backend-v2), trace it back to the Lisa template source files and update both the template and its tests. This ensures the pattern propagates to all projects using that stack template.
 
-Never parse JSON in shell scripts using grep/sed/cut/awk - always use jq for robust JSON handling.
-
 When creating Claude Code hooks for enforcement (linting, code quality, static analysis), always use blocking behavior (exit 2 on failures) so Claude receives feedback and can fix the errors. Notification-only hooks (like ntfy.sh) should exit 0 since they don't require Claude to take action.
 
 ## Skills and Commands

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -16,25 +16,6 @@ ticket over time, so this file shrinks instead of growing.
 
 ---
 
-## Never edit generated plugin artifacts (plugins/lisa, plugins/lisa-*)
-
-`plugins/lisa/` and every `plugins/lisa-<stack>/` directory are **generated build output**. `scripts/build-plugins.sh` (run via `bun run build:plugins`) does `rm -rf plugins/lisa && cp -r plugins/src/base`, so any edit made directly to an artifact is silently discarded on the next build or release.
-
-The source of truth is **`plugins/src/`**:
-
-- `plugins/src/base/` → builds `plugins/lisa`
-- `plugins/src/<stack>/` (typescript, expo, nestjs, cdk, harper-fabric, rails) → builds `plugins/lisa-<stack>`
-
-To change a skill, agent, rule, command, or hook:
-
-1. Edit the file under `plugins/src/...`.
-2. Run `bun run build:plugins`.
-3. Commit **both** `plugins/src` and the regenerated `plugins/lisa*`.
-
-The `🧩 Plugins Sync` CI workflow (and `bun run check:plugins` locally) rebuilds from source and fails if committed artifacts don't match — catching artifact-only edits. Two PRs (#471, #478) were wiped this way before the guard existed; do not reintroduce the pattern.
-
----
-
 ## package.json and package.lisa.json Management
 
 When updating package.json, always check if there's a corresponding `package.lisa.json` template file. Update both together:
@@ -86,30 +67,6 @@ Lisa-specific skills (like `lisa-integration-test`, `lisa-learn`, `lisa-review-p
 ## Task Metadata
 
 When creating tasks, do not include `/coding-philosophy` in the `skills` array of task metadata. The coding philosophy is distributed as a generated Lisa rule and does not need to be explicitly invoked.
-
-## ESLint Statement Order
-
-When writing utility functions, avoid calling shared validation helpers (expression statements/side effects) before const definitions, as this violates the enforce-statement-order rule. Instead, inline validation as `if` guard clauses, which are exempt from the ordering rule.
-
-Example:
-
-```typescript
-// Wrong - validation helper call before const
-function fibonacci(n: number): bigint {
-  validateNonNegativeInteger(n, "n"); // Expression statement
-  const result = compute(n); // Const after expression
-  return result;
-}
-
-// Correct - inline validation as guard clause
-function fibonacci(n: number): bigint {
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
-    throw new RangeError(`Expected a non-negative integer for n, got ${String(n)}`);
-  }
-  const result = compute(n);
-  return result;
-}
-```
 
 ## Test Isolation
 
@@ -182,24 +139,6 @@ Solution: Combine deletion of old file + creation of new file in the same atomic
 
 Example: Deleting `src/utils/fibonacci.ts` alone fails because `src/utils/index.ts` exports `export * from './fibonacci.js'`. Instead, delete the old implementation and add the new implementation in a single commit.
 
-## ESLint Disable Comments
-
-### Description Requirement
-
-All `eslint-disable` directives must include a description to satisfy the `eslint-comments/require-description` rule.
-
-Format: `/* eslint-disable rule-name -- description of why this exception is needed */`
-
-Example from generator pattern — prefer a single tuple over separate variables to group related state:
-
-```typescript
-/* eslint-disable functional/no-let -- generator requires mutable pair to track consecutive Fibonacci values */
-let pair: readonly [bigint, bigint] = [0n, 1n];
-/* eslint-enable functional/no-let -- re-enable after generator state declaration */
-```
-
-Using a tuple (`readonly [bigint, bigint]`) instead of separate `let a, b` declarations keeps coupled state in a single structure and minimizes the number of mutable bindings.
-
 ## TypeScript Type System
 
 ### readonly is Compile-Time Only
@@ -209,34 +148,6 @@ TypeScript's `readonly` modifier (e.g., `readonly bigint[]`) is a compile-time c
 Do NOT test runtime immutability with `Object.isFrozen()` for readonly types — TypeScript types are erased at runtime.
 
 Runtime immutability tests (`Object.freeze()`, `Object.isFrozen()`) are separate from TypeScript readonly type checks.
-
-## DRY Principle
-
-### Prefer Delegation to Single Source of Truth
-
-When multiple functions compute the same sequence or data structure, prefer delegating to a shared generator or canonical implementation rather than reimplementing the algorithm.
-
-Example from fibonacci implementation:
-
-```typescript
-// Before: Reimplements Fibonacci logic with tuple-reduce (O(1) space but duplicates logic)
-export function fibonacci(n: number): bigint {
-  const [, result] = Array.from({ length: n - 1 }).reduce<readonly [bigint, bigint]>(
-    ([prev, curr]) => [curr, prev + curr] as const,
-    [0n, 1n]
-  );
-  return result;
-}
-
-// After: Delegates to fibonacciGenerator (DRY - single source of truth)
-export function fibonacci(n: number): bigint {
-  const gen = fibonacciGenerator();
-  Array.from({ length: n }, () => gen.next());
-  return gen.next().value;
-}
-```
-
-Even when the reimplementation has theoretical performance benefits (O(1) space), prefer simplicity and DRY unless performance is empirically proven to be a bottleneck.
 
 ## Test Assertion Preservation During Rewrites
 
@@ -272,16 +183,3 @@ This sequence is necessary because:
 - Pre-commit hooks (lint/typecheck) run on every commit and will fail if barrel exports reference missing files
 
 Deviating from this sequence (e.g., deleting source without removing barrel export, or adding barrel export before implementation exists) causes pre-commit hook failures.
-
-## Verify Auto-Merge Actually Shipped Your Fix (Ancestry Check)
-
-Enabling auto-merge and pushing a fix commit does NOT guarantee the fix ships. GitHub auto-merge can merge the PRIOR head the instant required checks go green — before your new commit becomes the PR head. This shipped a real bug: release 2.124.5 shipped the `./hooks/` Cursor bug because a CodeRabbit fix commit raced past PR #1069's merge; it had to be fixed forward in 2.124.6 (issue #1055).
-
-Before declaring any auto-merge PR done — do NOT rely on "pushed + thread resolved + checks green" as proof:
-
-1. `git fetch origin`
-2. Confirm the fix commit is an ancestor of the merged base: `git merge-base --is-ancestor <fix-sha> origin/main` (exit 0 = shipped).
-3. Confirm the merge commit's parent is your fixed commit, not a stale head.
-
-If CI or CodeRabbit forces another commit after auto-merge is enabled, re-confirm the merged head includes it.
-

--- a/eslint-plugin-code-organization/rules/enforce-statement-order.js
+++ b/eslint-plugin-code-organization/rules/enforce-statement-order.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
     messages: {
       wrongOrder:
-        "{{current}} should come before {{previous}}. Expected order: definitions → side effects → return statement (tip: `if` guard clauses are exempt — inline validation as a guard instead of calling a helper)",
+        "{{current}} should come before {{previous}}. Expected order: definitions → side effects → return statement (tip: `if` statements are exempt from ordering checks — inline validation as an `if` guard clause instead of calling a helper)",
     },
   },
 

--- a/eslint-plugin-code-organization/rules/enforce-statement-order.js
+++ b/eslint-plugin-code-organization/rules/enforce-statement-order.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
     messages: {
       wrongOrder:
-        "{{current}} should come before {{previous}}. Expected order: definitions → side effects → return statement",
+        "{{current}} should come before {{previous}}. Expected order: definitions → side effects → return statement (tip: `if` guard clauses are exempt — inline validation as a guard instead of calling a helper)",
     },
   },
 

--- a/plugins/lisa-agy/hooks.json
+++ b/plugins/lisa-agy/hooks.json
@@ -24,5 +24,18 @@
         ]
       }
     ]
+  },
+  "lisa-block-shell-json-parsing": {
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.gemini/config/plugins/lisa/hooks/block-shell-json-parsing.agy.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/lisa-agy/hooks/block-shell-json-parsing.agy.sh
+++ b/plugins/lisa-agy/hooks/block-shell-json-parsing.agy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's canonical shell-JSON guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-shell-json-parsing.sh beside it (same delegation pattern as
+# parity-safety-net.agy.sh). Fail-open on missing runtimes: unlike the
+# safety net, a missed nudge here risks a fragile script, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-shell-json-parsing.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: structural JSON parsing with text tools; use jq."
+deny "$canonical_output"

--- a/plugins/lisa-agy/hooks/block-shell-json-parsing.sh
+++ b/plugins/lisa-agy/hooks/block-shell-json-parsing.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
+# Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
+# quotes, reordered keys, nested objects — producing silently wrong output
+# instead of errors. jq is the required tool for structural JSON reads and
+# writes in shell. Promoted from PROJECT_RULES.md prose to an executable
+# control by the learnings gardener (issue #1787).
+#
+# Precision-first: this hook fires only on high-confidence STRUCTURAL parsing
+# of a *.json input — never on plain text search. Blocked signatures:
+#   1. `sed -i` (or an s/…/…/ program) applied to a .json file or stream;
+#   2. `cut -d` with a structural delimiter (quote/colon/comma) on .json input;
+#   3. `awk` field extraction (-F or a $N program) on .json input;
+#   4. `grep -o` on .json input (value extraction, not search).
+# A "json input" is a *.json argument, a `< file.json` redirection, or a
+# pipeline stream originating from a .json file (e.g. `cat x.json | …`).
+#
+# Exemptions (allowed):
+#   - any command that invokes jq anywhere (already compliant or mixed-legit);
+#   - search-only usage: plain grep / grep -l / rg with no extraction signature;
+#   - *.jsonl targets (line-delimited streams are legitimately line-tooled);
+#   - heredoc payload text (stripped before classification).
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Fast path: no ".json" reference at all means nothing to classify.
+case "$command_str" in
+  *.json*) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_SHELL_JSON_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_SHELL_JSON_COMMAND", "")
+
+TEXT_TOOLS = {"grep", "egrep", "fgrep", "sed", "gsed", "awk", "gawk", "cut"}
+WRAPPERS = {"command", "env", "sudo", "time", "nohup"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_heredoc_bodies(text: str) -> str:
+    """Remove heredoc payload lines so prose .json mentions never classify."""
+    lines = text.splitlines()
+    output = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        markers = [
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        ]
+        index += 1
+        for marker in markers:
+            while index < len(lines):
+                if lines[index].strip() == marker:
+                    index += 1
+                    break
+                index += 1
+    return "\n".join(output)
+
+
+def tokenize(text: str):
+    lex = shlex.shlex(text, posix=True, punctuation_chars="|&;<>")
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
+def is_json_path(token: str) -> bool:
+    return token.lower().rstrip(")};").endswith(".json")
+
+
+def split_pipelines(tokens):
+    """Yield lists of pipe-connected segments; each segment is a token list."""
+    pipelines, pipeline, segment = [], [], []
+    for token in tokens:
+        if token in ("|", "|&"):
+            pipeline.append(segment)
+            segment = []
+        elif token in (";", "&&", "||", "&", "\n"):
+            pipeline.append(segment)
+            pipelines.append(pipeline)
+            pipeline, segment = [], []
+        else:
+            segment.append(token)
+    pipeline.append(segment)
+    pipelines.append(pipeline)
+    return pipelines
+
+
+def segment_parts(segment):
+    """Return (tool, args, reads_json) for one pipeline segment."""
+    reads_json = False
+    tool = None
+    args = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token == "<":
+            if index + 1 < len(segment) and is_json_path(segment[index + 1]):
+                reads_json = True
+            index += 2
+            continue
+        if token in (">", ">>", "<<", "<<<"):
+            index += 2
+            continue
+        if tool is None and (ASSIGNMENT.match(token) or token in WRAPPERS):
+            index += 1
+            continue
+        if tool is None:
+            tool = token.rsplit("/", 1)[-1]
+        else:
+            args.append(token)
+            if is_json_path(token):
+                reads_json = True
+        index += 1
+    return tool, args, reads_json
+
+
+def flags_of(args):
+    return [a for a in args if a.startswith("-")]
+
+
+def is_violation(tool, args, has_json_input):
+    if not has_json_input:
+        return False
+    flags = flags_of(args)
+    if tool in ("grep", "egrep", "fgrep"):
+        if any(f in ("-l", "-L", "--files-with-matches", "--files-without-match") for f in flags):
+            return False
+        return any(f == "-o" or f == "--only-matching" or ("o" in f[1:] and not f.startswith("--")) for f in flags)
+    if tool in ("sed", "gsed"):
+        if any(f.startswith("-i") or f == "--in-place" for f in flags):
+            return True
+        return any(re.match(r"^-?\d*s[/|#]", a) or a.startswith("s/") or a.startswith("s|") for a in args)
+    if tool == "cut":
+        for i, arg in enumerate(args):
+            if arg == "-d" and i + 1 < len(args) and args[i + 1] in ('"', "'", ":", ","):
+                return True
+            if arg.startswith("-d") and len(arg) > 2 and arg[2:] in ('"', "'", ":", ","):
+                return True
+        return False
+    if tool in ("awk", "gawk"):
+        if any(f == "-F" or f.startswith("-F") for f in flags):
+            return True
+        return any(re.search(r"\$\d", a) for a in args if not a.startswith("-"))
+    return False
+
+
+tokens = tokenize(strip_heredoc_bodies(command))
+if tokens is None:
+    sys.exit(0)
+
+pipelines = split_pipelines(tokens)
+
+# Whole-command jq exemption: any jq stage means the author is already using
+# the right tool; mixed pipelines (jq | grep) are legitimate.
+for pipeline in pipelines:
+    for segment in pipeline:
+        tool, _args, _reads = segment_parts(segment)
+        if tool == "jq":
+            sys.exit(0)
+
+for pipeline in pipelines:
+    json_stream = False
+    for segment in pipeline:
+        tool, args, reads_json = segment_parts(segment)
+        if tool is None:
+            continue
+        has_json_input = reads_json or json_stream
+        if tool in TEXT_TOOLS and is_violation(tool, args, has_json_input):
+            sys.exit(1)
+        # Streams originating from a .json file stay json-classified through
+        # pass-through text stages (cat x.json | grep … | cut …).
+        if reads_json or (json_stream and tool in TEXT_TOOLS | {"cat", "head", "tail", "sort", "uniq", "tr", "xargs"}):
+            json_stream = True
+        else:
+            json_stream = False
+
+sys.exit(0)
+PY
+then
+  cat >&2 <<'EOF'
+BLOCKED: this command parses JSON with text tools (grep/sed/cut/awk). Text
+tools break on valid JSON — multiline values, escaped quotes, reordered keys,
+nested objects — producing silently wrong output instead of errors. Use jq for
+all structural JSON reads and writes in shell. Typical fixes:
+  read a field:   jq -r '.field' file.json
+  filter items:   jq '.items[] | select(.name=="x")' file.json
+  edit in place:  jq '.key="value"' file.json > tmp && mv tmp file.json
+If you are only SEARCHING text inside a JSON file (not extracting values), use
+`rg <pattern> file.json` with no extraction pipe and this hook will not fire.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -50,16 +50,28 @@ EOF
 # text from the destructive-command scans below. Unknown executable heredocs
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
+#
+# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
+# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
+# and a bare denial strands the agent with no path forward (gardener #1789).
+block_heredoc() {
+  block "$1
+Heredoc commit invocations are blocked (the payload is executable shell).
+Fix: write the commit message to a file and run \`git commit -F <file>\`.
+Every commit must also carry a Co-authored-by trailer for a supported agent
+(Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+}
+
 command_for_guards="$command_str"
 case "$command_str" in
   *'<<'*)
     hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     heredoc_parser="$hook_dir/parity-safety-net-heredoc.py"
     if ! command -v python3 >/dev/null 2>&1 || [ ! -r "$heredoc_parser" ]; then
-      block "cannot safely classify heredoc command because its parser runtime is unavailable"
+      block_heredoc "cannot safely classify heredoc command because its parser runtime is unavailable"
     fi
     if ! printf '%s\n' "$command_str" | /bin/bash -n >/dev/null 2>&1; then
-      block "malformed heredoc command failed shell syntax validation"
+      block_heredoc "malformed heredoc command failed shell syntax validation"
     fi
 
     parser_status=0
@@ -72,8 +84,8 @@ case "$command_str" in
     case "$parser_status" in
       0) command_for_guards="$parser_output" ;;
       10) command_for_guards="$command_str" ;;
-      20) block "malformed or ambiguous heredoc command cannot be safely classified" ;;
-      *) block "heredoc parser failed; command was denied fail-closed" ;;
+      20) block_heredoc "malformed or ambiguous heredoc command cannot be safely classified" ;;
+      *) block_heredoc "heredoc parser failed; command was denied fail-closed" ;;
     esac
     ;;
 esac

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -48,6 +48,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
           }
         ]
       },

--- a/plugins/lisa-copilot/hooks/block-shell-json-parsing.sh
+++ b/plugins/lisa-copilot/hooks/block-shell-json-parsing.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
+# Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
+# quotes, reordered keys, nested objects — producing silently wrong output
+# instead of errors. jq is the required tool for structural JSON reads and
+# writes in shell. Promoted from PROJECT_RULES.md prose to an executable
+# control by the learnings gardener (issue #1787).
+#
+# Precision-first: this hook fires only on high-confidence STRUCTURAL parsing
+# of a *.json input — never on plain text search. Blocked signatures:
+#   1. `sed -i` (or an s/…/…/ program) applied to a .json file or stream;
+#   2. `cut -d` with a structural delimiter (quote/colon/comma) on .json input;
+#   3. `awk` field extraction (-F or a $N program) on .json input;
+#   4. `grep -o` on .json input (value extraction, not search).
+# A "json input" is a *.json argument, a `< file.json` redirection, or a
+# pipeline stream originating from a .json file (e.g. `cat x.json | …`).
+#
+# Exemptions (allowed):
+#   - any command that invokes jq anywhere (already compliant or mixed-legit);
+#   - search-only usage: plain grep / grep -l / rg with no extraction signature;
+#   - *.jsonl targets (line-delimited streams are legitimately line-tooled);
+#   - heredoc payload text (stripped before classification).
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Fast path: no ".json" reference at all means nothing to classify.
+case "$command_str" in
+  *.json*) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_SHELL_JSON_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_SHELL_JSON_COMMAND", "")
+
+TEXT_TOOLS = {"grep", "egrep", "fgrep", "sed", "gsed", "awk", "gawk", "cut"}
+WRAPPERS = {"command", "env", "sudo", "time", "nohup"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_heredoc_bodies(text: str) -> str:
+    """Remove heredoc payload lines so prose .json mentions never classify."""
+    lines = text.splitlines()
+    output = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        markers = [
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        ]
+        index += 1
+        for marker in markers:
+            while index < len(lines):
+                if lines[index].strip() == marker:
+                    index += 1
+                    break
+                index += 1
+    return "\n".join(output)
+
+
+def tokenize(text: str):
+    lex = shlex.shlex(text, posix=True, punctuation_chars="|&;<>")
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
+def is_json_path(token: str) -> bool:
+    return token.lower().rstrip(")};").endswith(".json")
+
+
+def split_pipelines(tokens):
+    """Yield lists of pipe-connected segments; each segment is a token list."""
+    pipelines, pipeline, segment = [], [], []
+    for token in tokens:
+        if token in ("|", "|&"):
+            pipeline.append(segment)
+            segment = []
+        elif token in (";", "&&", "||", "&", "\n"):
+            pipeline.append(segment)
+            pipelines.append(pipeline)
+            pipeline, segment = [], []
+        else:
+            segment.append(token)
+    pipeline.append(segment)
+    pipelines.append(pipeline)
+    return pipelines
+
+
+def segment_parts(segment):
+    """Return (tool, args, reads_json) for one pipeline segment."""
+    reads_json = False
+    tool = None
+    args = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token == "<":
+            if index + 1 < len(segment) and is_json_path(segment[index + 1]):
+                reads_json = True
+            index += 2
+            continue
+        if token in (">", ">>", "<<", "<<<"):
+            index += 2
+            continue
+        if tool is None and (ASSIGNMENT.match(token) or token in WRAPPERS):
+            index += 1
+            continue
+        if tool is None:
+            tool = token.rsplit("/", 1)[-1]
+        else:
+            args.append(token)
+            if is_json_path(token):
+                reads_json = True
+        index += 1
+    return tool, args, reads_json
+
+
+def flags_of(args):
+    return [a for a in args if a.startswith("-")]
+
+
+def is_violation(tool, args, has_json_input):
+    if not has_json_input:
+        return False
+    flags = flags_of(args)
+    if tool in ("grep", "egrep", "fgrep"):
+        if any(f in ("-l", "-L", "--files-with-matches", "--files-without-match") for f in flags):
+            return False
+        return any(f == "-o" or f == "--only-matching" or ("o" in f[1:] and not f.startswith("--")) for f in flags)
+    if tool in ("sed", "gsed"):
+        if any(f.startswith("-i") or f == "--in-place" for f in flags):
+            return True
+        return any(re.match(r"^-?\d*s[/|#]", a) or a.startswith("s/") or a.startswith("s|") for a in args)
+    if tool == "cut":
+        for i, arg in enumerate(args):
+            if arg == "-d" and i + 1 < len(args) and args[i + 1] in ('"', "'", ":", ","):
+                return True
+            if arg.startswith("-d") and len(arg) > 2 and arg[2:] in ('"', "'", ":", ","):
+                return True
+        return False
+    if tool in ("awk", "gawk"):
+        if any(f == "-F" or f.startswith("-F") for f in flags):
+            return True
+        return any(re.search(r"\$\d", a) for a in args if not a.startswith("-"))
+    return False
+
+
+tokens = tokenize(strip_heredoc_bodies(command))
+if tokens is None:
+    sys.exit(0)
+
+pipelines = split_pipelines(tokens)
+
+# Whole-command jq exemption: any jq stage means the author is already using
+# the right tool; mixed pipelines (jq | grep) are legitimate.
+for pipeline in pipelines:
+    for segment in pipeline:
+        tool, _args, _reads = segment_parts(segment)
+        if tool == "jq":
+            sys.exit(0)
+
+for pipeline in pipelines:
+    json_stream = False
+    for segment in pipeline:
+        tool, args, reads_json = segment_parts(segment)
+        if tool is None:
+            continue
+        has_json_input = reads_json or json_stream
+        if tool in TEXT_TOOLS and is_violation(tool, args, has_json_input):
+            sys.exit(1)
+        # Streams originating from a .json file stay json-classified through
+        # pass-through text stages (cat x.json | grep … | cut …).
+        if reads_json or (json_stream and tool in TEXT_TOOLS | {"cat", "head", "tail", "sort", "uniq", "tr", "xargs"}):
+            json_stream = True
+        else:
+            json_stream = False
+
+sys.exit(0)
+PY
+then
+  cat >&2 <<'EOF'
+BLOCKED: this command parses JSON with text tools (grep/sed/cut/awk). Text
+tools break on valid JSON — multiline values, escaped quotes, reordered keys,
+nested objects — producing silently wrong output instead of errors. Use jq for
+all structural JSON reads and writes in shell. Typical fixes:
+  read a field:   jq -r '.field' file.json
+  filter items:   jq '.items[] | select(.name=="x")' file.json
+  edit in place:  jq '.key="value"' file.json > tmp && mv tmp file.json
+If you are only SEARCHING text inside a JSON file (not extracting values), use
+`rg <pattern> file.json` with no extraction pipe and this hook will not fire.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -50,16 +50,28 @@ EOF
 # text from the destructive-command scans below. Unknown executable heredocs
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
+#
+# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
+# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
+# and a bare denial strands the agent with no path forward (gardener #1789).
+block_heredoc() {
+  block "$1
+Heredoc commit invocations are blocked (the payload is executable shell).
+Fix: write the commit message to a file and run \`git commit -F <file>\`.
+Every commit must also carry a Co-authored-by trailer for a supported agent
+(Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+}
+
 command_for_guards="$command_str"
 case "$command_str" in
   *'<<'*)
     hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     heredoc_parser="$hook_dir/parity-safety-net-heredoc.py"
     if ! command -v python3 >/dev/null 2>&1 || [ ! -r "$heredoc_parser" ]; then
-      block "cannot safely classify heredoc command because its parser runtime is unavailable"
+      block_heredoc "cannot safely classify heredoc command because its parser runtime is unavailable"
     fi
     if ! printf '%s\n' "$command_str" | /bin/bash -n >/dev/null 2>&1; then
-      block "malformed heredoc command failed shell syntax validation"
+      block_heredoc "malformed heredoc command failed shell syntax validation"
     fi
 
     parser_status=0
@@ -72,8 +84,8 @@ case "$command_str" in
     case "$parser_status" in
       0) command_for_guards="$parser_output" ;;
       10) command_for_guards="$command_str" ;;
-      20) block "malformed or ambiguous heredoc command cannot be safely classified" ;;
-      *) block "heredoc parser failed; command was denied fail-closed" ;;
+      20) block_heredoc "malformed or ambiguous heredoc command cannot be safely classified" ;;
+      *) block_heredoc "heredoc parser failed; command was denied fail-closed" ;;
     esac
     ;;
 esac

--- a/plugins/lisa-cursor/hooks/block-shell-json-parsing.sh
+++ b/plugins/lisa-cursor/hooks/block-shell-json-parsing.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
+# Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
+# quotes, reordered keys, nested objects — producing silently wrong output
+# instead of errors. jq is the required tool for structural JSON reads and
+# writes in shell. Promoted from PROJECT_RULES.md prose to an executable
+# control by the learnings gardener (issue #1787).
+#
+# Precision-first: this hook fires only on high-confidence STRUCTURAL parsing
+# of a *.json input — never on plain text search. Blocked signatures:
+#   1. `sed -i` (or an s/…/…/ program) applied to a .json file or stream;
+#   2. `cut -d` with a structural delimiter (quote/colon/comma) on .json input;
+#   3. `awk` field extraction (-F or a $N program) on .json input;
+#   4. `grep -o` on .json input (value extraction, not search).
+# A "json input" is a *.json argument, a `< file.json` redirection, or a
+# pipeline stream originating from a .json file (e.g. `cat x.json | …`).
+#
+# Exemptions (allowed):
+#   - any command that invokes jq anywhere (already compliant or mixed-legit);
+#   - search-only usage: plain grep / grep -l / rg with no extraction signature;
+#   - *.jsonl targets (line-delimited streams are legitimately line-tooled);
+#   - heredoc payload text (stripped before classification).
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Fast path: no ".json" reference at all means nothing to classify.
+case "$command_str" in
+  *.json*) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_SHELL_JSON_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_SHELL_JSON_COMMAND", "")
+
+TEXT_TOOLS = {"grep", "egrep", "fgrep", "sed", "gsed", "awk", "gawk", "cut"}
+WRAPPERS = {"command", "env", "sudo", "time", "nohup"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_heredoc_bodies(text: str) -> str:
+    """Remove heredoc payload lines so prose .json mentions never classify."""
+    lines = text.splitlines()
+    output = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        markers = [
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        ]
+        index += 1
+        for marker in markers:
+            while index < len(lines):
+                if lines[index].strip() == marker:
+                    index += 1
+                    break
+                index += 1
+    return "\n".join(output)
+
+
+def tokenize(text: str):
+    lex = shlex.shlex(text, posix=True, punctuation_chars="|&;<>")
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
+def is_json_path(token: str) -> bool:
+    return token.lower().rstrip(")};").endswith(".json")
+
+
+def split_pipelines(tokens):
+    """Yield lists of pipe-connected segments; each segment is a token list."""
+    pipelines, pipeline, segment = [], [], []
+    for token in tokens:
+        if token in ("|", "|&"):
+            pipeline.append(segment)
+            segment = []
+        elif token in (";", "&&", "||", "&", "\n"):
+            pipeline.append(segment)
+            pipelines.append(pipeline)
+            pipeline, segment = [], []
+        else:
+            segment.append(token)
+    pipeline.append(segment)
+    pipelines.append(pipeline)
+    return pipelines
+
+
+def segment_parts(segment):
+    """Return (tool, args, reads_json) for one pipeline segment."""
+    reads_json = False
+    tool = None
+    args = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token == "<":
+            if index + 1 < len(segment) and is_json_path(segment[index + 1]):
+                reads_json = True
+            index += 2
+            continue
+        if token in (">", ">>", "<<", "<<<"):
+            index += 2
+            continue
+        if tool is None and (ASSIGNMENT.match(token) or token in WRAPPERS):
+            index += 1
+            continue
+        if tool is None:
+            tool = token.rsplit("/", 1)[-1]
+        else:
+            args.append(token)
+            if is_json_path(token):
+                reads_json = True
+        index += 1
+    return tool, args, reads_json
+
+
+def flags_of(args):
+    return [a for a in args if a.startswith("-")]
+
+
+def is_violation(tool, args, has_json_input):
+    if not has_json_input:
+        return False
+    flags = flags_of(args)
+    if tool in ("grep", "egrep", "fgrep"):
+        if any(f in ("-l", "-L", "--files-with-matches", "--files-without-match") for f in flags):
+            return False
+        return any(f == "-o" or f == "--only-matching" or ("o" in f[1:] and not f.startswith("--")) for f in flags)
+    if tool in ("sed", "gsed"):
+        if any(f.startswith("-i") or f == "--in-place" for f in flags):
+            return True
+        return any(re.match(r"^-?\d*s[/|#]", a) or a.startswith("s/") or a.startswith("s|") for a in args)
+    if tool == "cut":
+        for i, arg in enumerate(args):
+            if arg == "-d" and i + 1 < len(args) and args[i + 1] in ('"', "'", ":", ","):
+                return True
+            if arg.startswith("-d") and len(arg) > 2 and arg[2:] in ('"', "'", ":", ","):
+                return True
+        return False
+    if tool in ("awk", "gawk"):
+        if any(f == "-F" or f.startswith("-F") for f in flags):
+            return True
+        return any(re.search(r"\$\d", a) for a in args if not a.startswith("-"))
+    return False
+
+
+tokens = tokenize(strip_heredoc_bodies(command))
+if tokens is None:
+    sys.exit(0)
+
+pipelines = split_pipelines(tokens)
+
+# Whole-command jq exemption: any jq stage means the author is already using
+# the right tool; mixed pipelines (jq | grep) are legitimate.
+for pipeline in pipelines:
+    for segment in pipeline:
+        tool, _args, _reads = segment_parts(segment)
+        if tool == "jq":
+            sys.exit(0)
+
+for pipeline in pipelines:
+    json_stream = False
+    for segment in pipeline:
+        tool, args, reads_json = segment_parts(segment)
+        if tool is None:
+            continue
+        has_json_input = reads_json or json_stream
+        if tool in TEXT_TOOLS and is_violation(tool, args, has_json_input):
+            sys.exit(1)
+        # Streams originating from a .json file stay json-classified through
+        # pass-through text stages (cat x.json | grep … | cut …).
+        if reads_json or (json_stream and tool in TEXT_TOOLS | {"cat", "head", "tail", "sort", "uniq", "tr", "xargs"}):
+            json_stream = True
+        else:
+            json_stream = False
+
+sys.exit(0)
+PY
+then
+  cat >&2 <<'EOF'
+BLOCKED: this command parses JSON with text tools (grep/sed/cut/awk). Text
+tools break on valid JSON — multiline values, escaped quotes, reordered keys,
+nested objects — producing silently wrong output instead of errors. Use jq for
+all structural JSON reads and writes in shell. Typical fixes:
+  read a field:   jq -r '.field' file.json
+  filter items:   jq '.items[] | select(.name=="x")' file.json
+  edit in place:  jq '.key="value"' file.json > tmp && mv tmp file.json
+If you are only SEARCHING text inside a JSON file (not extracting values), use
+`rg <pattern> file.json` with no extraction pipe and this hook will not fire.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa-cursor/hooks/hooks.json
+++ b/plugins/lisa-cursor/hooks/hooks.json
@@ -26,6 +26,10 @@
         "matcher": "Bash"
       },
       {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh",
+        "matcher": "Bash"
+      },
+      {
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
       }
     ],

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -50,16 +50,28 @@ EOF
 # text from the destructive-command scans below. Unknown executable heredocs
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
+#
+# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
+# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
+# and a bare denial strands the agent with no path forward (gardener #1789).
+block_heredoc() {
+  block "$1
+Heredoc commit invocations are blocked (the payload is executable shell).
+Fix: write the commit message to a file and run \`git commit -F <file>\`.
+Every commit must also carry a Co-authored-by trailer for a supported agent
+(Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+}
+
 command_for_guards="$command_str"
 case "$command_str" in
   *'<<'*)
     hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     heredoc_parser="$hook_dir/parity-safety-net-heredoc.py"
     if ! command -v python3 >/dev/null 2>&1 || [ ! -r "$heredoc_parser" ]; then
-      block "cannot safely classify heredoc command because its parser runtime is unavailable"
+      block_heredoc "cannot safely classify heredoc command because its parser runtime is unavailable"
     fi
     if ! printf '%s\n' "$command_str" | /bin/bash -n >/dev/null 2>&1; then
-      block "malformed heredoc command failed shell syntax validation"
+      block_heredoc "malformed heredoc command failed shell syntax validation"
     fi
 
     parser_status=0
@@ -72,8 +84,8 @@ case "$command_str" in
     case "$parser_status" in
       0) command_for_guards="$parser_output" ;;
       10) command_for_guards="$command_str" ;;
-      20) block "malformed or ambiguous heredoc command cannot be safely classified" ;;
-      *) block "heredoc parser failed; command was denied fail-closed" ;;
+      20) block_heredoc "malformed or ambiguous heredoc command cannot be safely classified" ;;
+      *) block_heredoc "heredoc parser failed; command was denied fail-closed" ;;
     esac
     ;;
 esac

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -102,6 +102,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
           }
         ]
       },

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -42,6 +42,10 @@
           {
             "type": "command",
             "command": "${PLUGIN_ROOT}/hooks/parity-safety-net.sh"
+          },
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
           }
         ]
       },

--- a/plugins/lisa/hooks/block-shell-json-parsing.agy.sh
+++ b/plugins/lisa/hooks/block-shell-json-parsing.agy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's canonical shell-JSON guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-shell-json-parsing.sh beside it (same delegation pattern as
+# parity-safety-net.agy.sh). Fail-open on missing runtimes: unlike the
+# safety net, a missed nudge here risks a fragile script, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-shell-json-parsing.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: structural JSON parsing with text tools; use jq."
+deny "$canonical_output"

--- a/plugins/lisa/hooks/block-shell-json-parsing.sh
+++ b/plugins/lisa/hooks/block-shell-json-parsing.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
+# Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
+# quotes, reordered keys, nested objects — producing silently wrong output
+# instead of errors. jq is the required tool for structural JSON reads and
+# writes in shell. Promoted from PROJECT_RULES.md prose to an executable
+# control by the learnings gardener (issue #1787).
+#
+# Precision-first: this hook fires only on high-confidence STRUCTURAL parsing
+# of a *.json input — never on plain text search. Blocked signatures:
+#   1. `sed -i` (or an s/…/…/ program) applied to a .json file or stream;
+#   2. `cut -d` with a structural delimiter (quote/colon/comma) on .json input;
+#   3. `awk` field extraction (-F or a $N program) on .json input;
+#   4. `grep -o` on .json input (value extraction, not search).
+# A "json input" is a *.json argument, a `< file.json` redirection, or a
+# pipeline stream originating from a .json file (e.g. `cat x.json | …`).
+#
+# Exemptions (allowed):
+#   - any command that invokes jq anywhere (already compliant or mixed-legit);
+#   - search-only usage: plain grep / grep -l / rg with no extraction signature;
+#   - *.jsonl targets (line-delimited streams are legitimately line-tooled);
+#   - heredoc payload text (stripped before classification).
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Fast path: no ".json" reference at all means nothing to classify.
+case "$command_str" in
+  *.json*) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_SHELL_JSON_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_SHELL_JSON_COMMAND", "")
+
+TEXT_TOOLS = {"grep", "egrep", "fgrep", "sed", "gsed", "awk", "gawk", "cut"}
+WRAPPERS = {"command", "env", "sudo", "time", "nohup"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_heredoc_bodies(text: str) -> str:
+    """Remove heredoc payload lines so prose .json mentions never classify."""
+    lines = text.splitlines()
+    output = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        markers = [
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        ]
+        index += 1
+        for marker in markers:
+            while index < len(lines):
+                if lines[index].strip() == marker:
+                    index += 1
+                    break
+                index += 1
+    return "\n".join(output)
+
+
+def tokenize(text: str):
+    lex = shlex.shlex(text, posix=True, punctuation_chars="|&;<>")
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
+def is_json_path(token: str) -> bool:
+    return token.lower().rstrip(")};").endswith(".json")
+
+
+def split_pipelines(tokens):
+    """Yield lists of pipe-connected segments; each segment is a token list."""
+    pipelines, pipeline, segment = [], [], []
+    for token in tokens:
+        if token in ("|", "|&"):
+            pipeline.append(segment)
+            segment = []
+        elif token in (";", "&&", "||", "&", "\n"):
+            pipeline.append(segment)
+            pipelines.append(pipeline)
+            pipeline, segment = [], []
+        else:
+            segment.append(token)
+    pipeline.append(segment)
+    pipelines.append(pipeline)
+    return pipelines
+
+
+def segment_parts(segment):
+    """Return (tool, args, reads_json) for one pipeline segment."""
+    reads_json = False
+    tool = None
+    args = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token == "<":
+            if index + 1 < len(segment) and is_json_path(segment[index + 1]):
+                reads_json = True
+            index += 2
+            continue
+        if token in (">", ">>", "<<", "<<<"):
+            index += 2
+            continue
+        if tool is None and (ASSIGNMENT.match(token) or token in WRAPPERS):
+            index += 1
+            continue
+        if tool is None:
+            tool = token.rsplit("/", 1)[-1]
+        else:
+            args.append(token)
+            if is_json_path(token):
+                reads_json = True
+        index += 1
+    return tool, args, reads_json
+
+
+def flags_of(args):
+    return [a for a in args if a.startswith("-")]
+
+
+def is_violation(tool, args, has_json_input):
+    if not has_json_input:
+        return False
+    flags = flags_of(args)
+    if tool in ("grep", "egrep", "fgrep"):
+        if any(f in ("-l", "-L", "--files-with-matches", "--files-without-match") for f in flags):
+            return False
+        return any(f == "-o" or f == "--only-matching" or ("o" in f[1:] and not f.startswith("--")) for f in flags)
+    if tool in ("sed", "gsed"):
+        if any(f.startswith("-i") or f == "--in-place" for f in flags):
+            return True
+        return any(re.match(r"^-?\d*s[/|#]", a) or a.startswith("s/") or a.startswith("s|") for a in args)
+    if tool == "cut":
+        for i, arg in enumerate(args):
+            if arg == "-d" and i + 1 < len(args) and args[i + 1] in ('"', "'", ":", ","):
+                return True
+            if arg.startswith("-d") and len(arg) > 2 and arg[2:] in ('"', "'", ":", ","):
+                return True
+        return False
+    if tool in ("awk", "gawk"):
+        if any(f == "-F" or f.startswith("-F") for f in flags):
+            return True
+        return any(re.search(r"\$\d", a) for a in args if not a.startswith("-"))
+    return False
+
+
+tokens = tokenize(strip_heredoc_bodies(command))
+if tokens is None:
+    sys.exit(0)
+
+pipelines = split_pipelines(tokens)
+
+# Whole-command jq exemption: any jq stage means the author is already using
+# the right tool; mixed pipelines (jq | grep) are legitimate.
+for pipeline in pipelines:
+    for segment in pipeline:
+        tool, _args, _reads = segment_parts(segment)
+        if tool == "jq":
+            sys.exit(0)
+
+for pipeline in pipelines:
+    json_stream = False
+    for segment in pipeline:
+        tool, args, reads_json = segment_parts(segment)
+        if tool is None:
+            continue
+        has_json_input = reads_json or json_stream
+        if tool in TEXT_TOOLS and is_violation(tool, args, has_json_input):
+            sys.exit(1)
+        # Streams originating from a .json file stay json-classified through
+        # pass-through text stages (cat x.json | grep … | cut …).
+        if reads_json or (json_stream and tool in TEXT_TOOLS | {"cat", "head", "tail", "sort", "uniq", "tr", "xargs"}):
+            json_stream = True
+        else:
+            json_stream = False
+
+sys.exit(0)
+PY
+then
+  cat >&2 <<'EOF'
+BLOCKED: this command parses JSON with text tools (grep/sed/cut/awk). Text
+tools break on valid JSON — multiline values, escaped quotes, reordered keys,
+nested objects — producing silently wrong output instead of errors. Use jq for
+all structural JSON reads and writes in shell. Typical fixes:
+  read a field:   jq -r '.field' file.json
+  filter items:   jq '.items[] | select(.name=="x")' file.json
+  edit in place:  jq '.key="value"' file.json > tmp && mv tmp file.json
+If you are only SEARCHING text inside a JSON file (not extracting values), use
+`rg <pattern> file.json` with no extraction pipe and this hook will not fire.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -50,16 +50,28 @@ EOF
 # text from the destructive-command scans below. Unknown executable heredocs
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
+#
+# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
+# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
+# and a bare denial strands the agent with no path forward (gardener #1789).
+block_heredoc() {
+  block "$1
+Heredoc commit invocations are blocked (the payload is executable shell).
+Fix: write the commit message to a file and run \`git commit -F <file>\`.
+Every commit must also carry a Co-authored-by trailer for a supported agent
+(Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+}
+
 command_for_guards="$command_str"
 case "$command_str" in
   *'<<'*)
     hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     heredoc_parser="$hook_dir/parity-safety-net-heredoc.py"
     if ! command -v python3 >/dev/null 2>&1 || [ ! -r "$heredoc_parser" ]; then
-      block "cannot safely classify heredoc command because its parser runtime is unavailable"
+      block_heredoc "cannot safely classify heredoc command because its parser runtime is unavailable"
     fi
     if ! printf '%s\n' "$command_str" | /bin/bash -n >/dev/null 2>&1; then
-      block "malformed heredoc command failed shell syntax validation"
+      block_heredoc "malformed heredoc command failed shell syntax validation"
     fi
 
     parser_status=0
@@ -72,8 +84,8 @@ case "$command_str" in
     case "$parser_status" in
       0) command_for_guards="$parser_output" ;;
       10) command_for_guards="$command_str" ;;
-      20) block "malformed or ambiguous heredoc command cannot be safely classified" ;;
-      *) block "heredoc parser failed; command was denied fail-closed" ;;
+      20) block_heredoc "malformed or ambiguous heredoc command cannot be safely classified" ;;
+      *) block_heredoc "heredoc parser failed; command was denied fail-closed" ;;
     esac
     ;;
 esac

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -102,6 +102,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
           }
         ]
       },

--- a/plugins/src/base/hooks/block-shell-json-parsing.agy.sh
+++ b/plugins/src/base/hooks/block-shell-json-parsing.agy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's canonical shell-JSON guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-shell-json-parsing.sh beside it (same delegation pattern as
+# parity-safety-net.agy.sh). Fail-open on missing runtimes: unlike the
+# safety net, a missed nudge here risks a fragile script, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-shell-json-parsing.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: structural JSON parsing with text tools; use jq."
+deny "$canonical_output"

--- a/plugins/src/base/hooks/block-shell-json-parsing.sh
+++ b/plugins/src/base/hooks/block-shell-json-parsing.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
+# Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
+# quotes, reordered keys, nested objects — producing silently wrong output
+# instead of errors. jq is the required tool for structural JSON reads and
+# writes in shell. Promoted from PROJECT_RULES.md prose to an executable
+# control by the learnings gardener (issue #1787).
+#
+# Precision-first: this hook fires only on high-confidence STRUCTURAL parsing
+# of a *.json input — never on plain text search. Blocked signatures:
+#   1. `sed -i` (or an s/…/…/ program) applied to a .json file or stream;
+#   2. `cut -d` with a structural delimiter (quote/colon/comma) on .json input;
+#   3. `awk` field extraction (-F or a $N program) on .json input;
+#   4. `grep -o` on .json input (value extraction, not search).
+# A "json input" is a *.json argument, a `< file.json` redirection, or a
+# pipeline stream originating from a .json file (e.g. `cat x.json | …`).
+#
+# Exemptions (allowed):
+#   - any command that invokes jq anywhere (already compliant or mixed-legit);
+#   - search-only usage: plain grep / grep -l / rg with no extraction signature;
+#   - *.jsonl targets (line-delimited streams are legitimately line-tooled);
+#   - heredoc payload text (stripped before classification).
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+if [ -z "$command_str" ]; then
+  exit 0
+fi
+
+# Fast path: no ".json" reference at all means nothing to classify.
+case "$command_str" in
+  *.json*) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+if ! BLOCK_SHELL_JSON_COMMAND="$command_str" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+command = os.environ.get("BLOCK_SHELL_JSON_COMMAND", "")
+
+TEXT_TOOLS = {"grep", "egrep", "fgrep", "sed", "gsed", "awk", "gawk", "cut"}
+WRAPPERS = {"command", "env", "sudo", "time", "nohup"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_heredoc_bodies(text: str) -> str:
+    """Remove heredoc payload lines so prose .json mentions never classify."""
+    lines = text.splitlines()
+    output = []
+    marker_pattern = re.compile(
+        r"<<-?\s*(?:'([^']+)'|\"([^\"]+)\"|\\?([A-Za-z_][A-Za-z0-9_]*))"
+    )
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        output.append(line)
+        markers = [
+            next(group for group in match.groups() if group)
+            for match in marker_pattern.finditer(line)
+        ]
+        index += 1
+        for marker in markers:
+            while index < len(lines):
+                if lines[index].strip() == marker:
+                    index += 1
+                    break
+                index += 1
+    return "\n".join(output)
+
+
+def tokenize(text: str):
+    lex = shlex.shlex(text, posix=True, punctuation_chars="|&;<>")
+    lex.whitespace_split = True
+    try:
+        return list(lex)
+    except ValueError:
+        return None
+
+
+def is_json_path(token: str) -> bool:
+    return token.lower().rstrip(")};").endswith(".json")
+
+
+def split_pipelines(tokens):
+    """Yield lists of pipe-connected segments; each segment is a token list."""
+    pipelines, pipeline, segment = [], [], []
+    for token in tokens:
+        if token in ("|", "|&"):
+            pipeline.append(segment)
+            segment = []
+        elif token in (";", "&&", "||", "&", "\n"):
+            pipeline.append(segment)
+            pipelines.append(pipeline)
+            pipeline, segment = [], []
+        else:
+            segment.append(token)
+    pipeline.append(segment)
+    pipelines.append(pipeline)
+    return pipelines
+
+
+def segment_parts(segment):
+    """Return (tool, args, reads_json) for one pipeline segment."""
+    reads_json = False
+    tool = None
+    args = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token == "<":
+            if index + 1 < len(segment) and is_json_path(segment[index + 1]):
+                reads_json = True
+            index += 2
+            continue
+        if token in (">", ">>", "<<", "<<<"):
+            index += 2
+            continue
+        if tool is None and (ASSIGNMENT.match(token) or token in WRAPPERS):
+            index += 1
+            continue
+        if tool is None:
+            tool = token.rsplit("/", 1)[-1]
+        else:
+            args.append(token)
+            if is_json_path(token):
+                reads_json = True
+        index += 1
+    return tool, args, reads_json
+
+
+def flags_of(args):
+    return [a for a in args if a.startswith("-")]
+
+
+def is_violation(tool, args, has_json_input):
+    if not has_json_input:
+        return False
+    flags = flags_of(args)
+    if tool in ("grep", "egrep", "fgrep"):
+        if any(f in ("-l", "-L", "--files-with-matches", "--files-without-match") for f in flags):
+            return False
+        return any(f == "-o" or f == "--only-matching" or ("o" in f[1:] and not f.startswith("--")) for f in flags)
+    if tool in ("sed", "gsed"):
+        if any(f.startswith("-i") or f == "--in-place" for f in flags):
+            return True
+        return any(re.match(r"^-?\d*s[/|#]", a) or a.startswith("s/") or a.startswith("s|") for a in args)
+    if tool == "cut":
+        for i, arg in enumerate(args):
+            if arg == "-d" and i + 1 < len(args) and args[i + 1] in ('"', "'", ":", ","):
+                return True
+            if arg.startswith("-d") and len(arg) > 2 and arg[2:] in ('"', "'", ":", ","):
+                return True
+        return False
+    if tool in ("awk", "gawk"):
+        if any(f == "-F" or f.startswith("-F") for f in flags):
+            return True
+        return any(re.search(r"\$\d", a) for a in args if not a.startswith("-"))
+    return False
+
+
+tokens = tokenize(strip_heredoc_bodies(command))
+if tokens is None:
+    sys.exit(0)
+
+pipelines = split_pipelines(tokens)
+
+# Whole-command jq exemption: any jq stage means the author is already using
+# the right tool; mixed pipelines (jq | grep) are legitimate.
+for pipeline in pipelines:
+    for segment in pipeline:
+        tool, _args, _reads = segment_parts(segment)
+        if tool == "jq":
+            sys.exit(0)
+
+for pipeline in pipelines:
+    json_stream = False
+    for segment in pipeline:
+        tool, args, reads_json = segment_parts(segment)
+        if tool is None:
+            continue
+        has_json_input = reads_json or json_stream
+        if tool in TEXT_TOOLS and is_violation(tool, args, has_json_input):
+            sys.exit(1)
+        # Streams originating from a .json file stay json-classified through
+        # pass-through text stages (cat x.json | grep … | cut …).
+        if reads_json or (json_stream and tool in TEXT_TOOLS | {"cat", "head", "tail", "sort", "uniq", "tr", "xargs"}):
+            json_stream = True
+        else:
+            json_stream = False
+
+sys.exit(0)
+PY
+then
+  cat >&2 <<'EOF'
+BLOCKED: this command parses JSON with text tools (grep/sed/cut/awk). Text
+tools break on valid JSON — multiline values, escaped quotes, reordered keys,
+nested objects — producing silently wrong output instead of errors. Use jq for
+all structural JSON reads and writes in shell. Typical fixes:
+  read a field:   jq -r '.field' file.json
+  filter items:   jq '.items[] | select(.name=="x")' file.json
+  edit in place:  jq '.key="value"' file.json > tmp && mv tmp file.json
+If you are only SEARCHING text inside a JSON file (not extracting values), use
+`rg <pattern> file.json` with no extraction pipe and this hook will not fire.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -50,16 +50,28 @@ EOF
 # text from the destructive-command scans below. Unknown executable heredocs
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
+#
+# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
+# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
+# and a bare denial strands the agent with no path forward (gardener #1789).
+block_heredoc() {
+  block "$1
+Heredoc commit invocations are blocked (the payload is executable shell).
+Fix: write the commit message to a file and run \`git commit -F <file>\`.
+Every commit must also carry a Co-authored-by trailer for a supported agent
+(Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+}
+
 command_for_guards="$command_str"
 case "$command_str" in
   *'<<'*)
     hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     heredoc_parser="$hook_dir/parity-safety-net-heredoc.py"
     if ! command -v python3 >/dev/null 2>&1 || [ ! -r "$heredoc_parser" ]; then
-      block "cannot safely classify heredoc command because its parser runtime is unavailable"
+      block_heredoc "cannot safely classify heredoc command because its parser runtime is unavailable"
     fi
     if ! printf '%s\n' "$command_str" | /bin/bash -n >/dev/null 2>&1; then
-      block "malformed heredoc command failed shell syntax validation"
+      block_heredoc "malformed heredoc command failed shell syntax validation"
     fi
 
     parser_status=0
@@ -72,8 +84,8 @@ case "$command_str" in
     case "$parser_status" in
       0) command_for_guards="$parser_output" ;;
       10) command_for_guards="$command_str" ;;
-      20) block "malformed or ambiguous heredoc command cannot be safely classified" ;;
-      *) block "heredoc parser failed; command was denied fail-closed" ;;
+      20) block_heredoc "malformed or ambiguous heredoc command cannot be safely classified" ;;
+      *) block_heredoc "heredoc parser failed; command was denied fail-closed" ;;
     esac
     ;;
 esac

--- a/scripts/generate-agy-plugin-artifacts.mjs
+++ b/scripts/generate-agy-plugin-artifacts.mjs
@@ -226,6 +226,14 @@ const AGY_PLUGIN_HOOKS = [
     agyScript: "parity-safety-net.agy.sh",
     supportScripts: ["parity-safety-net.sh", "parity-safety-net-heredoc.py"],
   },
+  {
+    sourceScript: "block-shell-json-parsing.sh",
+    hookName: "lisa-block-shell-json-parsing",
+    event: "PreToolUse",
+    matcher: "run_command",
+    agyScript: "block-shell-json-parsing.agy.sh",
+    supportScripts: ["block-shell-json-parsing.sh"],
+  },
 ];
 
 /**

--- a/scripts/lib/per-agent-hook-filter.mjs
+++ b/scripts/lib/per-agent-hook-filter.mjs
@@ -43,6 +43,13 @@ const SCRIPT_RULES = {
     agy: true,
     copilot: true,
   },
+  "block-shell-json-parsing.sh": {
+    claude: true,
+    codex: true,
+    cursor: true,
+    agy: true, // ships via AGY_PLUGIN_HOOKS (agy-protocol adapter), like the other PreToolUse guards
+    copilot: true,
+  },
   "enforce-team-first.sh": {
     claude: true,
     codex: false,

--- a/tests/unit/hooks/block-shell-json-parsing.test.ts
+++ b/tests/unit/hooks/block-shell-json-parsing.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the block-shell-json-parsing.sh hook behavior.
+ *
+ * The hook blocks structural JSON parsing with text tools (grep/sed/cut/awk)
+ * on *.json inputs — the executable control promoted from the PROJECT_RULES.md
+ * "always use jq" prose (gardener issue #1787). It must stay precision-first:
+ * plain text search over JSON files, .jsonl streams, non-JSON files, and any
+ * command that already invokes jq are all allowed.
+ * @module tests/unit/hooks/block-shell-json-parsing
+ */
+import { spawnSync } from "child_process";
+import path from "path";
+
+const HOOK_PATH = path.resolve(
+  "plugins/lisa/hooks/block-shell-json-parsing.sh"
+);
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const runHook = (
+  toolName: string,
+  command: string
+): { status: number | null; stderr: string } => {
+  const input = JSON.stringify({
+    tool_name: toolName,
+    tool_input: { command },
+  });
+
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    input,
+    encoding: "utf-8",
+  });
+
+  return { status: result.status, stderr: result.stderr };
+};
+
+describe("block-shell-json-parsing.sh", () => {
+  describe("blocks structural JSON extraction with text tools", () => {
+    it("blocks grep piped onward to cut with a quote delimiter", () => {
+      const { status, stderr } = runHook(
+        "Bash",
+        `grep '"version"' package.json | cut -d'"' -f4`
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("Use jq");
+      expect(stderr).toContain("jq -r '.field' file.json");
+    });
+
+    it("blocks sed -i on a .json file", () => {
+      const { status } = runHook("Bash", "sed -i 's/x/y/' config.json");
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks sed with an s/// program on a .json file", () => {
+      const { status } = runHook("Bash", `sed 's/"old"/"new"/' settings.json`);
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks awk field extraction with -F on a .json file", () => {
+      const { status } = runHook("Bash", `awk -F: '{print $2}' data.json`);
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks awk $N field programs on a json-derived stream", () => {
+      const { status } = runHook(
+        "Bash",
+        `cat package.json | grep name | awk '{print $2}'`
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks cut with a structural delimiter reading a .json redirection", () => {
+      const { status } = runHook("Bash", "cut -d: -f2 < package.json");
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks grep -o value extraction on a .json file", () => {
+      const { status } = runHook(
+        "Bash",
+        `grep -o '"version": "[^"]*"' package.json`
+      );
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+  });
+
+  describe("allows compliant and search-only usage", () => {
+    it("allows jq reads", () => {
+      const { status } = runHook("Bash", "jq -r '.version' package.json");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows mixed pipelines that invoke jq anywhere", () => {
+      const { status } = runHook(
+        "Bash",
+        "jq -r '.items[].name' data.json | grep -c widget"
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows plain grep search over a .json file (no extraction)", () => {
+      const { status } = runHook("Bash", "grep version package.json");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows grep -l file discovery over .json globs", () => {
+      const { status } = runHook("Bash", "grep -l pattern config.json");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows cat piped to plain grep (search, not extraction)", () => {
+      const { status } = runHook("Bash", "cat package.json | grep version");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows rg over .json files (not a blocked tool)", () => {
+      const { status } = runHook("Bash", "rg version package.json");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows text tools over .jsonl streams", () => {
+      const { status } = runHook("Bash", "cat data.jsonl | grep foo");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows sed on non-JSON files", () => {
+      const { status } = runHook("Bash", `sed 's/foo/bar/' README.md`);
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows --json CLI flags (not a file reference)", () => {
+      const { status } = runHook("Bash", "gh issue list --json number,body");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows commands with no .json reference at all", () => {
+      const { status } = runHook("Bash", "git status");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("ignores .json mentions inside heredoc payload text", () => {
+      const command = [
+        "cat > notes.txt <<'EOF'",
+        "see sed -i tricks for package.json parsing",
+        "EOF",
+      ].join("\n");
+      const { status } = runHook("Bash", command);
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("envelope handling", () => {
+    it("ignores non-Bash tools", () => {
+      const { status } = runHook("Read", "sed -i 's/x/y/' config.json");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows empty commands", () => {
+      const { status } = runHook("Bash", "");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+});

--- a/wiki/architecture/lisa-console-ui.md
+++ b/wiki/architecture/lisa-console-ui.md
@@ -1,0 +1,74 @@
+# Lisa Console UI (`ui/`) — Architecture and Test Mechanics
+
+Reference knowledge for the Lisa Console UI subsystem, demoted from the eager
+rules tier (`.claude/rules/PROJECT_RULES.md`) by gardener ticket #1788: these
+are durable, declarative facts that only matter when touching `ui/`,
+`src/cli/ui-cmd.ts`, or `tests/e2e/` — the wiki index is the routing surface.
+
+## Overview
+
+The console UI ships as a single hand-written file, `ui/index.html` — there is
+no bundler and no `ui/dist`. It is served by the `lisa ui` command via `runUi`
+in `src/cli/ui-cmd.ts`.
+
+## Running locally
+
+- The CLI entrypoint is `bun src/index.ts ui` (or `bun dist/index.js ui` after
+  build). Do not use `bun src/cli/index.ts ui` — that module has no `main()`.
+- After source changes that register new `/api/status` probes, rebuild
+  (`bun run build:dist`) or run via the source entrypoint before trusting live
+  `dist/` output; a stale `dist/` can silently omit newly added probe modules.
+
+## Build layout: built CLI entry is `dist/index.js`, not `dist/src/...`
+
+`tsconfig.local.json` sets `rootDir: "src"` + `outDir: "dist"`, which flattens
+`src/` out of the emitted tree. The CLI entry is `dist/index.js` (also
+`bin.lisa` in `package.json`) — **not** `dist/src/cli/index.js`. Verification,
+plan, and doctor commands that guess a nested `dist/src/...` path fail. Always
+target `dist/index.js`.
+
+## Testing `runUi`: always pass `{ sync: false }`
+
+Pass `sync: false` whenever calling `runUi` from a test. Without it, `runUi`
+calls `runConfigSync` and mutates the temp/working directory under test. All
+unit and e2e tests use `{ port: "0", sync: false }`.
+
+## Playwright pipeline boundary
+
+`playwright.config.ts` defines **one** global `webServer` on a fixed port
+(`UI_TEST_PORT = 4783`) with `baseURL: http://127.0.0.1:4783`. That single
+shared server cannot host per-test probe injection. To drive real code with
+stubbed edges (e.g. injected probes), a spec must bypass `baseURL`:
+`import { runUi }`, launch a per-test server on `port: "0"`, and navigate to
+the absolute `http://127.0.0.1:${address.port}` URL, closing the server in a
+`finally`. See `tests/e2e/ui-stacks.spec.ts`.
+
+e2e spec files are **not** type-checked by `tsc --noEmit` (root `tsconfig`
+`include` is `src/**`, and tests are excluded) and are ESLint-ignored
+(`eslint.ignore.config.json` ignores `e2e/**`). Playwright's own TypeScript
+pipeline is what typechecks them — do not expect the repo's `lint`/`typecheck`
+gates to cover changes made only inside `tests/e2e/`.
+
+## Toggle checkboxes need `dispatchEvent("click")`
+
+The console's toggle controls are an `opacity-0` `<input type="checkbox">`
+layered under a styled `.trk`/`span`. Playwright's `.click()` hits the visual
+layer and does not fire the input's change handler. Use
+`card.getByRole("checkbox").dispatchEvent("click")` — it reliably fires the
+handler. Reuse this for every console toggle test. (Web analog of the Maestro
+iOS `opacity-0`/`testID` accessibility gaps.)
+
+## `esc()` / `el()` are a text-context escaper and a raw-HTML sink
+
+In `ui/index.html`, `esc(s)` escapes `& < > "` but **not** `'` — it is safe
+only for text/element content interpolated into `innerHTML`, not for
+attribute-value contexts (which can be broken out of with a single quote).
+`el(tag, cls, html)` assigns its third argument straight to `innerHTML`, so it
+is a raw-HTML sink: only ever pass it `esc()`-wrapped values or trusted catalog
+constants. If you add attribute interpolation, add an attribute-safe escaper
+rather than reusing `esc()`.
+
+The single checkable invariant on this page — `runUi` called from tests
+without `{ sync: false }` — is a future EXECUTABLE-CONTROL candidate if
+violations recur; file it with recurrence evidence rather than re-promoting
+this page.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -33,6 +33,7 @@ Last updated by connector ingest on 2026-06-14 for Lisa `2.165.6` and current mo
   - Current template surface includes Phaser 4, Harper Fabric workflow/realtime guard additions, and the esbuild audit-ignore template exclusion.
 - [Coding-Agent Parity Architecture](architecture/coding-agent-parity.md)
 - [Lisa Hook Per-Agent Ship List](architecture/lisa-hook-per-agent-ship-list.md)
+- [Lisa Console UI](architecture/lisa-console-ui.md)
 - [Pattern B Per-Agent Plugin Fan-Out Specification](architecture/pattern-b-fan-out-spec.md)
 
 ## Requirements

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,12 @@
 # Lisa Wiki Log
 
+## 2026-07-19 - Gardener demotion: Console UI knowledge from eager rules to wiki
+
+- Created `wiki/architecture/lisa-console-ui.md` from the two Console-UI sections of `.claude/rules/PROJECT_RULES.md` ("Local `lisa ui` verification" and "Lisa Console UI (`ui/`)"), preserving every fact (entrypoints, `dist/index.js` flattening, `{ sync: false }`, Playwright pipeline boundary, toggle `dispatchEvent`, `esc()`/`el()` semantics).
+- Deleted both sections from `.claude/rules/PROJECT_RULES.md` in the same change; the wiki index is now the routing surface for this subsystem knowledge.
+- Provenance: gardener ticket CodySwannGT/lisa#1788 (learnings-audit run 2026-07-19, ladder rung WIKI).
+- Indexed the new page under `## Architecture` in `wiki/index.md`.
+
 ## 2026-06-14 - Incremental connector ingest
 
 - Synced the automation worktree with `origin/main` by fetching `origin` and created `wiki/ingest-20260614T000000Z` from current `origin/main` because the run started on a detached HEAD.


### PR DESCRIPTION
## Summary

Executes all four human-gated tickets from the first genuine learnings-audit (gardener) run of 2026-07-19 — #1787, #1788, #1789, #1790 — moving every audited piece of knowledge to the cheapest rung that still prevents the mistake, per the six-rung ladder (PRD #1729). Each promotion satisfies the four-leg promotion-to-control contract atomically within its own commit.

**Net effect: `.claude/rules/PROJECT_RULES.md` (the eager tier) shrinks 19,092 → 10,651 bytes (−44%) with zero loss of enforcement or teaching.**

## Changes by ticket

### #1787 — PROMOTE: jq-for-JSON rule → blocking executable control (`feat(hooks)`)

- New `block-shell-json-parsing.sh` PreToolUse Bash hook (exit 2): blocks structural JSON parsing with grep/sed/cut/awk on `*.json` inputs. Precision-first — exempts jq-invoking commands, search-only grep/`rg`, `grep -l`, `.jsonl`, `--json` CLI flags, non-JSON files, and heredoc payload text.
- Registered in the base plugin manifest; fanned out to codex/cursor/copilot; agy-protocol adapter (`block-shell-json-parsing.agy.sh`) registered in `AGY_PLUGIN_HOOKS`, delegating classification to the canonical script.
- Remediation-teaching diagnostic (invariant + why + concrete jq fixes).
- Violation population: **zero** (repo-wide scan) — control lands green, no ignores.
- Superseded prose deleted from PROJECT_RULES.md.
- 20 new unit tests (`tests/unit/hooks/block-shell-json-parsing.test.ts`) covering the full block/allow matrix from the ticket's QA plan.

### #1789 — PROMOTE: git-commit-F prose → teaching diagnostic (`feat(hooks)`)

- All four heredoc denial sites in `parity-safety-net.sh` now route through `block_heredoc()`, which appends the fix: write the message to a file, `git commit -F <file>`, include a supported Co-authored-by trailer. Previously the denial said only "malformed or ambiguous heredoc command cannot be safely classified" — blocking without teaching.
- The trailer half needed nothing: `.husky/commit-msg` already blocks and teaches (covered by `tests/unit/hooks/commit-msg.test.ts`).
- Superseded prose section deleted. The agy adapter delegates to the canonical script, so parity is inherited.

### #1788 — DEMOTE: Console-UI knowledge cluster → wiki (`docs(rules)`)

- ~60 lines of subsystem reference facts (the largest non-governance block in the eager tier, with no repeated-miss evidence earning eager placement) moved verbatim-preserving to `wiki/architecture/lisa-console-ui.md`.
- Indexed under Architecture in `wiki/index.md`; ingestion recorded in `wiki/log.md` per the wiki contract.

### #1790 — BATCH: five proof-citing retirements (`docs(rules)`)

Each deleted section restated an invariant a blocking owner already enforces:

| Deleted section | Mechanical/skill owner (proof) |
|---|---|
| ESLint Statement Order | `code-organization/enforce-statement-order` = "error" (`src/configs/eslint/typescript.ts:93`) — its unique guard-clause tip relocated into the rule's `wrongOrder` diagnostic in this PR |
| ESLint Disable Comments | `@eslint-community/eslint-comments/require-description` = "error" (`src/configs/eslint/base.ts:222`) |
| DRY Principle | eager `coding-philosophy` rule (DRY-with-KISS at 3+); the section's delegate-at-2 delta contradicted the canonical priority |
| Verify Auto-Merge Ancestry Check | `lisa-drive-pr-to-merge` SKILL.md §3 — identical `git merge-base --is-ancestor` procedure, loaded by every merge-driving flow |
| Never edit generated plugin artifacts | `scripts/check-plugins-sync.sh` + 🧩 Plugins Sync CI — failure diagnostic teaches the 3-step remediation verbatim |

## Verification

- `bun run check:plugins` — artifacts in sync with `plugins/src`, marketplace complete.
- `bunx tsc --noEmit` — clean.
- `bun run test:unit` — 329 files / 5,508 tests pass (includes 20 new hook tests).
- New hook exercised against the 16-case QA matrix from #1787 (blocks all 7 structural-extraction shapes; allows all 9 compliant/search-only shapes).
- Enriched heredoc denial empirically probed: denial output now carries the `git commit -F` remediation.

## Provenance

Gardener run artifacts: per-item tickets #1787, #1788, #1789; batch ticket #1790. Router: `skill-evaluator` (advisory). All fingerprint markers ride in the ticket bodies for idempotent dedupe.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that block structural JSON parsing with shell text-processing tools and provide guidance to use `jq`.
  * Extended protection across supported tool integrations and shell workflows.
  * Added more specific feedback for blocked heredoc commands.

* **Documentation**
  * Added architecture documentation for the Console UI and linked it from the wiki index.

* **Tests**
  * Added coverage for blocked JSON parsing patterns and allowed search, `jq`, JSONL, and non-Bash scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->