### PR TITLE
feat(rules): add automation-runbook-contract rule pair with six run-outcome vocabulary (#1795)

### DIFF
--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -4,9 +4,10 @@
 exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
 no runbook, or a run that stops without naming its outcome, is a contract violation.
 
-**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
-`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
-`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+**One vendor-neutral contract, to be cited by (wired in the loop-conformance ticket)
+`lisa-setup-automations`, `lisa-automation-status`, `lisa-tear-down-automations`, and every
+registered loop skill** (the `leaf-only-lifecycle` / `repo-scope-split` precedent: one shared slug,
+never divergent per-loop prose).
 
 ## Membership
 
@@ -19,22 +20,30 @@ no hardcoded roster of loops anywhere.
 Exactly one per run:
 **`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
 
-- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
-- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
-  downstream factory to pick up.
-- `change-proved` — the loop made a change and proved it with evidence.
-- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+Health and operator action are **orthogonal** — a healthy run can still need an answer:
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
+  action: review the proposed item and flip it ready when you want it built.
+- `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator
+  action: none (informational).
+- `approval-requested` — the loop reached a boundary it may not cross alone. **Healthy.** Operator
+  action: answer the approval question.
 - `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
-  and escalated a decision-ready packet.
-- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+  and escalated a decision-ready packet. **Not healthy.** Operator action: restore the named
+  capability, then close the escalation item.
+- `policy-obsolete` — the loop's own retirement policy (the retirement condition written in its
+  runbook) tripped, so it proposed its own teardown. **Healthy.** Operator action: approve the
+  teardown, decline it (close the proposal; the loop keeps running at cadence), or re-cadence it.
 
 ## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
 
 A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
-A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
-**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+A healthy cycle that routes a work item to `Blocked` with clarifying questions is
+`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+loop itself is broken, not that a work item was blocked.
 
 ## No silent exit
 

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -1,0 +1,51 @@
+# Automation Runbook Contract (load-bearing)
+
+**Every registered automation loop carries a checked-in runbook, and every run of that loop ends in
+exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
+no runbook, or a run that stops without naming its outcome, is a contract violation.
+
+**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
+`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
+`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+
+## Membership
+
+Membership is **registration, not skill-existence**: a loop is under this contract the moment it is
+registered as a scheduled automation, and registering a new one pulls it in automatically. There is
+no hardcoded roster of loops anywhere.
+
+## The six run outcomes
+
+Exactly one per run:
+**`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
+  downstream factory to pick up.
+- `change-proved` — the loop made a change and proved it with evidence.
+- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+- `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
+  and escalated a decision-ready packet.
+- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+
+## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
+
+A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
+already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
+state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
+A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
+**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+
+## No silent exit
+
+Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
+one-line operator summary of what happened, recorded where the status surface can read it —
+there is no silent exit. Silence and health must never look identical to an operator.
+
+## Never block, always degrade
+
+A missing runbook, an unreadable record surface, or an absent optional dependency **degrades** the
+run — say so in the summary and finish with an outcome — it never crashes the loop, never blocks
+other work, and never leaves the run unreported.
+
+Full contract (template, outcome definitions, escalation packet, retirement): [reference/automation-runbook-contract.md](../reference/automation-runbook-contract.md).

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -42,7 +42,8 @@ A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
 A healthy cycle that routes a work item to `Blocked` with clarifying questions is
-`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+`candidate-proposed` — it produced something — so it is **never `nothing-needed`**, which is
+reserved for runs that found nothing at all, and **never `recovery-required`**, which means the
 loop itself is broken, not that a work item was blocked.
 
 ## No silent exit

--- a/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
@@ -79,9 +79,9 @@ Next-run state
   finished is visible as claimed, and the repair path picks it up.
 
 Retirement condition
-  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
-  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
-  human acts on it.
+  Propose teardown when BOTH hold: no work item has entered this queue for 30 consecutive days, AND
+  this run proposed nothing. It files one teardown-proposal item and keeps running at its normal
+  cadence until someone approves, declines, or re-cadences it.
 ```
 
 ## The six run outcomes
@@ -89,21 +89,40 @@ Retirement condition
 Exactly one per run. The one-line operator summary is not optional — it is what the status surface
 shows and what makes the outcome actionable.
 
-| Outcome | Definition | Healthy? | One-line summary must contain |
-|---|---|---|---|
-| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
-| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
-| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
-| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
-| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
-| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+Health and operator action are **orthogonal**: several healthy outcomes still want an answer, and
+only `recovery-required` means the machinery itself is broken.
+
+| Outcome | Definition | Healthy? | Operator action? | One-line summary must contain |
+|---|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | None. | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Healthy | Review the proposed item and flip it ready when you want it built. | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Healthy | None — informational. | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Healthy | Answer the approval question. | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **Not healthy** — needs a human | Restore the named capability, then close the escalation item. | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The loop's own retirement policy — the retirement condition written in its runbook — tripped, so it proposed its own teardown. | Healthy | Decide: approve the teardown, decline it (close the proposal; the loop continues at cadence), or re-cadence it. | Why it looks obsolete and the teardown-proposal item. |
+
+### Exemplar one-line summaries
+
+These set the register every conforming loop copies — plain, specific, and actionable without
+reading code:
+
+```text
+nothing-needed      Scanned 12 ready items; nothing to propose.
+candidate-proposed  Proposed #1810 to fix the failing checkout step; awaiting your flip to ready.
+change-proved       Merged #1811 raising coverage to 84%; CI green and evidence posted on the item.
+approval-requested  Deploy to production is waiting on your approval; nothing ships until you answer.
+recovery-required   Lost access to the tracker; filed #1812 with the one decision needed to restore it.
+policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
+```
 
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
-contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
-assume its file is present.)
+contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
+terminal step posts its result record before stopping, so there is no silent exit — from one flow to
+every registered loop. (The run-record substrate that stores outcomes and summaries is named here
+only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -116,9 +135,11 @@ This is the highest-risk seam in the contract, so it is stated explicitly.
 
 They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
 `Blocked` — because the item's requirements are unresolvable and a human must answer — is
-`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
-means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
-and train operators to ignore the fleet verdict.
+`candidate-proposed`: the run produced something (a blocked item carrying clarifying questions), so
+it is **never `nothing-needed`**, which is reserved for runs that found nothing at all, and **never
+`recovery-required`**, which means the machinery is broken. Conflating a blocked work item with a
+broken loop would paint healthy intake cycles permanently red and train operators to ignore the
+fleet verdict.
 
 ## Escalation — the decision-ready packet
 
@@ -132,7 +153,8 @@ containing exactly these fields:
 | Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
 | Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
 | Risk of inaction | What degrades or stops if nobody acts, and how soon. |
-| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list — stated with **named options** (or as a yes/no), and what the loop will do with each answer. |
+| How to answer | The mechanical response path: comment on the item, flip a label, or close it — so the operator never has to guess how to reply. |
 
 The wording requirement is binding: a **non-technical operator must be able to act on the packet
 without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
@@ -142,8 +164,11 @@ packet must stand without it.
 
 A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
 the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
-a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
-learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+a tracker-derived condition is headless- and concurrent-safe by construction). This generalizes the
+*Retirement condition* section of `lisa-learnings-audit`, which already retires itself this way; its
+current wording still uses the older three-value "terminal states" vocabulary, and the
+loop-conformance ticket conforms it to the six run outcomes above. A loop proposes retirement when
+BOTH hold:
 
 1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
    within its trailing quiet window (sized to a small multiple of its cadence).
@@ -153,13 +178,39 @@ learnings-gardener precedent, a loop proposes retirement when BOTH hold:
 When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
 teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
 result and this run's summary as evidence, and proposing either a longer cadence or
-`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
-retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
-its own registration.
+`lisa-tear-down-automations`. The loop **keeps running at its normal cadence** until an operator
+flips that proposal one of three ways: **approve** it (`lisa-tear-down-automations` runs and the
+registration goes away), **decline** it (close the proposal — the loop simply continues), or
+**re-cadence** it (register it at the longer cadence instead of tearing it down). Retirement is a
+recommendation like any other, **never a self-executed exit**: a loop never deletes its own
+registration, and a proposal nobody answers changes nothing.
+
+## Never block, always degrade
+
+A loop degrades rather than blocking. Three triggers are expected and must never crash a run:
+
+- **A missing runbook** — the loop runs on the contract's defaults and says so.
+- **An unreadable record surface** — the loop still reports its outcome and summary in its own run
+  output, so the operator is never left with silence.
+- **An absent optional dependency** — a skill or surface that ships with a sibling ticket is not
+  yet installed; the loop skips that enrichment and continues.
+
+A degraded run still **reports its actual outcome from the same six values** — degradation does not
+mint a seventh token and, on its own, is not `recovery-required`. Its one-line summary **leads with
+the degradation**, then states the outcome:
+
+```text
+Runbook missing — ran on defaults; nothing to propose.
+```
+
+Degradation becomes `recovery-required` only when it prevents the loop from doing its actual job
+(the queue itself is unreadable, credentials are revoked) — and then it escalates the decision-ready
+packet above. A degraded run never blocks other work and never leaves the run unreported.
 
 ## Citing adjacent work
 
 Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template, the run-record substrate that
-stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
+that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
+(#1738) — named here, with no evidence format defined by this contract. Rejection memory
 extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
@@ -1,0 +1,165 @@
+# Automation Runbook Contract
+
+Scheduled loops are the busiest machinery in the factory and historically the least explicitly
+contracted: what a loop maintains, what it may do on its own, what it must escalate, and when it
+should stop existing all lived implicitly in each loop's prose. The cost lands on the operator — a
+quiet run and a broken run look identical, and "what is this scheduled thing?" has a different
+answer shape for every loop. This contract writes the answer down once.
+
+It is a **single vendor-neutral contract** consumed by `lisa-setup-automations` (which scaffolds a
+runbook per registered loop), `lisa-automation-status` (which reads runbooks and run outcomes back
+to an operator), `lisa-tear-down-automations` (which acts on retirement proposals), and every
+registered loop skill (which conforms its own run to it). Each consumer cites this slug; none of
+them redefines it.
+
+**Membership is registration, not skill-existence.** A loop falls under this contract when it is
+registered as a scheduled automation on the host project's runtime scheduler — not when its skill
+file happens to exist in the plugin tree. Registering a new loop pulls it in automatically, and
+un-registering drops it. Nothing in this contract, in the scaffolder, or in the status surface may
+carry a hardcoded roster of loops; the worked example below names one loop as illustration only.
+
+## The runbook template
+
+Every registered loop's runbook has these ten sections, in this order. Each is answered in prose a
+non-technical operator can read (`factory-model` rule 5).
+
+| Section | What a good answer looks like |
+|---|---|
+| Intent | One sentence naming what this loop maintains, in outcome terms, not mechanism terms. |
+| Sources of truth | The exact surfaces the loop reads, each reachable through its access layer (`integration-access-layer`) — never a direct vendor API call. |
+| Candidate selection | The query or filter that decides what this run acts on, and the bound on how many. |
+| Scope/bounds | What the loop will never touch, and the cap that keeps one run finite. |
+| Proof | What the loop must observe before claiming it changed anything — the evidence it records. |
+| Autonomous-vs-approval boundary | The named line: what it does alone, and the first thing on the other side that requires a human. |
+| Escalation | What it files when it cannot proceed — always the decision-ready packet below. |
+| Recovery | What a human or the next run does to get the loop working again after `recovery-required`. |
+| Next-run state | What the next run can observe from this one, derived from durable surfaces (tracker, records) rather than in-process memory. |
+| Retirement condition | The stateless, tracker-derived condition under which this loop proposes its own teardown. |
+
+### Worked example — the `intake-tickets` loop
+
+```text
+Loop: intake-tickets
+
+Intent
+  Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped
+  without anyone having to hand them to an agent.
+
+Sources of truth
+  The configured tracker's build queue (the ready/claimed/done lanes from .lisa.config.json), read
+  through the tracker access layer; the item's own comments and linked PRs.
+
+Candidate selection
+  The oldest eligible leaf work item currently in the ready lane, one per run. Containers with open
+  children are repaired out of the queue, never built.
+
+Scope/bounds
+  Only items in this repo's configured queue. It never edits the ready lane's meaning, never
+  invents work items, and never processes more than its per-run cap.
+
+Proof
+  A merged pull request plus the project's own verification evidence posted back to the work item;
+  a claim of "done" without that evidence is not made.
+
+Autonomous-vs-approval boundary
+  Alone: claim, plan, implement, open the PR, drive it to merge. Requires a human: anything that
+  needs a protected deployment approval, and any item whose requirements it cannot resolve — that
+  becomes a blocked work item with clarifying questions, not a guess.
+
+Escalation
+  When the loop itself cannot proceed (tracker credentials revoked, queue unreadable), it files the
+  decision-ready packet below, labeled status:blocked + human-needed.
+
+Recovery
+  A human restores the named access, then flips the escalation item closed; the next scheduled run
+  resumes with no manual replay needed.
+
+Next-run state
+  Nothing in memory. The tracker lanes and the run records are the state: a claimed item that never
+  finished is visible as claimed, and the repair path picks it up.
+
+Retirement condition
+  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
+  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
+  human acts on it.
+```
+
+## The six run outcomes
+
+Exactly one per run. The one-line operator summary is not optional — it is what the status surface
+shows and what makes the outcome actionable.
+
+| Outcome | Definition | Healthy? | One-line summary must contain |
+|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+
+**No silent exit.** Every run posts its outcome and its one-line summary before stopping —
+including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
+there is no silent exit for an operator to misread as health. A run that ends without a
+recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
+contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
+assume its file is present.)
+
+## A run outcome is not a work-item lifecycle terminal state
+
+This is the highest-risk seam in the contract, so it is stated explicitly.
+
+- A **run outcome** describes the LOOP ITERATION — how this scheduled execution ended.
+- A **terminal state** describes a TICKET — Lisa already uses that phrase for work-item lifecycles
+  (`lisa-intake`: "`Blocked` is a valid terminal state of the downstream lifecycles"; see
+  `prd-lifecycle-rollup`).
+
+They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
+`Blocked` — because the item's requirements are unresolvable and a human must answer — is
+`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
+means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
+and train operators to ignore the fleet verdict.
+
+## Escalation — the decision-ready packet
+
+A loop that cannot proceed escalates by filing a tracker item (through `lisa-tracker-write`, per
+`tracked-work` and `integration-access-layer`) labeled **`status:blocked`** and **`human-needed`**,
+containing exactly these fields:
+
+| Field | Content |
+|---|---|
+| Current state | Where things stand right now, in plain terms — what is and is not working. |
+| Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
+| Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
+| Risk of inaction | What degrades or stops if nobody acts, and how soon. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+
+The wording requirement is binding: a **non-technical operator must be able to act on the packet
+without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
+packet must stand without it.
+
+## Retirement condition
+
+A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
+the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
+a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
+learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
+   within its trailing quiet window (sized to a small multiple of its cadence).
+2. **This run proposes nothing** — the current run yields zero candidates (it is otherwise ending
+   `nothing-needed`).
+
+When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
+teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
+result and this run's summary as evidence, and proposing either a longer cadence or
+`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
+retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
+its own registration.
+
+## Citing adjacent work
+
+Cite these by name; each ships with its own ticket, do not assume its file is present in this
+branch: the runbook scaffolding that instantiates this template, the run-record substrate that
+stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
@@ -84,9 +84,9 @@ Next-run state
   finished is visible as claimed, and the repair path picks it up.
 
 Retirement condition
-  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
-  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
-  human acts on it.
+  Propose teardown when BOTH hold: no work item has entered this queue for 30 consecutive days, AND
+  this run proposed nothing. It files one teardown-proposal item and keeps running at its normal
+  cadence until someone approves, declines, or re-cadences it.
 ```
 
 ## The six run outcomes
@@ -94,21 +94,40 @@ Retirement condition
 Exactly one per run. The one-line operator summary is not optional — it is what the status surface
 shows and what makes the outcome actionable.
 
-| Outcome | Definition | Healthy? | One-line summary must contain |
-|---|---|---|---|
-| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
-| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
-| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
-| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
-| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
-| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+Health and operator action are **orthogonal**: several healthy outcomes still want an answer, and
+only `recovery-required` means the machinery itself is broken.
+
+| Outcome | Definition | Healthy? | Operator action? | One-line summary must contain |
+|---|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | None. | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Healthy | Review the proposed item and flip it ready when you want it built. | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Healthy | None — informational. | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Healthy | Answer the approval question. | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **Not healthy** — needs a human | Restore the named capability, then close the escalation item. | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The loop's own retirement policy — the retirement condition written in its runbook — tripped, so it proposed its own teardown. | Healthy | Decide: approve the teardown, decline it (close the proposal; the loop continues at cadence), or re-cadence it. | Why it looks obsolete and the teardown-proposal item. |
+
+### Exemplar one-line summaries
+
+These set the register every conforming loop copies — plain, specific, and actionable without
+reading code:
+
+```text
+nothing-needed      Scanned 12 ready items; nothing to propose.
+candidate-proposed  Proposed #1810 to fix the failing checkout step; awaiting your flip to ready.
+change-proved       Merged #1811 raising coverage to 84%; CI green and evidence posted on the item.
+approval-requested  Deploy to production is waiting on your approval; nothing ships until you answer.
+recovery-required   Lost access to the tracker; filed #1812 with the one decision needed to restore it.
+policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
+```
 
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
-contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
-assume its file is present.)
+contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
+terminal step posts its result record before stopping, so there is no silent exit — from one flow to
+every registered loop. (The run-record substrate that stores outcomes and summaries is named here
+only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -121,9 +140,11 @@ This is the highest-risk seam in the contract, so it is stated explicitly.
 
 They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
 `Blocked` — because the item's requirements are unresolvable and a human must answer — is
-`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
-means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
-and train operators to ignore the fleet verdict.
+`candidate-proposed`: the run produced something (a blocked item carrying clarifying questions), so
+it is **never `nothing-needed`**, which is reserved for runs that found nothing at all, and **never
+`recovery-required`**, which means the machinery is broken. Conflating a blocked work item with a
+broken loop would paint healthy intake cycles permanently red and train operators to ignore the
+fleet verdict.
 
 ## Escalation — the decision-ready packet
 
@@ -137,7 +158,8 @@ containing exactly these fields:
 | Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
 | Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
 | Risk of inaction | What degrades or stops if nobody acts, and how soon. |
-| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list — stated with **named options** (or as a yes/no), and what the loop will do with each answer. |
+| How to answer | The mechanical response path: comment on the item, flip a label, or close it — so the operator never has to guess how to reply. |
 
 The wording requirement is binding: a **non-technical operator must be able to act on the packet
 without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
@@ -147,8 +169,11 @@ packet must stand without it.
 
 A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
 the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
-a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
-learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+a tracker-derived condition is headless- and concurrent-safe by construction). This generalizes the
+*Retirement condition* section of `lisa-learnings-audit`, which already retires itself this way; its
+current wording still uses the older three-value "terminal states" vocabulary, and the
+loop-conformance ticket conforms it to the six run outcomes above. A loop proposes retirement when
+BOTH hold:
 
 1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
    within its trailing quiet window (sized to a small multiple of its cadence).
