### PR TITLE
docs(ci): correct learnings_budget rationale to bounded-projection design (#1794)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -537,11 +537,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Hard budget gate for the project learnings surface (per-entry length cap,
-    # entry count, and token ceiling). The learnings file is loaded eagerly by
-    # every coding agent in every session, so an over-budget file degrades them
-    # all — this job fails the build when it grows too large. The check reads the
-    # learnings file resolved from .lisa.config.json; a project that has never
-    # recorded a learning has no file and passes silently.
+    # entry count, and token ceiling). The ledger lives cold in .lisa/ and
+    # reaches agents only through the contract's bounded projection — this gate
+    # keeps the document contract-valid and the projection serveable, and fails
+    # the build when the file grows past budget. The check reads the learnings
+    # file resolved from .lisa.config.json; a project that has never recorded a
+    # learning has no file and passes silently.
     if: ${{ !contains(inputs.skip_jobs, 'learnings_budget') }}
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
Closes #1794

## Summary

Comment-only fix in `.github/workflows/quality.yml`. The `learnings_budget` job's header comment justified the gate with a premise that went stale with LLG-1 (#1730). No behavior change: the diff touches only comment lines.

## Before

> The learnings file is loaded eagerly by every coding agent in every session, so an over-budget file degrades them all — this job fails the build when it grows too large.

That is no longer true. The ledger lives cold at `.lisa/PROJECT_LEARNINGS.md`, outside every auto-loaded rules tree, and reaches agents only through the contract's bounded projection (`projectLearnings()`).

## After

> The ledger lives cold in .lisa/ and reaches agents only through the contract's bounded projection — this gate keeps the document contract-valid and the projection serveable, and fails the build when the file grows past budget.

The trailing sentence about resolving the learnings file from `.lisa.config.json` (and silent pass when no file exists) is unchanged and still accurate.

## Verification

- `git diff` confirms only comment lines inside the `learnings_budget` block changed.
- Workflow still parses as valid YAML (`js-yaml` load: ok).
- The `learnings_budget` job runs on this PR, exercising the gate itself.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation for the learnings budget check to clarify how the ledger is accessed.
  * No changes to the job’s behavior, commands, or pass/fail checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->