@@ -158,13 +183,39 @@ learnings-gardener precedent, a loop proposes retirement when BOTH hold:
 When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
 teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
 result and this run's summary as evidence, and proposing either a longer cadence or
-`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
-retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
-its own registration.
+`lisa-tear-down-automations`. The loop **keeps running at its normal cadence** until an operator
+flips that proposal one of three ways: **approve** it (`lisa-tear-down-automations` runs and the
+registration goes away), **decline** it (close the proposal — the loop simply continues), or
+**re-cadence** it (register it at the longer cadence instead of tearing it down). Retirement is a
+recommendation like any other, **never a self-executed exit**: a loop never deletes its own
+registration, and a proposal nobody answers changes nothing.
+
+## Never block, always degrade
+
+A loop degrades rather than blocking. Three triggers are expected and must never crash a run:
+
+- **A missing runbook** — the loop runs on the contract's defaults and says so.
+- **An unreadable record surface** — the loop still reports its outcome and summary in its own run
+  output, so the operator is never left with silence.
+- **An absent optional dependency** — a skill or surface that ships with a sibling ticket is not
+  yet installed; the loop skips that enrichment and continues.
+
+A degraded run still **reports its actual outcome from the same six values** — degradation does not
+mint a seventh token and, on its own, is not `recovery-required`. Its one-line summary **leads with
+the degradation**, then states the outcome:
+
+```text
+Runbook missing — ran on defaults; nothing to propose.
+```
+
+Degradation becomes `recovery-required` only when it prevents the loop from doing its actual job
+(the queue itself is unreadable, credentials are revoked) — and then it escalates the decision-ready
+packet above. A degraded run never blocks other work and never leaves the run unreported.
 
 ## Citing adjacent work
 
 Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template, the run-record substrate that
-stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
+that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
+(#1738) — named here, with no evidence format defined by this contract. Rejection memory
 extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
@@ -1,0 +1,170 @@
+---
+description: "Automation Runbook Contract"
+alwaysApply: false
+---
+
+# Automation Runbook Contract
+
+Scheduled loops are the busiest machinery in the factory and historically the least explicitly
+contracted: what a loop maintains, what it may do on its own, what it must escalate, and when it
+should stop existing all lived implicitly in each loop's prose. The cost lands on the operator — a
+quiet run and a broken run look identical, and "what is this scheduled thing?" has a different
+answer shape for every loop. This contract writes the answer down once.
+
+It is a **single vendor-neutral contract** consumed by `lisa-setup-automations` (which scaffolds a
+runbook per registered loop), `lisa-automation-status` (which reads runbooks and run outcomes back
+to an operator), `lisa-tear-down-automations` (which acts on retirement proposals), and every
+registered loop skill (which conforms its own run to it). Each consumer cites this slug; none of
+them redefines it.
+
+**Membership is registration, not skill-existence.** A loop falls under this contract when it is
+registered as a scheduled automation on the host project's runtime scheduler — not when its skill
+file happens to exist in the plugin tree. Registering a new loop pulls it in automatically, and
+un-registering drops it. Nothing in this contract, in the scaffolder, or in the status surface may
+carry a hardcoded roster of loops; the worked example below names one loop as illustration only.
+
+## The runbook template
+
+Every registered loop's runbook has these ten sections, in this order. Each is answered in prose a
+non-technical operator can read (`factory-model` rule 5).
+
+| Section | What a good answer looks like |
+|---|---|
+| Intent | One sentence naming what this loop maintains, in outcome terms, not mechanism terms. |
+| Sources of truth | The exact surfaces the loop reads, each reachable through its access layer (`integration-access-layer`) — never a direct vendor API call. |
+| Candidate selection | The query or filter that decides what this run acts on, and the bound on how many. |
+| Scope/bounds | What the loop will never touch, and the cap that keeps one run finite. |
+| Proof | What the loop must observe before claiming it changed anything — the evidence it records. |
+| Autonomous-vs-approval boundary | The named line: what it does alone, and the first thing on the other side that requires a human. |
+| Escalation | What it files when it cannot proceed — always the decision-ready packet below. |
+| Recovery | What a human or the next run does to get the loop working again after `recovery-required`. |
+| Next-run state | What the next run can observe from this one, derived from durable surfaces (tracker, records) rather than in-process memory. |
+| Retirement condition | The stateless, tracker-derived condition under which this loop proposes its own teardown. |
+
+### Worked example — the `intake-tickets` loop
+
+```text
+Loop: intake-tickets
+
+Intent
+  Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped
+  without anyone having to hand them to an agent.
+
+Sources of truth
+  The configured tracker's build queue (the ready/claimed/done lanes from .lisa.config.json), read
+  through the tracker access layer; the item's own comments and linked PRs.
+
+Candidate selection
+  The oldest eligible leaf work item currently in the ready lane, one per run. Containers with open
+  children are repaired out of the queue, never built.
+
+Scope/bounds
+  Only items in this repo's configured queue. It never edits the ready lane's meaning, never
+  invents work items, and never processes more than its per-run cap.
+
+Proof
+  A merged pull request plus the project's own verification evidence posted back to the work item;
+  a claim of "done" without that evidence is not made.
+
+Autonomous-vs-approval boundary
+  Alone: claim, plan, implement, open the PR, drive it to merge. Requires a human: anything that
+  needs a protected deployment approval, and any item whose requirements it cannot resolve — that
+  becomes a blocked work item with clarifying questions, not a guess.
+
+Escalation
+  When the loop itself cannot proceed (tracker credentials revoked, queue unreadable), it files the
+  decision-ready packet below, labeled status:blocked + human-needed.
+
+Recovery
+  A human restores the named access, then flips the escalation item closed; the next scheduled run
+  resumes with no manual replay needed.
+
+Next-run state
+  Nothing in memory. The tracker lanes and the run records are the state: a claimed item that never
+  finished is visible as claimed, and the repair path picks it up.
+
+Retirement condition
+  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
+  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
+  human acts on it.
+```
+
+## The six run outcomes
+
+Exactly one per run. The one-line operator summary is not optional — it is what the status surface
+shows and what makes the outcome actionable.
+
+| Outcome | Definition | Healthy? | One-line summary must contain |
+|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+
+**No silent exit.** Every run posts its outcome and its one-line summary before stopping —
+including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
+there is no silent exit for an operator to misread as health. A run that ends without a
+recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
+contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
+assume its file is present.)
+
+## A run outcome is not a work-item lifecycle terminal state
+
+This is the highest-risk seam in the contract, so it is stated explicitly.
+
+- A **run outcome** describes the LOOP ITERATION — how this scheduled execution ended.
+- A **terminal state** describes a TICKET — Lisa already uses that phrase for work-item lifecycles
+  (`lisa-intake`: "`Blocked` is a valid terminal state of the downstream lifecycles"; see
+  `prd-lifecycle-rollup`).
+
+They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
+`Blocked` — because the item's requirements are unresolvable and a human must answer — is
+`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
+means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
+and train operators to ignore the fleet verdict.
+
+## Escalation — the decision-ready packet
+
+A loop that cannot proceed escalates by filing a tracker item (through `lisa-tracker-write`, per
+`tracked-work` and `integration-access-layer`) labeled **`status:blocked`** and **`human-needed`**,
+containing exactly these fields:
+
+| Field | Content |
+|---|---|
+| Current state | Where things stand right now, in plain terms — what is and is not working. |
+| Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
+| Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
+| Risk of inaction | What degrades or stops if nobody acts, and how soon. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+
+The wording requirement is binding: a **non-technical operator must be able to act on the packet
+without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
+packet must stand without it.
+
+## Retirement condition
+
+A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
+the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
+a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
+learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
+   within its trailing quiet window (sized to a small multiple of its cadence).
+2. **This run proposes nothing** — the current run yields zero candidates (it is otherwise ending
+   `nothing-needed`).
+
+When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
+teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
+result and this run's summary as evidence, and proposing either a longer cadence or
+`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
+retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
+its own registration.
+
+## Citing adjacent work
+
+Cite these by name; each ships with its own ticket, do not assume its file is present in this
+branch: the runbook scaffolding that instantiates this template, the run-record substrate that
+stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -1,0 +1,56 @@
+---
+description: "Automation Runbook Contract (load-bearing)"
+alwaysApply: true
+---
+
+# Automation Runbook Contract (load-bearing)
+
+**Every registered automation loop carries a checked-in runbook, and every run of that loop ends in
+exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
+no runbook, or a run that stops without naming its outcome, is a contract violation.
+
+**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
+`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
+`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+
+## Membership
+
+Membership is **registration, not skill-existence**: a loop is under this contract the moment it is
+registered as a scheduled automation, and registering a new one pulls it in automatically. There is
+no hardcoded roster of loops anywhere.
+
+## The six run outcomes
+
+Exactly one per run:
+**`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
+  downstream factory to pick up.
+- `change-proved` — the loop made a change and proved it with evidence.
+- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+- `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
+  and escalated a decision-ready packet.
+- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+
+## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
+
+A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
+already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
+state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
+A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
+**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+
+## No silent exit
+
+Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
+one-line operator summary of what happened, recorded where the status surface can read it —
+there is no silent exit. Silence and health must never look identical to an operator.
+
+## Never block, always degrade
+
+A missing runbook, an unreadable record surface, or an absent optional dependency **degrades** the
+run — say so in the summary and finish with an outcome — it never crashes the loop, never blocks
+other work, and never leaves the run unreported.
+
+Full contract (template, outcome definitions, escalation packet, retirement): [reference/automation-runbook-contract.md](automation-runbook-contract-reference.mdc).

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -47,7 +47,8 @@ A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
 A healthy cycle that routes a work item to `Blocked` with clarifying questions is
-`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+`candidate-proposed` — it produced something — so it is **never `nothing-needed`**, which is
+reserved for runs that found nothing at all, and **never `recovery-required`**, which means the
 loop itself is broken, not that a work item was blocked.
 
 ## No silent exit

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -9,9 +9,10 @@ alwaysApply: true
 exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
 no runbook, or a run that stops without naming its outcome, is a contract violation.
 
-**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
-`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
-`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+**One vendor-neutral contract, to be cited by (wired in the loop-conformance ticket)
+`lisa-setup-automations`, `lisa-automation-status`, `lisa-tear-down-automations`, and every
+registered loop skill** (the `leaf-only-lifecycle` / `repo-scope-split` precedent: one shared slug,
+never divergent per-loop prose).
 
 ## Membership
 
@@ -24,22 +25,30 @@ no hardcoded roster of loops anywhere.
 Exactly one per run:
 **`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
 
-- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
-- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
-  downstream factory to pick up.
-- `change-proved` — the loop made a change and proved it with evidence.
-- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+Health and operator action are **orthogonal** — a healthy run can still need an answer:
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
+  action: review the proposed item and flip it ready when you want it built.
+- `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator
+  action: none (informational).
+- `approval-requested` — the loop reached a boundary it may not cross alone. **Healthy.** Operator
+  action: answer the approval question.
 - `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
-  and escalated a decision-ready packet.
-- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+  and escalated a decision-ready packet. **Not healthy.** Operator action: restore the named
+  capability, then close the escalation item.
+- `policy-obsolete` — the loop's own retirement policy (the retirement condition written in its
+  runbook) tripped, so it proposed its own teardown. **Healthy.** Operator action: approve the
+  teardown, decline it (close the proposal; the loop keeps running at cadence), or re-cadence it.
 
 ## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
 
 A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
-A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
-**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+A healthy cycle that routes a work item to `Blocked` with clarifying questions is
+`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+loop itself is broken, not that a work item was blocked.
 
 ## No silent exit
 

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -4,9 +4,10 @@
 exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
 no runbook, or a run that stops without naming its outcome, is a contract violation.
 
-**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
-`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
-`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+**One vendor-neutral contract, to be cited by (wired in the loop-conformance ticket)
+`lisa-setup-automations`, `lisa-automation-status`, `lisa-tear-down-automations`, and every
+registered loop skill** (the `leaf-only-lifecycle` / `repo-scope-split` precedent: one shared slug,
+never divergent per-loop prose).
 
 ## Membership
 
@@ -19,22 +20,30 @@ no hardcoded roster of loops anywhere.
 Exactly one per run:
 **`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
 
-- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
-- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
-  downstream factory to pick up.
-- `change-proved` — the loop made a change and proved it with evidence.
-- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+Health and operator action are **orthogonal** — a healthy run can still need an answer:
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
+  action: review the proposed item and flip it ready when you want it built.
+- `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator
+  action: none (informational).
+- `approval-requested` — the loop reached a boundary it may not cross alone. **Healthy.** Operator
+  action: answer the approval question.
 - `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
-  and escalated a decision-ready packet.
-- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+  and escalated a decision-ready packet. **Not healthy.** Operator action: restore the named
+  capability, then close the escalation item.
+- `policy-obsolete` — the loop's own retirement policy (the retirement condition written in its
+  runbook) tripped, so it proposed its own teardown. **Healthy.** Operator action: approve the
+  teardown, decline it (close the proposal; the loop keeps running at cadence), or re-cadence it.
 
 ## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
 
 A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
-A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
-**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+A healthy cycle that routes a work item to `Blocked` with clarifying questions is
+`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+loop itself is broken, not that a work item was blocked.
 
 ## No silent exit
 

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -1,0 +1,51 @@
+# Automation Runbook Contract (load-bearing)
+
+**Every registered automation loop carries a checked-in runbook, and every run of that loop ends in
+exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
+no runbook, or a run that stops without naming its outcome, is a contract violation.
+
+**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
+`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
+`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+
+## Membership
+
+Membership is **registration, not skill-existence**: a loop is under this contract the moment it is
+registered as a scheduled automation, and registering a new one pulls it in automatically. There is
+no hardcoded roster of loops anywhere.
+
+## The six run outcomes
+
+Exactly one per run:
+**`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
+  downstream factory to pick up.
+- `change-proved` — the loop made a change and proved it with evidence.
+- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+- `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
+  and escalated a decision-ready packet.
+- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+
+## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
+
+A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
+already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
+state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
+A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
+**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+
+## No silent exit
+
+Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
+one-line operator summary of what happened, recorded where the status surface can read it —
+there is no silent exit. Silence and health must never look identical to an operator.
+
+## Never block, always degrade
+
+A missing runbook, an unreadable record surface, or an absent optional dependency **degrades** the
+run — say so in the summary and finish with an outcome — it never crashes the loop, never blocks
+other work, and never leaves the run unreported.
+
+Full contract (template, outcome definitions, escalation packet, retirement): [reference/automation-runbook-contract.md](../reference/automation-runbook-contract.md).

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -42,7 +42,8 @@ A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
 A healthy cycle that routes a work item to `Blocked` with clarifying questions is
-`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+`candidate-proposed` — it produced something — so it is **never `nothing-needed`**, which is
+reserved for runs that found nothing at all, and **never `recovery-required`**, which means the
 loop itself is broken, not that a work item was blocked.
 
 ## No silent exit

--- a/plugins/lisa/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa/rules/reference/automation-runbook-contract.md
@@ -79,9 +79,9 @@ Next-run state
   finished is visible as claimed, and the repair path picks it up.
 
 Retirement condition
-  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
-  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
-  human acts on it.
+  Propose teardown when BOTH hold: no work item has entered this queue for 30 consecutive days, AND
+  this run proposed nothing. It files one teardown-proposal item and keeps running at its normal
+  cadence until someone approves, declines, or re-cadences it.
 ```
 
 ## The six run outcomes
@@ -89,21 +89,40 @@ Retirement condition
 Exactly one per run. The one-line operator summary is not optional — it is what the status surface
 shows and what makes the outcome actionable.
 
-| Outcome | Definition | Healthy? | One-line summary must contain |
-|---|---|---|---|
-| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
-| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
-| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
-| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
-| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
-| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+Health and operator action are **orthogonal**: several healthy outcomes still want an answer, and
+only `recovery-required` means the machinery itself is broken.
+
+| Outcome | Definition | Healthy? | Operator action? | One-line summary must contain |
+|---|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | None. | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Healthy | Review the proposed item and flip it ready when you want it built. | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Healthy | None — informational. | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Healthy | Answer the approval question. | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **Not healthy** — needs a human | Restore the named capability, then close the escalation item. | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The loop's own retirement policy — the retirement condition written in its runbook — tripped, so it proposed its own teardown. | Healthy | Decide: approve the teardown, decline it (close the proposal; the loop continues at cadence), or re-cadence it. | Why it looks obsolete and the teardown-proposal item. |
+
+### Exemplar one-line summaries
+
+These set the register every conforming loop copies — plain, specific, and actionable without
+reading code:
+
+```text
+nothing-needed      Scanned 12 ready items; nothing to propose.
+candidate-proposed  Proposed #1810 to fix the failing checkout step; awaiting your flip to ready.
+change-proved       Merged #1811 raising coverage to 84%; CI green and evidence posted on the item.
+approval-requested  Deploy to production is waiting on your approval; nothing ships until you answer.
+recovery-required   Lost access to the tracker; filed #1812 with the one decision needed to restore it.
+policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
+```
 
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
-contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
-assume its file is present.)
+contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
+terminal step posts its result record before stopping, so there is no silent exit — from one flow to
+every registered loop. (The run-record substrate that stores outcomes and summaries is named here
+only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -116,9 +135,11 @@ This is the highest-risk seam in the contract, so it is stated explicitly.
 
 They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
 `Blocked` — because the item's requirements are unresolvable and a human must answer — is
-`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
-means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
-and train operators to ignore the fleet verdict.
+`candidate-proposed`: the run produced something (a blocked item carrying clarifying questions), so
+it is **never `nothing-needed`**, which is reserved for runs that found nothing at all, and **never
+`recovery-required`**, which means the machinery is broken. Conflating a blocked work item with a
+broken loop would paint healthy intake cycles permanently red and train operators to ignore the
+fleet verdict.
 
 ## Escalation — the decision-ready packet
 
@@ -132,7 +153,8 @@ containing exactly these fields:
 | Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
 | Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
 | Risk of inaction | What degrades or stops if nobody acts, and how soon. |
-| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list — stated with **named options** (or as a yes/no), and what the loop will do with each answer. |
+| How to answer | The mechanical response path: comment on the item, flip a label, or close it — so the operator never has to guess how to reply. |
 
 The wording requirement is binding: a **non-technical operator must be able to act on the packet
 without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
@@ -142,8 +164,11 @@ packet must stand without it.
 
 A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
 the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
-a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
-learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+a tracker-derived condition is headless- and concurrent-safe by construction). This generalizes the
+*Retirement condition* section of `lisa-learnings-audit`, which already retires itself this way; its
+current wording still uses the older three-value "terminal states" vocabulary, and the
+loop-conformance ticket conforms it to the six run outcomes above. A loop proposes retirement when
+BOTH hold:
 
 1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
    within its trailing quiet window (sized to a small multiple of its cadence).
@@ -153,13 +178,39 @@ learnings-gardener precedent, a loop proposes retirement when BOTH hold:
 When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
 teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
 result and this run's summary as evidence, and proposing either a longer cadence or
-`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
-retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
-its own registration.
+`lisa-tear-down-automations`. The loop **keeps running at its normal cadence** until an operator
+flips that proposal one of three ways: **approve** it (`lisa-tear-down-automations` runs and the
+registration goes away), **decline** it (close the proposal — the loop simply continues), or
+**re-cadence** it (register it at the longer cadence instead of tearing it down). Retirement is a
+recommendation like any other, **never a self-executed exit**: a loop never deletes its own
+registration, and a proposal nobody answers changes nothing.
+
+## Never block, always degrade
+
+A loop degrades rather than blocking. Three triggers are expected and must never crash a run:
+
+- **A missing runbook** — the loop runs on the contract's defaults and says so.
+- **An unreadable record surface** — the loop still reports its outcome and summary in its own run
+  output, so the operator is never left with silence.
+- **An absent optional dependency** — a skill or surface that ships with a sibling ticket is not
+  yet installed; the loop skips that enrichment and continues.
+
+A degraded run still **reports its actual outcome from the same six values** — degradation does not
+mint a seventh token and, on its own, is not `recovery-required`. Its one-line summary **leads with
+the degradation**, then states the outcome:
+
+```text
+Runbook missing — ran on defaults; nothing to propose.
+```
+
+Degradation becomes `recovery-required` only when it prevents the loop from doing its actual job
+(the queue itself is unreadable, credentials are revoked) — and then it escalates the decision-ready
+packet above. A degraded run never blocks other work and never leaves the run unreported.
 
 ## Citing adjacent work
 
 Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template, the run-record substrate that
-stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
+that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
+(#1738) — named here, with no evidence format defined by this contract. Rejection memory
 extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa/rules/reference/automation-runbook-contract.md
@@ -1,0 +1,165 @@
+# Automation Runbook Contract
+
+Scheduled loops are the busiest machinery in the factory and historically the least explicitly
+contracted: what a loop maintains, what it may do on its own, what it must escalate, and when it
+should stop existing all lived implicitly in each loop's prose. The cost lands on the operator — a
+quiet run and a broken run look identical, and "what is this scheduled thing?" has a different
+answer shape for every loop. This contract writes the answer down once.
+
+It is a **single vendor-neutral contract** consumed by `lisa-setup-automations` (which scaffolds a
+runbook per registered loop), `lisa-automation-status` (which reads runbooks and run outcomes back
+to an operator), `lisa-tear-down-automations` (which acts on retirement proposals), and every
+registered loop skill (which conforms its own run to it). Each consumer cites this slug; none of
+them redefines it.
+
+**Membership is registration, not skill-existence.** A loop falls under this contract when it is
+registered as a scheduled automation on the host project's runtime scheduler — not when its skill
+file happens to exist in the plugin tree. Registering a new loop pulls it in automatically, and
+un-registering drops it. Nothing in this contract, in the scaffolder, or in the status surface may
+carry a hardcoded roster of loops; the worked example below names one loop as illustration only.
+
+## The runbook template
+
+Every registered loop's runbook has these ten sections, in this order. Each is answered in prose a
+non-technical operator can read (`factory-model` rule 5).
+
+| Section | What a good answer looks like |
+|---|---|
+| Intent | One sentence naming what this loop maintains, in outcome terms, not mechanism terms. |
+| Sources of truth | The exact surfaces the loop reads, each reachable through its access layer (`integration-access-layer`) — never a direct vendor API call. |
+| Candidate selection | The query or filter that decides what this run acts on, and the bound on how many. |
+| Scope/bounds | What the loop will never touch, and the cap that keeps one run finite. |
+| Proof | What the loop must observe before claiming it changed anything — the evidence it records. |
+| Autonomous-vs-approval boundary | The named line: what it does alone, and the first thing on the other side that requires a human. |
+| Escalation | What it files when it cannot proceed — always the decision-ready packet below. |
+| Recovery | What a human or the next run does to get the loop working again after `recovery-required`. |
+| Next-run state | What the next run can observe from this one, derived from durable surfaces (tracker, records) rather than in-process memory. |
+| Retirement condition | The stateless, tracker-derived condition under which this loop proposes its own teardown. |
+
+### Worked example — the `intake-tickets` loop
+
+```text
+Loop: intake-tickets
+
+Intent
+  Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped
+  without anyone having to hand them to an agent.
+
+Sources of truth
+  The configured tracker's build queue (the ready/claimed/done lanes from .lisa.config.json), read
+  through the tracker access layer; the item's own comments and linked PRs.
+
+Candidate selection
+  The oldest eligible leaf work item currently in the ready lane, one per run. Containers with open
+  children are repaired out of the queue, never built.
+
+Scope/bounds
+  Only items in this repo's configured queue. It never edits the ready lane's meaning, never
+  invents work items, and never processes more than its per-run cap.
+
+Proof
+  A merged pull request plus the project's own verification evidence posted back to the work item;
+  a claim of "done" without that evidence is not made.
+
+Autonomous-vs-approval boundary
+  Alone: claim, plan, implement, open the PR, drive it to merge. Requires a human: anything that
+  needs a protected deployment approval, and any item whose requirements it cannot resolve — that
+  becomes a blocked work item with clarifying questions, not a guess.
+
+Escalation
+  When the loop itself cannot proceed (tracker credentials revoked, queue unreadable), it files the
+  decision-ready packet below, labeled status:blocked + human-needed.
+
+Recovery
+  A human restores the named access, then flips the escalation item closed; the next scheduled run
+  resumes with no manual replay needed.
+
+Next-run state
+  Nothing in memory. The tracker lanes and the run records are the state: a claimed item that never
+  finished is visible as claimed, and the repair path picks it up.
+
+Retirement condition
+  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
+  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
+  human acts on it.
+```
+
+## The six run outcomes
+
+Exactly one per run. The one-line operator summary is not optional — it is what the status surface
+shows and what makes the outcome actionable.
+
+| Outcome | Definition | Healthy? | One-line summary must contain |
+|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+
+**No silent exit.** Every run posts its outcome and its one-line summary before stopping —
+including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
+there is no silent exit for an operator to misread as health. A run that ends without a
+recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
+contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
+assume its file is present.)
+
+## A run outcome is not a work-item lifecycle terminal state
+
+This is the highest-risk seam in the contract, so it is stated explicitly.
+
+- A **run outcome** describes the LOOP ITERATION — how this scheduled execution ended.
+- A **terminal state** describes a TICKET — Lisa already uses that phrase for work-item lifecycles
+  (`lisa-intake`: "`Blocked` is a valid terminal state of the downstream lifecycles"; see
+  `prd-lifecycle-rollup`).
+
+They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
+`Blocked` — because the item's requirements are unresolvable and a human must answer — is
+`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
+means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
+and train operators to ignore the fleet verdict.
+
+## Escalation — the decision-ready packet
+
+A loop that cannot proceed escalates by filing a tracker item (through `lisa-tracker-write`, per
+`tracked-work` and `integration-access-layer`) labeled **`status:blocked`** and **`human-needed`**,
+containing exactly these fields:
+
+| Field | Content |
+|---|---|
+| Current state | Where things stand right now, in plain terms — what is and is not working. |
+| Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
+| Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
+| Risk of inaction | What degrades or stops if nobody acts, and how soon. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+
+The wording requirement is binding: a **non-technical operator must be able to act on the packet
+without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
+packet must stand without it.
+
+## Retirement condition
+
+A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
+the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
+a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
+learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
+   within its trailing quiet window (sized to a small multiple of its cadence).
+2. **This run proposes nothing** — the current run yields zero candidates (it is otherwise ending
+   `nothing-needed`).
+
+When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
+teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
+result and this run's summary as evidence, and proposing either a longer cadence or
+`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
+retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
+its own registration.
+
+## Citing adjacent work
+
+Cite these by name; each ships with its own ticket, do not assume its file is present in this
+branch: the runbook scaffolding that instantiates this template, the run-record substrate that
+stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -4,9 +4,10 @@
 exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
 no runbook, or a run that stops without naming its outcome, is a contract violation.
 
-**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
-`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
-`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+**One vendor-neutral contract, to be cited by (wired in the loop-conformance ticket)
+`lisa-setup-automations`, `lisa-automation-status`, `lisa-tear-down-automations`, and every
+registered loop skill** (the `leaf-only-lifecycle` / `repo-scope-split` precedent: one shared slug,
+never divergent per-loop prose).
 
 ## Membership
 
@@ -19,22 +20,30 @@ no hardcoded roster of loops anywhere.
 Exactly one per run:
 **`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
 
-- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
-- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
-  downstream factory to pick up.
-- `change-proved` — the loop made a change and proved it with evidence.
-- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+Health and operator action are **orthogonal** — a healthy run can still need an answer:
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
+  action: review the proposed item and flip it ready when you want it built.
+- `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator
+  action: none (informational).
+- `approval-requested` — the loop reached a boundary it may not cross alone. **Healthy.** Operator
+  action: answer the approval question.
 - `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
-  and escalated a decision-ready packet.
-- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+  and escalated a decision-ready packet. **Not healthy.** Operator action: restore the named
+  capability, then close the escalation item.
+- `policy-obsolete` — the loop's own retirement policy (the retirement condition written in its
+  runbook) tripped, so it proposed its own teardown. **Healthy.** Operator action: approve the
+  teardown, decline it (close the proposal; the loop keeps running at cadence), or re-cadence it.
 
 ## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
 
 A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
-A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
-**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+A healthy cycle that routes a work item to `Blocked` with clarifying questions is
+`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+loop itself is broken, not that a work item was blocked.
 
 ## No silent exit
 

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -1,0 +1,51 @@
+# Automation Runbook Contract (load-bearing)
+
+**Every registered automation loop carries a checked-in runbook, and every run of that loop ends in
+exactly one of six run outcomes** with a one-line, operator-readable summary. A registered loop with
+no runbook, or a run that stops without naming its outcome, is a contract violation.
+
+**One vendor-neutral contract, cited by `lisa-setup-automations`, `lisa-automation-status`,
+`lisa-tear-down-automations`, and every registered loop skill** (the `leaf-only-lifecycle` /
+`repo-scope-split` precedent: one shared slug, never divergent per-loop prose).
+
+## Membership
+
+Membership is **registration, not skill-existence**: a loop is under this contract the moment it is
+registered as a scheduled automation, and registering a new one pulls it in automatically. There is
+no hardcoded roster of loops anywhere.
+
+## The six run outcomes
+
+Exactly one per run:
+**`nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`**
+
+- `nothing-needed` — the loop ran and found nothing to act on. **Healthy**; no operator action.
+- `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation) for a human or a
+  downstream factory to pick up.
+- `change-proved` — the loop made a change and proved it with evidence.
+- `approval-requested` — the loop reached a boundary it may not cross alone and asked a human.
+- `recovery-required` — the loop itself could not complete (access, tooling, or substrate broken)
+  and escalated a decision-ready packet.
+- `policy-obsolete` — the loop's retirement condition tripped; it proposed its own teardown.
+
+## A run outcome is NOT a work-item lifecycle terminal state (CRITICAL)
+
+A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a TICKET — Lisa
+already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
+state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
+A healthy cycle that routes a work item to `Blocked` is `nothing-needed` or `candidate-proposed` —
+**never `recovery-required`**, which means the loop is broken, not that an item was blocked.
+
+## No silent exit
+
+Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
+one-line operator summary of what happened, recorded where the status surface can read it —
+there is no silent exit. Silence and health must never look identical to an operator.
+
+## Never block, always degrade
+
+A missing runbook, an unreadable record surface, or an absent optional dependency **degrades** the
+run — say so in the summary and finish with an outcome — it never crashes the loop, never blocks
+other work, and never leaves the run unreported.
+
+Full contract (template, outcome definitions, escalation packet, retirement): [reference/automation-runbook-contract.md](../reference/automation-runbook-contract.md).

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -42,7 +42,8 @@ A **run outcome** describes the LOOP ITERATION. A **terminal state** describes a
 already uses that phrase for work-item lifecycles (`lisa-intake`: "`Blocked` is a valid terminal
 state of the downstream lifecycles"). The two vocabularies never merge in an operator-facing report.
 A healthy cycle that routes a work item to `Blocked` with clarifying questions is
-`candidate-proposed` — it produced something — and **never `recovery-required`**, which means the
+`candidate-proposed` — it produced something — so it is **never `nothing-needed`**, which is
+reserved for runs that found nothing at all, and **never `recovery-required`**, which means the
 loop itself is broken, not that a work item was blocked.
 
 ## No silent exit

--- a/plugins/src/base/rules/reference/automation-runbook-contract.md
+++ b/plugins/src/base/rules/reference/automation-runbook-contract.md
@@ -79,9 +79,9 @@ Next-run state
   finished is visible as claimed, and the repair path picks it up.
 
 Retirement condition
-  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
-  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
-  human acts on it.
+  Propose teardown when BOTH hold: no work item has entered this queue for 30 consecutive days, AND
+  this run proposed nothing. It files one teardown-proposal item and keeps running at its normal
+  cadence until someone approves, declines, or re-cadences it.
 ```
 
 ## The six run outcomes
@@ -89,21 +89,40 @@ Retirement condition
 Exactly one per run. The one-line operator summary is not optional — it is what the status surface
 shows and what makes the outcome actionable.
 
-| Outcome | Definition | Healthy? | One-line summary must contain |
-|---|---|---|---|
-| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
-| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
-| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
-| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
-| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
-| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+Health and operator action are **orthogonal**: several healthy outcomes still want an answer, and
+only `recovery-required` means the machinery itself is broken.
+
+| Outcome | Definition | Healthy? | Operator action? | One-line summary must contain |
+|---|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | None. | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Healthy | Review the proposed item and flip it ready when you want it built. | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Healthy | None — informational. | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Healthy | Answer the approval question. | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **Not healthy** — needs a human | Restore the named capability, then close the escalation item. | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The loop's own retirement policy — the retirement condition written in its runbook — tripped, so it proposed its own teardown. | Healthy | Decide: approve the teardown, decline it (close the proposal; the loop continues at cadence), or re-cadence it. | Why it looks obsolete and the teardown-proposal item. |
+
+### Exemplar one-line summaries
+
+These set the register every conforming loop copies — plain, specific, and actionable without
+reading code:
+
+```text
+nothing-needed      Scanned 12 ready items; nothing to propose.
+candidate-proposed  Proposed #1810 to fix the failing checkout step; awaiting your flip to ready.
+change-proved       Merged #1811 raising coverage to 84%; CI green and evidence posted on the item.
+approval-requested  Deploy to production is waiting on your approval; nothing ships until you answer.
+recovery-required   Lost access to the tracker; filed #1812 with the one decision needed to restore it.
+policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
+```
 
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
-contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
-assume its file is present.)
+contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
+terminal step posts its result record before stopping, so there is no silent exit — from one flow to
+every registered loop. (The run-record substrate that stores outcomes and summaries is named here
+only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -116,9 +135,11 @@ This is the highest-risk seam in the contract, so it is stated explicitly.
 
 They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
 `Blocked` — because the item's requirements are unresolvable and a human must answer — is
-`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
-means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
-and train operators to ignore the fleet verdict.
+`candidate-proposed`: the run produced something (a blocked item carrying clarifying questions), so
+it is **never `nothing-needed`**, which is reserved for runs that found nothing at all, and **never
+`recovery-required`**, which means the machinery is broken. Conflating a blocked work item with a
+broken loop would paint healthy intake cycles permanently red and train operators to ignore the
+fleet verdict.
 
 ## Escalation — the decision-ready packet
 
@@ -132,7 +153,8 @@ containing exactly these fields:
 | Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
 | Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
 | Risk of inaction | What degrades or stops if nobody acts, and how soon. |
-| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list — stated with **named options** (or as a yes/no), and what the loop will do with each answer. |
+| How to answer | The mechanical response path: comment on the item, flip a label, or close it — so the operator never has to guess how to reply. |
 
 The wording requirement is binding: a **non-technical operator must be able to act on the packet
 without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
@@ -142,8 +164,11 @@ packet must stand without it.
 
 A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
 the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
-a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
-learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+a tracker-derived condition is headless- and concurrent-safe by construction). This generalizes the
+*Retirement condition* section of `lisa-learnings-audit`, which already retires itself this way; its
+current wording still uses the older three-value "terminal states" vocabulary, and the
+loop-conformance ticket conforms it to the six run outcomes above. A loop proposes retirement when
+BOTH hold:
 
 1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
    within its trailing quiet window (sized to a small multiple of its cadence).
@@ -153,13 +178,39 @@ learnings-gardener precedent, a loop proposes retirement when BOTH hold:
 When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
 teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
 result and this run's summary as evidence, and proposing either a longer cadence or
-`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
-retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
-its own registration.
+`lisa-tear-down-automations`. The loop **keeps running at its normal cadence** until an operator
+flips that proposal one of three ways: **approve** it (`lisa-tear-down-automations` runs and the
+registration goes away), **decline** it (close the proposal — the loop simply continues), or
+**re-cadence** it (register it at the longer cadence instead of tearing it down). Retirement is a
+recommendation like any other, **never a self-executed exit**: a loop never deletes its own
+registration, and a proposal nobody answers changes nothing.
+
+## Never block, always degrade
+
+A loop degrades rather than blocking. Three triggers are expected and must never crash a run:
+
+- **A missing runbook** — the loop runs on the contract's defaults and says so.
+- **An unreadable record surface** — the loop still reports its outcome and summary in its own run
+  output, so the operator is never left with silence.
+- **An absent optional dependency** — a skill or surface that ships with a sibling ticket is not
+  yet installed; the loop skips that enrichment and continues.
+
+A degraded run still **reports its actual outcome from the same six values** — degradation does not
+mint a seventh token and, on its own, is not `recovery-required`. Its one-line summary **leads with
+the degradation**, then states the outcome:
+
+```text
+Runbook missing — ran on defaults; nothing to propose.
+```
+
+Degradation becomes `recovery-required` only when it prevents the loop from doing its actual job
+(the queue itself is unreadable, credentials are revoked) — and then it escalates the decision-ready
+packet above. A degraded run never blocks other work and never leaves the run unreported.
 
 ## Citing adjacent work
 
 Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template, the run-record substrate that
-stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
+that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
+(#1738) — named here, with no evidence format defined by this contract. Rejection memory
 extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/src/base/rules/reference/automation-runbook-contract.md
+++ b/plugins/src/base/rules/reference/automation-runbook-contract.md
@@ -1,0 +1,165 @@
+# Automation Runbook Contract
+
+Scheduled loops are the busiest machinery in the factory and historically the least explicitly
+contracted: what a loop maintains, what it may do on its own, what it must escalate, and when it
+should stop existing all lived implicitly in each loop's prose. The cost lands on the operator — a
+quiet run and a broken run look identical, and "what is this scheduled thing?" has a different
+answer shape for every loop. This contract writes the answer down once.
+
+It is a **single vendor-neutral contract** consumed by `lisa-setup-automations` (which scaffolds a
+runbook per registered loop), `lisa-automation-status` (which reads runbooks and run outcomes back
+to an operator), `lisa-tear-down-automations` (which acts on retirement proposals), and every
+registered loop skill (which conforms its own run to it). Each consumer cites this slug; none of
+them redefines it.
+
+**Membership is registration, not skill-existence.** A loop falls under this contract when it is
+registered as a scheduled automation on the host project's runtime scheduler — not when its skill
+file happens to exist in the plugin tree. Registering a new loop pulls it in automatically, and
+un-registering drops it. Nothing in this contract, in the scaffolder, or in the status surface may
+carry a hardcoded roster of loops; the worked example below names one loop as illustration only.
+
+## The runbook template
+
+Every registered loop's runbook has these ten sections, in this order. Each is answered in prose a
+non-technical operator can read (`factory-model` rule 5).
+
+| Section | What a good answer looks like |
+|---|---|
+| Intent | One sentence naming what this loop maintains, in outcome terms, not mechanism terms. |
+| Sources of truth | The exact surfaces the loop reads, each reachable through its access layer (`integration-access-layer`) — never a direct vendor API call. |
+| Candidate selection | The query or filter that decides what this run acts on, and the bound on how many. |
+| Scope/bounds | What the loop will never touch, and the cap that keeps one run finite. |
+| Proof | What the loop must observe before claiming it changed anything — the evidence it records. |
+| Autonomous-vs-approval boundary | The named line: what it does alone, and the first thing on the other side that requires a human. |
+| Escalation | What it files when it cannot proceed — always the decision-ready packet below. |
+| Recovery | What a human or the next run does to get the loop working again after `recovery-required`. |
+| Next-run state | What the next run can observe from this one, derived from durable surfaces (tracker, records) rather than in-process memory. |
+| Retirement condition | The stateless, tracker-derived condition under which this loop proposes its own teardown. |
+
+### Worked example — the `intake-tickets` loop
+
+```text
+Loop: intake-tickets
+
+Intent
+  Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped
+  without anyone having to hand them to an agent.
+
+Sources of truth
+  The configured tracker's build queue (the ready/claimed/done lanes from .lisa.config.json), read
+  through the tracker access layer; the item's own comments and linked PRs.
+
+Candidate selection
+  The oldest eligible leaf work item currently in the ready lane, one per run. Containers with open
+  children are repaired out of the queue, never built.
+
+Scope/bounds
+  Only items in this repo's configured queue. It never edits the ready lane's meaning, never
+  invents work items, and never processes more than its per-run cap.
+
+Proof
+  A merged pull request plus the project's own verification evidence posted back to the work item;
+  a claim of "done" without that evidence is not made.
+
+Autonomous-vs-approval boundary
+  Alone: claim, plan, implement, open the PR, drive it to merge. Requires a human: anything that
+  needs a protected deployment approval, and any item whose requirements it cannot resolve — that
+  becomes a blocked work item with clarifying questions, not a guess.
+
+Escalation
+  When the loop itself cannot proceed (tracker credentials revoked, queue unreadable), it files the
+  decision-ready packet below, labeled status:blocked + human-needed.
+
+Recovery
+  A human restores the named access, then flips the escalation item closed; the next scheduled run
+  resumes with no manual replay needed.
+
+Next-run state
+  Nothing in memory. The tracker lanes and the run records are the state: a claimed item that never
+  finished is visible as claimed, and the repair path picks it up.
+
+Retirement condition
+  Propose teardown when BOTH hold: no item has entered the queue in the trailing quiet window, AND
+  this run proposed nothing. Files one marker-deduped teardown-proposal item; keeps running until a
+  human acts on it.
+```
+
+## The six run outcomes
+
+Exactly one per run. The one-line operator summary is not optional — it is what the status surface
+shows and what makes the outcome actionable.
+
+| Outcome | Definition | Healthy? | One-line summary must contain |
+|---|---|---|---|
+| `nothing-needed` | The loop ran end to end and found nothing to act on. | Healthy — **no operator action** | What was scanned, how much was seen, and "nothing to propose". |
+| `candidate-proposed` | The loop proposed work — a ticket, PRD, or recommendation — for a human or a downstream factory. | Yes | What was proposed and where to find it (item refs). |
+| `change-proved` | The loop made a change and proved it with evidence. | Yes | What changed and the evidence that proves it. |
+| `approval-requested` | The loop reached its autonomous/approval boundary and asked a human. | Yes | What is waiting, on whom, and what happens if nobody answers. |
+| `recovery-required` | The loop itself could not complete: access, tooling, or substrate is broken. | **No** — needs a human | What broke, and the escalation item to act on. |
+| `policy-obsolete` | The retirement condition tripped; the loop proposed its own teardown. | Yes | Why it looks obsolete and the teardown-proposal item. |
+
+**No silent exit.** Every run posts its outcome and its one-line summary before stopping —
+including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
+there is no silent exit for an operator to misread as health. A run that ends without a
+recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
+contract removes. (The run-record substrate is named here only; it ships with that ticket, do not
+assume its file is present.)
+
+## A run outcome is not a work-item lifecycle terminal state
+
+This is the highest-risk seam in the contract, so it is stated explicitly.
+
+- A **run outcome** describes the LOOP ITERATION — how this scheduled execution ended.
+- A **terminal state** describes a TICKET — Lisa already uses that phrase for work-item lifecycles
+  (`lisa-intake`: "`Blocked` is a valid terminal state of the downstream lifecycles"; see
+  `prd-lifecycle-rollup`).
+
+They never merge in an operator-facing report. A perfectly healthy cycle that routes a work item to
+`Blocked` — because the item's requirements are unresolvable and a human must answer — is
+`nothing-needed` or `candidate-proposed`, and **never `recovery-required`**. `recovery-required`
+means the machinery is broken. Conflating the two would paint healthy intake cycles permanently red
+and train operators to ignore the fleet verdict.
+
+## Escalation — the decision-ready packet
+
+A loop that cannot proceed escalates by filing a tracker item (through `lisa-tracker-write`, per
+`tracked-work` and `integration-access-layer`) labeled **`status:blocked`** and **`human-needed`**,
+containing exactly these fields:
+
+| Field | Content |
+|---|---|
+| Current state | Where things stand right now, in plain terms — what is and is not working. |
+| Work already attempted | What the loop tried on its own before escalating, so nobody repeats it. |
+| Evidence | Links to the runs, items, logs, or records that show the problem (the evidence packet from the evidence PRD is the carrier; this contract names it and defines no evidence formats). |
+| Risk of inaction | What degrades or stops if nobody acts, and how soon. |
+| Smallest unresolved choice | The single smallest decision a human must make — one question, not a list. |
+
+The wording requirement is binding: a **non-technical operator must be able to act on the packet
+without reading code** (`factory-model` rule 5). A stack trace may be attached as evidence, but the
+packet must stand without it.
+
+## Retirement condition
+
+A loop that no longer earns its schedule should say so. The condition is **stateless — derived from
+the tracker, never from a counter or a state file** (there is no durable home for a run counter, and
+a tracker-derived condition is headless- and concurrent-safe by construction). Generalizing the
+learnings-gardener precedent, a loop proposes retirement when BOTH hold:
+
+1. **Quiet trailing window** — a date-filtered tracker search finds nothing this loop produced
+   within its trailing quiet window (sized to a small multiple of its cadence).
+2. **This run proposes nothing** — the current run yields zero candidates (it is otherwise ending
+   `nothing-needed`).
+
+When both hold, the run ends `policy-obsolete` and files **exactly ONE marker-deduped**
+teardown-proposal item — matched on the marker, never the title — carrying the date-filtered search
+result and this run's summary as evidence, and proposing either a longer cadence or
+`lisa-tear-down-automations`. The loop **keeps running** until a human acts on that proposal:
+retirement is a recommendation like any other, **never a self-executed exit**. A loop never deletes
+its own registration.
+
+## Citing adjacent work
+
+Cite these by name; each ships with its own ticket, do not assume its file is present in this
+branch: the runbook scaffolding that instantiates this template, the run-record substrate that
+stores outcomes and summaries, and the evidence packet defined by the evidence PRD. Rejection memory
+extends `rejection-detection`; this contract neither restates nor overrides it.

--- a/tests/unit/strategies/automation-runbook-contract-rule.test.ts
+++ b/tests/unit/strategies/automation-runbook-contract-rule.test.ts
@@ -89,6 +89,9 @@ describe("automation-runbook-contract rule contract", () => {
           /routes a work item to\s+`?Blocked`?[\s\S]{0,220}?`candidate-proposed`/
         );
         expect(doc).not.toMatch(/`nothing-needed` or `candidate-proposed`/);
+        // Both halves must rule out BOTH wrong outcomes — an agent that loads
+        // only the eager head must not mis-route a low-yield Blocked cycle.
+        expect(doc).toMatch(/never\s+\*{0,2}`?nothing-needed`?/i);
       }
       expect(reference).toContain("Blocked");
     });

--- a/tests/unit/strategies/automation-runbook-contract-rule.test.ts
+++ b/tests/unit/strategies/automation-runbook-contract-rule.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Contract coverage for the vendor-neutral automation-runbook-contract rule.
+ *
+ * The eager head + reference body are the executable contract every registered
+ * automation loop conforms to. These assertions pin the closed six-value run
+ * outcome vocabulary, the breadcrumb that the cursor generator rewrites, the
+ * run-outcome vs work-item-lifecycle disambiguation (conflating them would make
+ * healthy intake cycles report `recovery-required`), the ten runbook template
+ * sections, the no-silent-exit discipline, and the registration-not-existence
+ * membership test.
+ * @module tests/unit/strategies/automation-runbook-contract-rule
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+] as const;
+
+const TEMPLATE_SECTIONS = [
+  "Intent",
+  "Sources of truth",
+  "Candidate selection",
+  "Scope/bounds",
+  "Proof",
+  "Autonomous-vs-approval boundary",
+  "Escalation",
+  "Recovery",
+  "Next-run state",
+  "Retirement condition",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("automation-runbook-contract rule contract", () => {
+  describe.each(ROOTS)("%s", root => {
+    const eager = read(root, "rules/eager/automation-runbook-contract.md");
+    const reference = read(
+      root,
+      "rules/reference/automation-runbook-contract.md"
+    );
+
+    it("ships as a paired rule with a non-trivial body on both sides", () => {
+      expect(eager.length).toBeGreaterThan(500);
+      expect(reference.length).toBeGreaterThan(2000);
+    });
+
+    it("eager head breadcrumbs to the reference body verbatim", () => {
+      expect(eager).toContain(
+        "Full contract (template, outcome definitions, escalation packet, retirement): [reference/automation-runbook-contract.md](../reference/automation-runbook-contract.md)."
+      );
+    });
+
+    it("defines the closed six-value run outcome vocabulary in both halves", () => {
+      for (const doc of [eager, reference]) {
+        for (const outcome of RUN_OUTCOMES) {
+          expect(doc).toContain(outcome);
+        }
+        expect(doc).toMatch(/exactly one/i);
+      }
+    });
+
+    it("documents nothing-needed as healthy and needing no operator action", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toMatch(/`nothing-needed`[^\n]*[Hh]ealthy/);
+      }
+      expect(reference).toMatch(/no operator action/i);
+    });
+
+    it("disambiguates a run outcome from a work-item lifecycle terminal state", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toMatch(/terminal state/i);
+        expect(doc).toMatch(/run outcome[^.]*loop iteration/i);
+        expect(doc).toMatch(/never `?recovery-required`?/i);
+      }
+      expect(reference).toContain("Blocked");
+    });
+
+    it("carries one runbook template section per contracted field", () => {
+      for (const section of TEMPLATE_SECTIONS) {
+        expect(reference).toContain(section);
+      }
+    });
+
+    it("fills every template section for the intake-tickets worked example", () => {
+      expect(reference).toContain("intake-tickets");
+      const fence = /```text\n([\s\S]*?)```/.exec(reference)?.[1] ?? "";
+      expect(fence).toContain("intake-tickets");
+      for (const section of TEMPLATE_SECTIONS) {
+        expect(fence).toContain(section);
+      }
+    });
+
+    it("forbids a silent exit", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toContain("there is no silent exit");
+        expect(doc).toMatch(/one-line[^.]*summary/i);
+      }
+    });
+
+    it("prescribes a decision-ready escalation packet", () => {
+      expect(reference).toMatch(/current state/i);
+      expect(reference).toMatch(/already attempted|work attempted/i);
+      expect(reference).toMatch(/evidence/i);
+      expect(reference).toMatch(/risk of inaction/i);
+      expect(reference).toMatch(/smallest unresolved choice/i);
+      expect(reference).toContain("status:blocked");
+      expect(reference).toContain("human-needed");
+      expect(reference).toContain("factory-model");
+    });
+
+    it("keeps retirement stateless, tracker-derived, and never self-executed", () => {
+      expect(reference).toMatch(/stateless/i);
+      expect(reference).toMatch(/never.*(counter|state file)/i);
+      expect(reference).toMatch(/quiet/i);
+      expect(reference).toMatch(/marker-dedup/i);
+      expect(reference).toMatch(/never a self-executed exit/i);
+    });
+
+    it("tests membership by registration, not skill existence", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toMatch(/registration, not skill.existence/i);
+      }
+    });
+
+    it("cites sibling rules by bare slug rather than restating them", () => {
+      for (const slug of [
+        "factory-model",
+        "rejection-detection",
+        "tracked-work",
+        "integration-access-layer",
+      ]) {
+        expect(reference).toContain(slug);
+      }
+      expect(reference).not.toContain("rules/reference/factory-model.md");
+    });
+
+    it("hedges artifacts that ship with sibling tickets", () => {
+      expect(reference).toMatch(
+        /ships with that ticket, do not\s+assume its file is present/i
+      );
+    });
+
+    it("names the loop-facing consumers of the contract", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toContain("lisa-setup-automations");
+        expect(doc).toContain("lisa-automation-status");
+        expect(doc).toContain("lisa-tear-down-automations");
+      }
+    });
+  });
+});

--- a/tests/unit/strategies/automation-runbook-contract-rule.test.ts
+++ b/tests/unit/strategies/automation-runbook-contract-rule.test.ts
@@ -81,14 +81,38 @@ describe("automation-runbook-contract rule contract", () => {
       for (const doc of [eager, reference]) {
         expect(doc).toMatch(/terminal state/i);
         expect(doc).toMatch(/run outcome[^.]*loop iteration/i);
-        expect(doc).toMatch(/never `?recovery-required`?/i);
+        // Tolerant of markdown bolding and the ~100-char hard wrap in rule bodies.
+        expect(doc).toMatch(/never\s+\*{0,2}`?recovery-required`?/i);
+        // A blocked work item means the run PRODUCED something — `nothing-needed`
+        // stays reserved for runs that found nothing at all.
+        expect(doc).toMatch(
+          /routes a work item to\s+`?Blocked`?[\s\S]{0,220}?`candidate-proposed`/
+        );
+        expect(doc).not.toMatch(/`nothing-needed` or `candidate-proposed`/);
       }
       expect(reference).toContain("Blocked");
     });
 
-    it("carries one runbook template section per contracted field", () => {
+    it("separates health from operator action for every outcome", () => {
+      expect(reference).toContain("| Operator action? |");
+      for (const doc of [eager, reference]) {
+        expect(doc).toMatch(/orthogonal/i);
+      }
+    });
+
+    it("carries an exemplar one-line summary per run outcome", () => {
+      const examples = /### Exemplar one-line summaries\n([\s\S]*?)\n## /.exec(
+        reference
+      )?.[1];
+      expect(examples).toBeDefined();
+      for (const outcome of RUN_OUTCOMES) {
+        expect(examples).toContain(outcome);
+      }
+    });
+
+    it("carries one runbook template table row per contracted field", () => {
       for (const section of TEMPLATE_SECTIONS) {
-        expect(reference).toContain(section);
+        expect(reference).toContain(`| ${section} |`);
       }
     });
 
@@ -108,12 +132,24 @@ describe("automation-runbook-contract rule contract", () => {
       }
     });
 
+    it("degrades rather than blocks", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toMatch(/never block|degrade/i);
+      }
+      expect(reference).toMatch(/missing runbook/i);
+      expect(reference).toMatch(/unreadable record surface/i);
+      expect(reference).toMatch(/absent optional dependency/i);
+      expect(reference).toMatch(/does not\s+mint a seventh token/i);
+    });
+
     it("prescribes a decision-ready escalation packet", () => {
       expect(reference).toMatch(/current state/i);
       expect(reference).toMatch(/already attempted|work attempted/i);
       expect(reference).toMatch(/evidence/i);
       expect(reference).toMatch(/risk of inaction/i);
       expect(reference).toMatch(/smallest unresolved choice/i);
+      expect(reference).toMatch(/named options/i);
+      expect(reference).toMatch(/\| How to answer \|/);
       expect(reference).toContain("status:blocked");
       expect(reference).toContain("human-needed");
       expect(reference).toContain("factory-model");
@@ -125,6 +161,15 @@ describe("automation-runbook-contract rule contract", () => {
       expect(reference).toMatch(/quiet/i);
       expect(reference).toMatch(/marker-dedup/i);
       expect(reference).toMatch(/never a self-executed exit/i);
+      // The proposal's three named human responses, not a vague "acts on it".
+      expect(reference).toMatch(/approve/i);
+      expect(reference).toMatch(/decline/i);
+      expect(reference).toMatch(/re-cadence/i);
+    });
+
+    it("cites the precedent skills it generalizes by slug", () => {
+      expect(reference).toContain("lisa-learnings-audit");
+      expect(reference).toContain("lisa-improve-harness");
     });
 
     it("tests membership by registration, not skill existence", () => {
@@ -147,7 +192,7 @@ describe("automation-runbook-contract rule contract", () => {
 
     it("hedges artifacts that ship with sibling tickets", () => {
       expect(reference).toMatch(
-        /ships with that ticket, do not\s+assume its file is present/i
+        /ships with that ticket[^,]*, do not\s+assume its file is present in this\s+branch/i
       );
     });
 


### PR DESCRIPTION
Ships the automation runbook contract as an eager/reference rule pair — the single document every registered automation loop conforms to. RBC-1 of PRD #1737; RBC-2..RBC-7 scaffold it, record against it, and display it, but none of them redefine it.

Closes #1795

## What ships

- **`plugins/src/base/rules/eager/automation-runbook-contract.md`** — the load-bearing head: every registered loop carries a checked-in runbook, every run ends in exactly one of six run outcomes with a one-line operator summary, no silent exit, escalation is a decision-ready ticket.
- **`plugins/src/base/rules/reference/automation-runbook-contract.md`** — the full contract.
- **`tests/unit/strategies/automation-runbook-contract-rule.test.ts`** — companion contract test, read from both `plugins/src/base` and the regenerated `plugins/lisa` tree.
- Regenerated artifacts for the `lisa`, `lisa-copilot`, and `lisa-cursor` variants (fanout is directory-driven, so six-agent parity comes for free).

### The contract

- **A 10-section runbook template** — Intent · Sources of truth · Candidate selection · Scope/bounds · Proof · Autonomous-vs-approval boundary · Escalation · Recovery · Next-run state · Retirement condition — each with one "what a good answer looks like" sentence, plus a worked example filling every section for the `intake-tickets` loop.
- **Six run outcomes**, exactly one per run: `nothing-needed | candidate-proposed | change-proved | approval-requested | recovery-required | policy-obsolete`. The table keeps **`Healthy?` and `Operator action?` orthogonal** — several healthy outcomes still need an answer, and only `recovery-required` means the machinery is broken — and each outcome states what its one-line summary must contain, with a block of **exemplar summaries in the operator voice** that every conforming loop copies.
- **Disambiguation from work-item lifecycle terminal states.** A run outcome describes the LOOP ITERATION; a terminal state describes a TICKET (`lisa-intake`: "`Blocked` is a valid terminal state"). A healthy cycle that routes a work item to `Blocked` with clarifying questions is `candidate-proposed` — never `nothing-needed` (reserved for found-nothing runs) and never `recovery-required`. Stated in **both** halves, because conflating them would paint healthy intake cycles permanently red.
- **The escalation packet** — current state · work already attempted · evidence · risk of inaction · the single smallest unresolved choice (with **named options** and what the loop does with each answer) · **how to answer** (comment / label flip / close). Filed as a tracker item labeled `status:blocked` + `human-needed`, written so a non-technical operator can act without reading code (`factory-model` rule 5).
- **Stateless retirement** — tracker-derived, never a counter or state file; fires on a quiet trailing window AND a run that proposes nothing; files ONE marker-deduped teardown proposal and keeps running until an operator **approves** (`lisa-tear-down-automations` runs), **declines** (close it; the loop continues), or **re-cadences**. Never a self-executed exit.
- **Never block, always degrade** — three named triggers (missing runbook, unreadable record surface, absent optional dependency); a degraded run reports its actual outcome from the same six values with the summary leading with the degradation. No seventh token is minted.
- **Membership is registration, not skill-existence** — registering a loop later pulls it in automatically; no hardcoded roster anywhere.

Cites, does not restate: `factory-model`, `rejection-detection`, `tracked-work`, `integration-access-layer`, and the `lisa-learnings-audit` / `lisa-improve-harness` precedents it generalizes. Artifacts shipping in sibling tickets (#1796 scaffolding, #1797 run-record substrate, #1738 evidence packet) are named with the standard hedge and defined nowhere here.

## Review process

Built TDD (companion test written and failing first). Three review lanes ran against the result — product, quality, and spec conformance — and **every finding was applied**: the orthogonal operator-action column, the `nothing-needed`/`candidate-proposed` contradiction, the exemplar summaries, the escalation `How to answer` row and named-options requirement, the three named retirement responses, the reference-side degrade section, the real precedent slugs, hedge harmonization, and the concrete quiet window in the worked example. Independent verification then re-checked the contract end to end (C1–C5, including a mutation probe confirming the test actually fails when the pinned contract text is removed) — all pass. A final verification finding, that the eager head ruled out only `recovery-required`, is fixed in the last commit.

## Verification

- `bash scripts/check-rules-pairing.sh` → exit 0
- `bunx vitest run tests/unit/strategies/automation-runbook-contract-rule.test.ts` → **36 passed** (18 assertions × 2 roots)
- `bunx vitest run tests/unit/strategies/` → 134 files / 3225 passed, 0 failed
- `bun run typecheck` → exit 0
- post-commit `bun run check:plugins` → exit 0 (artifacts in sync; marketplace registers every built plugin)
- Cursor fanout confirmed: eager `.mdc` `alwaysApply: true`, reference `.mdc` `alwaysApply: false`, breadcrumb rewritten to `automation-runbook-contract-reference.mdc`

Out of scope (per the ticket): no loop behavior changes, no runbook scaffolding, no run-record substrate, no loop-skill conformance, no status surface, no rejection memory, no retirement mechanics, and no evidence formats.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a shared Automation Runbook Contract for registered automation loops.
  * Standardized ten-section runbook structure and six allowed run outcomes.
  * Required every run to publish an operator-readable summary, preventing silent exits.
  * Clarified escalation, retirement proposals, work-item state distinctions, and graceful degradation.
  * Added guidance for missing runbooks, unreadable status surfaces, and unavailable optional dependencies.

* **Tests**
  * Added coverage validating contract structure, outcome vocabulary, escalation rules, retirement behavior, and degradation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->